### PR TITLE
fix(release): upgrade npm to >=11.5.1 before OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           # Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1.
+          # Node 22.x bundles npm 10.x — we upgrade npm explicitly below.
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to >=11.5.1 (required for OIDC trusted publishing)
+        run: npm install -g npm@latest
 
       - name: Verify npm CLI version supports OIDC trusted publishing
         run: |


### PR DESCRIPTION
## Summary

The first v0.34.0 publish attempt ([run 26309198936](https://github.com/ArcadeAI/safeword/actions/runs/26309198936)) failed at our version-check step:

\`\`\`
npm CLI: 10.9.8
npm 10.9.8 too old — OIDC trusted publishing needs >= 11.5.1
\`\`\`

setup-node@v6 with \`node-version: '22'\` installs Node 22.x (satisfies the >=22.14.0 floor) but bundles **npm 10.9.8**. OIDC trusted publishing needs npm >= 11.5.1.

## Fix

Add \`npm install -g npm@latest\` immediately after setup-node. Picks up whatever 11.x is current — 11.5.1+ for the foreseeable future.

The version-check step stays as a belt-and-suspenders guard.

## Test plan

- [ ] Merge
- [ ] Move v0.34.0 tag forward to include this commit
- [ ] Re-push v0.34.0
- [ ] Approve in release env
- [ ] Verify npm 11.x prints in the upgraded-version step
- [ ] Verify safeword@0.34.0 appears on npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)