### PR TITLE
patch(hooks): per-pattern dedup for recentFailures (ticket 8CMXNG)

### DIFF
--- a/.safeword-project/tickets/8CMXNG/ticket.md
+++ b/.safeword-project/tickets/8CMXNG/ticket.md
@@ -1,0 +1,23 @@
+---
+id: 8CMXNG
+slug: bound-recent-failures
+type: patch
+phase: done
+status: done
+created: 2026-05-20T17:42:18.173Z
+last_modified: 2026-05-20T17:42:18.173Z
+---
+
+# Per-pattern dedup for recentFailures
+
+**Goal:** Bound `state.recentFailures` by distinct pattern count via per-pattern dedup with timestamp refresh, so the array can't grow unboundedly on repeated firings of the same pattern.
+
+**Why:** Audit during ticket 4N5Y28 found this as the one remaining unbounded mutable in `QualityState`. Low severity (session-scoped, sub-KB per entry) but a real shape mismatch — both consumers (`prompt-questions.ts:getFailureInjection`, `stop-quality.ts:471`) only ever ask "does pattern P exist?" or "what was the most recent pattern?", never iterate the full array. Per-pattern dedup matches that semantic exactly; the bound is implicit (≈ number of distinct patterns, currently 2-3).
+
+**Scope:** Single change in `recordFailure` (template + consumer pair) — on push, remove any prior entry for the same pattern, then push fresh; preserves `failures[last]` = most-recent semantics because the array stays ordered by last-occurrence. One new integration test in `failure-memory.test.ts` asserting (a) repeated firings yield length 1, (b) the surviving entry's timestamp is the most recent firing.
+
+**Out of scope:** Changing `recordFailure`'s signature, consumer code, the persistent counter logic (`incrementedPatterns` and the counter file are already per-pattern-dedup'd).
+
+## Work Log
+
+- 2026-05-20T17:42:18.173Z Started: Created ticket 8CMXNG

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -92,6 +92,13 @@ export function recordFailure(
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8'));
       const failures: FailureEntry[] = state.recentFailures ?? [];
+      // Per-pattern dedup: bound the array by distinct pattern count rather
+      // than letting it grow unboundedly with repeats. Remove any prior entry
+      // for this pattern, then push with a fresh timestamp so the array stays
+      // ordered by last-occurrence (preserves `failures[last]` = most-recent
+      // semantics that prompt-questions relies on). Ticket 8CMXNG.
+      const existingIndex = failures.findIndex(f => f.pattern === pattern);
+      if (existingIndex >= 0) failures.splice(existingIndex, 1);
       failures.push({ pattern, timestamp: new Date().toISOString() });
       state.recentFailures = failures;
 

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -92,15 +92,14 @@ export function recordFailure(
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8'));
       const failures: FailureEntry[] = state.recentFailures ?? [];
-      // Per-pattern dedup: bound the array by distinct pattern count rather
-      // than letting it grow unboundedly with repeats. Remove any prior entry
-      // for this pattern, then push with a fresh timestamp so the array stays
-      // ordered by last-occurrence (preserves `failures[last]` = most-recent
-      // semantics that prompt-questions relies on). Ticket 8CMXNG.
-      const existingIndex = failures.findIndex(f => f.pattern === pattern);
-      if (existingIndex >= 0) failures.splice(existingIndex, 1);
-      failures.push({ pattern, timestamp: new Date().toISOString() });
-      state.recentFailures = failures;
+      // Per-pattern dedup: keep entries for other patterns, then append this
+      // one with a fresh timestamp. Bounds the array by distinct pattern
+      // count instead of letting it grow with repeats, and keeps the array
+      // ordered by last-occurrence so `failures[last]` is the most-recent
+      // pattern (prompt-questions relies on this). Ticket 8CMXNG.
+      const updated = failures.filter(f => f.pattern !== pattern);
+      updated.push({ pattern, timestamp: new Date().toISOString() });
+      state.recentFailures = updated;
 
       // Per-session dedup for counter increment
       const incremented: string[] = state.incrementedPatterns ?? [];

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -92,6 +92,13 @@ export function recordFailure(
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8'));
       const failures: FailureEntry[] = state.recentFailures ?? [];
+      // Per-pattern dedup: bound the array by distinct pattern count rather
+      // than letting it grow unboundedly with repeats. Remove any prior entry
+      // for this pattern, then push with a fresh timestamp so the array stays
+      // ordered by last-occurrence (preserves `failures[last]` = most-recent
+      // semantics that prompt-questions relies on). Ticket 8CMXNG.
+      const existingIndex = failures.findIndex(f => f.pattern === pattern);
+      if (existingIndex >= 0) failures.splice(existingIndex, 1);
       failures.push({ pattern, timestamp: new Date().toISOString() });
       state.recentFailures = failures;
 

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -92,15 +92,14 @@ export function recordFailure(
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8'));
       const failures: FailureEntry[] = state.recentFailures ?? [];
-      // Per-pattern dedup: bound the array by distinct pattern count rather
-      // than letting it grow unboundedly with repeats. Remove any prior entry
-      // for this pattern, then push with a fresh timestamp so the array stays
-      // ordered by last-occurrence (preserves `failures[last]` = most-recent
-      // semantics that prompt-questions relies on). Ticket 8CMXNG.
-      const existingIndex = failures.findIndex(f => f.pattern === pattern);
-      if (existingIndex >= 0) failures.splice(existingIndex, 1);
-      failures.push({ pattern, timestamp: new Date().toISOString() });
-      state.recentFailures = failures;
+      // Per-pattern dedup: keep entries for other patterns, then append this
+      // one with a fresh timestamp. Bounds the array by distinct pattern
+      // count instead of letting it grow with repeats, and keeps the array
+      // ordered by last-occurrence so `failures[last]` is the most-recent
+      // pattern (prompt-questions relies on this). Ticket 8CMXNG.
+      const updated = failures.filter(f => f.pattern !== pattern);
+      updated.push({ pattern, timestamp: new Date().toISOString() });
+      state.recentFailures = updated;
 
       // Per-session dedup for counter increment
       const incremented: string[] = state.incrementedPatterns ?? [];

--- a/packages/cli/tests/integration/failure-memory.test.ts
+++ b/packages/cli/tests/integration/failure-memory.test.ts
@@ -183,6 +183,48 @@ describe('Failure Memory (#111)', () => {
       expect(failures[0]?.timestamp).toBeDefined();
     });
 
+    it('per-pattern dedup: re-firing the same pattern updates timestamp instead of growing the array (ticket 8CMXNG)', () => {
+      const head = getHead(projectDirectory);
+      writeState(projectDirectory, {
+        locSinceCommit: 450,
+        lastCommitHash: head,
+        activeTicket: null,
+        lastKnownPhase: 'implement',
+        gate: 'loc',
+        lastKnownTddStep: null,
+        locAtLastReview: 0,
+      });
+
+      // Fire the LOC gate three times via the pre-tool hook. Without dedup,
+      // we'd see three entries; with dedup, we see one entry whose timestamp
+      // is the most recent firing.
+      runPreTool(projectDirectory);
+      const firstTimestamp = (
+        readState(projectDirectory).recentFailures as { timestamp: string }[]
+      )[0]?.timestamp;
+
+      // Tiny delay so the timestamp can change observably.
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        /* spin */
+      }
+      runPreTool(projectDirectory);
+      runPreTool(projectDirectory);
+
+      const failures = readState(projectDirectory).recentFailures as {
+        pattern: string;
+        timestamp: string;
+      }[];
+      // Bounded by distinct pattern count, not firing count.
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.pattern).toBe('loc-exceeded');
+      // Timestamp refreshed to the most recent firing.
+      expect(failures[0]?.timestamp).not.toBe(firstTimestamp);
+      expect(new Date(failures[0]?.timestamp ?? 0).getTime()).toBeGreaterThan(
+        new Date(firstTimestamp ?? 0).getTime(),
+      );
+    });
+
     it('stop hook writes recentFailures when done gate blocks for test failure', () => {
       // Create a done-phase feature ticket (id without quotes — regex extracts literal)
       const ticketFolder = '.safeword-project/tickets/099-test';


### PR DESCRIPTION
## Summary

- `state.recentFailures` was unbounded — repeated firings of the same pattern (commonly `loc-exceeded` during long implement phases) pushed redundant entries forever.
- Both readers only ever ask "is pattern P in this array?" (membership) or "what was the most recent?" — never iterate the full list, never use timestamps as a filter.
- Applies per-pattern dedup with timestamp refresh: on push, remove any prior entry for the same pattern, then append with a fresh timestamp. Length is now implicitly bounded by distinct pattern count (≈ 2-3 in current usage).
- Array order still reflects last-occurrence, so `failures[failures.length - 1]` keeps returning the most-recently-fired pattern.
- Same shape as the adjacent `incrementedPatterns` array in the same file — applying a pattern the codebase already uses.

Followup from the audit during ticket 4N5Y28 (boolean → monotonic arrays). 4N5Y28 fixed the foonotgun-shaped boolean; this fixes the only remaining unbounded mutable in `QualityState`.

## Test plan

- [x] New integration test in `failure-memory.test.ts` asserting (a) repeated firings of the same pattern yield length 1, (b) the surviving entry's timestamp is the most-recent firing.
- [x] All existing `failure-memory.test.ts` tests still pass (11/11 green locally).
- [x] No callers of `recordFailure` need updates — signature unchanged.
- [x] Lint clean (root + packages/cli).
- [ ] CI: full vitest + lint + architecture check (runs on PR open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)