### PR TITLE
chore(release): v0.39.1

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release covering three Stop-hook prompt improvements that merged in PR #172:

- **F14BG2** — verdict reshaped into a scannable decision brief (`**CONFIDENT**` / `**BLOCKED**` bolded tokens + blank-line-separated `**Decided:**` / optional `**Rejected:**` / `**Open:**` / `**Next:**` sub-fields).
- **QSNKBB** — cut ~7 lines of SAFEWORD.md-duplicated philosophical preamble from the hook.
- **68SRC8** — long-session stickiness via SAFEWORD.md recency-placement + one-line hook pointer that re-anchors "Talking to the user" rules per Stop fire.

## Semver classification

**Patch (0.39.0 → 0.39.1).** Bug fix in the Stop-hook prompt template. Contract surfaces preserved (`getQualityMessage` signature, `QUALITY_REVIEW_MESSAGE` export, `CONFIDENT`/`BLOCKED` binary tokens, hook decision/reason shape, cursor parity).

Why not minor: the skill's "additive only — no removal/rename" rule for minor doesn't fit; we did remove preamble lines and restructure verdict shape.

Why not major: no public API broke; pre-1.0 stability claim not warranted yet.

## Test plan

- [x] CI green on PR #172 (lint + test node 22 both pass)
- [x] /verify and /audit clean
- [ ] CI green on this release PR
- [ ] After merge: annotated tag `v0.39.1` triggers `.github/workflows/release.yml`
- [ ] `npm view safeword version` returns `0.39.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)