### PR TITLE
feat(645W8H): per-worktree re-entry brief

### DIFF
--- a/.safeword-project/tickets/645W8H/test-definitions.md
+++ b/.safeword-project/tickets/645W8H/test-definitions.md
@@ -238,9 +238,9 @@ And a dirty-file conflict exists with another session (per Rule 5 detection)
 When the status-line script runs
 Then stdout includes `⚠️ conflict: <file>` before the Next: imperative
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5d90c34
+- [x] GREEN 8e3e1a4
+- [x] REFACTOR skip: detection logic already lives in the shared lib (`detectConflictFiles`); status-line just consumes it. Render is a 2-line prefix string — nothing to extract.
 
 ### Scenario: Empty or missing re-entry log → no Next: indicator
 
@@ -248,6 +248,6 @@ Given `.safeword-project/re-entry.md` is empty or missing
 When the status-line script runs
 Then stdout contains no Next: indicator (graceful absence; status line falls through to other content if any)
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: silent-on-empty guards were part of scenario 8.1's GREEN design — no failing test to write.
+- [x] GREEN 3fea90c
+- [x] REFACTOR skip: regression test only; no production code change.

--- a/.safeword-project/tickets/645W8H/test-definitions.md
+++ b/.safeword-project/tickets/645W8H/test-definitions.md
@@ -145,9 +145,9 @@ And none of those files are currently dirty in `git status`
 When the SessionStart hook fires
 Then additionalContext contains no conflict warning line
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: the no-conflict default state was preserved through scenarios 4.1–4.4 (current code never emitted a warning); no failing test to write.
+- [x] GREEN db421e2
+- [x] REFACTOR skip: regression test only; no production code change.
 
 ### Scenario: Single dirty-file overlap → warning names the file
 
@@ -156,9 +156,9 @@ And `foo.ts` is currently dirty in `git status`
 When the SessionStart hook fires
 Then additionalContext includes a warning line naming `foo.ts`
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 3b9e307
+- [x] GREEN 943021e
+- [x] REFACTOR skip: helpers are self-contained pure functions; lib extraction lands when Slice 3 (status-line) first reuses them.
 
 ### Scenario: Multiple dirty-file overlaps → all named
 
@@ -167,9 +167,9 @@ And both files are currently dirty in `git status`
 When the SessionStart hook fires
 Then additionalContext includes a warning line naming both files
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: `detectConflictFiles` returns a Set-derived list — multiple-file coverage falls out of scenario 5.2's GREEN structurally; no failing test to write.
+- [x] GREEN da659de
+- [x] REFACTOR skip: regression test only; no production code change.
 
 ## Rule: Render stays bounded
 

--- a/.safeword-project/tickets/645W8H/test-definitions.md
+++ b/.safeword-project/tickets/645W8H/test-definitions.md
@@ -251,3 +251,7 @@ Then stdout contains no Next: indicator (graceful absence; status line falls thr
 - [x] RED skip: silent-on-empty guards were part of scenario 8.1's GREEN design — no failing test to write.
 - [x] GREEN 3fea90c
 - [x] REFACTOR skip: regression test only; no production code change.
+
+## Feature-level cross-scenario refactor
+
+- [x] cross-scenario 45c1a5b # extracted shared pure functions to `.safeword/hooks/lib/re-entry.ts` (parseLogLine + conflict-detection helpers) so Slice 2 (SessionStart) and Slice 3 (statusline) can both consume them without duplication.

--- a/.safeword-project/tickets/645W8H/test-definitions.md
+++ b/.safeword-project/tickets/645W8H/test-definitions.md
@@ -227,9 +227,9 @@ Given the current session has entries in `.safeword-project/re-entry.md`
 When the status-line script runs with the standard Claude Code JSON input on stdin
 Then stdout includes the most recent Next: imperative for this session
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED b10af04
+- [x] GREEN 6a4073e
+- [x] REFACTOR skip: parseLogLine duplicated from session-start hook; lib extraction will land in scenario 8.2's GREEN when conflict-detection logic must be shared.
 
 ### Scenario: Conflict prefix appears when dirty-file overlap exists
 

--- a/.safeword-project/tickets/645W8H/ticket.md
+++ b/.safeword-project/tickets/645W8H/ticket.md
@@ -2,10 +2,10 @@
 id: 645W8H
 slug: session-reentry-brief
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 created: 2026-05-22T15:11:24.096Z
-last_modified: 2026-05-22T15:50:00.000Z
+last_modified: 2026-05-22T19:25:00.000Z
 scope:
   - Stop hook appends one line per turn to `.safeword-project/re-entry.md` in the canonical shape `<ISO-timestamp> <session-id> ticket=<id>/<phase> Next: <imperative>` (POSIX append, atomic for sub-PIPE_BUF writes).
   - All deterministic fields (timestamp, session_id, ticket id, ticket phase) are hook-injected from Stop-hook stdin and ticket frontmatter — never typed by the agent. Only the Next: imperative is extracted from the agent's final assistant message via regex.
@@ -106,3 +106,4 @@ A second research pass validated the "+orientation" shape against current Anthro
 - 2026-05-22T15:50:00.000Z Complete: Phase 5 — light decomposition; two slices (Slice 1 Stop-hook writer = 9 scenarios; Slice 2 SessionStart reader = 8 scenarios) sharing a `re-entry.ts` lib. No deeper breakdown needed (architecture clear). Advancing to implement.
 - 2026-05-22T16:00:00.000Z Complete: Slice 1 scenarios 1.1–1.3 (RED + GREEN + REFACTOR triplets, with scenarios 1.2/1.3 covered as side effect of 1.1's bail-out logic). 969 hook+integration tests green.
 - 2026-05-22T17:55:00.000Z In-flight re-scope after /elicit: Q1 → D (silent additionalContext + status-line ambient); Q2 → silent-unless-conflict, conflict = other session edited file AND dirty in git, surfaces in both additionalContext and status-line prefix; Q3 → A (fresh shows most-recent tagged "(from another session)"). Two parallel research agents validated Q1 (Trafton & Altmann blatant-cue + IDE convention) and Q3 (Anthropic memory-tool pattern + Parnin task-aligned cues). Cascade to test-definitions.md: replaced Rule 5 (multi-session trailer, 2 scenarios) with new Rule 5 (conflict detection, 3 scenarios); added Rule 8 (status-line script, 3 scenarios). Added Slice 3 (status-line script). Total: 21 scenarios across 8 rules (was 17/7). Slice 1 unaffected; resuming scenario 2.1 RED.
+- 2026-05-22T19:25:00.000Z Complete: Phase 6 — all 21 scenarios closed across Slices 1, 2, and 3. Cross-scenario REFACTOR (45c1a5b) extracted shared pure functions to `.safeword/hooks/lib/re-entry.ts`. Re-entry test surface: 22 tests across 5 files (re-entry-stop, re-entry-session-start, re-entry-conflict-detection, re-entry-statusline, re-entry-concurrent). Parity 106 pairs + 3 contracts. Advancing to verify.

--- a/.safeword-project/tickets/645W8H/ticket.md
+++ b/.safeword-project/tickets/645W8H/ticket.md
@@ -2,10 +2,10 @@
 id: 645W8H
 slug: session-reentry-brief
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-05-22T15:11:24.096Z
-last_modified: 2026-05-22T19:25:00.000Z
+last_modified: 2026-05-22T22:34:00.000Z
 scope:
   - Stop hook appends one line per turn to `.safeword-project/re-entry.md` in the canonical shape `<ISO-timestamp> <session-id> ticket=<id>/<phase> Next: <imperative>` (POSIX append, atomic for sub-PIPE_BUF writes).
   - All deterministic fields (timestamp, session_id, ticket id, ticket phase) are hook-injected from Stop-hook stdin and ticket frontmatter — never typed by the agent. Only the Next: imperative is extracted from the agent's final assistant message via regex.

--- a/.safeword-project/tickets/645W8H/verify.md
+++ b/.safeword-project/tickets/645W8H/verify.md
@@ -1,0 +1,87 @@
+# Verify — ticket 645W8H
+
+Per-worktree re-entry brief (Stop-hook log + SessionStart injection + status-line ambient).
+
+Refreshed 2026-05-22T22:31Z on HEAD = bdc123a.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 1981/1981 tests pass (1 skipped, 0 failed) — 114 test files, full suite `bun run test` from `packages/cli/`, duration 688s.
+**Build:** ✅ Success (`bun run build` in `packages/cli/` — ESM + DTS).
+**Lint:** ✅ Clean (`bun run lint:eslint`, `bun run format`, `bunx tsc --noEmit` — all silent).
+**Scenarios:** All 64 scenarios marked complete (`grep -c '^- \[x\]'` = 64; `grep -c '^- \[ \]'` = 0 in `test-definitions.md`).
+**Dep Drift:** ✅ Clean — no new `package.json` dependencies introduced by this branch. New runtime files are internal hook libs + a status-line script. `ARCHITECTURE.md` mentions every architectural dep (commander, yaml, astro, starlight, tsup, vitest, typescript). ESLint-plugin packages excluded per skill triage rule (tooling).
+**Parent Epic:** N/A (feature has no `parent:` field).
+
+## Audit
+
+Audit passed.
+
+- **Architecture (depcruise):** no dependency violations — 114 modules, 311 dependencies cruised.
+- **Dead code (knip):** clean. The initial run flagged `packages/cli/templates/statusline/reentry.ts` because the new templates dir wasn't covered by `knip.json` `ignoreFiles`. Extended the existing `templates/hooks/**` pattern to also cover `templates/statusline/**` in commit `bdc123a`.
+- **Duplication (jscpd):** 95 clones across 988 files (1.83% lines, 2.11% tokens) — all pre-existing, none introduced by this branch's new modules.
+- **Outdated deps:** 3 dev-only updates available — `knip` 6.14.1 → 6.14.2 (patch, Low), `eslint-plugin-jsdoc` 62 → 63 (major, Medium), `eslint` 9 → 10 (major, High). All deferred to dedicated migration tasks (matches J7VBGJ standing position).
+- **Learning files:** all conform to the `Covers:` line-3 convention (no `[W006]` flags).
+- **Agent configs:** CLAUDE.md = 33 lines, AGENTS.md = 176 lines, ARCHITECTURE.md = 525 lines, SAFEWORD.md = 198 lines — all within sane bounds.
+
+## What this feature delivers
+
+Three sites of context recovery for per-worktree re-entry, designed in concert:
+
+1. **Stop-hook log** ([re-entry.ts](.safeword/hooks/lib/re-entry.ts)) — appends one line per turn to `.safeword-project/re-entry.md`, shape `<ISO-timestamp> <session-id> ticket=<id>/<phase> Next: <imperative>`. Deterministic fields are hook-injected from Stop-hook stdin + ticket frontmatter; only the `Next: <imperative>` is regex-extracted from the assistant's final message. POSIX append, atomic for sub-PIPE_BUF writes.
+2. **SessionStart injection** ([session-start-reentry.ts](.safeword/hooks/session-start-reentry.ts)) — reads the log tail, filters by current session_id, injects the last 3 matching entries silently via `additionalContext`. Fresh `claude` (no session match): shows the single most-recent entry across all sessions tagged "(from another session)". On detected conflict (another session edited a file in its last 10 turns AND that file is dirty in `git status`): includes a one-line warning naming the file(s).
+3. **Status-line script** ([reentry.ts](.safeword/statusline/reentry.ts)) — reads the same log tail, calls the shared conflict-detection lib, emits an ambient one-line indicator for the user's glance. On conflict: prepends `⚠️ conflict: <file>` before the Next: imperative. Silent otherwise.
+
+Three slices, all delivered. 64/64 scenarios closed (8 rules × ~3 R/G/R sub-checkboxes per scenario row, by the per-scenario annotated-checkbox ledger from J7VBGJ).
+
+## Multi-session behavior
+
+Two concurrent sessions in one worktree are first-class:
+
+- Append-only writes (atomic under PIPE_BUF) — no interleaving.
+- Session-tagged lines — filtering at SessionStart is by `session_id`.
+- Conflict signal is silent unless real (file-edited-recently AND currently-dirty); avoids "you have N other sessions" noise.
+
+## Next:-extraction rule
+
+Regex matches the **last** `**Next:** <imperative>` occurrence in the assistant's final message (Phase 4 refinement). Aligns with the SAFEWORD.md "end with the call" voice rule. Absence of `**Next:** ...` → no log entry (no garbage entries with empty intent). No-active-ticket case renders `ticket=∅/freeform` with the imperative.
+
+## Defect found at verify
+
+The verify run caught a schema-completeness bug introduced by this branch:
+
+- `.safeword/statusline/reentry.ts` was registered in `SAFEWORD_SCHEMA.ownedFiles` but its parent `.safeword/statusline` was missing from `ownedDirs`.
+- At uninstall, `removeIfEmpty('.safeword/statusline')` was never planned (non-recursive `rmdirSync`), so the now-empty directory survived. That empty subdir then made `removeIfEmpty('.safeword')` fail — `.safeword/` directory survived too.
+- Symptom: 4 failing tests (`tests/commands/reset.test.ts` 11.2 / 11.4 / 11.7 plus `tests/reconcile.test.ts > uninstall mode`), all asserting `.safeword/` is gone after `safeword reset`.
+
+Fix in commit `bdc123a`:
+
+1. Add `'.safeword/statusline'` to `SAFEWORD_SCHEMA.ownedDirs` (one line; the actual repair).
+2. New structural test in `packages/cli/tests/schema.test.ts` — every `dirname(ownedFile)` must be in `ownedDirs` / `sharedDirs` / `preservedDirs`, or match the `.claude/*` auto-cleanup path in `reconcile.ts`. Catches the "owned file under unregistered directory" bug class by construction. Verified by reverting the schema entry: test fails with `'.safeword/statusline/reentry.ts' needs '.safeword/statusline' in ownedDirs/sharedDirs/preservedDirs`.
+3. Extend `knip.json` `ignoreFiles` to cover `templates/statusline/**` (same pattern as the existing `templates/hooks/**` entry).
+
+## Out of scope (kept honest)
+
+- Cross-worktree dashboard (Option B from figure-it-out) — pointless without per-worktree artifact existing; possible follow-up.
+- Auto-trim / TTL on the log file — Phase 2 if size becomes a problem.
+- SDK `memory_20250818` integration — useful but beta-primitive dependency; revisit after this ships.
+- Retrospective state on the line (last test verdict, dirty count) — promoted to scope only if it would change the agent's next action. Current candidates don't clear that bar.
+
+## Commits on branch
+
+53 commits between `main` and HEAD (`bdc123a`). The final arc:
+
+```
+bdc123a fix(645W8H): register .safeword/statusline in ownedDirs + guard test
+d4120e9 chore(645W8H): all 21 scenarios closed; advance phase implement → verify
+8e191a2 chore(645W8H): close Rule 8 — 8.2 GREEN, 8.3 GREEN
+3fea90c test(645W8H): scenario 8.3 — statusline silent when no entries (regression)
+8e3e1a4 feat(645W8H): GREEN scenario 8.2 — statusline conflict prefix
+5d90c34 test(645W8H): RED scenario 8.2 — statusline conflict prefix
+45c1a5b refactor(645W8H): extract shared re-entry lib (deferred from scenario 1.1)
+4b78b38 chore(645W8H): close scenario 8.1 (RED b10af04, GREEN 6a4073e, REFACTOR skip)
+6a4073e feat(645W8H): GREEN scenario 8.1 — statusline prints latest Next:
+b10af04 test(645W8H): RED scenario 8.1 — statusline surfaces latest Next:
+```
+
+Full history: `git log main..HEAD --oneline`.

--- a/.safeword-project/tickets/645W8H/verify.md
+++ b/.safeword-project/tickets/645W8H/verify.md
@@ -2,11 +2,11 @@
 
 Per-worktree re-entry brief (Stop-hook log + SessionStart injection + status-line ambient).
 
-Refreshed 2026-05-22T22:31Z on HEAD = bdc123a.
+Refreshed 2026-05-23T00:30Z on HEAD = a775ee1 (after rebase onto origin/main `726fc30`).
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 1981/1981 tests pass (1 skipped, 0 failed) — 114 test files, full suite `bun run test` from `packages/cli/`, duration 688s.
+**Test Suite:** ✓ 2001/2001 tests pass (1 skipped, 0 failed) — 115 test files, full suite `bun run test` from `packages/cli/`, duration 859s. Re-run after rebase onto current main; the +20 tests vs the pre-rebase 1981 are from main's PR #134 (learning-verification-stamps).
 **Build:** ✅ Success (`bun run build` in `packages/cli/` — ESM + DTS).
 **Lint:** ✅ Clean (`bun run lint:eslint`, `bun run format`, `bunx tsc --noEmit` — all silent).
 **Scenarios:** All 64 scenarios marked complete (`grep -c '^- \[x\]'` = 64; `grep -c '^- \[ \]'` = 0 in `test-definitions.md`).
@@ -15,11 +15,11 @@ Refreshed 2026-05-22T22:31Z on HEAD = bdc123a.
 
 ## Audit
 
-Audit passed.
+Audit passed. (Numbers reflect the audit at HEAD before rebase; rebase only changed the base, not this branch's diff. Full-suite re-run on post-rebase HEAD confirmed 2001/2001 green.)
 
-- **Architecture (depcruise):** no dependency violations — 114 modules, 311 dependencies cruised.
-- **Dead code (knip):** clean. The initial run flagged `packages/cli/templates/statusline/reentry.ts` because the new templates dir wasn't covered by `knip.json` `ignoreFiles`. Extended the existing `templates/hooks/**` pattern to also cover `templates/statusline/**` in commit `bdc123a`.
-- **Duplication (jscpd):** 95 clones across 988 files (1.83% lines, 2.11% tokens) — all pre-existing, none introduced by this branch's new modules.
+- **Architecture (depcruise):** no dependency violations.
+- **Dead code (knip):** clean. The initial run flagged `packages/cli/templates/statusline/reentry.ts` because the new templates dir wasn't covered by `knip.json` `ignoreFiles`. Extended the existing `templates/hooks/**` pattern to also cover `templates/statusline/**` in commit `0cde744`.
+- **Duplication (jscpd):** 95 clones, 1.83% lines / 2.11% tokens — all pre-existing, none introduced by this branch's new modules.
 - **Outdated deps:** 3 dev-only updates available — `knip` 6.14.1 → 6.14.2 (patch, Low), `eslint-plugin-jsdoc` 62 → 63 (major, Medium), `eslint` 9 → 10 (major, High). All deferred to dedicated migration tasks (matches J7VBGJ standing position).
 - **Learning files:** all conform to the `Covers:` line-3 convention (no `[W006]` flags).
 - **Agent configs:** CLAUDE.md = 33 lines, AGENTS.md = 176 lines, ARCHITECTURE.md = 525 lines, SAFEWORD.md = 198 lines — all within sane bounds.
@@ -54,11 +54,15 @@ The verify run caught a schema-completeness bug introduced by this branch:
 - At uninstall, `removeIfEmpty('.safeword/statusline')` was never planned (non-recursive `rmdirSync`), so the now-empty directory survived. That empty subdir then made `removeIfEmpty('.safeword')` fail — `.safeword/` directory survived too.
 - Symptom: 4 failing tests (`tests/commands/reset.test.ts` 11.2 / 11.4 / 11.7 plus `tests/reconcile.test.ts > uninstall mode`), all asserting `.safeword/` is gone after `safeword reset`.
 
-Fix in commit `bdc123a`:
+Fix in commit `0cde744`:
 
 1. Add `'.safeword/statusline'` to `SAFEWORD_SCHEMA.ownedDirs` (one line; the actual repair).
 2. New structural test in `packages/cli/tests/schema.test.ts` — every `dirname(ownedFile)` must be in `ownedDirs` / `sharedDirs` / `preservedDirs`, or match the `.claude/*` auto-cleanup path in `reconcile.ts`. Catches the "owned file under unregistered directory" bug class by construction. Verified by reverting the schema entry: test fails with `'.safeword/statusline/reentry.ts' needs '.safeword/statusline' in ownedDirs/sharedDirs/preservedDirs`.
 3. Extend `knip.json` `ignoreFiles` to cover `templates/statusline/**` (same pattern as the existing `templates/hooks/**` entry).
+
+## Rebase note
+
+This branch was rebased onto `origin/main` after PR #133 was squash-merged. The squash on main (commit `920b578`) was byte-identical to PR #133's tip (`be08fec`), so `git rebase --onto origin/main be08fec` cleanly replayed our 17 incremental commits with no manual conflict — git's 3-way auto-merge handled the only overlap (`packages/cli/src/schema.ts`, where main and this branch both made additive changes to different parts of the schema object).
 
 ## Out of scope (kept honest)
 
@@ -69,19 +73,21 @@ Fix in commit `bdc123a`:
 
 ## Commits on branch
 
-53 commits between `main` and HEAD (`bdc123a`). The final arc:
+17 commits between `origin/main` (`726fc30`) and HEAD (`a775ee1`). The final arc:
 
 ```
-bdc123a fix(645W8H): register .safeword/statusline in ownedDirs + guard test
-d4120e9 chore(645W8H): all 21 scenarios closed; advance phase implement → verify
-8e191a2 chore(645W8H): close Rule 8 — 8.2 GREEN, 8.3 GREEN
-3fea90c test(645W8H): scenario 8.3 — statusline silent when no entries (regression)
-8e3e1a4 feat(645W8H): GREEN scenario 8.2 — statusline conflict prefix
-5d90c34 test(645W8H): RED scenario 8.2 — statusline conflict prefix
-45c1a5b refactor(645W8H): extract shared re-entry lib (deferred from scenario 1.1)
-4b78b38 chore(645W8H): close scenario 8.1 (RED b10af04, GREEN 6a4073e, REFACTOR skip)
-6a4073e feat(645W8H): GREEN scenario 8.1 — statusline prints latest Next:
-b10af04 test(645W8H): RED scenario 8.1 — statusline surfaces latest Next:
+a775ee1 chore(645W8H): advance phase verify → done; status → done
+98540f8 chore(645W8H): verify artifact — full suite green on post-rebase HEAD
+0cde744 fix(645W8H): register .safeword/statusline in ownedDirs + guard test
+d7d4ca3 chore(645W8H): all 21 scenarios closed; advance phase implement → verify
+aa5d8d9 chore(645W8H): close Rule 8 — 8.2 GREEN, 8.3 GREEN
+f379ddc test(645W8H): scenario 8.3 — statusline silent when no entries (regression)
+b662a2e feat(645W8H): GREEN scenario 8.2 — statusline conflict prefix
+7929e0b test(645W8H): RED scenario 8.2 — statusline conflict prefix
+2db50f8 refactor(645W8H): extract shared re-entry lib (deferred from scenario 1.1)
+5fa59d8 chore(645W8H): close scenario 8.1
+2b9037c feat(645W8H): GREEN scenario 8.1 — statusline prints latest Next:
+f3f133d test(645W8H): RED scenario 8.1 — statusline surfaces latest Next:
 ```
 
-Full history: `git log main..HEAD --oneline`.
+Full history: `git log origin/main..HEAD --oneline`.

--- a/.safeword/hooks/lib/re-entry.ts
+++ b/.safeword/hooks/lib/re-entry.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared pure functions for the re-entry brief (ticket 645W8H).
+ *
+ * Both `.safeword/hooks/session-start-reentry.ts` (Slice 2) and
+ * `.safeword/statusline/reentry.ts` (Slice 3) parse the same canonical
+ * log line and detect the same kind of dirty-file conflict between
+ * concurrent Claude sessions. The functions here are pure (no stdin
+ * reading, no stdout writing); the hook/script wrappers handle I/O.
+ */
+
+import { execSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+
+export interface Entry {
+  timestamp: string;
+  sessionId: string;
+  ticket: string;
+  nextImperative: string;
+}
+
+interface ToolUse {
+  type: string;
+  name?: string;
+  input?: { file_path?: string };
+}
+
+interface TranscriptEntry {
+  type?: string;
+  message?: { role?: string; content?: ToolUse[] };
+}
+
+// Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
+const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
+const RECENT_TURNS = 10;
+
+export function parseLogLine(line: string): Entry | null {
+  const match = LINE_REGEX.exec(line.trim());
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    sessionId: match[2],
+    ticket: match[3],
+    nextImperative: match[4],
+  };
+}
+
+export function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
+  const directory = dirname(currentTranscriptPath);
+  const currentBase = basename(currentTranscriptPath);
+  try {
+    return readdirSync(directory)
+      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
+      .map(name => join(directory, name));
+  } catch {
+    return [];
+  }
+}
+
+export function readRecentEditedFiles(transcriptPath: string): string[] {
+  const edited = new Set<string>();
+  try {
+    const raw = readFileSync(transcriptPath, 'utf8').trim();
+    if (raw.length === 0) return [];
+    const lines = raw.split('\n');
+    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
+    // turn often emits multiple tool-use events.
+    for (const line of lines.slice(-RECENT_TURNS * 5)) {
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        if (entry.type !== 'assistant' || !entry.message?.content) continue;
+        for (const item of entry.message.content) {
+          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
+            const filePath = item.input?.file_path;
+            if (filePath) edited.add(filePath);
+          }
+        }
+      } catch {
+        // Skip malformed lines silently.
+      }
+    }
+  } catch {
+    // Transcript unreadable — no edits to report.
+  }
+  return [...edited];
+}
+
+export function getDirtyFiles(cwd: string): string[] {
+  try {
+    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
+    return output
+      .split('\n')
+      .map(line => line.slice(3).trim())
+      .filter(line => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export function normalizeRelative(filePath: string, cwd: string): string {
+  // Edit tool_use events typically use absolute paths; git status emits paths
+  // relative to the repo root (== cwd here).
+  if (filePath.startsWith(cwd)) {
+    return relative(cwd, filePath);
+  }
+  return filePath;
+}
+
+export function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
+  if (!transcriptPath) return [];
+  const dirtyFiles = new Set(getDirtyFiles(cwd));
+  if (dirtyFiles.size === 0) return [];
+  const overlap = new Set<string>();
+  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
+    for (const editedFile of readRecentEditedFiles(otherPath)) {
+      const relativePath = normalizeRelative(editedFile, cwd);
+      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
+    }
+  }
+  return [...overlap];
+}

--- a/.safeword/hooks/session-start-reentry.ts
+++ b/.safeword/hooks/session-start-reentry.ts
@@ -9,15 +9,22 @@
  * (silent — not shown in chat; for Claude recall when the user asks
  * "where were we?"). The status-line script (Slice 3) is the user-facing
  * surface.
+ *
+ * Also detects conflict: when another session's transcript has Edit/Write
+ * tool calls on files that are currently dirty in `git status`, append a
+ * warning line so the agent (and via Slice 3, the user) knows to step
+ * lightly around those files.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
 
 interface HookInput {
   session_id?: string;
   source?: 'startup' | 'resume' | 'clear' | 'compact';
   cwd?: string;
+  transcript_path?: string;
 }
 
 interface Entry {
@@ -27,8 +34,21 @@ interface Entry {
   nextImperative: string;
 }
 
+interface ToolUse {
+  type: string;
+  name?: string;
+  input?: { file_path?: string };
+}
+
+interface TranscriptEntry {
+  type?: string;
+  message?: { role?: string; content?: ToolUse[] };
+}
+
 // Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
 const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
+const RECENT_TURNS = 10;
 
 function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
@@ -49,6 +69,87 @@ function renderBrief(entries: Entry[], options: { fromAnotherSession?: boolean }
   return `${header}\n${lines.join('\n')}`;
 }
 
+function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
+  const directory = dirname(currentTranscriptPath);
+  const currentBase = basename(currentTranscriptPath);
+  try {
+    return readdirSync(directory)
+      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
+      .map(name => join(directory, name));
+  } catch {
+    return [];
+  }
+}
+
+function readRecentEditedFiles(transcriptPath: string): string[] {
+  const edited = new Set<string>();
+  try {
+    const raw = readFileSync(transcriptPath, 'utf8').trim();
+    if (raw.length === 0) return [];
+    const lines = raw.split('\n');
+    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
+    // turn often emits multiple tool-use events.
+    for (const line of lines.slice(-RECENT_TURNS * 5)) {
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        if (entry.type !== 'assistant' || !entry.message?.content) continue;
+        for (const item of entry.message.content) {
+          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
+            const filePath = item.input?.file_path;
+            if (filePath) edited.add(filePath);
+          }
+        }
+      } catch {
+        // Skip malformed lines silently.
+      }
+    }
+  } catch {
+    // Transcript unreadable — no edits to report.
+  }
+  return [...edited];
+}
+
+function getDirtyFiles(cwd: string): string[] {
+  try {
+    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
+    return output
+      .split('\n')
+      .map(line => line.slice(3).trim())
+      .filter(line => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRelative(filePath: string, cwd: string): string {
+  // Edit tool_use events typically use absolute paths; git status emits paths
+  // relative to the repo root (== cwd here).
+  if (filePath.startsWith(cwd)) {
+    return relative(cwd, filePath);
+  }
+  return filePath;
+}
+
+function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
+  if (!transcriptPath) return [];
+  const dirtyFiles = new Set(getDirtyFiles(cwd));
+  if (dirtyFiles.size === 0) return [];
+  const overlap = new Set<string>();
+  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
+    for (const editedFile of readRecentEditedFiles(otherPath)) {
+      const relativePath = normalizeRelative(editedFile, cwd);
+      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
+    }
+  }
+  return [...overlap];
+}
+
+function renderConflictWarning(files: string[]): string {
+  if (files.length === 0) return '';
+  const quoted = files.map(f => `\`${f}\``).join(', ');
+  return `\n\n⚠️ Conflict: another session edited ${quoted} (still dirty in the working tree).`;
+}
+
 async function main(): Promise<void> {
   const stdinText = await new Response(Bun.stdin.stream()).text();
   let input: HookInput;
@@ -58,14 +159,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { session_id, cwd, source } = input;
+  const { session_id, cwd, source, transcript_path } = input;
   if (!session_id || !cwd) return;
 
   const logPath = join(cwd, '.safeword-project', 're-entry.md');
-  if (!existsSync(logPath)) return;
-
-  const content = readFileSync(logPath, 'utf8').trim();
-  if (content.length === 0) return;
+  const logExists = existsSync(logPath);
+  const content = logExists ? readFileSync(logPath, 'utf8').trim() : '';
 
   const allEntries = content
     .split('\n')
@@ -74,24 +173,23 @@ async function main(): Promise<void> {
 
   const currentEntries = allEntries.filter(e => e.sessionId === session_id);
 
-  let renderEntries: Entry[];
-  let fromAnotherSession = false;
-
+  let briefBody = '';
   if (currentEntries.length > 0) {
-    // Normal path: this session's last 3 (chronological — log is append-only).
-    renderEntries = currentEntries.slice(-3);
+    briefBody = renderBrief(currentEntries.slice(-3));
   } else if (source === 'startup' && allEntries.length > 0) {
-    // Fresh `claude` fallback: most-recent entry across all sessions, tagged.
-    renderEntries = [allEntries[allEntries.length - 1]];
-    fromAnotherSession = true;
-  } else {
-    return;
+    briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
   }
+
+  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const conflictWarning = renderConflictWarning(conflictFiles);
+
+  // Nothing to inject in either channel → stay silent.
+  if (briefBody.length === 0 && conflictWarning.length === 0) return;
 
   const output = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
-      additionalContext: renderBrief(renderEntries, { fromAnotherSession }),
+      additionalContext: `${briefBody}${conflictWarning}`,
     },
   };
   process.stdout.write(`${JSON.stringify(output)}\n`);

--- a/.safeword/hooks/session-start-reentry.ts
+++ b/.safeword/hooks/session-start-reentry.ts
@@ -16,9 +16,10 @@
  * lightly around those files.
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { detectConflictFiles, type Entry, parseLogLine } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -27,121 +28,12 @@ interface HookInput {
   transcript_path?: string;
 }
 
-interface Entry {
-  timestamp: string;
-  sessionId: string;
-  ticket: string;
-  nextImperative: string;
-}
-
-interface ToolUse {
-  type: string;
-  name?: string;
-  input?: { file_path?: string };
-}
-
-interface TranscriptEntry {
-  type?: string;
-  message?: { role?: string; content?: ToolUse[] };
-}
-
-// Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
-const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
-const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
-const RECENT_TURNS = 10;
-
-function parseLogLine(line: string): Entry | null {
-  const match = LINE_REGEX.exec(line.trim());
-  if (!match) return null;
-  return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
-  };
-}
-
 function renderBrief(entries: Entry[], options: { fromAnotherSession?: boolean } = {}): string {
   const header = options.fromAnotherSession
     ? 'Re-entry brief — most recent entry (from another session):'
     : `Re-entry brief — last ${entries.length} entries from this session:`;
   const lines = entries.map(e => `- ${e.timestamp} [${e.ticket}] ${e.nextImperative}`);
   return `${header}\n${lines.join('\n')}`;
-}
-
-function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
-  const directory = dirname(currentTranscriptPath);
-  const currentBase = basename(currentTranscriptPath);
-  try {
-    return readdirSync(directory)
-      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
-      .map(name => join(directory, name));
-  } catch {
-    return [];
-  }
-}
-
-function readRecentEditedFiles(transcriptPath: string): string[] {
-  const edited = new Set<string>();
-  try {
-    const raw = readFileSync(transcriptPath, 'utf8').trim();
-    if (raw.length === 0) return [];
-    const lines = raw.split('\n');
-    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
-    // turn often emits multiple tool-use events.
-    for (const line of lines.slice(-RECENT_TURNS * 5)) {
-      try {
-        const entry = JSON.parse(line) as TranscriptEntry;
-        if (entry.type !== 'assistant' || !entry.message?.content) continue;
-        for (const item of entry.message.content) {
-          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
-            const filePath = item.input?.file_path;
-            if (filePath) edited.add(filePath);
-          }
-        }
-      } catch {
-        // Skip malformed lines silently.
-      }
-    }
-  } catch {
-    // Transcript unreadable — no edits to report.
-  }
-  return [...edited];
-}
-
-function getDirtyFiles(cwd: string): string[] {
-  try {
-    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
-    return output
-      .split('\n')
-      .map(line => line.slice(3).trim())
-      .filter(line => line.length > 0);
-  } catch {
-    return [];
-  }
-}
-
-function normalizeRelative(filePath: string, cwd: string): string {
-  // Edit tool_use events typically use absolute paths; git status emits paths
-  // relative to the repo root (== cwd here).
-  if (filePath.startsWith(cwd)) {
-    return relative(cwd, filePath);
-  }
-  return filePath;
-}
-
-function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
-  if (!transcriptPath) return [];
-  const dirtyFiles = new Set(getDirtyFiles(cwd));
-  if (dirtyFiles.size === 0) return [];
-  const overlap = new Set<string>();
-  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
-    for (const editedFile of readRecentEditedFiles(otherPath)) {
-      const relativePath = normalizeRelative(editedFile, cwd);
-      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
-    }
-  }
-  return [...overlap];
 }
 
 function renderConflictWarning(files: string[]): string {

--- a/.safeword/statusline/reentry.ts
+++ b/.safeword/statusline/reentry.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+/**
+ * Status line: surface the latest `**Next:**` for the current session.
+ *
+ * Ticket 645W8H. Slice 3.
+ *
+ * Claude Code runs a status-line script with session JSON on stdin and renders
+ * whatever it prints at the bottom of the editor. This script reads
+ * `.safeword-project/re-entry.md`, finds the most recent entry for the current
+ * session_id, and prints `Next: <imperative>` for the user to glance at.
+ *
+ * RED phase: stub. Behaviour is missing.
+ */
+
+async function main(): Promise<void> {
+  await new Response(Bun.stdin.stream()).text();
+  // Behaviour deliberately absent — the failing test should drive GREEN.
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `statusline-reentry: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/.safeword/statusline/reentry.ts
+++ b/.safeword/statusline/reentry.ts
@@ -9,7 +9,7 @@
  * reads `.safeword-project/re-entry.md`, finds the most recent entry
  * for the current session_id, and prints `Next: <imperative>`. When a
  * dirty-file conflict exists with another session, the line is
- * prepended with `⚠️ conflict: <file>` (scenarios 8.2 onward).
+ * prepended with `⚠️ conflict: <file>`.
  *
  * Not wired into settings.json automatically — Claude Code's
  * `statusLine` config slot is single-valued; auto-installing would
@@ -20,29 +20,12 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { detectConflictFiles, type Entry, parseLogLine } from '../hooks/lib/re-entry';
+
 interface StatusLineInput {
   session_id?: string;
   cwd?: string;
-}
-
-interface Entry {
-  timestamp: string;
-  sessionId: string;
-  ticket: string;
-  nextImperative: string;
-}
-
-const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
-
-function parseLogLine(line: string): Entry | null {
-  const match = LINE_REGEX.exec(line.trim());
-  if (!match) return null;
-  return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
-  };
+  transcript_path?: string;
 }
 
 async function main(): Promise<void> {
@@ -54,7 +37,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { session_id, cwd } = input;
+  const { session_id, cwd, transcript_path } = input;
   if (!session_id || !cwd) return;
 
   const logPath = join(cwd, '.safeword-project', 're-entry.md');
@@ -72,7 +55,11 @@ async function main(): Promise<void> {
   if (entries.length === 0) return;
 
   const latest = entries[entries.length - 1];
-  process.stdout.write(`Next: ${latest.nextImperative}`);
+
+  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const prefix = conflictFiles.length > 0 ? `⚠️ conflict: ${conflictFiles.join(', ')} — ` : '';
+
+  process.stdout.write(`${prefix}Next: ${latest.nextImperative}`);
 }
 
 main().catch((error: unknown) => {

--- a/.safeword/statusline/reentry.ts
+++ b/.safeword/statusline/reentry.ts
@@ -1,20 +1,78 @@
 #!/usr/bin/env bun
 /**
- * Status line: surface the latest `**Next:**` for the current session.
+ * Status line: surface the latest `Next:` for the current session.
  *
  * Ticket 645W8H. Slice 3.
  *
- * Claude Code runs a status-line script with session JSON on stdin and renders
- * whatever it prints at the bottom of the editor. This script reads
- * `.safeword-project/re-entry.md`, finds the most recent entry for the current
- * session_id, and prints `Next: <imperative>` for the user to glance at.
+ * Claude Code runs a status-line script with session JSON on stdin and
+ * renders whatever it prints at the bottom of the editor. This script
+ * reads `.safeword-project/re-entry.md`, finds the most recent entry
+ * for the current session_id, and prints `Next: <imperative>`. When a
+ * dirty-file conflict exists with another session, the line is
+ * prepended with `⚠️ conflict: <file>` (scenarios 8.2 onward).
  *
- * RED phase: stub. Behaviour is missing.
+ * Not wired into settings.json automatically — Claude Code's
+ * `statusLine` config slot is single-valued; auto-installing would
+ * clobber a user's existing status-line. The user opts in by setting
+ * their `statusLine.command` to `bun .safeword/statusline/reentry.ts`.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface StatusLineInput {
+  session_id?: string;
+  cwd?: string;
+}
+
+interface Entry {
+  timestamp: string;
+  sessionId: string;
+  ticket: string;
+  nextImperative: string;
+}
+
+const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+
+function parseLogLine(line: string): Entry | null {
+  const match = LINE_REGEX.exec(line.trim());
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    sessionId: match[2],
+    ticket: match[3],
+    nextImperative: match[4],
+  };
+}
+
 async function main(): Promise<void> {
-  await new Response(Bun.stdin.stream()).text();
-  // Behaviour deliberately absent — the failing test should drive GREEN.
+  const stdinText = await new Response(Bun.stdin.stream()).text();
+  let input: StatusLineInput;
+  try {
+    input = JSON.parse(stdinText) as StatusLineInput;
+  } catch {
+    return;
+  }
+
+  const { session_id, cwd } = input;
+  if (!session_id || !cwd) return;
+
+  const logPath = join(cwd, '.safeword-project', 're-entry.md');
+  if (!existsSync(logPath)) return;
+
+  const content = readFileSync(logPath, 'utf8').trim();
+  if (content.length === 0) return;
+
+  const entries = content
+    .split('\n')
+    .map(parseLogLine)
+    .filter((e): e is Entry => e !== null)
+    .filter(e => e.sessionId === session_id);
+
+  if (entries.length === 0) return;
+
+  const latest = entries[entries.length - 1];
+  process.stdout.write(`Next: ${latest.nextImperative}`);
 }
 
 main().catch((error: unknown) => {

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "ignore": [".safeword/**", ".safeword-project/**"],
-  "ignoreFiles": ["packages/cli/templates/hooks/**"],
+  "ignoreFiles": ["packages/cli/templates/hooks/**", "packages/cli/templates/statusline/**"],
   "ignoreDependencies": ["eslint-plugin-jsdoc"],
   "ignoreBinaries": ["shfmt", "dot"],
   "ignoreIssues": {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -272,6 +272,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
 
     // Hooks shared library - TypeScript with Bun runtime
     '.safeword/hooks/lib/active-ticket.ts': { template: 'hooks/lib/active-ticket.ts' },
+    '.safeword/hooks/lib/re-entry.ts': { template: 'hooks/lib/re-entry.ts' },
     '.safeword/hooks/lib/hierarchy.ts': { template: 'hooks/lib/hierarchy.ts' },
     '.safeword/hooks/lib/lint.ts': { template: 'hooks/lib/lint.ts' },
     '.safeword/hooks/lib/quality.ts': { template: 'hooks/lib/quality.ts' },

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -116,6 +116,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/templates',
     '.safeword/prompts',
     '.safeword/scripts',
+    '.safeword/statusline',
     '.cursor',
     '.cursor/rules',
     '.cursor/commands',

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -346,6 +346,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/session-start-reentry.ts': {
       template: 'hooks/session-start-reentry.ts',
     },
+    '.safeword/statusline/reentry.ts': {
+      template: 'statusline/reentry.ts',
+    },
     '.safeword/hooks/post-tool-sync-learnings.ts': {
       template: 'hooks/post-tool-sync-learnings.ts',
     },

--- a/packages/cli/templates/hooks/lib/re-entry.ts
+++ b/packages/cli/templates/hooks/lib/re-entry.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared pure functions for the re-entry brief (ticket 645W8H).
+ *
+ * Both `.safeword/hooks/session-start-reentry.ts` (Slice 2) and
+ * `.safeword/statusline/reentry.ts` (Slice 3) parse the same canonical
+ * log line and detect the same kind of dirty-file conflict between
+ * concurrent Claude sessions. The functions here are pure (no stdin
+ * reading, no stdout writing); the hook/script wrappers handle I/O.
+ */
+
+import { execSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+
+export interface Entry {
+  timestamp: string;
+  sessionId: string;
+  ticket: string;
+  nextImperative: string;
+}
+
+interface ToolUse {
+  type: string;
+  name?: string;
+  input?: { file_path?: string };
+}
+
+interface TranscriptEntry {
+  type?: string;
+  message?: { role?: string; content?: ToolUse[] };
+}
+
+// Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
+const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
+const RECENT_TURNS = 10;
+
+export function parseLogLine(line: string): Entry | null {
+  const match = LINE_REGEX.exec(line.trim());
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    sessionId: match[2],
+    ticket: match[3],
+    nextImperative: match[4],
+  };
+}
+
+export function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
+  const directory = dirname(currentTranscriptPath);
+  const currentBase = basename(currentTranscriptPath);
+  try {
+    return readdirSync(directory)
+      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
+      .map(name => join(directory, name));
+  } catch {
+    return [];
+  }
+}
+
+export function readRecentEditedFiles(transcriptPath: string): string[] {
+  const edited = new Set<string>();
+  try {
+    const raw = readFileSync(transcriptPath, 'utf8').trim();
+    if (raw.length === 0) return [];
+    const lines = raw.split('\n');
+    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
+    // turn often emits multiple tool-use events.
+    for (const line of lines.slice(-RECENT_TURNS * 5)) {
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        if (entry.type !== 'assistant' || !entry.message?.content) continue;
+        for (const item of entry.message.content) {
+          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
+            const filePath = item.input?.file_path;
+            if (filePath) edited.add(filePath);
+          }
+        }
+      } catch {
+        // Skip malformed lines silently.
+      }
+    }
+  } catch {
+    // Transcript unreadable — no edits to report.
+  }
+  return [...edited];
+}
+
+export function getDirtyFiles(cwd: string): string[] {
+  try {
+    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
+    return output
+      .split('\n')
+      .map(line => line.slice(3).trim())
+      .filter(line => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export function normalizeRelative(filePath: string, cwd: string): string {
+  // Edit tool_use events typically use absolute paths; git status emits paths
+  // relative to the repo root (== cwd here).
+  if (filePath.startsWith(cwd)) {
+    return relative(cwd, filePath);
+  }
+  return filePath;
+}
+
+export function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
+  if (!transcriptPath) return [];
+  const dirtyFiles = new Set(getDirtyFiles(cwd));
+  if (dirtyFiles.size === 0) return [];
+  const overlap = new Set<string>();
+  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
+    for (const editedFile of readRecentEditedFiles(otherPath)) {
+      const relativePath = normalizeRelative(editedFile, cwd);
+      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
+    }
+  }
+  return [...overlap];
+}

--- a/packages/cli/templates/hooks/session-start-reentry.ts
+++ b/packages/cli/templates/hooks/session-start-reentry.ts
@@ -9,15 +9,22 @@
  * (silent — not shown in chat; for Claude recall when the user asks
  * "where were we?"). The status-line script (Slice 3) is the user-facing
  * surface.
+ *
+ * Also detects conflict: when another session's transcript has Edit/Write
+ * tool calls on files that are currently dirty in `git status`, append a
+ * warning line so the agent (and via Slice 3, the user) knows to step
+ * lightly around those files.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
 
 interface HookInput {
   session_id?: string;
   source?: 'startup' | 'resume' | 'clear' | 'compact';
   cwd?: string;
+  transcript_path?: string;
 }
 
 interface Entry {
@@ -27,8 +34,21 @@ interface Entry {
   nextImperative: string;
 }
 
+interface ToolUse {
+  type: string;
+  name?: string;
+  input?: { file_path?: string };
+}
+
+interface TranscriptEntry {
+  type?: string;
+  message?: { role?: string; content?: ToolUse[] };
+}
+
 // Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
 const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
+const RECENT_TURNS = 10;
 
 function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
@@ -49,6 +69,87 @@ function renderBrief(entries: Entry[], options: { fromAnotherSession?: boolean }
   return `${header}\n${lines.join('\n')}`;
 }
 
+function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
+  const directory = dirname(currentTranscriptPath);
+  const currentBase = basename(currentTranscriptPath);
+  try {
+    return readdirSync(directory)
+      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
+      .map(name => join(directory, name));
+  } catch {
+    return [];
+  }
+}
+
+function readRecentEditedFiles(transcriptPath: string): string[] {
+  const edited = new Set<string>();
+  try {
+    const raw = readFileSync(transcriptPath, 'utf8').trim();
+    if (raw.length === 0) return [];
+    const lines = raw.split('\n');
+    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
+    // turn often emits multiple tool-use events.
+    for (const line of lines.slice(-RECENT_TURNS * 5)) {
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        if (entry.type !== 'assistant' || !entry.message?.content) continue;
+        for (const item of entry.message.content) {
+          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
+            const filePath = item.input?.file_path;
+            if (filePath) edited.add(filePath);
+          }
+        }
+      } catch {
+        // Skip malformed lines silently.
+      }
+    }
+  } catch {
+    // Transcript unreadable — no edits to report.
+  }
+  return [...edited];
+}
+
+function getDirtyFiles(cwd: string): string[] {
+  try {
+    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
+    return output
+      .split('\n')
+      .map(line => line.slice(3).trim())
+      .filter(line => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRelative(filePath: string, cwd: string): string {
+  // Edit tool_use events typically use absolute paths; git status emits paths
+  // relative to the repo root (== cwd here).
+  if (filePath.startsWith(cwd)) {
+    return relative(cwd, filePath);
+  }
+  return filePath;
+}
+
+function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
+  if (!transcriptPath) return [];
+  const dirtyFiles = new Set(getDirtyFiles(cwd));
+  if (dirtyFiles.size === 0) return [];
+  const overlap = new Set<string>();
+  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
+    for (const editedFile of readRecentEditedFiles(otherPath)) {
+      const relativePath = normalizeRelative(editedFile, cwd);
+      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
+    }
+  }
+  return [...overlap];
+}
+
+function renderConflictWarning(files: string[]): string {
+  if (files.length === 0) return '';
+  const quoted = files.map(f => `\`${f}\``).join(', ');
+  return `\n\n⚠️ Conflict: another session edited ${quoted} (still dirty in the working tree).`;
+}
+
 async function main(): Promise<void> {
   const stdinText = await new Response(Bun.stdin.stream()).text();
   let input: HookInput;
@@ -58,14 +159,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { session_id, cwd, source } = input;
+  const { session_id, cwd, source, transcript_path } = input;
   if (!session_id || !cwd) return;
 
   const logPath = join(cwd, '.safeword-project', 're-entry.md');
-  if (!existsSync(logPath)) return;
-
-  const content = readFileSync(logPath, 'utf8').trim();
-  if (content.length === 0) return;
+  const logExists = existsSync(logPath);
+  const content = logExists ? readFileSync(logPath, 'utf8').trim() : '';
 
   const allEntries = content
     .split('\n')
@@ -74,24 +173,23 @@ async function main(): Promise<void> {
 
   const currentEntries = allEntries.filter(e => e.sessionId === session_id);
 
-  let renderEntries: Entry[];
-  let fromAnotherSession = false;
-
+  let briefBody = '';
   if (currentEntries.length > 0) {
-    // Normal path: this session's last 3 (chronological — log is append-only).
-    renderEntries = currentEntries.slice(-3);
+    briefBody = renderBrief(currentEntries.slice(-3));
   } else if (source === 'startup' && allEntries.length > 0) {
-    // Fresh `claude` fallback: most-recent entry across all sessions, tagged.
-    renderEntries = [allEntries[allEntries.length - 1]];
-    fromAnotherSession = true;
-  } else {
-    return;
+    briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
   }
+
+  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const conflictWarning = renderConflictWarning(conflictFiles);
+
+  // Nothing to inject in either channel → stay silent.
+  if (briefBody.length === 0 && conflictWarning.length === 0) return;
 
   const output = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
-      additionalContext: renderBrief(renderEntries, { fromAnotherSession }),
+      additionalContext: `${briefBody}${conflictWarning}`,
     },
   };
   process.stdout.write(`${JSON.stringify(output)}\n`);

--- a/packages/cli/templates/hooks/session-start-reentry.ts
+++ b/packages/cli/templates/hooks/session-start-reentry.ts
@@ -16,9 +16,10 @@
  * lightly around those files.
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { detectConflictFiles, type Entry, parseLogLine } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -27,121 +28,12 @@ interface HookInput {
   transcript_path?: string;
 }
 
-interface Entry {
-  timestamp: string;
-  sessionId: string;
-  ticket: string;
-  nextImperative: string;
-}
-
-interface ToolUse {
-  type: string;
-  name?: string;
-  input?: { file_path?: string };
-}
-
-interface TranscriptEntry {
-  type?: string;
-  message?: { role?: string; content?: ToolUse[] };
-}
-
-// Canonical log line: `<ISO-ts> <session-id> ticket=<id>/<phase> Next: <imperative>`
-const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
-const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit']);
-const RECENT_TURNS = 10;
-
-function parseLogLine(line: string): Entry | null {
-  const match = LINE_REGEX.exec(line.trim());
-  if (!match) return null;
-  return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
-  };
-}
-
 function renderBrief(entries: Entry[], options: { fromAnotherSession?: boolean } = {}): string {
   const header = options.fromAnotherSession
     ? 'Re-entry brief — most recent entry (from another session):'
     : `Re-entry brief — last ${entries.length} entries from this session:`;
   const lines = entries.map(e => `- ${e.timestamp} [${e.ticket}] ${e.nextImperative}`);
   return `${header}\n${lines.join('\n')}`;
-}
-
-function listOtherSessionTranscripts(currentTranscriptPath: string): string[] {
-  const directory = dirname(currentTranscriptPath);
-  const currentBase = basename(currentTranscriptPath);
-  try {
-    return readdirSync(directory)
-      .filter(name => name.endsWith('.jsonl') && name !== currentBase)
-      .map(name => join(directory, name));
-  } catch {
-    return [];
-  }
-}
-
-function readRecentEditedFiles(transcriptPath: string): string[] {
-  const edited = new Set<string>();
-  try {
-    const raw = readFileSync(transcriptPath, 'utf8').trim();
-    if (raw.length === 0) return [];
-    const lines = raw.split('\n');
-    // Scan the last RECENT_TURNS * 5 lines as a coarse upper bound — one assistant
-    // turn often emits multiple tool-use events.
-    for (const line of lines.slice(-RECENT_TURNS * 5)) {
-      try {
-        const entry = JSON.parse(line) as TranscriptEntry;
-        if (entry.type !== 'assistant' || !entry.message?.content) continue;
-        for (const item of entry.message.content) {
-          if (item.type === 'tool_use' && item.name && EDIT_TOOL_NAMES.has(item.name)) {
-            const filePath = item.input?.file_path;
-            if (filePath) edited.add(filePath);
-          }
-        }
-      } catch {
-        // Skip malformed lines silently.
-      }
-    }
-  } catch {
-    // Transcript unreadable — no edits to report.
-  }
-  return [...edited];
-}
-
-function getDirtyFiles(cwd: string): string[] {
-  try {
-    const output = execSync('git status --porcelain', { cwd, encoding: 'utf8' });
-    return output
-      .split('\n')
-      .map(line => line.slice(3).trim())
-      .filter(line => line.length > 0);
-  } catch {
-    return [];
-  }
-}
-
-function normalizeRelative(filePath: string, cwd: string): string {
-  // Edit tool_use events typically use absolute paths; git status emits paths
-  // relative to the repo root (== cwd here).
-  if (filePath.startsWith(cwd)) {
-    return relative(cwd, filePath);
-  }
-  return filePath;
-}
-
-function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {
-  if (!transcriptPath) return [];
-  const dirtyFiles = new Set(getDirtyFiles(cwd));
-  if (dirtyFiles.size === 0) return [];
-  const overlap = new Set<string>();
-  for (const otherPath of listOtherSessionTranscripts(transcriptPath)) {
-    for (const editedFile of readRecentEditedFiles(otherPath)) {
-      const relativePath = normalizeRelative(editedFile, cwd);
-      if (dirtyFiles.has(relativePath)) overlap.add(relativePath);
-    }
-  }
-  return [...overlap];
 }
 
 function renderConflictWarning(files: string[]): string {

--- a/packages/cli/templates/statusline/reentry.ts
+++ b/packages/cli/templates/statusline/reentry.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+/**
+ * Status line: surface the latest `**Next:**` for the current session.
+ *
+ * Ticket 645W8H. Slice 3.
+ *
+ * Claude Code runs a status-line script with session JSON on stdin and renders
+ * whatever it prints at the bottom of the editor. This script reads
+ * `.safeword-project/re-entry.md`, finds the most recent entry for the current
+ * session_id, and prints `Next: <imperative>` for the user to glance at.
+ *
+ * RED phase: stub. Behaviour is missing.
+ */
+
+async function main(): Promise<void> {
+  await new Response(Bun.stdin.stream()).text();
+  // Behaviour deliberately absent — the failing test should drive GREEN.
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `statusline-reentry: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/cli/templates/statusline/reentry.ts
+++ b/packages/cli/templates/statusline/reentry.ts
@@ -9,7 +9,7 @@
  * reads `.safeword-project/re-entry.md`, finds the most recent entry
  * for the current session_id, and prints `Next: <imperative>`. When a
  * dirty-file conflict exists with another session, the line is
- * prepended with `⚠️ conflict: <file>` (scenarios 8.2 onward).
+ * prepended with `⚠️ conflict: <file>`.
  *
  * Not wired into settings.json automatically — Claude Code's
  * `statusLine` config slot is single-valued; auto-installing would
@@ -20,29 +20,12 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { detectConflictFiles, type Entry, parseLogLine } from '../hooks/lib/re-entry';
+
 interface StatusLineInput {
   session_id?: string;
   cwd?: string;
-}
-
-interface Entry {
-  timestamp: string;
-  sessionId: string;
-  ticket: string;
-  nextImperative: string;
-}
-
-const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
-
-function parseLogLine(line: string): Entry | null {
-  const match = LINE_REGEX.exec(line.trim());
-  if (!match) return null;
-  return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
-  };
+  transcript_path?: string;
 }
 
 async function main(): Promise<void> {
@@ -54,7 +37,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { session_id, cwd } = input;
+  const { session_id, cwd, transcript_path } = input;
   if (!session_id || !cwd) return;
 
   const logPath = join(cwd, '.safeword-project', 're-entry.md');
@@ -72,7 +55,11 @@ async function main(): Promise<void> {
   if (entries.length === 0) return;
 
   const latest = entries[entries.length - 1];
-  process.stdout.write(`Next: ${latest.nextImperative}`);
+
+  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const prefix = conflictFiles.length > 0 ? `⚠️ conflict: ${conflictFiles.join(', ')} — ` : '';
+
+  process.stdout.write(`${prefix}Next: ${latest.nextImperative}`);
 }
 
 main().catch((error: unknown) => {

--- a/packages/cli/templates/statusline/reentry.ts
+++ b/packages/cli/templates/statusline/reentry.ts
@@ -1,20 +1,78 @@
 #!/usr/bin/env bun
 /**
- * Status line: surface the latest `**Next:**` for the current session.
+ * Status line: surface the latest `Next:` for the current session.
  *
  * Ticket 645W8H. Slice 3.
  *
- * Claude Code runs a status-line script with session JSON on stdin and renders
- * whatever it prints at the bottom of the editor. This script reads
- * `.safeword-project/re-entry.md`, finds the most recent entry for the current
- * session_id, and prints `Next: <imperative>` for the user to glance at.
+ * Claude Code runs a status-line script with session JSON on stdin and
+ * renders whatever it prints at the bottom of the editor. This script
+ * reads `.safeword-project/re-entry.md`, finds the most recent entry
+ * for the current session_id, and prints `Next: <imperative>`. When a
+ * dirty-file conflict exists with another session, the line is
+ * prepended with `⚠️ conflict: <file>` (scenarios 8.2 onward).
  *
- * RED phase: stub. Behaviour is missing.
+ * Not wired into settings.json automatically — Claude Code's
+ * `statusLine` config slot is single-valued; auto-installing would
+ * clobber a user's existing status-line. The user opts in by setting
+ * their `statusLine.command` to `bun .safeword/statusline/reentry.ts`.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface StatusLineInput {
+  session_id?: string;
+  cwd?: string;
+}
+
+interface Entry {
+  timestamp: string;
+  sessionId: string;
+  ticket: string;
+  nextImperative: string;
+}
+
+const LINE_REGEX = /^(\S+)\s+(\S+)\s+(ticket=\S+)\s+Next:\s+(.+)$/;
+
+function parseLogLine(line: string): Entry | null {
+  const match = LINE_REGEX.exec(line.trim());
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    sessionId: match[2],
+    ticket: match[3],
+    nextImperative: match[4],
+  };
+}
+
 async function main(): Promise<void> {
-  await new Response(Bun.stdin.stream()).text();
-  // Behaviour deliberately absent — the failing test should drive GREEN.
+  const stdinText = await new Response(Bun.stdin.stream()).text();
+  let input: StatusLineInput;
+  try {
+    input = JSON.parse(stdinText) as StatusLineInput;
+  } catch {
+    return;
+  }
+
+  const { session_id, cwd } = input;
+  if (!session_id || !cwd) return;
+
+  const logPath = join(cwd, '.safeword-project', 're-entry.md');
+  if (!existsSync(logPath)) return;
+
+  const content = readFileSync(logPath, 'utf8').trim();
+  if (content.length === 0) return;
+
+  const entries = content
+    .split('\n')
+    .map(parseLogLine)
+    .filter((e): e is Entry => e !== null)
+    .filter(e => e.sessionId === session_id);
+
+  if (entries.length === 0) return;
+
+  const latest = entries[entries.length - 1];
+  process.stdout.write(`Next: ${latest.nextImperative}`);
 }
 
 main().catch((error: unknown) => {

--- a/packages/cli/tests/integration/re-entry-conflict-detection.test.ts
+++ b/packages/cli/tests/integration/re-entry-conflict-detection.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test: SessionStart conflict-detection warning.
+ *
+ * Ticket 645W8H. Rule 5 (post-elicit Q2 re-scope).
+ *
+ * Conflict = another Claude session in this worktree edited a file in its
+ * last ~10 turns AND that file is currently dirty in `git status`. On conflict,
+ * the SessionStart hook adds a warning line to additionalContext naming the
+ * file(s); status-line surfacing is Slice 3.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTemporaryDirectory, removeTemporaryDirectory, TIMEOUT_QUICK } from '../helpers';
+
+const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+const SESSION_START_REENTRY = nodePath.join(
+  SAFEWORD_ROOT,
+  '.safeword/hooks/session-start-reentry.ts',
+);
+
+function makeLogFile(directory: string, lines: string[]): void {
+  const briefDirectory = nodePath.join(directory, '.safeword-project');
+  mkdirSync(briefDirectory, { recursive: true });
+  writeFileSync(nodePath.join(briefDirectory, 're-entry.md'), `${lines.join('\n')}\n`);
+}
+
+function initGitRepoWithDirtyFile(directory: string, file: string): void {
+  // Set up a minimal git repo, commit a baseline of the file, then dirty it.
+  execSync('git init -q', { cwd: directory });
+  execSync('git config user.email "test@example.com"', { cwd: directory });
+  execSync('git config user.name "Test"', { cwd: directory });
+  writeFileSync(nodePath.join(directory, file), 'original content\n');
+  execSync('git add .', { cwd: directory });
+  execSync('git commit -q -m "baseline"', { cwd: directory });
+  // Dirty it.
+  writeFileSync(nodePath.join(directory, file), 'dirty content\n');
+}
+
+function makeTranscriptWithEdit(
+  transcriptsDirectory: string,
+  sessionFilename: string,
+  editedFilePath: string,
+): string {
+  mkdirSync(transcriptsDirectory, { recursive: true });
+  const line = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          name: 'Edit',
+          id: 'tu_1',
+          input: { file_path: editedFilePath },
+        },
+      ],
+    },
+  });
+  const path = nodePath.join(transcriptsDirectory, sessionFilename);
+  writeFileSync(path, line);
+  return path;
+}
+
+function runSessionStartWithTranscript(
+  directory: string,
+  sessionId: string,
+  source: 'startup' | 'resume',
+  transcriptPath: string,
+) {
+  return spawnSync('bun', [SESSION_START_REENTRY], {
+    input: JSON.stringify({
+      session_id: sessionId,
+      source,
+      cwd: directory,
+      transcript_path: transcriptPath,
+    }),
+    cwd: directory,
+    encoding: 'utf8',
+    timeout: TIMEOUT_QUICK,
+  });
+}
+
+describe('session-start-reentry hook — Rule 5: conflict detection', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(projectDirectory);
+  });
+
+  it('single dirty-file overlap → warning names the file', () => {
+    // Set up: foo.ts is dirty in git, another session edited it recently.
+    initGitRepoWithDirtyFile(projectDirectory, 'foo.ts');
+
+    const transcriptsDirectory = nodePath.join(projectDirectory, '.fake-claude-projects');
+    makeTranscriptWithEdit(
+      transcriptsDirectory,
+      'sess_other.jsonl',
+      nodePath.join(projectDirectory, 'foo.ts'),
+    );
+    const currentTranscript = nodePath.join(transcriptsDirectory, 'sess_current.jsonl');
+    writeFileSync(currentTranscript, '');
+
+    // Give the current session some entries so the brief renders too.
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: continue here',
+    ]);
+
+    const result = runSessionStartWithTranscript(
+      projectDirectory,
+      'sess_current',
+      'resume',
+      currentTranscript,
+    );
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    const ctx = parsed.hookSpecificOutput?.additionalContext ?? '';
+
+    // Warning naming the file should appear.
+    expect(ctx).toContain('foo.ts');
+    expect(ctx.toLowerCase()).toContain('conflict');
+
+    // Normal brief still renders alongside the warning.
+    expect(ctx).toContain('continue here');
+  });
+});

--- a/packages/cli/tests/integration/re-entry-conflict-detection.test.ts
+++ b/packages/cli/tests/integration/re-entry-conflict-detection.test.ts
@@ -96,6 +96,65 @@ describe('session-start-reentry hook — Rule 5: conflict detection', () => {
     removeTemporaryDirectory(projectDirectory);
   });
 
+  it('multiple dirty-file overlaps → warning names all of them', () => {
+    initGitRepoWithDirtyFile(projectDirectory, 'foo.ts');
+    // Dirty a second file too.
+    writeFileSync(nodePath.join(projectDirectory, 'bar.ts'), 'fresh\n');
+    execSync('git add bar.ts', { cwd: projectDirectory });
+    execSync('git commit -q -m "add bar"', { cwd: projectDirectory });
+    writeFileSync(nodePath.join(projectDirectory, 'bar.ts'), 'dirty\n');
+
+    const transcriptsDirectory = nodePath.join(projectDirectory, '.fake-claude-projects');
+    // Same other-session transcript records edits on BOTH files.
+    mkdirSync(transcriptsDirectory, { recursive: true });
+    const otherLines = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Edit',
+              id: 'tu_foo',
+              input: { file_path: nodePath.join(projectDirectory, 'foo.ts') },
+            },
+            {
+              type: 'tool_use',
+              name: 'Edit',
+              id: 'tu_bar',
+              input: { file_path: nodePath.join(projectDirectory, 'bar.ts') },
+            },
+          ],
+        },
+      }),
+    ];
+    writeFileSync(nodePath.join(transcriptsDirectory, 'sess_other.jsonl'), otherLines.join('\n'));
+    const currentTranscript = nodePath.join(transcriptsDirectory, 'sess_current.jsonl');
+    writeFileSync(currentTranscript, '');
+
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: keep going',
+    ]);
+
+    const result = runSessionStartWithTranscript(
+      projectDirectory,
+      'sess_current',
+      'resume',
+      currentTranscript,
+    );
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    const ctx = parsed.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(ctx).toContain('foo.ts');
+    expect(ctx).toContain('bar.ts');
+    expect(ctx.toLowerCase()).toContain('conflict');
+  });
+
   it('single dirty-file overlap → warning names the file', () => {
     // Set up: foo.ts is dirty in git, another session edited it recently.
     initGitRepoWithDirtyFile(projectDirectory, 'foo.ts');

--- a/packages/cli/tests/integration/re-entry-session-start.test.ts
+++ b/packages/cli/tests/integration/re-entry-session-start.test.ts
@@ -87,6 +87,28 @@ describe('session-start-reentry hook — Rule 4: filtered tail', () => {
     expect(ctx).not.toContain('old three');
   });
 
+  it('no dirty-file overlap with other sessions → additionalContext has no conflict warning', () => {
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: do current work',
+    ]);
+
+    const result = runSessionStartHook(projectDirectory, 'sess_current', 'resume');
+    expect(result.status).toBe(0);
+
+    const parsed = JSON.parse(result.stdout) as {
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    const ctx = parsed.hookSpecificOutput?.additionalContext ?? '';
+
+    // Brief still renders for the current session.
+    expect(ctx).toContain('do current work');
+
+    // No conflict markers when there's no overlap (no other-session edits,
+    // no dirty files — neither side has anything to flag).
+    expect(ctx).not.toContain('⚠️');
+    expect(ctx.toLowerCase()).not.toContain('conflict');
+  });
+
   it('renders only the last 3 when filter matches more than 3 entries', () => {
     makeLogFile(projectDirectory, [
       '2026-05-22T01:00:00Z sess_long ticket=∅/freeform Next: entry one',

--- a/packages/cli/tests/integration/re-entry-statusline.test.ts
+++ b/packages/cli/tests/integration/re-entry-statusline.test.ts
@@ -10,7 +10,7 @@
  * scenarios 8.2 onwards).
  */
 
-import { spawnSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -27,12 +27,13 @@ function makeLogFile(directory: string, lines: string[]): void {
   writeFileSync(nodePath.join(briefDirectory, 're-entry.md'), `${lines.join('\n')}\n`);
 }
 
-function runStatusline(directory: string, sessionId: string) {
+function runStatusline(directory: string, sessionId: string, transcriptPath?: string) {
   // Mirrors the Claude Code status-line JSON shape (subset).
   return spawnSync('bun', [STATUSLINE_REENTRY], {
     input: JSON.stringify({
       session_id: sessionId,
       cwd: directory,
+      transcript_path: transcriptPath,
       model: { id: 'claude-opus-4-7', display_name: 'Opus 4.7' },
     }),
     cwd: directory,
@@ -50,6 +51,55 @@ describe('statusline-reentry script — Rule 8: surface latest Next:', () => {
 
   afterEach(() => {
     removeTemporaryDirectory(projectDirectory);
+  });
+
+  it('prefixes ⚠️ conflict: <file> before the Next: when overlap exists', () => {
+    // Set up git with a dirty foo.ts.
+    execSync('git init -q', { cwd: projectDirectory });
+    execSync('git config user.email "test@example.com"', { cwd: projectDirectory });
+    execSync('git config user.name "Test"', { cwd: projectDirectory });
+    writeFileSync(nodePath.join(projectDirectory, 'foo.ts'), 'original\n');
+    execSync('git add .', { cwd: projectDirectory });
+    execSync('git commit -q -m "baseline"', { cwd: projectDirectory });
+    writeFileSync(nodePath.join(projectDirectory, 'foo.ts'), 'dirty\n');
+
+    // Another session edited foo.ts; current session's transcript exists.
+    const transcriptsDirectory = nodePath.join(projectDirectory, '.fake-claude-projects');
+    mkdirSync(transcriptsDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(transcriptsDirectory, 'sess_other.jsonl'),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Edit',
+              id: 'tu_1',
+              input: { file_path: nodePath.join(projectDirectory, 'foo.ts') },
+            },
+          ],
+        },
+      }),
+    );
+    const currentTranscript = nodePath.join(transcriptsDirectory, 'sess_current.jsonl');
+    writeFileSync(currentTranscript, '');
+
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: keep going',
+    ]);
+
+    const result = runStatusline(projectDirectory, 'sess_current', currentTranscript);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('⚠️');
+    expect(result.stdout).toContain('conflict');
+    expect(result.stdout).toContain('foo.ts');
+    expect(result.stdout).toContain('Next: keep going');
+
+    // Order: conflict prefix appears BEFORE the Next: imperative.
+    expect(result.stdout.indexOf('conflict')).toBeLessThan(result.stdout.indexOf('Next:'));
   });
 
   it('prints the latest Next: imperative for the current session', () => {

--- a/packages/cli/tests/integration/re-entry-statusline.test.ts
+++ b/packages/cli/tests/integration/re-entry-statusline.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration test: statusline re-entry script surfaces latest Next:.
+ *
+ * Ticket 645W8H. Slice 3 — Rule 8.
+ *
+ * The script receives Claude Code's standard status-line JSON on stdin
+ * and prints whatever should appear at the bottom of the editor. For
+ * re-entry, we print the latest `Next: <imperative>` for the current
+ * session (with a `⚠️ conflict: <file>` prefix when applicable — that's
+ * scenarios 8.2 onwards).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTemporaryDirectory, removeTemporaryDirectory, TIMEOUT_QUICK } from '../helpers';
+
+const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+const STATUSLINE_REENTRY = nodePath.join(SAFEWORD_ROOT, '.safeword/statusline/reentry.ts');
+
+function makeLogFile(directory: string, lines: string[]): void {
+  const briefDirectory = nodePath.join(directory, '.safeword-project');
+  mkdirSync(briefDirectory, { recursive: true });
+  writeFileSync(nodePath.join(briefDirectory, 're-entry.md'), `${lines.join('\n')}\n`);
+}
+
+function runStatusline(directory: string, sessionId: string) {
+  // Mirrors the Claude Code status-line JSON shape (subset).
+  return spawnSync('bun', [STATUSLINE_REENTRY], {
+    input: JSON.stringify({
+      session_id: sessionId,
+      cwd: directory,
+      model: { id: 'claude-opus-4-7', display_name: 'Opus 4.7' },
+    }),
+    cwd: directory,
+    encoding: 'utf8',
+    timeout: TIMEOUT_QUICK,
+  });
+}
+
+describe('statusline-reentry script — Rule 8: surface latest Next:', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(projectDirectory);
+  });
+
+  it('prints the latest Next: imperative for the current session', () => {
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: first thing',
+      '2026-05-22T11:00:00Z sess_current ticket=∅/freeform Next: second thing',
+      '2026-05-22T12:00:00Z sess_current ticket=∅/freeform Next: latest action',
+    ]);
+
+    const result = runStatusline(projectDirectory, 'sess_current');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('latest action');
+    // Older entries should NOT be on the status line — it's a single most-recent.
+    expect(result.stdout).not.toContain('first thing');
+    expect(result.stdout).not.toContain('second thing');
+  });
+});

--- a/packages/cli/tests/integration/re-entry-statusline.test.ts
+++ b/packages/cli/tests/integration/re-entry-statusline.test.ts
@@ -102,6 +102,30 @@ describe('statusline-reentry script — Rule 8: surface latest Next:', () => {
     expect(result.stdout.indexOf('conflict')).toBeLessThan(result.stdout.indexOf('Next:'));
   });
 
+  it('empty or missing log → no Next: indicator (graceful absence)', () => {
+    // Case 1: log file does not exist.
+    const resultA = runStatusline(projectDirectory, 'sess_any');
+    expect(resultA.status).toBe(0);
+    expect(resultA.stdout).not.toContain('Next:');
+    expect(resultA.stderr).toBe('');
+
+    // Case 2: log file exists but is empty.
+    makeLogFile(projectDirectory, []);
+    const resultB = runStatusline(projectDirectory, 'sess_any');
+    expect(resultB.status).toBe(0);
+    expect(resultB.stdout).not.toContain('Next:');
+    expect(resultB.stderr).toBe('');
+
+    // Case 3: log has entries but none for the current session.
+    makeLogFile(projectDirectory, [
+      '2026-05-22T10:00:00Z sess_someone_else ticket=∅/freeform Next: not mine',
+    ]);
+    const resultC = runStatusline(projectDirectory, 'sess_any');
+    expect(resultC.status).toBe(0);
+    expect(resultC.stdout).not.toContain('Next:');
+    expect(resultC.stdout).not.toContain('not mine');
+  });
+
   it('prints the latest Next: imperative for the current session', () => {
     makeLogFile(projectDirectory, [
       '2026-05-22T10:00:00Z sess_current ticket=∅/freeform Next: first thing',

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -81,6 +81,49 @@ describe('Schema - Single Source of Truth', () => {
         expect(SAFEWORD_SCHEMA.ownedDirs).not.toContain(dir);
       }
     });
+
+    // Regression: v0.36.x shipped with .safeword/statusline/reentry.ts owned but
+    // .safeword/statusline missing from ownedDirs — uninstall left an empty
+    // directory behind, which made removeIfEmpty('.safeword') silently fail.
+    // The bug class is "owned file under unregistered directory", so the test
+    // is structural: every dirname(ownedFile) must be removable at uninstall
+    // — either by an explicit ownedDirs/sharedDirs/preservedDirs entry, or by
+    // the .claude/* auto-cleanup path in reconcile.ts (getClaudeParentDirectoryForCleanup).
+    it('should declare a directory for every parent of every ownedFile', async () => {
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+      const declared = new Set<string>([
+        ...SAFEWORD_SCHEMA.ownedDirs,
+        ...SAFEWORD_SCHEMA.sharedDirs,
+        ...SAFEWORD_SCHEMA.preservedDirs,
+      ]);
+
+      // Mirrors getClaudeParentDirectoryForCleanup in reconcile.ts: any
+      // .claude/* path deeper than .claude, .claude/skills, .claude/commands
+      // gets removed automatically at uninstall.
+      const isAutoCleanedClaudePath = (parent: string): boolean =>
+        parent.startsWith('.claude/') &&
+        parent !== '.claude/skills' &&
+        parent !== '.claude/commands';
+
+      const missing: { file: string; parent: string }[] = [];
+      for (const filePath of Object.keys(SAFEWORD_SCHEMA.ownedFiles)) {
+        const parent = nodePath.posix.dirname(filePath);
+        if (parent === '.' || parent === '') continue;
+        if (declared.has(parent)) continue;
+        if (isAutoCleanedClaudePath(parent)) continue;
+        missing.push({ file: filePath, parent });
+      }
+
+      if (missing.length > 0) {
+        const detail = missing
+          .map(
+            ({ file, parent }) =>
+              `  - '${file}' needs '${parent}' in ownedDirs/sharedDirs/preservedDirs`,
+          )
+          .join('\n');
+        expect.fail(`ownedFiles point to undeclared directories:\n${detail}`);
+      }
+    });
   });
 
   describe('sharedDirs', () => {


### PR DESCRIPTION
## Summary

- Adds a per-worktree session re-entry brief: Stop-hook appends one line per turn to `.safeword-project/re-entry.md` (`<timestamp> <session-id> ticket=<id>/<phase> Next: <imperative>`); SessionStart hook silently injects the last 3 entries via `additionalContext`; a status-line script renders the latest `Next:` ambient for the user's glance.
- Multi-session aware: append-only POSIX writes (atomic <PIPE_BUF), session-tagged filtering, conflict signal only when another session edited a file in its last 10 turns AND that file is currently dirty in `git status`.
- Includes a verify-time schema-completeness fix and a structural guard test: every parent dir of every `ownedFiles` entry must be in `ownedDirs` / `sharedDirs` / `preservedDirs` (or covered by the `.claude/*` auto-cleanup path). Catches the "owned file under unregistered directory" bug class by construction — the same class that caused 4 reset/reconcile tests to fail at verify in this branch.

53 commits, +968 / -736 across 31 files. 64/64 scenarios closed. Full suite green: 1981/1981 pass, 1 skipped. Verify artifact at `.safeword-project/tickets/645W8H/verify.md`.

Key commits:
- `bdc123a` — schema fix + structural guard test + knip ignore for the new `templates/statusline/**` dir
- `d373d1e` — `verify.md`
- `6a8fdb5` — `phase: done`, `status: done`

## Test plan

- [ ] Confirm CI runs the full vitest suite and lands green (matches the local run at 1981/1981).
- [ ] Spot-check: in a worktree, do a few turns, then `claude --continue` — confirm the `additionalContext` injection shows the last 3 entries for the session.
- [ ] Spot-check: open a fresh `claude` in a worktree with prior re-entry entries — confirm a single most-recent entry tagged `(from another session)` is shown.
- [ ] Spot-check: have two sessions in the same worktree touch the same file (one edits and leaves it dirty) — confirm the conflict warning appears in both the SessionStart context and the status line.
- [ ] Run `safeword reset --yes` in a configured project — confirm `.safeword/` is fully removed (the bug fixed by `bdc123a`).
- [ ] Confirm the new structural test in `packages/cli/tests/schema.test.ts` runs as part of `bun run test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)