### PR TITLE
ci: drop obsolete Build CLI step from lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
             exit 1
           }
 
-      - name: Build CLI (required by eslint.config.mjs)
-        run: bun run --cwd packages/cli build
-
       - name: Lint
         run: bun run lint
 


### PR DESCRIPTION
## Summary

Follow-up to #98 — the lint job no longer requires `packages/cli/dist/` after that PR landed (`eslint.config.ts` imports from source). The "Build CLI (required by eslint.config.mjs)" step is now dead bloat citing a file that no longer exists.

The test job's separate Build step remains because tests exercise the built CLI binary.

Saves ~20s per lint CI run.

## Test plan

- [x] Local lint passes with `packages/cli/dist/` absent (already verified in #98)
- [ ] CI lint job still green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)