### PR TITLE
docs(husky): cross-reference fresh-worktree defenses in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,6 +16,8 @@ node -e 'var c=require("./packages/cli/package.json").version,m=require("./marke
 # binaries that actually exist on disk. Fresh git worktrees (and fresh clones)
 # don't have node_modules installed yet, so bare `lint-staged` would fail with
 # "command not found". Replace that with an actionable message.
+# See also: the core.bare reset at the top of this file (ticket #141) — both
+# defend against fresh-worktree breakage in Claude Code's parallel flow.
 if [ ! -x node_modules/.bin/lint-staged ]; then
   echo "pre-commit: node_modules not installed in this worktree. Run \`bun install\` first." >&2
   exit 1


### PR DESCRIPTION
## Summary

The pre-commit hook contains two independent defenses against Claude Code parallel-worktree breakage:

- **`core.bare` reset** at the top of the file — ticket #141, landed in `aeb342b`. Fixes Claude Code's parallel-worktree flow setting parent `.git/config` to `core.bare = true` mid-flight.
- **`node_modules`-missing friendly error** — landed in `1362adb` via #77. Replaces a cryptic `lint-staged: command not found` with an actionable \"run \`bun install\`\" message when committing from a freshly-created worktree before deps are installed.

They're separated by two unrelated guards (nested-config check, version-sync check), so a future engineer editing one might not notice the other. One-line cross-reference in the comment block of the newer defense.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)