### PR TITLE
NMSD94: two-tier review enforcement (Tier 1 inline + Tier 2 fork, default-off)

### DIFF
--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -44,6 +44,24 @@ phase: implement # intake | define-behavior | scenario-gate | implement | verify
 - All scenarios pass → set `verify`
 - /verify + /audit complete (verify.md exists) → set `done`
 
+### Phase-exit review (Tier 2)
+
+Leaving a phase is gated on an **independent** review of that phase's work — not
+your own pass. (Your own inline pass is Tier 1: `/self-review`, per asset, as you
+author.) The phase exit is reviewed by a _fresh reviewer with no conversation
+history_ so the author can't grade their own work: spawn one via the Agent tool
+(it starts clean), hand it only the phase's artifacts and the ticket's scope, and
+let **its** verdict decide. On a pass, record the stamp that unblocks the advance:
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>
+```
+
+If the reviewer finds blocking issues, fix them and re-review — don't stamp. To
+skip a trivial or docs-only phase, append a reason
+(`… --phase <phase> "<why no independent review is needed>"`). The phase-advance
+gate enforces this when the review gate is enabled, and is inert otherwise.
+
 ---
 
 ## Resume Logic

--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -49,9 +49,10 @@ phase: implement # intake | define-behavior | scenario-gate | implement | verify
 Leaving a phase is gated on an **independent** review of that phase's work — not
 your own pass. (Your own inline pass is Tier 1: `/self-review`, per asset, as you
 author.) The phase exit is reviewed by a _fresh reviewer with no conversation
-history_ so the author can't grade their own work: spawn one via the Agent tool
-(it starts clean), hand it only the phase's artifacts and the ticket's scope, and
-let **its** verdict decide. On a pass, record the stamp that unblocks the advance:
+history_ so the author can't grade their own work: run it in a forked subagent —
+a skill with `context: fork`, or an explicit subagent — hand it only the phase's
+artifacts and the ticket's scope, and let **its** verdict decide. On a pass,
+record the stamp that unblocks the advance:
 
 ```bash
 bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: self-review
+description: Self-review a just-authored workflow artifact (the spec) inline and
+  earn its Tier 1 review stamp, so the next step's gate passes. Use after
+  authoring spec.md and before writing test-definitions.md, or whenever the
+  review gate blocks asking for a spec review. The review is your own inline
+  pass — do not spawn a sub-agent.
+allowed-tools: '*'
+---
+
+# Self-Review
+
+Review the artifact you just authored, then earn its review stamp so the next
+step is unblocked. This is **Tier 1** — a cheap, inline floor. You review your
+own work; no sub-agent is spawned. The independent check is Tier 2 (the fork
+review at each phase exit), not this.
+
+## Earn the stamp
+
+The line below runs the stamp-earning step at render time. It binds a
+`review:<scope>` stamp to the active ticket's `spec.md` **at its current
+content** and appends it to `.safeword-project/skill-invocations.log`, where the
+per-asset gate reads it back. Invoking this skill is what writes the stamp —
+hand-editing the log is the gameable floor this tier deliberately accepts.
+
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "$PROJECT_DIR/.safeword/hooks/write-review-stamp.ts" spec`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `✓` line at all**: STOP.
+The stamp was not written and the gate will keep blocking. Most likely the bash
+injection was denied or no in_progress ticket was found — report it to the user
+and resolve before retrying.
+
+## Review the spec (do this now, with the stamp written)
+
+The stamp records that a review was invoked; the actual scrutiny is yours. Read
+the active ticket's `spec.md` and check, against `personas.md` and the ticket's
+`scope` / `out_of_scope` frontmatter:
+
+- **Every JTBD resolves to a real persona** and reads as a genuine job (`When
+I…, I want…, so I can…`), not a restated feature.
+- **Each JTBD carries ≥1 Acceptance Criterion** stating an observable, product-
+  level guarantee — not an implementation detail.
+- **The ACs cover the ticket's scope** and stop at its `out_of_scope` line — no
+  silent scope creep, no orphan capability.
+- **Nothing leaks implementation** (file names, function names, libraries) into
+  spec-level prose.
+
+If the review surfaces a fix, **edit `spec.md` and re-invoke `/review`** — the
+content-bound stamp goes stale on any edit, so the gate correctly re-blocks
+until the corrected spec is re-reviewed. That is the point: a review that
+changes the artifact must be re-earned.
+
+## Skip valve
+
+If the artifact is genuinely trivial to review (boilerplate, a docs-only
+change), log a skip with a reason instead of a review — it clears the same gate
+and records why:
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+```
+
+An empty reason does not clear the gate.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: self-review
-description: Self-review a just-authored workflow artifact (the spec) inline and
-  earn its Tier 1 review stamp, so the next step's gate passes. Use after
-  authoring spec.md and before writing test-definitions.md, or whenever the
-  review gate blocks asking for a spec review. The review is your own inline
-  pass — do not spawn a sub-agent.
+description: Use when finishing spec.md before writing test-definitions.md, or
+  when the review gate asks for a spec review — self-reviews the just-authored
+  spec inline and earns its Tier 1 review stamp. Your own inline pass; do not
+  spawn a sub-agent.
 allowed-tools: '*'
 ---
 

--- a/.cursor/commands/self-review.md
+++ b/.cursor/commands/self-review.md
@@ -1,0 +1,39 @@
+---
+description: Self-review the spec inline and earn its Tier 1 review stamp (project)
+---
+
+# Self-Review
+
+Review the artifact you just authored, then earn its review stamp so the next
+step is unblocked. Tier 1 — your own inline pass, no sub-agent. The independent
+check is Tier 2 (the phase-exit review), not this.
+
+## Earn the stamp
+
+The line below binds a `review:<scope>` stamp to the active ticket's `spec.md`
+at its **current content** and appends it to the skill-invocation-log, where the
+per-asset gate reads it back.
+
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "$PROJECT_DIR/.safeword/hooks/write-review-stamp.ts" spec`
+
+If you see `[skill-invocation-log] FAILED` or no `✓` line, the stamp was not
+written and the gate will keep blocking — resolve before retrying.
+
+## Review the spec
+
+Read the active ticket's `spec.md` and check, against `personas.md` and the
+ticket's `scope` / `out_of_scope`: every JTBD resolves to a real persona and
+reads as a genuine job; each JTBD has ≥1 observable, product-level Acceptance
+Criterion; the ACs cover scope and stop at `out_of_scope`; no implementation
+detail leaks into spec prose. If the review surfaces a fix, edit `spec.md` and
+re-run — the content-bound stamp goes stale on any edit, so the gate correctly
+re-blocks until the corrected spec is re-reviewed.
+
+## Skip valve
+
+Trivial or docs-only? Log a skip with a reason instead — it clears the same gate
+and records why (an empty reason does not clear it):
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+```

--- a/.safeword-project/tickets/K4VHF4-reviewgate-enablement/ticket.md
+++ b/.safeword-project/tickets/K4VHF4-reviewgate-enablement/ticket.md
@@ -1,0 +1,34 @@
+---
+id: K4VHF4
+slug: reviewgate-enablement
+type: task
+phase: intake
+status: backlog
+created: 2026-06-03T18:05:41.071Z
+last_modified: 2026-06-03T18:05:41.071Z
+---
+
+# Enable reviewGate (dogfood the two-tier review)
+
+**Goal:** Turn on the NMSD94 review gates (`reviewGate: true` in `.safeword/config.json`) so safeword dogfoods its own two-tier review enforcement.
+
+**Why:** NMSD94 shipped both tiers inert behind a default-off flag. Enabling is a deliberate, separable decision — it changes our own dev loop and should follow a short soak, not ride along with the build.
+
+## Before flipping — know what turns on
+
+- **Every phase transition needs a phase-exit stamp**, not just "forward" ones: `intake`-exit, every middle transition, **and `→done`**. `detectPhaseAdvance` is direction-agnostic, so a backward correction (e.g. `implement → define-behavior`) is gated too. The gate's deny message names the exact phase, so it is self-documenting at the moment it fires — but budget for a fork review (or a logged skip) at each transition.
+- **Tier 1** fires only at the `spec → test-definitions.md` creation boundary today; earning the stamp is `/self-review`.
+- **Skip valve** clears any gate: `write-review-stamp.ts <artifact|--phase X> "<reason>"`.
+
+## Scope
+
+- Flip `reviewGate: true` in `.safeword/config.json`; soak; watch for false-blocks.
+- **Build the Tier 2 reviewer as a `context: fork` skill** (e.g. `/phase-review`) — the native Agent Skills mechanism (`context: fork` + `agent` frontmatter, per current Claude Code docs) for an independent, no-history reviewer. Today Tier 2's fork review is bdd prose ("run it in a forked subagent"); a dedicated skill makes it one invocation that stamps via `write-review-stamp.ts --phase` on pass. Parallels `/self-review` (Tier 1, inline).
+
+**Out of scope:** the gate mechanics themselves (NMSD94, done); the coverage gate (ZRMDKD).
+
+**Done when:** reviewGate is on in our config; a `context: fork` phase-review skill exists and earns Tier 2 stamps; a soak shows no spurious blocks (alert-to-action measured).
+
+## Work Log
+
+- 2026-06-03T18:05:41.071Z Created: split from NMSD94 — the dogfood flip + the `context: fork` Tier 2 reviewer skill are deliberate follow-ups, deferred so the build ships inert.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
@@ -1,0 +1,32 @@
+# Dimensions — NMSD94: two-tier review enforcement
+
+Derived from the 6 ACs. Splits the same way ticket 153 did: **[hook]** = deterministic gate logic (unit-tested); **[agent]** = the review actually running (skill prose, live-verified).
+
+## Behavioral dimensions
+
+| Dimension                 | Partitions                                                          | AC            |
+| ------------------------- | ------------------------------------------------------------------- | ------------- |
+| Prior-asset review state  | stamped / unstamped / skip-stamped                                  | DEV1.AC1      |
+| Asset position            | has a prior asset to gate on / is the first asset (nothing to gate) | DEV1.AC1      |
+| Per-asset review actor    | working agent inline (no spawn) / would-be sub-agent (forbidden)    | DEV1.AC2      |
+| Phase-exit stamp          | present / absent / skip-stamped                                     | DEV2.AC1      |
+| Phase-review independence | fresh reviewer (no history) / author self-review                    | DEV2.AC2      |
+| Coverage state            | complete / uncovered AC / orphan scenario                           | SM1.AC1       |
+| Skip valve                | provided (with reason) / absent                                     | DEV1/DEV2/SM1 |
+
+## Partitions → rules
+
+- Prior-asset state × position → **Rule: per-asset stamp gates the next asset** (unstamped blocks; stamped/skip allows; first asset has nothing to gate)
+- Per-asset review actor → **Rule: per-asset review is inline** (no sub-agent spawned)
+- Phase-exit stamp × independence → **Rule: phase advance needs an independent review stamp**
+- Coverage state → **Rule: coverage gate fires on genuine gaps, silent otherwise**
+- Skip valve → **Rule: every new gate has a logged one-step skip** (cross-cutting)
+
+## Baked decisions (resolve the intake open questions)
+
+- **Inline stamp surface** (open question 1): a `<!-- review: <sha-or-skip> -->` style stamp line is rejected (invisible); use an explicit **review-ledger line** in the session skill-invocation-log keyed by asset id — same store Tier 2 uses, one mechanism. The PreToolUse gate reads the ledger, not the artifact.
+- **Tier-1 worth-it** (open question 2): keep the cheap floor but make it **skippable and silent on first-asset** so it can't be the thing that trains bypass; the alert-to-action measurement (SM1) decides if it stays after a trial.
+
+## Invariant
+
+- `templates/hooks/` ↔ `.safeword/hooks/` byte-identical (`diff -q`).

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
@@ -42,3 +42,16 @@ Derived from the 6 ACs. Splits the same way ticket 153 did: **[hook]** = determi
 1. **Pure decision core** (new `lib/review-ledger.ts`): `gateNextAsset(priorAssetId, ledger)`, `gatePhaseAdvance(phase, ledger)`, `coverageGate(spec, testDefs)` (wraps the existing `scenario-coverage.ts`), reusing `parse-annotation.ts` `isValidSkipReason` for the skip valve. Unit-test the 12 `[hook]` scenarios here.
 2. **Wire into the hooks**: per-asset + coverage gates into `pre-tool-quality.ts`; phase-advance gate where the ticket `phase:` edit is seen; phase-exit stamp read via the existing `skill-invocation-log`. Sync dogfood + parity.
 3. **Skill prose** (`[agent]`): the inline per-asset review checklist (Tier 1) + the phase-exit `context: fork` review instructions (Tier 2) — written tight per the B1TWX7 constraint; live-verified.
+
+## Asset-identity model (resolved 2026-06-03 via /figure-it-out)
+
+**The asset = the workflow artifact** (a file or a frontmatter block), keyed by name — NOT a section inferred from a Write, and NOT a sub-phase advance event. Gate the _next_ artifact's write on the _prior_ artifact carrying a review stamp. Phase-0 artifacts in order: `spec.md` (jobs + ACs together) → scope frontmatter → `test-definitions.md`; TDD steps stay on the existing SHA ledger.
+
+- **Rejected — parse the Write content** to split JTBD-write from AC-write: fragile (agents write whole files), content-inference not artifact-based.
+- **Rejected — track sub-phase advance**: pause-based, which epic 172 explicitly names "the failure mode"; and sub-phase tracking doesn't exist yet.
+- **Decisive evidence:** epic 172 (phase-step-enforcement) records the principle — _"enforcement should be artifact-based wherever possible… Pause-based enforcement is the failure mode."_ NMSD94's Tier 1 is the **first concrete instance of 172**; coordinate.
+- **Accepted cost:** jobs + ACs are reviewed together as "the spec" (both in `spec.md`); finer granularity would need a rejected option.
+
+## Coverage gate split (SM1.AC1)
+
+Split to a child ticket — enforcing it in a hook needs porting `scenario-coverage.ts` (192 lines, in `src/`, unreachable from a standalone hook) + a differential test. Separable, the "trial" piece, and the ticket pre-authorized the split. This ticket keeps the core two-tier mechanism (DEV1 + DEV2); SM1.AC1's scenarios move with it.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/dimensions.md
@@ -30,3 +30,15 @@ Derived from the 6 ACs. Splits the same way ticket 153 did: **[hook]** = determi
 ## Invariant
 
 - `templates/hooks/` ↔ `.safeword/hooks/` byte-identical (`diff -q`).
+
+## Scenario-gate exit (2026-06-03)
+
+**AODI:** clean. **Adversarial pass:** +2 scenarios (`stamp_for_other_asset_does_not_allow`, `empty_skip_reason_rejected`). 14 total — 12 `[hook]` (unit) + 2 `[agent]` (live-verified skip).
+
+**Test layers:** all `[hook]` → unit tests over pure decision functions (no integration/E2E — the logic is pure over ledger + coverage state). `[agent]` → skill prose, live-verified.
+
+**Build order:**
+
+1. **Pure decision core** (new `lib/review-ledger.ts`): `gateNextAsset(priorAssetId, ledger)`, `gatePhaseAdvance(phase, ledger)`, `coverageGate(spec, testDefs)` (wraps the existing `scenario-coverage.ts`), reusing `parse-annotation.ts` `isValidSkipReason` for the skip valve. Unit-test the 12 `[hook]` scenarios here.
+2. **Wire into the hooks**: per-asset + coverage gates into `pre-tool-quality.ts`; phase-advance gate where the ticket `phase:` edit is seen; phase-exit stamp read via the existing `skill-invocation-log`. Sync dogfood + parity.
+3. **Skill prose** (`[agent]`): the inline per-asset review checklist (Tier 1) + the phase-exit `context: fork` review instructions (Tier 2) — written tight per the B1TWX7 constraint; live-verified.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/spec.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/spec.md
@@ -60,6 +60,8 @@ The phase-exit review is performed by a fresh reviewer with no conversation hist
 
 #### review-gate.SM1.AC1 — the coverage gate fires on genuine gaps and stays silent otherwise
 
+> **Deferred to ticket ZRMDKD.** The coverage gate needs a hook-side `scenario-coverage` port + differential test, separable from the two-tier review mechanism this ticket delivers. Its scenarios here are skip-closed; ZRMDKD owns them.
+
 Test-definitions with an uncovered acceptance criterion or an orphan scenario are blocked; complete, well-covered work passes with no prompt (bias-quiet, measured alert-to-action).
 
 #### review-gate.SM1.AC2 — every block offers a one-step skip with a recorded reason

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/spec.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/spec.md
@@ -1,74 +1,67 @@
-# Spec: Per-asset review gate for Phase 0 + TDD (ledger model)
-
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
+# Spec: Two-tier review enforcement (per-asset stamp + phase-exit independent review)
 
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Make "work is reviewed before it's built on" enforceable in the safeword workflow, at two tiers — a cheap per-asset inline review stamp (early catch) and an independent fresh-agent review at each phase exit (the strong backstop) — closing the gap where review is under-triggered unless a human manually prompts it.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- CC/Opus/skills research workflow `wf_c57312ee-82c` (2026-06-03) — verified Claude Code hook/skills primitives + the plan-validate-execute pattern.
+- The TDD SHA-or-skip ledger (J7VBGJ) — the proven "stamp proves the step happened" pattern this generalizes.
+- The `skill-invocation-log` + done-gate (147) — already requires `verify ✓` + `audit ✓` at done; Tier 2 reuses it at other phase exits.
+- Ticket 153 — alert-to-action / bias-quiet lesson for the coverage-gate trial.
+- B1TWX7 (wontfix) — authoring constraint: write the new review prose tight, no force-it padding.
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-.safeword-project/personas.md (e.g., Platform Operator (PO)). Add new
-personas to that file — don't invent them here. -->
+- **Agent-Driven Developer (DEV)** — builds features through the agent; bears the cost of a flawed early asset compounding downstream, and of review being silently skipped.
+- **Safeword Maintainer (SM)** — owns the gates; bears the cost of bloat and of low-signal gates training `--no-verify` bypass.
 
 ## Vocabulary
 
-<!-- Domain terms specific to this feature, consistent with
-.safeword-project/glossary.md. Optional. -->
+- **Review stamp** — a logged marker that a review ran for a given asset/phase (proof it happened, not a quality guarantee).
+- **Phase exit** — the boundary where a ticket advances from one workflow phase to the next.
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### review-gate.DEV1 — catch a weak asset before downstream work is built on it
 
-Uncomment and customize:
+**Persona:** Agent-Driven Developer (DEV)
 
-### oauth-flow.PO1 — Rotate credentials without a flag day
+> When I'm building a feature and the agent produces each artifact in turn (jobs → acceptance criteria → scenarios, and each TDD step), I want a quick review forced on each one before the next is authored, so a flawed foundation is caught early instead of after the whole chain has been poured on top of it.
 
-**Persona:** Platform Operator (PO)
+#### review-gate.DEV1.AC1 — the next artifact can't be authored until the prior one is reviewed
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
+Authoring artifact N+1 is denied (with a reason naming what's unreviewed) until artifact N carries a review stamp; a `skip: <reason>` stamp also clears it.
 
-Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
-in descriptive product language (a guarantee the user can observe), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario will prove a specific AC. If a JTBD has no user-observable capability
-to enumerate, write `skip: <reason>` under it instead of ACs.
+#### review-gate.DEV1.AC2 — the forced per-asset review is inline, no separate agent run
 
-#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+Satisfying the per-asset stamp spawns no fresh sub-agent — the review is the working agent's own inline pass, so it adds no per-asset spin-up cost.
 
-#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
--->
+### review-gate.DEV2 — guarantee an independent review actually ran at each phase
 
-## Outcomes
+**Persona:** Agent-Driven Developer (DEV)
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+> When the agent advances from one workflow phase to the next, I want proof that an independent review ran — not the author grading its own work, and not skipped — so review isn't silently dropped and I don't have to keep manually prompting for it.
 
-## Open Questions
+#### review-gate.DEV2.AC1 — a phase can't advance until an independent review of it has run
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+Advancing past a phase boundary is denied until a logged independent-review stamp for that phase exists; a recorded skip clears it.
+
+#### review-gate.DEV2.AC2 — the phase-exit review is independent, not the author
+
+The phase-exit review is performed by a fresh reviewer with no conversation history (so it can't rubber-stamp its own work), and its verdict is what the stamp records.
+
+### review-gate.SM1 — keep the enforcement high-signal and cheap
+
+**Persona:** Safeword Maintainer (SM)
+
+> When I maintain safeword's gates, I want the review enforcement to reuse the existing stamp/ledger machinery, fire only on genuine gaps, and offer a clear skip valve, so it doesn't bloat the hooks or train people to bypass it.
+
+#### review-gate.SM1.AC1 — the coverage gate fires on genuine gaps and stays silent otherwise
+
+Test-definitions with an uncovered acceptance criterion or an orphan scenario are blocked; complete, well-covered work passes with no prompt (bias-quiet, measured alert-to-action).
+
+#### review-gate.SM1.AC2 — every block offers a one-step skip with a recorded reason
+
+Each new gate (per-asset, phase-exit, coverage) can be cleared by an explicit `skip: <reason>` that is logged, so a maintainer is never hard-stuck and the override is auditable.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
@@ -64,9 +64,9 @@ Given the agent reviews a just-authored asset to earn its stamp
 When the review runs
 Then it is the working agent's own inline pass — no sub-agent is spawned
 
-- [ ] RED skip: agent behavior — live-verified, not unit-tested
-- [ ] GREEN skip: agent behavior
-- [ ] REFACTOR skip: agent behavior
+- [x] RED skip: agent behavior — /self-review prose mandates the working agent's own inline pass, no sub-agent (21794b3e); not unit-testable
+- [x] GREEN skip: agent behavior — verified by the /self-review SKILL.md
+- [x] REFACTOR skip: agent behavior
 
 ## Rule: Phase advance needs an independent review stamp **[hook]**
 
@@ -108,9 +108,9 @@ Given a phase exit triggers the independent review
 When the review runs
 Then it runs as a fresh reviewer (isolation, no conversation history) and its verdict becomes the recorded stamp
 
-- [ ] RED skip: agent behavior — live-verified
-- [ ] GREEN skip: agent behavior
-- [ ] REFACTOR skip: agent behavior
+- [x] RED skip: agent behavior — bdd phase-exit prose mandates a fresh reviewer (no history) whose verdict becomes the stamp (6b35e078); not unit-testable
+- [x] GREEN skip: agent behavior — verified by the bdd SKILL.md phase-exit section
+- [x] REFACTOR skip: agent behavior
 
 ## Rule: Coverage gate fires on genuine gaps, silent otherwise **[hook]**
 
@@ -120,9 +120,9 @@ Given a test-definitions.md with an acceptance criterion no scenario covers
 When it is created
 Then the write is denied, naming the uncovered AC
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: split to ZRMDKD — coverage gate is a separate hook-side scenario-coverage port
+- [x] GREEN skip: split to ZRMDKD
+- [x] REFACTOR skip: split to ZRMDKD
 
 ### Scenario: review-gate.SM1.AC1.orphan_scenario_blocks
 
@@ -130,9 +130,9 @@ Given a scenario whose name carries no `<jtbd>.AC<n>` lineage to any AC
 When the test-definitions is created
 Then the write is denied, naming the orphan scenario
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: split to ZRMDKD
+- [x] GREEN skip: split to ZRMDKD
+- [x] REFACTOR skip: split to ZRMDKD
 
 ### Scenario: review-gate.SM1.AC1.complete_coverage_silent
 
@@ -140,9 +140,9 @@ Given every AC is covered and there are no orphan scenarios
 When the test-definitions is created
 Then it passes with no prompt
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: split to ZRMDKD
+- [x] GREEN skip: split to ZRMDKD
+- [x] REFACTOR skip: split to ZRMDKD
 
 ## Rule: Every new gate has a logged one-step skip **[hook]**
 
@@ -152,9 +152,9 @@ Given any of the new gates would deny
 When the agent supplies `skip: <non-empty reason>`
 Then the gate clears and the reason is recorded in the ledger
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 961c2b50
+- [x] GREEN 961c2b50
+- [x] REFACTOR skip: skip valve proven end-to-end for both tiers (review-stamp 961c2b50, phase-review 507b7979)
 
 ### Scenario: review-gate.SM1.AC2.empty_skip_reason_rejected
 

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
@@ -1,0 +1,151 @@
+# Test Definitions — NMSD94: two-tier review enforcement
+
+**Architecture split:** **[hook]** scenarios are unit-tested — deterministic functions over the review ledger + ticket/coverage state decide deny/allow. **[agent]** scenarios are skill prose (the review actually running inline / in a fresh fork) — verified by live observation like 153's FSX1PP/V6N5PW, and their R/G/R close with `skip: <reason — agent behavior>`.
+
+The per-asset and phase stamps live as lines in the session skill-invocation-log (one store, reused). The PreToolUse gate reads the ledger; the coverage gate reuses `scenario-coverage.ts`.
+
+## Rule: Per-asset stamp gates the next asset **[hook]**
+
+### Scenario: review-gate.DEV1.AC1.unstamped_prior_blocks_next
+
+Given the prior asset has no review stamp in the ledger
+When the agent tries to author the next asset
+Then the write is denied, naming the unreviewed prior asset
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.DEV1.AC1.stamped_prior_allows_next
+
+Given the prior asset carries a review stamp
+When the agent authors the next asset
+Then the write is allowed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.DEV1.AC1.skip_stamp_allows_next
+
+Given the prior asset carries a `skip: <reason>` stamp
+When the agent authors the next asset
+Then the write is allowed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.DEV1.AC1.first_asset_not_gated
+
+Given no prior asset exists for this ticket
+When the agent authors the first asset
+Then the write is allowed (nothing to gate on)
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Per-asset review is inline **[agent]**
+
+### Scenario: review-gate.DEV1.AC2.stamping_spawns_no_subagent
+
+Given the agent reviews a just-authored asset to earn its stamp
+When the review runs
+Then it is the working agent's own inline pass — no sub-agent is spawned
+
+- [ ] RED skip: agent behavior — live-verified, not unit-tested
+- [ ] GREEN skip: agent behavior
+- [ ] REFACTOR skip: agent behavior
+
+## Rule: Phase advance needs an independent review stamp **[hook]**
+
+### Scenario: review-gate.DEV2.AC1.no_phase_stamp_blocks_advance
+
+Given no phase-exit review stamp exists for the current phase
+When the agent tries to advance the ticket's phase
+Then the transition is denied
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.DEV2.AC1.phase_stamp_allows_advance
+
+Given a phase-exit review stamp exists for the current phase
+When the agent advances the phase
+Then the transition is allowed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.DEV2.AC1.phase_skip_allows_advance
+
+Given a logged `skip: <reason>` for the phase-exit review
+When the agent advances the phase
+Then the transition is allowed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Phase review is independent **[agent]**
+
+### Scenario: review-gate.DEV2.AC2.phase_review_runs_fresh
+
+Given a phase exit triggers the independent review
+When the review runs
+Then it runs as a fresh reviewer (isolation, no conversation history) and its verdict becomes the recorded stamp
+
+- [ ] RED skip: agent behavior — live-verified
+- [ ] GREEN skip: agent behavior
+- [ ] REFACTOR skip: agent behavior
+
+## Rule: Coverage gate fires on genuine gaps, silent otherwise **[hook]**
+
+### Scenario: review-gate.SM1.AC1.uncovered_ac_blocks
+
+Given a test-definitions.md with an acceptance criterion no scenario covers
+When it is created
+Then the write is denied, naming the uncovered AC
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.SM1.AC1.orphan_scenario_blocks
+
+Given a scenario whose name carries no `<jtbd>.AC<n>` lineage to any AC
+When the test-definitions is created
+Then the write is denied, naming the orphan scenario
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.SM1.AC1.complete_coverage_silent
+
+Given every AC is covered and there are no orphan scenarios
+When the test-definitions is created
+Then it passes with no prompt
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Every new gate has a logged one-step skip **[hook]**
+
+### Scenario: review-gate.SM1.AC2.skip_clears_and_logs
+
+Given any of the new gates would deny
+When the agent supplies `skip: <non-empty reason>`
+Then the gate clears and the reason is recorded in the ledger
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Invariants
+
+- `templates/hooks/` and `.safeword/hooks/` are byte-identical (`diff -q`) after all changes.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
@@ -46,6 +46,16 @@ Then the write is allowed (nothing to gate on)
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: review-gate.DEV1.AC1.stamp_for_other_asset_does_not_allow
+
+Given a review stamp exists but keyed to a different asset
+When the agent tries to author the next asset
+Then the write is denied (the stamp must match the specific prior asset)
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ## Rule: Per-asset review is inline **[agent]**
 
 ### Scenario: review-gate.DEV1.AC2.stamping_spawns_no_subagent
@@ -141,6 +151,16 @@ Then it passes with no prompt
 Given any of the new gates would deny
 When the agent supplies `skip: <non-empty reason>`
 Then the gate clears and the reason is recorded in the ledger
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: review-gate.SM1.AC2.empty_skip_reason_rejected
+
+Given a gate would deny
+When the agent supplies `skip:` with no reason after the colon
+Then the gate still denies (an empty skip does not clear it)
 
 - [ ] RED
 - [ ] GREEN

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/test-definitions.md
@@ -12,9 +12,9 @@ Given the prior asset has no review stamp in the ledger
 When the agent tries to author the next asset
 Then the write is denied, naming the unreviewed prior asset
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV1.AC1.stamped_prior_allows_next
 
@@ -22,9 +22,9 @@ Given the prior asset carries a review stamp
 When the agent authors the next asset
 Then the write is allowed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV1.AC1.skip_stamp_allows_next
 
@@ -32,9 +32,9 @@ Given the prior asset carries a `skip: <reason>` stamp
 When the agent authors the next asset
 Then the write is allowed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV1.AC1.first_asset_not_gated
 
@@ -42,9 +42,9 @@ Given no prior asset exists for this ticket
 When the agent authors the first asset
 Then the write is allowed (nothing to gate on)
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV1.AC1.stamp_for_other_asset_does_not_allow
 
@@ -52,9 +52,9 @@ Given a review stamp exists but keyed to a different asset
 When the agent tries to author the next asset
 Then the write is denied (the stamp must match the specific prior asset)
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ## Rule: Per-asset review is inline **[agent]**
 
@@ -76,9 +76,9 @@ Given no phase-exit review stamp exists for the current phase
 When the agent tries to advance the ticket's phase
 Then the transition is denied
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9631623b
+- [x] GREEN 9631623b
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV2.AC1.phase_stamp_allows_advance
 
@@ -86,9 +86,9 @@ Given a phase-exit review stamp exists for the current phase
 When the agent advances the phase
 Then the transition is allowed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9631623b
+- [x] GREEN 9631623b
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ### Scenario: review-gate.DEV2.AC1.phase_skip_allows_advance
 
@@ -96,9 +96,9 @@ Given a logged `skip: <reason>` for the phase-exit review
 When the agent advances the phase
 Then the transition is allowed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9631623b
+- [x] GREEN 9631623b
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ## Rule: Phase review is independent **[agent]**
 
@@ -162,9 +162,9 @@ Given a gate would deny
 When the agent supplies `skip:` with no reason after the colon
 Then the gate still denies (an empty skip does not clear it)
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d60ba0c6
+- [x] GREEN d60ba0c6
+- [x] REFACTOR skip: pure decision fn, landed clean
 
 ## Invariants
 

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -2,7 +2,7 @@
 id: NMSD94
 slug: per-asset-review-gate
 type: feature
-phase: scenario-gate
+phase: implement
 status: in_progress
 created: 2026-06-03T03:23:27.177Z
 last_modified: 2026-06-03T04:15:00.000Z

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -2,10 +2,24 @@
 id: NMSD94
 slug: per-asset-review-gate
 type: feature
-phase: intake
-status: backlog
+phase: define-behavior
+status: in_progress
 created: 2026-06-03T03:23:27.177Z
-last_modified: 2026-06-03T04:01:00.000Z
+last_modified: 2026-06-03T04:15:00.000Z
+scope:
+  - 'Tier 1 — per-asset inline review stamp: a PreToolUse gate denies authoring artifact N+1 until artifact N (Phase-0 asset or TDD step) carries a review stamp or a logged skip; the review is the working agent inline (no sub-agent)'
+  - 'Tier 2 — phase-exit independent review: a context:fork reviewer runs once per phase boundary and logs a verdict stamp via the existing skill-invocation-log; the phase-advance gate blocks until the stamp exists'
+  - 'Coverage gate (trial): promote the advisory AC↔scenario coverage check (scenario-coverage.ts) to a skippable blocking gate (deny on uncovered ACs / orphan scenarios), bias-quiet, with measured alert-to-action'
+out_of_scope:
+  - 'A fresh sub-agent per asset — the cost trap; independence is bought once per phase (Tier 2), not per asset'
+  - 'Making Tier 1 faking-proof — it is a deliberate cheap floor; genuine independent scrutiny lives in Tier 2'
+  - 'A per-TDD-step independent fork review — the SHA-or-skip ledger already proves work-per-step; phase granularity only for Tier 2'
+  - 'A new standalone ledger — reuse skill-invocation-log + the existing PreToolUse gate machinery'
+done_when:
+  - 'Authoring an asset is blocked until the prior asset carries a review stamp, with a one-step logged skip valve (DEV1.AC1); stamping spawns no sub-agent (DEV1.AC2)'
+  - 'Advancing a phase is blocked until an independent context:fork review stamp for that phase exists (DEV2.AC1), produced by a fresh reviewer not the author (DEV2.AC2)'
+  - 'The coverage gate blocks uncovered-AC / orphan-scenario test-definitions and passes complete work silently (SM1.AC1); every new gate has a logged skip (SM1.AC2)'
+  - 'Reuses skill-invocation-log; no per-asset sub-agent; templates/hooks ↔ .safeword/hooks byte-identical; full suite + parity green'
 ---
 
 # Two-tier review enforcement: per-asset inline stamp + phase-exit independent review
@@ -48,6 +62,7 @@ Evidence the gap is real: this session needed the user to manually prompt `/qual
 
 ## Work Log
 
+- 2026-06-03T04:16:00.000Z Complete: intake. spec.md authored — 3 JTBD (DEV1 early-catch, DEV2 independent-review-ran, SM1 high-signal/cheap), 6 ACs (2/job), all user-signed-off. Engineering scope/out_of_scope/done_when written to frontmatter. Phase → define-behavior.
 - 2026-06-03T04:01:00.000Z **Reshaped to the two-tier hybrid** (user accepted). Restored per-asset review (cheap inline stamp, the early-catch the original ticket wanted) after recognizing the cost trap was the fresh-sub-agent-per-asset combination, not per-asset granularity. Independent fresh-agent review kept but moved to phase exits only (amortized). Honest limit recorded: Tier 1 inline stamp is gameable (a floor), Tier 2 fork review is the strong backstop.
 - 2026-06-03T03:45:00.000Z Reshaped to phase-exit-only stamp (superseded above — it dropped the per-asset early-catch the user wanted). Original per-asset A→C scope rejected: A redundant with the existing intake-exit gate, C (fork-per-asset) over-cost.
 - 2026-06-03T03:23:27.177Z Started: Created ticket NMSD94 (follow-up from the CC/Opus/skills research workflow).

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -5,38 +5,40 @@ type: feature
 phase: intake
 status: backlog
 created: 2026-06-03T03:23:27.177Z
-last_modified: 2026-06-03T03:23:27.177Z
+last_modified: 2026-06-03T03:45:00.000Z
 ---
 
-# Per-asset review gate for Phase 0 + TDD (ledger model)
+# Phase-exit "review-ran" stamp ledger (reshaped from per-asset gate)
 
-**Goal:** Make "each asset/step is reviewed before the next is authored" a HARD gate, not a soft prompt — closing the enforcement gap where safeword hard-gates phase _boundaries_ but leaves intra-phase step order and per-asset quality-review to agent compliance.
+**Goal:** Make "a quality review actually ran before advancing" enforceable at each **phase exit**, by extending the existing `skill-invocation-log` ledger (which already gates `done` on `/verify` + `/audit` stamps) to require a `/quality-review` stamp at the other phase boundaries — closing the demonstrated gap where review is under-triggered without building new per-asset machinery.
 
-**Why:** Analysis this session + live-docs research (workflow `wf_c57312ee-82c`, 2026-06-03). Today only the boundary gates are deterministic; the per-asset (Phase 0: JTBD → ACs → scope/out*of_scope/done_when → scenarios) and per-step (TDD R/G/R) \_review* discipline rides on prompt injections. The TDD SHA-or-skip ledger already proves the ledger/gate pattern works for proof-of-work; this extends it to **quality**. Opus 4.8 is more reliable but vendor-stated + effort-coupled ("fewer/less likely", never "never") — gates still cover the residual, which is safeword's whole thesis.
+**Why (revalidated 2026-06-03 — supersedes the original A→C scope):** A `/figure-it-out` against the actual code changed the design:
 
-**Scope (staged — ship A first, then C):**
+- **Original Option A (per-asset structural gate) is largely redundant.** The existing intake-exit gate (`pre-tool-quality.ts`) already blocks scenario creation until `scope`/`out_of_scope`/`done_when` exist + are non-empty, the phase advanced, and the JTBD + AC gates pass. The only real gap is that AC↔scenario lineage coverage is computed (`scenario-coverage.ts`) but **deliberately advisory** (`check.ts`: "Zero-exit — advisory, never a gate") — made non-blocking on purpose to avoid over-fire.
+- **Original Option C (per-asset `context: fork` reviewer) is over-cost + shape-mismatched.** A fork-subagent per Phase-0 asset AND per TDD step is heavy; its verdict is itself an LLM judgment (proves review _ran_, not _correct_); and the defects review actually caught this session were cross-cutting/implementation (found by _epic-level_ `/quality-review`), not per-Phase-0-asset.
+- **The gap is real, though:** this session needed the user to manually prompt `/quality-review` three times, each finding genuine defects — soft review is under-triggered. The right fix is the _proven ledger pattern_ at the _right granularity + cost_, not a new per-asset mechanism.
 
-- **A — widen the PreToolUse gate from per-phase to per-asset (existence/structure).** Deny the Write that creates `test-definitions.md` scenarios unless `scope`/`out_of_scope`/`done_when` are present and non-trivial; deny frontmatter authoring unless ACs exist; etc. Reuse `safeword check`'s lineage validation (uncovered ACs / orphan scenarios). Deterministic, model-independent, uses machinery safeword already owns. Mirrors the ecosystem's TDD-Guard pattern one rung finer.
-- **C — add the quality layer A structurally can't do.** A `context: fork` reviewer skill (isolated subagent — doesn't grade its own work) emits a verdict artifact per asset (e.g. `.review/<asset>.pass`); the PreToolUse gate blocks the next asset's Write until that artifact exists and reads `pass`. This realizes the **plan-validate-execute** best practice (verified, Claude Code skills docs) as enforcement: reviewer = validator, hook = gate.
+**Scope:**
+
+- Extend the `skill-invocation-log` + done-gate mechanism (`stop-quality.ts` / `skill-invocation-log.ts`) to require a logged `/quality-review` stamp at each **phase exit** (define-behavior → scenario-gate → implement → verify), mirroring how `done` already requires `verify ✓` + `audit ✓`.
+- Promote the advisory AC↔scenario coverage check (`scenario-coverage.ts`) to a **skippable trial** blocking gate (deny on uncovered ACs / orphan scenarios, with a `skip: <reason>` escape), and measure its alert-to-action ratio before making it permanent.
 
 **Out of scope:**
 
-- **Option D** (lean on Opus 4.8 + sharper prompts as the _strategy_) — rejected: converts safeword's core value into a bet on vendor-stated, effort-coupled reliability. (The one good point — trimming force-it padding — is split to B1TWX7.)
-- **Dynamic Workflows** as the mechanism — preview-only, docs 404, token-heavy; not for a shipped plugin.
-- Rebuilding the TDD SHA-or-skip ledger — it already exists; extend the _concept_, don't replace it.
-- Tuning Phase 0's asset _order_ itself (that's the existing workflow).
-
-**Design constraint (verified):** an invoked `SKILL.md` stays resident and is NOT re-read per turn — so the per-asset reviewer must be a `context: fork` invocation or a hook-driven external script, never a "re-read the skill each step" assumption.
+- The per-asset `context: fork` reviewer (original C) — over-cost (fork per asset/step), gates an LLM verdict, shape-mismatched to where defects actually surfaced. Revisit only if phase-exit stamps prove insufficient.
+- Broad per-asset structural gating (original A) — redundant with the existing intake-exit gate.
+- Per-TDD-step review stamp — the SHA-or-skip ledger already proves work-per-step; adding a review stamp per step is the same over-cost as C. Phase granularity only.
 
 **Done when:**
 
-- Authoring asset N+1 is blocked until asset N passes its structural lineage check (A) — out-of-order/empty intermediate assets are denied at the Write, with a clear reason.
-- A `context: fork` reviewer's verdict artifact gates the next asset (C); a missing/`fail` verdict blocks, a `pass` allows.
-- The gate's alert-to-action ratio stays high (fires on genuine gaps, not legitimate authoring) — explicitly measured, per the alert-fatigue lesson from ticket 153.
+- Advancing past a phase boundary is blocked unless a `/quality-review` stamp for that phase exists in the session skill-invocation-log (escape: explicit skip with reason).
+- The AC-coverage trial gate blocks uncovered-AC / orphan-scenario test-definitions, with a measured alert-to-action ratio (per the 153 alert-fatigue lesson) and a skip valve.
+- Reuses existing ledger machinery — no new per-asset fork mechanism.
 - `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; full suite + parity green.
 
-**Note:** This is a feature — run `/bdd` when picked up (multiple components + new gate state + the fork-reviewer flow). Consider splitting A and C into child tickets at scenario-gate if the scope proves large.
+**Note:** Material design pivot from the filed scope — surface to the user before building. Feature → run `/bdd` once the reshape is accepted.
 
 ## Work Log
 
+- 2026-06-03T03:45:00.000Z **Reshaped** via revalidate + `/figure-it-out` (grounded in pre-tool-quality.ts + check.ts + scenario-coverage.ts): original per-asset A→C scope rejected — A redundant with the existing intake-exit gate, C over-cost/shape-mismatched. Repointed at extending the existing `skill-invocation-log` to a phase-exit `/quality-review` stamp + promoting the advisory AC-coverage check to a skippable trial gate. Awaiting user acceptance of the pivot before `/bdd`.
 - 2026-06-03T03:23:27.177Z Started: Created ticket NMSD94 (follow-up from the CC/Opus/skills research workflow — staged Option A→C recommendation).

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -42,6 +42,8 @@ Evidence the gap is real: this session needed the user to manually prompt `/qual
 - What's the concrete inline stamp surface for a Phase-0 asset (it has no R/G/R checkbox like TDD) — a frontmatter field, a review-ledger line, or a checkbox in the artifact?
 - Tier-1 stamp gameability vs. friction — is the cheap floor worth it, or does Tier 2 alone suffice? (Resolve with the alert-to-action measurement.)
 
+**Authoring constraint (carried from B1TWX7):** the new review prose this ticket writes — per-asset checklist, phase-exit review instructions, stamp/deny messages — must be written tight: state the rule once, no defensive "CRITICAL/you MUST" padding. Opus reads literally (4.8 finding), and the session evidence is that review is _under_-triggered, not over-padded — so the lever is a hard stamp gate (this ticket), not louder prompts. B1TWX7 (strip existing padding) stays wontfix — the existing prose is already tight; this is the forward application of its kernel.
+
 **Note:** Feature — run `/bdd` when picked up. Consider splitting the three pieces (Tier 1, Tier 2, coverage gate) into children at scenario-gate if scope proves large.
 
 ## Work Log

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -2,10 +2,10 @@
 id: NMSD94
 slug: per-asset-review-gate
 type: feature
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-06-03T03:23:27.177Z
-last_modified: 2026-06-03T04:15:00.000Z
+last_modified: 2026-06-03T17:42:00.000Z
 scope:
   - 'Tier 1 — per-asset inline review stamp: a PreToolUse gate denies authoring artifact N+1 until artifact N (Phase-0 asset or TDD step) carries a review stamp or a logged skip; the review is the working agent inline (no sub-agent)'
   - 'Tier 2 — phase-exit independent review: a context:fork reviewer runs once per phase boundary and logs a verdict stamp via the existing skill-invocation-log; the phase-advance gate blocks until the stamp exists'
@@ -62,6 +62,7 @@ Evidence the gap is real: this session needed the user to manually prompt `/qual
 
 ## Work Log
 
+- 2026-06-03T17:42:00.000Z **Done.** Both tiers built, wired (default-off), hardened (quality-review: input sanitization + multi-ticket guard), and refactored (extracted isReviewGateOn/readReviewStamps). /verify + /audit passed, verify.md written. Full suite 2485 green against a fresh build. Stamp-earning shipped as write-review-stamp.ts + /self-review skill + bdd phase-exit prose. Ships inert behind reviewGate. Follow-ups: ZRMDKD (coverage gate), reviewGate dogfood enablement (deferred).
 - 2026-06-03T04:16:00.000Z Complete: intake. spec.md authored — 3 JTBD (DEV1 early-catch, DEV2 independent-review-ran, SM1 high-signal/cheap), 6 ACs (2/job), all user-signed-off. Engineering scope/out_of_scope/done_when written to frontmatter. Phase → define-behavior.
 - 2026-06-03T04:01:00.000Z **Reshaped to the two-tier hybrid** (user accepted). Restored per-asset review (cheap inline stamp, the early-catch the original ticket wanted) after recognizing the cost trap was the fresh-sub-agent-per-asset combination, not per-asset granularity. Independent fresh-agent review kept but moved to phase exits only (amortized). Honest limit recorded: Tier 1 inline stamp is gameable (a floor), Tier 2 fork review is the strong backstop.
 - 2026-06-03T03:45:00.000Z Reshaped to phase-exit-only stamp (superseded above — it dropped the per-asset early-catch the user wanted). Original per-asset A→C scope rejected: A redundant with the existing intake-exit gate, C (fork-per-asset) over-cost.

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -2,7 +2,7 @@
 id: NMSD94
 slug: per-asset-review-gate
 type: feature
-phase: define-behavior
+phase: scenario-gate
 status: in_progress
 created: 2026-06-03T03:23:27.177Z
 last_modified: 2026-06-03T04:15:00.000Z

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/ticket.md
@@ -5,40 +5,47 @@ type: feature
 phase: intake
 status: backlog
 created: 2026-06-03T03:23:27.177Z
-last_modified: 2026-06-03T03:45:00.000Z
+last_modified: 2026-06-03T04:01:00.000Z
 ---
 
-# Phase-exit "review-ran" stamp ledger (reshaped from per-asset gate)
+# Two-tier review enforcement: per-asset inline stamp + phase-exit independent review
 
-**Goal:** Make "a quality review actually ran before advancing" enforceable at each **phase exit**, by extending the existing `skill-invocation-log` ledger (which already gates `done` on `/verify` + `/audit` stamps) to require a `/quality-review` stamp at the other phase boundaries — closing the demonstrated gap where review is under-triggered without building new per-asset machinery.
+**Goal:** Make "work is reviewed before it's built on" enforceable, at two tiers: a **cheap per-asset inline review stamp** (early catch, before the next asset is poured on a flawed one) and an **independent fresh-agent review at each phase exit** (catches what self-review misses). Close the demonstrated gap — review is under-triggered unless the user manually prompts it — without a fresh sub-agent firing on every artifact.
 
-**Why (revalidated 2026-06-03 — supersedes the original A→C scope):** A `/figure-it-out` against the actual code changed the design:
+**Why (revalidated + reshaped 2026-06-03):** Two `/figure-it-out` passes against the code:
 
-- **Original Option A (per-asset structural gate) is largely redundant.** The existing intake-exit gate (`pre-tool-quality.ts`) already blocks scenario creation until `scope`/`out_of_scope`/`done_when` exist + are non-empty, the phase advanced, and the JTBD + AC gates pass. The only real gap is that AC↔scenario lineage coverage is computed (`scenario-coverage.ts`) but **deliberately advisory** (`check.ts`: "Zero-exit — advisory, never a gate") — made non-blocking on purpose to avoid over-fire.
-- **Original Option C (per-asset `context: fork` reviewer) is over-cost + shape-mismatched.** A fork-subagent per Phase-0 asset AND per TDD step is heavy; its verdict is itself an LLM judgment (proves review _ran_, not _correct_); and the defects review actually caught this session were cross-cutting/implementation (found by _epic-level_ `/quality-review`), not per-Phase-0-asset.
-- **The gap is real, though:** this session needed the user to manually prompt `/quality-review` three times, each finding genuine defects — soft review is under-triggered. The right fix is the _proven ledger pattern_ at the _right granularity + cost_, not a new per-asset mechanism.
+1. The filed per-asset A→C scope conflated two independent knobs — _how often_ you review (per-asset vs per-phase) and _who_ reviews (the same agent inline = cheap, vs a fresh sub-agent = independent but a full spin-up each time). Only the **fresh-sub-agent-per-asset** combination is expensive; per-asset review _itself_ is cheap if done inline + stamped (the same model as the TDD per-step SHA ledger, which already stamps every step).
+2. Dropping per-asset entirely (the earlier phase-exit-only reshape) lost the early-catch property the user actually wants: a weak goal shouldn't be reviewable only _after_ its ACs are already built. So keep per-asset — just make the stamp cheap (inline), and reserve the costly independent reviewer for phase boundaries.
 
-**Scope:**
+Evidence the gap is real: this session needed the user to manually prompt `/quality-review` three times, each finding genuine defects.
 
-- Extend the `skill-invocation-log` + done-gate mechanism (`stop-quality.ts` / `skill-invocation-log.ts`) to require a logged `/quality-review` stamp at each **phase exit** (define-behavior → scenario-gate → implement → verify), mirroring how `done` already requires `verify ✓` + `audit ✓`.
-- Promote the advisory AC↔scenario coverage check (`scenario-coverage.ts`) to a **skippable trial** blocking gate (deny on uncovered ACs / orphan scenarios, with a `skip: <reason>` escape), and measure its alert-to-action ratio before making it permanent.
+**Scope (two tiers + a coverage gate):**
+
+- **Tier 1 — per-asset inline review stamp (cheap, early-catch).** Each Phase-0 asset (JTBD set → ACs → scope/out*of_scope/done_when → scenarios) and each TDD step gets an inline self-review against a short checklist, recording a stamp. A PreToolUse gate denies authoring asset N+1 until asset N carries a stamp. Model = the TDD SHA-per-step ledger, generalized to assets. **Honest limit:** an inline self-review stamp proves the agent \_paused and reviewed*, not that the review was correct or even genuine (it's gameable — the agent can stamp without truly reviewing). It raises the floor; it is not the strong check.
+- **Tier 2 — independent review at each phase exit (strong, amortized).** A `context: fork` reviewer (fresh agent, no conversation history, can't grade its own work) runs once per phase boundary and logs a verdict stamp, reusing the existing `skill-invocation-log` + done-gate pattern (which already requires `verify ✓` + `audit ✓` at done). The phase-advance gate blocks until the stamp exists. This is the ungameable check that backstops Tier 1's gameable one.
+- **Coverage gate (trial).** Promote the deliberately-advisory AC↔scenario coverage check (`scenario-coverage.ts`, currently zero-exit) to a **skippable** blocking gate (deny on uncovered ACs / orphan scenarios, `skip: <reason>` escape); measure alert-to-action before making it permanent.
 
 **Out of scope:**
 
-- The per-asset `context: fork` reviewer (original C) — over-cost (fork per asset/step), gates an LLM verdict, shape-mismatched to where defects actually surfaced. Revisit only if phase-exit stamps prove insufficient.
-- Broad per-asset structural gating (original A) — redundant with the existing intake-exit gate.
-- Per-TDD-step review stamp — the SHA-or-skip ledger already proves work-per-step; adding a review stamp per step is the same over-cost as C. Phase granularity only.
+- A fresh **sub-agent per asset** — the cost trap. Independence is bought once per phase (Tier 2), not per asset.
+- Faking-proof inline review — Tier 1 is a deliberate cheap floor; Tier 2 is where genuine independent scrutiny lives. Don't over-engineer Tier 1 to be ungameable.
 
 **Done when:**
 
-- Advancing past a phase boundary is blocked unless a `/quality-review` stamp for that phase exists in the session skill-invocation-log (escape: explicit skip with reason).
-- The AC-coverage trial gate blocks uncovered-AC / orphan-scenario test-definitions, with a measured alert-to-action ratio (per the 153 alert-fatigue lesson) and a skip valve.
-- Reuses existing ledger machinery — no new per-asset fork mechanism.
-- `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; full suite + parity green.
+- Authoring an asset is blocked until the prior asset carries an inline review stamp (Tier 1), with a skip valve.
+- Advancing a phase is blocked until an independent (`context: fork`) review stamp for that phase exists (Tier 2), reusing the skill-invocation-log mechanism.
+- The AC-coverage trial gate blocks uncovered-AC/orphan-scenario test-definitions with a measured alert-to-action ratio (per the 153 alert-fatigue lesson) + skip valve.
+- No fresh sub-agent fires per asset; `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; full suite + parity green.
 
-**Note:** Material design pivot from the filed scope — surface to the user before building. Feature → run `/bdd` once the reshape is accepted.
+**Open design questions for `/bdd` intake:**
+
+- What's the concrete inline stamp surface for a Phase-0 asset (it has no R/G/R checkbox like TDD) — a frontmatter field, a review-ledger line, or a checkbox in the artifact?
+- Tier-1 stamp gameability vs. friction — is the cheap floor worth it, or does Tier 2 alone suffice? (Resolve with the alert-to-action measurement.)
+
+**Note:** Feature — run `/bdd` when picked up. Consider splitting the three pieces (Tier 1, Tier 2, coverage gate) into children at scenario-gate if scope proves large.
 
 ## Work Log
 
-- 2026-06-03T03:45:00.000Z **Reshaped** via revalidate + `/figure-it-out` (grounded in pre-tool-quality.ts + check.ts + scenario-coverage.ts): original per-asset A→C scope rejected — A redundant with the existing intake-exit gate, C over-cost/shape-mismatched. Repointed at extending the existing `skill-invocation-log` to a phase-exit `/quality-review` stamp + promoting the advisory AC-coverage check to a skippable trial gate. Awaiting user acceptance of the pivot before `/bdd`.
-- 2026-06-03T03:23:27.177Z Started: Created ticket NMSD94 (follow-up from the CC/Opus/skills research workflow — staged Option A→C recommendation).
+- 2026-06-03T04:01:00.000Z **Reshaped to the two-tier hybrid** (user accepted). Restored per-asset review (cheap inline stamp, the early-catch the original ticket wanted) after recognizing the cost trap was the fresh-sub-agent-per-asset combination, not per-asset granularity. Independent fresh-agent review kept but moved to phase exits only (amortized). Honest limit recorded: Tier 1 inline stamp is gameable (a floor), Tier 2 fork review is the strong backstop.
+- 2026-06-03T03:45:00.000Z Reshaped to phase-exit-only stamp (superseded above — it dropped the per-asset early-catch the user wanted). Original per-asset A→C scope rejected: A redundant with the existing intake-exit gate, C (fork-per-asset) over-cost.
+- 2026-06-03T03:23:27.177Z Started: Created ticket NMSD94 (follow-up from the CC/Opus/skills research workflow).

--- a/.safeword-project/tickets/NMSD94-per-asset-review-gate/verify.md
+++ b/.safeword-project/tickets/NMSD94-per-asset-review-gate/verify.md
@@ -1,0 +1,25 @@
+# Verify — NMSD94: two-tier review enforcement
+
+## Verify Checklist
+
+**Test Suite:** ✓ 2485/2485 tests pass (1 skipped) — full suite against a fresh build
+**Build:** ✅ Success
+**Lint:** ✅ Clean (eslint + tsc, `bun run lint`)
+**Scenarios:** All 45 scenarios marked complete
+**Dep Drift:** ✅ Clean — NMSD94 added no dependencies (node stdlib only)
+**Parent Epic:** N/A (standalone ticket)
+**Reconcile:** ✅ No pattern deviation — reused the skill-invocation-log, the PreToolUse gate machinery, and the SHA-ledger "stamp proves the work" pattern; no new persistence introduced.
+
+Audit passed — architecture clean (no circular deps or layer violations across 122 modules), **0 duplication** in the NMSD94 source, and **no dead code** from NMSD94. knip's findings (`collectNewTransitions`, `JtbdEntry`, `MAX_CODE_LENGTH`, 7 unused deps) are all pre-existing baseline noise — the hook-template false-positives knip always reports — and none are NMSD94's.
+
+## What shipped
+
+- **Tier 1 (per-asset, gameable floor):** `/self-review` + `write-review-stamp.ts` earn a content-bound spec stamp (`<ticket>:spec@<hash>`); the PreToolUse gate blocks `test-definitions.md` creation until the spec is reviewed at its current content. DEV1.AC1 (hook) + DEV1.AC2 (inline, no sub-agent — skill prose).
+- **Tier 2 (phase exit, independent):** the phase-advance gate blocks leaving a phase until a ticket-qualified phase-exit stamp exists; bdd prose directs a fresh fork reviewer whose verdict becomes the stamp. DEV2.AC1 (hook) + DEV2.AC2 (fork — skill prose).
+- **Hardening (post quality-review):** whitespace-collapsed stamp inputs (no log-line injection) + fail-loud guard on ambiguous active ticket (`--ticket` override).
+- **Rollout guard:** both gates are inert unless `.safeword/config.json` sets `reviewGate: true` — ships off, enable deliberately.
+
+## Follow-ups (separate tickets)
+
+- **ZRMDKD** — promote the AC↔scenario coverage check to a blocking gate (owns NMSD94's SM1.AC1).
+- **reviewGate dogfood enablement** — deferred by design; ship inert, enable after a soak.

--- a/.safeword-project/tickets/ZRMDKD-coverage-gate-blocking/ticket.md
+++ b/.safeword-project/tickets/ZRMDKD-coverage-gate-blocking/ticket.md
@@ -1,0 +1,31 @@
+---
+id: ZRMDKD
+slug: coverage-gate-blocking
+type: task
+phase: intake
+status: backlog
+created: 2026-06-03T04:42:30.504Z
+last_modified: 2026-06-03T04:42:30.504Z
+---
+
+# Promote scenario-coverage to a blocking gate (split from NMSD94 SM1.AC1)
+
+**Goal:** Promote the deliberately-advisory AC↔scenario coverage check to a skippable blocking gate, so test-definitions with an uncovered AC or an orphan scenario are denied (not just warned), with a measured alert-to-action ratio.
+
+**Why:** Split from NMSD94 (which owns the two-tier review mechanism). The coverage logic lives in `packages/cli/src/utils/scenario-coverage.ts` (192 lines, 3 fns: `parseAcReferenceFromTitle`, `parseAcIdsByJtbd`, `buildCoverageReport`). A PreToolUse hook can't import from `src/` (the cross-runtime boundary), so promoting it to blocking needs a hook-side port + a differential test — a self-contained sub-build that shouldn't bloat NMSD94. It's also the "trial" piece (`check.ts` made it advisory on purpose to avoid over-fire), so it deserves its own alert-to-action measurement.
+
+**Scope:**
+
+- Port `scenario-coverage.ts`'s coverage computation into a hook lib (mirror, like `jtbd.ts` mirrors `markdown-sections.ts`), pinned by a **differential test** against the `src/` original (the P58R22 pattern).
+- Wire it into `pre-tool-quality.ts` as a blocking gate on test-definitions.md creation: deny on an uncovered AC (naming it) or an orphan scenario (naming it); pass complete, well-covered work silently.
+- Skip valve: `skip: <reason>` clears it, logged.
+
+**Out of scope:** the two-tier review stamp mechanism (NMSD94 owns it).
+
+**Done when:** uncovered-AC / orphan-scenario test-definitions are denied with a clear reason; complete work passes silently; alert-to-action measured before making it permanent; differential test pins the hook port to the CLI original; `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; full suite + parity green.
+
+**Owns:** NMSD94's SM1.AC1 scenarios (`uncovered_ac_blocks`, `orphan_scenario_blocks`, `complete_coverage_silent`).
+
+## Work Log
+
+- 2026-06-03T04:42:30.504Z Created: split from NMSD94 via /figure-it-out — the coverage gate needs a hook-side `scenario-coverage` port + differential test, separable from the two-tier review mechanism.

--- a/.safeword/hooks/lib/active-ticket.ts
+++ b/.safeword/hooks/lib/active-ticket.ts
@@ -207,6 +207,32 @@ export function resolveStopPhase(
   return EMPTY;
 }
 
+/**
+ * Every in_progress, non-epic ticket folder — the build tickets a session could
+ * be working. The stamp-earning step (NMSD94) uses this to resolve which ticket
+ * to stamp and to fail loudly when more than one is active, rather than silently
+ * guessing a ticket that may differ from the one the gate is checking.
+ */
+export function getInProgressTicketFolders(projectDirectory: string): string[] {
+  const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
+  if (!existsSync(ticketsDirectory)) return [];
+
+  try {
+    return readdirSync(ticketsDirectory).filter(folder => {
+      if (folder === 'completed' || folder === 'tmp') return false;
+      const ticketFile = nodePath.join(ticketsDirectory, folder, 'ticket.md');
+      if (!existsSync(ticketFile)) return false;
+      const content = readFileSync(ticketFile, 'utf8');
+      return (
+        content.match(/^status:\s*(\S+)/m)?.[1] === 'in_progress' &&
+        content.match(/^type:\s*(\S+)/m)?.[1] !== 'epic'
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
 export function getActiveTicket(projectDirectory: string): ActiveTicketInfo {
   const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
   if (!existsSync(ticketsDirectory)) return EMPTY;

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -16,7 +16,7 @@ export interface ReviewStamp {
    * only for THIS ticket's artifact at THIS content (no cross-ticket or
    * stale-after-edit false-allows).
    */
-  assetId: string;
+  scope: string;
   /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
   skipReason?: string;
 }
@@ -45,7 +45,7 @@ function isSatisfyingStamp(stamp: ReviewStamp): boolean {
 
 /** Whether the ledger holds a satisfying review stamp for `id` (an asset or a phase). */
 function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean {
-  return stamps.some(stamp => stamp.assetId === id && isSatisfyingStamp(stamp));
+  return stamps.some(stamp => stamp.scope === id && isSatisfyingStamp(stamp));
 }
 
 /**
@@ -54,14 +54,14 @@ function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean
  * never gated.
  */
 export function reviewGateForNextAsset(
-  priorAssetId: string | undefined,
+  priorScope: string | undefined,
   stamps: readonly ReviewStamp[],
 ): GateVerdict {
-  if (priorAssetId === undefined) return { ok: true };
-  if (hasSatisfyingStamp(priorAssetId, stamps)) return { ok: true };
+  if (priorScope === undefined) return { ok: true };
+  if (hasSatisfyingStamp(priorScope, stamps)) return { ok: true };
   return {
     ok: false,
-    reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+    reason: `"${priorScope}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
   };
 }
 
@@ -119,7 +119,7 @@ export function parseReviewStamps(logContent: string): ReviewStamp[] {
     if (match?.[1] === undefined) continue;
     const skipReason = match[2];
     stamps.push(
-      skipReason === undefined ? { assetId: match[1] } : { assetId: match[1], skipReason },
+      skipReason === undefined ? { scope: match[1] } : { scope: match[1], skipReason },
     );
   }
   return stamps;

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -63,6 +63,26 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
  */
 const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
 
+/**
+ * Rollout guard: the review gate is OFF unless `.safeword/config.json` sets
+ * `reviewGate: true`. Default-off so this self-applying blocking gate can ship
+ * inert (no bricking the dogfood or customers) and be enabled deliberately once
+ * the stamp-earning step is in place. Fail-safe to off on missing/malformed config.
+ */
+export function isReviewGateEnabled(rawConfig: string | undefined): boolean {
+  if (rawConfig === undefined) return false;
+  try {
+    const config: unknown = JSON.parse(rawConfig);
+    return (
+      typeof config === 'object' &&
+      config !== null &&
+      (config as Record<string, unknown>).reviewGate === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -5,13 +5,35 @@
 // `.js` specifier (bun resolves it to the .ts source) so tsc accepts this module
 // when the test suite pulls it into the typecheck graph — the tested-lib rule.
 
+import { createHash } from 'node:crypto';
+
 import { isValidSkipReason } from './parse-annotation.js';
 
 export interface ReviewStamp {
-  /** The asset (or phase) the review covers. */
+  /**
+   * The review's scope key — see {@link reviewScope}. Ticket-qualified and
+   * content-bound (`<ticket>:<artifact>@<hash>`), so a stamp matches the gate
+   * only for THIS ticket's artifact at THIS content (no cross-ticket or
+   * stale-after-edit false-allows).
+   */
   assetId: string;
   /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
   skipReason?: string;
+}
+
+/** Short content hash binding a stamp to the reviewed artifact's exact state. */
+export function hashArtifact(content: string): string {
+  return createHash('sha1').update(content).digest('hex').slice(0, 12);
+}
+
+/**
+ * Canonical review-stamp scope: `<ticketId>:<artifact>@<contentHash>`. Both the
+ * gate and the stamp-earning step build keys this way so a review satisfies the
+ * gate only for the same ticket + artifact + content — a review of another
+ * ticket's spec, or of a now-edited spec, no longer matches.
+ */
+export function reviewScope(ticketId: string, artifact: string, contentHash: string): string {
+  return `${ticketId}:${artifact}@${contentHash}`;
 }
 
 export type GateVerdict = { ok: true } | { ok: false; reason: string };
@@ -56,11 +78,17 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
   };
 }
 
-/**
- * A review entry in the skill-invocation-log: `review:<artifactId>` for a real
- * review, or `review:<artifactId> skip:<reason>` for a logged skip. The line is
- * `<timestamp> <session> <entry>`, so the review token is matched at line end.
- */
+// A review entry in the skill-invocation-log. Format contract (the
+// stamp-earning step writes exactly this): `review:<scope>` for a real review,
+// or `review:<scope> skip:<reason>` for a logged skip, where <scope> is a
+// space-free reviewScope() key. The line is `<timestamp> <session> <entry>`, so
+// the review token is matched at line end.
+//
+// Trust boundary: a stamp is only as trustworthy as the log file's integrity —
+// a crafted `review:<scope>` line satisfies this gate. That's by design: Tier 1
+// is the cheap, gameable floor; the ungameable check is Tier 2 (independent
+// fork review). The content-hash binding in <scope> at least defeats accidental
+// stale-after-edit passes, not deliberate spoofing.
 const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
 
 /**

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -55,3 +55,24 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
     reason: `phase "${phase}" has no independent review stamp — run the phase-exit review (or log a skip with a reason) before advancing`,
   };
 }
+
+/**
+ * A review entry in the skill-invocation-log: `review:<artifactId>` for a real
+ * review, or `review:<artifactId> skip:<reason>` for a logged skip. The line is
+ * `<timestamp> <session> <entry>`, so the review token is matched at line end.
+ */
+const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
+
+/** Read review stamps from skill-invocation-log content (non-review lines ignored). */
+export function parseReviewStamps(logContent: string): ReviewStamp[] {
+  const stamps: ReviewStamp[] = [];
+  for (const line of logContent.split('\n')) {
+    const match = REVIEW_LINE.exec(line);
+    if (match?.[1] === undefined) continue;
+    const skipReason = match[2];
+    stamps.push(
+      skipReason === undefined ? { assetId: match[1] } : { assetId: match[1], skipReason },
+    );
+  }
+  return stamps;
+}

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -1,0 +1,41 @@
+// Safeword: two-tier review-enforcement decision core (ticket NMSD94). Pure, no
+// I/O. The PreToolUse / phase-advance gates wire these to the real
+// skill-invocation-log, which stores one review stamp per asset/phase.
+//
+// `.js` specifier (bun resolves it to the .ts source) so tsc accepts this module
+// when the test suite pulls it into the typecheck graph — the tested-lib rule.
+
+import { isValidSkipReason } from './parse-annotation.js';
+
+export interface ReviewStamp {
+  /** The asset (or phase) the review covers. */
+  assetId: string;
+  /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
+  skipReason?: string;
+}
+
+export type GateVerdict = { ok: true } | { ok: false; reason: string };
+
+/** A stamp satisfies a gate when it's a real review, or a skip with a non-empty reason. */
+function isSatisfyingStamp(stamp: ReviewStamp): boolean {
+  return stamp.skipReason === undefined || isValidSkipReason(stamp.skipReason);
+}
+
+/**
+ * Per-asset gate (DEV1.AC1): authoring the next asset is allowed only when the
+ * prior asset carries a satisfying review stamp. The first asset (no prior) is
+ * never gated.
+ */
+export function reviewGateForNextAsset(
+  priorAssetId: string | undefined,
+  stamps: readonly ReviewStamp[],
+): GateVerdict {
+  if (priorAssetId === undefined) return { ok: true };
+  if (stamps.some(stamp => stamp.assetId === priorAssetId && isSatisfyingStamp(stamp))) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+  };
+}

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -118,9 +118,7 @@ export function parseReviewStamps(logContent: string): ReviewStamp[] {
     const match = REVIEW_LINE.exec(line);
     if (match?.[1] === undefined) continue;
     const skipReason = match[2];
-    stamps.push(
-      skipReason === undefined ? { scope: match[1] } : { scope: match[1], skipReason },
-    );
+    stamps.push(skipReason === undefined ? { scope: match[1] } : { scope: match[1], skipReason });
   }
   return stamps;
 }

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -69,7 +69,7 @@ const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
  * inert (no bricking the dogfood or customers) and be enabled deliberately once
  * the stamp-earning step is in place. Fail-safe to off on missing/malformed config.
  */
-export function isReviewGateEnabled(rawConfig: string | undefined): boolean {
+export function isReviewGateEnabled(rawConfig?: string): boolean {
   if (rawConfig === undefined) return false;
   try {
     const config: unknown = JSON.parse(rawConfig);

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -111,6 +111,21 @@ export function isReviewGateEnabled(rawConfig?: string): boolean {
   }
 }
 
+const PHASE_FIELD = /^phase:\s*(\S+)/m;
+
+/**
+ * The phase being EXITED by a ticket.md edit (Tier 2): the old phase, when the
+ * edit changes `phase:` to a different value. Returns undefined when the phase
+ * is unchanged or absent on either side (nothing to gate). Forward/backward
+ * ordering isn't distinguished — leaving any phase requires its exit review.
+ */
+export function detectPhaseAdvance(oldContent: string, newContent: string): string | undefined {
+  const from = PHASE_FIELD.exec(oldContent)?.[1];
+  const to = PHASE_FIELD.exec(newContent)?.[1];
+  if (from === undefined || to === undefined || from === to) return undefined;
+  return from;
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -126,6 +126,16 @@ export function detectPhaseAdvance(oldContent: string, newContent: string): stri
   return from;
 }
 
+/**
+ * Render a stamp token for the skill-invocation-log — the inverse of
+ * {@link parseReviewStamps}. The stamp-earning step (`write-review-stamp.ts`)
+ * prefixes `<timestamp> <session> ` and appends the result, so the gate reads
+ * back exactly this `scope`. A non-empty `skipReason` records a logged skip.
+ */
+export function formatReviewStamp(scope: string, skipReason?: string): string {
+  return skipReason === undefined ? `review:${scope}` : `review:${scope} skip:${skipReason}`;
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/.safeword/hooks/lib/review-ledger.ts
+++ b/.safeword/hooks/lib/review-ledger.ts
@@ -21,6 +21,11 @@ function isSatisfyingStamp(stamp: ReviewStamp): boolean {
   return stamp.skipReason === undefined || isValidSkipReason(stamp.skipReason);
 }
 
+/** Whether the ledger holds a satisfying review stamp for `id` (an asset or a phase). */
+function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean {
+  return stamps.some(stamp => stamp.assetId === id && isSatisfyingStamp(stamp));
+}
+
 /**
  * Per-asset gate (DEV1.AC1): authoring the next asset is allowed only when the
  * prior asset carries a satisfying review stamp. The first asset (no prior) is
@@ -31,11 +36,22 @@ export function reviewGateForNextAsset(
   stamps: readonly ReviewStamp[],
 ): GateVerdict {
   if (priorAssetId === undefined) return { ok: true };
-  if (stamps.some(stamp => stamp.assetId === priorAssetId && isSatisfyingStamp(stamp))) {
-    return { ok: true };
-  }
+  if (hasSatisfyingStamp(priorAssetId, stamps)) return { ok: true };
   return {
     ok: false,
     reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+  };
+}
+
+/**
+ * Phase-exit gate (DEV2.AC1): advancing past a phase is allowed only when an
+ * independent review stamp for that phase exists. Unlike the per-asset gate
+ * there is no "first" exemption — every phase exit needs a stamp.
+ */
+export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]): GateVerdict {
+  if (hasSatisfyingStamp(phase, stamps)) return { ok: true };
+  return {
+    ok: false,
+    reason: `phase "${phase}" has no independent review stamp — run the phase-exit review (or log a skip with a reason) before advancing`,
   };
 }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -331,7 +331,7 @@ if (
       if (!reviewGateForNextAsset(priorScope, stamps).ok) {
         deny(
           'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
-          'Run the spec review, then create test-definitions.md.',
+          'Run `/self-review` (or log a skip), then create test-definitions.md.',
         );
       }
     }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -19,6 +19,7 @@ import {
   hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
+  type ReviewStamp,
   reviewGateForNextAsset,
   reviewScope,
 } from './lib/review-ledger.ts';
@@ -129,6 +130,13 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 function isReviewGateOn(): boolean {
   const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
   return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
+// The review stamps both gates read from the shared skill-invocation-log
+// (write-review-stamp.ts appends to the same file).
+function readReviewStamps(): ReviewStamp[] {
+  const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+  return existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
 }
 
 /**
@@ -326,8 +334,7 @@ if (
     // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
     // brick a workflow before the stamp-earning step ships.
     if (isReviewGateOn()) {
-      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const stamps = readReviewStamps();
       const priorScope = reviewScope(
         nodePath.basename(ticketDirectory),
         'spec',
@@ -374,8 +381,7 @@ if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/t
     );
     if (exitedPhase !== undefined) {
       const ticketDirectory = nodePath.dirname(editedFile);
-      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const stamps = readReviewStamps();
       const phaseScope = reviewScope(nodePath.basename(ticketDirectory), 'phase', exitedPhase);
       if (!gatePhaseAdvance(phaseScope, stamps).ok) {
         deny(

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -14,6 +14,11 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  isReviewGateEnabled,
+  parseReviewStamps,
+  reviewGateForNextAsset,
+} from './lib/review-ledger.ts';
+import {
   getStateFilePath,
   LOC_THRESHOLD,
   META_PATHS,
@@ -302,6 +307,23 @@ if (
         `spec.md AC gate: ${acVerdict.reason}.`,
         'Add an Acceptance Criterion under each JTBD as `#### <jtbd-id>.AC<n> — <capability>` (a product-level guarantee, not implementation), or `skip: <reason>` under that JTBD to omit it deliberately.',
       );
+    }
+  }
+
+  // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
+  // `.safeword/config.json` sets `reviewGate: true`. Scenarios require spec.md
+  // to carry a review stamp first; inert until enabled so it can't brick a
+  // workflow before the stamp-earning step ships.
+  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  const reviewConfig = existsSync(reviewConfigFile)
+    ? readFileSync(reviewConfigFile, 'utf8')
+    : undefined;
+  if (isReviewGateEnabled(reviewConfig)) {
+    const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+    const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+    const reviewVerdict = reviewGateForNextAsset('spec', stamps);
+    if (!reviewVerdict.ok) {
+      deny(reviewVerdict.reason, 'Review spec.md (or log a skip with a reason) before scenarios.');
     }
   }
 }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -14,6 +14,8 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  detectPhaseAdvance,
+  gatePhaseAdvance,
   hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
@@ -332,6 +334,54 @@ if (
         deny(
           'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
           'Run `/self-review` (or log a skip), then create test-definitions.md.',
+        );
+      }
+    }
+  }
+}
+
+// Reconstruct the file content an Edit/Write/MultiEdit would produce, so a gate
+// can compare it against the on-disk content. Write/NotebookEdit carry the full
+// new content; Edit/MultiEdit carry replacement regions applied to the prior text.
+function nextContentAfterEdit(toolInput: HookInput['tool_input'], priorContent: string): string {
+  if (toolInput?.content !== undefined) return toolInput.content;
+  if (toolInput?.edits) {
+    return toolInput.edits.reduce(
+      (text, edit) => text.replace(edit.old_string ?? '', edit.new_string ?? ''),
+      priorContent,
+    );
+  }
+  if (toolInput?.old_string !== undefined) {
+    return priorContent.replace(toolInput.old_string, toolInput.new_string ?? '');
+  }
+  return priorContent;
+}
+
+// Review gate (NMSD94, Tier 2) — DEFAULT-OFF, same flag as Tier 1. On a
+// ticket.md edit that changes `phase:`, block leaving the phase until an
+// independent phase-exit review stamp exists for it. The stamp is produced by a
+// fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
+// so the author can't grade their own phase. Inert until reviewGate is enabled.
+if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/tickets/')) {
+  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  const reviewConfig = existsSync(reviewConfigFile)
+    ? readFileSync(reviewConfigFile, 'utf8')
+    : undefined;
+  if (isReviewGateEnabled(reviewConfig)) {
+    const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
+    const exitedPhase = detectPhaseAdvance(
+      priorContent,
+      nextContentAfterEdit(input.tool_input, priorContent),
+    );
+    if (exitedPhase !== undefined) {
+      const ticketDirectory = nodePath.dirname(editedFile);
+      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const phaseScope = reviewScope(nodePath.basename(ticketDirectory), 'phase', exitedPhase);
+      if (!gatePhaseAdvance(phaseScope, stamps).ok) {
+        deny(
+          `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
+          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
         );
       }
     }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -14,9 +14,11 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
   reviewGateForNextAsset,
+  reviewScope,
 } from './lib/review-ledger.ts';
 import {
   getStateFilePath,
@@ -308,22 +310,30 @@ if (
         'Add an Acceptance Criterion under each JTBD as `#### <jtbd-id>.AC<n> — <capability>` (a product-level guarantee, not implementation), or `skip: <reason>` under that JTBD to omit it deliberately.',
       );
     }
-  }
 
-  // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
-  // `.safeword/config.json` sets `reviewGate: true`. Scenarios require spec.md
-  // to carry a review stamp first; inert until enabled so it can't brick a
-  // workflow before the stamp-earning step ships.
-  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-  const reviewConfig = existsSync(reviewConfigFile)
-    ? readFileSync(reviewConfigFile, 'utf8')
-    : undefined;
-  if (isReviewGateEnabled(reviewConfig)) {
-    const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-    const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
-    const reviewVerdict = reviewGateForNextAsset('spec', stamps);
-    if (!reviewVerdict.ok) {
-      deny(reviewVerdict.reason, 'Review spec.md (or log a skip with a reason) before scenarios.');
+    // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
+    // `.safeword/config.json` sets `reviewGate: true`. Scenarios require a review
+    // stamp bound to THIS ticket's spec.md at its CURRENT content (so a stale or
+    // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
+    // brick a workflow before the stamp-earning step ships.
+    const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+    const reviewConfig = existsSync(reviewConfigFile)
+      ? readFileSync(reviewConfigFile, 'utf8')
+      : undefined;
+    if (isReviewGateEnabled(reviewConfig)) {
+      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const priorScope = reviewScope(
+        nodePath.basename(ticketDirectory),
+        'spec',
+        hashArtifact(specContent),
+      );
+      if (!reviewGateForNextAsset(priorScope, stamps).ok) {
+        deny(
+          'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
+          'Run the spec review, then create test-definitions.md.',
+        );
+      }
     }
   }
 }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -124,6 +124,13 @@ function isMissingFrontmatterField(value: string | string[] | undefined): boolea
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
+// Both review gates (NMSD94, Tier 1 + Tier 2) are off unless `.safeword/config.json`
+// sets `reviewGate: true`. Shared so the two call sites can't drift on the path.
+function isReviewGateOn(): boolean {
+  const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
 /**
  * REFACTOR commit gate: if the active ticket is in `phase: implement` and the
  * current TDD step (parsed from test-definitions.md) is REFACTOR, inspect
@@ -318,11 +325,7 @@ if (
     // stamp bound to THIS ticket's spec.md at its CURRENT content (so a stale or
     // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
     // brick a workflow before the stamp-earning step ships.
-    const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-    const reviewConfig = existsSync(reviewConfigFile)
-      ? readFileSync(reviewConfigFile, 'utf8')
-      : undefined;
-    if (isReviewGateEnabled(reviewConfig)) {
+    if (isReviewGateOn()) {
       const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
       const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
       const priorScope = reviewScope(
@@ -363,11 +366,7 @@ function nextContentAfterEdit(toolInput: HookInput['tool_input'], priorContent: 
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
 if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/tickets/')) {
-  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-  const reviewConfig = existsSync(reviewConfigFile)
-    ? readFileSync(reviewConfigFile, 'utf8')
-    : undefined;
-  if (isReviewGateEnabled(reviewConfig)) {
+  if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
       priorContent,

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// Safeword: the review-stamp earning step (ticket NMSD94).
+//
+// Appends a `review:<scope>` line to the skill-invocation-log so the review
+// gates in pre-tool-quality.ts read it back and allow the next step. Two callers:
+//   - Tier 1 (per-asset): the `/review` skill's render-time injection runs this
+//     to stamp the just-reviewed artifact at its CURRENT content.
+//   - Tier 2 (phase exit): the working agent runs this AFTER a fork review
+//     passes, to stamp the phase being exited.
+//
+// Scope is built with the SAME reviewScope()/hashArtifact() the gate uses (same
+// hook lib, same runtime), so the stamp matches by construction — no
+// cross-language hash contract to drift. Trust boundary: this writes a stamp on
+// invocation, which is the cheap Tier 1 floor; Tier 2's real independence is the
+// fork reviewer, not this script.
+//
+// Usage:
+//   bun write-review-stamp.ts <artifact> [skip reason…]      # stamp <artifact>.md at current content
+//   bun write-review-stamp.ts --phase <phase> [skip reason…] # stamp a phase exit
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { getActiveTicket } from './lib/active-ticket.ts';
+import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
+
+const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+
+function fail(message: string): never {
+  process.stdout.write(`[skill-invocation-log] FAILED — ${message}\n`);
+  process.exit(1);
+}
+
+// The active in_progress ticket's FOLDER name — the same key the gate derives
+// from the edited path (nodePath.basename(ticketDirectory)), so scopes align.
+const { folder } = getActiveTicket(projectDirectory);
+if (folder === undefined) {
+  fail('no in_progress ticket found — nothing to stamp');
+}
+
+const isPhase = process.argv[2] === '--phase';
+const skipReason =
+  process.argv
+    .slice(isPhase ? 4 : 3)
+    .join(' ')
+    .trim() || undefined;
+
+function resolveScope(ticketFolder: string): { scope: string; label: string } {
+  if (isPhase) {
+    const phase = process.argv[3];
+    if (phase === undefined || phase === '') fail('--phase requires a phase name');
+    return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
+  }
+  const artifact = process.argv[2] ?? 'spec';
+  const artifactFile = nodePath.join(
+    projectDirectory,
+    '.safeword-project',
+    'tickets',
+    ticketFolder,
+    `${artifact}.md`,
+  );
+  if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
+  const content = readFileSync(artifactFile, 'utf8');
+  return {
+    scope: reviewScope(ticketFolder, artifact, hashArtifact(content)),
+    label: `${artifact}.md`,
+  };
+}
+
+const { scope, label } = resolveScope(folder);
+
+const logDirectory = nodePath.join(projectDirectory, '.safeword-project');
+const logFile = nodePath.join(logDirectory, 'skill-invocations.log');
+mkdirSync(logDirectory, { recursive: true });
+appendFileSync(
+  logFile,
+  `${new Date().toISOString()} ${sessionId} ${formatReviewStamp(scope, skipReason)}\n`,
+);
+
+const kind = skipReason === undefined ? 'review' : `skip (${skipReason})`;
+process.stdout.write(`[skill-invocation-log] ${kind} stamped for ${label} ✓\n`);

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -42,13 +42,23 @@ function singleLine(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+// A bare path component — no whitespace, separators, or `..`. The ticket and
+// artifact names index into `tickets/<folder>/<artifact>.md`, so a separator
+// would let the path escape the tickets dir; reject it at the boundary.
+function bareName(value: string, label: string): string {
+  if (/[\s/\\]/.test(value) || value.includes('..')) {
+    fail(`${label} must be a bare name (no whitespace, slashes, or "..")`);
+  }
+  return value;
+}
+
 // Optional leading `--ticket <folder>`, then the positional command.
 let positional = process.argv.slice(2);
 let explicitTicket: string | undefined;
 if (positional[0] === '--ticket') {
-  explicitTicket = positional[1];
-  if (explicitTicket === undefined || explicitTicket === '')
-    fail('--ticket requires a folder name');
+  const value = positional[1];
+  if (value === undefined || value === '') fail('--ticket requires a folder name');
+  explicitTicket = bareName(value, '--ticket');
   positional = positional.slice(2);
 }
 
@@ -76,13 +86,12 @@ const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || un
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {
-    const phase = positional[1];
-    if (phase === undefined || phase === '') fail('--phase requires a phase name');
-    if (/\s/.test(phase)) fail('phase name must not contain whitespace');
+    const value = positional[1];
+    if (value === undefined || value === '') fail('--phase requires a phase name');
+    const phase = bareName(value, 'phase name');
     return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
   }
-  const artifact = positional[0] ?? 'spec';
-  if (/\s/.test(artifact)) fail('artifact name must not contain whitespace');
+  const artifact = bareName(positional[0] ?? 'spec', 'artifact name');
   const artifactFile = nodePath.join(ticketsDirectory, ticketFolder, `${artifact}.md`);
   if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
   return {

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -3,8 +3,8 @@
 //
 // Appends a `review:<scope>` line to the skill-invocation-log so the review
 // gates in pre-tool-quality.ts read it back and allow the next step. Two callers:
-//   - Tier 1 (per-asset): the `/review` skill's render-time injection runs this
-//     to stamp the just-reviewed artifact at its CURRENT content.
+//   - Tier 1 (per-asset): the `/self-review` skill's render-time injection runs
+//     this to stamp the just-reviewed artifact at its CURRENT content.
 //   - Tier 2 (phase exit): the working agent runs this AFTER a fork review
 //     passes, to stamp the phase being exited.
 //
@@ -15,61 +15,83 @@
 // fork reviewer, not this script.
 //
 // Usage:
-//   bun write-review-stamp.ts <artifact> [skip reason…]      # stamp <artifact>.md at current content
-//   bun write-review-stamp.ts --phase <phase> [skip reason…] # stamp a phase exit
+//   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
+//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
+// With more than one in_progress ticket, pass --ticket to disambiguate; without
+// it the step fails rather than guess a ticket the gate may not be checking.
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { getActiveTicket } from './lib/active-ticket.ts';
+import { getInProgressTicketFolders } from './lib/active-ticket.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
 
 function fail(message: string): never {
   process.stdout.write(`[skill-invocation-log] FAILED — ${message}\n`);
   process.exit(1);
 }
 
-// The active in_progress ticket's FOLDER name — the same key the gate derives
-// from the edited path (nodePath.basename(ticketDirectory)), so scopes align.
-const { folder } = getActiveTicket(projectDirectory);
-if (folder === undefined) {
-  fail('no in_progress ticket found — nothing to stamp');
+// Collapse all whitespace (incl. newlines) to single spaces. The log is one
+// stamp per line, so an un-collapsed reason could inject a second, forged line.
+function singleLine(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
 }
 
-const isPhase = process.argv[2] === '--phase';
-const skipReason =
-  process.argv
-    .slice(isPhase ? 4 : 3)
-    .join(' ')
-    .trim() || undefined;
+// Optional leading `--ticket <folder>`, then the positional command.
+let positional = process.argv.slice(2);
+let explicitTicket: string | undefined;
+if (positional[0] === '--ticket') {
+  explicitTicket = positional[1];
+  if (explicitTicket === undefined || explicitTicket === '')
+    fail('--ticket requires a folder name');
+  positional = positional.slice(2);
+}
+
+// Resolve the ticket the same way the gate does conceptually (the one being worked),
+// failing loudly on ambiguity instead of stamping a ticket the gate isn't checking.
+function resolveTicketFolder(): string {
+  if (explicitTicket !== undefined) {
+    if (!existsSync(nodePath.join(ticketsDirectory, explicitTicket, 'ticket.md'))) {
+      fail(`--ticket "${explicitTicket}" not found`);
+    }
+    return explicitTicket;
+  }
+  const inProgress = getInProgressTicketFolders(projectDirectory);
+  if (inProgress.length === 0) fail('no in_progress ticket found — nothing to stamp');
+  if (inProgress.length > 1) {
+    fail(
+      `multiple in_progress tickets (${inProgress.join(', ')}) — pass --ticket <folder> to disambiguate`,
+    );
+  }
+  return inProgress[0] ?? fail('no in_progress ticket found — nothing to stamp');
+}
+
+const isPhase = positional[0] === '--phase';
+const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || undefined;
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {
-    const phase = process.argv[3];
+    const phase = positional[1];
     if (phase === undefined || phase === '') fail('--phase requires a phase name');
+    if (/\s/.test(phase)) fail('phase name must not contain whitespace');
     return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
   }
-  const artifact = process.argv[2] ?? 'spec';
-  const artifactFile = nodePath.join(
-    projectDirectory,
-    '.safeword-project',
-    'tickets',
-    ticketFolder,
-    `${artifact}.md`,
-  );
+  const artifact = positional[0] ?? 'spec';
+  if (/\s/.test(artifact)) fail('artifact name must not contain whitespace');
+  const artifactFile = nodePath.join(ticketsDirectory, ticketFolder, `${artifact}.md`);
   if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
-  const content = readFileSync(artifactFile, 'utf8');
   return {
-    scope: reviewScope(ticketFolder, artifact, hashArtifact(content)),
+    scope: reviewScope(ticketFolder, artifact, hashArtifact(readFileSync(artifactFile, 'utf8'))),
     label: `${artifact}.md`,
   };
 }
 
-const { scope, label } = resolveScope(folder);
+const { scope, label } = resolveScope(resolveTicketFolder());
 
 const logDirectory = nodePath.join(projectDirectory, '.safeword-project');
 const logFile = nodePath.join(logDirectory, 'skill-invocations.log');

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -487,6 +487,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.claude/skills/lint/SKILL.md': { template: 'skills/lint/SKILL.md' },
     '.claude/skills/verify/SKILL.md': { template: 'skills/verify/SKILL.md' },
     '.claude/skills/audit/SKILL.md': { template: 'skills/audit/SKILL.md' },
+    '.claude/skills/self-review/SKILL.md': { template: 'skills/self-review/SKILL.md' },
     '.claude/skills/cleanup-zombies/SKILL.md': {
       template: 'skills/cleanup-zombies/SKILL.md',
     },

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -286,6 +286,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/lib/jtbd.ts': { template: 'hooks/lib/jtbd.ts' },
     '.safeword/hooks/lib/replan-relevance.ts': { template: 'hooks/lib/replan-relevance.ts' },
     '.safeword/hooks/lib/replan.ts': { template: 'hooks/lib/replan.ts' },
+    '.safeword/hooks/lib/review-ledger.ts': { template: 'hooks/lib/review-ledger.ts' },
     '.safeword/hooks/lib/lint-config.ts': { template: 'hooks/lib/lint-config.ts' },
     '.safeword/hooks/lib/typecheck-gate.ts': { template: 'hooks/lib/typecheck-gate.ts' },
     '.safeword/hooks/lib/checkbox-transitions.ts': {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -562,6 +562,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.cursor/commands/bdd.md': { template: 'commands/bdd.md' },
     '.cursor/commands/debug.md': { template: 'commands/debug.md' },
     '.cursor/commands/verify.md': { template: 'commands/verify.md' },
+    '.cursor/commands/self-review.md': { template: 'commands/self-review.md' },
     '.cursor/commands/audit.md': { template: 'commands/audit.md' },
     '.cursor/commands/cleanup-zombies.md': {
       template: 'commands/cleanup-zombies.md',

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -340,6 +340,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/pre-tool-quality.ts': {
       template: 'hooks/pre-tool-quality.ts',
     },
+    '.safeword/hooks/write-review-stamp.ts': {
+      template: 'hooks/write-review-stamp.ts',
+    },
     '.safeword/hooks/pre-tool-config-guard.ts': {
       template: 'hooks/pre-tool-config-guard.ts',
     },

--- a/packages/cli/templates/commands/self-review.md
+++ b/packages/cli/templates/commands/self-review.md
@@ -1,0 +1,39 @@
+---
+description: Self-review the spec inline and earn its Tier 1 review stamp (project)
+---
+
+# Self-Review
+
+Review the artifact you just authored, then earn its review stamp so the next
+step is unblocked. Tier 1 — your own inline pass, no sub-agent. The independent
+check is Tier 2 (the phase-exit review), not this.
+
+## Earn the stamp
+
+The line below binds a `review:<scope>` stamp to the active ticket's `spec.md`
+at its **current content** and appends it to the skill-invocation-log, where the
+per-asset gate reads it back.
+
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "$PROJECT_DIR/.safeword/hooks/write-review-stamp.ts" spec`
+
+If you see `[skill-invocation-log] FAILED` or no `✓` line, the stamp was not
+written and the gate will keep blocking — resolve before retrying.
+
+## Review the spec
+
+Read the active ticket's `spec.md` and check, against `personas.md` and the
+ticket's `scope` / `out_of_scope`: every JTBD resolves to a real persona and
+reads as a genuine job; each JTBD has ≥1 observable, product-level Acceptance
+Criterion; the ACs cover scope and stop at `out_of_scope`; no implementation
+detail leaks into spec prose. If the review surfaces a fix, edit `spec.md` and
+re-run — the content-bound stamp goes stale on any edit, so the gate correctly
+re-blocks until the corrected spec is re-reviewed.
+
+## Skip valve
+
+Trivial or docs-only? Log a skip with a reason instead — it clears the same gate
+and records why (an empty reason does not clear it):
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+```

--- a/packages/cli/templates/hooks/lib/active-ticket.ts
+++ b/packages/cli/templates/hooks/lib/active-ticket.ts
@@ -207,6 +207,32 @@ export function resolveStopPhase(
   return EMPTY;
 }
 
+/**
+ * Every in_progress, non-epic ticket folder — the build tickets a session could
+ * be working. The stamp-earning step (NMSD94) uses this to resolve which ticket
+ * to stamp and to fail loudly when more than one is active, rather than silently
+ * guessing a ticket that may differ from the one the gate is checking.
+ */
+export function getInProgressTicketFolders(projectDirectory: string): string[] {
+  const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
+  if (!existsSync(ticketsDirectory)) return [];
+
+  try {
+    return readdirSync(ticketsDirectory).filter(folder => {
+      if (folder === 'completed' || folder === 'tmp') return false;
+      const ticketFile = nodePath.join(ticketsDirectory, folder, 'ticket.md');
+      if (!existsSync(ticketFile)) return false;
+      const content = readFileSync(ticketFile, 'utf8');
+      return (
+        content.match(/^status:\s*(\S+)/m)?.[1] === 'in_progress' &&
+        content.match(/^type:\s*(\S+)/m)?.[1] !== 'epic'
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
 export function getActiveTicket(projectDirectory: string): ActiveTicketInfo {
   const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
   if (!existsSync(ticketsDirectory)) return EMPTY;

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -63,6 +63,26 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
  */
 const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
 
+/**
+ * Rollout guard: the review gate is OFF unless `.safeword/config.json` sets
+ * `reviewGate: true`. Default-off so this self-applying blocking gate can ship
+ * inert (no bricking the dogfood or customers) and be enabled deliberately once
+ * the stamp-earning step is in place. Fail-safe to off on missing/malformed config.
+ */
+export function isReviewGateEnabled(rawConfig: string | undefined): boolean {
+  if (rawConfig === undefined) return false;
+  try {
+    const config: unknown = JSON.parse(rawConfig);
+    return (
+      typeof config === 'object' &&
+      config !== null &&
+      (config as Record<string, unknown>).reviewGate === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -5,13 +5,35 @@
 // `.js` specifier (bun resolves it to the .ts source) so tsc accepts this module
 // when the test suite pulls it into the typecheck graph — the tested-lib rule.
 
+import { createHash } from 'node:crypto';
+
 import { isValidSkipReason } from './parse-annotation.js';
 
 export interface ReviewStamp {
-  /** The asset (or phase) the review covers. */
+  /**
+   * The review's scope key — see {@link reviewScope}. Ticket-qualified and
+   * content-bound (`<ticket>:<artifact>@<hash>`), so a stamp matches the gate
+   * only for THIS ticket's artifact at THIS content (no cross-ticket or
+   * stale-after-edit false-allows).
+   */
   assetId: string;
   /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
   skipReason?: string;
+}
+
+/** Short content hash binding a stamp to the reviewed artifact's exact state. */
+export function hashArtifact(content: string): string {
+  return createHash('sha1').update(content).digest('hex').slice(0, 12);
+}
+
+/**
+ * Canonical review-stamp scope: `<ticketId>:<artifact>@<contentHash>`. Both the
+ * gate and the stamp-earning step build keys this way so a review satisfies the
+ * gate only for the same ticket + artifact + content — a review of another
+ * ticket's spec, or of a now-edited spec, no longer matches.
+ */
+export function reviewScope(ticketId: string, artifact: string, contentHash: string): string {
+  return `${ticketId}:${artifact}@${contentHash}`;
 }
 
 export type GateVerdict = { ok: true } | { ok: false; reason: string };
@@ -56,11 +78,17 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
   };
 }
 
-/**
- * A review entry in the skill-invocation-log: `review:<artifactId>` for a real
- * review, or `review:<artifactId> skip:<reason>` for a logged skip. The line is
- * `<timestamp> <session> <entry>`, so the review token is matched at line end.
- */
+// A review entry in the skill-invocation-log. Format contract (the
+// stamp-earning step writes exactly this): `review:<scope>` for a real review,
+// or `review:<scope> skip:<reason>` for a logged skip, where <scope> is a
+// space-free reviewScope() key. The line is `<timestamp> <session> <entry>`, so
+// the review token is matched at line end.
+//
+// Trust boundary: a stamp is only as trustworthy as the log file's integrity —
+// a crafted `review:<scope>` line satisfies this gate. That's by design: Tier 1
+// is the cheap, gameable floor; the ungameable check is Tier 2 (independent
+// fork review). The content-hash binding in <scope> at least defeats accidental
+// stale-after-edit passes, not deliberate spoofing.
 const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
 
 /**

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -55,3 +55,24 @@ export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]):
     reason: `phase "${phase}" has no independent review stamp — run the phase-exit review (or log a skip with a reason) before advancing`,
   };
 }
+
+/**
+ * A review entry in the skill-invocation-log: `review:<artifactId>` for a real
+ * review, or `review:<artifactId> skip:<reason>` for a logged skip. The line is
+ * `<timestamp> <session> <entry>`, so the review token is matched at line end.
+ */
+const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
+
+/** Read review stamps from skill-invocation-log content (non-review lines ignored). */
+export function parseReviewStamps(logContent: string): ReviewStamp[] {
+  const stamps: ReviewStamp[] = [];
+  for (const line of logContent.split('\n')) {
+    const match = REVIEW_LINE.exec(line);
+    if (match?.[1] === undefined) continue;
+    const skipReason = match[2];
+    stamps.push(
+      skipReason === undefined ? { assetId: match[1] } : { assetId: match[1], skipReason },
+    );
+  }
+  return stamps;
+}

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -16,7 +16,7 @@ export interface ReviewStamp {
    * only for THIS ticket's artifact at THIS content (no cross-ticket or
    * stale-after-edit false-allows).
    */
-  assetId: string;
+  scope: string;
   /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
   skipReason?: string;
 }
@@ -45,7 +45,7 @@ function isSatisfyingStamp(stamp: ReviewStamp): boolean {
 
 /** Whether the ledger holds a satisfying review stamp for `id` (an asset or a phase). */
 function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean {
-  return stamps.some(stamp => stamp.assetId === id && isSatisfyingStamp(stamp));
+  return stamps.some(stamp => stamp.scope === id && isSatisfyingStamp(stamp));
 }
 
 /**
@@ -54,14 +54,14 @@ function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean
  * never gated.
  */
 export function reviewGateForNextAsset(
-  priorAssetId: string | undefined,
+  priorScope: string | undefined,
   stamps: readonly ReviewStamp[],
 ): GateVerdict {
-  if (priorAssetId === undefined) return { ok: true };
-  if (hasSatisfyingStamp(priorAssetId, stamps)) return { ok: true };
+  if (priorScope === undefined) return { ok: true };
+  if (hasSatisfyingStamp(priorScope, stamps)) return { ok: true };
   return {
     ok: false,
-    reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+    reason: `"${priorScope}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
   };
 }
 
@@ -118,9 +118,7 @@ export function parseReviewStamps(logContent: string): ReviewStamp[] {
     const match = REVIEW_LINE.exec(line);
     if (match?.[1] === undefined) continue;
     const skipReason = match[2];
-    stamps.push(
-      skipReason === undefined ? { assetId: match[1] } : { assetId: match[1], skipReason },
-    );
+    stamps.push(skipReason === undefined ? { scope: match[1] } : { scope: match[1], skipReason });
   }
   return stamps;
 }

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -1,0 +1,41 @@
+// Safeword: two-tier review-enforcement decision core (ticket NMSD94). Pure, no
+// I/O. The PreToolUse / phase-advance gates wire these to the real
+// skill-invocation-log, which stores one review stamp per asset/phase.
+//
+// `.js` specifier (bun resolves it to the .ts source) so tsc accepts this module
+// when the test suite pulls it into the typecheck graph — the tested-lib rule.
+
+import { isValidSkipReason } from './parse-annotation.js';
+
+export interface ReviewStamp {
+  /** The asset (or phase) the review covers. */
+  assetId: string;
+  /** Present → a skip (must be non-empty to satisfy the gate); absent → a real review. */
+  skipReason?: string;
+}
+
+export type GateVerdict = { ok: true } | { ok: false; reason: string };
+
+/** A stamp satisfies a gate when it's a real review, or a skip with a non-empty reason. */
+function isSatisfyingStamp(stamp: ReviewStamp): boolean {
+  return stamp.skipReason === undefined || isValidSkipReason(stamp.skipReason);
+}
+
+/**
+ * Per-asset gate (DEV1.AC1): authoring the next asset is allowed only when the
+ * prior asset carries a satisfying review stamp. The first asset (no prior) is
+ * never gated.
+ */
+export function reviewGateForNextAsset(
+  priorAssetId: string | undefined,
+  stamps: readonly ReviewStamp[],
+): GateVerdict {
+  if (priorAssetId === undefined) return { ok: true };
+  if (stamps.some(stamp => stamp.assetId === priorAssetId && isSatisfyingStamp(stamp))) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+  };
+}

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -69,7 +69,7 @@ const REVIEW_LINE = /(?:^|\s)review:(\S+)(?:\s+skip:(.+))?$/;
  * inert (no bricking the dogfood or customers) and be enabled deliberately once
  * the stamp-earning step is in place. Fail-safe to off on missing/malformed config.
  */
-export function isReviewGateEnabled(rawConfig: string | undefined): boolean {
+export function isReviewGateEnabled(rawConfig?: string): boolean {
   if (rawConfig === undefined) return false;
   try {
     const config: unknown = JSON.parse(rawConfig);

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -111,6 +111,21 @@ export function isReviewGateEnabled(rawConfig?: string): boolean {
   }
 }
 
+const PHASE_FIELD = /^phase:\s*(\S+)/m;
+
+/**
+ * The phase being EXITED by a ticket.md edit (Tier 2): the old phase, when the
+ * edit changes `phase:` to a different value. Returns undefined when the phase
+ * is unchanged or absent on either side (nothing to gate). Forward/backward
+ * ordering isn't distinguished — leaving any phase requires its exit review.
+ */
+export function detectPhaseAdvance(oldContent: string, newContent: string): string | undefined {
+  const from = PHASE_FIELD.exec(oldContent)?.[1];
+  const to = PHASE_FIELD.exec(newContent)?.[1];
+  if (from === undefined || to === undefined || from === to) return undefined;
+  return from;
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -126,6 +126,16 @@ export function detectPhaseAdvance(oldContent: string, newContent: string): stri
   return from;
 }
 
+/**
+ * Render a stamp token for the skill-invocation-log — the inverse of
+ * {@link parseReviewStamps}. The stamp-earning step (`write-review-stamp.ts`)
+ * prefixes `<timestamp> <session> ` and appends the result, so the gate reads
+ * back exactly this `scope`. A non-empty `skipReason` records a logged skip.
+ */
+export function formatReviewStamp(scope: string, skipReason?: string): string {
+  return skipReason === undefined ? `review:${scope}` : `review:${scope} skip:${skipReason}`;
+}
+
 /** Read review stamps from skill-invocation-log content (non-review lines ignored). */
 export function parseReviewStamps(logContent: string): ReviewStamp[] {
   const stamps: ReviewStamp[] = [];

--- a/packages/cli/templates/hooks/lib/review-ledger.ts
+++ b/packages/cli/templates/hooks/lib/review-ledger.ts
@@ -21,6 +21,11 @@ function isSatisfyingStamp(stamp: ReviewStamp): boolean {
   return stamp.skipReason === undefined || isValidSkipReason(stamp.skipReason);
 }
 
+/** Whether the ledger holds a satisfying review stamp for `id` (an asset or a phase). */
+function hasSatisfyingStamp(id: string, stamps: readonly ReviewStamp[]): boolean {
+  return stamps.some(stamp => stamp.assetId === id && isSatisfyingStamp(stamp));
+}
+
 /**
  * Per-asset gate (DEV1.AC1): authoring the next asset is allowed only when the
  * prior asset carries a satisfying review stamp. The first asset (no prior) is
@@ -31,11 +36,22 @@ export function reviewGateForNextAsset(
   stamps: readonly ReviewStamp[],
 ): GateVerdict {
   if (priorAssetId === undefined) return { ok: true };
-  if (stamps.some(stamp => stamp.assetId === priorAssetId && isSatisfyingStamp(stamp))) {
-    return { ok: true };
-  }
+  if (hasSatisfyingStamp(priorAssetId, stamps)) return { ok: true };
   return {
     ok: false,
     reason: `"${priorAssetId}" has not been reviewed — review it (or log a skip with a reason) before authoring the next asset`,
+  };
+}
+
+/**
+ * Phase-exit gate (DEV2.AC1): advancing past a phase is allowed only when an
+ * independent review stamp for that phase exists. Unlike the per-asset gate
+ * there is no "first" exemption — every phase exit needs a stamp.
+ */
+export function gatePhaseAdvance(phase: string, stamps: readonly ReviewStamp[]): GateVerdict {
+  if (hasSatisfyingStamp(phase, stamps)) return { ok: true };
+  return {
+    ok: false,
+    reason: `phase "${phase}" has no independent review stamp — run the phase-exit review (or log a skip with a reason) before advancing`,
   };
 }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -331,7 +331,7 @@ if (
       if (!reviewGateForNextAsset(priorScope, stamps).ok) {
         deny(
           'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
-          'Run the spec review, then create test-definitions.md.',
+          'Run `/self-review` (or log a skip), then create test-definitions.md.',
         );
       }
     }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -19,6 +19,7 @@ import {
   hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
+  type ReviewStamp,
   reviewGateForNextAsset,
   reviewScope,
 } from './lib/review-ledger.ts';
@@ -129,6 +130,13 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 function isReviewGateOn(): boolean {
   const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
   return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
+// The review stamps both gates read from the shared skill-invocation-log
+// (write-review-stamp.ts appends to the same file).
+function readReviewStamps(): ReviewStamp[] {
+  const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+  return existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
 }
 
 /**
@@ -326,8 +334,7 @@ if (
     // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
     // brick a workflow before the stamp-earning step ships.
     if (isReviewGateOn()) {
-      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const stamps = readReviewStamps();
       const priorScope = reviewScope(
         nodePath.basename(ticketDirectory),
         'spec',
@@ -374,8 +381,7 @@ if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/t
     );
     if (exitedPhase !== undefined) {
       const ticketDirectory = nodePath.dirname(editedFile);
-      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const stamps = readReviewStamps();
       const phaseScope = reviewScope(nodePath.basename(ticketDirectory), 'phase', exitedPhase);
       if (!gatePhaseAdvance(phaseScope, stamps).ok) {
         deny(

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -14,6 +14,11 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  isReviewGateEnabled,
+  parseReviewStamps,
+  reviewGateForNextAsset,
+} from './lib/review-ledger.ts';
+import {
   getStateFilePath,
   LOC_THRESHOLD,
   META_PATHS,
@@ -302,6 +307,23 @@ if (
         `spec.md AC gate: ${acVerdict.reason}.`,
         'Add an Acceptance Criterion under each JTBD as `#### <jtbd-id>.AC<n> — <capability>` (a product-level guarantee, not implementation), or `skip: <reason>` under that JTBD to omit it deliberately.',
       );
+    }
+  }
+
+  // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
+  // `.safeword/config.json` sets `reviewGate: true`. Scenarios require spec.md
+  // to carry a review stamp first; inert until enabled so it can't brick a
+  // workflow before the stamp-earning step ships.
+  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  const reviewConfig = existsSync(reviewConfigFile)
+    ? readFileSync(reviewConfigFile, 'utf8')
+    : undefined;
+  if (isReviewGateEnabled(reviewConfig)) {
+    const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+    const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+    const reviewVerdict = reviewGateForNextAsset('spec', stamps);
+    if (!reviewVerdict.ok) {
+      deny(reviewVerdict.reason, 'Review spec.md (or log a skip with a reason) before scenarios.');
     }
   }
 }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -14,6 +14,8 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  detectPhaseAdvance,
+  gatePhaseAdvance,
   hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
@@ -332,6 +334,54 @@ if (
         deny(
           'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
           'Run `/self-review` (or log a skip), then create test-definitions.md.',
+        );
+      }
+    }
+  }
+}
+
+// Reconstruct the file content an Edit/Write/MultiEdit would produce, so a gate
+// can compare it against the on-disk content. Write/NotebookEdit carry the full
+// new content; Edit/MultiEdit carry replacement regions applied to the prior text.
+function nextContentAfterEdit(toolInput: HookInput['tool_input'], priorContent: string): string {
+  if (toolInput?.content !== undefined) return toolInput.content;
+  if (toolInput?.edits) {
+    return toolInput.edits.reduce(
+      (text, edit) => text.replace(edit.old_string ?? '', edit.new_string ?? ''),
+      priorContent,
+    );
+  }
+  if (toolInput?.old_string !== undefined) {
+    return priorContent.replace(toolInput.old_string, toolInput.new_string ?? '');
+  }
+  return priorContent;
+}
+
+// Review gate (NMSD94, Tier 2) — DEFAULT-OFF, same flag as Tier 1. On a
+// ticket.md edit that changes `phase:`, block leaving the phase until an
+// independent phase-exit review stamp exists for it. The stamp is produced by a
+// fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
+// so the author can't grade their own phase. Inert until reviewGate is enabled.
+if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/tickets/')) {
+  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  const reviewConfig = existsSync(reviewConfigFile)
+    ? readFileSync(reviewConfigFile, 'utf8')
+    : undefined;
+  if (isReviewGateEnabled(reviewConfig)) {
+    const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
+    const exitedPhase = detectPhaseAdvance(
+      priorContent,
+      nextContentAfterEdit(input.tool_input, priorContent),
+    );
+    if (exitedPhase !== undefined) {
+      const ticketDirectory = nodePath.dirname(editedFile);
+      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const phaseScope = reviewScope(nodePath.basename(ticketDirectory), 'phase', exitedPhase);
+      if (!gatePhaseAdvance(phaseScope, stamps).ok) {
+        deny(
+          `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
+          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
         );
       }
     }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -14,9 +14,11 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
   reviewGateForNextAsset,
+  reviewScope,
 } from './lib/review-ledger.ts';
 import {
   getStateFilePath,
@@ -308,22 +310,30 @@ if (
         'Add an Acceptance Criterion under each JTBD as `#### <jtbd-id>.AC<n> — <capability>` (a product-level guarantee, not implementation), or `skip: <reason>` under that JTBD to omit it deliberately.',
       );
     }
-  }
 
-  // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
-  // `.safeword/config.json` sets `reviewGate: true`. Scenarios require spec.md
-  // to carry a review stamp first; inert until enabled so it can't brick a
-  // workflow before the stamp-earning step ships.
-  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-  const reviewConfig = existsSync(reviewConfigFile)
-    ? readFileSync(reviewConfigFile, 'utf8')
-    : undefined;
-  if (isReviewGateEnabled(reviewConfig)) {
-    const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
-    const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
-    const reviewVerdict = reviewGateForNextAsset('spec', stamps);
-    if (!reviewVerdict.ok) {
-      deny(reviewVerdict.reason, 'Review spec.md (or log a skip with a reason) before scenarios.');
+    // Review gate (NMSD94, Tier 1) — DEFAULT-OFF: only fires when
+    // `.safeword/config.json` sets `reviewGate: true`. Scenarios require a review
+    // stamp bound to THIS ticket's spec.md at its CURRENT content (so a stale or
+    // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
+    // brick a workflow before the stamp-earning step ships.
+    const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+    const reviewConfig = existsSync(reviewConfigFile)
+      ? readFileSync(reviewConfigFile, 'utf8')
+      : undefined;
+    if (isReviewGateEnabled(reviewConfig)) {
+      const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
+      const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
+      const priorScope = reviewScope(
+        nodePath.basename(ticketDirectory),
+        'spec',
+        hashArtifact(specContent),
+      );
+      if (!reviewGateForNextAsset(priorScope, stamps).ok) {
+        deny(
+          'spec.md has not been reviewed at its current content. Review it (or log a skip with a reason) before writing scenarios.',
+          'Run the spec review, then create test-definitions.md.',
+        );
+      }
     }
   }
 }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -124,6 +124,13 @@ function isMissingFrontmatterField(value: string | string[] | undefined): boolea
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
+// Both review gates (NMSD94, Tier 1 + Tier 2) are off unless `.safeword/config.json`
+// sets `reviewGate: true`. Shared so the two call sites can't drift on the path.
+function isReviewGateOn(): boolean {
+  const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
 /**
  * REFACTOR commit gate: if the active ticket is in `phase: implement` and the
  * current TDD step (parsed from test-definitions.md) is REFACTOR, inspect
@@ -318,11 +325,7 @@ if (
     // stamp bound to THIS ticket's spec.md at its CURRENT content (so a stale or
     // cross-ticket review doesn't satisfy it). Inert until enabled, so it can't
     // brick a workflow before the stamp-earning step ships.
-    const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-    const reviewConfig = existsSync(reviewConfigFile)
-      ? readFileSync(reviewConfigFile, 'utf8')
-      : undefined;
-    if (isReviewGateEnabled(reviewConfig)) {
+    if (isReviewGateOn()) {
       const logFile = nodePath.join(projectDirectory, '.safeword-project', 'skill-invocations.log');
       const stamps = existsSync(logFile) ? parseReviewStamps(readFileSync(logFile, 'utf8')) : [];
       const priorScope = reviewScope(
@@ -363,11 +366,7 @@ function nextContentAfterEdit(toolInput: HookInput['tool_input'], priorContent: 
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
 if (editedFile.endsWith('ticket.md') && editedFile.includes('.safeword-project/tickets/')) {
-  const reviewConfigFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
-  const reviewConfig = existsSync(reviewConfigFile)
-    ? readFileSync(reviewConfigFile, 'utf8')
-    : undefined;
-  if (isReviewGateEnabled(reviewConfig)) {
+  if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
       priorContent,

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// Safeword: the review-stamp earning step (ticket NMSD94).
+//
+// Appends a `review:<scope>` line to the skill-invocation-log so the review
+// gates in pre-tool-quality.ts read it back and allow the next step. Two callers:
+//   - Tier 1 (per-asset): the `/review` skill's render-time injection runs this
+//     to stamp the just-reviewed artifact at its CURRENT content.
+//   - Tier 2 (phase exit): the working agent runs this AFTER a fork review
+//     passes, to stamp the phase being exited.
+//
+// Scope is built with the SAME reviewScope()/hashArtifact() the gate uses (same
+// hook lib, same runtime), so the stamp matches by construction — no
+// cross-language hash contract to drift. Trust boundary: this writes a stamp on
+// invocation, which is the cheap Tier 1 floor; Tier 2's real independence is the
+// fork reviewer, not this script.
+//
+// Usage:
+//   bun write-review-stamp.ts <artifact> [skip reason…]      # stamp <artifact>.md at current content
+//   bun write-review-stamp.ts --phase <phase> [skip reason…] # stamp a phase exit
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { getActiveTicket } from './lib/active-ticket.ts';
+import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
+
+const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+
+function fail(message: string): never {
+  process.stdout.write(`[skill-invocation-log] FAILED — ${message}\n`);
+  process.exit(1);
+}
+
+// The active in_progress ticket's FOLDER name — the same key the gate derives
+// from the edited path (nodePath.basename(ticketDirectory)), so scopes align.
+const { folder } = getActiveTicket(projectDirectory);
+if (folder === undefined) {
+  fail('no in_progress ticket found — nothing to stamp');
+}
+
+const isPhase = process.argv[2] === '--phase';
+const skipReason =
+  process.argv
+    .slice(isPhase ? 4 : 3)
+    .join(' ')
+    .trim() || undefined;
+
+function resolveScope(ticketFolder: string): { scope: string; label: string } {
+  if (isPhase) {
+    const phase = process.argv[3];
+    if (phase === undefined || phase === '') fail('--phase requires a phase name');
+    return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
+  }
+  const artifact = process.argv[2] ?? 'spec';
+  const artifactFile = nodePath.join(
+    projectDirectory,
+    '.safeword-project',
+    'tickets',
+    ticketFolder,
+    `${artifact}.md`,
+  );
+  if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
+  const content = readFileSync(artifactFile, 'utf8');
+  return {
+    scope: reviewScope(ticketFolder, artifact, hashArtifact(content)),
+    label: `${artifact}.md`,
+  };
+}
+
+const { scope, label } = resolveScope(folder);
+
+const logDirectory = nodePath.join(projectDirectory, '.safeword-project');
+const logFile = nodePath.join(logDirectory, 'skill-invocations.log');
+mkdirSync(logDirectory, { recursive: true });
+appendFileSync(
+  logFile,
+  `${new Date().toISOString()} ${sessionId} ${formatReviewStamp(scope, skipReason)}\n`,
+);
+
+const kind = skipReason === undefined ? 'review' : `skip (${skipReason})`;
+process.stdout.write(`[skill-invocation-log] ${kind} stamped for ${label} ✓\n`);

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -42,13 +42,23 @@ function singleLine(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+// A bare path component — no whitespace, separators, or `..`. The ticket and
+// artifact names index into `tickets/<folder>/<artifact>.md`, so a separator
+// would let the path escape the tickets dir; reject it at the boundary.
+function bareName(value: string, label: string): string {
+  if (/[\s/\\]/.test(value) || value.includes('..')) {
+    fail(`${label} must be a bare name (no whitespace, slashes, or "..")`);
+  }
+  return value;
+}
+
 // Optional leading `--ticket <folder>`, then the positional command.
 let positional = process.argv.slice(2);
 let explicitTicket: string | undefined;
 if (positional[0] === '--ticket') {
-  explicitTicket = positional[1];
-  if (explicitTicket === undefined || explicitTicket === '')
-    fail('--ticket requires a folder name');
+  const value = positional[1];
+  if (value === undefined || value === '') fail('--ticket requires a folder name');
+  explicitTicket = bareName(value, '--ticket');
   positional = positional.slice(2);
 }
 
@@ -76,13 +86,12 @@ const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || un
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {
-    const phase = positional[1];
-    if (phase === undefined || phase === '') fail('--phase requires a phase name');
-    if (/\s/.test(phase)) fail('phase name must not contain whitespace');
+    const value = positional[1];
+    if (value === undefined || value === '') fail('--phase requires a phase name');
+    const phase = bareName(value, 'phase name');
     return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
   }
-  const artifact = positional[0] ?? 'spec';
-  if (/\s/.test(artifact)) fail('artifact name must not contain whitespace');
+  const artifact = bareName(positional[0] ?? 'spec', 'artifact name');
   const artifactFile = nodePath.join(ticketsDirectory, ticketFolder, `${artifact}.md`);
   if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
   return {

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -3,8 +3,8 @@
 //
 // Appends a `review:<scope>` line to the skill-invocation-log so the review
 // gates in pre-tool-quality.ts read it back and allow the next step. Two callers:
-//   - Tier 1 (per-asset): the `/review` skill's render-time injection runs this
-//     to stamp the just-reviewed artifact at its CURRENT content.
+//   - Tier 1 (per-asset): the `/self-review` skill's render-time injection runs
+//     this to stamp the just-reviewed artifact at its CURRENT content.
 //   - Tier 2 (phase exit): the working agent runs this AFTER a fork review
 //     passes, to stamp the phase being exited.
 //
@@ -15,61 +15,83 @@
 // fork reviewer, not this script.
 //
 // Usage:
-//   bun write-review-stamp.ts <artifact> [skip reason…]      # stamp <artifact>.md at current content
-//   bun write-review-stamp.ts --phase <phase> [skip reason…] # stamp a phase exit
+//   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
+//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
+// With more than one in_progress ticket, pass --ticket to disambiguate; without
+// it the step fails rather than guess a ticket the gate may not be checking.
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { getActiveTicket } from './lib/active-ticket.ts';
+import { getInProgressTicketFolders } from './lib/active-ticket.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets');
 
 function fail(message: string): never {
   process.stdout.write(`[skill-invocation-log] FAILED — ${message}\n`);
   process.exit(1);
 }
 
-// The active in_progress ticket's FOLDER name — the same key the gate derives
-// from the edited path (nodePath.basename(ticketDirectory)), so scopes align.
-const { folder } = getActiveTicket(projectDirectory);
-if (folder === undefined) {
-  fail('no in_progress ticket found — nothing to stamp');
+// Collapse all whitespace (incl. newlines) to single spaces. The log is one
+// stamp per line, so an un-collapsed reason could inject a second, forged line.
+function singleLine(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
 }
 
-const isPhase = process.argv[2] === '--phase';
-const skipReason =
-  process.argv
-    .slice(isPhase ? 4 : 3)
-    .join(' ')
-    .trim() || undefined;
+// Optional leading `--ticket <folder>`, then the positional command.
+let positional = process.argv.slice(2);
+let explicitTicket: string | undefined;
+if (positional[0] === '--ticket') {
+  explicitTicket = positional[1];
+  if (explicitTicket === undefined || explicitTicket === '')
+    fail('--ticket requires a folder name');
+  positional = positional.slice(2);
+}
+
+// Resolve the ticket the same way the gate does conceptually (the one being worked),
+// failing loudly on ambiguity instead of stamping a ticket the gate isn't checking.
+function resolveTicketFolder(): string {
+  if (explicitTicket !== undefined) {
+    if (!existsSync(nodePath.join(ticketsDirectory, explicitTicket, 'ticket.md'))) {
+      fail(`--ticket "${explicitTicket}" not found`);
+    }
+    return explicitTicket;
+  }
+  const inProgress = getInProgressTicketFolders(projectDirectory);
+  if (inProgress.length === 0) fail('no in_progress ticket found — nothing to stamp');
+  if (inProgress.length > 1) {
+    fail(
+      `multiple in_progress tickets (${inProgress.join(', ')}) — pass --ticket <folder> to disambiguate`,
+    );
+  }
+  return inProgress[0] ?? fail('no in_progress ticket found — nothing to stamp');
+}
+
+const isPhase = positional[0] === '--phase';
+const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || undefined;
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {
-    const phase = process.argv[3];
+    const phase = positional[1];
     if (phase === undefined || phase === '') fail('--phase requires a phase name');
+    if (/\s/.test(phase)) fail('phase name must not contain whitespace');
     return { scope: reviewScope(ticketFolder, 'phase', phase), label: `phase ${phase}` };
   }
-  const artifact = process.argv[2] ?? 'spec';
-  const artifactFile = nodePath.join(
-    projectDirectory,
-    '.safeword-project',
-    'tickets',
-    ticketFolder,
-    `${artifact}.md`,
-  );
+  const artifact = positional[0] ?? 'spec';
+  if (/\s/.test(artifact)) fail('artifact name must not contain whitespace');
+  const artifactFile = nodePath.join(ticketsDirectory, ticketFolder, `${artifact}.md`);
   if (!existsSync(artifactFile)) fail(`artifact not found: ${artifact}.md in ${ticketFolder}`);
-  const content = readFileSync(artifactFile, 'utf8');
   return {
-    scope: reviewScope(ticketFolder, artifact, hashArtifact(content)),
+    scope: reviewScope(ticketFolder, artifact, hashArtifact(readFileSync(artifactFile, 'utf8'))),
     label: `${artifact}.md`,
   };
 }
 
-const { scope, label } = resolveScope(folder);
+const { scope, label } = resolveScope(resolveTicketFolder());
 
 const logDirectory = nodePath.join(projectDirectory, '.safeword-project');
 const logFile = nodePath.join(logDirectory, 'skill-invocations.log');

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -44,6 +44,24 @@ phase: implement # intake | define-behavior | scenario-gate | implement | verify
 - All scenarios pass → set `verify`
 - /verify + /audit complete (verify.md exists) → set `done`
 
+### Phase-exit review (Tier 2)
+
+Leaving a phase is gated on an **independent** review of that phase's work — not
+your own pass. (Your own inline pass is Tier 1: `/self-review`, per asset, as you
+author.) The phase exit is reviewed by a _fresh reviewer with no conversation
+history_ so the author can't grade their own work: spawn one via the Agent tool
+(it starts clean), hand it only the phase's artifacts and the ticket's scope, and
+let **its** verdict decide. On a pass, record the stamp that unblocks the advance:
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>
+```
+
+If the reviewer finds blocking issues, fix them and re-review — don't stamp. To
+skip a trivial or docs-only phase, append a reason
+(`… --phase <phase> "<why no independent review is needed>"`). The phase-advance
+gate enforces this when the review gate is enabled, and is inert otherwise.
+
 ---
 
 ## Resume Logic

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -49,9 +49,10 @@ phase: implement # intake | define-behavior | scenario-gate | implement | verify
 Leaving a phase is gated on an **independent** review of that phase's work — not
 your own pass. (Your own inline pass is Tier 1: `/self-review`, per asset, as you
 author.) The phase exit is reviewed by a _fresh reviewer with no conversation
-history_ so the author can't grade their own work: spawn one via the Agent tool
-(it starts clean), hand it only the phase's artifacts and the ticket's scope, and
-let **its** verdict decide. On a pass, record the stamp that unblocks the advance:
+history_ so the author can't grade their own work: run it in a forked subagent —
+a skill with `context: fork`, or an explicit subagent — hand it only the phase's
+artifacts and the ticket's scope, and let **its** verdict decide. On a pass,
+record the stamp that unblocks the advance:
 
 ```bash
 bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>

--- a/packages/cli/templates/skills/self-review/SKILL.md
+++ b/packages/cli/templates/skills/self-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: self-review
+description: Self-review a just-authored workflow artifact (the spec) inline and
+  earn its Tier 1 review stamp, so the next step's gate passes. Use after
+  authoring spec.md and before writing test-definitions.md, or whenever the
+  review gate blocks asking for a spec review. The review is your own inline
+  pass — do not spawn a sub-agent.
+allowed-tools: '*'
+---
+
+# Self-Review
+
+Review the artifact you just authored, then earn its review stamp so the next
+step is unblocked. This is **Tier 1** — a cheap, inline floor. You review your
+own work; no sub-agent is spawned. The independent check is Tier 2 (the fork
+review at each phase exit), not this.
+
+## Earn the stamp
+
+The line below runs the stamp-earning step at render time. It binds a
+`review:<scope>` stamp to the active ticket's `spec.md` **at its current
+content** and appends it to `.safeword-project/skill-invocations.log`, where the
+per-asset gate reads it back. Invoking this skill is what writes the stamp —
+hand-editing the log is the gameable floor this tier deliberately accepts.
+
+!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "$PROJECT_DIR/.safeword/hooks/write-review-stamp.ts" spec`
+
+**If you see `[skill-invocation-log] FAILED` above, or no `✓` line at all**: STOP.
+The stamp was not written and the gate will keep blocking. Most likely the bash
+injection was denied or no in_progress ticket was found — report it to the user
+and resolve before retrying.
+
+## Review the spec (do this now, with the stamp written)
+
+The stamp records that a review was invoked; the actual scrutiny is yours. Read
+the active ticket's `spec.md` and check, against `personas.md` and the ticket's
+`scope` / `out_of_scope` frontmatter:
+
+- **Every JTBD resolves to a real persona** and reads as a genuine job (`When
+I…, I want…, so I can…`), not a restated feature.
+- **Each JTBD carries ≥1 Acceptance Criterion** stating an observable, product-
+  level guarantee — not an implementation detail.
+- **The ACs cover the ticket's scope** and stop at its `out_of_scope` line — no
+  silent scope creep, no orphan capability.
+- **Nothing leaks implementation** (file names, function names, libraries) into
+  spec-level prose.
+
+If the review surfaces a fix, **edit `spec.md` and re-invoke `/review`** — the
+content-bound stamp goes stale on any edit, so the gate correctly re-blocks
+until the corrected spec is re-reviewed. That is the point: a review that
+changes the artifact must be re-earned.
+
+## Skip valve
+
+If the artifact is genuinely trivial to review (boilerplate, a docs-only
+change), log a skip with a reason instead of a review — it clears the same gate
+and records why:
+
+```bash
+bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+```
+
+An empty reason does not clear the gate.

--- a/packages/cli/templates/skills/self-review/SKILL.md
+++ b/packages/cli/templates/skills/self-review/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: self-review
-description: Self-review a just-authored workflow artifact (the spec) inline and
-  earn its Tier 1 review stamp, so the next step's gate passes. Use after
-  authoring spec.md and before writing test-definitions.md, or whenever the
-  review gate blocks asking for a spec review. The review is your own inline
-  pass — do not spawn a sub-agent.
+description: Use when finishing spec.md before writing test-definitions.md, or
+  when the review gate asks for a spec review — self-reviews the just-authored
+  spec inline and earns its Tier 1 review stamp. Your own inline pass; do not
+  spawn a sub-agent.
 allowed-tools: '*'
 ---
 

--- a/packages/cli/tests/fixtures/skill-cursor-pairs.ts
+++ b/packages/cli/tests/fixtures/skill-cursor-pairs.ts
@@ -41,4 +41,5 @@ export const SKILL_CURSOR_PAIRS: readonly SkillCursorPair[] = [
   { skill: 'verify', cursorRules: undefined },
   { skill: 'audit', cursorRules: undefined },
   { skill: 'cleanup-zombies', cursorRules: undefined },
+  { skill: 'self-review', cursorRules: undefined },
 ];

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  gatePhaseAdvance,
   reviewGateForNextAsset,
   type ReviewStamp,
 } from '../../templates/hooks/lib/review-ledger.js';
@@ -40,5 +41,23 @@ describe('reviewGateForNextAsset (DEV1.AC1 — per-asset stamp gates the next as
   it('empty_skip_reason_rejected (SM1.AC2): an empty skip reason does not satisfy the gate', () => {
     const stamps: ReviewStamp[] = [{ assetId: 'jtbd', skipReason: '   ' }];
     expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
+  });
+});
+
+describe('gatePhaseAdvance (DEV2.AC1 — phase advance needs an independent review stamp)', () => {
+  it('no_phase_stamp_blocks_advance: no stamp for the phase denies, naming the phase', () => {
+    const verdict = gatePhaseAdvance('define-behavior', []);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toContain('define-behavior');
+  });
+
+  it('phase_stamp_allows_advance: a review stamp for the phase allows', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'define-behavior' }];
+    expect(gatePhaseAdvance('define-behavior', stamps)).toEqual({ ok: true });
+  });
+
+  it('phase_skip_allows_advance: a non-empty skip stamp for the phase allows', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'define-behavior', skipReason: 'docs-only phase' }];
+    expect(gatePhaseAdvance('define-behavior', stamps)).toEqual({ ok: true });
   });
 });

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   detectPhaseAdvance,
+  formatReviewStamp,
   gatePhaseAdvance,
   hashArtifact,
   isReviewGateEnabled,
@@ -97,6 +98,30 @@ describe('parseReviewStamps (read stamps from the skill-invocation-log)', () => 
 
   it('returns empty for empty input', () => {
     expect(parseReviewStamps('')).toEqual([]);
+  });
+});
+
+describe('formatReviewStamp (write a stamp the gate will read — inverse of parseReviewStamps)', () => {
+  it('formats a real-review stamp as review:<scope>', () => {
+    expect(formatReviewStamp('NMSD94:spec@abc123')).toBe('review:NMSD94:spec@abc123');
+  });
+
+  it('formats a skip stamp as review:<scope> skip:<reason>', () => {
+    expect(formatReviewStamp('NMSD94:spec@abc123', 'docs-only change')).toBe(
+      'review:NMSD94:spec@abc123 skip:docs-only change',
+    );
+  });
+
+  it('round-trips through parseReviewStamps (real review)', () => {
+    const scope = reviewScope('NMSD94', 'spec', hashArtifact('spec body'));
+    const line = `2026-06-03T00:00:00Z sess ${formatReviewStamp(scope)}`;
+    expect(parseReviewStamps(line)).toEqual([{ scope }]);
+  });
+
+  it('round-trips through parseReviewStamps (skip)', () => {
+    const scope = reviewScope('NMSD94', 'spec', hashArtifact('spec body'));
+    const line = `2026-06-03T00:00:00Z sess ${formatReviewStamp(scope, 'trivial spec')}`;
+    expect(parseReviewStamps(line)).toEqual([{ scope, skipReason: 'trivial spec' }]);
   });
 });
 

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -24,12 +24,12 @@ describe('reviewGateForNextAsset (DEV1.AC1 — per-asset stamp gates the next as
   });
 
   it('stamped_prior_allows_next: a real review stamp for the prior asset allows', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'jtbd' }];
+    const stamps: ReviewStamp[] = [{ scope: 'jtbd' }];
     expect(reviewGateForNextAsset('jtbd', stamps)).toEqual({ ok: true });
   });
 
   it('skip_stamp_allows_next: a non-empty skip stamp for the prior asset allows', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'jtbd', skipReason: 'trivial — boilerplate' }];
+    const stamps: ReviewStamp[] = [{ scope: 'jtbd', skipReason: 'trivial — boilerplate' }];
     expect(reviewGateForNextAsset('jtbd', stamps)).toEqual({ ok: true });
   });
 
@@ -38,12 +38,12 @@ describe('reviewGateForNextAsset (DEV1.AC1 — per-asset stamp gates the next as
   });
 
   it('stamp_for_other_asset_does_not_allow: a stamp keyed to a different asset denies', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'acs' }];
+    const stamps: ReviewStamp[] = [{ scope: 'acs' }];
     expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
   });
 
   it('empty_skip_reason_rejected (SM1.AC2): an empty skip reason does not satisfy the gate', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'jtbd', skipReason: '   ' }];
+    const stamps: ReviewStamp[] = [{ scope: 'jtbd', skipReason: '   ' }];
     expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
   });
 });
@@ -56,12 +56,12 @@ describe('gatePhaseAdvance (DEV2.AC1 — phase advance needs an independent revi
   });
 
   it('phase_stamp_allows_advance: a review stamp for the phase allows', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'define-behavior' }];
+    const stamps: ReviewStamp[] = [{ scope: 'define-behavior' }];
     expect(gatePhaseAdvance('define-behavior', stamps)).toEqual({ ok: true });
   });
 
   it('phase_skip_allows_advance: a non-empty skip stamp for the phase allows', () => {
-    const stamps: ReviewStamp[] = [{ assetId: 'define-behavior', skipReason: 'docs-only phase' }];
+    const stamps: ReviewStamp[] = [{ scope: 'define-behavior', skipReason: 'docs-only phase' }];
     expect(gatePhaseAdvance('define-behavior', stamps)).toEqual({ ok: true });
   });
 });
@@ -71,12 +71,12 @@ describe('parseReviewStamps (read stamps from the skill-invocation-log)', () => 
   // `review:<artifactId>` or `review:<artifactId> skip:<reason>`.
   it('parses a real-review stamp', () => {
     const log = '2026-06-03T00:00:00Z sess-1 review:spec';
-    expect(parseReviewStamps(log)).toEqual([{ assetId: 'spec' }]);
+    expect(parseReviewStamps(log)).toEqual([{ scope: 'spec' }]);
   });
 
   it('parses a skip stamp with its reason', () => {
     const log = '2026-06-03T00:00:00Z sess-1 review:scope skip:docs-only change';
-    expect(parseReviewStamps(log)).toEqual([{ assetId: 'scope', skipReason: 'docs-only change' }]);
+    expect(parseReviewStamps(log)).toEqual([{ scope: 'scope', skipReason: 'docs-only change' }]);
   });
 
   it('ignores non-review log lines (verify/audit invocations)', () => {
@@ -91,7 +91,7 @@ describe('parseReviewStamps (read stamps from the skill-invocation-log)', () => 
       '2026-06-03T00:00:00Z sess-1 review:spec',
       '2026-06-03T00:00:01Z sess-1 review:scope',
     ].join('\n');
-    expect(parseReviewStamps(log)).toEqual([{ assetId: 'spec' }, { assetId: 'scope' }]);
+    expect(parseReviewStamps(log)).toEqual([{ scope: 'spec' }, { scope: 'scope' }]);
   });
 
   it('returns empty for empty input', () => {
@@ -135,7 +135,7 @@ describe('reviewScope + hashArtifact (ticket-qualified, content-bound stamps)', 
   });
 
   it('cross-ticket: a stamp from another ticket does not satisfy this ticket', () => {
-    const stamps: ReviewStamp[] = [{ assetId: reviewScope('OTHER', 'spec', 'h1') }];
+    const stamps: ReviewStamp[] = [{ scope: reviewScope('OTHER', 'spec', 'h1') }];
     const here = reviewScope('NMSD94', 'spec', 'h1');
     expect(reviewGateForNextAsset(here, stamps).ok).toBe(false);
   });
@@ -144,7 +144,7 @@ describe('reviewScope + hashArtifact (ticket-qualified, content-bound stamps)', 
     const oldContent = 'spec v1';
     const newContent = 'spec v2';
     const stamps: ReviewStamp[] = [
-      { assetId: reviewScope('NMSD94', 'spec', hashArtifact(oldContent)) },
+      { scope: reviewScope('NMSD94', 'spec', hashArtifact(oldContent)) },
     ];
     const now = reviewScope('NMSD94', 'spec', hashArtifact(newContent));
     expect(reviewGateForNextAsset(now, stamps).ok).toBe(false);
@@ -153,6 +153,6 @@ describe('reviewScope + hashArtifact (ticket-qualified, content-bound stamps)', 
   it('matching ticket + artifact + content hash satisfies the gate', () => {
     const content = 'spec v1';
     const scope = reviewScope('NMSD94', 'spec', hashArtifact(content));
-    expect(reviewGateForNextAsset(scope, [{ assetId: scope }]).ok).toBe(true);
+    expect(reviewGateForNextAsset(scope, [{ scope }]).ok).toBe(true);
   });
 });

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  detectPhaseAdvance,
   gatePhaseAdvance,
   hashArtifact,
   isReviewGateEnabled,
@@ -154,5 +155,27 @@ describe('reviewScope + hashArtifact (ticket-qualified, content-bound stamps)', 
     const content = 'spec v1';
     const scope = reviewScope('NMSD94', 'spec', hashArtifact(content));
     expect(reviewGateForNextAsset(scope, [{ scope }]).ok).toBe(true);
+  });
+});
+
+describe('detectPhaseAdvance (Tier 2 — the phase being exited by a ticket.md edit)', () => {
+  const withPhase = (phase: string): string => `---\nid: T1\nphase: ${phase}\n---\n# T\n`;
+
+  it('returns the exited phase when the edit changes phase', () => {
+    expect(detectPhaseAdvance(withPhase('scenario-gate'), withPhase('implement'))).toBe(
+      'scenario-gate',
+    );
+  });
+
+  it('returns undefined when the phase is unchanged', () => {
+    expect(detectPhaseAdvance(withPhase('implement'), withPhase('implement'))).toBeUndefined();
+  });
+
+  it('returns undefined when the old content has no phase (nothing to exit)', () => {
+    expect(detectPhaseAdvance('---\nid: T1\n---\n', withPhase('intake'))).toBeUndefined();
+  });
+
+  it('returns undefined when the new content has no phase', () => {
+    expect(detectPhaseAdvance(withPhase('intake'), '---\nid: T1\n---\n')).toBeUndefined();
   });
 });

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the two-tier review-enforcement decision core (ticket NMSD94).
+ * Pure functions over the review-stamp ledger — no I/O. The PreToolUse / phase
+ * gates wire these to the real skill-invocation-log.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  reviewGateForNextAsset,
+  type ReviewStamp,
+} from '../../templates/hooks/lib/review-ledger.js';
+
+describe('reviewGateForNextAsset (DEV1.AC1 — per-asset stamp gates the next asset)', () => {
+  it('unstamped_prior_blocks_next: denies, naming the unreviewed prior asset', () => {
+    const verdict = reviewGateForNextAsset('jtbd', []);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toContain('jtbd');
+  });
+
+  it('stamped_prior_allows_next: a real review stamp for the prior asset allows', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'jtbd' }];
+    expect(reviewGateForNextAsset('jtbd', stamps)).toEqual({ ok: true });
+  });
+
+  it('skip_stamp_allows_next: a non-empty skip stamp for the prior asset allows', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'jtbd', skipReason: 'trivial — boilerplate' }];
+    expect(reviewGateForNextAsset('jtbd', stamps)).toEqual({ ok: true });
+  });
+
+  it('first_asset_not_gated: no prior asset (undefined) allows', () => {
+    expect(reviewGateForNextAsset(undefined, [])).toEqual({ ok: true });
+  });
+
+  it('stamp_for_other_asset_does_not_allow: a stamp keyed to a different asset denies', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'acs' }];
+    expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
+  });
+
+  it('empty_skip_reason_rejected (SM1.AC2): an empty skip reason does not satisfy the gate', () => {
+    const stamps: ReviewStamp[] = [{ assetId: 'jtbd', skipReason: '   ' }];
+    expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
+  });
+});

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   gatePhaseAdvance,
+  isReviewGateEnabled,
   parseReviewStamps,
   reviewGateForNextAsset,
   type ReviewStamp,
@@ -93,5 +94,27 @@ describe('parseReviewStamps (read stamps from the skill-invocation-log)', () => 
 
   it('returns empty for empty input', () => {
     expect(parseReviewStamps('')).toEqual([]);
+  });
+});
+
+describe('isReviewGateEnabled (default-off rollout guard)', () => {
+  it('defaults to off when there is no config', () => {
+    expect(isReviewGateEnabled()).toBe(false);
+  });
+
+  it('defaults to off when the flag is absent', () => {
+    expect(isReviewGateEnabled('{}')).toBe(false);
+  });
+
+  it('is on only when reviewGate is explicitly true', () => {
+    expect(isReviewGateEnabled('{"reviewGate": true}')).toBe(true);
+  });
+
+  it('is off when reviewGate is false', () => {
+    expect(isReviewGateEnabled('{"reviewGate": false}')).toBe(false);
+  });
+
+  it('is off on malformed config (fail-safe)', () => {
+    expect(isReviewGateEnabled('not json {')).toBe(false);
   });
 });

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   gatePhaseAdvance,
+  parseReviewStamps,
   reviewGateForNextAsset,
   type ReviewStamp,
 } from '../../templates/hooks/lib/review-ledger.js';
@@ -59,5 +60,38 @@ describe('gatePhaseAdvance (DEV2.AC1 — phase advance needs an independent revi
   it('phase_skip_allows_advance: a non-empty skip stamp for the phase allows', () => {
     const stamps: ReviewStamp[] = [{ assetId: 'define-behavior', skipReason: 'docs-only phase' }];
     expect(gatePhaseAdvance('define-behavior', stamps)).toEqual({ ok: true });
+  });
+});
+
+describe('parseReviewStamps (read stamps from the skill-invocation-log)', () => {
+  // Log lines are `<timestamp> <session> <entry>`; review entries are
+  // `review:<artifactId>` or `review:<artifactId> skip:<reason>`.
+  it('parses a real-review stamp', () => {
+    const log = '2026-06-03T00:00:00Z sess-1 review:spec';
+    expect(parseReviewStamps(log)).toEqual([{ assetId: 'spec' }]);
+  });
+
+  it('parses a skip stamp with its reason', () => {
+    const log = '2026-06-03T00:00:00Z sess-1 review:scope skip:docs-only change';
+    expect(parseReviewStamps(log)).toEqual([{ assetId: 'scope', skipReason: 'docs-only change' }]);
+  });
+
+  it('ignores non-review log lines (verify/audit invocations)', () => {
+    const log = ['2026-06-03T00:00:00Z sess-1 verify', '2026-06-03T00:00:01Z sess-1 audit'].join(
+      '\n',
+    );
+    expect(parseReviewStamps(log)).toEqual([]);
+  });
+
+  it('collects multiple stamps in order', () => {
+    const log = [
+      '2026-06-03T00:00:00Z sess-1 review:spec',
+      '2026-06-03T00:00:01Z sess-1 review:scope',
+    ].join('\n');
+    expect(parseReviewStamps(log)).toEqual([{ assetId: 'spec' }, { assetId: 'scope' }]);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(parseReviewStamps('')).toEqual([]);
   });
 });

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -8,9 +8,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   gatePhaseAdvance,
+  hashArtifact,
   isReviewGateEnabled,
   parseReviewStamps,
   reviewGateForNextAsset,
+  reviewScope,
   type ReviewStamp,
 } from '../../templates/hooks/lib/review-ledger.js';
 
@@ -116,5 +118,41 @@ describe('isReviewGateEnabled (default-off rollout guard)', () => {
 
   it('is off on malformed config (fail-safe)', () => {
     expect(isReviewGateEnabled('not json {')).toBe(false);
+  });
+});
+
+describe('reviewScope + hashArtifact (ticket-qualified, content-bound stamps)', () => {
+  it('hashArtifact is deterministic for the same content', () => {
+    expect(hashArtifact('hello')).toBe(hashArtifact('hello'));
+  });
+
+  it('hashArtifact changes when the content changes', () => {
+    expect(hashArtifact('v1')).not.toBe(hashArtifact('v2'));
+  });
+
+  it('reviewScope ties a stamp to a ticket + artifact + content hash', () => {
+    expect(reviewScope('NMSD94', 'spec', 'abc123')).toBe('NMSD94:spec@abc123');
+  });
+
+  it('cross-ticket: a stamp from another ticket does not satisfy this ticket', () => {
+    const stamps: ReviewStamp[] = [{ assetId: reviewScope('OTHER', 'spec', 'h1') }];
+    const here = reviewScope('NMSD94', 'spec', 'h1');
+    expect(reviewGateForNextAsset(here, stamps).ok).toBe(false);
+  });
+
+  it('stale-after-edit: a stamp for an older content hash does not satisfy the new content', () => {
+    const oldContent = 'spec v1';
+    const newContent = 'spec v2';
+    const stamps: ReviewStamp[] = [
+      { assetId: reviewScope('NMSD94', 'spec', hashArtifact(oldContent)) },
+    ];
+    const now = reviewScope('NMSD94', 'spec', hashArtifact(newContent));
+    expect(reviewGateForNextAsset(now, stamps).ok).toBe(false);
+  });
+
+  it('matching ticket + artifact + content hash satisfies the gate', () => {
+    const content = 'spec v1';
+    const scope = reviewScope('NMSD94', 'spec', hashArtifact(content));
+    expect(reviewGateForNextAsset(scope, [{ assetId: scope }]).ok).toBe(true);
   });
 });

--- a/packages/cli/tests/integration/phase-review-gate.test.ts
+++ b/packages/cli/tests/integration/phase-review-gate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test for the NMSD94 Tier 2 phase-advance gate, wired into the real
+ * pre-tool-quality hook. A ticket.md edit that changes `phase:` is blocked until
+ * an independent phase-exit review stamp exists for the phase being left — across
+ * both Write and Edit, default-off, with a skip valve and the end-to-end loop via
+ * write-review-stamp --phase.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reviewScope } from '../../templates/hooks/lib/review-ledger.js';
+import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
+
+const GATE_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-quality.ts');
+const STAMP_PATH = nodePath.resolve(__dirname, '../../templates/hooks/write-review-stamp.ts');
+const TICKET_ID = 'ABC123';
+
+const ticketBody = (phase: string): string =>
+  [
+    '---',
+    'id: ABC123',
+    'type: feature',
+    `phase: ${phase}`,
+    'status: in_progress',
+    'last_modified: 2026-06-03T00:00:00.000Z',
+    'scope:',
+    '  - does a thing',
+    '---',
+    '',
+    '# Ticket',
+    '',
+  ].join('\n');
+
+describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
+  let projectRoot: string;
+  let ticketDirectory: string;
+  let ticketFile: string;
+
+  function runGateWrite(newPhase: string): HookResult {
+    const result = spawnSync('bun', [GATE_PATH], {
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: { file_path: ticketFile, content: ticketBody(newPhase) },
+      }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function runGateEdit(fromPhase: string, toPhase: string): HookResult {
+    const result = spawnSync('bun', [GATE_PATH], {
+      input: JSON.stringify({
+        tool_name: 'Edit',
+        tool_input: {
+          file_path: ticketFile,
+          old_string: `phase: ${fromPhase}`,
+          new_string: `phase: ${toPhase}`,
+        },
+      }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function stampPhase(phase: string, ...skip: string[]): void {
+    spawnSync('bun', [STAMP_PATH, '--phase', phase, ...skip], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot, CLAUDE_SESSION_ID: 'sess-1' },
+    });
+  }
+
+  function writeConfig(reviewGate: boolean): void {
+    mkdirSync(nodePath.join(projectRoot, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(projectRoot, '.safeword', 'config.json'),
+      JSON.stringify({ reviewGate }),
+    );
+  }
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'phase-gate-'));
+    ticketDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', TICKET_ID);
+    mkdirSync(ticketDirectory, { recursive: true });
+    ticketFile = nodePath.join(ticketDirectory, 'ticket.md');
+    writeFileSync(ticketFile, ticketBody('define-behavior'));
+    writeConfig(true);
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('blocks a Write that advances the phase with no stamp (DEV2.AC1)', () => {
+    expectHookDeny(runGateWrite('implement'), 'define-behavior');
+  });
+
+  it('blocks an Edit that advances the phase with no stamp', () => {
+    expectHookDeny(runGateEdit('define-behavior', 'implement'), 'no independent review stamp');
+  });
+
+  it('allows the advance once a phase-exit stamp exists', () => {
+    writeFileSync(
+      nodePath.join(projectRoot, '.safeword-project', 'skill-invocations.log'),
+      `2026-06-03T00:00:00Z sess review:${reviewScope(TICKET_ID, 'phase', 'define-behavior')}\n`,
+    );
+    expectHookAllow(runGateWrite('implement'));
+  });
+
+  it('end to end: write-review-stamp --phase earns a stamp the gate accepts', () => {
+    expectHookDeny(runGateWrite('implement'), 'define-behavior');
+    stampPhase('define-behavior');
+    expectHookAllow(runGateWrite('implement'));
+  });
+
+  it('a skip stamp clears the phase gate', () => {
+    stampPhase('define-behavior', 'docs-only', 'phase');
+    expectHookAllow(runGateWrite('implement'));
+  });
+
+  it('allows a ticket.md edit that does not change the phase', () => {
+    expectHookAllow(runGateWrite('define-behavior'));
+  });
+
+  it('is inert when reviewGate is off (default)', () => {
+    writeConfig(false);
+    expectHookAllow(runGateWrite('implement'));
+  });
+});

--- a/packages/cli/tests/integration/phase-review-gate.test.ts
+++ b/packages/cli/tests/integration/phase-review-gate.test.ts
@@ -11,7 +11,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 
 import { reviewScope } from '../../templates/hooks/lib/review-ledger.js';
 import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';

--- a/packages/cli/tests/integration/review-gate.test.ts
+++ b/packages/cli/tests/integration/review-gate.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test for the NMSD94 Tier 1 review gate, wired into the real
+ * pre-tool-quality hook. Verifies the wired path the unit tests can't: the gate
+ * is default-off, and when enabled it denies an unreviewed/stale/cross-ticket
+ * spec and allows a matching stamp or a logged skip. Proves the content-binding
+ * fix from the quality-review end-to-end.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+import { hashArtifact, reviewScope } from '../../templates/hooks/lib/review-ledger.js';
+import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
+
+const HOOK_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-quality.ts');
+const TICKET_ID = 'ABC123';
+
+const TICKET_FRONTMATTER = [
+  'id: ABC123',
+  'type: feature',
+  'phase: define-behavior',
+  'status: in_progress',
+  'scope:',
+  '  - does a thing',
+  'out_of_scope:',
+  '  - another thing',
+  'done_when:',
+  '  - the thing works',
+].join('\n');
+
+const SPEC = [
+  '# Spec: x',
+  '',
+  '## Jobs To Be Done',
+  '',
+  '### feat.PO1 — title',
+  '',
+  '**Persona:** Platform Operator (PO)',
+  '',
+  '> When I do x, I want y, so I can z.',
+  '',
+  '#### feat.PO1.AC1 — a capability',
+  '',
+  'The capability.',
+  '',
+].join('\n');
+
+const PERSONAS = '# Personas\n\n## Platform Operator (PO)\n\n**Role:** Owns infra.\n';
+
+describe('NMSD94 Tier 1 review gate (wired)', () => {
+  let projectRoot: string;
+  let ticketDirectory: string;
+
+  function runWriteScenarios(): HookResult {
+    const result = spawnSync('bun', [HOOK_PATH], {
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: {
+          file_path: nodePath.join(ticketDirectory, 'test-definitions.md'),
+          content: '# Test Definitions\n',
+        },
+      }),
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function writeConfig(reviewGate: boolean): void {
+    mkdirSync(nodePath.join(projectRoot, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(projectRoot, '.safeword', 'config.json'),
+      JSON.stringify({ reviewGate }),
+    );
+  }
+
+  function writeLog(line: string): void {
+    writeFileSync(nodePath.join(projectRoot, '.safeword-project', 'skill-invocations.log'), line);
+  }
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'review-gate-'));
+    ticketDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', TICKET_ID);
+    mkdirSync(ticketDirectory, { recursive: true });
+    writeFileSync(nodePath.join(ticketDirectory, 'ticket.md'), `---\n${TICKET_FRONTMATTER}\n---\n`);
+    writeFileSync(nodePath.join(ticketDirectory, 'spec.md'), SPEC);
+    writeFileSync(nodePath.join(ticketDirectory, 'dimensions.md'), 'skip: one obvious dimension');
+    writeFileSync(nodePath.join(projectRoot, '.safeword-project', 'personas.md'), PERSONAS);
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('default-off: with no reviewGate flag, scenarios are allowed (inert)', () => {
+    writeConfig(false);
+    expectHookAllow(runWriteScenarios());
+  });
+
+  it('enabled + unreviewed: denies, asking for a spec review', () => {
+    writeConfig(true);
+    expectHookDeny(runWriteScenarios(), 'not been reviewed');
+  });
+
+  it('enabled + matching stamp: allows', () => {
+    writeConfig(true);
+    writeLog(
+      `2026-06-03T00:00:00Z sess review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`,
+    );
+    expectHookAllow(runWriteScenarios());
+  });
+
+  it('enabled + stale stamp (old content hash): denies', () => {
+    writeConfig(true);
+    writeLog(
+      `2026-06-03T00:00:00Z sess review:${reviewScope(TICKET_ID, 'spec', hashArtifact('old spec'))}`,
+    );
+    expectHookDeny(runWriteScenarios(), 'not been reviewed');
+  });
+
+  it('enabled + skip stamp: allows', () => {
+    writeConfig(true);
+    const scope = reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC));
+    writeLog(`2026-06-03T00:00:00Z sess review:${scope} skip:trivial spec`);
+    expectHookAllow(runWriteScenarios());
+  });
+});

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -168,6 +168,16 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(stamp.stdout).toContain('multiple in_progress tickets');
   });
 
+  it('rejects a path-separator in --ticket or the artifact (no escaping tickets/)', () => {
+    const traversedTicket = runStamp('--ticket', '../../etc', 'spec');
+    expect(traversedTicket.status).toBe(1);
+    expect(traversedTicket.stdout).toContain('bare name');
+
+    const traversedArtifact = runStamp('--ticket', TICKET_ID, '../../../secret');
+    expect(traversedArtifact.status).toBe(1);
+    expect(traversedArtifact.stdout).toContain('bare name');
+  });
+
   it('--ticket disambiguates when more than one ticket is in_progress', () => {
     const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
     mkdirSync(second, { recursive: true });

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -12,7 +12,11 @@ import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { hashArtifact, reviewScope } from '../../templates/hooks/lib/review-ledger.js';
+import {
+  hashArtifact,
+  parseReviewStamps,
+  reviewScope,
+} from '../../templates/hooks/lib/review-ledger.js';
 import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
 
 const STAMP_PATH = nodePath.resolve(__dirname, '../../templates/hooks/write-review-stamp.ts');
@@ -140,5 +144,39 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     // Edit the spec — the prior stamp's content hash is now stale.
     writeFileSync(nodePath.join(ticketDirectory, 'spec.md'), `${SPEC}\nedited.\n`);
     expectHookDeny(runGate(), 'not been reviewed');
+  });
+
+  it('a newline in the skip reason cannot inject a second stamp line', () => {
+    // A reason crafted to forge a stamp for another scope must be collapsed to
+    // one line — the log stays one stamp, and parsing yields only the real one.
+    runStamp('spec', 'looks fine\nreview:HACKED:spec@deadbeefcafe');
+    const stamps = parseReviewStamps(readLog());
+    expect(stamps).toHaveLength(1);
+    expect(stamps[0]?.scope).toBe(reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC)));
+    expect(stamps.some(s => s.scope === 'HACKED:spec@deadbeefcafe')).toBe(false);
+  });
+
+  it('fails loudly when more than one ticket is in_progress (no --ticket)', () => {
+    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
+    mkdirSync(second, { recursive: true });
+    writeFileSync(
+      nodePath.join(second, 'ticket.md'),
+      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
+    );
+    const stamp = runStamp('spec');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('multiple in_progress tickets');
+  });
+
+  it('--ticket disambiguates when more than one ticket is in_progress', () => {
+    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
+    mkdirSync(second, { recursive: true });
+    writeFileSync(
+      nodePath.join(second, 'ticket.md'),
+      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
+    );
+    const stamp = runStamp('--ticket', TICKET_ID, 'spec');
+    expect(stamp.status).toBe(0);
+    expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
   });
 });

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration test for the NMSD94 stamp-earning step (write-review-stamp.ts).
+ * Proves the loop the unit tests can't: running the real stamp script earns a
+ * stamp the real pre-tool-quality gate reads back and accepts — deny → stamp →
+ * allow, end to end. Also covers the skip valve and the Tier 2 phase stamp.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { hashArtifact, reviewScope } from '../../templates/hooks/lib/review-ledger.js';
+import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
+
+const STAMP_PATH = nodePath.resolve(__dirname, '../../templates/hooks/write-review-stamp.ts');
+const GATE_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-quality.ts');
+const TICKET_ID = 'ABC123';
+
+const TICKET_FRONTMATTER = [
+  'id: ABC123',
+  'type: feature',
+  'phase: define-behavior',
+  'status: in_progress',
+  'last_modified: 2026-06-03T00:00:00.000Z',
+  'scope:',
+  '  - does a thing',
+  'out_of_scope:',
+  '  - another thing',
+  'done_when:',
+  '  - the thing works',
+].join('\n');
+
+const SPEC = [
+  '# Spec: x',
+  '',
+  '## Jobs To Be Done',
+  '',
+  '### feat.PO1 — title',
+  '',
+  '**Persona:** Platform Operator (PO)',
+  '',
+  '> When I do x, I want y, so I can z.',
+  '',
+  '#### feat.PO1.AC1 — a capability',
+  '',
+  'The capability.',
+  '',
+].join('\n');
+
+const PERSONAS = '# Personas\n\n## Platform Operator (PO)\n\n**Role:** Owns infra.\n';
+
+describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
+  let projectRoot: string;
+  let ticketDirectory: string;
+
+  function runStamp(...args: string[]): HookResult {
+    const result = spawnSync('bun', [STAMP_PATH, ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot, CLAUDE_SESSION_ID: 'sess-1' },
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function runGate(): HookResult {
+    const result = spawnSync('bun', [GATE_PATH], {
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: {
+          file_path: nodePath.join(ticketDirectory, 'test-definitions.md'),
+          content: '# Test Definitions\n',
+        },
+      }),
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function readLog(): string {
+    const logFile = nodePath.join(projectRoot, '.safeword-project', 'skill-invocations.log');
+    return existsSync(logFile) ? readFileSync(logFile, 'utf8') : '';
+  }
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'review-stamp-'));
+    ticketDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', TICKET_ID);
+    mkdirSync(ticketDirectory, { recursive: true });
+    writeFileSync(nodePath.join(ticketDirectory, 'ticket.md'), `---\n${TICKET_FRONTMATTER}\n---\n`);
+    writeFileSync(nodePath.join(ticketDirectory, 'spec.md'), SPEC);
+    writeFileSync(nodePath.join(ticketDirectory, 'dimensions.md'), 'skip: one obvious dimension');
+    writeFileSync(nodePath.join(projectRoot, '.safeword-project', 'personas.md'), PERSONAS);
+    // Enable the gate so the deny→stamp→allow loop is observable.
+    mkdirSync(nodePath.join(projectRoot, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(projectRoot, '.safeword', 'config.json'),
+      JSON.stringify({ reviewGate: true }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('earns a stamp the gate accepts: deny → stamp spec → allow', () => {
+    expectHookDeny(runGate(), 'not been reviewed');
+
+    const stamp = runStamp('spec');
+    expect(stamp.status).toBe(0);
+    expect(stamp.stdout).toContain('✓');
+
+    expectHookAllow(runGate());
+  });
+
+  it('writes a content-bound scope matching the gate (folder + spec + hash)', () => {
+    runStamp('spec');
+    expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+  });
+
+  it('a skip stamp clears the gate and records its reason', () => {
+    const stamp = runStamp('spec', 'trivial', 'boilerplate', 'spec');
+    expect(stamp.status).toBe(0);
+    expect(readLog()).toContain('skip:trivial boilerplate spec');
+    expectHookAllow(runGate());
+  });
+
+  it('--phase writes a ticket-qualified phase scope', () => {
+    const stamp = runStamp('--phase', 'define-behavior');
+    expect(stamp.status).toBe(0);
+    expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'phase', 'define-behavior')}`);
+  });
+
+  it('a stale stamp (spec edited after stamping) no longer satisfies the gate', () => {
+    runStamp('spec');
+    expectHookAllow(runGate());
+    // Edit the spec — the prior stamp's content hash is now stale.
+    writeFileSync(nodePath.join(ticketDirectory, 'spec.md'), `${SPEC}\nedited.\n`);
+    expectHookDeny(runGate(), 'not been reviewed');
+  });
+});

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -320,7 +320,7 @@ describe('Schema - Single Source of Truth', () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
 
       // Action skills have disable-model-invocation and use Cursor commands instead of rules
-      const ACTION_SKILLS = new Set(['lint', 'verify', 'audit', 'cleanup-zombies']);
+      const ACTION_SKILLS = new Set(['lint', 'verify', 'audit', 'cleanup-zombies', 'self-review']);
 
       // Extract skill names from Claude schema paths (short names: debug, quality-review, refactor)
       const claudeSkills = Object.keys(SAFEWORD_SCHEMA.ownedFiles)
@@ -448,6 +448,12 @@ describe('Schema - Single Source of Truth', () => {
         }
       }
 
+      // write-review-stamp.ts is a manually-invoked utility (run by the
+      // /self-review skill injection and by the agent post-fork), not a wired
+      // event hook — it shares the hook lib and writes the log the gates read,
+      // but Claude Code never fires it on an event, so it has no SETTINGS_HOOKS entry.
+      const MANUAL_HOOK_SCRIPTS = new Set(['write-review-stamp.ts']);
+
       // Hook files in ownedFiles (excluding lib/ modules and cursor/ adapters)
       const hookFiles = Object.keys(SAFEWORD_SCHEMA.ownedFiles)
         .filter(
@@ -457,7 +463,8 @@ describe('Schema - Single Source of Truth', () => {
             !path.includes('/cursor/'),
         )
         .map(path => path.split('/').pop())
-        .filter(isDefined);
+        .filter(isDefined)
+        .filter(file => !MANUAL_HOOK_SCRIPTS.has(file));
 
       const unwired: string[] = [];
       for (const file of hookFiles) {


### PR DESCRIPTION
## What

Two-tier review enforcement for the safeword BDD workflow (NMSD94), shipped **inert behind a default-off flag** (`reviewGate` in `.safeword/config.json`).

- **Tier 1 — per-asset inline (the cheap, gameable floor):** a PreToolUse gate blocks creating `test-definitions.md` until the ticket's `spec.md` carries a content-bound review stamp (`<ticket>:spec@<hash>`). Earned by `/self-review` — the working agent's own inline pass, no sub-agent — plus `write-review-stamp.ts`. Editing the spec after review makes the stamp stale and re-blocks; a logged `skip:<reason>` clears it.
- **Tier 2 — phase-exit independent (the ungameable backstop):** a gate blocks advancing a ticket's `phase:` until an independent phase-exit stamp exists, produced by a fresh reviewer with no conversation history (`context: fork`) so the author can't grade their own phase. Wired via `detectPhaseAdvance` + `gatePhaseAdvance`.

Both tiers share one decision core (`review-ledger.ts`) and the existing skill-invocation-log. The stamp-earner reuses the gate's own `reviewScope`/`hashArtifact`, so a stamp matches the gate by construction — no cross-language hash contract to drift.

## Why default-off

The gate is self-applying, so shipping it inert (`reviewGate` absent) means it can't brick the dogfood or customers. Enablement is a deliberate follow-up after a soak (K4VHF4).

## Testing

- Decision-core unit tests + integration tests that spawn the real hook: deny → stamp → allow end-to-end, stale-hash denial, the skip valve, multi-ticket fail-loud, path-traversal rejection, and default-off inertness.
- Full suite green (2485 pass, 1 skipped) against a fresh build; lint + `tsc` + build clean; 120 dogfood template↔install pairs in sync.
- `/verify` + `/audit` passed; `verify.md` in the ticket folder.

## Verified against current docs

Skill patterns checked against the live Claude Code / Agent Skills docs: the `!`…``render-time injection and the`name`/`description`/`allowed-tools`frontmatter are current, and Tier 2 names the native`context: fork` mechanism.

## Follow-ups (separate tickets)

- **K4VHF4** — enable `reviewGate` (dogfood the gate) and build the Tier 2 reviewer as a `context: fork` skill.
- **ZRMDKD** — promote the AC↔scenario coverage check from advisory to a blocking gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
