### PR TITLE
docs+chore: README permissions FAQ and ticket 150 follow-up to #101

### DIFF
--- a/.safeword-project/tickets/150-setup-pre-allow-skill-bash/ticket.md
+++ b/.safeword-project/tickets/150-setup-pre-allow-skill-bash/ticket.md
@@ -1,0 +1,56 @@
+---
+id: 150
+type: task
+phase: understand
+status: open
+related: [101]
+created: 2026-05-17T19:36:00Z
+last_modified: 2026-05-17T19:36:00Z
+---
+
+# `safeword setup` offers to pre-allow the skill-invocation bash injection
+
+**Goal:** Have `bunx safeword setup` (and `safeword upgrade` when appropriate) detect whether `.claude/settings.json` pre-approves the two Bash patterns the skill-invocation log injection needs, and — if not — offer to add them. Prevents the failure mode at install time rather than only documenting it.
+
+**Why:** PR #101 ([safeword#101](https://github.com/ArcadeAI/safeword/pull/101)) made the failure visible (sentinel + diagnostic) and documented the required permissions in the README FAQ. But docs are an after-the-fact recovery surface: new users still hit the silent-bash-denial failure mode on their first `/verify` or `/audit`, then have to find the FAQ. Setup-time pre-approval addresses the root cause for the common case (interactive `safeword setup`).
+
+Customer trace: Nate (2026-05-17) — first observed in #101's session. The user ran `/verify`, Claude Code denied the bash injection, agent improvised with "run manually," done-gate hard-blocked downstream. Documented but not yet prevented at install time.
+
+## Scope (proposed — open for converge)
+
+**In:**
+
+- `safeword setup` reads `.claude/settings.json` (creating if absent), checks whether `permissions.allow` covers `Bash(mkdir -p:*)` and `Bash(echo:*)` (or whether `defaultMode` is permissive: `bypassPermissions`/`acceptEdits`/`dontAsk`/`auto`).
+- If not covered, interactive setup prompts the user: _"Pre-allow `Bash(mkdir -p:_)`and`Bash(echo:_)`so`/verify`and`/audit` don't trigger permission prompts? [Y/n]"_.
+- On accept, merge the two patterns into the existing `permissions.allow` array (idempotent, preserve all other entries, preserve key ordering).
+- Behavior in non-interactive contexts (CI, scheduled, `--yes` flag) — see open questions.
+
+**Out of Scope:**
+
+- Modifying user-level `~/.claude/settings.json` (project-scope only).
+- Adding deny patterns or modifying existing allow entries.
+- Auto-enabling permission patterns for other skills/hooks beyond `/verify` and `/audit` — scope creep; revisit when another skill needs bash injection.
+- Replacing bash injection with a no-bash mechanism (separate deferred discussion).
+
+## Open Questions (must converge before define-behavior)
+
+1. **Default for non-interactive `safeword setup`** — silently add, silently skip, or refuse and print a hint? The same install path is used in CI by some users; surprising file edits in CI are unfriendly, but skipping reintroduces the failure mode.
+2. **`safeword upgrade` behavior** — should upgrade also offer this for projects installed before the prompt existed? Or only `setup`? Risk: spamming existing users with a one-time fix-up prompt.
+3. **Merge semantics when `permissions.allow` is absent vs. present-but-different patterns** — if the user has `Bash(*)` (allow-all), do nothing? If they have a similar pattern (`Bash(mkdir:*)` without the `-p`), do we suggest the more surgical replacement or just add the new one and accept overlap?
+4. **Reversibility / advertise opt-out** — should the prompt include "you can revert with `safeword setup --reset-permissions`" or similar, or is the user expected to edit settings.json directly?
+
+## Done When (placeholder — finalize after converge)
+
+- [ ] Detection logic for "are the required patterns covered" in setup
+- [ ] Interactive prompt path with accept/reject
+- [ ] Non-interactive policy decided and implemented
+- [ ] Idempotency: re-running `safeword setup` doesn't duplicate entries or rewrite ordering
+- [ ] Test coverage for: empty settings.json, settings.json with existing allow array, settings.json with permissive defaultMode, settings.json with conflicting deny
+- [ ] README FAQ entry updated to reference the setup-time offer (replacing or supplementing the manual-edit guidance)
+
+## References
+
+- PR #101 ([safeword#101](https://github.com/ArcadeAI/safeword/pull/101)) — sentinel + diagnostic + FAQ; this ticket is the root-cause follow-up
+- README FAQ "What Claude Code permissions does safeword need?" — the manual-edit guidance this ticket supersedes (or augments)
+- `packages/cli/src/schema.ts` — `SAFEWORD_SCHEMA.ownedFiles` references `.claude/settings.json` as templated; need to confirm setup's existing merge semantics for that file before designing this layer
+- Claude Code permissions docs — pattern syntax, precedence (managed → settings.local → settings → user), `defaultMode` values

--- a/README.md
+++ b/README.md
@@ -333,6 +333,26 @@ No. Commit the `.safeword/`, `.claude/`, and `.cursor/` directories to git. When
 **Will it interfere with my development workflow?**
 No. Safeword's hooks and stricter linting rules only fire during AI agent sessions. They don't run when you code normally, and safeword does not install git hooks. It adds `lint` and `format` scripts to `package.json` that you can optionally use in CI or precommit hooks.
 
+**What Claude Code permissions does safeword need?**
+Safeword's done-gate verifies that `/verify` and `/audit` were actually invoked by reading a session-scoped log written via bash injection at the top of each skill. If Claude Code denies that bash injection, the gate hard-blocks at done-phase.
+
+To pre-approve the injection without prompts (recommended for headless / non-interactive sessions), add these two patterns to `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(mkdir -p:*)", "Bash(echo:*)"]
+  }
+}
+```
+
+This is the **minimum surgical scope**:
+
+- `Bash(mkdir -p:*)` matches only `mkdir -p ...` invocations (word boundary enforced), not bare `mkdir`.
+- `Bash(echo:*)` is the only way to pre-approve `echo` — Claude Code bash patterns cannot constrain by what is being echoed or where it writes (`>>` redirects are part of the command string, not a separator).
+
+The injection itself only writes timestamped lines to `.safeword-project/skill-invocations.log` — no network calls, no file mutation outside that path. If you cannot or do not want to allow bash injection in your environment, the done-gate is currently inoperable — please open an issue if this affects you.
+
 ---
 
 ## Development


### PR DESCRIPTION
## Summary

Follow-up to [#101](https://github.com/ArcadeAI/safeword/pull/101) — these two commits were pushed to that branch after the squash-merge, so they got orphaned. Re-landing them here.

- **`docs(readme)`** — FAQ entry *"What Claude Code permissions does safeword need?"* documents the minimum surgical scope (`Bash(mkdir -p:*)` + `Bash(echo:*)`) that pre-approves the skill-invocation bash injection. Pairs with the diagnostic message that already names these patterns when the done-gate hard-blocks.
- **`chore(tickets)`** — files ticket 150 to track the root-cause follow-up (have `safeword setup` offer to add these patterns interactively), with open questions captured for next-session converge.

## Test plan

- [x] FAQ section visible at the right place in README (after "Will it interfere with my development workflow?" in the FAQ block)
- [x] Ticket 150 frontmatter validates (type, phase, status fields present)
- [x] No code or test changes — pure docs/tracking
- [ ] Skim FAQ wording for tone consistency with surrounding entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)