### PR TITLE
chore(tickets): triage — close 13 stale/superseded/shipped tickets

### DIFF
--- a/.safeword-project/tickets/009-audit-lint-ignore-rules/ticket.md
+++ b/.safeword-project/tickets/009-audit-lint-ignore-rules/ticket.md
@@ -2,10 +2,10 @@
 id: 009
 type: feature
 phase: backlog
-status: pending
+status: cancelled
 parent: 001
 created: 2026-01-07T16:39:00Z
-last_modified: 2026-01-07T16:39:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Iteration 8: Audit/Lint Ignore Rules
@@ -73,3 +73,7 @@ audit:
 
 - Changing what rules exist
 - Adding new audit/lint checks
+
+## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (cancelled) via ticket-triage: stale — three design options, never decided since Jan; abandoned.

--- a/.safeword-project/tickets/011-skill-testing-infrastructure/ticket.md
+++ b/.safeword-project/tickets/011-skill-testing-infrastructure/ticket.md
@@ -2,10 +2,10 @@
 id: 011
 type: feature
 phase: intake
-status: backlog
+status: cancelled
 parent: null
 created: 2026-01-07T19:53:00Z
-last_modified: 2026-01-07T19:53:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Skill Testing Infrastructure
@@ -165,6 +165,8 @@ describe('Split Artifact Creation', () => {
 - API credits for classification tests (~$0.40 per full run)
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (cancelled) via ticket-triage: stale — aspirational skill-behavior harness, never built.
 
 ---
 

--- a/.safeword-project/tickets/012-auto-update-notifications/ticket.md
+++ b/.safeword-project/tickets/012-auto-update-notifications/ticket.md
@@ -2,10 +2,10 @@
 id: 012
 type: feature
 phase: intake
-status: backlog
+status: superseded
 parent: null
 created: 2026-01-07T23:11:00Z
-last_modified: 2026-01-07T23:11:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Auto-Update Notifications
@@ -67,3 +67,7 @@ Store in `.safeword/.update-cache.json` (gitignored):
 - [ ] Silent failure on network errors
 - [ ] Respects `--offline` flag
 - [ ] CLI auto-adds cache file to project's `.gitignore` when creating it
+
+## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (superseded) via ticket-triage: superseded by 081 (session-start auto-upgrade absorbs the notification).

--- a/.safeword-project/tickets/016c-claude-code-hook-wiring/ticket.md
+++ b/.safeword-project/tickets/016c-claude-code-hook-wiring/ticket.md
@@ -1,10 +1,10 @@
 ---
 id: 016c
 type: task
-phase: implement
-status: ready
+phase: done
+status: done
 created: 2026-01-10T18:40:00Z
-last_modified: 2026-01-10T19:51:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Protect config files from accidental LLM changes
@@ -81,6 +81,8 @@ Add to `.claude/settings.json` hooks configuration:
 - [ ] Integration test verifies hooks are triggered
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (done) via ticket-triage: config-guard + bypass-warn hooks are wired in .claude/settings.json.
 
 ---
 

--- a/.safeword-project/tickets/019-customer-override-rules/ticket.md
+++ b/.safeword-project/tickets/019-customer-override-rules/ticket.md
@@ -2,9 +2,9 @@
 id: 019
 type: task
 phase: implement
-status: ready
+status: superseded
 created: 2026-01-10T19:15:00Z
-last_modified: 2026-01-11T05:46:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Allow customers to override LLM-specific checker rules
@@ -260,6 +260,8 @@ safeword override --rule no-incomplete-error-handling=warn
 **Rejected:** Yet another CLI command, harder to discover than file.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (superseded) via ticket-triage: superseded by 138 (single-surface override contract shipped instead).
 
 ---
 

--- a/.safeword-project/tickets/054-declarative-rule-engine/ticket.md
+++ b/.safeword-project/tickets/054-declarative-rule-engine/ticket.md
@@ -2,9 +2,9 @@
 id: '054'
 type: feature
 phase: define-behavior
-status: backlog
+status: cancelled
 created: 2026-03-26T20:56:55Z
-last_modified: 2026-03-26T23:23:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 ---
 
 # Declarative rule engine for enforcement policies
@@ -14,6 +14,8 @@ last_modified: 2026-03-26T23:23:00Z
 **Why:** Today's enforcement logic is spread across 5+ hook files with different patterns. Users can't customize rules. Adding new gates requires modifying TypeScript. A rule engine makes policies portable, customizable, and checkable.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (cancelled) via ticket-triage: stale — strawman rewrite of the hooks, spec-only; abandoned.
 
 - 2026-03-26T23:23:00Z Spec: wrote feature spec with 4 stories (refs: ./spec.md)
 - 2026-03-26T20:56:55Z Created: ticket from formal verification research discussion

--- a/.safeword-project/tickets/065-eslint-plugin-migrations/ticket.md
+++ b/.safeword-project/tickets/065-eslint-plugin-migrations/ticket.md
@@ -2,8 +2,8 @@
 id: 065
 slug: eslint-plugin-migrations
 type: task
-status: backlog
-phase: research
+status: done
+phase: done
 ---
 
 # Task: Migrate eslint-plugin-security 4.0 and eslint-plugin-sonarjs 4.0
@@ -24,5 +24,7 @@ phase: research
 - [ ] Customer preset tested against sample projects
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (done) via ticket-triage: eslint-plugin-security 4.0.0 + sonarjs 4.0.3 shipped (commit fe16d586).
 
 - 2026-03-28 Created from dep bump audit. Reverted to 3.x due to 128+ new errors.

--- a/.safeword-project/tickets/078-auto-commit-setup/ticket.md
+++ b/.safeword-project/tickets/078-auto-commit-setup/ticket.md
@@ -3,7 +3,7 @@ id: '078'
 slug: auto-commit-setup
 title: 'Auto-commit after safeword setup and upgrade'
 type: Improvement
-status: open
+status: superseded
 epic: setup-lifecycle
 ---
 
@@ -41,3 +41,7 @@ After setup/upgrade completes successfully:
 - [ ] Non-git-repo gracefully skips commit with a warning
 - [ ] User-owned files (learnings, logs, tickets) are excluded from auto-commit
 - [ ] Dead `pythonFiles` return value removed from setup flow
+
+## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (superseded) via ticket-triage: superseded by 081 (inline commit at setup/upgrade).

--- a/.safeword-project/tickets/080-ticket-id-collision/ticket.md
+++ b/.safeword-project/tickets/080-ticket-id-collision/ticket.md
@@ -3,7 +3,8 @@ id: '080'
 slug: ticket-id-collision
 title: 'Ticket system: prevent ID collisions from parallel sessions'
 type: Bug
-status: open
+status: done
+phase: done
 ---
 
 # Task: Ticket system: prevent ID collisions from parallel sessions
@@ -33,3 +34,7 @@ Option 2 is simplest and most robust — retry on `EEXIST`.
 
 - [ ] Concurrent ticket creation from parallel sessions does not produce ID collisions
 - [ ] Existing sequential ID format preserved
+
+## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (done) via ticket-triage: atomic Crockford IDs via `safeword ticket new`; legacy format documented.

--- a/.safeword-project/tickets/106-user-collaboration-guide/ticket.md
+++ b/.safeword-project/tickets/106-user-collaboration-guide/ticket.md
@@ -5,6 +5,7 @@ type: feature
 phase: intake
 created: 2026-04-11
 related: '105'
+status: cancelled
 ---
 
 ## Goal
@@ -45,5 +46,7 @@ Tells the agent to persist decisions and reasoning before moving on. Prevents co
 Observed during ticket #100 design conversation (2026-04-11). The user's directives followed a consistent pattern across 8+ design iterations that produced demonstrably better outcomes than the agent's default explore → propose cycle.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (cancelled) via ticket-triage: stale — intake-only open-questions doc, no scope/owner since Apr.
 
 - 2026-04-11T15:33Z Created: Captured from ticket #100 open question #2

--- a/.safeword-project/tickets/107-new-hook-events/ticket.md
+++ b/.safeword-project/tickets/107-new-hook-events/ticket.md
@@ -5,6 +5,7 @@ type: task
 phase: intake
 created: 2026-04-11
 related: '101'
+status: superseded
 ---
 
 ## Goal
@@ -32,6 +33,8 @@ A Haiku-based prompt hook is cheap, fast, and independent from the main agent â€
 Identified during quality review of ticket #100 (2026-04-11). Current hook architecture predates several of these events.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (superseded) via ticket-triage: superseded by 8R54HV (CC changelog-alignment epic owns new-primitive realignment).
 
 - 2026-04-16T16:04:00Z Cross-ref: Ticket #126 evaluated PostToolUse additionalContext vs two-hook flag-and-clear for one-shot reminders. Existing events (PostToolUse + UserPromptSubmit) are sufficient â€” no new events needed for this pattern. Data point for evaluation: newer events may help elsewhere but aren't required for reminder-tier enforcement.
 - 2026-04-11T15:42Z Created: Flagged during quality review

--- a/.safeword-project/tickets/110-multi-session-coordination/ticket.md
+++ b/.safeword-project/tickets/110-multi-session-coordination/ticket.md
@@ -4,6 +4,7 @@ title: Prevent concurrent agent sessions from overwriting each other's commits
 type: task
 phase: intake
 created: 2026-04-11
+status: cancelled
 ---
 
 ## Goal
@@ -36,5 +37,7 @@ No mechanism prevents concurrent pushes to main from different sessions. Each se
 Cherry-picked all 8 commits from the reflog onto current main, resolved conflicts (took our version for design files, kept their version for CI files). Pushed successfully. No work was permanently lost.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (cancelled) via ticket-triage: moot — worktree-per-session is now standard; the concurrent-overwrite root cause is gone.
 
 - 2026-04-11T22:04Z Created: Incident during concurrent session work

--- a/.safeword-project/tickets/133-schema-drift-detection/ticket.md
+++ b/.safeword-project/tickets/133-schema-drift-detection/ticket.md
@@ -1,10 +1,10 @@
 ---
 id: '133'
 type: task
-phase: intake
-status: backlog
+phase: done
+status: done
 created: 2026-04-17T13:35:00Z
-last_modified: 2026-04-17T13:35:00Z
+last_modified: 2026-06-03T19:05:00.000Z
 scope:
   - Add drift-detection tests to schema.test.ts that catch files deployed locally but missing from templates/schema/config
 out_of_scope:
@@ -73,5 +73,7 @@ Catches: cli-reference.md class of drift (file removed from ownedFiles but still
 The existing release test checks **content equality** between dogfood files and templates. Running it in the default suite would block development whenever a local file is being iterated on before syncing to templates. The three new tests check **structural completeness** (does a template exist? is the hook wired? is the file tracked?) which should always pass and won't block normal iteration.
 
 ## Work Log
+
+- 2026-06-03T19:05:00.000Z Closed (done) via ticket-triage: drift tests shipped in schema.test.ts (feat 133); ticket was never closed.
 
 - 2026-04-17T13:35:00Z Created: from audit session that found 5 drift issues (SessionEnd unwired, VERIFY.md/brainstorm/tdd-review missing from templates, cli-reference.md missing from deprecatedFiles). All 5 fixed in same session — this ticket prevents recurrence.


### PR DESCRIPTION
Read-only triage of all 133 open tickets (six parallel assessment agents). These 13 are no longer live; the rest are legitimately-parked initiatives (arcade-absorb, codex, cursor, monitor, cc-changelog) and stay open.

**Closed `done` — shipped, never closed**
- `133` schema-drift-detection — drift tests in `schema.test.ts` (feat 133)
- `016c` claude-code-hook-wiring — hooks wired in `.claude/settings.json`
- `065` eslint-plugin-migrations — security 4.0.0 + sonarjs 4.0.3 (`fe16d586`)
- `080` ticket-id-collision — atomic Crockford IDs via `safeword ticket new`

**Closed `superseded`**
- `012` auto-update-notifications → 081
- `078` auto-commit-setup → 081
- `019` customer-override-rules → 138
- `107` new-hook-events → 8R54HV

**Closed `cancelled` — moot / stale**
- `110` multi-session-coordination — moot, worktree-per-session is now standard
- `009` audit-lint-ignore-rules — stale, never decided since Jan
- `011` skill-testing-infrastructure — stale, never built
- `054` declarative-rule-engine — stale, spec-only
- `106` user-collaboration-guide — stale, no scope/owner

Each ticket carries a work-log line with the reason. Two ambiguous calls (108, H7M3KQ) and the decomposition-vocabulary rescopes were intentionally left out for separate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)