### PR TITLE
chore(release): v0.30.3

### DIFF
--- a/.safeword-project/tickets/145-claudemd-createifmissing-drift/ticket.md
+++ b/.safeword-project/tickets/145-claudemd-createifmissing-drift/ticket.md
@@ -1,0 +1,61 @@
+---
+id: 145
+type: task
+phase: done
+status: done
+created: 2026-05-14T15:30:00Z
+last_modified: 2026-05-14T16:50:00Z
+---
+
+# Schema `createIfMissing: false` is silently ignored by executor
+
+**Goal:** Make `executeTextPatch` honor the `createIfMissing: false` flag on `TextPatchDefinition`, or remove the flag and update the schema comment to match actual behavior. Pick whichever direction reflects the intended product behavior.
+
+## Why
+
+While writing the #142 integration test, I expected `safeword install` on a project with no `CLAUDE.md` to leave it absent — the schema comment at `packages/cli/src/schema.ts` on the `CLAUDE.md` entry said `createIfMissing: false, // Only patch if exists, don't create (AGENTS.md is primary)`. The integration test confirmed the opposite: `CLAUDE.md` is created with just the safeword preamble block.
+
+Tracing it down:
+
+- The schema field existed (`TextPatchDefinition.createIfMissing: boolean`).
+- The planner used it for _reporting_ — `planTextPatchesWithCreation` only added the path to `wouldCreate` if `createIfMissing` was true.
+- The executor (`executeTextPatch`) **never read the field**. It unconditionally did `readFileSafe(...) ?? ''` then `writeFile(fullPath, definition.content + content)` on cache-miss. Empty-string + content wrote a new file.
+
+So the documented contract ("Only patch if exists, don't create") was not enforced. The behavior was "always create on install, regardless of flag."
+
+## Resolution
+
+After exploring three options (enforce as-configured / enforce + flip default / drop the flag), maintainer confirmed:
+
+- AGENTS.md-only setups were not a deliberate product target.
+- CLAUDE.md is the canonical Claude Code entry point and should be present on fresh install.
+
+Direction: **drop the flag**. The field had no consumer that exercised `false`, and project philosophy ("Don't design for hypothetical future requirements") argues against keeping dead affordance. If a future AGENTS.md-only need surfaces, the field can be reintroduced with a real consumer and a test.
+
+## Scope
+
+- Removed `createIfMissing: boolean` from `TextPatchDefinition`.
+- Removed the field from both `AGENTS.md` and `CLAUDE.md` schema entries.
+- Dropped `planTextPatchesWithCreation`; inlined at the single caller with `wouldCreate` tracking driven by filesystem state (which now honestly reports `CLAUDE.md` on fresh install — previously silent creation).
+- Updated `tests/schema.test.ts` to assert `marker` and `operation` (the surviving structural fields) instead of the removed flag.
+
+## Out of Scope
+
+- Generalizing to other "schema field documented but unenforced" drift across the codebase. One-shot fix for this specific field.
+
+## Done When
+
+- [x] `executeTextPatch` and `TextPatchDefinition.createIfMissing` agree on a single contract.
+- [x] Schema comment on `CLAUDE.md` reflects actual behavior.
+- [x] Integration test for the "install when CLAUDE.md absent" case asserts the agreed contract and would fail if the contract regressed.
+- [x] No flake — bundled into release PR #89 with full suite green.
+
+## Notes
+
+- Surfaced during #142 integration-test work — see that ticket's verify.md for the discovery context.
+- Bundled into release v0.30.3 (PR #89) so the upgrade-mode heal fix and the schema/executor reconciliation ship together.
+
+## Work Log
+
+- 2026-05-14T15:30:00Z Created: filed after #142 surfaced the drift. Documented behavior says `createIfMissing: false` on CLAUDE.md prevents creation; actual behavior creates anyway. Integration test pinned actual behavior to keep #142 from drifting; this ticket reconciles the schema and the executor.
+- 2026-05-14T16:45:00Z Implement + Done: dropped the flag, simplified the planner, updated tests. Full suite 1565 passed, 1 skipped. Bundled into release/v0.30.3 (PR #89).

--- a/.safeword-project/tickets/145-claudemd-createifmissing-drift/verify.md
+++ b/.safeword-project/tickets/145-claudemd-createifmissing-drift/verify.md
@@ -1,0 +1,19 @@
+Verified: 2026-05-14T16:50:00Z
+
+## Verify Checklist
+
+**Test Suite:** ✓ 1565/1566 tests pass (1 skipped, 81 files)
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Typecheck:** ✅ Clean
+**Scenarios:** ⏭️ Skipped — task type, no test-definitions.md required
+**Doc Refs:** ✅ Clean (no `.md` references to the removed `createIfMissing` field outside this ticket)
+**Dep Drift:** N/A — no dependency changes
+**Parent Epic:** N/A
+
+## Evidence
+
+- Schema: `TextPatchDefinition.createIfMissing` field removed; both `AGENTS.md` and `CLAUDE.md` schema entries cleaned up.
+- Reconcile: `planTextPatchesWithCreation` dropped; inlined at single caller with truthful filesystem-driven `wouldCreate` tracking.
+- Tests: `tests/schema.test.ts` updated to assert `marker` + `operation` instead of removed flag.
+- Bundled into v0.30.3 release: https://github.com/ArcadeAI/safeword/pull/89

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -166,21 +166,6 @@ function planManagedFileWrites(
   return planFileWrites(files, ctx, (filePath, c) => exists(nodePath.join(c.cwd, filePath)));
 }
 
-function planTextPatchesWithCreation(
-  patches: Record<string, TextPatchDefinition>,
-  ctx: ProjectContext,
-): { actions: Action[]; created: string[] } {
-  const actions = planTextPatches(patches, ctx.isGitRepo);
-  const created: string[] = [];
-  for (const [filePath, definition] of Object.entries(patches)) {
-    if (shouldSkipForNonGit(filePath, ctx.isGitRepo)) continue;
-    if (definition.createIfMissing && !exists(nodePath.join(ctx.cwd, filePath))) {
-      created.push(filePath);
-    }
-  }
-  return { actions, created };
-}
-
 /** Plan rmdir actions for directories that exist */
 function planExistingDirectoriesRemoval(
   directories: string[],
@@ -367,10 +352,15 @@ function computeInstallPlan(schema: SafewordSchema, ctx: ProjectContext): Reconc
     actions.push({ type: 'json-merge', path: filePath, definition });
   }
 
-  // 6. Text patches
-  const patches = planTextPatchesWithCreation(schema.textPatches, ctx);
-  actions.push(...patches.actions);
-  wouldCreate.push(...patches.created);
+  // 6. Text patches — the executor creates absent target files unconditionally,
+  // so any text-patch path that doesn't exist now will be created.
+  const textPatchActions = planTextPatches(schema.textPatches, ctx.isGitRepo);
+  actions.push(...textPatchActions);
+  for (const action of textPatchActions) {
+    if (action.type === 'text-patch' && !exists(nodePath.join(ctx.cwd, action.path))) {
+      wouldCreate.push(action.path);
+    }
+  }
 
   // 7. Compute packages to install
   const packagesToInstall = computePackagesToInstall(

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -35,7 +35,6 @@ export interface TextPatchDefinition {
   operation: 'prepend' | 'append';
   content: string;
   marker: string; // Used to detect if already applied & for removal
-  createIfMissing: boolean;
 }
 
 export interface SafewordSchema {
@@ -602,7 +601,6 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       operation: 'prepend',
       content: AGENTS_MD_LINK,
       marker: '.safeword/SAFEWORD.md',
-      createIfMissing: true,
     },
     'CLAUDE.md': {
       operation: 'prepend',
@@ -616,7 +614,6 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       // Existing prose lingers harmlessly — agents skim it; only the import
       // is functionally load-bearing.
       marker: '@./.safeword/SAFEWORD.md',
-      createIfMissing: false, // Only patch if exists, don't create (AGENTS.md is primary)
     },
   },
 

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -205,20 +205,20 @@ describe('Schema - Single Source of Truth', () => {
   });
 
   describe('textPatches', () => {
-    it('should include AGENTS.md patch (creates if missing)', async () => {
+    it('should include AGENTS.md prepend patch with safeword marker', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
       const agentsPatch = SAFEWORD_SCHEMA.textPatches['AGENTS.md'];
       expect(agentsPatch).toBeDefined();
       expect(agentsPatch?.operation).toBe('prepend');
-      expect(agentsPatch?.createIfMissing).toBe(true);
+      expect(agentsPatch?.marker).toBe('.safeword/SAFEWORD.md');
     });
 
-    it('should include CLAUDE.md patch (only if exists)', async () => {
+    it('should include CLAUDE.md prepend patch with @ import marker', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
       const claudePatch = SAFEWORD_SCHEMA.textPatches['CLAUDE.md'];
       expect(claudePatch).toBeDefined();
       expect(claudePatch?.operation).toBe('prepend');
-      expect(claudePatch?.createIfMissing).toBe(false);
+      expect(claudePatch?.marker).toBe('@./.safeword/SAFEWORD.md');
     });
   });
 


### PR DESCRIPTION
## Summary

Patch release reconciling the text-patch surface between schema and executor. Two changes:

### 1. Upgrade-mode heal now actually fires (carried over from `chore(release): v0.30.3` commit)

The heal logic from [a304af8](https://github.com/ArcadeAI/safeword/commit/a304af88e8755b09230426613509ca7c57af6008) (PR #79) was advertised as healing legacy \`---#\` artifacts on both \`safeword install\` and \`safeword upgrade\`. Only install worked — the upgrade planner's \`planTextPatches\` skipped already-patched files, so \`executeTextPatch\` (where the heal lives) never ran for the case the heal was built for. Caught by the integration test added in PR #85 (ticket #142). Already on \`main\` as part of #85; the release commit just bumps the version.

### 2. Drop the unenforced \`createIfMissing\` flag (closes #145)

The schema's \`TextPatchDefinition.createIfMissing\` field was read by the planner for reporting but ignored by the executor. The \`CLAUDE.md\` entry's \`createIfMissing: false\` comment ("Only patch if exists, don't create") described a contract that never existed — every install created \`CLAUDE.md\` regardless. Maintainer confirmed AGENTS.md-only setups are not a deliberate target. Dropped the field, simplified the planner, updated schema tests to assert the surviving fields (\`marker\` / \`operation\`).

Side effect: \`wouldCreate\` / \`result.created\` now honestly reports \`CLAUDE.md\` on fresh install (previously silent creation).

## Version

- \`packages/cli/package.json\`: 0.30.2 → 0.30.3
- \`marketplace.json\` (plugins[0]): 0.30.2 → 0.30.3

## Test plan

- [x] Targeted: \`schema.test.ts\`, \`reconcile.test.ts\`, \`tests/integration/install-upgrade.test.ts\`, \`commands/{check,upgrade,setup}-reconcile.test.ts\` — 98 passed.
- [x] Full suite: \`packages/cli\` vitest — **1565 passed, 1 skipped**.
- [x] Lint clean, typecheck clean, build success.
- [x] CI will exercise node 20 + node 22 matrix.

## Not in this PR

- Tag push and npm publish — leaving to maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)