### PR TITLE
fix(140): clean pre-existing TypeScript errors

### DIFF
--- a/packages/cli/src/presets/typescript/detect.test.ts
+++ b/packages/cli/src/presets/typescript/detect.test.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { detect } from './detect';
+import { detect } from './detect.js';
 
 describe('findNextConfigPaths', () => {
   let temporaryDirectory: string;

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -4,7 +4,12 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getEslintConfig, SETTINGS_HOOKS } from './config';
+import { getEslintConfig, SETTINGS_HOOKS } from './config.js';
+
+// Element type of any SETTINGS_HOOKS bucket (PostToolUse, PreToolUse, etc.)
+// Each is a list of { matcher?, hooks: { type, command }[] } entries.
+type HookEntry = (typeof SETTINGS_HOOKS)[keyof typeof SETTINGS_HOOKS][number];
+type HookCommand = HookEntry['hooks'][number];
 
 describe('getEslintConfig', () => {
   it('should use import.meta.dirname for config-relative path resolution (not CWD)', () => {
@@ -140,8 +145,11 @@ describe('SETTINGS_HOOKS', () => {
   });
 
   it('should have PostToolUse quality observer matcher that includes Bash', () => {
-    const qualityHook = SETTINGS_HOOKS.PostToolUse.find(h =>
-      h.hooks.some(hook => hook.type === 'command' && hook.command.includes('post-tool-quality')),
+    const qualityHook = SETTINGS_HOOKS.PostToolUse.find((h: HookEntry) =>
+      h.hooks.some(
+        (hook: HookCommand) =>
+          hook.type === 'command' && hook.command.includes('post-tool-quality'),
+      ),
     );
     if (!qualityHook) {
       throw new Error('PostToolUse quality hook not found');
@@ -164,17 +172,19 @@ describe('SETTINGS_HOOKS', () => {
     const preToolHooks = SETTINGS_HOOKS.PreToolUse;
     expect(preToolHooks.length).toBe(2);
 
-    const commands = preToolHooks.flatMap(h =>
-      h.hooks.filter(hook => hook.type === 'command').map(hook => hook.command),
+    const commands = preToolHooks.flatMap((h: HookEntry) =>
+      h.hooks
+        .filter((hook: HookCommand) => hook.type === 'command')
+        .map((hook: HookCommand) => hook.command),
     );
 
-    expect(commands.some(c => c.includes('pre-tool-quality'))).toBe(true);
-    expect(commands.some(c => c.includes('pre-tool-config-guard'))).toBe(true);
+    expect(commands.some((c: string) => c.includes('pre-tool-quality'))).toBe(true);
+    expect(commands.some((c: string) => c.includes('pre-tool-config-guard'))).toBe(true);
   });
 
   it('should have all commands reference $CLAUDE_PROJECT_DIR', () => {
     const commands: string[] = [];
-    for (const entries of Object.values(SETTINGS_HOOKS)) {
+    for (const entries of Object.values(SETTINGS_HOOKS) as HookEntry[][]) {
       for (const entry of entries) {
         for (const hook of entry.hooks) {
           if (hook.type === 'command') {

--- a/packages/cli/src/utils/project-detector.test.ts
+++ b/packages/cli/src/utils/project-detector.test.ts
@@ -10,9 +10,9 @@ import {
   createTemporaryDirectory,
   removeTemporaryDirectory,
   writeTestFile,
-} from '../../tests/helpers';
-import type { Languages, PackageJson, PythonProjectType } from './project-detector';
-import { detectLanguages, detectProjectType, detectPythonType } from './project-detector';
+} from '../../tests/helpers.js';
+import type { Languages, PackageJson, PythonProjectType } from './project-detector.js';
+import { detectLanguages, detectProjectType, detectPythonType } from './project-detector.js';
 
 describe('detectProjectType', () => {
   describe('Test 4.1: Detects TypeScript project', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "noEmit": true
   },
   "include": ["packages/*/src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "packages/website"]
 }


### PR DESCRIPTION
## Summary
Closes #140. Restores \`bunx tsc --noEmit\` from repo root to **0 errors** (was producing 13 errors across 4 files).

## Four classes of fix, all mechanical

1. **Missing \`.js\` extensions on 5 relative imports** (NodeNext requires explicit extensions):
   - \`detect.test.ts\`, \`config.test.ts\`, \`project-detector.test.ts\`

2. **Implicit-any callbacks in \`config.test.ts\`** — added explicit types derived from \`SETTINGS_HOOKS\`:
   \`\`\`typescript
   type HookEntry = (typeof SETTINGS_HOOKS)[keyof typeof SETTINGS_HOOKS][number];
   type HookCommand = HookEntry['hooks'][number];
   \`\`\`
   Used for \`.find\` / \`.some\` / \`.flatMap\` / \`.filter\` / \`.map\` callbacks (lines 143-180).

3. **\`Object.values(SETTINGS_HOOKS)\` returning \`unknown\`** — type-assertion \`as HookEntry[][]\` on the loop variable.

4. **\`astro:content\` module not found** in \`packages/website/src/content.config.ts\`. The root \`tsconfig.json\` doesn't load Astro's tsconfig, so the virtual module is invisible. Excluded \`packages/website\` from root tsconfig — the website has its own toolchain (\`astro check\`) and shouldn't be typechecked by the CLI's tsc invocation. This matches how Astro projects are typically integrated in monorepos.

## Why this is safe
- Zero behavior changes — pure type annotations + path string fixes + tsconfig include adjustment
- All touched test files still pass (59/59 in the 3 affected suites)
- \`tsc --noEmit\` now produces zero output
- The Astro exclusion doesn't reduce coverage — \`packages/website\` uses \`astro check\` which is its own typecheck

## Test plan
- [x] \`bunx tsc --noEmit\` from repo root: 0 errors (verified)
- [x] \`npx vitest run\` on the 3 affected test files: 59/59 pass
- [ ] Full vitest suite — CI will verify
- [ ] CI lint passes (the new type assertions are eslint-compliant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)