### PR TITLE
chore(release): v0.41.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.40.1",
+      "version": "0.41.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.41.0 (minor)

Version bump for the release. The shipped feature (#181) is already on `main`.

### Feature
- **#181 — design-first ordering with rigorous reconcile in Clarify.** The Clarify phase now runs Frame → design-the-ideal (`/figure-it-out`) → Survey existing patterns → Reconcile (conform by default; to deviate, cite a named defect + call-site count + pre-mortem + uplevel ticket). Wired into `SAFEWORD.md`, `architecture-guide.md`, bdd `DISCOVERY.md`, and the verify skill/command. Pure markdown/process — no code, deps, or APIs.

Additive per semver (auto-upgrade test passes: new guidance, nothing removed/changed). Both version files at 0.41.0 (parity enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)