### PR TITLE
debug: print OIDC claims to diagnose v0.35.0 publish 404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,28 @@ jobs:
         working-directory: packages/cli
         run: bun pm pack --destination ../../release-artifacts
 
+      - name: Debug — print OIDC claims and npm config (diagnostic for #140 404)
+        run: |
+          echo "=== npm/node versions ==="
+          which npm
+          npm --version
+          node --version
+          echo ""
+          echo "=== NPM_CONFIG_USERCONFIG path ==="
+          echo "$NPM_CONFIG_USERCONFIG"
+          echo ""
+          echo "=== .npmrc contents (auth token masked) ==="
+          if [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed 's/=.*$/=<masked>/' "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "no .npmrc"
+          fi
+          echo ""
+          echo "=== OIDC claims for audience npm:registry.npmjs.org ==="
+          TOKEN=$(curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq . || echo "(token decode failed)"
+
       - name: Publish to npm with provenance via OIDC
         run: |
           # --ignore-scripts: build + tests already ran above; prepublishOnly
@@ -112,4 +134,5 @@ jobs:
           npm publish ./release-artifacts/safeword-*.tgz \
             --provenance \
             --access public \
-            --ignore-scripts
+            --ignore-scripts \
+            --loglevel=verbose


### PR DESCRIPTION
## Why

6 publish attempts hit the same wall: Sigstore step succeeds, npm PUT returns 404. Node-24 bump didn't help. Need actual diagnostic data instead of more guessing.

## What

Adds a debug step before publish that prints:
- \`which npm\`, \`npm --version\`, \`node --version\`
- \`.npmrc\` contents (auth values masked)
- Decoded OIDC token claims for audience \`npm:registry.npmjs.org\`

Plus \`--loglevel=verbose\` on the publish itself so npm CLI prints the actual handshake attempt.

## Plan

- [ ] Merge
- [ ] Re-tag v0.35.0
- [ ] Read the OIDC claims output → match against trusted publisher config to find the mismatch
- [ ] Fix the actual config (or workflow) issue
- [ ] Remove this debug step in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)