### PR TITLE
chore(ci): drop Node 20, require Node 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22']
+        node-version: ['22']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ This section is for contributors to safeword itself.
 
 | Component | Technology                  |
 | --------- | --------------------------- |
-| Runtime   | Bun (dev), Node 20+ (users) |
+| Runtime   | Bun (dev), Node 22+ (users) |
 | CLI       | TypeScript, Commander.js    |
 | Build     | tsup (ESM-only output)      |
 | Tests     | Vitest                      |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "templates"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary
- Node 20 (Iron) reached upstream end-of-life on 2026-04-30, so it no longer belongs in CI or as an advertised runtime.
- CI matrix in `.github/workflows/ci.yml` reduced to `['22']` (Active LTS through 2026-10).
- `packages/cli/package.json` `engines.node` bumped to `>=22`; README runtime row updated to match.

## Follow-up (manual, outside this PR)
- **Branch protection:** if `test (node 20)` is currently a required status check in repo Settings → Branches, remove it before merging — the job no longer runs and PRs will hang waiting on it.
- **Versioning:** treating the `engines` bump as a routine EOL-drop rather than a major version bump. Flag if you want it rolled into a major release instead.

## Test plan
- [ ] CI passes with the single Node 22 matrix entry
- [ ] No required-status-check left dangling on `test (node 20)` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)