### PR TITLE
chore(release): v0.37.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor — strictly additive on the CLI surface.

**New capability**
- `safeword sync-config --check` reports drift without writing (PR #161, ticket 6R84DY)
- `safeword setup` explains `.dependency-cruiser.cjs` on first creation so customers know what the wrapper is and how to extend it (PR #161, ticket 2GPM47)

**Bug fix**
- `/audit` no longer mutates the working tree. Stale depcruise config is now surfaced as new `[W007]` warning instead of silently regenerating files (PR #161, ticket 6R84DY)

## Semver classification

Minor (0.36.0 → 0.37.0). Verified against the auto-upgrade Key Test:
- `--check` is an optional flag; existing no-flag behavior unchanged
- `/audit` change ships through auto-replaced skill markdown, not a CLI contract; removes an unwanted side effect that no legitimate workflow depends on
- W007 + setup explainer are additive output

If a reviewer reads the /audit side-effect removal as more breaking than additive, override to major.

## Test plan

- [ ] CI green (test + lint)
- [ ] After merge: tag `v0.37.0`, push, verify `release.yml` workflow publishes to npm with provenance
- [ ] `npm view safeword version` returns `0.37.0`
- [ ] Round-trip dogfood: `bunx safeword@latest upgrade` in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)