### PR TITLE
fix(engines): bump min Node to 22.12 for require-of-ESM support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "templates"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary

Quality-review on PR #168 (ticket H150ZW) revealed a latent Node version regression: \`eslint-plugin-storybook@10.4.0\` and \`eslint-plugin-better-tailwindcss@4.5.0\` ship as pure ESM with no \`require\` condition in their \`exports\`. The lazy-load refactor's \`createRequire()\` calls throw \`ERR_REQUIRE_ESM\` for those two plugin paths on Node 22.0–22.11.

\`require()\` of pure-ESM modules requires Node 22.12+ (default-enabled there; needed \`--experimental-require-module\` flag before that).

This patch corrects the declared minimum from \`\">=22\"\` to \`\">=22.12\"\` so npm/bun emit install-time warnings for customers on older Node. No code change — the runtime already needed 22.12 to handle Storybook/Tailwind config access; we're just admitting it.

## Provenance

Inspected each of the 7 stack plugin \`exports['.']\` fields:

| Plugin | Has \`require\` condition? |
|---|---|
| eslint-plugin-storybook | ❌ pure ESM |
| eslint-plugin-better-tailwindcss | ❌ pure ESM |
| eslint-plugin-astro | ✅ |
| @tanstack/eslint-plugin-query | ✅ |
| eslint-plugin-playwright | ✅ |
| eslint-plugin-turbo, @next/eslint-plugin-next | CJS native |

## Context

- Node 20 EOL'd 2026-04-30
- Node 22.12 shipped 2024-12-03 (~18 months ago)
- Reasonable floor

## Test plan

- [ ] Existing CI suite (Node 22 setup-node@v4 resolves to latest 22.x, which is 22.12+)
- [ ] No behavior change — pure metadata correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)