### PR TITLE
chore(release): v0.38.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.38.0

Minor — adds a user-visible legibility improvement to the ticket folder format. Auto-upgrade safe: the resolver already handles both the old `{ID}/` shape (for existing tickets on disk) and the new `{ID}-{slug}/` shape (for newly minted tickets) via the prefix-match branch.

## Changes since v0.37.0

- **feat(tickets): mint folders as `{ID}-{slug}` for legibility** (#160, ticket CXXB3P).
  Folders were named by Crockford ID alone (`G2E72G/`), opaque to humans and agents scanning `ls` output. Mint now produces `{ID}-{slug}/` matching the shape legacy numeric tickets already use (`009-audit-lint-ignore-rules/`). ID-collision check is now slug-aware: `idsAlreadyTaken()` scans existing folders and splits on the first dash to recover the ID portion, so two tickets minting the same ID still fail loudly at creation time regardless of slug suffix. Hook resolver unchanged — the existing `${id}-` prefix branch already handled the new shape. Open Base32 tickets retrofitted via `git mv`; completed tickets left in their as-shipped shape per the [closed-tickets-stay-opaque](.safeword-project/learnings/closed-tickets-stay-opaque.md) learning.

## Safety-layer trade-off

The previous `{ID}/`-only layout used identical filesystem paths as a merge-time conflict layer — two branches force-minting the same ID would `CONFLICT` on merge. The slug suffix breaks that property (different slugs → different paths → clean merge). Detection now relies entirely on the post-merge `check-ticket-ids.ts` detector, which has been wired into pre-commit + CI since slice 5 of the original ticketing work. The duplicate-ID detector is still loud and still catches everything the merge-conflict layer caught — just one step later in the pipeline. Documented in `packages/cli/src/utils/ticket-writer.ts` header.

## Follow-up tickets opened from this PR

- [FM5EDA-ticket-slug-rename](.safeword-project/tickets/FM5EDA-ticket-slug-rename/ticket.md) — `safeword ticket rename` CLI + lint warning for frontmatter/dir drift.
- [54XH90-lint-config-unify](.safeword-project/tickets/54XH90-lint-config-unify/ticket.md) — converge local `bun run lint` and CI lint to the same invocation path.

## Test plan

- [x] Local full vitest suite: 2005/2005 pass, 115/115 files, 0 failures (CXXB3P verify.md)
- [x] CI green on PR #160 HEAD before merge: lint + test (node 22) both pass
- [x] /audit clean: 0 errors, 0 warnings, depcruise 223/0, knip clean, jscpd 2.09%
- [ ] Tag push triggers `release.yml`, npm publishes with provenance
- [ ] `npm view safeword version` → 0.38.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)