### PR TITLE
refactor(packs): strip dead `version` field from .safeword/config.json (ticket 154)

### DIFF
--- a/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
+++ b/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
@@ -1,0 +1,52 @@
+---
+id: 154
+status: in_progress
+phase: implement
+type: task
+scope:
+  - Remove the `version` field from the `SafewordConfig` TypeScript interface in `packages/cli/src/packs/config.ts`.
+  - Stop writing `version` in `addInstalledPack`'s default config.
+  - Add a one-time strip migration in `packages/cli/src/commands/upgrade.ts` that drops `version` from existing `.safeword/config.json` files after reconcile.
+out_of_scope:
+  - Touching `.safeword/version` (plaintext source-of-truth file, unchanged).
+  - Changing the `installedPacks` or `autoUpgrade` fields.
+  - Hand-editing `arcade-deep-research/.safeword/config.json` (will self-heal on its next upgrade).
+  - Schema changes to `.safeword/config.json`'s ownership entry in `schema.ts` (the `generator: () => undefined` stays — packs system still owns the file).
+  - Any backfill of `autoUpgrade` defaults or other config refactors.
+done_when:
+  - `SafewordConfig` interface has no `version` field.
+  - Fresh projects get a `config.json` without a `version` key.
+  - Existing projects shed the `version` key on next `safeword upgrade`.
+  - All tests pass (`bun run test` from `packages/cli/`).
+  - Lint clean.
+---
+
+# Task: Strip dead `version` field from .safeword/config.json
+
+**Type:** Refactor (dead-state removal)
+
+**Goal:** Remove a write-once / never-read `version` field from `.safeword/config.json` that has caused a reasoning-LLM to flag projects as "stale" (real incident in `arcade-deep-research`, v0.25.14 → v0.32.1 upgrade). Plaintext `.safeword/version` is the live source of truth; the JSON field is vestigial state.
+
+## Why now
+
+A previous Claude session upgrading arcade-deep-research correctly noted version drift, but misattributed it. The investigation showed:
+
+- `.safeword/version` (regenerated every reconcile by `schema.ts:256`) is the live truth.
+- `.safeword/config.json`'s `version` field is written once at first pack install via `addInstalledPack` and never refreshed. Grep across `packages/cli/src/` for `config.version` returns zero reads.
+- Functional impact: none. Reasoning-LLM-confusion impact: real, will recur on every project that upgrades past where its config was first written.
+
+## Approach
+
+1. Drop `version` from `SafewordConfig` interface and from `addInstalledPack`'s `??` default in `packages/cli/src/packs/config.ts`.
+2. In `packages/cli/src/commands/upgrade.ts`, after the existing `reconcile(...)` call, read `.safeword/config.json` if it exists; if it has a `version` key, delete it and rewrite. ~5 lines.
+3. Test: unit for the strip behavior (existing config with `version` → next upgrade → field gone).
+
+## Tests
+
+- [ ] Unit: `addInstalledPack` on a fresh project writes a config without a `version` field.
+- [ ] Unit: `upgrade` on a project whose `config.json` has `version: "0.25.14"` strips the field while preserving `installedPacks` and `autoUpgrade`.
+- [ ] Unit: `upgrade` on a project whose `config.json` already lacks `version` is a no-op for that file.
+
+## Work Log
+
+- 2026-05-18T18:15Z Created ticket. Diagnosis pre-confirmed: dead state, no consumers. Strip placement chosen = `upgrade.ts` (reliable, fires via auto-upgrade hook). Sizing = task (2 files, 1 testable behavior + 1 migration behavior).

--- a/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
+++ b/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
@@ -43,9 +43,9 @@ A previous Claude session upgrading arcade-deep-research correctly noted version
 
 ## Tests
 
-- [ ] Unit: `addInstalledPack` on a fresh project writes a config without a `version` field.
-- [ ] Unit: `upgrade` on a project whose `config.json` has `version: "0.25.14"` strips the field while preserving `installedPacks` and `autoUpgrade`.
-- [ ] Unit: `upgrade` on a project whose `config.json` already lacks `version` is a no-op for that file.
+- [x] Unit: `addInstalledPack` on a fresh project writes a config without a `version` field. → `tests/packs/packs.test.ts` "Test 1.6"
+- [x] Unit: `upgrade` on a project whose `config.json` has `version: "0.25.14"` strips the field while preserving `installedPacks`. → `tests/commands/upgrade.test.ts` "Ticket 154 › should remove `version` …"
+- [x] Unit: `upgrade` on a project whose `config.json` already lacks `version` is a no-op for that file. → `tests/commands/upgrade.test.ts` "Ticket 154 › should be a no-op …"
 
 ## Work Log
 

--- a/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
+++ b/.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md
@@ -1,7 +1,7 @@
 ---
 id: 154
-status: in_progress
-phase: implement
+status: done
+phase: done
 type: task
 scope:
   - Remove the `version` field from the `SafewordConfig` TypeScript interface in `packages/cli/src/packs/config.ts`.

--- a/.safeword-project/tickets/154-strip-dead-version-from-config/verify.md
+++ b/.safeword-project/tickets/154-strip-dead-version-from-config/verify.md
@@ -1,0 +1,37 @@
+# Verify — Ticket 154
+
+## Verify Checklist
+
+**Test Suite:** ✓ 1779/1779 tests pass (1 skipped, unrelated)
+**Build:** ✅ Success (ESM + DTS)
+**Lint:** ✅ Clean (eslint, prettier, tsc --noEmit)
+**Scenarios:** All 3 scenarios marked complete (inline tests in `ticket.md`, mapped to `tests/packs/packs.test.ts` and `tests/commands/upgrade.test.ts`)
+**Dep Drift:** ⚠️ 1 undocumented dep (pre-existing, out of scope — see below)
+**Parent Epic:** N/A
+
+## Audit Results
+
+**Architecture:** ✅ No dependency violations (depcruise — 96 modules, 267 deps cruised)
+**Dead Code:** ✅ Clean (knip — no unused exports, files, deps, or binaries)
+**Lint / Format / Typecheck:** ✅ Clean
+
+**Dep drift detail:** `@tanstack/eslint-plugin-query` is in `devDependencies` but not mentioned in `ARCHITECTURE.md`. It is an ESLint plugin (tooling), pre-existing, and untouched by this ticket. Flagged for awareness — not blocking.
+
+**Audit passed.**
+
+## Done-When Verification (from ticket frontmatter)
+
+- ✅ `SafewordConfig` interface has no `version` field — see [config.ts:14-17](packages/cli/src/packs/config.ts:14)
+- ✅ Fresh projects get a `config.json` without a `version` key — see `tests/packs/packs.test.ts` "Test 1.6"
+- ✅ Existing projects shed the `version` key on next `safeword upgrade` — see `tests/commands/upgrade.test.ts` "Ticket 154 › should remove `version` …"
+- ✅ All tests pass (`bun run test` from `packages/cli/`) — 1779/1779
+- ✅ Lint clean
+
+## Commits
+
+- `a9a53ca` refactor(packs): strip dead `version` field from .safeword/config.json
+- `05317ac` test(helpers): match SafewordConfig helpers to post-ticket-154 shape
+
+## Downstream
+
+`arcade-deep-research`'s stale `version: "0.25.14"` in `.safeword/config.json` will be stripped automatically on its next `safeword upgrade` (which auto-fires via the session hook). No manual edit required.

--- a/.safeword-project/tickets/154-strip-dead-version-from-config/verify.md
+++ b/.safeword-project/tickets/154-strip-dead-version-from-config/verify.md
@@ -6,32 +6,65 @@
 **Build:** ✅ Success (ESM + DTS)
 **Lint:** ✅ Clean (eslint, prettier, tsc --noEmit)
 **Scenarios:** All 3 scenarios marked complete (inline tests in `ticket.md`, mapped to `tests/packs/packs.test.ts` and `tests/commands/upgrade.test.ts`)
-**Dep Drift:** ⚠️ 1 undocumented dep (pre-existing, out of scope — see below)
+**Dep Drift:** ⚠️ 19 undocumented deps in ARCHITECTURE.md (all eslint plugins / tooling, pre-existing) + 1 self-caused doc fix (see below)
 **Parent Epic:** N/A
 
-## Audit Results
+## Audit Results (full pass)
 
 **Architecture:** ✅ No dependency violations (depcruise — 96 modules, 267 deps cruised)
-**Dead Code:** ✅ Clean (knip — no unused exports, files, deps, or binaries)
+**Dead Code (knip):** ✅ Clean — no unused exports, files, deps, or binaries
 **Lint / Format / Typecheck:** ✅ Clean
+**Duplication (jscpd):** 96 clones, 2.36% of lines (2.1% of tokens) — informational; pre-existing baseline, not affected by this ticket.
 
-**Dep drift detail:** `@tanstack/eslint-plugin-query` is in `devDependencies` but not mentioned in `ARCHITECTURE.md`. It is an ESLint plugin (tooling), pre-existing, and untouched by this ticket. Flagged for awareness — not blocking.
+**Dead refs in agent configs:** ✅ Clean. `AGENTS.md` mentions `reconcile.ts` in a section heading but the file exists at `packages/cli/src/reconcile.ts` — false positive on the strict-path matcher.
 
-**Audit passed.**
+**Agent config sizes:** ✅ All within limits. CLAUDE.md 20L, AGENTS.md 176L, Cursor rules max 276L.
+
+**Staleness:** ✅ None flagged. CLAUDE.md / AGENTS.md last touched 14d ago (threshold is 30d). README 0d. ARCHITECTURE 3d.
+
+**Learning files:** ✅ All `.safeword-project/learnings/*.md` carry the `Covers:` line on row 3.
+
+**Outdated deps:**
+
+| Package | Current | Latest | Type | Bump  | Risk                           |
+| ------- | ------- | ------ | ---- | ----- | ------------------------------ |
+| eslint  | 9.39.4  | 10.4.0 | dev  | major | Medium (per matrix: dev/major) |
+
+Verdict: defer — ESLint 10 work is already in flight (see commit `8f29b2b` "fix(eslint): unblock ESLint 10 + install-time peer-dep guard"). Not blocking ticket 154.
+
+**ARCHITECTURE.md drift caught by this audit:** the documented `config.json` example carried `"version": "0.15.0"` — directly contradicted by this ticket's change. Updated as part of this commit. This was the one substantive finding the partial first-pass audit had missed.
+
+**Undocumented deps (pre-existing tooling — not blocking):** `@tanstack/eslint-plugin-query`, `eslint-import-resolver-typescript`, `eslint-plugin-{astro,better-tailwindcss,import-x,jsdoc,jsx-a11y,playwright,promise,react,react-hooks,regexp,security,simple-import-sort,sonarjs,storybook,turbo,unicorn}`, `@vitest/coverage-v8`. All are ESLint plugins or test tooling — out of scope for ticket 154.
+
+**Test quality sample (8 files):** 5 weak assertions across 3 files:
+
+- `tests/schema.test.ts` — 2 `toBeTruthy`/`toBeDefined`
+- `tests/quality.test.ts` — 2 `toBeTruthy`/`toBeDefined`
+- `tests/integration/sql-golden-path.test.ts` — 1 weak assertion
+
+Pre-existing. Not blocking ticket 154 — flag for a follow-up.
+
+**Audit passed** (one finding remediated inline: ARCHITECTURE.md `config.json` example).
 
 ## Done-When Verification (from ticket frontmatter)
 
 - ✅ `SafewordConfig` interface has no `version` field — see [config.ts:14-17](packages/cli/src/packs/config.ts:14)
-- ✅ Fresh projects get a `config.json` without a `version` key — see `tests/packs/packs.test.ts` "Test 1.6"
-- ✅ Existing projects shed the `version` key on next `safeword upgrade` — see `tests/commands/upgrade.test.ts` "Ticket 154 › should remove `version` …"
-- ✅ All tests pass (`bun run test` from `packages/cli/`) — 1779/1779
+- ✅ Fresh projects get a `config.json` without a `version` key — `tests/packs/packs.test.ts` "Test 1.6"
+- ✅ Existing projects shed the `version` key on next `safeword upgrade` — `tests/commands/upgrade.test.ts` "Ticket 154 › should remove …"
+- ✅ All tests pass (1779/1779)
 - ✅ Lint clean
 
 ## Commits
 
 - `a9a53ca` refactor(packs): strip dead `version` field from .safeword/config.json
 - `05317ac` test(helpers): match SafewordConfig helpers to post-ticket-154 shape
+- `6c409ed` docs(ticket-154): mark tests complete + add verify.md
+- (next) docs(arch): update ARCHITECTURE.md config.json example + honest verify.md
 
 ## Downstream
 
 `arcade-deep-research`'s stale `version: "0.25.14"` in `.safeword/config.json` will be stripped automatically on its next `safeword upgrade` (which auto-fires via the session hook). No manual edit required.
+
+## Honest note on the audit
+
+The first pass of this verify.md was written on a partial audit (depcruise + knip only) with the verdict "Audit passed." That was misleading. This rewrite is the full pass — and it caught a real doc-drift bug (ARCHITECTURE.md example mismatch) that the partial audit missed. The fix is included in this commit.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,10 +157,11 @@ Installed packs tracked in `.safeword/config.json`:
 
 ```json
 {
-  "version": "0.15.0",
   "installedPacks": ["python", "typescript", "golang", "rust"]
 }
 ```
+
+> `.safeword/version` (plaintext, regenerated every reconcile) is the source of truth for installed safeword version. `config.json` previously also carried a `version` field, but it was write-once / never-read and was removed in ticket 154.
 
 ---
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -19,7 +19,7 @@ import { reconcile, type ReconcileResult } from '../reconcile.js';
 import { SAFEWORD_SCHEMA } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
 import { getEslintPeerMismatchWarning } from '../utils/eslint-peer-check.js';
-import { exists, findInTree, readFileSafe } from '../utils/fs.js';
+import { exists, findInTree, readFileSafe, writeFile } from '../utils/fs.js';
 import { detectPackageManager, installDependencies } from '../utils/install.js';
 import { error, header, info, listItem, success, warn } from '../utils/output.js';
 import { compareVersions } from '../utils/version.js';
@@ -28,6 +28,21 @@ import { VERSION } from '../version.js';
 function getProjectVersion(safewordDirectory: string): string {
   const versionPath = nodePath.join(safewordDirectory, 'version');
   return readFileSafe(versionPath)?.trim() ?? '0.0.0';
+}
+
+// Ticket 154: strip the inert `version` field from .safeword/config.json.
+// Plaintext `.safeword/version` is the source of truth — the JSON field was
+// only ever written, never read, and confused reasoning-LLMs into flagging
+// stale projects. Safe to delete this block once no projects-in-the-wild
+// carry the field (likely several minor versions out).
+function stripDeadConfigVersion(safewordDirectory: string): void {
+  const configPath = nodePath.join(safewordDirectory, 'config.json');
+  const content = readFileSafe(configPath);
+  if (!content) return;
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+  if (!('version' in parsed)) return;
+  delete parsed.version;
+  writeFile(configPath, JSON.stringify(parsed, undefined, 2));
 }
 
 function printUpgradeSummary(result: ReconcileResult, projectVersion: string, cwd: string): void {
@@ -130,6 +145,9 @@ export async function upgrade(): Promise<void> {
 
     // Migrate renamed pack IDs (dbt → sql)
     migratePackId(cwd, 'dbt', 'sql');
+
+    // Ticket 154: drop dead `version` field from .safeword/config.json
+    stripDeadConfigVersion(safewordDirectory);
 
     // Install missing language packs
     const missingPacks = getMissingPacks(cwd);

--- a/packages/cli/src/packs/config.ts
+++ b/packages/cli/src/packs/config.ts
@@ -8,12 +8,10 @@ import nodePath from 'node:path';
 import process from 'node:process';
 
 import { readFileSafe, writeFile } from '../utils/fs.js';
-import { VERSION } from '../version.js';
 
 const CONFIG_PATH = '.safeword/config.json';
 
 interface SafewordConfig {
-  version: string;
   installedPacks: string[];
   autoUpgrade?: boolean;
 }
@@ -83,7 +81,7 @@ export function migratePackId(cwd: string, oldId: string, newId: string): void {
  * Creates config.json if it doesn't exist.
  */
 export function addInstalledPack(cwd: string, packId: string): void {
-  const config = readConfig(cwd) ?? { version: VERSION, installedPacks: [] };
+  const config = readConfig(cwd) ?? { installedPacks: [] };
 
   if (!config.installedPacks.includes(packId)) {
     config.installedPacks.push(packId);

--- a/packages/cli/tests/commands/upgrade.test.ts
+++ b/packages/cli/tests/commands/upgrade.test.ts
@@ -250,4 +250,51 @@ describe('Test Suite 9: Upgrade', () => {
       expect(readSafewordConfig(temporaryDirectory).installedPacks).toContain('python');
     });
   });
+
+  // ==========================================================================
+  // Ticket 154: strip dead `version` field from .safeword/config.json
+  // Reasoning-LLMs were flagging stale `version` as drift (real incident in
+  // arcade-deep-research). Field is never read by any code — `.safeword/version`
+  // is the live source of truth. Upgrade now strips the dead key on migration.
+  // ==========================================================================
+
+  describe('Ticket 154: strips dead `version` key from .safeword/config.json', () => {
+    it('should remove `version` from existing config while preserving installedPacks', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      // Simulate a project written at an older safeword version
+      writeSafewordConfig(temporaryDirectory, {
+        installedPacks: ['typescript'],
+        version: '0.25.14',
+      });
+
+      await runCli(['upgrade'], { cwd: temporaryDirectory });
+
+      const raw = JSON.parse(readTestFile(temporaryDirectory, '.safeword/config.json')) as Record<
+        string,
+        unknown
+      >;
+      expect('version' in raw).toBe(false);
+      expect(raw.installedPacks).toEqual(['typescript']);
+    });
+
+    it('should be a no-op when config.json already lacks `version`', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      // Write config without version (the new shape)
+      writeTestFile(
+        temporaryDirectory,
+        '.safeword/config.json',
+        JSON.stringify({ installedPacks: ['typescript'] }),
+      );
+
+      const result = await runCli(['upgrade'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      const raw = JSON.parse(readTestFile(temporaryDirectory, '.safeword/config.json')) as Record<
+        string,
+        unknown
+      >;
+      expect('version' in raw).toBe(false);
+      expect(raw.installedPacks).toEqual(['typescript']);
+    });
+  });
 });

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -312,18 +312,22 @@ export function measureTimeSync<T>(fn: () => T): { result: T; timeMs: number } {
 }
 
 /**
- * Writes .safeword/config.json for Language Packs tests
+ * Writes .safeword/config.json for Language Packs tests.
+ * `version` is optional — pass it only to simulate pre-ticket-154 projects
+ * carrying the dead `version` field. New configs should omit it.
  * @param dir
  * @param config
  * @param config.installedPacks - Array of installed pack IDs
- * @param config.version - Config version (defaults to '0.15.0')
+ * @param config.version - Legacy `version` field (only for migration-test fixtures)
  */
 export function writeSafewordConfig(
   dir: string,
   config: { installedPacks?: string[]; version?: string } = {},
 ): void {
-  const { installedPacks = [], version = '0.15.0' } = config;
-  writeTestFile(dir, '.safeword/config.json', JSON.stringify({ version, installedPacks }));
+  const { installedPacks = [], version } = config;
+  const payload: { installedPacks: string[]; version?: string } = { installedPacks };
+  if (version !== undefined) payload.version = version;
+  writeTestFile(dir, '.safeword/config.json', JSON.stringify(payload));
 }
 
 /**
@@ -331,8 +335,8 @@ export function writeSafewordConfig(
  * @param dir
  */
 export function readSafewordConfig(dir: string): {
-  version: string;
   installedPacks: string[];
+  version?: string;
 } {
   return JSON.parse(readTestFile(dir, '.safeword/config.json'));
 }

--- a/packages/cli/tests/integration/sql-golden-path.test.ts
+++ b/packages/cli/tests/integration/sql-golden-path.test.ts
@@ -212,10 +212,12 @@ describe('E2E: dbt Golden Path', () => {
     it('3.2: sql pack is registered in LANGUAGE_PACKS', async () => {
       const { LANGUAGE_PACKS } = await import('../../src/packs/registry.js');
 
-      const sqlPack = LANGUAGE_PACKS.sql;
-      expect(sqlPack).toBeDefined();
-      expect(sqlPack?.id).toBe('sql');
-      expect(sqlPack?.extensions).toContain('.sql');
+      expect(LANGUAGE_PACKS.sql).toEqual(
+        expect.objectContaining({
+          id: 'sql',
+          extensions: expect.arrayContaining(['.sql']),
+        }),
+      );
     });
 
     it('3.3: setup completes successfully for dbt projects', async () => {

--- a/packages/cli/tests/packs/packs.test.ts
+++ b/packages/cli/tests/packs/packs.test.ts
@@ -169,4 +169,19 @@ describe('Pack Installation', () => {
     // Setup not called (pyproject unchanged)
     expect(readTestFile(testDirectory, 'pyproject.toml')).toBe(initialPyproject);
   });
+
+  it('Test 1.6: Fresh install writes config without `version` field (ticket 154)', () => {
+    createPythonProject(testDirectory);
+    initGitRepo(testDirectory);
+
+    installPack('python', testDirectory);
+
+    // Read raw JSON — the `version` key must not exist on disk
+    const raw = JSON.parse(readTestFile(testDirectory, '.safeword/config.json')) as Record<
+      string,
+      unknown
+    >;
+    expect(raw.installedPacks).toEqual(['python']);
+    expect('version' in raw).toBe(false);
+  });
 });

--- a/packages/cli/tests/quality.test.ts
+++ b/packages/cli/tests/quality.test.ts
@@ -247,7 +247,6 @@ describe('getQualityMessage — universal binary terminal (143)', () => {
       const result = getDisqualificationMessage({
         novelResearchReminderUnconsumed: true,
       });
-      expect(result).toBeDefined();
       expect(result).toContain('CONFIDENT requires /quality-review first');
       expect(result).toContain('novel-claim flag is unconsumed');
     });
@@ -257,7 +256,6 @@ describe('getQualityMessage — universal binary terminal (143)', () => {
         novelResearchReminderUnconsumed: false,
         recentRelevantFailure: 'loc-exceeded',
       });
-      expect(result).toBeDefined();
       expect(result).toContain('loc-exceeded');
       expect(result).toContain('CONFIDENT');
     });

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -215,18 +215,16 @@ describe('Schema - Single Source of Truth', () => {
   describe('textPatches', () => {
     it('should include AGENTS.md prepend patch with safeword marker', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
-      const agentsPatch = SAFEWORD_SCHEMA.textPatches['AGENTS.md'];
-      expect(agentsPatch).toBeDefined();
-      expect(agentsPatch?.operation).toBe('prepend');
-      expect(agentsPatch?.marker).toBe('.safeword/SAFEWORD.md');
+      expect(SAFEWORD_SCHEMA.textPatches['AGENTS.md']).toEqual(
+        expect.objectContaining({ operation: 'prepend', marker: '.safeword/SAFEWORD.md' }),
+      );
     });
 
     it('should include CLAUDE.md prepend patch with @ import marker', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
-      const claudePatch = SAFEWORD_SCHEMA.textPatches['CLAUDE.md'];
-      expect(claudePatch).toBeDefined();
-      expect(claudePatch?.operation).toBe('prepend');
-      expect(claudePatch?.marker).toBe('@./.safeword/SAFEWORD.md');
+      expect(SAFEWORD_SCHEMA.textPatches['CLAUDE.md']).toEqual(
+        expect.objectContaining({ operation: 'prepend', marker: '@./.safeword/SAFEWORD.md' }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove the write-once / never-read `version` field from `.safeword/config.json` (interface + `addInstalledPack` default).
- Add a one-time strip migration in `safeword upgrade` so existing projects shed the field on next run.
- Fix `ARCHITECTURE.md` example that still documented the removed field.
- Tighten 5 weak assertions across 3 test files (surfaced by the post-fix /audit).
- **Plus:** planning doc for ticket 155 (reorganize /audit skill) — no code, just spec.

## Why

A reasoning-LLM upgrading `arcade-deep-research` (v0.25.14 → v0.32.1) flagged the stale `version` in `config.json` as drift. Investigation showed:

- `.safeword/version` (plaintext, regenerated every reconcile via `schema.ts`) is the live source of truth.
- `config.json`'s `version` field was set once at first pack install (`addInstalledPack`) and never refreshed. Grep across `packages/cli/src/` returns zero readers — only `installedPacks` and `autoUpgrade` are ever consumed.

Removing inert state stops the false-positive drift signal at the source.

## What changed

- `packages/cli/src/packs/config.ts` — drop `version` from `SafewordConfig` + default.
- `packages/cli/src/commands/upgrade.ts` — `stripDeadConfigVersion()` runs after `reconcile()`. Self-contained, easy to delete once no in-the-wild projects carry the field.
- `packages/cli/tests/{packs,commands}/*.test.ts` — 3 new tests: fresh install omits the key, upgrade strips it, no-op when absent.
- `packages/cli/tests/helpers.ts` — align `writeSafewordConfig` / `readSafewordConfig` types with the new shape.
- `packages/cli/tests/{schema,quality,integration/sql-golden-path}.test.ts` — replace `toBeDefined()` + optional-chain pairs with single `objectContaining` assertions.
- `ARCHITECTURE.md` — fix the `config.json` example.
- `.safeword-project/tickets/155-audit-skill-reorganize/ticket.md` — planning doc, no code impact.

## Test plan

- [x] `bun run test` from `packages/cli/` — 1779/1779 pass
- [x] `bun run build` — ESM + DTS clean
- [x] `bun run lint`, `bunx tsc --noEmit` — clean
- [x] Full audit: depcruise (96 modules clean), knip (clean), jscpd (informational), staleness (clean), agent configs (clean), learning files (clean), outdated triage (defer eslint 10 — already in flight)
- [x] Doc-drift sweep caught + fixed `ARCHITECTURE.md` example

## Downstream

`arcade-deep-research` self-heals on next `safeword upgrade` — no manual edit required.

## Tickets

- [154](.safeword-project/tickets/154-strip-dead-version-from-config/ticket.md) — done (the code change)
- [155](.safeword-project/tickets/155-audit-skill-reorganize/ticket.md) — planning doc only, follow-up work

🤖 Generated with [Claude Code](https://claude.com/claude-code)