### PR TITLE
fix(reconcile): heal legacy CLAUDE.md/AGENTS.md `---#` artifact in existing installs

### DIFF
--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -795,7 +795,20 @@ function executeTextPatch(cwd: string, path: string, definition: TextPatchDefini
   let content = readFileSafe(fullPath) ?? '';
 
   // Check if already patched
-  if (content.includes(definition.marker)) return;
+  if (content.includes(definition.marker)) {
+    // Heal legacy artifact from safeword <=0.30.1: the prepend templates
+    // (CLAUDE_MD_IMPORT_BLOCK, AGENTS_MD_LINK) ended with bare `---` and no
+    // trailing newline, so the `---` separator glued to the user's first
+    // heading line (e.g. `---# CLAUDE.md`). Templates are fixed going
+    // forward; this pass repairs files already corrupted by past installs.
+    // Narrowly scoped: only fires when the safeword marker is present
+    // (proving the block was authored by us) and the exact artifact matches.
+    if (content.includes('\n\n---#')) {
+      const healed = content.replaceAll('\n\n---#', '\n\n---\n\n#');
+      writeFile(fullPath, healed);
+    }
+    return;
+  }
 
   // Apply patch
   content =

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -257,6 +257,49 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).toMatch(/\n---\n\n# CLAUDE\.md/);
     });
 
+    it('should heal legacy ---# artifact in CLAUDE.md from pre-fix installs', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      // Reproduce a CLAUDE.md as it would exist after a pre-fix safeword install:
+      // the import block is present (marker found, reconcile would skip the patch),
+      // but the `---` separator is glued to the user's first heading.
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'CLAUDE.md'),
+        '@./.safeword/SAFEWORD.md\n\n---# CLAUDE.md — my project\n\nSome existing notes.\n',
+      );
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, 'CLAUDE.md'), 'utf8');
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# CLAUDE\.md/);
+      // Heal must be idempotent: running reconcile again leaves the file unchanged.
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+      const contentAfter = readFileSync(nodePath.join(temporaryDirectory, 'CLAUDE.md'), 'utf8');
+      expect(contentAfter).toBe(content);
+    });
+
+    it('should heal legacy ---# artifact in AGENTS.md from pre-fix installs', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'AGENTS.md'),
+        '**⚠️ ALWAYS READ FIRST:** `.safeword/SAFEWORD.md`\n\n---# AGENTS.md — my project\n\nSome existing notes.\n',
+      );
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, 'AGENTS.md'), 'utf8');
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# AGENTS\.md/);
+    });
+
     it('should preserve a line break between prepended AGENTS.md separator and existing heading', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');


### PR DESCRIPTION
## Summary

Follow-up to #77. That PR fixed the template going forward; this PR repairs files already corrupted by past safeword installs.

`executeTextPatch` early-returns when the safeword marker is present, so re-running `safeword install` / `safeword upgrade` on an affected project would never heal the file. Without this PR, every project that ran `safeword install` on <=0.30.1 keeps the `---# Heading` artifact at the top of its CLAUDE.md/AGENTS.md until someone fixes it by hand.

**Heal logic:** when the marker is found (proving the block was authored by safeword), additionally rewrite `\n\n---#` → `\n\n---\n\n#`. Pattern is narrow — legitimate markdown doesn't glue a thematic break to a heading on one line. Idempotent.

(Original PR #78 was auto-closed when its base branch was deleted on merge of #77; this is the same commit, rebased onto main.)

## Test plan

- [x] `npx vitest run tests/reconcile.test.ts` — 41 pass (2 new heal tests, including an idempotency assertion)
- [ ] Manual: on a project with the legacy `---#` artifact, run `safeword upgrade` and confirm CLAUDE.md is repaired in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)