### PR TITLE
feat(skills): add explore-and-debate skill

### DIFF
--- a/.claude/skills/bdd/DECOMPOSITION.md
+++ b/.claude/skills/bdd/DECOMPOSITION.md
@@ -4,6 +4,8 @@
 
 **Optional:** Skip if the architecture is clear from the converged proposal and the agent can sequence work naturally.
 
+**When slicing, sequencing, or data-model choices are non-obvious** (multiple plausible decompositions exist) — call `/explore-and-debate` to research each option against current evidence before locking the breakdown.
+
 ## Analyze Scenarios
 
 1. **Identify components** — What parts of the system does each scenario touch?

--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -16,6 +16,8 @@ If any answer is vague, you have open questions — surface them.
 
 **When the gap is user-only knowledge** (intent, priorities, constraints not derivable from code/docs) — call `/elicit` to extract it via microquestions before drafting scope.
 
+**When the gap is the option space itself** (multiple plausible scopes, framings, or boundaries with no clear winner) — call `/explore-and-debate` to weigh options against current docs and research before drafting scope.
+
 ### Concrete example
 
 **Context:** User says "I want to add a --verbose flag to the lint command."

--- a/.claude/skills/explore-and-debate/SKILL.md
+++ b/.claude/skills/explore-and-debate/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: explore-and-debate
+description: Explore and debate options with fresh documentation and research before committing. Use when facing a real decision with multiple plausible approaches — library/framework choice, architecture call, API or schema design, algorithm selection, or any communication / strategy call where being wrong has cost. Enumerates relevant research domains, looks up current docs and evidence-based methods, weighs options on correctness and elegance, resists bloat. Do NOT use for divergent ideation (brainstorm), extracting user intent (elicit), or reviewing already-written code (quality-review).
+allowed-tools: '*'
+---
+
+# Explore and Debate: Evidence-Backed Option Weighing
+
+**Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
+
+## When to Use
+
+A real decision with two or more plausible directions: library or framework choice, architecture, API or schema design, algorithm selection, communication strategy, policy call. User invokes `/explore-and-debate`.
+
+Skip for:
+
+- Single obvious answer → just do it
+- Need more options first → `brainstorm`
+- Don't know what the user wants → `elicit`
+- Reviewing existing code → `quality-review`
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] Phase 1: Frame the decision in one sentence
+- [ ] Phase 2: Generate 2-3 concrete options
+- [ ] Phase 3a: Enumerate relevant research domains (multiple)
+- [ ] Phase 3b: Research each named domain
+- [ ] Phase 4: Debate, steelman both sides, commit to one
+```
+
+### Phase 1: Frame
+
+One sentence: what are we deciding, and what would make a choice wrong? If you can't write it, call `/elicit` — the option space is undefined.
+
+### Phase 2: Generate options
+
+Two or three, concrete enough to debate. For each: **what** (one sentence), **looks like** (sketch — code, config, or example), **smallest viable form**. Two strong options beat five hedged ones.
+
+### Phase 3: Enumerate domains, then research
+
+**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A list with fewer than two or three entries means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
+
+Worked example — drafting a one-line block message for a CLI hook isn't just "writing copy." Domain list:
+
+- Developer error-message UX research (Nielsen Norman, humanized-error patterns, name-the-gate-condition principle)
+- Instructional design — state the rule, the violation, the next action
+- High-frequency-interruption tone calibration (annoyance compounds across a session)
+- Accessibility — screen readers, line length, no color-only signals
+- Recovery ergonomics — can the user unblock themselves from this text alone?
+- Observability — does the message give enough to file a useful bug or self-diagnose?
+
+Each is a distinct body of work. Most agents pattern-match "it's just an error string" and skip all six.
+
+**3b — Research each named domain.** For every one:
+
+- **Library / API:** Context7 for live docs and version status
+- **Established methods:** web search the domain name plus "research," "method," or "evidence-based" — surface named approaches you didn't know existed
+- **Patterns and tradeoffs:** recent postmortems, benchmarks, contested debates
+- **Boundary conditions:** what breaks under scale, load, failure, or adversarial input
+
+**The trap.** _"This is just taste / style / vibes"_ is the warning sign, not the exit. Your training data taught you which domains feel aesthetic — those are usually the ones with the most established research you haven't met. Run 3a anyway.
+
+**Only-valid skip.** The domain list comes up genuinely empty after honest enumeration: no humans affected, no measurable outcome, reversible in seconds. State the skip and why.
+
+### Phase 4: Debate and commit
+
+Argue both sides. Steelman the option you don't prefer **first**. For each, write:
+
+- **Correct:** solves the actual problem, including edge cases?
+- **Elegant:** readable, minimal, free of incidental complexity?
+- **Cost:** lines, dependencies, abstractions, ongoing maintenance.
+
+Then commit. Format:
+
+> Recommend **X** because [single load-bearing reason]. Y was close on Z but loses on W. Cite: [doc or research link].
+
+If two options tie on correctness and elegance, the smaller one wins.
+
+**No hedging.** If you genuinely can't pick, you're missing one input — name it and ask one question. "Either could work" is not an answer.

--- a/.cursor/rules/safeword-explore-and-debate.mdc
+++ b/.cursor/rules/safeword-explore-and-debate.mdc
@@ -1,0 +1,6 @@
+---
+alwaysApply: false
+description: Explore and debate options with fresh documentation and research before committing. Use when facing a real decision with multiple plausible approaches — library/framework choice, architecture call, API or schema design, algorithm selection. Looks up current docs and recent research, weighs options on correctness and elegance, and resists bloat.
+---
+
+@.claude/skills/explore-and-debate/SKILL.md

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -467,6 +467,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.claude/skills/tdd-review/SKILL.md': {
       template: 'skills/tdd-review/SKILL.md',
     },
+    '.claude/skills/explore-and-debate/SKILL.md': {
+      template: 'skills/explore-and-debate/SKILL.md',
+    },
 
     // Cursor rules
     '.cursor/rules/safeword-core.mdc': {
@@ -480,6 +483,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     },
     '.cursor/rules/safeword-elicitation.mdc': {
       template: 'cursor/rules/safeword-elicitation.mdc',
+    },
+    '.cursor/rules/safeword-explore-and-debate.mdc': {
+      template: 'cursor/rules/safeword-explore-and-debate.mdc',
     },
     '.cursor/rules/safeword-quality-reviewing.mdc': {
       template: 'cursor/rules/safeword-quality-reviewing.mdc',

--- a/packages/cli/templates/cursor/rules/safeword-explore-and-debate.mdc
+++ b/packages/cli/templates/cursor/rules/safeword-explore-and-debate.mdc
@@ -1,0 +1,6 @@
+---
+alwaysApply: false
+description: Explore and debate options with fresh documentation and research before committing. Use when facing a real decision with multiple plausible approaches — library/framework choice, architecture call, API or schema design, algorithm selection. Looks up current docs and recent research, weighs options on correctness and elegance, and resists bloat.
+---
+
+@.claude/skills/explore-and-debate/SKILL.md

--- a/packages/cli/templates/skills/bdd/DECOMPOSITION.md
+++ b/packages/cli/templates/skills/bdd/DECOMPOSITION.md
@@ -4,6 +4,8 @@
 
 **Optional:** Skip if the architecture is clear from the converged proposal and the agent can sequence work naturally.
 
+**When slicing, sequencing, or data-model choices are non-obvious** (multiple plausible decompositions exist) — call `/explore-and-debate` to research each option against current evidence before locking the breakdown.
+
 ## Analyze Scenarios
 
 1. **Identify components** — What parts of the system does each scenario touch?

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -16,6 +16,8 @@ If any answer is vague, you have open questions — surface them.
 
 **When the gap is user-only knowledge** (intent, priorities, constraints not derivable from code/docs) — call `/elicit` to extract it via microquestions before drafting scope.
 
+**When the gap is the option space itself** (multiple plausible scopes, framings, or boundaries with no clear winner) — call `/explore-and-debate` to weigh options against current docs and research before drafting scope.
+
 ### Concrete example
 
 **Context:** User says "I want to add a --verbose flag to the lint command."

--- a/packages/cli/templates/skills/explore-and-debate/SKILL.md
+++ b/packages/cli/templates/skills/explore-and-debate/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: explore-and-debate
+description: Explore and debate options with fresh documentation and research before committing. Use when facing a real decision with multiple plausible approaches — library/framework choice, architecture call, API or schema design, algorithm selection, or any communication / strategy call where being wrong has cost. Enumerates relevant research domains, looks up current docs and evidence-based methods, weighs options on correctness and elegance, resists bloat. Do NOT use for divergent ideation (brainstorm), extracting user intent (elicit), or reviewing already-written code (quality-review).
+allowed-tools: '*'
+---
+
+# Explore and Debate: Evidence-Backed Option Weighing
+
+**Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
+
+## When to Use
+
+A real decision with two or more plausible directions: library or framework choice, architecture, API or schema design, algorithm selection, communication strategy, policy call. User invokes `/explore-and-debate`.
+
+Skip for:
+
+- Single obvious answer → just do it
+- Need more options first → `brainstorm`
+- Don't know what the user wants → `elicit`
+- Reviewing existing code → `quality-review`
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] Phase 1: Frame the decision in one sentence
+- [ ] Phase 2: Generate 2-3 concrete options
+- [ ] Phase 3a: Enumerate relevant research domains (multiple)
+- [ ] Phase 3b: Research each named domain
+- [ ] Phase 4: Debate, steelman both sides, commit to one
+```
+
+### Phase 1: Frame
+
+One sentence: what are we deciding, and what would make a choice wrong? If you can't write it, call `/elicit` — the option space is undefined.
+
+### Phase 2: Generate options
+
+Two or three, concrete enough to debate. For each: **what** (one sentence), **looks like** (sketch — code, config, or example), **smallest viable form**. Two strong options beat five hedged ones.
+
+### Phase 3: Enumerate domains, then research
+
+**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A list with fewer than two or three entries means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
+
+Worked example — drafting a one-line block message for a CLI hook isn't just "writing copy." Domain list:
+
+- Developer error-message UX research (Nielsen Norman, humanized-error patterns, name-the-gate-condition principle)
+- Instructional design — state the rule, the violation, the next action
+- High-frequency-interruption tone calibration (annoyance compounds across a session)
+- Accessibility — screen readers, line length, no color-only signals
+- Recovery ergonomics — can the user unblock themselves from this text alone?
+- Observability — does the message give enough to file a useful bug or self-diagnose?
+
+Each is a distinct body of work. Most agents pattern-match "it's just an error string" and skip all six.
+
+**3b — Research each named domain.** For every one:
+
+- **Library / API:** Context7 for live docs and version status
+- **Established methods:** web search the domain name plus "research," "method," or "evidence-based" — surface named approaches you didn't know existed
+- **Patterns and tradeoffs:** recent postmortems, benchmarks, contested debates
+- **Boundary conditions:** what breaks under scale, load, failure, or adversarial input
+
+**The trap.** _"This is just taste / style / vibes"_ is the warning sign, not the exit. Your training data taught you which domains feel aesthetic — those are usually the ones with the most established research you haven't met. Run 3a anyway.
+
+**Only-valid skip.** The domain list comes up genuinely empty after honest enumeration: no humans affected, no measurable outcome, reversible in seconds. State the skip and why.
+
+### Phase 4: Debate and commit
+
+Argue both sides. Steelman the option you don't prefer **first**. For each, write:
+
+- **Correct:** solves the actual problem, including edge cases?
+- **Elegant:** readable, minimal, free of incidental complexity?
+- **Cost:** lines, dependencies, abstractions, ongoing maintenance.
+
+Then commit. Format:
+
+> Recommend **X** because [single load-bearing reason]. Y was close on Z but loses on W. Cite: [doc or research link].
+
+If two options tie on correctness and elegance, the smaller one wins.
+
+**No hedging.** If you genuinely can't pick, you're missing one input — name it and ask one question. "Either could work" is not an answer.

--- a/packages/cli/tests/fixtures/skill-cursor-pairs.ts
+++ b/packages/cli/tests/fixtures/skill-cursor-pairs.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical mapping of safeword skills to their Cursor rules.
+ *
+ * Source of truth for parity tests across:
+ * - `tests/schema.test.ts` (Claude/Cursor schema parity)
+ * - `tests/integration/skills-commands-validation.test.ts` (Skills-Cursor parity)
+ *
+ * - `cursorRules: string[]` — skill maps to one or more cursor rules
+ * - `cursorRules: undefined` — action skill (uses Cursor commands instead of rules,
+ *   per `disable-model-invocation`)
+ */
+export interface SkillCursorPair {
+  skill: string;
+  cursorRules: string[] | undefined;
+}
+
+export const SKILL_CURSOR_PAIRS: readonly SkillCursorPair[] = [
+  {
+    skill: 'bdd',
+    cursorRules: [
+      'bdd-core',
+      'bdd-discovery',
+      'bdd-scenarios',
+      'bdd-decomposition',
+      'bdd-tdd',
+      'bdd-done',
+      'bdd-splitting',
+    ],
+  },
+  { skill: 'brainstorm', cursorRules: ['safeword-brainstorming'] },
+  { skill: 'debug', cursorRules: ['safeword-debugging'] },
+  { skill: 'elicit', cursorRules: ['safeword-elicitation'] },
+  { skill: 'explore-and-debate', cursorRules: ['safeword-explore-and-debate'] },
+  { skill: 'quality-review', cursorRules: ['safeword-quality-reviewing'] },
+  { skill: 'refactor', cursorRules: ['safeword-refactoring'] },
+  { skill: 'tdd-review', cursorRules: ['safeword-tdd-review'] },
+  { skill: 'testing', cursorRules: ['safeword-testing'] },
+  { skill: 'ticket-system', cursorRules: ['safeword-ticket-system'] },
+  // Action skills use Cursor commands, not rules
+  { skill: 'lint', cursorRules: undefined },
+  { skill: 'verify', cursorRules: undefined },
+  { skill: 'audit', cursorRules: undefined },
+  { skill: 'cleanup-zombies', cursorRules: undefined },
+];

--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -643,6 +643,7 @@ describe('Skills-Cursor Parity', () => {
     brainstorm: 'safeword-brainstorming',
     debug: 'safeword-debugging',
     elicit: 'safeword-elicitation',
+    'explore-and-debate': 'safeword-explore-and-debate',
     'quality-review': 'safeword-quality-reviewing',
     refactor: 'safeword-refactoring',
     'tdd-review': 'safeword-tdd-review',

--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -13,6 +13,8 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { SKILL_CURSOR_PAIRS } from '../fixtures/skill-cursor-pairs.js';
+
 const __dirname = import.meta.dirname;
 const TEMPLATES_DIR = nodePath.join(__dirname, '../../templates');
 const SKILLS_DIR = nodePath.join(TEMPLATES_DIR, 'skills');
@@ -628,33 +630,16 @@ describe('Cursor Rules Validation (.mdc Format)', () => {
 });
 
 describe('Skills-Cursor Parity', () => {
-  // Mapping from skill short names to cursor rule names
-  // Skills use short names (bdd, debug, etc.), cursor rules keep safeword- prefix
-  const SKILL_TO_RULE_MAP: Record<string, string | string[] | undefined> = {
-    bdd: [
-      'bdd-core',
-      'bdd-discovery',
-      'bdd-scenarios',
-      'bdd-decomposition',
-      'bdd-tdd',
-      'bdd-done',
-      'bdd-splitting',
-    ],
-    brainstorm: 'safeword-brainstorming',
-    debug: 'safeword-debugging',
-    elicit: 'safeword-elicitation',
-    'explore-and-debate': 'safeword-explore-and-debate',
-    'quality-review': 'safeword-quality-reviewing',
-    refactor: 'safeword-refactoring',
-    'tdd-review': 'safeword-tdd-review',
-    testing: 'safeword-testing',
-    'ticket-system': 'safeword-ticket-system',
-    // Action skills use Cursor commands, not rules (disable-model-invocation)
-    lint: undefined,
-    verify: undefined,
-    audit: undefined,
-    'cleanup-zombies': undefined,
-  };
+  // Derived from canonical SKILL_CURSOR_PAIRS fixture.
+  // Skills use short names (bdd, debug, etc.), cursor rules keep safeword- prefix.
+  // Action skills (lint, verify, etc.) use Cursor commands, not rules — null in fixture.
+  const SKILL_TO_RULE_MAP: Record<string, string | string[] | undefined> = Object.fromEntries(
+    SKILL_CURSOR_PAIRS.map(pair => {
+      if (pair.cursorRules === undefined) return [pair.skill, undefined];
+      if (pair.cursorRules.length === 1) return [pair.skill, pair.cursorRules[0]];
+      return [pair.skill, pair.cursorRules];
+    }),
+  );
 
   it('each skill should have corresponding cursor rule(s)', () => {
     const skillDirectories = getSkillDirectories();

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -15,6 +15,7 @@ import YAML from 'yaml';
 
 import { ESLINT_PACKAGE } from '../src/packs/typescript/files.js';
 import { SETTINGS_HOOKS } from '../src/templates/config.js';
+import { SKILL_CURSOR_PAIRS } from './fixtures/skill-cursor-pairs.js';
 
 // Type guard for filtering out undefined values
 const isDefined = <T>(x: T | undefined): x is T => x !== undefined;
@@ -288,14 +289,15 @@ describe('Schema - Single Source of Truth', () => {
         .filter(isDefined)
         .toSorted((a, b) => a.localeCompare(b));
 
-      // Cursor rules use gerund names, Claude skills use short names
-      const CURSOR_RULE_TO_SKILL: Record<string, string> = {
-        brainstorming: 'brainstorm',
-        debugging: 'debug',
-        elicitation: 'elicit',
-        'quality-reviewing': 'quality-review',
-        refactoring: 'refactor',
-      };
+      // Derived from canonical SKILL_CURSOR_PAIRS fixture: cursor-rule suffix → skill name.
+      // Covers gerund-form rules (brainstorming → brainstorm) and identity cases alike.
+      const CURSOR_RULE_TO_SKILL: Record<string, string> = Object.fromEntries(
+        SKILL_CURSOR_PAIRS.flatMap(pair =>
+          (pair.cursorRules ?? [])
+            .filter(rule => rule.startsWith('safeword-'))
+            .map(rule => [rule.replace(/^safeword-/, ''), pair.skill] as const),
+        ),
+      );
       const normalizedCursorRules = cursorRules
         .map(name => CURSOR_RULE_TO_SKILL[name] ?? name)
         .toSorted((a, b) => a.localeCompare(b));


### PR DESCRIPTION
## Summary
- **New `/explore-and-debate` skill** — four-phase workflow for weighing multi-option decisions against fresh documentation and research rather than training-data instinct. Phase 3 explicitly closes the "this is just taste" loophole: agents must enumerate multiple research domains before claiming a decision has no empirical surface. Worked example (hook error-message UX) demonstrates the failure mode in-domain.
- **Wired into BDD phases** — surgical references in `bdd/DISCOVERY.md` (option-space ambiguity) and `bdd/DECOMPOSITION.md` (slicing/sequencing/data-model choices). Mirrors the existing single `/elicit` ref rather than adding blanket headers across every phase — every line of skill content is a recurring token cost.
- **Cursor rule** mirrors the skill via @-reference. Registered in `SAFEWORD_SCHEMA.ownedFiles` so installs and upgrades carry it forward.
- **Parity-map refactor** — extracted `SKILL_CURSOR_PAIRS` fixture so the schema test and integration parity test derive from one source instead of maintaining parallel maps. Caught by a pre-push failure mid-PR; refactor prevents the recurrence.

## Commits
- `adb9a42` feat(skills): add explore-and-debate skill
- `63efa53` test(skills): register in integration `SKILL_TO_RULE_MAP`
- `b938c8a` docs(bdd): wire into DISCOVERY and DECOMPOSITION
- `5035ed9` refactor(tests): extract `SKILL_CURSOR_PAIRS` fixture

## Test plan
- [x] `bun test schema.test.ts owned-paths.test.ts parity.test.ts` — 54/54
- [x] Pre-push targeted gate (schema + skills-commands-validation + golden-path + setup-hooks + reset-reconcile) — 567/567 on every push
- [ ] Auto-trigger sanity: open a session, ask a multi-option design question, confirm the skill activates
- [ ] Slash invocation: `/explore-and-debate` runs and renders the checklist
- [ ] BDD composition: open a ticket at `intake` phase with ambiguous scope and confirm DISCOVERY surfaces the `/explore-and-debate` callout
- [ ] Cursor: rule appears under "Manual" alongside `safeword-brainstorming` and `safeword-elicitation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)