### PR TITLE
fix(release): add repository field for OIDC provenance verification

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,12 @@
   "name": "safeword",
   "version": "0.35.0",
   "description": "CLI for setting up and managing safeword development environments",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ArcadeAI/safeword.git"
+  },
+  "homepage": "https://github.com/ArcadeAI/safeword",
+  "bugs": "https://github.com/ArcadeAI/safeword/issues",
   "type": "module",
   "bin": {
     "safeword": "dist/cli.js"


### PR DESCRIPTION
## Summary

OIDC handshake now works after the trusted publisher fix. Latest publish attempt got past auth, hit a different validation:

\`\`\`
422 - Error verifying sigstore provenance bundle:
  package.json: "repository.url" is "",
  expected to match "https://github.com/ArcadeAI/safeword" from provenance
\`\`\`

npm's provenance verification requires \`package.json.repository.url\` to match the sigstore attestation's source repo. Adding standard metadata fields (\`repository\`, \`homepage\`, \`bugs\`) — they're also nice-to-have for npmjs.com presentation.

## Plan

- [ ] Merge
- [ ] Re-tag v0.35.0
- [ ] Re-push → workflow auto-publishes
- [ ] Verify safeword@0.35.0 on npm with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)