### PR TITLE
chore(release): v0.35.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "CLI for setting up and managing safeword development environments",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Version bump 0.34.0 → 0.35.0. v0.34.0 was bumped in files and tagged but never published (first OIDC publish attempt failed at npm version check; tag deleted from origin). Skipping straight to v0.35.0 with the OIDC fix from #137 already in place.

## What ships

Full rollup is in the tag annotation. Highlights:

- **OIDC trusted publishing for npm** (#132 + #137)
- **Skip-with-reason mechanic** for TDD (J7VBGJ + MKVNFB)
- **Crockford Base32 ticket IDs** (ticket 158)
- **explore-and-debate skill**
- **CODEOWNERS + dual-merger setup**
- **Voice + skill discipline docs** (#127, #133)
- Hook + lint infrastructure improvements

## Test plan

- [ ] CI green on this PR
- [ ] Admin-merge (release commits)
- [ ] Tag v0.35.0
- [ ] Push tag -> Release workflow fires
- [ ] Approve in release environment
- [ ] Verify safeword@0.35.0 on npm with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)