### PR TITLE
fix(release): prefix tarball path with ./ for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,11 @@ jobs:
           # --provenance: cryptographically attest the build came from this
           # exact workflow run + commit. Auto-enabled with OIDC but explicit.
           # --access public: safeword is a public package.
-          npm publish release-artifacts/safeword-*.tgz \
+          # ./ prefix is REQUIRED — without it, npm parses the path as a
+          # GitHub repo shorthand (release-artifacts/safeword-0.35.0.tgz →
+          # ssh://git@github.com/release-artifacts/safeword-0.35.0.tgz.git)
+          # and tries to git-clone instead of reading the local tarball.
+          npm publish ./release-artifacts/safeword-*.tgz \
             --provenance \
             --access public \
             --ignore-scripts


### PR DESCRIPTION
## Summary

Third publish-flow bug found by the first real run, this time at the actual \`npm publish\` step:

\`\`\`
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/release-artifacts/safeword-0.35.0.tgz.git
npm error git@github.com: Permission denied (publickey).
\`\`\`

npm parses \`release-artifacts/safeword-0.35.0.tgz\` as a GitHub repo shorthand (user/repo), beats local-path detection, tries to git-clone it. \`./\` prefix forces local-file mode.

Verified against [npm-publish docs](https://docs.npmjs.com/cli/v11/commands/npm-publish/) — \`<package-spec>\` precedence puts git-shorthand ahead of bare relative paths.

## Test plan

- [ ] Merge
- [ ] Move v0.35.0 tag to include this commit
- [ ] Re-push tag → Release workflow fires
- [ ] Verify safeword@0.35.0 on npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)