### PR TITLE
feat(hooks): PreToolUse Bash hook resets core.bare before git ops (#151)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,6 +106,16 @@
             "command": "bun \"$CLAUDE_PROJECT_DIR\"/.safeword/hooks/pre-tool-config-guard.ts"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.safeword/hooks/pre-tool-git-bare-fix.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.safeword-project/tickets/151-pre-tool-git-bare-fix/ticket.md
+++ b/.safeword-project/tickets/151-pre-tool-git-bare-fix/ticket.md
@@ -1,0 +1,44 @@
+---
+id: 151
+type: task
+phase: tdd
+status: open
+created: 2026-05-17T23:00:00Z
+last_modified: 2026-05-17T23:00:00Z
+scope:
+  - Add PreToolUse Bash hook `pre-tool-git-bare-fix.sh` that resets `core.bare = false` before any `git *` command
+  - Use config-level `if: "Bash(git *)"` filter so non-git Bash calls incur zero hook-process spawn
+  - Ship via `packages/cli/templates/hooks/` + `packages/cli/templates/settings.json` so all safeword users benefit
+  - Sync dogfooded copy into `.safeword/hooks/` and `.claude/settings.json`
+  - Add release-gate test asserting hook resets a deliberately-flipped `core.bare`
+out_of_scope:
+  - Touching `.husky/pre-commit` — defense-in-depth retained for non-Claude commits
+  - SessionStart hook variant (PreToolUse covers the actual observed in-session races; SessionStart adds zero coverage)
+  - Filtering for `gh`/`bun` — no observed failures from those callers; will extend if/when seen
+  - Fixing the upstream Claude Code bug itself (issue #58345 commented today with evidence)
+done_when:
+  - Hook resets `core.bare = false` when invoked with a git command on a parent whose config has `core.bare = true`
+  - Hook is registered in templates settings.json and dogfooded in .claude/settings.json
+  - Release-gate test passes (deliberately flips, runs hook, asserts reset)
+  - Pair-parity holds: `.safeword/hooks/` matches `packages/cli/templates/hooks/`
+---
+
+# PreToolUse hook: reset core.bare before git commands
+
+**Goal:** Defend ad-hoc git ops (status, mv, push) from Claude Code's parallel-worktree `core.bare = true` race, not just `git commit`.
+
+**Why:** Surfaced repeatedly during ticket #147 — hit ~5 times in one session on non-commit git ops. The husky pre-commit reset (shipped v0.30.0) only fires inside `git commit`. Every `git status`, `git mv`, `git push`, `gh` shellout, IDE poll between commits hits the race unprotected. Filed upstream evidence on Claude Code issue [#58345](https://github.com/anthropics/claude-code/issues/58345); shipping this local hook for immediate relief.
+
+## Design
+
+- **Matcher**: `Bash` (per [Claude Code hooks docs](https://code.claude.com/docs/en/hooks), matcher = tool name only)
+- **If**: `Bash(git *)` — permission-rule syntax, evaluated **before** hook process spawn, so zero overhead on non-git Bash calls
+- **Hook script**: POSIX sh (`.sh`, not TS — avoid bun startup tax for a 2-line reset)
+- **Body**: existing `.husky/pre-commit` reset logic, extracted
+
+## References
+
+- Upstream issue: anthropics/claude-code#58345 (commented today with three live reproductions)
+- Ticket #141 (cancelled — was about _filing_ upstream, not local mitigation)
+- Ticket #147 — surfaced this gap repeatedly during its execution
+- Ticket #130 — original husky reset shipped here

--- a/.safeword/hooks/pre-tool-git-bare-fix.sh
+++ b/.safeword/hooks/pre-tool-git-bare-fix.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Safeword: PreToolUse Bash hook — reset core.bare=false before git commands
+#
+# Defends against an upstream Claude Code race
+# (anthropics/claude-code#58345): parallel-worktree creation momentarily flips
+# the parent repo's .git/config core.bare=true, and if anything reads it
+# mid-flight the flag stays set. Subsequent git ops in any sibling worktree
+# then fail with `fatal: this operation must be run in a work tree`.
+#
+# This hook fires before every Bash command beginning with `git` (filtered
+# at the config level via `if: "Bash(git *)"`, so non-git Bash calls incur
+# zero process-spawn overhead). The reset is idempotent: it only writes
+# when core.bare is actually true, and silently no-ops otherwise.
+#
+# A defensive copy of the same reset still lives in .husky/pre-commit for
+# coverage of git commits outside Claude Code (manual commits, IDE git UIs).
+#
+# Exits 0 unconditionally — never block Claude Code, even if git is missing
+# or we're not in a repo.
+
+# Drain stdin (Claude Code sends the PreToolUse JSON payload). We don't need
+# its contents — the `if` filter already confirmed this is a git command.
+cat > /dev/null 2>&1 || true
+
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2> /dev/null) || exit 0
+[ -n "$GIT_COMMON_DIR" ] || exit 0
+
+CONFIG_PATH="$GIT_COMMON_DIR/config"
+[ -f "$CONFIG_PATH" ] || exit 0
+
+# Only write if currently true — avoids redundant fs writes that would bump
+# the config mtime on every git call.
+CURRENT=$(git config -f "$CONFIG_PATH" --get core.bare 2> /dev/null || echo "")
+if [ "$CURRENT" = "true" ]; then
+  git config -f "$CONFIG_PATH" core.bare false 2> /dev/null || true
+fi
+
+exit 0

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -324,6 +324,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/pre-tool-config-guard.ts': {
       template: 'hooks/pre-tool-config-guard.ts',
     },
+    '.safeword/hooks/pre-tool-git-bare-fix.sh': {
+      template: 'hooks/pre-tool-git-bare-fix.sh',
+    },
     '.safeword/hooks/session-auto-upgrade.ts': {
       template: 'hooks/session-auto-upgrade.ts',
     },

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -168,9 +168,9 @@ describe('SETTINGS_HOOKS', () => {
     expect(regex.test('Grep')).toBe(false);
   });
 
-  it('should have PreToolUse hooks for quality enforcement and config guard', () => {
+  it('should have PreToolUse hooks for quality enforcement, config guard, and git-bare-race fix', () => {
     const preToolHooks = SETTINGS_HOOKS.PreToolUse;
-    expect(preToolHooks.length).toBe(2);
+    expect(preToolHooks.length).toBe(3);
 
     const commands = preToolHooks.flatMap((h: HookEntry) =>
       h.hooks
@@ -180,6 +180,22 @@ describe('SETTINGS_HOOKS', () => {
 
     expect(commands.some((c: string) => c.includes('pre-tool-quality'))).toBe(true);
     expect(commands.some((c: string) => c.includes('pre-tool-config-guard'))).toBe(true);
+    expect(commands.some((c: string) => c.includes('pre-tool-git-bare-fix'))).toBe(true);
+  });
+
+  it('git-bare-race hook uses Bash matcher with if-filter to avoid spawning on non-git Bash calls', () => {
+    const bareRaceHook = SETTINGS_HOOKS.PreToolUse.find((h: HookEntry) =>
+      h.hooks.some(
+        (hook: HookCommand) =>
+          hook.type === 'command' && hook.command.includes('pre-tool-git-bare-fix'),
+      ),
+    );
+    expect(bareRaceHook).toBeDefined();
+    expect(bareRaceHook?.matcher).toBe('Bash');
+    const command = bareRaceHook?.hooks.find((h: HookCommand) => h.type === 'command') as
+      | { if?: string; command: string }
+      | undefined;
+    expect(command?.if).toBe('Bash(git *)');
   });
 
   it('should have all commands reference $CLAUDE_PROJECT_DIR', () => {

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -320,6 +320,20 @@ function matchedHook(matcher: string, command: string) {
   return { matcher, hooks: [{ type: 'command', command }] };
 }
 
+/**
+ * Create a hook entry with a tool matcher AND an `if` permission-rule filter.
+ *
+ * The `if` field uses Claude Code's permission-rule syntax (e.g., `Bash(git *)`)
+ * and is evaluated BEFORE spawning the hook process, so non-matching tool calls
+ * incur zero overhead. See https://code.claude.com/docs/en/hooks.
+ */
+function matchedHookWithIf(matcher: string, ifRule: string, command: string) {
+  return {
+    matcher,
+    hooks: [{ type: 'command', if: ifRule, command }],
+  };
+}
+
 const EDIT_TOOLS = 'Edit|Write|MultiEdit|NotebookEdit';
 
 export const SETTINGS_HOOKS = {
@@ -340,6 +354,10 @@ export const SETTINGS_HOOKS = {
   PreToolUse: [
     matchedHook(EDIT_TOOLS, `bun ${HOOKS_DIR}/pre-tool-quality.ts`),
     matchedHook(EDIT_TOOLS, `bun ${HOOKS_DIR}/pre-tool-config-guard.ts`),
+    // Defends ad-hoc git ops against Claude Code's parallel-worktree
+    // core.bare=true race (anthropics/claude-code#58345). `if` filters at the
+    // config level so non-git Bash calls incur zero hook-process spawn.
+    matchedHookWithIf('Bash', 'Bash(git *)', `bash ${HOOKS_DIR}/pre-tool-git-bare-fix.sh`),
   ],
   PostToolUse: [
     matchedHook(EDIT_TOOLS, `bun ${HOOKS_DIR}/post-tool-lint.ts`),

--- a/packages/cli/templates/hooks/pre-tool-git-bare-fix.sh
+++ b/packages/cli/templates/hooks/pre-tool-git-bare-fix.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Safeword: PreToolUse Bash hook — reset core.bare=false before git commands
+#
+# Defends against an upstream Claude Code race
+# (anthropics/claude-code#58345): parallel-worktree creation momentarily flips
+# the parent repo's .git/config core.bare=true, and if anything reads it
+# mid-flight the flag stays set. Subsequent git ops in any sibling worktree
+# then fail with `fatal: this operation must be run in a work tree`.
+#
+# This hook fires before every Bash command beginning with `git` (filtered
+# at the config level via `if: "Bash(git *)"`, so non-git Bash calls incur
+# zero process-spawn overhead). The reset is idempotent: it only writes
+# when core.bare is actually true, and silently no-ops otherwise.
+#
+# A defensive copy of the same reset still lives in .husky/pre-commit for
+# coverage of git commits outside Claude Code (manual commits, IDE git UIs).
+#
+# Exits 0 unconditionally — never block Claude Code, even if git is missing
+# or we're not in a repo.
+
+# Drain stdin (Claude Code sends the PreToolUse JSON payload). We don't need
+# its contents — the `if` filter already confirmed this is a git command.
+cat > /dev/null 2>&1 || true
+
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2> /dev/null) || exit 0
+[ -n "$GIT_COMMON_DIR" ] || exit 0
+
+CONFIG_PATH="$GIT_COMMON_DIR/config"
+[ -f "$CONFIG_PATH" ] || exit 0
+
+# Only write if currently true — avoids redundant fs writes that would bump
+# the config mtime on every git call.
+CURRENT=$(git config -f "$CONFIG_PATH" --get core.bare 2> /dev/null || echo "")
+if [ "$CURRENT" = "true" ]; then
+  git config -f "$CONFIG_PATH" core.bare false 2> /dev/null || true
+fi
+
+exit 0

--- a/packages/cli/tests/pre-tool-git-bare-fix.release.test.ts
+++ b/packages/cli/tests/pre-tool-git-bare-fix.release.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Release gate: PreToolUse Bash hook resets `core.bare = false`.
+ *
+ * Why this matters: Claude Code's parallel-worktree creation has an upstream
+ * race that flips the parent repo's `.git/config` `core.bare = true` mid-flight
+ * (anthropics/claude-code#58345). Every git op in any sibling worktree then
+ * fails with `fatal: this operation must be run in a work tree`.
+ *
+ * Our `.husky/pre-commit` already resets it inside `git commit`. This hook
+ * extends the defense to ad-hoc git reads (`git status`, `git mv`, `git push`,
+ * etc.) by running before every Bash tool call whose command starts with `git`.
+ *
+ * This test fixtures the failure: creates a temp repo, deliberately flips
+ * `core.bare = true`, invokes the hook script, asserts the flag was reset.
+ *
+ * Excluded from `bun run test` (release-gate only).
+ * Run with: bun run test:release
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../..');
+const HOOK_PATH = nodePath.join(REPO_ROOT, 'packages/cli/templates/hooks/pre-tool-git-bare-fix.sh');
+
+function gitConfigGet(directory: string, key: string): string {
+  const result = spawnSync('git', ['config', '--get', key], {
+    cwd: directory,
+    encoding: 'utf8',
+  });
+  return result.stdout.trim();
+}
+
+describe('pre-tool-git-bare-fix hook', () => {
+  let temporaryRepo: string;
+
+  beforeEach(() => {
+    temporaryRepo = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bare-fix-'));
+    spawnSync('git', ['init', '--initial-branch=main'], { cwd: temporaryRepo });
+    // Deliberately flip the race condition we're defending against
+    spawnSync('git', ['config', 'core.bare', 'true'], { cwd: temporaryRepo });
+    expect(gitConfigGet(temporaryRepo, 'core.bare')).toBe('true');
+  });
+
+  afterEach(() => {
+    rmSync(temporaryRepo, { recursive: true, force: true });
+  });
+
+  it('resets core.bare to false when invoked from a worktree with bare=true', () => {
+    // Hook reads JSON tool_input from stdin (PreToolUse contract).
+    // Body is the Claude Code hook payload for a Bash call running `git status`.
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+    });
+
+    const result = spawnSync(HOOK_PATH, [], {
+      cwd: temporaryRepo,
+      input: payload,
+      encoding: 'utf8',
+    });
+
+    expect(
+      result.status,
+      `hook exited ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    ).toBe(0);
+    expect(gitConfigGet(temporaryRepo, 'core.bare')).toBe('false');
+  });
+
+  it('is idempotent — running on already-false config does not error', () => {
+    spawnSync('git', ['config', 'core.bare', 'false'], { cwd: temporaryRepo });
+    expect(gitConfigGet(temporaryRepo, 'core.bare')).toBe('false');
+
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'git log' },
+    });
+
+    const result = spawnSync(HOOK_PATH, [], {
+      cwd: temporaryRepo,
+      input: payload,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(gitConfigGet(temporaryRepo, 'core.bare')).toBe('false');
+  });
+
+  it('exits cleanly when not inside a git repository', () => {
+    // Use a non-git temp directory
+    const nonGitDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-non-git-'));
+    try {
+      const payload = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git status' },
+      });
+
+      const result = spawnSync(HOOK_PATH, [], {
+        cwd: nonGitDirectory,
+        input: payload,
+        encoding: 'utf8',
+      });
+
+      // Hook must not block Claude Code if there's no git repo to fix
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(nonGitDirectory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Defends ad-hoc git ops (`git status`, `git mv`, `git push`, etc.) against an upstream Claude Code race that flips parent `core.bare = true` mid-flight during parallel-worktree creation ([anthropics/claude-code#58345](https://github.com/anthropics/claude-code/issues/58345)).

The existing `.husky/pre-commit` reset only covers `git commit`. I hit the race ~5 times on non-commit git ops during a single recent session.

## Approach (researched against [Claude Code hooks docs](https://code.claude.com/docs/en/hooks))

- New POSIX shell hook `pre-tool-git-bare-fix.sh` — idempotent, exits 0 unconditionally (never blocks Claude Code)
- Registered with `matcher: "Bash"` + `if: "Bash(git *)"`. The `if` field uses Claude Code's permission-rule syntax and is evaluated **before** spawning the hook process, so non-git Bash calls incur zero overhead
- Shipped via `packages/cli/templates/hooks/` so all safeword users benefit
- `.husky/pre-commit` reset retained for defense-in-depth (covers non-Claude commits)

## Upstream filing

Commented on [anthropics/claude-code#58345](https://github.com/anthropics/claude-code/issues/58345#issuecomment-4472776936) with three independent reproductions and analysis showing the symptom surface is broader than the original report (race fires on ad-hoc reads, not just at Enter/Exit boundaries) and that the misleading error message ("not a work tree") hides the real cause.

Ticket #141 was about *filing* upstream — done. This PR is the local-mitigation companion (ticket #151).

## Why `if: "Bash(git *)"` instead of matching all Bash

Per docs, the `if` filter is evaluated before the hook process spawns. With ~1000 Bash calls per session and ~20-150ms spawn overhead, blanket matching would add real cost. The narrow `if` rule covers 100% of my observed failure cases (all 5 hits were direct `git` commands; `gh` shellouts hit GitHub's API, not local git) at zero cost. Easy to extend with `| "Bash(gh *)"` if we ever see other-caller failures.

## Test plan

- [x] Release-gate test (`pre-tool-git-bare-fix.release.test.ts`) — 3 assertions: hook resets bare=true, is idempotent on bare=false, exits cleanly outside git repos
- [x] Unit tests for templates/config.ts updated — 18/18 pass
- [x] Pre-push schema-test gate — 521/521 pass
- [x] Parity check — 95 pairs in sync (was 94 + 1 new hook)
- [x] End-to-end on real repo: deliberate `core.bare = true` → hook invoked → `core.bare = false`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)