### PR TITLE
docs(tickets): open three epic shells — intake, propulsion, subagents

### DIFF
--- a/.safeword-project/tickets/169-pm-grade-intake/ticket.md
+++ b/.safeword-project/tickets/169-pm-grade-intake/ticket.md
@@ -1,0 +1,27 @@
+---
+id: '169'
+slug: pm-grade-intake
+title: 'Epic: PM-grade intake protocol'
+type: Feature
+status: open
+epic: pm-grade-intake
+---
+
+# Epic: PM-grade intake protocol
+
+**Type:** Feature (epic — shell, not yet scoped)
+
+**Goal:** Make Clarify the part of safeword people brag about. Today it's propose-and-converge with five contribution techniques (failure modes, boundaries, scenarios, regret, UX) that produces `scope` / `out_of_scope` / `done_when` frontmatter. A PM-grade intake also surfaces: who asked, what user-facing problem this solves, the success metric, what changes if we don't build it, and an explicit reversibility/regret read. The output is an intake brief, not just frontmatter.
+
+**Context:** The `elicit` and `brainstorm` skills already extract tacit knowledge and explore options. This epic ties Clarify + `elicit` + `brainstorm` into one named intake protocol with a real artifact.
+
+## Open questions (to resolve when this epic is Clarified)
+
+- Upgrade Clarify in place, or add a pre-Clarify "Intake" phase that writes a brief doc?
+- Does the brief replace the ticket frontmatter, or sit alongside it?
+- Which sizes need the full intake? (Likely features only; tasks/patches stay lean.)
+- What's the minimum brief — three questions? A template?
+
+## Child tickets
+
+_(none yet — fan out after this epic is Clarified)_

--- a/.safeword-project/tickets/170-propulsive-by-default/ticket.md
+++ b/.safeword-project/tickets/170-propulsive-by-default/ticket.md
@@ -1,0 +1,28 @@
+---
+id: '170'
+slug: propulsive-by-default
+title: 'Epic: Propulsive by default'
+type: Feature
+status: open
+epic: propulsive-by-default
+---
+
+# Epic: Propulsive by default
+
+**Type:** Feature (epic — shell, not yet scoped)
+
+**Goal:** Claude keeps moving unless something is genuinely blocking. Today the model pauses at every seam — sizing announcement, before building, between phases, after every test run. Propulsive means: reversible / low-blast-radius decisions get made silently; only irreversible or high-stakes ones stop the loop.
+
+**Context:** Safeword today optimizes for control and visibility at the cost of momentum. Most pauses are wasted — the user would have said "yes, keep going." The blocker filter should be sharp: destructive git, irreversible writes, money/billing, security, or a genuine ambiguity that materially changes scope.
+
+## Open questions (to resolve when this epic is Clarified)
+
+- Heuristic for "propulsive vs. ask": file count + persistence + destructiveness + external side effects? Codified where?
+- Config knob (`autonomy: high | medium | low`) or single new default?
+- Operational definition of "critical question" — irreversible writes, money, destructive git, security, anything else?
+- Does this change the phase gates, or layer on top of them?
+- How does the model recover gracefully when it pushed through something it shouldn't have?
+
+## Child tickets
+
+_(none yet — fan out after this epic is Clarified)_

--- a/.safeword-project/tickets/171-subagents-in-the-loop/ticket.md
+++ b/.safeword-project/tickets/171-subagents-in-the-loop/ticket.md
@@ -1,0 +1,28 @@
+---
+id: '171'
+slug: subagents-in-the-loop
+title: 'Epic: Subagents in the safeword loop'
+type: Feature
+status: open
+epic: subagents-in-the-loop
+---
+
+# Epic: Subagents in the safeword loop
+
+**Type:** Feature (epic — shell, not yet scoped)
+
+**Goal:** Identify where delegating to a subagent dominates inline work, and wire it into the safeword workflow. Today Plan / Explore / general-purpose agents exist but aren't referenced in the prescribed phases — they're used opportunistically, not by design.
+
+**Context:** Likely starting points: Explore for research-before-Clarify, an independent reviewer after GREEN (already partly served by `quality-review`), parallel test runs on large features, BDD scenario drafting. Output is probably a decision table in CLAUDE.md plus one or two new safeword-specific subagent definitions.
+
+## Open questions (to resolve when this epic is Clarified)
+
+- Pick from the existing agent menu (Explore / Plan / general-purpose / quality-review), or define new safeword-specific ones (e.g., `bdd-scenario-writer`, `failure-investigator`)?
+- Are subagents triggered by hooks (automatic) or by skills (opt-in)?
+- How do we keep parent-agent context coherent when a subagent runs — what's the handoff contract?
+- Which phases get hard-wired delegation vs. left to the model's discretion?
+- Cost / latency budget — when does a subagent dominate, and when is it overhead?
+
+## Child tickets
+
+_(none yet — fan out after this epic is Clarified)_


### PR DESCRIPTION
## Summary
- Files three parent epic tickets without scope/done_when so the phase gate stays quiet until each is Clarified.
- 169 pm-grade-intake — upgrade Clarify into a real PM intake protocol
- 170 propulsive-by-default — keep moving unless genuinely blocked
- 171 subagents-in-the-loop — wire subagent use into the workflow

## Test plan
- [x] Docs-only — no tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)