### PR TITLE
chore(release): v0.36.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.35.2",
+      "version": "0.36.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release. **Additive schema change** — auto-applies safely on customer upgrade per the versioning skill (marker-gated append, preserves customer content, idempotent, reset cleanly unmerges).

## What's in v0.36.0

- `feat(schema): exclude .safeword/ and .cursor/ from prettier (#157)` — adds a `.prettierignore` text-patch to `SAFEWORD_SCHEMA.textPatches` so customers running `prettier --write .` don't reformat safeword-owned files. Marker `# Safeword - managed prettier exclusions`. Includes customer-existing-entries preservation test + dogfood fix authoring missing `.prettierrc` files in this repo.

## Why minor (not patch)

PR #157 contains an **additive schema change** (a new file safeword now manages on customer projects). Per the versioning skill: *"Additive schema changes (new owned/managed files)"* → **Minor**. The Key Test confirms: auto-upgrade doesn't break anything, but it does add new capability.

## Test plan

- [x] CI green on the merged PR (#157): lint 1m2s + test 15m51s.
- [x] Pre-commit version-match hook satisfied (both `packages/cli/package.json` and `marketplace.json` → `plugins[0].version` set to `0.36.0`).
- [x] `plugin/.claude-plugin/plugin.json` intentionally untouched per CLAUDE.md (relative-path plugins use marketplace entry only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)