### PR TITLE
feat: OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+# OIDC trusted publishing to npm. Triggered when a v* annotated tag is
+# pushed to the repo (tag push is restricted to repo mergers via ruleset).
+#
+# Flow: tag push → manual approval in `release` environment → pack with
+# bun (preserves workspace-protocol stripping) → npm publish the tarball
+# with --provenance (npm CLI auto-detects OIDC).
+#
+# bun publish does not yet support OIDC trusted publishing — see
+# oven-sh/bun#15601. The bun-pack + npm-publish split is the documented
+# workaround until that lands.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write # required to mint OIDC token for npm
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false # never cancel an in-flight publish
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: release
+      url: https://www.npmjs.com/package/safeword
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history so tag metadata is available
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          # Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1.
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm CLI version supports OIDC trusted publishing
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm CLI: $NPM_VERSION"
+          # Minimum 11.5.1 per https://docs.npmjs.com/trusted-publishers/
+          node -e "
+            const [maj, min, patch] = '$NPM_VERSION'.split('.').map(Number);
+            if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) {
+              console.error('npm ' + '$NPM_VERSION' + ' too old — OIDC trusted publishing needs >= 11.5.1');
+              process.exit(1);
+            }
+          "
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -e "console.log(require('./packages/cli/package.json').version)")
+          MKT_VERSION=$(node -e "console.log(require('./marketplace.json').plugins[0].version)")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match packages/cli/package.json version $PKG_VERSION"
+            exit 1
+          fi
+          if [ "$PKG_VERSION" != "$MKT_VERSION" ]; then
+            echo "::error::package.json ($PKG_VERSION) and marketplace.json ($MKT_VERSION) disagree"
+            exit 1
+          fi
+          echo "All version sources agree: $PKG_VERSION"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run --cwd packages/cli build
+
+      - name: Release-gate tests (supply-chain + dogfood parity)
+        run: bun run --cwd packages/cli test:release
+
+      - name: 'Pack tarball with bun (preserves workspace-protocol stripping)'
+        working-directory: packages/cli
+        run: bun pm pack --destination ../../release-artifacts
+
+      - name: Publish to npm with provenance via OIDC
+        run: |
+          # --ignore-scripts: build + tests already ran above; prepublishOnly
+          # otherwise enforces bun (via npm_config_user_agent), which fails here.
+          # --provenance: cryptographically attest the build came from this
+          # exact workflow run + commit. Auto-enabled with OIDC but explicit.
+          # --access public: safeword is a public package.
+          npm publish release-artifacts/safeword-*.tgz \
+            --provenance \
+            --access public \
+            --ignore-scripts


### PR DESCRIPTION
## Summary
Replaces the local-laptop \`bun publish\` flow with a GitHub Actions workflow that publishes via npm's OIDC trusted publishing. Eliminates the long-lived npm token from any developer machine — the only path to publish is a \`v*\` tag push followed by a manual approval in the \`release\` environment.

## Why
The 2025 npm supply-chain attacks (Shai-Hulud worm, qix phishing → chalk/debug compromise across 2.6B weekly downloads) all started with a phished maintainer token. Trusted publishing removes the token entirely: GitHub issues a short-lived OIDC token per workflow run, npm verifies the workflow identity against a pre-registered allowlist.

## The flow
1. Merger pushes a \`v*\` annotated tag (tag-push is already restricted to @TheMostlyGreat + @nbarbettini via the v* tag ruleset).
2. \`release.yml\` triggers.
3. Workflow pauses at the \`release\` environment — Alex or Nate clicks Approve.
4. Workflow verifies tag matches \`packages/cli/package.json\` and \`marketplace.json\` versions.
5. Build + release-gate tests run.
6. \`bun pm pack\` produces the tarball (preserves workspace-protocol stripping that bun publish handled).
7. \`npm publish --provenance --access public --ignore-scripts\` publishes via OIDC. Cryptographic provenance attestation auto-attached.

## bun limitation
\`bun publish\` doesn't yet support OIDC trusted publishing — [oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601) is still open. The bun-pack + npm-publish split is the documented workaround until that lands.

## Server-side prep already done (this PR contains code only)
- ✅ \`release\` Environment created with @TheMostlyGreat + @nbarbettini as required reviewers.
- ✅ Environment restricted to \`v*\` tag refs only (workflow can't be triggered from a feature branch).

## Required manual follow-up BEFORE first tag push
**Alex must configure npm Trusted Publisher** at https://www.npmjs.com/package/safeword/access:
- Provider: GitHub Actions
- Organization: \`ArcadeAI\`
- Repository: \`safeword\`
- Workflow filename: \`release.yml\`
- Environment name: \`release\`

Without this, the workflow will fail at the \`npm publish\` step with an auth error.

## After first successful CI publish
- Delete the npm token from \`~/.npmrc\` on developer machines.
- Optionally revoke the token on npmjs.com for belt-and-suspenders.
- The local \`bun publish\` path remains a defense-in-depth guard via \`prepublishOnly\` but won't actually authenticate without the token.

## Test plan
- [ ] Merge this PR
- [ ] Configure npm Trusted Publisher on npmjs.com (manual step above)
- [ ] Push the existing \`v0.34.0\` tag (already version-bumped but unpublished)
- [ ] Approve in \`release\` environment when prompted
- [ ] Verify safeword@0.34.0 appears on npm with a provenance badge
- [ ] Delete local npm token

🤖 Generated with [Claude Code](https://claude.com/claude-code)