### PR TITLE
fix(hooks): resolve project root from cwd drift in re-entry hooks

### DIFF
--- a/.safeword/hooks/lib/re-entry.ts
+++ b/.safeword/hooks/lib/re-entry.ts
@@ -9,8 +9,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
 export interface Entry {
   timestamp: string;
@@ -105,6 +105,34 @@ export function normalizeRelative(filePath: string, cwd: string): string {
     return relative(cwd, filePath);
   }
   return filePath;
+}
+
+/**
+ * Resolve the project root reliably, regardless of where the session's cwd drifted.
+ *
+ * Claude Code passes `input.cwd` = the session's current working directory, which
+ * is not necessarily the project root. Hooks that wrote `join(cwd, '.safeword-project')`
+ * blindly would silently mkdirSync a bogus nested `.safeword-project/` inside whatever
+ * subdir the session happened to be in (e.g. `<root>/.safeword-project/tickets/.safeword-project/`).
+ *
+ * Implementation: walk up from `cwd` looking for a `.git` marker. Pure (no subprocess),
+ * preserves the cwd path form (matters on macOS where `git rev-parse --show-toplevel`
+ * canonicalizes `/var/folders/...` symlinks to `/private/var/folders/...` and breaks
+ * downstream `startsWith` comparisons against absolute paths captured by other code).
+ *
+ * Returns null when no `.git/` ancestor exists — caller bails silently rather than
+ * write to a stray path. Note: we intentionally do NOT match on `.safeword-project/`
+ * during the walk because the bogus nested directories created by the old code would
+ * mislead the resolver.
+ */
+export function resolveProjectRoot(cwd: string): string | null {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
 }
 
 export function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {

--- a/.safeword/hooks/session-start-reentry.ts
+++ b/.safeword/hooks/session-start-reentry.ts
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { detectConflictFiles, type Entry, parseLogLine } from './lib/re-entry';
+import { detectConflictFiles, type Entry, parseLogLine, resolveProjectRoot } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -54,7 +54,11 @@ async function main(): Promise<void> {
   const { session_id, cwd, source, transcript_path } = input;
   if (!session_id || !cwd) return;
 
-  const logPath = join(cwd, '.safeword-project', 're-entry.md');
+  // Same cwd-drift defense as stop-reentry: resolve real project root.
+  const projectRoot = resolveProjectRoot(cwd);
+  if (!projectRoot) return;
+
+  const logPath = join(projectRoot, '.safeword-project', 're-entry.md');
   const logExists = existsSync(logPath);
   const content = logExists ? readFileSync(logPath, 'utf8').trim() : '';
 
@@ -72,7 +76,7 @@ async function main(): Promise<void> {
     briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
   }
 
-  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const conflictFiles = detectConflictFiles(projectRoot, transcript_path);
   const conflictWarning = renderConflictWarning(conflictFiles);
 
   // Nothing to inject in either channel → stay silent.

--- a/.safeword/hooks/stop-reentry.ts
+++ b/.safeword/hooks/stop-reentry.ts
@@ -14,6 +14,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getActiveTicket } from './lib/active-ticket';
+import { resolveProjectRoot } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -96,18 +97,25 @@ async function main(): Promise<void> {
   const { session_id, transcript_path, cwd } = input;
   if (!session_id || !transcript_path || !cwd) return;
 
+  // Claude Code passes input.cwd = the session's current working directory,
+  // which can drift into a subdirectory. Resolve the real project root so we
+  // never write to a stray nested `.safeword-project/`. Bail silently if we
+  // can't find a git repo to anchor to.
+  const projectRoot = resolveProjectRoot(cwd);
+  if (!projectRoot) return;
+
   const assistantText = readLastAssistantText(transcript_path);
   if (!assistantText) return;
 
   const imperative = extractLastNextImperative(assistantText);
   if (!imperative) return;
 
-  const ticketField = resolveTicketField(cwd);
+  const ticketField = resolveTicketField(projectRoot);
 
   const timestamp = new Date().toISOString();
   const line = `${timestamp} ${session_id} ${ticketField} Next: ${imperative}\n`;
 
-  const projectDirectory = join(cwd, '.safeword-project');
+  const projectDirectory = join(projectRoot, '.safeword-project');
   if (!existsSync(projectDirectory)) {
     mkdirSync(projectDirectory, { recursive: true });
   }

--- a/packages/cli/templates/hooks/lib/re-entry.ts
+++ b/packages/cli/templates/hooks/lib/re-entry.ts
@@ -9,8 +9,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
 export interface Entry {
   timestamp: string;
@@ -105,6 +105,34 @@ export function normalizeRelative(filePath: string, cwd: string): string {
     return relative(cwd, filePath);
   }
   return filePath;
+}
+
+/**
+ * Resolve the project root reliably, regardless of where the session's cwd drifted.
+ *
+ * Claude Code passes `input.cwd` = the session's current working directory, which
+ * is not necessarily the project root. Hooks that wrote `join(cwd, '.safeword-project')`
+ * blindly would silently mkdirSync a bogus nested `.safeword-project/` inside whatever
+ * subdir the session happened to be in (e.g. `<root>/.safeword-project/tickets/.safeword-project/`).
+ *
+ * Implementation: walk up from `cwd` looking for a `.git` marker. Pure (no subprocess),
+ * preserves the cwd path form (matters on macOS where `git rev-parse --show-toplevel`
+ * canonicalizes `/var/folders/...` symlinks to `/private/var/folders/...` and breaks
+ * downstream `startsWith` comparisons against absolute paths captured by other code).
+ *
+ * Returns null when no `.git/` ancestor exists — caller bails silently rather than
+ * write to a stray path. Note: we intentionally do NOT match on `.safeword-project/`
+ * during the walk because the bogus nested directories created by the old code would
+ * mislead the resolver.
+ */
+export function resolveProjectRoot(cwd: string): string | null {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
 }
 
 export function detectConflictFiles(cwd: string, transcriptPath: string | undefined): string[] {

--- a/packages/cli/templates/hooks/session-start-reentry.ts
+++ b/packages/cli/templates/hooks/session-start-reentry.ts
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { detectConflictFiles, type Entry, parseLogLine } from './lib/re-entry';
+import { detectConflictFiles, type Entry, parseLogLine, resolveProjectRoot } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -54,7 +54,11 @@ async function main(): Promise<void> {
   const { session_id, cwd, source, transcript_path } = input;
   if (!session_id || !cwd) return;
 
-  const logPath = join(cwd, '.safeword-project', 're-entry.md');
+  // Same cwd-drift defense as stop-reentry: resolve real project root.
+  const projectRoot = resolveProjectRoot(cwd);
+  if (!projectRoot) return;
+
+  const logPath = join(projectRoot, '.safeword-project', 're-entry.md');
   const logExists = existsSync(logPath);
   const content = logExists ? readFileSync(logPath, 'utf8').trim() : '';
 
@@ -72,7 +76,7 @@ async function main(): Promise<void> {
     briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
   }
 
-  const conflictFiles = detectConflictFiles(cwd, transcript_path);
+  const conflictFiles = detectConflictFiles(projectRoot, transcript_path);
   const conflictWarning = renderConflictWarning(conflictFiles);
 
   // Nothing to inject in either channel → stay silent.

--- a/packages/cli/templates/hooks/stop-reentry.ts
+++ b/packages/cli/templates/hooks/stop-reentry.ts
@@ -14,6 +14,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getActiveTicket } from './lib/active-ticket';
+import { resolveProjectRoot } from './lib/re-entry';
 
 interface HookInput {
   session_id?: string;
@@ -96,18 +97,25 @@ async function main(): Promise<void> {
   const { session_id, transcript_path, cwd } = input;
   if (!session_id || !transcript_path || !cwd) return;
 
+  // Claude Code passes input.cwd = the session's current working directory,
+  // which can drift into a subdirectory. Resolve the real project root so we
+  // never write to a stray nested `.safeword-project/`. Bail silently if we
+  // can't find a git repo to anchor to.
+  const projectRoot = resolveProjectRoot(cwd);
+  if (!projectRoot) return;
+
   const assistantText = readLastAssistantText(transcript_path);
   if (!assistantText) return;
 
   const imperative = extractLastNextImperative(assistantText);
   if (!imperative) return;
 
-  const ticketField = resolveTicketField(cwd);
+  const ticketField = resolveTicketField(projectRoot);
 
   const timestamp = new Date().toISOString();
   const line = `${timestamp} ${session_id} ${ticketField} Next: ${imperative}\n`;
 
-  const projectDirectory = join(cwd, '.safeword-project');
+  const projectDirectory = join(projectRoot, '.safeword-project');
   if (!existsSync(projectDirectory)) {
     mkdirSync(projectDirectory, { recursive: true });
   }

--- a/packages/cli/tests/integration/re-entry-concurrent.test.ts
+++ b/packages/cli/tests/integration/re-entry-concurrent.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -59,6 +59,8 @@ describe('stop-reentry hook — Rule 3: concurrent writers do not interleave', (
 
   beforeEach(() => {
     projectDirectory = createTemporaryDirectory();
+    // Seed .git so resolveProjectRoot anchors to projectDirectory.
+    mkdirSync(nodePath.join(projectDirectory, '.git'), { recursive: true });
   });
 
   afterEach(() => {

--- a/packages/cli/tests/integration/re-entry-session-start.test.ts
+++ b/packages/cli/tests/integration/re-entry-session-start.test.ts
@@ -50,6 +50,8 @@ describe('session-start-reentry hook — Rule 4: filtered tail', () => {
 
   beforeEach(() => {
     projectDirectory = createTemporaryDirectory();
+    // Seed .git so resolveProjectRoot anchors to projectDirectory.
+    mkdirSync(nodePath.join(projectDirectory, '.git'), { recursive: true });
   });
 
   afterEach(() => {

--- a/packages/cli/tests/integration/re-entry-stop.test.ts
+++ b/packages/cli/tests/integration/re-entry-stop.test.ts
@@ -51,6 +51,9 @@ describe('stop-reentry hook — Rule 1: records intent when present', () => {
 
   beforeEach(() => {
     projectDirectory = createTemporaryDirectory();
+    // Seed a .git marker so resolveProjectRoot anchors to projectDirectory.
+    // Mirrors real-world conditions — safeword hooks run inside git repos.
+    mkdirSync(nodePath.join(projectDirectory, '.git'), { recursive: true });
   });
 
   afterEach(() => {
@@ -181,6 +184,47 @@ describe('stop-reentry hook — Rule 1: records intent when present', () => {
 
     expect(lines[0]).toContain('Next: do thing X');
     expect(lines[0]).not.toContain('then also do Y');
+  });
+
+  it('writes to project-root .safeword-project/ even when input.cwd is a subdirectory', () => {
+    // Repro for the nested-`.safeword-project/.safeword-project/` bug: Claude Code
+    // hooks receive input.cwd = the session's current working directory, which can
+    // be a subdirectory if the session has navigated. The hook must resolve the
+    // project root (where .safeword-project/ already lives) rather than join cwd
+    // blindly and silently mkdirSync a bogus nested path.
+    const projectRoot = projectDirectory;
+    // Initialize a fake project: real .safeword-project/ exists at the root, plus
+    // a .git marker so resolveProjectRoot can walk up to find it.
+    mkdirSync(nodePath.join(projectRoot, '.safeword-project'), { recursive: true });
+    mkdirSync(nodePath.join(projectRoot, '.git'), { recursive: true });
+
+    // Session cwd has drifted into a subdirectory.
+    const drifted = nodePath.join(projectRoot, '.safeword-project', 'tickets');
+    mkdirSync(drifted, { recursive: true });
+
+    const transcriptPath = makeTranscript(drifted, 'Done.\n\n**Next:** carry on');
+
+    const result = spawnSync('bun', [STOP_REENTRY], {
+      input: JSON.stringify({
+        session_id: 'sess_drifted_cwd',
+        transcript_path: transcriptPath,
+        cwd: drifted, // ← drifted, not projectRoot
+      }),
+      cwd: drifted,
+      encoding: 'utf8',
+      timeout: TIMEOUT_QUICK,
+    });
+
+    expect(result.status).toBe(0);
+
+    // The log lands at the real project root, not nested inside the subdir.
+    const correctPath = nodePath.join(projectRoot, '.safeword-project', 're-entry.md');
+    expect(existsSync(correctPath)).toBe(true);
+    expect(readFileSync(correctPath, 'utf8')).toContain('sess_drifted_cwd');
+
+    // And no bogus nested .safeword-project/ got materialized under the subdir.
+    const bogus = nodePath.join(drifted, '.safeword-project');
+    expect(existsSync(bogus)).toBe(false);
   });
 
   it('renders ticket=<id>/<phase> when an active ticket exists in this worktree', () => {


### PR DESCRIPTION
## Summary

`stop-reentry.ts` and `session-start-reentry.ts` treated Claude Code's `input.cwd` as the project root and called `join(cwd, '.safeword-project')` directly. Claude Code's contract is that `cwd` is the session's current working directory — which can drift into a subdirectory if any bash invocation `cd`'d somewhere. When that happened, `stop-reentry.ts`'s `mkdirSync(projectDirectory, { recursive: true })` silently materialized a bogus nested `.safeword-project/` inside whatever subdir the session was in (e.g. `<root>/.safeword-project/tickets/.safeword-project/`). No error, no warning — just a stray directory of duplicated session logs.

Repro caught in this repo earlier today: `.safeword-project/tickets/.safeword-project/re-entry.md` had a full copy of session entries that should have landed at the project root.

## What changed

- New `resolveProjectRoot(cwd)` in `lib/re-entry.ts` — pure walk-up from `cwd` looking for a `.git/` marker. Returns `null` when no git ancestor is found (caller bails silently rather than writing to a stray path).
- `stop-reentry.ts` and `session-start-reentry.ts` both call `resolveProjectRoot(cwd)` first and bail on null. Same fix also corrects `resolveTicketField(cwd)` (wrong ticket lookup on drifted cwd) and `detectConflictFiles(cwd, ...)` (wrong relative paths in conflict detector).
- Walk-up preferred over `git rev-parse --show-toplevel` because git canonicalizes symlinked paths on macOS (`/var/folders/...` → `/private/var/folders/...`), which breaks downstream `startsWith` comparisons in `normalizeRelative`.
- Dogfood (`.safeword/hooks/`) ↔ template (`packages/cli/templates/hooks/`) kept byte-identical per project convention.

## Test plan

- [x] New integration test repros the bug: `writes to project-root .safeword-project/ even when input.cwd is a subdirectory` (`re-entry-stop.test.ts`).
- [x] Existing re-entry test fixtures gained `.git/` seed in `beforeEach` — matches real-world conditions where safeword hooks run inside git repos.
- [x] All 22 re-entry integration tests pass (`re-entry-stop`, `re-entry-session-start`, `re-entry-concurrent`, `re-entry-conflict-detection`, `re-entry-statusline`).
- [x] Full vitest suite shows no new regressions — pre-existing E2E setup-path failures (golden-path, rust-golden-path, etc.) reproduce on clean main without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)