### PR TITLE
fix(skills): fallback to pwd when CLAUDE_PROJECT_DIR is unset

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -14,7 +14,7 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" && mkdir -p "$PROJECT_DIR/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "$PROJECT_DIR/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
 
 **If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
@@ -24,7 +24,7 @@ This skill is required at the done-gate (ticket 147). The line below appends a s
 
 ```bash
 # Ensure we're in the project root regardless of prior CWD state
-cd "$CLAUDE_PROJECT_DIR" || exit 1
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 1
 
 # =========================================================================
 # REFRESH CONFIG (detect current architecture)

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -14,7 +14,7 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" && mkdir -p "$PROJECT_DIR/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "$PROJECT_DIR/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
 
 **If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -14,7 +14,7 @@ Run a comprehensive code audit. Execute checks and report results by severity.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /audit was actually invoked. Bash injection runs at render time — hand-writing audit results cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" && mkdir -p "$PROJECT_DIR/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} audit" >> "$PROJECT_DIR/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] audit ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
 
 **If you see `[skill-invocation-log] FAILED` above, or no `audit ✓` line at all**: STOP. Do not run /audit manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /audit.
 
@@ -24,7 +24,7 @@ This skill is required at the done-gate (ticket 147). The line below appends a s
 
 ```bash
 # Ensure we're in the project root regardless of prior CWD state
-cd "$CLAUDE_PROJECT_DIR" || exit 1
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 1
 
 # =========================================================================
 # REFRESH CONFIG (detect current architecture)

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -14,7 +14,7 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 This skill is required at the done-gate (ticket 147). The line below appends a session-scoped entry to `.safeword-project/skill-invocations.log` so the done-gate hook can verify /verify was actually invoked. Bash injection runs at render time — hand-writing verify.md cannot produce this entry.
 
-!`mkdir -p "${CLAUDE_PROJECT_DIR}/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "${CLAUDE_PROJECT_DIR}/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" && mkdir -p "$PROJECT_DIR/.safeword-project" && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${CLAUDE_SESSION_ID} verify" >> "$PROJECT_DIR/.safeword-project/skill-invocations.log" && echo "[skill-invocation-log] verify ✓" || echo "[skill-invocation-log] FAILED — done-gate will block"`
 
 **If you see `[skill-invocation-log] FAILED` above, or no `verify ✓` line at all**: STOP. Do not run /verify manually — that line is the only proof the done-gate accepts. Report the failure to the user (most likely cause: Claude Code's bash permission denied the injection) and ask them to resolve it before re-invoking /verify.
 

--- a/packages/cli/tests/skill-invocation-log.test.ts
+++ b/packages/cli/tests/skill-invocation-log.test.ts
@@ -48,9 +48,10 @@ describe('skill-invocation log: bash injection in /verify and /audit (147)', () 
     it.each([...verifyForms, ...auditForms])(
       '%s bash injection uses append (>>), not overwrite (>)',
       (_name, content) => {
-        // The injection must use `>>` to preserve prior entries
+        // The injection must use `>>` to preserve prior entries.
+        // Accepts ${CLAUDE_PROJECT_DIR}/ (older form) or $PROJECT_DIR/ (after PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" indirection).
         expect(content).toMatch(
-          />>\s*"?(\$\{CLAUDE_PROJECT_DIR\}\/)?\.safeword-project\/skill-invocations\.log/,
+          />>\s*"\$(\{?CLAUDE_)?PROJECT_DIR\}?\/\.safeword-project\/skill-invocations\.log/,
         );
       },
     );
@@ -58,14 +59,15 @@ describe('skill-invocation log: bash injection in /verify and /audit (147)', () 
     it.each([...verifyForms, ...auditForms])(
       '%s bash injection ensures .safeword-project/ directory exists (mkdir -p)',
       (_name, content) => {
-        expect(content).toMatch(/mkdir\s+-p\s+"?(\$\{CLAUDE_PROJECT_DIR\}\/)?\.safeword-project/);
+        expect(content).toMatch(/mkdir\s+-p\s+"\$(\{?CLAUDE_)?PROJECT_DIR\}?\/\.safeword-project/);
       },
     );
 
     it.each([...verifyForms, ...auditForms])(
-      '%s bash injection uses absolute path via $CLAUDE_PROJECT_DIR (cwd-independent)',
+      '%s bash injection references $CLAUDE_PROJECT_DIR (directly or via PROJECT_DIR fallback)',
       (_name, content) => {
-        expect(content).toContain('${CLAUDE_PROJECT_DIR}');
+        // Accepts bare ${CLAUDE_PROJECT_DIR} or the defensive ${CLAUDE_PROJECT_DIR:-$(pwd)} fallback.
+        expect(content).toMatch(/\$\{CLAUDE_PROJECT_DIR(:-\$\(pwd\))?\}/);
       },
     );
   });


### PR DESCRIPTION
## Summary

The `verify` and `audit` skill bash injections used bare `\${CLAUDE_PROJECT_DIR}`, which resolves to empty in certain harness contexts (observed: Claude Desktop running in a worktree session). That made the invocation-log mkdir target `/` and fail with `Read-only file system`, silently breaking the done-gate invocation log. Every safeword TypeScript hook already uses the defensive `process.env.CLAUDE_PROJECT_DIR ?? process.cwd()` pattern; the lone bash hook uses `\${CLAUDE_PROJECT_DIR:-\$(pwd)}`. This patch applies the same fallback to the skills (3 lines × 2 files × 2 copies = 6 edits).

## Repro

In a worktree session where `CLAUDE_PROJECT_DIR` is unset in the harness env:

```
> /verify
Shell command failed: mkdir: /.safeword-project: Read-only file system
```

The skill exits before producing the invocation-log entry. Subsequent done-gate validation hard-blocks ticket completion with no clear pointer to the root cause.

## Fix

Each skill now derives `PROJECT_DIR="\${CLAUDE_PROJECT_DIR:-\$(pwd)}"` once and uses it for both `mkdir` and `tee`. Audit's `cd \$CLAUDE_PROJECT_DIR || exit 1` uses the same fallback. Verified end-to-end on this branch: `/verify` produces `[skill-invocation-log] verify ✓` and the log entry lands in `.safeword-project/skill-invocations.log`.

## Test plan

- [x] `/verify` in fresh session writes log entry (verified locally — log now contains entry from this session)
- [x] `bun scripts/parity-check.ts --mode=all` clean — All 94 pairs and 1 contracts in sync
- [x] Pre-commit hook clean (eslint, prettier, markdownlint)
- [ ] `/verify` and `/audit` work in fresh worktree sessions for other devs

## Related

Discovered while gating ticket 150 (PR #103). The fix unblocks the done-gate discipline in PRs #100 and #103 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)