### PR TITLE
feat(139): harden unified customer override contract

### DIFF
--- a/.safeword-project/tickets/139-harden-unified-override-contract/ticket.md
+++ b/.safeword-project/tickets/139-harden-unified-override-contract/ticket.md
@@ -2,9 +2,9 @@
 id: 139
 type: task
 phase: implement
-status: ready
+status: in_progress
 created: 2026-04-19T13:29:51Z
-last_modified: 2026-04-19T13:29:51Z
+last_modified: 2026-05-03T18:32:00Z
 scope: |
   Harden the unified customer override contract shipped in ticket 138.
   Three concrete changes:
@@ -130,5 +130,10 @@ New describe block `Rule: Python overrides in standalone-generated ruff.toml (ti
 ---
 
 - 2026-04-19T13:29:51Z Filed from 138's follow-up section. Specs debated and locked in 138's ticket body; this ticket is the actionable form tooling can surface.
+- 2026-05-03T18:32:00Z Implementation landed:
+  1. Deleted `getSafewordEslintConfigStandalone` and simplified `getSafewordEslintConfig` dispatch — fresh `safeword setup` now generates `.safeword/eslint.config.mjs` using the extending template, so customer overrides reach the LLM hook from day one (no longer need a `safeword upgrade` to enable the indirection).
+  2. Replaced extending template's broad try/catch with `existsSync` gate using `new URL('../eslint.config.mjs', import.meta.url)`. Customer syntax errors / missing-plugin errors now surface loud; only legitimately-missing files are silently tolerated. Universal Node 20+ compatibility (no `import.meta.dirname` dependency).
+  3. Added Scenario 2.4 (parameterized `it.each` × 3 rows: ignore, per-file-ignores, extend-select) covering Ruff's standalone-generated mode. Codifies the manual end-to-end verification that was inferred but not pinned during ticket 138.
+     Local results: 10/10 override-survival.test.ts GREEN; invisible-extension.test.ts updated for new behavior + 8/8 GREEN; lint + typecheck + depcruise all pass.
 
 ---

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -190,16 +190,19 @@ export function getSafewordEslintConfig(
   existingConfig: string | undefined,
   hasExistingFormatter = false,
 ): string {
-  if (existingConfig) {
-    // Check if it's a legacy config (.eslintrc.*)
-    if (existingConfig.startsWith('.eslintrc')) {
-      return getSafewordEslintConfigLegacy(existingConfig, hasExistingFormatter);
-    }
-    return getSafewordEslintConfigExtending(existingConfig, hasExistingFormatter);
+  // Legacy `.eslintrc.*` path: use FlatCompat shim.
+  if (existingConfig?.startsWith('.eslintrc')) {
+    return getSafewordEslintConfigLegacy(existingConfig, hasExistingFormatter);
   }
-
-  // No existing config - generate standalone (same as project-level)
-  return getSafewordEslintConfigStandalone(hasExistingFormatter);
+  // Flat-config path. When customer has no pre-existing config, safeword's
+  // managedFiles generates `eslint.config.mjs` at the project root in the same
+  // setup run, so by hook execution time the file always exists. The
+  // existsSync gate in the template covers the edge case (file truly missing)
+  // gracefully — see ticket 139.
+  return getSafewordEslintConfigExtending(
+    existingConfig ?? 'eslint.config.mjs',
+    hasExistingFormatter,
+  );
 }
 
 /**
@@ -216,17 +219,22 @@ function getSafewordEslintConfigExtending(
   return `// Safeword ESLint config - extends project config with stricter rules
 // Used by hooks for LLM enforcement. Human pre-commits use project config.
 // Re-run \`safeword upgrade\` to regenerate after project config changes.
+import { existsSync } from "node:fs";
 ${safewordImport}${prettier.import}
 
+// Ticket 139: existsSync gate + no try/catch.
+// - File present, import fails → real error (syntax, missing plugin, etc.) → throw,
+//   so the hook fails loud instead of silently dropping customer overrides.
+// - File absent → projectConfig stays [] → hook runs with safeword defaults only.
+//   In practice, safeword's managedFiles generates the project eslint.config.mjs
+//   in the same setup run, so this fallback only fires in degenerate cases.
 let projectConfig = [];
-try {
+const projectConfigPath = new URL("../${existingConfig}", import.meta.url);
+if (existsSync(projectConfigPath)) {
   projectConfig = (await import("../${existingConfig}")).default;
-  // Ensure it's an array
   if (!Array.isArray(projectConfig)) {
     projectConfig = [projectConfig];
   }
-} catch (e) {
-  console.warn("Safeword: Could not load project ESLint config, using defaults only");
 }
 
 ${SAFEWORD_STRICT_RULES_FULL}
@@ -282,41 +290,6 @@ export default [
   ...projectConfig,
 ${prettier.configEntry}
 ];
-`;
-}
-
-/**
- * Standalone safeword ESLint config (no project config to extend)
- */
-function getSafewordEslintConfigStandalone(hasExistingFormatter: boolean): string {
-  const prettier = getPrettierConfig(hasExistingFormatter);
-
-  return `// Safeword ESLint config - standalone (no project config to extend)
-// Used by hooks for LLM enforcement.
-import { dirname } from "node:path";
-import { defineConfig } from "eslint/config";
-import safeword from "safeword/eslint";
-${prettier.import}
-
-const { detect, configs } = safeword;
-const __dirname = import.meta.dirname;
-// Look in parent directory for deps (this file is in .safeword/)
-const projectDir = dirname(__dirname);
-const deps = detect.collectAllDeps(projectDir);
-const framework = detect.detectFramework(deps);
-
-${getMonorepoSnippet('projectDir')}
-
-${SAFEWORD_STRICT_RULES_FULL}
-
-export default defineConfig([
-  { ignores: detect.getIgnores() },
-  ...baseConfigs[framework],
-  ...scopedNextConfigs,
-${OPTIONAL_CONFIGS_SNIPPET}
-  safewordStrictRules,
-${prettier.configEntry}
-]);
 `;
 }
 

--- a/packages/cli/tests/integration/invisible-extension.test.ts
+++ b/packages/cli/tests/integration/invisible-extension.test.ts
@@ -115,7 +115,7 @@ export default [
     );
 
     it(
-      'creates standalone .safeword/eslint.config.mjs when no existing config',
+      'creates extending .safeword/eslint.config.mjs even when no pre-existing config (ticket 139)',
       async () => {
         projectDirectory = createTemporaryDirectory();
         createTypeScriptPackageJson(projectDirectory);
@@ -126,16 +126,18 @@ export default [
           timeout: SETUP_TIMEOUT,
         });
 
-        // Project-level config should be created (since no existing)
+        // Project-level config gets generated (managedFiles)
         expect(fileExists(projectDirectory, 'eslint.config.mjs')).toBe(true);
 
-        // .safeword/eslint.config.mjs should also exist (standalone)
+        // .safeword/eslint.config.mjs uses the extending template now (post-139).
+        // Customer overrides reach the LLM hook from day-one of `safeword setup`,
+        // not after the next `safeword upgrade`.
         expect(fileExists(projectDirectory, '.safeword/eslint.config.mjs')).toBe(true);
         const safewordConfig = readTestFile(projectDirectory, '.safeword/eslint.config.mjs');
-
-        // Should be standalone (no import from project config)
-        expect(safewordConfig).toContain('safeword/eslint');
+        expect(safewordConfig).toContain('await import("../eslint.config.mjs")');
         expect(safewordConfig).toContain('safewordStrictRules');
+        // existsSync gate (ticket 139)
+        expect(safewordConfig).toContain('existsSync(projectConfigPath)');
       },
       SETUP_TIMEOUT,
     );

--- a/packages/cli/tests/integration/override-survival.test.ts
+++ b/packages/cli/tests/integration/override-survival.test.ts
@@ -343,4 +343,85 @@ extend-select = ["D"]
       TIMEOUT_BUN_INSTALL,
     );
   });
+
+  describe.skipIf(!isRuffInstalled())(
+    'Rule: Python overrides in standalone-generated ruff.toml (ticket 139)',
+    () => {
+      // Rule 2 pre-creates ruff.toml BEFORE safeword setup. This rule covers the
+      // complementary path: customer has NO prior ruff.toml; safeword generates a
+      // BARE customer ruff.toml during setup; customer adds overrides AFTER. The
+      // unified-extend mechanism (post-138) means `.safeword/ruff.toml` always
+      // extends `../ruff.toml`, so customer's edits propagate to the LLM hook.
+      let projectDirectory: string;
+      let bareRuffToml: string;
+
+      beforeAll(async () => {
+        projectDirectory = realpathSync(createTemporaryDirectory());
+        createPythonProject(projectDirectory);
+        // Note: NO pre-existing ruff.toml — let safeword generate the bare one.
+        initGitRepo(projectDirectory);
+        await runCli(['setup', '--yes'], { cwd: projectDirectory });
+        bareRuffToml = readTestFile(projectDirectory, 'ruff.toml');
+      }, TIMEOUT_BUN_INSTALL);
+
+      afterAll(() => {
+        if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+      });
+
+      beforeEach(() => {
+        // Reset ruff.toml to safeword's bare-generated version between scenarios.
+        writeTestFile(projectDirectory, 'ruff.toml', bareRuffToml);
+      });
+
+      const examples = [
+        {
+          label: '2.4a: ignore-rule override',
+          customerAddition: '\n[lint]\nignore = ["E501"]\n',
+          violationPath: 'src/violation_2_4a.py',
+          violationContent: `x = "${'a'.repeat(150)}"\n`,
+          expectAbsent: 'E501',
+          expectPresent: undefined as string | undefined,
+        },
+        {
+          label: '2.4b: per-file-ignores override',
+          customerAddition: '\n[lint.per-file-ignores]\n"tests/**" = ["S101"]\n',
+          violationPath: 'tests/violation_2_4b.py',
+          violationContent: `def test_foo():\n    assert 1 == 1\n`,
+          expectAbsent: 'S101',
+          expectPresent: undefined as string | undefined,
+        },
+        {
+          label: '2.4c: extend-select adds a new rule group',
+          customerAddition: '\n[lint]\nextend-select = ["D"]\n',
+          violationPath: 'src/violation_2_4c.py',
+          violationContent: `def undocumented(x):\n    return x + 1\n`,
+          expectAbsent: undefined as string | undefined,
+          expectPresent: 'D103',
+        },
+      ];
+
+      it.each(examples)(
+        'Scenario $label persists through upgrade and hook honors it',
+        async ({
+          customerAddition,
+          violationPath,
+          violationContent,
+          expectAbsent,
+          expectPresent,
+        }) => {
+          // Customer edits the bare ruff.toml to add overrides AFTER setup.
+          const customerRuff = bareRuffToml + customerAddition;
+          writeTestFile(projectDirectory, 'ruff.toml', customerRuff);
+          writeTestFile(projectDirectory, violationPath, violationContent);
+
+          await runUpgradeAndAssertFileUnchanged(projectDirectory, 'ruff.toml');
+
+          const hookOutput = runHookAndGetOutput(projectDirectory, violationPath);
+          if (expectAbsent !== undefined) expect(hookOutput).not.toContain(expectAbsent);
+          if (expectPresent !== undefined) expect(hookOutput).toContain(expectPresent);
+        },
+        TIMEOUT_BUN_INSTALL,
+      );
+    },
+  );
 });


### PR DESCRIPTION
Follow-up to PR #64 (ticket 138). Specs were debated and locked in [ticket 138's follow-up section](https://github.com/ArcadeAI/safeword/blob/main/.safeword-project/tickets/completed/138-unify-customer-override-contract/ticket.md) during quality review. This PR is the actionable form.

## Summary

1. **Delete `getSafewordEslintConfigStandalone`; always extend.** Fresh `safeword setup` was generating `.safeword/eslint.config.mjs` via the standalone template — customer overrides silently ignored by the LLM hook until the next `safeword upgrade` re-detected and switched templates. Verified empirically. Fix: always use the extending template, since safeword's managedFiles generates customer's `eslint.config.mjs` in the same setup run.

2. **Narrow extending template's catch with `existsSync` gate.** Previous try/catch swallowed ALL errors including customer syntax errors and nested missing-plugin errors (both fire `ERR_MODULE_NOT_FOUND`). Solution: gate behind `existsSync(new URL('../eslint.config.mjs', import.meta.url))` and let any import failure throw when the file exists. Customer errors surface loud; truly-missing files stay graceful. Universal Node 20+ (no `import.meta.dirname` dependency).

3. **Scenario 2.4** parameterized `it.each` × 3 rows for Ruff's unified-standalone path (ignore / per-file-ignores / extend-select). Codifies the manual verification from ticket 138.

## Test plan

- [x] `override-survival.test.ts` — 10/10 GREEN (was 7, +Scenario 2.4 × 3 rows)
- [x] `invisible-extension.test.ts` — 8/8 GREEN (one test updated for new always-extending behavior)
- [x] `bun run lint` clean
- [x] `bun run --cwd packages/cli typecheck` clean
- [x] `bun run deps` — 0 violations

## Closes

- Ticket 139 (specs in completed/138's follow-up section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)