### PR TITLE
fix(ci): silence noUncheckedIndexedAccess + restore presets self-containment

### DIFF
--- a/packages/cli/src/presets/typescript/detect.ts
+++ b/packages/cli/src/presets/typescript/detect.ts
@@ -9,7 +9,25 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { getWorkspacePatterns } from '../../utils/workspaces.js';
+/**
+ * Read workspace glob patterns from a package.json. Inlined here (rather than
+ * importing from `utils/workspaces.ts`) so the presets package stays
+ * self-contained — see `cli-presets-self-contained` rule in
+ * `.dependency-cruiser.cjs`.
+ */
+function getWorkspacePatterns(cwd: string): string[] {
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!existsSync(pkgPath)) return [];
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      workspaces?: string[] | { packages?: string[] };
+    };
+    if (!pkg.workspaces) return [];
+    return Array.isArray(pkg.workspaces) ? pkg.workspaces : (pkg.workspaces.packages ?? []);
+  } catch {
+    return [];
+  }
+}
 
 /**
  * TanStack Query package names across all supported frameworks.

--- a/packages/cli/tests/integration/failure-memory.test.ts
+++ b/packages/cli/tests/integration/failure-memory.test.ts
@@ -179,8 +179,8 @@ describe('Failure Memory (#111)', () => {
       const failures = state.recentFailures as { pattern: string; timestamp: string }[];
       expect(failures).toBeDefined();
       expect(failures.length).toBeGreaterThan(0);
-      expect(failures[0].pattern).toBe('loc-exceeded');
-      expect(failures[0].timestamp).toBeDefined();
+      expect(failures[0]?.pattern).toBe('loc-exceeded');
+      expect(failures[0]?.timestamp).toBeDefined();
     });
 
     it('stop hook writes recentFailures when done gate blocks for test failure', () => {

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -367,7 +367,7 @@ describe('Schema - Single Source of Truth', () => {
         for (const entry of entries) {
           for (const hookDefinition of entry.hooks) {
             const match = /\/([^/]+)$/.exec(hookDefinition.command);
-            if (match) wiredHooks.add(match[1]);
+            if (match?.[1]) wiredHooks.add(match[1]);
           }
         }
       }


### PR DESCRIPTION
## Summary

Two pre-existing CI lint-job failures on `main`, both blocking [PR #62](https://github.com/ArcadeAI/safeword/pull/62) and [PR #64](https://github.com/ArcadeAI/safeword/pull/64). Neither was introduced by feature work; both surface as the lint job's `Type check` and `Architecture check` steps.

### 1. TypeScript `noUncheckedIndexedAccess` errors (Type check step)

- `tests/integration/failure-memory.test.ts:182,183` — `failures[0].pattern` / `.timestamp` accessed without checking for undefined
- `tests/schema.test.ts:370` — `match[1]` accessed without checking the regex group exists

Fixed via optional chaining (`?.[N]`, `?.field`) — more idiomatic than `!` in tests; fails clearly if assumption breaks at runtime.

### 2. `cli-presets-self-contained` violation (Architecture check / depcruise)

PR #134 (3bf6454, `refactor: use shared getWorkspacePatterns`) introduced an import in `packages/cli/src/presets/typescript/detect.ts` from `packages/cli/src/utils/workspaces.ts`. Violates the architecture rule: presets must be self-contained for external publishability.

Fix: re-inline a minimal `getWorkspacePatterns` directly in `detect.ts` using the same `readFileSync` pattern already in use there. 7-line inline replacement; `utils/workspaces.ts` stays in place for non-preset consumers.

## Why this matters

Both PR #62 and PR #64 fail CI's lint job for these unrelated reasons. Tests pass on both. This tiny PR unblocks both.

## Test plan

- [x] `bun run lint` (eslint .) — clean locally
- [x] `bun run --cwd packages/cli typecheck` — clean locally
- [x] `bun run deps` — 0 violations across 92 modules
- [x] `marketplace.json` and `packages/cli/package.json` versions match

## After merge

PR #62 and PR #64 need rebase to pick up these fixes; CI on both should then pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)