### PR TITLE
fix: smoother install in fresh worktrees

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,4 +12,13 @@ bun scripts/check-nested-configs.ts || exit 1
 # Version sync: package.json is source of truth, marketplace.json must match
 node -e 'var c=require("./packages/cli/package.json").version,m=require("./marketplace.json").plugins[0].version;if(c!=m){console.error("Version mismatch: package.json="+c+" marketplace.json="+m+". Update marketplace.json.");process.exit(1)}'
 
+# Friendly guard: husky prepends node_modules/.bin to PATH, but only resolves
+# binaries that actually exist on disk. Fresh git worktrees (and fresh clones)
+# don't have node_modules installed yet, so bare `lint-staged` would fail with
+# "command not found". Replace that with an actionable message.
+if [ ! -x node_modules/.bin/lint-staged ]; then
+  echo "pre-commit: node_modules not installed in this worktree. Run \`bun install\` first." >&2
+  exit 1
+fi
+
 lint-staged

--- a/packages/cli/src/templates/content.ts
+++ b/packages/cli/src/templates/content.ts
@@ -16,7 +16,9 @@ export const AGENTS_MD_LINK = `**⚠️ ALWAYS READ FIRST:** \`.safeword/SAFEWOR
 The SAFEWORD.md file contains core development patterns, workflows, and conventions.
 Read it BEFORE working on any task in this project.
 
----`;
+---
+
+`;
 
 /**
  * Import block for CLAUDE.md — uses Claude Code's \`@\` import syntax so
@@ -28,4 +30,6 @@ Read it BEFORE working on any task in this project.
  */
 export const CLAUDE_MD_IMPORT_BLOCK = `@./.safeword/SAFEWORD.md
 
----`;
+---
+
+`;

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -235,6 +235,47 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).toContain('.safeword/SAFEWORD.md');
     });
 
+    it('should preserve a line break between prepended separator and existing CLAUDE.md heading', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      // Simulate an existing user CLAUDE.md whose first content line is a heading.
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'CLAUDE.md'),
+        '# CLAUDE.md — my project\n\nSome existing notes.\n',
+      );
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, 'CLAUDE.md'), 'utf8');
+
+      // The `---` separator and the user's `# Heading` must not be glued into
+      // a single `---# Heading` line — markdown would render that as literal text.
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# CLAUDE\.md/);
+    });
+
+    it('should preserve a line break between prepended AGENTS.md separator and existing heading', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'AGENTS.md'),
+        '# AGENTS.md — my project\n\nSome existing notes.\n',
+      );
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, 'AGENTS.md'), 'utf8');
+
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# AGENTS\.md/);
+    });
+
     it('should compute packages to install', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');


### PR DESCRIPTION
## Summary

Two small fixes for rough edges in the safeword install / worktree-bootstrap flow:

- **CLAUDE.md template:** `CLAUDE_MD_IMPORT_BLOCK` and `AGENTS_MD_LINK` ended with `---` and no trailing newline. When prepended to an existing CLAUDE.md/AGENTS.md whose first content line is a heading, the concat produced `---# Heading` on a single line, which CommonMark renders as literal text rather than a thematic break + H1. Templates now end with `\n---\n\n`, so the boundary is always `\n---\n\n# Heading`. Added regression tests in `reconcile.test.ts`.
- **Pre-commit hook:** Fresh git worktrees (and fresh clones) don't have `node_modules` installed, so bare `lint-staged` failed with a cryptic `command not found` from husky's PATH shim. Added an explicit guard that prints `pre-commit: node_modules not installed in this worktree. Run \`bun install\` first.`

## Test plan

- [x] `npx vitest run tests/reconcile.test.ts` — 39 pass (2 new regression tests included)
- [x] `npx vitest run tests/schema.test.ts` — 24 pass
- [ ] Manual: create a fresh worktree without `bun install`, attempt a commit → expect the friendly error
- [ ] Manual: install safeword into a project whose existing CLAUDE.md starts with `# Heading` → expect `---` and heading on distinct lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)