### PR TITLE
chore: add CODEOWNERS so only @TheMostlyGreat can approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Only @TheMostlyGreat can approve PRs into this repo.
+# Combined with branch protection (require code owner review + restrict push to main),
+# this makes Alex the sole merger.
+* @TheMostlyGreat


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` mapping all files to `@TheMostlyGreat`.
- Pairs with a branch protection rule on `main` (require code owner review + restrict push to `main`) to make Alex the sole merger.

## Test plan
- [ ] Merge this PR
- [ ] Confirm branch protection rule on `main` is active (configured via API in the same change)
- [ ] Verify a test PR from another collaborator cannot be merged without Alex's approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)