### PR TITLE
chore: clear knip findings — drop prettier-plugin-sh, tag UpdateCache

### DIFF
--- a/.safeword/hooks/lib/update-cache.ts
+++ b/.safeword/hooks/lib/update-cache.ts
@@ -11,7 +11,13 @@
  * before they auto-propagate.
  */
 
-/** Shape of `.safeword/.update-cache.json`. All fields optional for forward compat. */
+/**
+ * Shape of `.safeword/.update-cache.json`. All fields optional for forward compat.
+ *
+ * @public — consumed by session-auto-upgrade.ts via a `.ts`-extension import,
+ * which knip's resolver doesn't trace. The tag suppresses the false-positive
+ * "unused exports" finding.
+ */
 export interface UpdateCache {
   latestVersion?: string;
   /** Unix ms timestamp of when `latestVersion` was published to npm (from registry `time[version]`). */

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "lint-staged": "^17.0.5",
         "markdownlint-cli2": "^0.22.1",
         "prettier": "^3.8.3",
-        "prettier-plugin-sh": "^0.18.1",
         "shellcheck": "^4.1.0",
       },
     },
@@ -454,8 +453,6 @@
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
     "@publint/pack": ["@publint/pack@0.1.4", "", {}, "sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ=="],
-
-    "@reteps/dockerfmt": ["@reteps/dockerfmt@0.5.2", "", {}, "sha512-Hbr7yen4fP5TxGM54ucXa4o5NwWXatJ6Bd9I8gp0PValYbI4Rug2Gu+rVv7K7o/efQc3F5ctqWJz47rYaa8zBw=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -1785,8 +1782,6 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
-    "prettier-plugin-sh": ["prettier-plugin-sh@0.18.1", "", { "dependencies": { "@reteps/dockerfmt": "^0.5.1", "sh-syntax": "^0.5.8" }, "peerDependencies": { "prettier": "^3.6.0" } }, "sha512-uZmU22wBMevjh3rmCatNQqiEer2+5KLa0xYCBX6zQQUQkcNzVL+s6FbPKK6ZSUNUbQk6jMAcQHrYPvuL2W6ihQ=="],
-
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
@@ -1948,8 +1943,6 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
-
-    "sh-syntax": ["sh-syntax@0.5.8", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-JfVoxf4FxQI5qpsPbkHhZo+n6N9YMJobyl4oGEUBb/31oQYlgTjkXQD8PBiafS2UbWoxrTO0Z5PJUBXEPAG1Zw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lint-staged": "^17.0.5",
     "markdownlint-cli2": "^0.22.1",
     "prettier": "^3.8.3",
-    "prettier-plugin-sh": "^0.18.1",
     "shellcheck": "^4.1.0"
   },
   "lint-staged": {

--- a/packages/cli/templates/hooks/lib/update-cache.ts
+++ b/packages/cli/templates/hooks/lib/update-cache.ts
@@ -11,7 +11,13 @@
  * before they auto-propagate.
  */
 
-/** Shape of `.safeword/.update-cache.json`. All fields optional for forward compat. */
+/**
+ * Shape of `.safeword/.update-cache.json`. All fields optional for forward compat.
+ *
+ * @public — consumed by session-auto-upgrade.ts via a `.ts`-extension import,
+ * which knip's resolver doesn't trace. The tag suppresses the false-positive
+ * "unused exports" finding.
+ */
 export interface UpdateCache {
   latestVersion?: string;
   /** Unix ms timestamp of when `latestVersion` was published to npm (from registry `time[version]`). */


### PR DESCRIPTION
## Summary

Two pre-existing knip findings (surfaced during #147 audit), bundled because both are trivial bloat-removal:

### 1. Drop `prettier-plugin-sh` from root devDependencies

Genuinely unused locally. Safeword's own `.sh` files are formatted with `shfmt` (`format:sh` script + Homebrew); `lint-staged` for `.sh` runs only `shellcheck`. The package only matters for **customer** projects — it's a *conditional* install in `packages/cli/src/packs/typescript/files.ts` (added when the customer has shell projects).

The `src/reconcile.ts:53` and `src/packs/typescript/files.ts` references are symbolic string identifiers in a `KNOWN_PRETTIER_PLUGINS` set, not real imports. Removing the devDep has zero runtime impact.

`bun install` removed 1 package after the change.

### 2. Tag `UpdateCache` with `@public` JSDoc

The interface IS used by `session-auto-upgrade.ts` in the same `templates/hooks/` tree, but knip's resolver doesn't trace `.ts`-extension imports — which all 10+ template hooks deliberately use (templates run under `bun` in customer projects with no build step, so they reference each other by their on-disk extension).

Per [knip's recommended pattern](https://knip.dev/reference/jsdoc-tsdoc-tags), `@public` is the canonical fix for "intentionally exported" symbols. Applied to both the template and the dogfooded `.safeword/` copy (pair-sync).

## Why not wire prettier-plugin-sh up instead?

Considered — would let safeword dogfood its own customer recommendation and drop the external `shfmt` (Homebrew) dep. Rejected because:
- Trades one form of bloat (unused dep) for another (`.prettierrc` + reformat of ~11 .sh files + style-drift risk vs shfmt)
- Customer-side install is **conditional** (only customers with shell projects get it), so the "we don't eat our own dogfood" framing is weaker than it sounds
- Out of scope for a knip-cleanup patch

If shell-file dogfooding becomes a priority, that's a separate proposal — clean to file later.

## Test plan

- [x] `bun install` — succeeds, removes 1 package
- [x] `bunx knip` — empty output (was 2 findings)
- [x] `bun scripts/parity-check.ts` — 98 pairs in sync
- [x] `bun run lint` — exit 0
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)