### PR TITLE
feat(skills): port elicit skill from arcade-way + register in schema

### DIFF
--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -14,6 +14,8 @@ Follow the understanding pattern from SAFEWORD.md — including contribution tec
 
 If any answer is vague, you have open questions — surface them.
 
+**When the gap is user-only knowledge** (intent, priorities, constraints not derivable from code/docs) — call `/elicit` to extract it via microquestions before drafting scope.
+
 ### Concrete example
 
 **Context:** User says "I want to add a --verbose flag to the lint command."

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -53,6 +53,8 @@ Don't skip past errors. They often contain the exact solution.
 | Sometimes       | Gather more data - when does it happen vs not?       |
 | Never           | Cannot debug what you cannot reproduce - gather logs |
 
+**When repro hinges on user-only context** (env, timeline, "what were you doing"), call `/elicit` — its multiple-choice format constrains the answer space better than open prompts.
+
 #### 3. Check Recent Changes
 
 ```bash

--- a/.claude/skills/elicit/SKILL.md
+++ b/.claude/skills/elicit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: elicit
+description: "Extract tacit knowledge through non-obvious microquestions — things only the user knows that can't be found in code, docs, or research. Use when you're about to guess at intent, context, or constraints during SAFEWORD's understanding flow. Also use when user says 'ask me', 'what do you need to know', or when another skill (bdd, brainstorm, debug) needs user context before proceeding. Do NOT use for questions answerable by reading the codebase or searching the web."
+allowed-tools: '*'
+---
+
+# Elicit: Tacit Knowledge Extraction
+
+Draw out what the user knows and you can't research. Then check the latest evidence. Then explore options together.
+
+**Iron Law:** NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF. Read the code, search the docs, check git history first. Only ask what's left.
+
+## When to Run
+
+1. **Explicitly** — user invokes `/elicit`
+2. **From other skills** — any skill can call "run /elicit" before a decision point (e.g. `bdd` before scenarios, `brainstorm` when narrowing, `debug` when symptoms are ambiguous)
+3. **Proactively** — when you're about to make an assumption only the user can confirm
+
+## Relationship to other skills
+
+- **brainstorm** widens the option space (divergent). **elicit** narrows your uncertainty about user intent (convergent). Use brainstorm when you don't know the options; use elicit when you don't know the user's priorities among options.
+- **SAFEWORD understanding flow** already does contribute-before-asking. `elicit` is the structured form for decision points where guessing would be costly.
+
+## Phase 1: Microquestions
+
+Ask one question at a time. Multiple choice (3-5 options). Force yourself to pre-think the option space so the user reacts rather than generates.
+
+### What to ask about
+
+- **Intent:** Why this way and not another? What was tried and rejected?
+- **Constraints:** What's off-limits? What's coming soon that would change the answer?
+- **Priorities:** When two good options conflict, which value wins?
+- **Audience:** Who reads/uses this? What do they already know?
+- **Omissions:** Is something missing because it's not ready, not wanted, or not thought of yet?
+
+### Question format
+
+Good:
+
+> This could live in (a) the onboarding flow, (b) the decision-making page, or (c) as a standalone guide. Where would someone look for it?
+
+Bad:
+
+> Where do you think this should go?
+
+The good version does the thinking. The bad version makes the user do it.
+
+### How many
+
+Keep asking until one of:
+
+- Answers start repeating or converging
+- You have enough to distinguish between options in Phase 3
+- User says "enough" or "go"
+
+Typical: 3-7 questions. Fewer for small scope, more for ambiguous scope.
+
+## Phase 2: Research
+
+After elicitation, check the latest evidence on the decision at hand. Web-search for:
+
+- Meta-analyses or systematic reviews
+- Replicated findings with effect sizes
+- How leading organizations handle this
+- Boundary conditions and known limitations
+
+**Skip** if the task is purely operational (no empirical claims involved).
+**Defer** if the calling skill has its own research phase — don't duplicate work.
+
+## Phase 3: Options
+
+Present 2-3 options. Each option:
+
+- **What:** the approach, concretely
+- **Why it's good:** what it gets right
+- **What it costs:** complexity, length, tradeoff
+- **Evidence:** what supports it (from Phase 2, if applicable)
+
+For small scope (patch/task): just do it — skip the proposal, apply the best option directly.
+For larger scope (feature/policy): present options, let the user pick.
+
+## From Other Skills
+
+When called from another skill, the elicitation results feed directly into the calling skill's next phase. No separate artifact — the conversation is the artifact.

--- a/.safeword-project/tickets/150-claude-only-skill-classification/ticket.md
+++ b/.safeword-project/tickets/150-claude-only-skill-classification/ticket.md
@@ -1,0 +1,61 @@
+---
+id: 150
+type: task
+phase: intake
+status: pending
+created: 2026-05-17T18:55:00Z
+last_modified: 2026-05-17T18:55:00Z
+---
+
+# Revisit "Claude-only" Skill Classification
+
+**Goal:** Decide whether the `CLAUDE_ONLY_SKILLS` set (`brainstorm`, `tdd-review`, `elicit`) reflects a principled boundary or historical under-investment in Cursor parity. If principled, document the rule. If historical, add Cursor rules for the affected skills.
+
+**Why:** While porting `elicit` from arcade-way, I classified it as Claude-only by matching the existing pattern, but did not interrogate whether the pattern itself is correct. The convention currently lives in two test files (`schema.test.ts`, `skills-commands-validation.test.ts`) with no written rationale.
+
+## Current State
+
+Three skills have no Cursor rule counterpart:
+
+- `brainstorm` — divergent thinking partner
+- `tdd-review` — quality check at TDD step transitions
+- `elicit` — microquestion-based tacit knowledge extraction
+
+All three trigger on **conversation state** (about-to-guess, about-to-converge, TDD-step-just-finished) rather than file context. Cursor rules trigger on `alwaysApply` or glob/description matching against files.
+
+Every other safeword skill either:
+
+- Has a Cursor rule (`debugging`, `quality-reviewing`, `refactoring`, `testing`, `ticket-system`, `bdd-*`), OR
+- Is an action skill mapped to a Cursor command (`lint`, `verify`, `audit`, `cleanup-zombies`)
+
+## Open Question
+
+Is "conversation-state trigger" a sufficient reason to skip Cursor, or could these skills propagate to Cursor as `alwaysApply: true` discipline rules that Cursor's agent applies opportunistically?
+
+## Investigation
+
+- Read Cursor's latest rule-system docs (alwaysApply, agentRequested, manual modes)
+- Check whether any Cursor rule in this repo uses pure conversation-state triggers
+- Survey what `brainstorm` and `tdd-review` would look like as Cursor rules (concrete drafts)
+- Decide: keep Claude-only (and document rationale in `schema.ts`) OR add Cursor rules for all three
+
+## Scope
+
+- Likely either:
+  - Add a comment in `packages/cli/src/schema.ts` near the contextual-skills section explaining why these three are Claude-only, OR
+  - Add `templates/cursor/rules/safeword-brainstorming.mdc`, `safeword-tdd-review.mdc`, `safeword-elicitation.mdc` + register pairs in `SAFEWORD_SCHEMA.ownedFiles` + update `SKILL_TO_RULE_MAP` and `CLAUDE_ONLY_SKILLS` in the two test files
+
+## Out of Scope
+
+- Changing what the three skills _do_ — only their distribution to Cursor
+- Other skills' rule mappings (already settled)
+
+## Done When
+
+- Decision documented (either inline comment in `schema.ts` explaining Claude-only, or Cursor rules shipped and tests updated)
+- `bun scripts/parity-check.ts --mode=all` clean
+- `tests/schema.test.ts` and `tests/integration/skills-commands-validation.test.ts` green
+
+## Work Log
+
+- 2026-05-17 18:55 UTC — Ticket created as follow-up while porting `elicit` skill from arcade-way (commit pending). Original work shipped under current convention; this ticket interrogates whether the convention is right.

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -451,6 +451,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.claude/skills/brainstorm/SKILL.md': {
       template: 'skills/brainstorm/SKILL.md',
     },
+    '.claude/skills/elicit/SKILL.md': {
+      template: 'skills/elicit/SKILL.md',
+    },
     '.claude/skills/tdd-review/SKILL.md': {
       template: 'skills/tdd-review/SKILL.md',
     },

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -14,6 +14,8 @@ Follow the understanding pattern from SAFEWORD.md — including contribution tec
 
 If any answer is vague, you have open questions — surface them.
 
+**When the gap is user-only knowledge** (intent, priorities, constraints not derivable from code/docs) — call `/elicit` to extract it via microquestions before drafting scope.
+
 ### Concrete example
 
 **Context:** User says "I want to add a --verbose flag to the lint command."

--- a/packages/cli/templates/skills/debug/SKILL.md
+++ b/packages/cli/templates/skills/debug/SKILL.md
@@ -53,6 +53,8 @@ Don't skip past errors. They often contain the exact solution.
 | Sometimes       | Gather more data - when does it happen vs not?       |
 | Never           | Cannot debug what you cannot reproduce - gather logs |
 
+**When repro hinges on user-only context** (env, timeline, "what were you doing"), call `/elicit` — its multiple-choice format constrains the answer space better than open prompts.
+
 #### 3. Check Recent Changes
 
 ```bash

--- a/packages/cli/templates/skills/elicit/SKILL.md
+++ b/packages/cli/templates/skills/elicit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: elicit
+description: "Extract tacit knowledge through non-obvious microquestions — things only the user knows that can't be found in code, docs, or research. Use when you're about to guess at intent, context, or constraints during SAFEWORD's understanding flow. Also use when user says 'ask me', 'what do you need to know', or when another skill (bdd, brainstorm, debug) needs user context before proceeding. Do NOT use for questions answerable by reading the codebase or searching the web."
+allowed-tools: '*'
+---
+
+# Elicit: Tacit Knowledge Extraction
+
+Draw out what the user knows and you can't research. Then check the latest evidence. Then explore options together.
+
+**Iron Law:** NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF. Read the code, search the docs, check git history first. Only ask what's left.
+
+## When to Run
+
+1. **Explicitly** — user invokes `/elicit`
+2. **From other skills** — any skill can call "run /elicit" before a decision point (e.g. `bdd` before scenarios, `brainstorm` when narrowing, `debug` when symptoms are ambiguous)
+3. **Proactively** — when you're about to make an assumption only the user can confirm
+
+## Relationship to other skills
+
+- **brainstorm** widens the option space (divergent). **elicit** narrows your uncertainty about user intent (convergent). Use brainstorm when you don't know the options; use elicit when you don't know the user's priorities among options.
+- **SAFEWORD understanding flow** already does contribute-before-asking. `elicit` is the structured form for decision points where guessing would be costly.
+
+## Phase 1: Microquestions
+
+Ask one question at a time. Multiple choice (3-5 options). Force yourself to pre-think the option space so the user reacts rather than generates.
+
+### What to ask about
+
+- **Intent:** Why this way and not another? What was tried and rejected?
+- **Constraints:** What's off-limits? What's coming soon that would change the answer?
+- **Priorities:** When two good options conflict, which value wins?
+- **Audience:** Who reads/uses this? What do they already know?
+- **Omissions:** Is something missing because it's not ready, not wanted, or not thought of yet?
+
+### Question format
+
+Good:
+
+> This could live in (a) the onboarding flow, (b) the decision-making page, or (c) as a standalone guide. Where would someone look for it?
+
+Bad:
+
+> Where do you think this should go?
+
+The good version does the thinking. The bad version makes the user do it.
+
+### How many
+
+Keep asking until one of:
+
+- Answers start repeating or converging
+- You have enough to distinguish between options in Phase 3
+- User says "enough" or "go"
+
+Typical: 3-7 questions. Fewer for small scope, more for ambiguous scope.
+
+## Phase 2: Research
+
+After elicitation, check the latest evidence on the decision at hand. Web-search for:
+
+- Meta-analyses or systematic reviews
+- Replicated findings with effect sizes
+- How leading organizations handle this
+- Boundary conditions and known limitations
+
+**Skip** if the task is purely operational (no empirical claims involved).
+**Defer** if the calling skill has its own research phase — don't duplicate work.
+
+## Phase 3: Options
+
+Present 2-3 options. Each option:
+
+- **What:** the approach, concretely
+- **Why it's good:** what it gets right
+- **What it costs:** complexity, length, tradeoff
+- **Evidence:** what supports it (from Phase 2, if applicable)
+
+For small scope (patch/task): just do it — skip the proposal, apply the best option directly.
+For larger scope (feature/policy): present options, let the user pick.
+
+## From Other Skills
+
+When called from another skill, the elicitation results feed directly into the calling skill's next phase. No separate artifact — the conversation is the artifact.

--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -640,6 +640,7 @@ describe('Skills-Cursor Parity', () => {
     'cleanup-zombies': undefined,
     // Contextual skills — Claude-only, no Cursor rule counterpart
     brainstorm: undefined,
+    elicit: undefined,
     'tdd-review': undefined,
   };
 

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -267,7 +267,7 @@ describe('Schema - Single Source of Truth', () => {
       // Action skills have disable-model-invocation and use Cursor commands instead of rules
       const ACTION_SKILLS = new Set(['lint', 'verify', 'audit', 'cleanup-zombies']);
       // Contextual skills without Cursor rule counterparts
-      const CLAUDE_ONLY_SKILLS = new Set(['brainstorm', 'tdd-review']);
+      const CLAUDE_ONLY_SKILLS = new Set(['brainstorm', 'elicit', 'tdd-review']);
 
       // Extract skill names from Claude schema paths (short names: debug, quality-review, refactor)
       const claudeSkills = Object.keys(SAFEWORD_SCHEMA.ownedFiles)


### PR DESCRIPTION
## Summary

- Ports the `elicit` skill from arcade-way: microquestion-based tacit knowledge extraction for moments when the model is about to guess at user-only context. Registered as the 94th `ownedFiles` pair in `SAFEWORD_SCHEMA`.
- Classified as contextual/Claude-only alongside `brainstorm` and `tdd-review` — added to both `CLAUDE_ONLY_SKILLS` (`schema.test.ts`) and `SKILL_TO_RULE_MAP` (`skills-commands-validation.test.ts`).
- Wired one-line `/elicit` callouts in `bdd/DISCOVERY.md` (intake phase, when specificity self-test fails on user-only knowledge) and `debug/SKILL.md` (Phase 1 reproduction, when repro hinges on env/timeline). Both root and template copies in sync.
- Filed [ticket 150](.safeword-project/tickets/150-claude-only-skill-classification/ticket.md) as a follow-up to interrogate whether the Claude-only classification is principled or historical.

## Test plan

- [x] Parity-check clean: `bun scripts/parity-check.ts --mode=all` reports "All 94 pairs and 1 contracts in sync."
- [x] Schema parity tests pass: `tests/schema.test.ts` 484/484
- [x] Skills-commands validation passes: `tests/integration/skills-commands-validation.test.ts` (no skills missing rules, no orphan rules)
- [x] Pre-commit hook ran clean (eslint --fix, prettier --write, markdownlint --fix)
- [ ] `/elicit` visible in available-skills list when starting a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)