### PR TITLE
fix(skills): catch silent bash-injection failures in /verify and /audit

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -14,7 +14,9 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
 ## Instructions
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -14,7 +14,9 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 
 ## Instructions
 

--- a/.cursor/commands/audit.md
+++ b/.cursor/commands/audit.md
@@ -10,7 +10,9 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
 ## Instructions
 

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -10,7 +10,9 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 
 ## Instructions
 

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -380,7 +380,7 @@ if (currentPhase === 'done') {
       recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
       const missingList = skillCheck.missing.map(s => `/${s}`).join(' and ');
       hardBlockDone(
-        `Required skill invocation(s) missing in this session: ${missingList}. Run ${missingList} before marking done. The bash-injection log at .safeword-project/skill-invocations.log proves invocation; hand-written verify.md does not satisfy this gate.`,
+        `Required skill invocation(s) missing in this session: ${missingList}. Run ${missingList} before marking done. The bash-injection log at .safeword-project/skill-invocations.log proves invocation; hand-written verify.md does not satisfy this gate. If you ran ${missingList} but no entry was logged, the bash injection at the top of the skill was likely denied — check Claude Code permissions for Bash(mkdir:*) and Bash(echo:*).`,
       );
     }
   }

--- a/packages/cli/templates/commands/audit.md
+++ b/packages/cli/templates/commands/audit.md
@@ -10,7 +10,9 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
 ## Instructions
 

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -10,7 +10,9 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 
 ## Instructions
 

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -380,7 +380,7 @@ if (currentPhase === 'done') {
       recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
       const missingList = skillCheck.missing.map(s => `/${s}`).join(' and ');
       hardBlockDone(
-        `Required skill invocation(s) missing in this session: ${missingList}. Run ${missingList} before marking done. The bash-injection log at .safeword-project/skill-invocations.log proves invocation; hand-written verify.md does not satisfy this gate.`,
+        `Required skill invocation(s) missing in this session: ${missingList}. Run ${missingList} before marking done. The bash-injection log at .safeword-project/skill-invocations.log proves invocation; hand-written verify.md does not satisfy this gate. If you ran ${missingList} but no entry was logged, the bash injection at the top of the skill was likely denied — check Claude Code permissions for Bash(mkdir:*) and Bash(echo:*).`,
       );
     }
   }

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -14,7 +14,9 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
 ## Instructions
 

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -14,7 +14,9 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log"`
+!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

When the bash injection at the top of `/verify` and `/audit` is denied (most often: Claude Code bash permission), the agent saw no positive signal and improvised — *"run /verify manually"* — but a manual run cannot satisfy the gate's anti-forgery invariant, so the done phase hard-blocked later with no obvious cause.

- **A — Sentinel:** the bash injection now emits `[skill-invocation-log] verify ✓` on success or `... FAILED — done-gate will block` on failure. Skill instructions tell the agent to STOP on FAILED rather than improvise.
- **C — Diagnostic:** the done-gate hard-block message now points at the likely fix: *check Claude Code permissions for `Bash(mkdir:*)` and `Bash(echo:*)`*.

Customer trace: Nate (2026-05-17).

Two related options were considered and **deferred**:
- (B) Reject malformed log entries in the tokenizer — marginal value, defer.
- (D/SessionStart probe) Preflight check for permission misconfiguration at session start — feasible but its catch-rate is limited by runtime flags it can't see; A+C address the immediate failure surface. Open for a follow-up ticket.

## Test plan

- [x] All 4 template/runtime/cursor pairs byte-equal (parity test)
- [x] `tests/parity.test.ts`, `tests/verify-skill.test.ts`, `tests/schema.test.ts`, `tests/quality.test.ts` — 98 passed
- [ ] Live exercise: deny Bash permission in a test session, run /verify, confirm the agent halts on the FAILED marker rather than proceeding
- [ ] Live exercise: trigger the done-gate hard-block, confirm the new diagnostic line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)