### PR TITLE
docs: codify voice norms — debate-then-pick + brainstorm Voice

### DIFF
--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -24,6 +24,16 @@ The modes are fluid. Don't announce them. Follow the user's energy.
 - **Ideas over implementation.** Read code for context, but focus on exploring — follow the user's lead if they want to transition to building.
 - **No forced artifact.** Brainstorming may produce a decision, better questions, or a decision NOT to build. All valid.
 
+## Voice
+
+Diverge on _ideas_, converge on _proposals_. Generate breadth, but each idea is a concrete sketch — not a fragment.
+
+- **Concrete, not rambling.** "Low fidelity" means rough and bounded, not vague. "Use a state machine here" beats "maybe some kind of stateful thing." A short concrete sketch reads as an idea; a long conversational ramble reads as filler.
+- **Batch the options.** When generating, drop 3-5 candidates in one breath — not one at a time waiting for reaction. The user scans a gallery, not a parade.
+- **Mirror plus add.** Even rubber-ducking, never reflect alone — reflect _and_ contribute a challenge, surfaced assumption, or angle the user didn't name. Open questions live inside the contribution.
+
+Brainstorm is the explicit escape hatch from "commit to one path" — not from "be specific."
+
 ## When You Notice Convergence
 
 Offer a lightweight check-in: "Sounds like we're converging on X — want me to pull this together?"

--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -99,6 +99,10 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **End with the call.** When the user needs to decide, act, or answer something, the last line is what's next — a question, a choice, a proposed step. Don't bury it mid-reply.
 
+**Debate-then-pick.** When there's a real choice, surface 2-3 options weighed in one breath, then the pick — one line each on the candidates, one on the tradeoff, one on the call. Don't ping-pong one option at a time. Skip the debate when there's no real choice (rename, mechanical edit, single obvious path).
+
+**Frame the structural choice.** Name the architectural call ("reuse `quality-state.ts` paths vs. duplicate the list") before the surface change ("add a check"). The proposal _is_ the architectural read, not a description of what to type.
+
 **Front-load load-bearing words.** The first two words of every line, bullet, and heading do the work — readers eye-jump down the left edge before deciding where to drop in. Start with the noun or verb that carries the meaning. "Failed because…" beats "It looks like the test failed because…"
 
 **Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it. Assume the user knows their stack — don't explain TypeScript, async, or `git rebase` to a developer who's using them.
@@ -120,7 +124,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 Optimize for **Clarity → Simplicity → Correctness**, in that order. When in doubt, choose the simpler solution that works today.
 
 - **Elegant code:** readable at a glance; clear naming; minimal cognitive load.
-- **No bloat:** delete unused code; no premature abstractions; no "just in case."
+- **No bloat:** delete unused code; no premature abstractions; no "just in case"; reuse existing patterns/tools before adding new ones.
 - **Explicit errors:** every catch re-throws with context, or logs with details.
 - **Self-documenting:** comment only the non-obvious "why" — business rules, workarounds.
 

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -99,6 +99,10 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **End with the call.** When the user needs to decide, act, or answer something, the last line is what's next — a question, a choice, a proposed step. Don't bury it mid-reply.
 
+**Debate-then-pick.** When there's a real choice, surface 2-3 options weighed in one breath, then the pick — one line each on the candidates, one on the tradeoff, one on the call. Don't ping-pong one option at a time. Skip the debate when there's no real choice (rename, mechanical edit, single obvious path).
+
+**Frame the structural choice.** Name the architectural call ("reuse `quality-state.ts` paths vs. duplicate the list") before the surface change ("add a check"). The proposal _is_ the architectural read, not a description of what to type.
+
 **Front-load load-bearing words.** The first two words of every line, bullet, and heading do the work — readers eye-jump down the left edge before deciding where to drop in. Start with the noun or verb that carries the meaning. "Failed because…" beats "It looks like the test failed because…"
 
 **Speak plainly.** Use everyday words. Don't make the user learn safeword's internal vocabulary (Propose-and-Converge, sizing, gates, phases) — just describe what's happening. Reach for a domain term only when defining it would be longer than using it. Assume the user knows their stack — don't explain TypeScript, async, or `git rebase` to a developer who's using them.
@@ -120,7 +124,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 Optimize for **Clarity → Simplicity → Correctness**, in that order. When in doubt, choose the simpler solution that works today.
 
 - **Elegant code:** readable at a glance; clear naming; minimal cognitive load.
-- **No bloat:** delete unused code; no premature abstractions; no "just in case."
+- **No bloat:** delete unused code; no premature abstractions; no "just in case"; reuse existing patterns/tools before adding new ones.
 - **Explicit errors:** every catch re-throws with context, or logs with details.
 - **Self-documenting:** comment only the non-obvious "why" — business rules, workarounds.
 

--- a/packages/cli/templates/skills/brainstorm/SKILL.md
+++ b/packages/cli/templates/skills/brainstorm/SKILL.md
@@ -24,6 +24,16 @@ The modes are fluid. Don't announce them. Follow the user's energy.
 - **Ideas over implementation.** Read code for context, but focus on exploring — follow the user's lead if they want to transition to building.
 - **No forced artifact.** Brainstorming may produce a decision, better questions, or a decision NOT to build. All valid.
 
+## Voice
+
+Diverge on _ideas_, converge on _proposals_. Generate breadth, but each idea is a concrete sketch — not a fragment.
+
+- **Concrete, not rambling.** "Low fidelity" means rough and bounded, not vague. "Use a state machine here" beats "maybe some kind of stateful thing." A short concrete sketch reads as an idea; a long conversational ramble reads as filler.
+- **Batch the options.** When generating, drop 3-5 candidates in one breath — not one at a time waiting for reaction. The user scans a gallery, not a parade.
+- **Mirror plus add.** Even rubber-ducking, never reflect alone — reflect _and_ contribute a challenge, surfaced assumption, or angle the user didn't name. Open questions live inside the contribution.
+
+Brainstorm is the explicit escape hatch from "commit to one path" — not from "be specific."
+
 ## When You Notice Convergence
 
 Offer a lightweight check-in: "Sounds like we're converging on X — want me to pull this together?"


### PR DESCRIPTION
## Summary

- **SAFEWORD.md "Talking to the user"**: add **Debate-then-pick** (surface 2-3 options weighed in one breath, then the pick) and **Frame the structural choice** (name the architectural call before the surface change). Amend Code Philosophy "No bloat" to require reusing existing patterns/tools before adding new ones.
- **brainstorm SKILL**: add a `## Voice` section — concrete-not-rambling, batch 3-5 options, mirror-plus-add. Brainstorm is the escape hatch from "commit to one path," not from "be specific."
- Both edits land in `packages/cli/templates/` (source of truth) and the synced install copies in `.safeword/` and `.claude/`.

These changes codify the maintainer's voice prefs (direction-first, debate-then-pick, minimize divergent code) into safeword's own norms — the agent now speaks the same shape across SAFEWORD.md guidance and brainstorm divergence.

## Decision context

Considered also extending `stop-quality.ts`'s CONFIDENT/BLOCKED verdict header to match. Held off — calibration research (Kadavath/Lin/Tian + 2025 CoCA) backs the binary tokenized verdict as load-bearing; RECAST 2026 shows multi-constraint adherence degrades with bloat; the existing header already encodes debate-then-pick in spirit via "enumerate options, debate, recommend." Voice prefs and end-of-turn verdict format are orthogonal surfaces.

## Test plan

- [ ] Read both diffs and confirm the prose matches your voice prefs
- [ ] Sanity check `bunx safeword upgrade` still leaves the install copies matching templates (already verified locally)
- [ ] Confirm no other template files drifted incidentally (config.json + eslint.config.mjs drift reverted; flagged as a separate upgrade-bug candidate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)