### PR TITLE
chore(release): v0.35.1 — verify hardened release workflow end-to-end

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release with no code changes, purely to exercise the post-#144 + post-#146 release workflow end-to-end and confirm:

- Two-job split (build → publish) actually publishes
- Pinned action SHAs work
- Node 24's bundled npm (11.12.1) satisfies OIDC trusted publishing without the upgrade step
- Provenance attestation lands on npm

If this publishes safeword@0.35.1 with provenance, the hardening is verified. If it fails, we've caught the regression before a real release would have.

## Test plan

- [ ] CI green on PR
- [ ] Admin-merge
- [ ] Tag v0.35.1
- [ ] Push tag → workflow fires (no manual approval needed; gate is off)
- [ ] Both jobs succeed
- [ ] safeword@0.35.1 lands on npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)