### PR TITLE
Ignore .claude/worktrees/ in eslint (preset + dogfood)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -24,6 +24,7 @@ const ignores = [
   '**/coverage/',
   '**/.astro/', // Astro generated types - not our code
   '**/.safeword/', // Generated hooks - linted separately by installed safeword config
+  '**/.claude/worktrees/', // Stale worktree leftovers from Claude Code's worktree isolation
   '.safeword-project/', // Project-specific hooks - not part of distributed package
   'examples/',
   'eslint.config.ts', // Self - loaded by ESLint's own pipeline, not part of the linted tree

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/configs.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/configs.test.ts
@@ -232,6 +232,22 @@ describe('default ignores', () => {
 
     expect(hasDistributionIgnore).toBe(true);
   });
+
+  it('includes .claude/worktrees in ignores (stale worktree leftovers)', () => {
+    const hasWorktreesIgnore = recommended.some(config => {
+      if (typeof config === 'object' && config !== null && 'ignores' in config) {
+        const ignores = config.ignores;
+        if (Array.isArray(ignores)) {
+          return ignores.some(
+            pattern => typeof pattern === 'string' && pattern.includes('.claude/worktrees'),
+          );
+        }
+      }
+      return false;
+    });
+
+    expect(hasWorktreesIgnore).toBe(true);
+  });
 });
 
 describe('eslint-comments governance', () => {

--- a/packages/cli/src/presets/typescript/eslint-configs/base.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/base.ts
@@ -66,7 +66,13 @@ function scopeToFiles(configs: any[], files: string[]): any[] {
 const basePluginsUnscoped: any[] = [
   // Default ignores - always skip these directories
   {
-    ignores: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.git/**'],
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/.git/**',
+      '**/.claude/worktrees/**',
+    ],
   },
 
   // ESLint core recommended


### PR DESCRIPTION
## Summary

Claude Code's worktree-isolation leaves stale copies under `.claude/worktrees/<name>/`. Eslint was scanning them and emitting ~1622 errors against orphaned worktree state — all in untracked debris, but the noise drowned out real signals from `bun run lint` and /audit.

Two surfaces fixed:

- **Customer-facing preset** ([packages/cli/src/presets/typescript/eslint-configs/base.ts](packages/cli/src/presets/typescript/eslint-configs/base.ts)) — added `'**/.claude/worktrees/**'` to default ignores. Mirror test added alongside existing `node_modules`/`dist` coverage.
- **Dogfood** ([eslint.config.ts](eslint.config.ts)) — same pattern at the project's local ignores.

Surfaced during /audit on #111 and flagged as out-of-scope there. Handled now as a focused follow-up.

## Test plan

- [x] `bun run lint` — 0 errors, 0 `.claude/worktrees/` references (down from 1622)
- [x] Preset config tests — 31/31 pass including new `'includes .claude/worktrees in ignores'` assertion
- [x] No tracked-file changes affect live code paths — only ignore-list additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)