### PR TITLE
docs(tickets): close G2BA7M (not-a-bug) + supersede G8PBE6

### DIFF
--- a/.safeword-project/tickets/7JDZFF/ticket.md
+++ b/.safeword-project/tickets/7JDZFF/ticket.md
@@ -28,6 +28,7 @@ done_when:
   - Full test suite green, including the existing setup / integration / preset tests; no behavior regression for customers whose stack matches the detection rules.
   - Migration doc lives at `packages/website/src/content/docs/migrations/v1-eslint-peer-deps.md` (or equivalent path), linked from CHANGELOG.
   - safeword's own repo dogfooded: safeword's dev deps shrink (we don't use Storybook ourselves), and `bun run lint` still passes.
+  - `bunx knip` reports zero "unused dependency" false-positives for the 7 stack-specific plugins (next, tanstack-query, astro, better-tailwindcss, playwright, storybook, turbo) after the peer-dep migration. Optional peer-deps aren't flagged by knip as unused, so this should hold without any `ignoreDependencies` entries. Closes the concern from superseded ticket G8PBE6.
 ---
 
 # Move stack-specific ESLint plugins to optional peer-deps (antfu pattern)

--- a/.safeword-project/tickets/G2BA7M-vitest-eslint-plugin-peer-dep/ticket.md
+++ b/.safeword-project/tickets/G2BA7M-vitest-eslint-plugin-peer-dep/ticket.md
@@ -3,9 +3,9 @@ id: G2BA7M
 slug: vitest-eslint-plugin-peer-dep
 type: patch
 phase: intake
-status: in_progress
+status: wontfix
 created: 2026-05-27T11:44:58.292Z
-last_modified: 2026-05-27T11:44:58.292Z
+last_modified: 2026-05-28T05:02:00.000Z
 scope: |
   Install or otherwise resolve the missing `@vitest/eslint-plugin` peer-dependency
   in `packages/cli` so that two currently-broken paths work again:
@@ -76,3 +76,4 @@ Failure trace points at [packages/cli/src/presets/typescript/eslint-configs/vite
 ## Work Log
 
 - 2026-05-27T11:44:58Z Started: Created ticket G2BA7M after F14BG2/QSNKBB verify pass surfaced this as a pre-existing blocker on lint + DTS build. Bounded scope (one decision: direct dep vs lazy-load; one install; verification). Sized patch.
+- 2026-05-28T05:02:00Z Closed wontfix — NOT A BUG. Investigation findings: `@vitest/eslint-plugin@^1.6.17` is correctly declared in `packages/cli/package.json` dependencies, installs cleanly into `packages/cli/node_modules`, ships its own types (`./dist/index.d.mts`), and resolves. With node_modules present, `bun run build` completes both ESM and DTS phases and `npx eslint --print-config` loads the config without error. CI passed lint+test on PRs #172 and #173, confirming a clean install works. The original `TS2307` / `Cannot find module` failures were purely the harness-created worktree lacking `node_modules` (the same artifact the session-start "ESLint config not found" warning points at). This is the identical class of non-bug that ticket 7JDZFF already documented in its out_of_scope ("harness-created-worktree-without-bun-install artifact, not a safeword bug"). No code fix warranted. Residual (NOT tracked here): the session-start hook's "ESLint config not found - run 'bun run lint' may fail" message is misleading — real cause is missing node_modules. Open a fresh ticket only if that diagnostic confuses someone again.

--- a/.safeword-project/tickets/G8PBE6-knip-dynamic-load-false-positives/ticket.md
+++ b/.safeword-project/tickets/G8PBE6-knip-dynamic-load-false-positives/ticket.md
@@ -3,9 +3,10 @@ id: G8PBE6
 slug: knip-dynamic-load-false-positives
 type: task
 phase: intake
-status: in_progress
+status: superseded
+superseded_by: 7JDZFF
 created: 2026-05-27T11:44:58.839Z
-last_modified: 2026-05-27T11:44:58.839Z
+last_modified: 2026-05-28T05:02:00.000Z
 scope: |
   Make `bunx knip` stop flagging the seven stack-specific ESLint plugins
   H150ZW switched to lazy-loading as "unused dependencies." They ARE used —
@@ -89,3 +90,4 @@ Today returns the seven plugins under "Unused dependencies."
 ## Work Log
 
 - 2026-05-27T11:44:58Z Started: Created ticket G8PBE6 after F14BG2/QSNKBB verify pass surfaced these as pre-existing knip noise. Bounded scope (one architectural decision in /figure-it-out, one knip-config or annotation pass, documentation note). Sized task.
+- 2026-05-28T05:02:00Z Superseded by 7JDZFF. Investigation confirmed the false-positive mechanism: the 7 plugins load via `createRequire(import.meta.url)` inside `lazyConfigArray` (H150ZW), which knip's static analyzer can't follow → flagged as unused dependencies. The cheap fix (add the 7 to `ignoreDependencies` in packages/cli/knip.json, matching the existing `eslint-plugin-jsdoc` precedent in the root knip.json) would be throwaway: 7JDZFF (in_progress) moves all 7 from `dependencies` to optional `peerDependencies`, and knip does not flag optional peer-deps as unused — so the migration dissolves these false-positives as a side effect. Fixing here now would leave stale `ignoreDependencies` entries that /audit's W005 check would flag once 7JDZFF lands. Folding into 7JDZFF instead; added a done_when line there so 7JDZFF explicitly owns closing the knip concern.


### PR DESCRIPTION
## Summary

Ticket bookkeeping from investigating the two follow-ups surfaced during the v0.39.1 verify/audit passes. Neither needs its own code fix:

- **G2BA7M** → `wontfix`. `@vitest/eslint-plugin` is correctly declared, installed, ships types, resolves. Build + lint pass with `node_modules` present; CI was green on #172/#173. Original failures were the harness worktree lacking `bun install` — the same non-bug class 7JDZFF already documented.
- **G8PBE6** → `superseded` by 7JDZFF. The 7 plugins load via `createRequire` (H150ZW lazy-load) which knip can't follow. 7JDZFF moves them to optional `peerDependencies` — which knip doesn't flag as unused — dissolving the false-positives without throwaway `ignoreDependencies`. Added a `done_when` line to 7JDZFF so it owns closing the knip concern.

No code changes — only ticket frontmatter + work logs.

## Test plan

- [ ] CI green (no source touched; should be trivially green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)