### PR TITLE
fix(eslint): unblock ESLint 10 + install-time peer-dep guard

### DIFF
--- a/.safeword-project/tickets/099-eslint-10-migration/ticket.md
+++ b/.safeword-project/tickets/099-eslint-10-migration/ticket.md
@@ -4,7 +4,7 @@ type: task
 phase: implement
 status: in_progress
 created: 2026-04-11
-last_modified: 2026-05-14T16:35:00Z
+last_modified: 2026-05-18T02:00:00Z
 ---
 
 # Task: ESLint 10 Migration
@@ -125,3 +125,41 @@ Verified via PR #3979 diff + reading safeword's `recommended-react.ts` preset:
 - ~~Phase 1: vendor promise rules~~ → trivial peerDep verification + version bump (the bump may already be in main)
 - ~~Phase 2: compat-bump deps~~ → already shipped via dependabot bumps across April–May (multiple PRs, not just #83)
 - **Phase 3 (the only remaining work): ESLint 10 install** — blocked on `eslint-plugin-react` upstream, which is itself blocked on `eslint-plugin-import#3227`. Monitor upstream weekly.
+
+## Status refresh 2026-05-18
+
+### Phase 2 was NOT actually done — vitest migration just landed today
+
+The 2026-05-14 claim "Current main has all 18 plugins at ESLint-10-ready versions (verified via `npm view` on each package's peerDeps)" was wrong on one entry. PR #66's announcement listed `@vitest/eslint-plugin 1.6.17` as bumped but the actual diff shows it did not — and the legacy package name `eslint-plugin-vitest@0.5.4` remained in `packages/cli/package.json` and was still being imported in `packages/cli/src/presets/typescript/eslint-configs/vitest.ts`. The `npm view` verification passed because every entry that existed in package.json had a compatible peer range; the audit missed that the package itself was the abandoned name.
+
+**Real-world impact surfaced:** a separate session (2026-05-17, `www` project at `wonderful-bassi-e4f6b7`) hit the `@typescript-eslint/utils@7.18.0` `LegacyESLint` crash during a lint run after a clean `safeword@0.30.3` install on top of pre-existing ESLint 10.0.0. Stack trace verbatim: `TypeError: Class extends value undefined is not a constructor or null at .../@typescript-eslint+utils@7.18.0+.../LegacyESLint.js:12:51`. That session worked around it by downgrading ESLint to 9.39.4. Root cause was in safeword.
+
+**Fixed in commit `b93b696`:** `eslint-plugin-vitest@0.5.4` → `@vitest/eslint-plugin@1.6.17`. Drop-in replacement (same repo `vitest-dev/eslint-plugin-vitest`, rule names unchanged, plugin object key `vitest` unchanged, flat-config registration unchanged). Verified single `@typescript-eslint/utils@8.59.3` resolution across the whole lockfile (was two: 7.18.0 + 8.59.3). 1764/1764 CLI tests pass. Also removed the speculative `@vitest/eslint-plugin` entry from `deprecatedPackages` in `schema.ts` — that line was added in Dec 2025 anticipating this migration, but the import migration never landed, so it was telling customers to uninstall a package safeword never told them to install.
+
+**`peerDependencies.eslint` intentionally left at `^9.22.0`** — not expanded to include `^10.0.0` because `eslint-plugin-react@7.37.5` still crashes on v10 (see Phase 3 below). Honesty over a clean-looking peer range.
+
+### `eslint-plugin-jsx-a11y` empirically verified clean on ESLint 10
+
+The 2026-04-19 ticket entry asserted "all rules work at runtime" but the verification was source-level audit only. Done empirically today: downloaded `eslint-plugin-jsx-a11y@6.10.2` tarball from npm, grepped all 184 `.js` files for any of the seven removed-in-ESLint-10 RuleContext methods (`getFilename`, `getSourceCode`, `getScope`, `getAncestors`, `markVariableAsUsed`, `getDeclaredVariables`, `getFirstTokens`). **Zero matches.** The only `context.*` access is `context.settings`, which is not on the removal list. Confirms the "soft blocker, override peerDep" decision.
+
+### Phase 3 upstream chain unchanged
+
+Re-checked 2026-05-18:
+
+- `eslint-plugin-react` — still 7.37.5 on npm latest (the `next` dist-tag points at `7.8.0-rc.0`, a numerically older 2014-era RC unrelated to ESLint 10 — stale tag, ignore). PR [#3979](https://github.com/jsx-eslint/eslint-plugin-react/pull/3979) **OPEN, last update 2026-05-15** (3 days ago — active but not merged). PR #3972 still open, last update 2026-05-12.
+- `eslint-plugin-import#3227` — **OPEN, last update 2026-05-15**.
+
+### Genuinely remaining Phase 2 work
+
+- Wire `eslint-plugin-jsx-a11y` peerDep override (still 6.10.2, peer caps at `^9`). Defensive — only matters once Phase 3 lands and ESLint 10 is the install target.
+
+### Full plugin bundle audit (2026-05-18)
+
+Audited all 24 packages safeword ships against npm: latest version, latest-release date, repo activity, archive/deprecation status. None archived, none `npm deprecate`d. The one abandoned plugin (`eslint-plugin-vitest@0.5.4`, last released April 2024) was the cause of this whole thread and is gone as of `b93b696`.
+
+**Watch-list (not action items, but worth a recheck in ~6 months):**
+
+- `eslint-plugin-jsx-a11y@6.10.2` — **19 months since last release** (Oct 2024). Repo not archived; last commit Jan 6, 2026 (dev-dep pins + JSDoc tweaks, no rule work, no v10 prep). ARIA semantics are genuinely stable so the release gap isn't disqualifying, and we've verified empirically that the rules don't touch any removed-in-v10 RuleContext methods. **This is the most "asleep" plugin in safeword's bundle.** If it ever does become a problem, the live alternative is `@eslint-react/eslint-plugin` (jsx-a11y subset).
+- `eslint-plugin-react@7.37.5` — release stale (13mo) but **repo is very active** (5 commits in the last week as of 2026-05-18, including ESLint-v10 RuleTester work). Slow to release, not abandoned. Already tracked above as the Phase 3 upstream blocker.
+
+Everything else: active maintenance within 3 months. `eslint-config-prettier` (10mo) and `eslint-import-resolver-typescript` (11mo) are quiet but stable — a pure rule-disabler and a resolver respectively, both genuinely "done."

--- a/.safeword-project/tickets/152-resolve-bun-audit-advisories/ticket.md
+++ b/.safeword-project/tickets/152-resolve-bun-audit-advisories/ticket.md
@@ -1,0 +1,70 @@
+---
+id: 152
+type: task
+phase: understand
+status: open
+created: 2026-05-18T04:58:00Z
+last_modified: 2026-05-18T04:58:00Z
+---
+
+# Resolve `bun audit` advisories surfaced 2026-05-18
+
+**Goal:** Clear the 4 advisories that `bun audit` flags in safeword's tree (1 high, 3 moderate) by bumping the deps that pull in vulnerable transitives. None of these are caused by safeword's own direct deps — they're all transitives — but they show up in `bun audit` output, which customers run too.
+
+**Why this is a ticket, not "just run `bun update`":** Two of the three advisories require upstream-major bumps to resolve (astro 5→6, possibly shellcheck), which means real regression risk — not a thoughtless ride-along on dependabot. They should be bumped in a focused PR with verification.
+
+## Surfaced this session (during `/quality-review` of branch `wizardly-joliot-76687b`)
+
+Verified via `bun audit` on 2026-05-18:
+
+1. **`file-type@<21.3.1`** — moderate × 2. Chain: `safeword (devDep) → shellcheck → @xhmikosr/decompress-unzip → file-type`.
+   - [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473): infinite loop in ASF parser on malformed input.
+   - [GHSA-j47w-4g3g-c36v](https://github.com/advisories/GHSA-j47w-4g3g-c36v): ZIP decompression-bomb DoS via `[Content_Types].xml`.
+   - Dev-only — `shellcheck@4.1.0` is in safeword's root `devDependencies`. Likely fixable by bumping `shellcheck` to whatever version pulls a `file-type@>=21.3.1` transitive, or replacing `shellcheck` (the npm wrapper) with the system binary.
+
+2. **`yaml@<2.8.3`** — moderate. Chain: many. Direct entries:
+   - `workspace:safeword → yaml`
+   - `workspace:safeword → knip`
+   - `lint-staged → yaml`
+   - `workspace:safeword → tsup`
+   - `workspace:@safeword/website → astro`
+   - `workspace:safeword → vitest`
+   - `workspace:@safeword/website → @astrojs/check`
+   - [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp): stack-overflow via deeply nested YAML collections.
+   - Safeword's _direct_ dep is `yaml@2.8.4` (clean), but the named-dep entry in `bun audit` suggests an older version is still being resolved somewhere in the tree — likely a `bun.lock` consolidation issue rather than a real version pin. Investigate whether `bun update yaml` collapses the duplicate, or whether one of the listed packages pins yaml itself transitively.
+
+3. **`devalue@>=5.6.3 <=5.8.0`** — **HIGH**. Chain: `workspace:@safeword/website → astro → devalue`.
+   - [GHSA-77vg-94rm-hx3p](https://github.com/advisories/GHSA-77vg-94rm-hx3p): Svelte devalue DoS via sparse-array deserialization.
+   - Website workspace is on `astro@5.16.3`; latest Astro is in the 6.x line (per cross-session note from babelbot work on 2026-05-17). Likely fixed by an astro major bump, which is its own scoped piece of work.
+
+## Scope (proposed — open for converge)
+
+**In:**
+
+- Investigate the actual fix for each advisory (transitive bump vs. direct dep bump vs. dedupe).
+- Land the bumps in _one_ PR per workspace if the workspaces don't share the offending transitive (`astro` is website-only; `shellcheck` is root-only; `yaml` likely both).
+- Verify lint + typecheck + full test suite green after each bump.
+- Verify `bun audit` is clean (or, if not zeroable, the residue is documented and accepted).
+
+**Out of Scope:**
+
+- General dependency-bump hygiene beyond these three advisories.
+- Migrating away from `shellcheck` (the npm wrapper) to the system binary — that's a separate UX decision, raise as a new ticket if it surfaces during investigation.
+- Promoting `bun audit` to a CI-blocking gate — covered (or not) in `092` and friends.
+
+**Done When:**
+
+- `bun audit` reports zero advisories, OR
+- Any remaining advisory has an explicit "accepted, here's why" entry in this ticket.
+- Tests pass on both workspaces post-bump.
+- Build artifacts (CLI dist, website build) succeed.
+
+## Open Questions
+
+- `shellcheck@4.1.0` — is there a newer version with a `decompress-unzip` bump? If not, is the system-binary swap worth it for a dev-only DoS in a tarball parser nobody feeds untrusted ZIPs to?
+- `yaml` — does the duplicate resolve on `bun update`, or is one of the listed deps actually pinning `yaml@^2.0.0` and forcing the old line? `bun pm ls yaml` should answer.
+- `astro@5 → 6` — semver-major upgrade for the website workspace. Likely a real migration story, not a one-liner. Should this stay one ticket or split out to its own?
+
+## Provenance
+
+Surfaced during `/quality-review` on branch `wizardly-joliot-76687b` after the [vitest-plugin migration + installer peer-dep guard work](https://github.com/) (commits `b93b696`, `fb280b4`, `553c364`). The quality-review verified those three commits introduced **zero new advisories**; everything in `bun audit` was pre-existing. This ticket exists so the pre-existing surface gets addressed rather than continuing to be tolerated.

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@eslint/js": "^9.39.2",
         "@next/eslint-plugin-next": "16.2.6",
         "@tanstack/eslint-plugin-query": "5.100.10",
+        "@vitest/eslint-plugin": "^1.6.17",
         "commander": "14.0.3",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -50,7 +51,6 @@
         "eslint-plugin-storybook": "10.4.0",
         "eslint-plugin-turbo": "2.9.14",
         "eslint-plugin-unicorn": "64.0.0",
-        "eslint-plugin-vitest": "^0.5.4",
         "typescript-eslint": "8.59.3",
         "yaml": "^2.8.4",
       },
@@ -658,6 +658,8 @@
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.6", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.6", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.6", "vitest": "4.1.6" }, "optionalPeers": ["@vitest/browser"] }, "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ=="],
 
+    "@vitest/eslint-plugin": ["@vitest/eslint-plugin@1.6.17", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.58.0", "@typescript-eslint/utils": "^8.58.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "*", "eslint": ">=8.57.0", "typescript": ">=5.0.0", "vitest": "*" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "typescript", "vitest"] }, "sha512-sIVY9ZeVcXyPxFCNRkIt8Yw4keKIcUyp9/8qnmuomPwE+ST1htw5sZsbqdUMTiah9SmCg1JYoK9RqdDtPeNYYg=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
@@ -731,8 +733,6 @@
     "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
-
-    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "array.prototype.findlast": ["array.prototype.findlast@1.2.5", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ=="],
 
@@ -972,8 +972,6 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
-    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
-
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
@@ -1081,8 +1079,6 @@
     "eslint-plugin-turbo": ["eslint-plugin-turbo@2.9.14", "", { "dependencies": { "dotenv": "16.0.3" }, "peerDependencies": { "eslint": ">6.6.0", "turbo": ">2.0.0" } }, "sha512-ROTlsO1JBJLATxtDNd7t22vviSb0hD8fKnjOO0WRgtxJW3VBRNO3BLAC129GPZSvEvtMH/f71Y2TzrqGPjLpEw=="],
 
     "eslint-plugin-unicorn": ["eslint-plugin-unicorn@64.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.1", "change-case": "^5.4.4", "ci-info": "^4.4.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.49.0", "find-up-simple": "^1.0.1", "globals": "^17.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA=="],
-
-    "eslint-plugin-vitest": ["eslint-plugin-vitest@0.5.4", "", { "dependencies": { "@typescript-eslint/utils": "^7.7.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "vitest": "*" }, "optionalPeers": ["vitest"] }, "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -1741,8 +1737,6 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
-
-    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -2410,8 +2404,6 @@
 
     "eslint-plugin-unicorn/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
-    "eslint-plugin-vitest/@typescript-eslint/utils": ["@typescript-eslint/utils@7.18.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "7.18.0", "@typescript-eslint/types": "7.18.0", "@typescript-eslint/typescript-estree": "7.18.0" }, "peerDependencies": { "eslint": "^8.56.0" } }, "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw=="],
-
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -2540,12 +2532,6 @@
 
     "eslint-plugin-sonarjs/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "@typescript-eslint/visitor-keys": "7.18.0" } }, "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@7.18.0", "", {}, "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "@typescript-eslint/visitor-keys": "7.18.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^1.3.0" } }, "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA=="],
-
     "globby/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "istanbul-lib-report/make-dir/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
@@ -2582,36 +2568,10 @@
 
     "eslint-plugin-sonarjs/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "eslint-visitor-keys": "^3.4.3" } }, "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@7.18.0", "", { "dependencies": { "@typescript-eslint/types": "7.18.0", "eslint-visitor-keys": "^3.4.3" } }, "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
-
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
-
-    "eslint-plugin-vitest/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@eslint/js": "^9.39.2",
     "@next/eslint-plugin-next": "16.2.6",
     "@tanstack/eslint-plugin-query": "5.100.10",
+    "@vitest/eslint-plugin": "^1.6.17",
     "commander": "14.0.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -67,7 +68,6 @@
     "eslint-plugin-storybook": "10.4.0",
     "eslint-plugin-turbo": "2.9.14",
     "eslint-plugin-unicorn": "64.0.0",
-    "eslint-plugin-vitest": "^0.5.4",
     "typescript-eslint": "8.59.3",
     "yaml": "^2.8.4"
   },

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -21,6 +21,7 @@ import { detectLanguages as detectLanguagePacks } from '../packs/registry.js';
 import { reconcile, type ReconcileResult } from '../reconcile.js';
 import { type ProjectContext, SAFEWORD_SCHEMA } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
+import { getEslintPeerMismatchWarning } from '../utils/eslint-peer-check.js';
 import { exists, readJson, writeJson } from '../utils/fs.js';
 import { installDependencies } from '../utils/install.js';
 import { error, header, info, listItem, success, warn } from '../utils/output.js';
@@ -336,6 +337,9 @@ function setupJavaScriptProject(
   }
 
   logExistingFormatter(ctx);
+
+  const eslintWarning = getEslintPeerMismatchWarning(cwd);
+  if (eslintWarning) warn(`\n${eslintWarning}`);
 
   installDependencies(cwd, packagesToInstall, 'linting devDependencies');
   info('These are dev-only tools — your application dependencies are unchanged.');

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -18,6 +18,7 @@ import { getMissingPacks } from '../packs/registry.js';
 import { reconcile, type ReconcileResult } from '../reconcile.js';
 import { SAFEWORD_SCHEMA } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
+import { getEslintPeerMismatchWarning } from '../utils/eslint-peer-check.js';
 import { exists, findInTree, readFileSafe } from '../utils/fs.js';
 import { detectPackageManager, installDependencies } from '../utils/install.js';
 import { error, header, info, listItem, success, warn } from '../utils/output.js';
@@ -118,6 +119,9 @@ export async function upgrade(): Promise<void> {
 
   header('Safeword Upgrade');
   info(`Upgrading from v${projectVersion} to v${VERSION}`);
+
+  const eslintWarning = getEslintPeerMismatchWarning(cwd);
+  if (eslintWarning) warn(`\n${eslintWarning}`);
 
   try {
     const ctx = createProjectContext(cwd);

--- a/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- ESLint config types are incompatible across plugin packages */
 
-import vitestPlugin from 'eslint-plugin-vitest';
+import vitestPlugin from '@vitest/eslint-plugin';
 
 /**
  * Vitest test linting config

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -226,7 +226,6 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     'eslint-plugin-jsx-a11y',
     '@next/eslint-plugin-next',
     'eslint-plugin-astro',
-    '@vitest/eslint-plugin',
   ],
 
   // Directories to delete on upgrade (no longer managed by safeword)

--- a/packages/cli/src/utils/eslint-peer-check.test.ts
+++ b/packages/cli/src/utils/eslint-peer-check.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for eslint peer-dep mismatch detection.
+ *
+ * The guard reads the project's declared eslint version (dep or devDep) and
+ * compares against safeword's own peerDependencies.eslint range. If the major
+ * version is outside the supported set, returns a warning string; otherwise
+ * returns null. Skips silently when nothing is declared or the range can't
+ * be parsed — only positively-mismatched majors warn.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createTemporaryDirectory,
+  removeTemporaryDirectory,
+  writeTestFile,
+} from '../../tests/helpers.js';
+import { getEslintPeerMismatchWarning } from './eslint-peer-check.js';
+
+describe('getEslintPeerMismatchWarning', () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(temporaryDirectory);
+  });
+
+  it('returns null when no package.json exists', () => {
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns null when package.json declares no eslint dependency', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { typescript: '^5.0.0' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns null when eslint is in the supported major (9.x as caret range)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^9.39.4' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns null for a pinned 9.x version', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '9.39.4' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns a warning for pinned eslint 10.0.0 (above safeword supported range)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '10.0.0' } }),
+    );
+    const warning = getEslintPeerMismatchWarning(temporaryDirectory);
+    expect(warning).not.toBeUndefined();
+    expect(warning).toContain('eslint');
+    expect(warning).toContain('10');
+  });
+
+  it('returns a warning for eslint ^10 caret range', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^10.4.0' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
+  });
+
+  it('returns a warning for eslint below supported range (8.x)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^8.57.0' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
+  });
+
+  it('detects eslint declared in dependencies (not just devDependencies)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', dependencies: { eslint: '10.0.0' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
+  });
+
+  it('returns null for unparseable ranges (workspace:*, file:, git:)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: 'workspace:*' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('warning message names the safeword supported major (9) and the conflict', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^10.0.0' } }),
+    );
+    const warning = getEslintPeerMismatchWarning(temporaryDirectory);
+    expect(warning).toContain('9');
+  });
+});

--- a/packages/cli/src/utils/eslint-peer-check.test.ts
+++ b/packages/cli/src/utils/eslint-peer-check.test.ts
@@ -4,7 +4,7 @@
  * The guard reads the project's declared eslint version (dep or devDep) and
  * compares against safeword's own peerDependencies.eslint range. If the major
  * version is outside the supported set, returns a warning string; otherwise
- * returns null. Skips silently when nothing is declared or the range can't
+ * returns undefined. Skips silently when nothing is declared or the range can't
  * be parsed — only positively-mismatched majors warn.
  */
 
@@ -28,11 +28,11 @@ describe('getEslintPeerMismatchWarning', () => {
     removeTemporaryDirectory(temporaryDirectory);
   });
 
-  it('returns null when no package.json exists', () => {
+  it('returns undefined when no package.json exists', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('returns null when package.json declares no eslint dependency', () => {
+  it('returns undefined when package.json declares no eslint dependency', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
@@ -41,7 +41,7 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('returns null when eslint is in the supported major (9.x as caret range)', () => {
+  it('returns undefined when eslint is in the supported major (9.x as caret range)', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
@@ -50,7 +50,7 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('returns null for a pinned 9.x version', () => {
+  it('returns undefined for a pinned 9.x version', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
@@ -98,7 +98,7 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
   });
 
-  it('returns null for unparseable ranges (workspace:*, file:, git:)', () => {
+  it('returns undefined for unparseable ranges (workspace:*, file:, git:)', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',

--- a/packages/cli/src/utils/eslint-peer-check.ts
+++ b/packages/cli/src/utils/eslint-peer-check.ts
@@ -15,9 +15,9 @@
  * install time rather than the first lint run.
  */
 
-import { createRequire } from 'node:module';
 import nodePath from 'node:path';
 
+import { SAFEWORD_PEER_DEPENDENCIES } from '../version.js';
 import { exists, readJson } from './fs.js';
 
 interface ProjectPackageJson {
@@ -25,19 +25,17 @@ interface ProjectPackageJson {
   devDependencies?: Record<string, string>;
 }
 
-interface SafewordPackageJson {
-  peerDependencies?: Record<string, string>;
-}
-
-const require = createRequire(import.meta.url);
-
 /**
  * Pull the supported eslint major versions from safeword's own peerDependencies.
  * `^9.22.0` → [9]; `^9.22.0 || ^10.0.0` → [9, 10].
+ *
+ * Reads from version.ts rather than calling require() locally — version.ts sits
+ * at src/ depth (same as the bundled dist/) so its `require('../package.json')`
+ * resolves correctly in both contexts. A direct require() here would resolve
+ * `../../package.json` to a nonexistent path post-bundling.
  */
 function getSupportedEslintMajors(): number[] {
-  const pkg = require('../../package.json') as SafewordPackageJson;
-  const range = pkg.peerDependencies?.eslint;
+  const range = SAFEWORD_PEER_DEPENDENCIES.eslint;
   if (!range) return [];
   return extractMajors(range);
 }

--- a/packages/cli/src/utils/eslint-peer-check.ts
+++ b/packages/cli/src/utils/eslint-peer-check.ts
@@ -1,0 +1,100 @@
+/**
+ * ESLint peer-dep mismatch detection for safeword install/upgrade flows.
+ *
+ * Reads the project's declared `eslint` version (dependencies or devDependencies)
+ * and compares its major against safeword's own peerDependencies.eslint range.
+ * Returns a human-readable warning when the customer's major is outside the
+ * supported set; returns undefined otherwise (including when nothing is
+ * declared or the range can't be parsed — only positively-mismatched majors
+ * warn).
+ *
+ * Background: safeword's ESLint preset bundles plugins whose internals can
+ * break on ESLint majors safeword hasn't tested against. The vitest plugin's
+ * transitive @typescript-eslint/utils@7.x crashed on ESLint 10 LegacyESLint
+ * removal; that motivated this guard so the next collision surfaces at
+ * install time rather than the first lint run.
+ */
+
+import { createRequire } from 'node:module';
+import nodePath from 'node:path';
+
+import { exists, readJson } from './fs.js';
+
+interface ProjectPackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+interface SafewordPackageJson {
+  peerDependencies?: Record<string, string>;
+}
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Pull the supported eslint major versions from safeword's own peerDependencies.
+ * `^9.22.0` → [9]; `^9.22.0 || ^10.0.0` → [9, 10].
+ */
+function getSupportedEslintMajors(): number[] {
+  const pkg = require('../../package.json') as SafewordPackageJson;
+  const range = pkg.peerDependencies?.eslint;
+  if (!range) return [];
+  return extractMajors(range);
+}
+
+/**
+ * Extract the leading numeric major from a single version comparator
+ * (e.g. `^9.22.0`, `>=9.0.0`, `9.x`, `9.0.0`). Returns undefined for ranges
+ * that can't be coerced (workspace:*, file:, git+, *, latest).
+ */
+function extractMajorFromComparator(comparator: string): number | undefined {
+  const cleaned = comparator.trim().replace(/^[\^~>=<]+/, '');
+  const match = /^(\d+)\./.exec(cleaned) ?? /^(\d+)(?:\.x|\.\*|$)/.exec(cleaned);
+  const majorString = match?.[1];
+  if (majorString === undefined) return undefined;
+  const major = Number.parseInt(majorString, 10);
+  return Number.isNaN(major) ? undefined : major;
+}
+
+/**
+ * Parse a possibly-disjunctive range (`^9.22.0 || ^10.0.0`) into the set of
+ * majors it covers. Comparators that don't yield a major are dropped.
+ */
+function extractMajors(range: string): number[] {
+  const majors = new Set<number>();
+  for (const part of range.split('||')) {
+    const major = extractMajorFromComparator(part);
+    if (major !== undefined) majors.add(major);
+  }
+  return [...majors].toSorted((a, b) => a - b);
+}
+
+/**
+ * Returns a warning string when the project's declared eslint major is
+ * outside safeword's supported peer range; undefined otherwise.
+ */
+export function getEslintPeerMismatchWarning(cwd: string): string | undefined {
+  const packageJsonPath = nodePath.join(cwd, 'package.json');
+  if (!exists(packageJsonPath)) return undefined;
+
+  const pkg = readJson(packageJsonPath) as ProjectPackageJson | undefined;
+  if (!pkg) return undefined;
+
+  const declared = pkg.dependencies?.eslint ?? pkg.devDependencies?.eslint;
+  if (!declared) return undefined;
+
+  const installedMajor = extractMajorFromComparator(declared);
+  if (installedMajor === undefined) return undefined;
+
+  const supportedMajors = getSupportedEslintMajors();
+  if (supportedMajors.length === 0) return undefined;
+  if (supportedMajors.includes(installedMajor)) return undefined;
+
+  const supportedDisplay = supportedMajors.map(major => `${major}.x`).join(' or ');
+  return [
+    `Project declares eslint@${declared} (major ${installedMajor}), but safeword`,
+    `supports eslint ${supportedDisplay}. Safeword's bundled plugins are tested`,
+    `against the supported range; lint may crash on other majors (e.g. plugin`,
+    `transitives that reference removed ESLint APIs).`,
+  ].join('\n');
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,6 +1,15 @@
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const pkg = require('../package.json') as { version: string };
+// The relative path is intentional and must stay at one `..` — version.ts is at
+// src/ (depth 1 from packages/cli/), and tsup bundles it to dist/ (also depth 1),
+// so `../package.json` resolves correctly in both contexts. Helpers nested under
+// src/utils/ cannot read package.json directly without breaking once bundled —
+// they should import the metadata from here instead.
+const pkg = require('../package.json') as {
+  version: string;
+  peerDependencies?: Record<string, string>;
+};
 
 export const VERSION = pkg.version;
+export const SAFEWORD_PEER_DEPENDENCIES = pkg.peerDependencies ?? {};


### PR DESCRIPTION
## Summary

- **Unblock ESLint 10 customers.** Migrate `eslint-plugin-vitest@0.5.4` (abandoned, last published April 2024) → `@vitest/eslint-plugin@1.6.17` (the official renamed successor, same repo). The old plugin transitively pulled `@typescript-eslint/utils@7.18.0`, whose `LegacyESLint` class was removed in ESLint 10 — *any* safeword consumer who lands on ESLint 10 crashes at plugin load. Confirmed trace from a separate session (`www` project, post-Biome→ESLint-10 migration, clean safeword@0.30.3 install). Verified single `@typescript-eslint/utils@8.59.3` resolution across the whole lockfile post-swap.
- **Prevent the next collision at install time.** New `getEslintPeerMismatchWarning` utility reads the project's declared `eslint` version, compares the major against safeword's own `peerDependencies.eslint` range, and warns via `safeword setup` / `safeword upgrade` when out of range. Doesn't block — bun's own peer-dep warnings don't, and we're not stricter than bun. 10 unit tests cover the major branches.
- **Honesty over false-positive support.** `peerDependencies.eslint` deliberately *not* expanded to include `^10.0.0`. `eslint-plugin-react@7.37.5` still crashes on v10 (Phase 3 of [ticket #099](https://github.com/ArcadeAI/safeword/blob/wizardly-joliot-76687b/.safeword-project/tickets/099-eslint-10-migration/ticket.md), blocked on `jsx-eslint/eslint-plugin-react#3979` + `import-js/eslint-plugin-import#3227`, both still open). When upstream lands and the peer range expands, the new guard automatically broadens with it — it reads safeword's own peerDependencies, no hardcoded `9`.
- **Two ticket updates as part of the same PR.** #099 corrects the 2026-05-14 "Phase 2 effectively done" overclaim (vitest plugin migration was missed; jsx-a11y empirically verified clean for v10 via 184-file source grep). #152 files the four `bun audit` advisories surfaced by `/quality-review` (all pre-existing, none caused by this branch — separate scoped follow-up).

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `b93b696` | `fix(eslint)`: vitest plugin swap |
| 2 | `fb280b4` | `docs(099)`: Phase 2 correction + plugin audit findings |
| 3 | `553c364` | `feat(setup,upgrade)`: install-time peer-dep guard |
| 4 | `81892d8` | `docs(152)`: track `bun audit` advisories for follow-up |
| 5 | `b4e4002` | `docs(test)`: cosmetic test-name drift cleanup (caught by `/audit`) |

## Test plan

- [x] Full CLI test suite: 1774 / 1775 pass (1 pre-existing skip), 92 files
- [x] 10/10 new tests for `getEslintPeerMismatchWarning`
- [x] `bun run lint:eslint` clean
- [x] `bun run format:check` clean
- [x] `tsc --noEmit` clean (0 errors)
- [x] `bunx depcruise` clean (0 violations, 190 modules cruised)
- [x] `jscpd` 0 clones in session-changed files
- [x] `@vitest/eslint-plugin` rule names verified against upstream README (drop-in)
- [x] `@typescript-eslint/utils@7.x` confirmed removed from lockfile (single 8.59.3 resolution)
- [x] `bun audit`: zero new advisories; 4 pre-existing tracked in #152
- [ ] **Suggested before merge:** smoke `safeword setup` on a project pinned to `eslint@10.0.0` and confirm the new warning string appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)