### PR TITLE
fix(release): bump to Node 24 for OIDC handshake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           # Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1.
-          # Node 22.x bundles npm 10.x — we upgrade npm explicitly below.
-          node-version: '22'
+          # Node 22.x bundles npm 10.x; even after `npm install -g npm@latest`
+          # below, the OIDC handshake at npm registry still returned 404 (5x
+          # publish attempts at v0.35.0). Node 24.x ships npm 11+ natively,
+          # which fixed the handshake for others hitting this exact symptom.
+          # See: https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm to >=11.5.1 (required for OIDC trusted publishing)


### PR DESCRIPTION
## Summary

5 publish attempts at v0.35.0 all failed with the same symptom: provenance signed + pushed to Sigstore successfully, but the actual \`PUT\` to npm registry returned 404. With OIDC, 404 = anonymous-user fallback when the handshake doesn't match a trusted publisher.

Even with \`npm install -g npm@latest\` upgrading to 11.15.0 (verified by our version-check step), the handshake fails on Node 22. The fix per the linked article: bump to Node 24, which ships npm 11.x natively. The bundled-vs-upgraded npm distinction matters at the OIDC layer.

## Test plan

- [ ] Merge
- [ ] Move v0.35.0 tag to include this commit
- [ ] Re-push tag → Release workflow fires
- [ ] Verify safeword@0.35.0 lands on npm with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)