### PR TITLE
feat(142): install/upgrade integration test

### DIFF
--- a/.safeword-project/tickets/142-install-upgrade-integration-test/ticket.md
+++ b/.safeword-project/tickets/142-install-upgrade-integration-test/ticket.md
@@ -1,10 +1,10 @@
 ---
 id: 142
 type: task
-phase: understand
-status: open
+phase: implement
+status: in_progress
 created: 2026-05-13T20:10:00Z
-last_modified: 2026-05-13T20:10:00Z
+last_modified: 2026-05-13T23:05:00Z
 ---
 
 # End-to-end integration test for `install` / `upgrade` against a temp project
@@ -54,3 +54,4 @@ A single integration test that does `mkdir /tmp/foo && safeword install && asser
 ## Work Log
 
 - 2026-05-13T20:10:00Z Created: filed after v0.30.2 release retrospective. Two recent bugs (#77 template glue, #82 estree dual-install) both lived at the install/compose seam — neither would have been caught by unit tests alone. ~1-2 hours of work; small but high-leverage.
+- 2026-05-13T23:10:00Z Implement: added `packages/cli/tests/integration/install-upgrade.test.ts` (6 cases × CLAUDE.md and AGENTS.md). While writing case 3 (upgrade heal) discovered the heal logic from a304af8 didn't actually fire in `'upgrade'` mode: `computeUpgradePlan` planned text-patches via a marker-aware planner that skipped already-patched files, so `executeTextPatch` (where the heal lives) never ran on legacy-corrupted projects during `safeword upgrade` — contrary to the commit message. Fixed by dropping the marker check from `planTextPatches`; the executor's existing skip/heal branch is the single source of truth. Verified done-when: reverting d6dce6d flips the 2 install-over-heading tests red; reverting a304af8 flips the 2 upgrade-heal tests red.

--- a/.safeword-project/tickets/142-install-upgrade-integration-test/ticket.md
+++ b/.safeword-project/tickets/142-install-upgrade-integration-test/ticket.md
@@ -1,10 +1,10 @@
 ---
 id: 142
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-05-13T20:10:00Z
-last_modified: 2026-05-13T23:05:00Z
+last_modified: 2026-05-14T01:35:00Z
 ---
 
 # End-to-end integration test for `install` / `upgrade` against a temp project
@@ -55,3 +55,4 @@ A single integration test that does `mkdir /tmp/foo && safeword install && asser
 
 - 2026-05-13T20:10:00Z Created: filed after v0.30.2 release retrospective. Two recent bugs (#77 template glue, #82 estree dual-install) both lived at the install/compose seam — neither would have been caught by unit tests alone. ~1-2 hours of work; small but high-leverage.
 - 2026-05-13T23:10:00Z Implement: added `packages/cli/tests/integration/install-upgrade.test.ts` (6 cases × CLAUDE.md and AGENTS.md). While writing case 3 (upgrade heal) discovered the heal logic from a304af8 didn't actually fire in `'upgrade'` mode: `computeUpgradePlan` planned text-patches via a marker-aware planner that skipped already-patched files, so `executeTextPatch` (where the heal lives) never ran on legacy-corrupted projects during `safeword upgrade` — contrary to the commit message. Fixed by dropping the marker check from `planTextPatches`; the executor's existing skip/heal branch is the single source of truth. Verified done-when: reverting d6dce6d flips the 2 install-over-heading tests red; reverting a304af8 flips the 2 upgrade-heal tests red.
+- 2026-05-14T01:35:00Z Done: /verify passed (1565/1566 tests, lint clean, build success); /audit passed with only pre-existing warnings (eslint 10 deferred to #099); /quality-review APPROVE. PR https://github.com/ArcadeAI/safeword/pull/85 ready for squash-merge. Out-of-scope finding noted but not filed: `createIfMissing: false` on CLAUDE.md in schema is documentation-only — `executeTextPatch` always creates.

--- a/.safeword-project/tickets/142-install-upgrade-integration-test/verify.md
+++ b/.safeword-project/tickets/142-install-upgrade-integration-test/verify.md
@@ -1,0 +1,22 @@
+Verified: 2026-05-13T23:56:00Z
+
+## Verify Checklist
+
+**Test Suite:** ✓ 1565/1566 tests pass (1 skipped, 81 files)
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** ⏭️ Skipped — task type, no test-definitions.md required
+**Doc Refs:** ✅ Clean (only match for `planTextPatches`/`executeTextPatch` in `.md` is this ticket)
+**Dep Drift:** ✅ Clean — `commander`, `yaml`, `vitest`, `prettier`, `knip`, `tsup`, `typescript` all documented in ARCHITECTURE.md
+**Parent Epic:** N/A
+
+## Evidence
+
+- New: `packages/cli/tests/integration/install-upgrade.test.ts` — 6 cases (install absent / install over user heading / upgrade heals legacy artifact, × CLAUDE.md and AGENTS.md).
+- Modified: `packages/cli/src/reconcile.ts` — `planTextPatches` drops marker check (lets executor handle heal on upgrade); `planTextPatchesWithCreation` delegates to it.
+- Done-when from ticket:
+  - [x] Revert `d6dce6d` → 2 install-over-heading tests fail. Restored → green.
+  - [x] Revert `a304af8` → 2 upgrade-heal tests fail. Restored → green.
+  - [x] Idempotency: case 3 runs `reconcile(..., 'upgrade', ...)` twice and asserts byte-stability.
+  - [x] Test runtime added <1s to suite.
+- PR: https://github.com/ArcadeAI/safeword/pull/85

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -170,11 +170,10 @@ function planTextPatchesWithCreation(
   patches: Record<string, TextPatchDefinition>,
   ctx: ProjectContext,
 ): { actions: Action[]; created: string[] } {
-  const actions: Action[] = [];
+  const actions = planTextPatches(patches, ctx.isGitRepo);
   const created: string[] = [];
   for (const [filePath, definition] of Object.entries(patches)) {
     if (shouldSkipForNonGit(filePath, ctx.isGitRepo)) continue;
-    actions.push({ type: 'text-patch', path: filePath, definition });
     if (definition.createIfMissing && !exists(nodePath.join(ctx.cwd, filePath))) {
       created.push(filePath);
     }

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -109,19 +109,22 @@ function planMissingDirectories(
   return { actions, created };
 }
 
-/** Plan text-patch actions for files missing the marker */
+/**
+ * Plan text-patch actions for all targets. The executor (`executeTextPatch`)
+ * decides whether to prepend, heal a legacy `---#` artifact, or no-op based on
+ * the file's current contents — so the planner stays uniform across modes.
+ * Keeping the marker check in the executor (not here) ensures `safeword
+ * upgrade` reaches the heal path on pre-fix installs, which is what commit
+ * a304af8 promised.
+ */
 function planTextPatches(
   patches: Record<string, TextPatchDefinition>,
-  cwd: string,
   isGitRepo: boolean,
 ): Action[] {
   const actions: Action[] = [];
   for (const [filePath, definition] of Object.entries(patches)) {
     if (shouldSkipForNonGit(filePath, isGitRepo)) continue;
-    const content = readFileSafe(nodePath.join(cwd, filePath)) ?? '';
-    if (!content.includes(definition.marker)) {
-      actions.push({ type: 'text-patch', path: filePath, definition });
-    }
+    actions.push({ type: 'text-patch', path: filePath, definition });
   }
   return actions;
 }
@@ -490,7 +493,7 @@ function computeUpgradePlan(schema: SafewordSchema, ctx: ProjectContext): Reconc
   }
 
   // 7. Text patches (only if marker missing)
-  actions.push(...planTextPatches(schema.textPatches, ctx.cwd, ctx.isGitRepo));
+  actions.push(...planTextPatches(schema.textPatches, ctx.isGitRepo));
 
   // 8. Compute packages to install
   const packagesToInstall = computePackagesToInstall(

--- a/packages/cli/tests/integration/install-upgrade.test.ts
+++ b/packages/cli/tests/integration/install-upgrade.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Integration: install / upgrade text-patch composition.
+ *
+ * Pins the seam between `templates/content.ts` (the static strings) and
+ * `reconcile.ts` (planner + executor) for CLAUDE.md / AGENTS.md. Both pieces
+ * are unit-tested in isolation; their composition is where bugs hide:
+ *
+ *   - PR #77 / commit d6dce6d — template strings now end with `---\n\n` so the
+ *     prepended separator does not glue to a user's first heading line.
+ *   - PR #79 / commit a304af8 — `executeTextPatch` heals legacy `\n\n---#`
+ *     artifacts in place when the safeword marker is already present.
+ *
+ * Tests drive the real `reconcile()` entry point against a `mkdtempSync`
+ * project directory, with both `'install'` and `'upgrade'` modes, and assert
+ * the resulting file contents byte-for-byte where it matters.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reconcile } from '../../src/reconcile.js';
+import { type ProjectContext, SAFEWORD_SCHEMA } from '../../src/schema.js';
+
+const DEFAULT_PROJECT_TYPE = {
+  typescript: false,
+  react: false,
+  nextjs: false,
+  astro: false,
+  vitest: false,
+  playwright: false,
+  tailwind: false,
+  tanstackQuery: false,
+  publishableLibrary: false,
+  shell: false,
+  existingLinter: false,
+  existingFormatter: false,
+  existingEslintConfig: undefined,
+  legacyEslint: false,
+  existingRuffConfig: undefined,
+  existingMypyConfig: false,
+  existingImportLinterConfig: false,
+  existingGolangciConfig: undefined,
+  existingClippyConfig: undefined,
+  existingRustfmtConfig: undefined,
+  existingSqlfluffConfig: undefined,
+};
+
+describe('Integration: install / upgrade text-patch composition', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-install-upgrade-'));
+    writeFileSync(
+      nodePath.join(projectDirectory, 'package.json'),
+      JSON.stringify({ name: 'test', version: '1.0.0' }, undefined, 2),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  });
+
+  function makeContext(): ProjectContext {
+    return {
+      cwd: projectDirectory,
+      projectType: DEFAULT_PROJECT_TYPE,
+      developmentDeps: {},
+      productionDeps: {},
+      isGitRepo: true,
+      languages: { javascript: true, python: false, golang: false, rust: false, sql: false },
+    };
+  }
+
+  function read(file: string): string {
+    return readFileSync(nodePath.join(projectDirectory, file), 'utf8');
+  }
+
+  function seed(file: string, content: string): void {
+    writeFileSync(nodePath.join(projectDirectory, file), content);
+  }
+
+  describe('AGENTS.md', () => {
+    it('install creates AGENTS.md with safeword preamble when absent', async () => {
+      await reconcile(SAFEWORD_SCHEMA, 'install', makeContext());
+
+      expect(existsSync(nodePath.join(projectDirectory, 'AGENTS.md'))).toBe(true);
+      const content = read('AGENTS.md');
+      expect(content).toContain('.safeword/SAFEWORD.md');
+      expect(content).not.toMatch(/---#/);
+    });
+
+    it('install over a user heading preserves the `\\n---\\n\\n#` boundary', async () => {
+      seed('AGENTS.md', '# AGENTS.md — my project\n\nSome existing notes.\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', makeContext());
+
+      const content = read('AGENTS.md');
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# AGENTS\.md/);
+      expect(content).toContain('Some existing notes.');
+    });
+
+    it('upgrade heals legacy `---#` artifact and is idempotent', async () => {
+      seed(
+        'AGENTS.md',
+        '**⚠️ ALWAYS READ FIRST:** `.safeword/SAFEWORD.md`\n\n---# AGENTS.md — my project\n\nSome existing notes.\n',
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', makeContext());
+
+      const healed = read('AGENTS.md');
+      expect(healed).not.toMatch(/---#/);
+      expect(healed).toMatch(/\n---\n\n# AGENTS\.md/);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', makeContext());
+      expect(read('AGENTS.md')).toBe(healed);
+    });
+  });
+
+  describe('CLAUDE.md', () => {
+    it('install creates CLAUDE.md with safeword preamble when absent', async () => {
+      await reconcile(SAFEWORD_SCHEMA, 'install', makeContext());
+
+      expect(existsSync(nodePath.join(projectDirectory, 'CLAUDE.md'))).toBe(true);
+      const content = read('CLAUDE.md');
+      expect(content).toContain('@./.safeword/SAFEWORD.md');
+      expect(content).not.toMatch(/---#/);
+    });
+
+    it('install over a user heading preserves the `\\n---\\n\\n#` boundary', async () => {
+      seed('CLAUDE.md', '# CLAUDE.md — my project\n\nSome existing notes.\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', makeContext());
+
+      const content = read('CLAUDE.md');
+      expect(content).not.toMatch(/---#/);
+      expect(content).toMatch(/\n---\n\n# CLAUDE\.md/);
+      expect(content).toContain('Some existing notes.');
+    });
+
+    it('upgrade heals legacy `---#` artifact and is idempotent', async () => {
+      seed(
+        'CLAUDE.md',
+        '@./.safeword/SAFEWORD.md\n\n---# CLAUDE.md — my project\n\nSome existing notes.\n',
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', makeContext());
+
+      const healed = read('CLAUDE.md');
+      expect(healed).not.toMatch(/---#/);
+      expect(healed).toMatch(/\n---\n\n# CLAUDE\.md/);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', makeContext());
+      expect(read('CLAUDE.md')).toBe(healed);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/cli/tests/integration/install-upgrade.test.ts` — 6 cases (install absent / install over user heading / upgrade heals legacy artifact, × CLAUDE.md and AGENTS.md) that drive `reconcile()` against a `mkdtempSync` project directory and assert the resulting file contents byte-for-byte.
- Pins the two v0.30.2 seam fixes that lived between `templates/content.ts` and `reconcile.ts`:
  - [d6dce6d](https://github.com/ArcadeAI/safeword/commit/d6dce6d25b8d363ece92f55b037a635abe63e9d9) — templates end with `---\n\n` so the prepended separator doesn't glue to a user's first heading. Reverting flips the 2 install-over-heading tests red.
  - [a304af8](https://github.com/ArcadeAI/safeword/commit/a304af88e8755b09230426613509ca7c57af6008) — `executeTextPatch` heals legacy `\n\n---#` artifacts in place. Reverting flips the 2 upgrade-heal tests red.
- Fixes a latent gap surfaced while writing case 3: `a304af8`'s commit message promised the heal fires on `safeword upgrade`, but `computeUpgradePlan` used a marker-aware planner (`planTextPatches`) that skipped already-patched files, so `executeTextPatch` (where the heal lives) never ran during upgrade on legacy-corrupted projects. Drop the marker check from `planTextPatches`; the executor's existing skip/heal branch is the single source of truth for both modes.

## Test plan

- [x] `npx vitest run tests/integration/install-upgrade.test.ts` — 6 passed
- [x] Full suite (`npx vitest run` in `packages/cli/`) — 1565 passed, 1 skipped
- [x] Revert `d6dce6d` locally → 2 install-over-heading tests fail. Restore → green.
- [x] Revert `a304af8` locally → 2 upgrade-heal tests fail. Restore → green.
- [x] Idempotency: case 3 runs `reconcile(..., 'upgrade', ...)` twice and asserts file is byte-stable on the second pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)