### PR TITLE
chore(release): v0.39.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor — strictly additive on the CLI surface.

**Performance**
- feat(eslint): lazy-load 7 stack-specific plugins via \`createRequire\` ([PR #168](https://github.com/ArcadeAI/safeword/pull/168), ticket H150ZW). Stack plugins (Storybook, Turbo, Astro, Playwright, TanStack Query, Tailwind, Next.js) no longer load into Node memory on every ESLint invocation when the customer's stack doesn't include them. ~140ms startup cost eliminated per cold start for the no-match case.

**Compat correction**
- fix(engines): bump min Node to 22.12 for require-of-ESM support ([PR #169](https://github.com/ArcadeAI/safeword/pull/169)). The lazy-load refactor uses \`createRequire\`; two plugins (storybook, better-tailwindcss) ship as pure ESM with no \`require\` condition. Node 22.12+ is required for \`require()\` of pure-ESM modules without an experimental flag. Was already de-facto required; this corrects the declared minimum.

**Dogfood**
- fix(dogfood): re-sync .safeword/depcruise-config.cjs (AK8REW, [PR #166](https://github.com/ArcadeAI/safeword/pull/166)). Repo-internal; no customer impact.

## Semver

Minor (0.38.0 → 0.39.0). Lazy-load is non-breaking (public \`xConfig\` shape preserved via Proxy). Engines bump is technically additive — declares the floor that the code already required.

## Test plan

- [ ] CI green
- [ ] After merge: tag \`v0.39.0\`, release workflow publishes to npm
- [ ] \`npm view safeword version\` returns \`0.39.0\`
- [ ] Round-trip dogfood install in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)