### PR TITLE
docs: refresh ARCHITECTURE.md for 2026-05 state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Safeword Architecture
 
-**Version:** 1.12
-**Last Updated:** 2026-04-17
+**Version:** 1.13
+**Last Updated:** 2026-05-14
 **Status:** Production
 
 ---
@@ -65,7 +65,7 @@ ESLint configs are bundled in the main package and accessed via `import safeword
 ```text
 packages/cli/
 ├── src/
-│   ├── commands/       # CLI commands (setup, upgrade, check, diff, reset, sync-config)
+│   ├── commands/       # CLI commands (setup, upgrade, check, diff, reset, sync-config, sync-learnings)
 │   ├── packs/          # Language packs + registry
 │   │   ├── {lang}/     # index.ts, files.ts, setup.ts per language
 │   │   ├── registry.ts # Central pack registry and detection


### PR DESCRIPTION
## Summary
42 commits since the doc was last touched, but most were maintenance. Two real drifts to fix:

- Metadata stale: version \`1.12\` → \`1.13\`, date \`2026-04-17\` → \`2026-05-14\`
- Commands list missed \`sync-learnings\` (added in #130 to regenerate \`.safeword-project/learnings/INDEX.md\`)

## Verified accurate against current code
- Reconciliation modes: \`install\` / \`upgrade\` / \`uninstall\` / \`uninstall-full\` ✓
- Schema content sources: \`template\` / \`content\` / \`generator\` ✓
- Language pack pattern unchanged ✓
- ESLint plugin tier breakdown unchanged ✓

## Deferred
Auto-upgrade architecture (PR #81) deliberately not documented here — will land alongside that PR's merge so the doc reflects shipped behavior.

## Test plan
- [x] Diff is 3 lines changed
- [x] No code references touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)