### PR TITLE
chore(release): v0.35.2

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch — ships re-entry hook cwd-drift fix.

## Changes since v0.35.1

- **fix(hooks):** resolve project root from cwd drift in re-entry hooks (#155). `stop-reentry.ts` and `session-start-reentry.ts` no longer treat Claude Code's `input.cwd` as the project root — they walk up to find a `.git/` ancestor first, and bail silently when none exists. Fixes silent `mkdirSync` of bogus nested `.safeword-project/` dirs.
- **docs(tickets):** open G2E72G — YOLO mode (#154). Intake-only scaffold; no behavior change.

## Auto-upgrade safety

Patch — fix is strictly defensive (resolves a wrong path to the right path; never made anything go to a *different* place than intended). Auto-upgrade at SessionStart will silently apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)