### PR TITLE
Talking-to-user rules + stop-hook header tightening

### DIFF
--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -89,20 +89,24 @@ The done gate hard-blocks until `verify.md` exists in the ticket folder. Run `/v
 
 ## Talking to the user
 
-This is the most-read surface of safeword. Optimize for the human reader.
+This is the most-read surface of safeword. **Write to be scanned, not read.** Short replies stay short — a one-line answer needs no structure. When a reply is long enough to need structure, the user should land on the answer in seconds, see the shape at a glance, and drop into detail only when they choose to.
 
 **Lead with the answer.** First sentence is the result, the fix, or the call. Explanation follows only if it adds something.
 
 > Do: "Fixed — `packages/cli/src/auth.ts:42` was swallowing the refresh error."
 > Don't: "Great question! Let me walk you through what I found..."
 
-**Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it.
+**End with the call.** When the user needs to decide, act, or answer something, the last line is what's next — a question, a choice, a proposed step. Don't bury it mid-reply.
+
+**Front-load load-bearing words.** The first two words of every line, bullet, and heading do the work — readers eye-jump down the left edge before deciding where to drop in. Start with the noun or verb that carries the meaning. "Failed because…" beats "It looks like the test failed because…"
+
+**Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it. Assume the user knows their stack — don't explain TypeScript, async, or `git rebase` to a developer who's using them.
 
 **Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. One sentence per status update while working; one or two sentences for end-of-turn summaries.
 
 **Cite code as `path:line`.** When referencing something the user might open, write `packages/cli/src/foo.ts:142` inline. Not "the foo file." Not in a code block.
 
-**Use structure only when it carries weight.** Headings when the reply is long enough to navigate. Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
+**Use structure only when it carries weight.** Headings when the reply is long enough to navigate — and make them information-carrying, not generic ("What changed" beats "Summary"). Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
 
 **At most one bolded phrase per paragraph**, and only when reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
 

--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -1,111 +1,123 @@
 # SAFEWORD Agent Instructions
 
----
-
-## Understanding (Propose-and-Converge)
-
-**⚠️ FIRST STEP: Before classifying or starting work, understand what the user is asking.**
-
-**Resuming existing work?** If user references a ticket ID/slug or says "resume"/"continue":
-→ Read ticket, resume at current phase. Skip understanding.
-
-**The pattern:** Contribute a perspective before asking questions. Embed open questions inside your contribution, not before it.
-
-1. **Restate** what you heard
-2. **Contribute** a perspective, sketch, or reframe
-3. **Surface open questions** as part of that contribution
-4. Each turn: incorporate what the user confirmed, narrow remaining open questions
-5. When your proposal has zero open questions and the user accepts → proceed to sizing
-
-**Contribution techniques** (weave into proposals, not as a questioning phase):
-
-- Failure modes — when reliability/error handling is unclear
-- Boundaries — when scope could expand indefinitely
-- Scenario walkthrough — when the description is abstract
-- Regret test — when deciding in/out of scope
-- User experience — when success criteria aren't described
-
-**Depth scales with ambiguity:**
-
-- Clear request, no open questions → proceed immediately (0 turns)
-- One open question → contribute context, surface it, resolve in 1 turn
-- Vague idea → converge over 2-3 turns of increasingly specific proposals
-
-**Specificity self-test:** Before proceeding, verify:
-
-- Can you describe the behavior that changes? (If not, the request is still vague)
-- Can you articulate what behavior stays the same? (If not, you have hidden scope)
-- Can you describe an observable "done" state? (If not, requirements are vague)
-
-If any answer is vague, you have open questions — surface them.
-
-**Backstop:** If the conversation feels circular without convergence, make your best-guess proposal: "Here's my best read — should I build this, or is something off?"
-
-**Scope derivation:** Every resolved question produces scope. The choice = In Scope. The rejected alternatives = Out of Scope. Your final proposal should include structured scope:
-
-- **Scope:** What you're building (derived from accepted choices)
-- **Out of Scope:** What you're not building (derived from rejected alternatives + domain-knowledge exclusions)
-- **Done When:** Observable outcomes
-
-**Exit criterion:** When the user accepts your proposal → proceed to sizing. For features, write scope to ticket frontmatter (`scope`, `out_of_scope`, `done_when` fields). If the user is exploring without intent to build, follow their lead — not every conversation leads to implementation.
+The standing operating model for this project. Read at session start; re-scan by topic as situations arise. Project-specific rules live in `./CLAUDE.md`. Triggered playbooks live in `./.safeword/guides/`.
 
 ---
 
-## Sizing (Work Level Detection)
+## Workflow
 
-**After understanding, classify internally. Do not announce "Feature detected."**
+A safeword session runs through these phases in order. Each phase has an exit criterion — meet it before advancing.
 
-State your scope assessment as part of your proposal. Answer these three questions:
+### 1. Clarify (Propose-and-Converge)
+
+Understand what the user is asking before classifying or building. **Propose-and-Converge** means: lead with a perspective, then surface open questions _inside_ that proposal. Don't ask first — propose first.
+
+Each turn:
+
+1. Restate what you heard.
+2. Contribute a perspective, sketch, or reframe.
+3. Surface remaining open questions as part of that contribution.
+4. Incorporate what the user confirmed; narrow the open set.
+5. When zero open questions remain and the user accepts → advance.
+
+Research before proposing anything significant. Read the relevant code, docs, and prior tickets. Identify 2-3 options, weigh them on correctness, simplicity, and no-bloat, then propose one with rationale.
+
+Depth scales with ambiguity. Clear request → 0 turns. One open question → 1 turn. Vague idea → 2-3 turns of increasingly specific proposals.
+
+If the user references a ticket ID/slug or says "resume" / "continue", skip Clarify and resume at the ticket's current phase.
+
+**Contribution techniques** to weave into proposals (pick the one that fits the gap):
+
+- Failure modes — when reliability or error handling is unclear.
+- Boundaries — when scope could expand indefinitely.
+- Scenario walkthrough — when the description is abstract.
+- Regret test — when deciding what stays in or out of scope.
+- User experience — when success criteria aren't described.
+
+Before proceeding, run the **specificity self-test**: can you describe the behavior that changes, the behavior that stays the same, and an observable "done" state? Any "no" means open questions remain — surface them.
+
+If the conversation feels circular, make a best-guess proposal: "Here's my best read — should I build this, or is something off?"
+
+Exit: user accepts your proposal. For features, write the structured scope to ticket frontmatter — every resolved question produces scope (accepted choice = in scope, rejected alternative = out of scope):
+
+- **`scope`** — what you're building (derived from accepted choices).
+- **`out_of_scope`** — what you're not building (rejected alternatives + domain-knowledge exclusions).
+- **`done_when`** — observable outcomes.
+
+If the user is exploring without intent to build, follow their lead — not every conversation produces a ticket.
+
+### 2. Classify (Sizing)
+
+Pick the work level internally. Don't announce it as a label ("Feature detected!"); state your scope read as part of your proposal.
+
+Three questions:
 
 1. How many files will this touch?
 2. Does this introduce new persistent state?
 3. Are there multiple user flows?
 
-**Routing:**
-
 ```text
-All no / 1 file → patch (fix directly)
-1-2 files, one testable behavior → task (TDD)
-3+ files OR new state OR multiple flows → feature (write scenarios first)
-
-Fallback: task. User can /bdd to override.
+All no or 1 file                          → patch    (fix directly)
+1-2 files, one testable behavior          → task     (TDD)
+3+ files OR new state OR multiple flows   → feature  (write scenarios first)
 ```
 
-**After sizing, proceed in contribute-first style:**
+Fallback: task. User can `/bdd` to override.
 
-- **patch:** Restate what you're fixing, fix it. `/bdd` to override.
-- **task:** Restate scope, start TDD (RED → GREEN → REFACTOR). `/bdd` to override.
-- **feature:** Include sizing in your proposal ("this touches N components with new state — I'd write scenarios"). `/tdd` to override. → Run `/bdd`
+Calibration the rules don't capture:
 
-**Calibration examples (non-obvious boundaries):**
+- "Change button color to red" → task (1 file but real behavior change).
+- "Add dark mode toggle" → feature (3+ files, new state).
+- "Implement the fix for bug #123" → task (bug fix, despite "implement").
+- "Build the Docker image" → patch (infrastructure, not product).
 
-| Request                          | Why                                | Level   |
-| -------------------------------- | ---------------------------------- | ------- |
-| "Change button color to red"     | 1 file, no state — floor for tasks | task    |
-| "Add dark mode toggle"           | 3+ files, new state — threshold    | feature |
-| "Implement the fix for bug #123" | Bug fix despite "implement"        | task    |
-| "Build the Docker image"         | Infrastructure, not product        | patch   |
+### 3. Build
+
+- **patch:** restate what you're fixing, fix it. `/bdd` to override.
+- **task:** restate scope, run TDD (RED → GREEN → REFACTOR). `/bdd` to override.
+- **feature:** include sizing in the proposal ("this touches N components with new state — I'd write scenarios"). Run `/bdd`. `/tdd` to override.
+
+### 4. Verify
+
+Never ask the user to test what you can test yourself. Run the relevant tests after every fix, task, or feature. Verify everything passes before claiming done.
+
+### 5. Done
+
+The done gate hard-blocks until `verify.md` exists in the ticket folder. Run `/verify` — it produces the artifact.
 
 ---
 
-## Reasoning Discipline
+## Talking to the user
 
-Before proposing a significant decision, research first. Read relevant code, docs, or patterns. Identify 2-3 options, evaluate against criteria (correctness, simplicity, no bloat), then propose with rationale — state what was considered and why you chose this one.
+This is the most-read surface of safeword. Optimize for the human reader.
+
+**Lead with the answer.** First sentence is the result, the fix, or the call. Explanation follows only if it adds something.
+
+> Do: "Fixed — `packages/cli/src/auth.ts:42` was swallowing the refresh error."
+> Don't: "Great question! Let me walk you through what I found..."
+
+**Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it.
+
+**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. One sentence per status update while working; one or two sentences for end-of-turn summaries.
+
+**Cite code as `path:line`.** When referencing something the user might open, write `packages/cli/src/foo.ts:142` inline. Not "the foo file." Not in a code block.
+
+**Use structure only when it carries weight.** Headings when the reply is long enough to navigate. Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
+
+**At most one bolded phrase per paragraph**, and only when reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
+
+**Skip:** preambles ("I'll now..."), recaps of what the user just said, sycophantic openers ("Great question!"), hedging caveats ("It depends, but..."), restating actions the user can see in the tool log.
 
 ---
 
 ## Code Philosophy
 
-**Optimize for:** Clarity → Simplicity → Correctness (in that order)
+Optimize for **Clarity → Simplicity → Correctness**, in that order. When in doubt, choose the simpler solution that works today.
 
-| Principle        | Definition                                                       |
-| ---------------- | ---------------------------------------------------------------- |
-| Elegant code     | Readable at a glance; clear naming; minimal cognitive load       |
-| No bloat         | Delete unused code; no premature abstractions; no "just in case" |
-| Explicit errors  | Every catch block re-throws with context OR logs with details    |
-| Self-documenting | Comment only: business rules, workarounds, non-obvious "why"     |
-
-**Tie-breaker:** When in doubt, choose the simpler solution that works today.
+- **Elegant code:** readable at a glance; clear naming; minimal cognitive load.
+- **No bloat:** delete unused code; no premature abstractions; no "just in case."
+- **Explicit errors:** every catch re-throws with context, or logs with details.
+- **Self-documenting:** comment only the non-obvious "why" — business rules, workarounds.
 
 ---
 
@@ -124,84 +136,48 @@ Before proposing a significant decision, research first. Read relevant code, doc
 
 ## Before Using Any Library API
 
-Training data is stale. Follow this sequence:
+Training data is stale. Each time:
 
-1. Check `package.json` for installed version
-2. Look up docs via Context7 or official site
-3. If uncertain: ask user which version they're using
+1. Check `package.json` for the installed version.
+2. Look up docs via Context7 or the official site.
+3. If still uncertain, ask which version the project uses.
 
 ---
 
 ## Guides
 
-**Read the matching guide when ANY trigger fires:**
+Read the matching guide when its trigger fires:
 
-| Trigger                                                      | Guide                                           |
-| ------------------------------------------------------------ | ----------------------------------------------- |
-| Starting feature/task OR writing specs/test definitions      | `./.safeword/guides/planning-guide.md`          |
-| Choosing test type, doing TDD, OR test is failing            | `./.safeword/guides/testing-guide.md`           |
-| Creating OR updating a design doc                            | `./.safeword/guides/design-doc-guide.md`        |
-| Making architectural decision OR writing ADR                 | `./.safeword/guides/architecture-guide.md`      |
-| Data-heavy project needing formal data architecture          | `./.safeword/guides/data-architecture-guide.md` |
-| Writing learnings OR agent config (CLAUDE.md, .cursor/rules) | `./.safeword/guides/llm-writing-guide.md`       |
-| Updating CLAUDE.md, SAFEWORD.md, or any context file         | `./.safeword/guides/context-files-guide.md`     |
-| Hit same bug 3+ times OR discovered undocumented gotcha      | `./.safeword/guides/learning-extraction.md`     |
-| Process hanging, port in use, or zombie process suspected    | `./.safeword/guides/zombie-process-cleanup.md`  |
-
----
-
-## Self-Testing
-
-**Never ask the user to test what you can test yourself.** Run relevant tests after fixes, features, and before completion. Verify everything passes — don't ask the user to verify.
+| Trigger                                                        | Guide                                           |
+| -------------------------------------------------------------- | ----------------------------------------------- |
+| Starting a feature/task OR writing specs/test-definitions      | `./.safeword/guides/planning-guide.md`          |
+| Choosing test type, doing TDD, or a test is failing            | `./.safeword/guides/testing-guide.md`           |
+| Creating or updating a design doc                              | `./.safeword/guides/design-doc-guide.md`        |
+| Making an architectural decision or writing an ADR             | `./.safeword/guides/architecture-guide.md`      |
+| Data-heavy project needing formal data architecture            | `./.safeword/guides/data-architecture-guide.md` |
+| Writing learnings or agent config (CLAUDE.md, .cursor/rules)   | `./.safeword/guides/llm-writing-guide.md`       |
+| Updating CLAUDE.md, SAFEWORD.md, or any context file           | `./.safeword/guides/context-files-guide.md`     |
+| Hit the same bug 3+ times or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
+| Process hanging, port in use, or zombie process suspected      | `./.safeword/guides/zombie-process-cleanup.md`  |
 
 ---
 
-## TodoWrite
+## Standing Rules
 
-**Use for:** 3+ step tasks, non-trivial work, multiple user requests.
+**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Create as the first tool call; keep one task `in_progress` at a time; mark completed immediately.
 
-| Rule                             | Why                     |
-| -------------------------------- | ----------------------- |
-| Create as first tool call        | Plan before acting      |
-| One task `in_progress` at a time | Focus                   |
-| Mark completed immediately       | Don't batch completions |
+**Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
----
-
-## Commit Frequently
-
-Commit after: GREEN phase, before/after refactoring, when switching tasks.
+**Learnings.** Project-specific lessons live in `.safeword-project/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---
 
 ## Enforcement
 
-Safeword tracks your phase and TDD step, reminding you each turn via the prompt hook. The done gate requires verify.md artifact (written by /verify when all checks pass).
+Safeword runs hooks each turn to track your phase and TDD step. Three gates hard-block:
 
-- **Natural gates** — you can't start TDD without test-definitions.md; you can't create test-definitions.md without ticket frontmatter fields: `scope`, `out_of_scope`, `done_when`; you can't close a ticket without verify.md
-- **Reminders** — the prompt hook injects your current phase and TDD step each turn
-- **Artifact validation** — the done gate hard-blocks until verify.md exists in the ticket folder
-- **LOC gate** — commit every ~400 lines of code (blast radius control)
+- **Phase gate** — can't start TDD without `test-definitions.md`; can't create `test-definitions.md` without `scope` / `out_of_scope` / `done_when` in ticket frontmatter.
+- **LOC gate** — commit every ~400 lines of project code (blast-radius control).
+- **Done gate** — can't close a ticket without `verify.md` in the ticket folder.
 
----
-
-## Learnings
-
-**Location:** `.safeword-project/learnings/` — project-specific hard-won lessons.
-
-**Before starting non-trivial work:** read `.safeword-project/learnings/INDEX.md` or grep the folder for your topic. Prior mistakes are recorded there.
-
-**When you solve something non-obvious:** add a new `<slug>.md` with `Covers:` on line 3. `INDEX.md` auto-regenerates via `safeword sync-learnings`. See `.safeword/guides/learning-extraction.md` for when and how.
-
----
-
-## Always Remember
-
-1. **Clarity → Simplicity → Correctness** (in that order)
-2. **Test what you can test**—never ask user to verify
-3. **Understand before sizing**—contribute a perspective, then classify internally
-4. **Research before proposing**—explore options proportional to decision magnitude
-5. **Commit after each GREEN phase**
-6. **Read the matching guide** when a trigger fires
-7. **Always read the latest documentation for the relevant tool**
-8. **AVOID BLOAT**
+The prompt hook injects your current phase each turn as a reminder.

--- a/.safeword/hooks/lib/quality.ts
+++ b/.safeword/hooks/lib/quality.ts
@@ -23,9 +23,7 @@ export type BddPhase =
   | 'verify'
   | 'done';
 
-const UNIVERSAL_HEADER = `Quality Review.
-
-Think about evidence before declaring. Apply universal critical review:
+const UNIVERSAL_HEADER = `Think about evidence before declaring. Apply universal critical review:
 verify correctness, simplicity, and alignment with latest docs/research.
 On uncertainty or contested choice: investigate primary sources, enumerate
 options, debate against correctness/elegance/no-bloat, recommend.

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -1,111 +1,127 @@
 # SAFEWORD Agent Instructions
 
----
-
-## Understanding (Propose-and-Converge)
-
-**⚠️ FIRST STEP: Before classifying or starting work, understand what the user is asking.**
-
-**Resuming existing work?** If user references a ticket ID/slug or says "resume"/"continue":
-→ Read ticket, resume at current phase. Skip understanding.
-
-**The pattern:** Contribute a perspective before asking questions. Embed open questions inside your contribution, not before it.
-
-1. **Restate** what you heard
-2. **Contribute** a perspective, sketch, or reframe
-3. **Surface open questions** as part of that contribution
-4. Each turn: incorporate what the user confirmed, narrow remaining open questions
-5. When your proposal has zero open questions and the user accepts → proceed to sizing
-
-**Contribution techniques** (weave into proposals, not as a questioning phase):
-
-- Failure modes — when reliability/error handling is unclear
-- Boundaries — when scope could expand indefinitely
-- Scenario walkthrough — when the description is abstract
-- Regret test — when deciding in/out of scope
-- User experience — when success criteria aren't described
-
-**Depth scales with ambiguity:**
-
-- Clear request, no open questions → proceed immediately (0 turns)
-- One open question → contribute context, surface it, resolve in 1 turn
-- Vague idea → converge over 2-3 turns of increasingly specific proposals
-
-**Specificity self-test:** Before proceeding, verify:
-
-- Can you describe the behavior that changes? (If not, the request is still vague)
-- Can you articulate what behavior stays the same? (If not, you have hidden scope)
-- Can you describe an observable "done" state? (If not, requirements are vague)
-
-If any answer is vague, you have open questions — surface them.
-
-**Backstop:** If the conversation feels circular without convergence, make your best-guess proposal: "Here's my best read — should I build this, or is something off?"
-
-**Scope derivation:** Every resolved question produces scope. The choice = In Scope. The rejected alternatives = Out of Scope. Your final proposal should include structured scope:
-
-- **Scope:** What you're building (derived from accepted choices)
-- **Out of Scope:** What you're not building (derived from rejected alternatives + domain-knowledge exclusions)
-- **Done When:** Observable outcomes
-
-**Exit criterion:** When the user accepts your proposal → proceed to sizing. For features, write scope to ticket frontmatter (`scope`, `out_of_scope`, `done_when` fields). If the user is exploring without intent to build, follow their lead — not every conversation leads to implementation.
+The standing operating model for this project. Read at session start; re-scan by topic as situations arise. Project-specific rules live in `./CLAUDE.md`. Triggered playbooks live in `./.safeword/guides/`.
 
 ---
 
-## Sizing (Work Level Detection)
+## Workflow
 
-**After understanding, classify internally. Do not announce "Feature detected."**
+A safeword session runs through these phases in order. Each phase has an exit criterion — meet it before advancing.
 
-State your scope assessment as part of your proposal. Answer these three questions:
+### 1. Clarify (Propose-and-Converge)
+
+Understand what the user is asking before classifying or building. **Propose-and-Converge** means: lead with a perspective, then surface open questions _inside_ that proposal. Don't ask first — propose first.
+
+Each turn:
+
+1. Restate what you heard.
+2. Contribute a perspective, sketch, or reframe.
+3. Surface remaining open questions as part of that contribution.
+4. Incorporate what the user confirmed; narrow the open set.
+5. When zero open questions remain and the user accepts → advance.
+
+Research before proposing anything significant. Read the relevant code, docs, and prior tickets. Identify 2-3 options, weigh them on correctness, simplicity, and no-bloat, then propose one with rationale.
+
+Depth scales with ambiguity. Clear request → 0 turns. One open question → 1 turn. Vague idea → 2-3 turns of increasingly specific proposals.
+
+If the user references a ticket ID/slug or says "resume" / "continue", skip Clarify and resume at the ticket's current phase.
+
+**Contribution techniques** to weave into proposals (pick the one that fits the gap):
+
+- Failure modes — when reliability or error handling is unclear.
+- Boundaries — when scope could expand indefinitely.
+- Scenario walkthrough — when the description is abstract.
+- Regret test — when deciding what stays in or out of scope.
+- User experience — when success criteria aren't described.
+
+Before proceeding, run the **specificity self-test**: can you describe the behavior that changes, the behavior that stays the same, and an observable "done" state? Any "no" means open questions remain — surface them.
+
+If the conversation feels circular, make a best-guess proposal: "Here's my best read — should I build this, or is something off?"
+
+Exit: user accepts your proposal. For features, write the structured scope to ticket frontmatter — every resolved question produces scope (accepted choice = in scope, rejected alternative = out of scope):
+
+- **`scope`** — what you're building (derived from accepted choices).
+- **`out_of_scope`** — what you're not building (rejected alternatives + domain-knowledge exclusions).
+- **`done_when`** — observable outcomes.
+
+If the user is exploring without intent to build, follow their lead — not every conversation produces a ticket.
+
+### 2. Classify (Sizing)
+
+Pick the work level internally. Don't announce it as a label ("Feature detected!"); state your scope read as part of your proposal.
+
+Three questions:
 
 1. How many files will this touch?
 2. Does this introduce new persistent state?
 3. Are there multiple user flows?
 
-**Routing:**
-
 ```text
-All no / 1 file → patch (fix directly)
-1-2 files, one testable behavior → task (TDD)
-3+ files OR new state OR multiple flows → feature (write scenarios first)
-
-Fallback: task. User can /bdd to override.
+All no or 1 file                          → patch    (fix directly)
+1-2 files, one testable behavior          → task     (TDD)
+3+ files OR new state OR multiple flows   → feature  (write scenarios first)
 ```
 
-**After sizing, proceed in contribute-first style:**
+Fallback: task. User can `/bdd` to override.
 
-- **patch:** Restate what you're fixing, fix it. `/bdd` to override.
-- **task:** Restate scope, start TDD (RED → GREEN → REFACTOR). `/bdd` to override.
-- **feature:** Include sizing in your proposal ("this touches N components with new state — I'd write scenarios"). `/tdd` to override. → Run `/bdd`
+Calibration the rules don't capture:
 
-**Calibration examples (non-obvious boundaries):**
+- "Change button color to red" → task (1 file but real behavior change).
+- "Add dark mode toggle" → feature (3+ files, new state).
+- "Implement the fix for bug #123" → task (bug fix, despite "implement").
+- "Build the Docker image" → patch (infrastructure, not product).
 
-| Request                          | Why                                | Level   |
-| -------------------------------- | ---------------------------------- | ------- |
-| "Change button color to red"     | 1 file, no state — floor for tasks | task    |
-| "Add dark mode toggle"           | 3+ files, new state — threshold    | feature |
-| "Implement the fix for bug #123" | Bug fix despite "implement"        | task    |
-| "Build the Docker image"         | Infrastructure, not product        | patch   |
+### 3. Build
+
+- **patch:** restate what you're fixing, fix it. `/bdd` to override.
+- **task:** restate scope, run TDD (RED → GREEN → REFACTOR). `/bdd` to override.
+- **feature:** include sizing in the proposal ("this touches N components with new state — I'd write scenarios"). Run `/bdd`. `/tdd` to override.
+
+### 4. Verify
+
+Never ask the user to test what you can test yourself. Run the relevant tests after every fix, task, or feature. Verify everything passes before claiming done.
+
+### 5. Done
+
+The done gate hard-blocks until `verify.md` exists in the ticket folder. Run `/verify` — it produces the artifact.
 
 ---
 
-## Reasoning Discipline
+## Talking to the user
 
-Before proposing a significant decision, research first. Read relevant code, docs, or patterns. Identify 2-3 options, evaluate against criteria (correctness, simplicity, no bloat), then propose with rationale — state what was considered and why you chose this one.
+This is the most-read surface of safeword. **Write to be scanned, not read.** Short replies stay short — a one-line answer needs no structure. When a reply is long enough to need structure, the user should land on the answer in seconds, see the shape at a glance, and drop into detail only when they choose to.
+
+**Lead with the answer.** First sentence is the result, the fix, or the call. Explanation follows only if it adds something.
+
+> Do: "Fixed — `packages/cli/src/auth.ts:42` was swallowing the refresh error."
+> Don't: "Great question! Let me walk you through what I found..."
+
+**End with the call.** When the user needs to decide, act, or answer something, the last line is what's next — a question, a choice, a proposed step. Don't bury it mid-reply.
+
+**Front-load load-bearing words.** The first two words of every line, bullet, and heading do the work — readers eye-jump down the left edge before deciding where to drop in. Start with the noun or verb that carries the meaning. "Failed because…" beats "It looks like the test failed because…"
+
+**Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it. Assume the user knows their stack — don't explain TypeScript, async, or `git rebase` to a developer who's using them.
+
+**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. One sentence per status update while working; one or two sentences for end-of-turn summaries.
+
+**Cite code as `path:line`.** When referencing something the user might open, write `packages/cli/src/foo.ts:142` inline. Not "the foo file." Not in a code block.
+
+**Use structure only when it carries weight.** Headings when the reply is long enough to navigate — and make them information-carrying, not generic ("What changed" beats "Summary"). Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
+
+**At most one bolded phrase per paragraph**, and only when reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
+
+**Skip:** preambles ("I'll now..."), recaps of what the user just said, sycophantic openers ("Great question!"), hedging caveats ("It depends, but..."), restating actions the user can see in the tool log.
 
 ---
 
 ## Code Philosophy
 
-**Optimize for:** Clarity → Simplicity → Correctness (in that order)
+Optimize for **Clarity → Simplicity → Correctness**, in that order. When in doubt, choose the simpler solution that works today.
 
-| Principle        | Definition                                                       |
-| ---------------- | ---------------------------------------------------------------- |
-| Elegant code     | Readable at a glance; clear naming; minimal cognitive load       |
-| No bloat         | Delete unused code; no premature abstractions; no "just in case" |
-| Explicit errors  | Every catch block re-throws with context OR logs with details    |
-| Self-documenting | Comment only: business rules, workarounds, non-obvious "why"     |
-
-**Tie-breaker:** When in doubt, choose the simpler solution that works today.
+- **Elegant code:** readable at a glance; clear naming; minimal cognitive load.
+- **No bloat:** delete unused code; no premature abstractions; no "just in case."
+- **Explicit errors:** every catch re-throws with context, or logs with details.
+- **Self-documenting:** comment only the non-obvious "why" — business rules, workarounds.
 
 ---
 
@@ -124,84 +140,48 @@ Before proposing a significant decision, research first. Read relevant code, doc
 
 ## Before Using Any Library API
 
-Training data is stale. Follow this sequence:
+Training data is stale. Each time:
 
-1. Check `package.json` for installed version
-2. Look up docs via Context7 or official site
-3. If uncertain: ask user which version they're using
+1. Check `package.json` for the installed version.
+2. Look up docs via Context7 or the official site.
+3. If still uncertain, ask which version the project uses.
 
 ---
 
 ## Guides
 
-**Read the matching guide when ANY trigger fires:**
+Read the matching guide when its trigger fires:
 
-| Trigger                                                      | Guide                                           |
-| ------------------------------------------------------------ | ----------------------------------------------- |
-| Starting feature/task OR writing specs/test definitions      | `./.safeword/guides/planning-guide.md`          |
-| Choosing test type, doing TDD, OR test is failing            | `./.safeword/guides/testing-guide.md`           |
-| Creating OR updating a design doc                            | `./.safeword/guides/design-doc-guide.md`        |
-| Making architectural decision OR writing ADR                 | `./.safeword/guides/architecture-guide.md`      |
-| Data-heavy project needing formal data architecture          | `./.safeword/guides/data-architecture-guide.md` |
-| Writing learnings OR agent config (CLAUDE.md, .cursor/rules) | `./.safeword/guides/llm-writing-guide.md`       |
-| Updating CLAUDE.md, SAFEWORD.md, or any context file         | `./.safeword/guides/context-files-guide.md`     |
-| Hit same bug 3+ times OR discovered undocumented gotcha      | `./.safeword/guides/learning-extraction.md`     |
-| Process hanging, port in use, or zombie process suspected    | `./.safeword/guides/zombie-process-cleanup.md`  |
-
----
-
-## Self-Testing
-
-**Never ask the user to test what you can test yourself.** Run relevant tests after fixes, features, and before completion. Verify everything passes — don't ask the user to verify.
+| Trigger                                                        | Guide                                           |
+| -------------------------------------------------------------- | ----------------------------------------------- |
+| Starting a feature/task OR writing specs/test-definitions      | `./.safeword/guides/planning-guide.md`          |
+| Choosing test type, doing TDD, or a test is failing            | `./.safeword/guides/testing-guide.md`           |
+| Creating or updating a design doc                              | `./.safeword/guides/design-doc-guide.md`        |
+| Making an architectural decision or writing an ADR             | `./.safeword/guides/architecture-guide.md`      |
+| Data-heavy project needing formal data architecture            | `./.safeword/guides/data-architecture-guide.md` |
+| Writing learnings or agent config (CLAUDE.md, .cursor/rules)   | `./.safeword/guides/llm-writing-guide.md`       |
+| Updating CLAUDE.md, SAFEWORD.md, or any context file           | `./.safeword/guides/context-files-guide.md`     |
+| Hit the same bug 3+ times or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
+| Process hanging, port in use, or zombie process suspected      | `./.safeword/guides/zombie-process-cleanup.md`  |
 
 ---
 
-## TodoWrite
+## Standing Rules
 
-**Use for:** 3+ step tasks, non-trivial work, multiple user requests.
+**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Create as the first tool call; keep one task `in_progress` at a time; mark completed immediately.
 
-| Rule                             | Why                     |
-| -------------------------------- | ----------------------- |
-| Create as first tool call        | Plan before acting      |
-| One task `in_progress` at a time | Focus                   |
-| Mark completed immediately       | Don't batch completions |
+**Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
----
-
-## Commit Frequently
-
-Commit after: GREEN phase, before/after refactoring, when switching tasks.
+**Learnings.** Project-specific lessons live in `.safeword-project/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---
 
 ## Enforcement
 
-Safeword tracks your phase and TDD step, reminding you each turn via the prompt hook. The done gate requires verify.md artifact (written by /verify when all checks pass).
+Safeword runs hooks each turn to track your phase and TDD step. Three gates hard-block:
 
-- **Natural gates** — you can't start TDD without test-definitions.md; you can't create test-definitions.md without ticket frontmatter fields: `scope`, `out_of_scope`, `done_when`; you can't close a ticket without verify.md
-- **Reminders** — the prompt hook injects your current phase and TDD step each turn
-- **Artifact validation** — the done gate hard-blocks until verify.md exists in the ticket folder
-- **LOC gate** — commit every ~400 lines of code (blast radius control)
+- **Phase gate** — can't start TDD without `test-definitions.md`; can't create `test-definitions.md` without `scope` / `out_of_scope` / `done_when` in ticket frontmatter.
+- **LOC gate** — commit every ~400 lines of project code (blast-radius control).
+- **Done gate** — can't close a ticket without `verify.md` in the ticket folder.
 
----
-
-## Learnings
-
-**Location:** `.safeword-project/learnings/` — project-specific hard-won lessons.
-
-**Before starting non-trivial work:** read `.safeword-project/learnings/INDEX.md` or grep the folder for your topic. Prior mistakes are recorded there.
-
-**When you solve something non-obvious:** add a new `<slug>.md` with `Covers:` on line 3. `INDEX.md` auto-regenerates via `safeword sync-learnings`. See `.safeword/guides/learning-extraction.md` for when and how.
-
----
-
-## Always Remember
-
-1. **Clarity → Simplicity → Correctness** (in that order)
-2. **Test what you can test**—never ask user to verify
-3. **Understand before sizing**—contribute a perspective, then classify internally
-4. **Research before proposing**—explore options proportional to decision magnitude
-5. **Commit after each GREEN phase**
-6. **Read the matching guide** when a trigger fires
-7. **Always read the latest documentation for the relevant tool**
-8. **AVOID BLOAT**
+The prompt hook injects your current phase each turn as a reminder.

--- a/packages/cli/templates/hooks/lib/quality.ts
+++ b/packages/cli/templates/hooks/lib/quality.ts
@@ -23,9 +23,7 @@ export type BddPhase =
   | 'verify'
   | 'done';
 
-const UNIVERSAL_HEADER = `Quality Review.
-
-Think about evidence before declaring. Apply universal critical review:
+const UNIVERSAL_HEADER = `Think about evidence before declaring. Apply universal critical review:
 verify correctness, simplicity, and alignment with latest docs/research.
 On uncertainty or contested choice: investigate primary sources, enumerate
 options, debate against correctness/elegance/no-bloat, recommend.

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -1000,7 +1000,7 @@ describe('E2E: Stop Hook', () => {
 
       expect(result.exitCode).toBe(0);
       expect(output.decision).toBe('block');
-      expect(output.reason).toContain('Quality Review');
+      expect(output.reason).toContain('critical review');
       expect(output.reason).toContain('CONFIDENT');
     });
 
@@ -1044,7 +1044,7 @@ describe('E2E: Stop Hook', () => {
 
       expect(result.exitCode).toBe(0);
       expect(output.decision).toBe('block');
-      expect(output.reason).toContain('Quality Review');
+      expect(output.reason).toContain('critical review');
     });
 
     it('exits with error when usage limit reached in last message', () => {

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -224,7 +224,7 @@ describe('Stop Hook: Ticket Resolution Context', () => {
     // Should soft-block with quality review (edits were made)
     const parsed = JSON.parse(result.stdout.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/quality review|double check|critique/i);
+    expect(parsed.reason).toMatch(/critical review|evidence before declaring/i);
   });
 
   it('shows generic quality review when no ticket exists', () => {
@@ -236,7 +236,7 @@ describe('Stop Hook: Ticket Resolution Context', () => {
     // Should still soft-block with generic quality review (edits were made, no ticket context)
     const parsed = JSON.parse(result.stdout.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/quality review|double check|critique/i);
+    expect(parsed.reason).toMatch(/critical review|evidence before declaring/i);
   });
 
   it('shows done-phase hard block when active ticket at done phase', () => {


### PR DESCRIPTION
## Summary

- **SAFEWORD.md "Talking to the user" rewrite** — 9 rules grounded in NN/G scanning research, Anthropic's Claude Code system prompt, and cognitive load theory (Sweller, Mayer, Kalyuga et al. 2003). Covers: lead with the answer, end with the call, front-load load-bearing words, speak plainly (with expertise-reversal), match length to the ask, cite code as `path:line`, use structure only when it carries weight, one bold per paragraph, skip preambles/recaps/sycophancy.
- **Stop-hook header tightening** — drops the `Quality Review.` preamble label from `UNIVERSAL_HEADER`. The header now leads with the directive ("Think about evidence before declaring") instead of a section title. Applies the same "no preambles" rule to agent-facing hook output. Synced to both the live hook and the CLI template.
- **Test sync** — updates 4 test assertions that over-asserted on the literal `"Quality Review"` phrase. The semantic contract ("hook fires critical-review-style guidance") is preserved; the matching string moves to `critical review` / `evidence before declaring`.

## Commits

- `3f916fa` docs(safeword): rewrite for concision, scannability, plain language
- `11c7009` docs(safeword): research-grounded rules for talking-to-user section
- `d253cae` chore(hooks): drop "Quality Review." preamble from stop-hook header
- `10b095b` test(hooks): update assertions to match new stop-hook header wording

## Test plan

- [x] `bun run test` — 1765/1765 tests pass (1 skipped pre-existing)
- [x] `bun run build` — Success
- [x] depcruise — no dependency violations (916 modules, 2508 deps)
- [x] /verify — passed
- [x] /audit — passed with warnings (no errors)

## Out of scope (pre-existing issues surfaced during audit)

- `.claude/worktrees/` not in `eslint.config.ts` ignores — produces 1622 lint errors and many knip findings in stale worktree debris. Not introduced by this PR; recommend a follow-up to add the ignore.
- `eslint` 9.39.4 → 10.4.0 major dev-dep bump available. Defer to dedicated task (flat config and plugin compatibility need migration research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)