### PR TITLE
fix(9EA27P): require spec.md for features — drop the no-spec grandfather skip

### DIFF
--- a/.safeword-project/tickets/9EA27P-feature-spec-required/ticket.md
+++ b/.safeword-project/tickets/9EA27P-feature-spec-required/ticket.md
@@ -1,0 +1,51 @@
+---
+id: 9EA27P
+slug: feature-spec-required
+type: task
+phase: done
+status: done
+created: 2026-06-04T05:17:12.086Z
+last_modified: 2026-06-04T06:01:00.000Z
+---
+
+# Require spec.md for all features (drop the no-spec grandfather skip)
+
+**Goal:** Make the spec.md requirement fail-closed for features — a `type: feature` ticket with no `spec.md` is denied at `test-definitions.md` creation, instead of silently skipping the JTBD/AC gates.
+
+**Why:** The JTBD and AC gates in `pre-tool-quality.ts` only run `if (existsSync(specFile))`, so a feature with no `spec.md` bypasses them entirely — and nothing downstream re-checks (the stop/done gate only requires scenarios + `verify.md`/audit). A feature can reach `done` with zero personas, jobs, or criteria. Confirmed live: FM5EDA was in exactly that state. The skip was transitional grandfathering for tickets predating the product layer (epic DZ2NM5); the CLI now scaffolds `spec.md` for new features (`ticket-writer.test.ts:44`), so new work is already covered and the exemption is vestigial.
+
+**Decision (from `/figure-it-out`):** no-grandfather over a date cutoff. Uniform fail-closed, no magic-date constant, and legacy compliance is a lazy two-line `## Jobs To Be Done` + `skip: <reason>` paid only when a pre-scaffold feature is next advanced — not a big-bang migration. The cutoff was rejected as strictly more code plus a permanent two-tier system (filed-before-date exempt forever) for a gentleness the existing scaffold makes unnecessary.
+
+## Scope
+
+- In `pre-tool-quality.ts`, at the `test-definitions.md` creation gate: for `type: feature`, **deny when no `spec.md` exists** (require it), instead of skipping the JTBD/AC gates on absence. Tasks and patches are untouched.
+- Deny message names the fix and the escape valve: author a Job To Be Done, or write `skip: <reason>` under `## Jobs To Be Done`.
+- Mirror the change into `templates/hooks/pre-tool-quality.ts` (byte-identical).
+- Invert the two grandfather tests — `jtbd-gate.test.ts` "skips the JTBD gate when no spec.md is present" (~:93) and the AC equivalent (~:132) — to assert denial for features.
+- Audit other fixtures that build a feature's `test-definitions.md` without a `spec.md`; give them a `spec.md` (real JTBD/AC or a `skip:`) so they reflect the new rule.
+
+## Out of scope
+
+- Date-cutoff / grandfathering — explicitly rejected (no-grandfather chosen).
+- Backfilling `spec.md` into the 54 existing spec-less features — lazy migration: each pays a two-line `skip:` only when next advanced.
+- The review-gate enablement (`reviewGate: true`) — separate decision.
+- Scaffold-on-creation behavior — already exists for features; not touched here.
+
+## Done when
+
+- Creating `test-definitions.md` for a `type: feature` with no `spec.md` is denied, with a reason naming the missing `spec.md` and the `skip:` valve.
+- A feature whose `spec.md` carries real JTBDs/ACs **or** a `skip:` still passes (existing gates unchanged).
+- Tasks and patches are unaffected (no `spec.md` required).
+- The two grandfather tests are inverted; full suite green; `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; parity green.
+
+## Related
+
+- **Y2HCNJ** (JTBD gate), **31W8M3** (AC gate), **DZ2NM5** (product-layer epic) — this hardens their enforcement to fail-closed.
+- Surfaced during the FM5EDA `/bdd` smoke test (2026-06-04); FM5EDA itself is unrelated work — just the vehicle that exposed the gap.
+
+## Work Log
+
+- 2026-06-04T05:17:12.086Z Started: Created ticket 9EA27P
+- 2026-06-04T05:17:12.086Z Filed (backlog): No-spec.md feature bypass — JTBD/AC gates skip on `spec.md` absence, nothing re-checks downstream, so a feature reaches `done` with no product layer. Sized **task** (one gate change + template mirror + two test inversions). Approach decided via `/figure-it-out`: **no-grandfather** (require `spec.md` for all features), chosen over a date cutoff. Not started.
+- 2026-06-04T06:01:00.000Z Implemented (task, TDD): RED — inverted the two grandfather tests in `jtbd-gate.test.ts` to assert denial; GREEN — made the gate fail-closed in `pre-tool-quality.ts` + byte-identical template mirror (a `type: feature` creating `test-definitions.md` with no `spec.md` is denied, naming the `skip:` valve). Fixed `quality-gates.test.ts` 9.3/9.8/9.11 fixtures (added a `spec.md` skip). Refactor — hoisted `specExists` to dedup the existsSync check. Commits `3d2ef3b0` (fix) + `c8d50181` (refactor).
+- 2026-06-04T06:01:00.000Z Verified + done: full suite **2486/2486 green on fresh dist**, build ✓, lint ✓, parity identical, depcruise/jscpd/knip clean for changed files. Baseline diff confirmed **zero net regressions** — the earlier "174 failures" were stale-`dist` phantoms, not environmental. `/verify` + `/audit` invoked; `verify.md` written. Status → done.

--- a/.safeword-project/tickets/9EA27P-feature-spec-required/verify.md
+++ b/.safeword-project/tickets/9EA27P-feature-spec-required/verify.md
@@ -1,0 +1,26 @@
+# Verify — 9EA27P (require spec.md for features)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 2486/2486 tests pass (1 skipped) — full suite on fresh dist (`bun run build && bun run test`)
+**Build:** ✅ Success — tsup ESM + DTS
+**Lint:** ✅ Clean — `eslint src tests && tsc --noEmit`, exit 0
+**Scenarios:** ⏭️ N/A — task (no test-definitions.md; tasks carry no scenarios)
+**Dep Drift:** ✅ Clean — no dependency changes (`package.json` untouched)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — the new feature-only deny mirrors the adjacent `dimensions.md` gate's `meta.type === 'feature'` shape; no new pattern introduced.
+
+**Audit:** Audit passed (not gate-required for tasks; run for hygiene). depcruise ✔ no violations (2398 modules); jscpd 0.58% (the refactor _reduced_ duplication); knip flags nothing in changed files — the 8 unused deps + 3 unused exports are pre-existing baseline (hook-template false-positives per project memory).
+
+## Done-when evidence
+
+- **Feature + no `spec.md` → denied**, naming the missing `spec.md` and the `skip:` valve — `jtbd-gate.test.ts` (two inverted grandfather tests, both assert `expectHookDeny(…, 'spec.md')`). ✓
+- **Feature with real JTBDs/ACs or a `skip:` still passes** — `jtbd-gate.test.ts` (resolving JTBD + AC) and `quality-gates.test.ts` 9.3/9.8/9.11 (now carry a `spec.md` skip). ✓
+- **Tasks and patches unaffected** — `quality-gates.test.ts` 9.9 (task, no dimensions/spec → allowed). ✓
+- **Grandfather tests inverted; `templates/` ↔ `.safeword/` byte-identical; full suite green; parity green** — all confirmed (`diff` identical; 2486/2486). ✓
+
+## Regression proof
+
+Baseline full-suite diff (clean `main` vs branch) isolated the _only_ delta to the 3 `quality-gates` fixtures, now fixed. The earlier "174 failures" were a stale-`dist` artifact (integration tests run the built CLI), not environmental — fresh build → 0 failures.
+
+Ready to mark done.

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -302,11 +302,25 @@ if (
     }
   }
 
-  // JTBD gate (ticket Y2HCNJ): when the ticket carries a spec.md (new-flow
-  // feature — epic DZ2NM5/D5 routes by spec.md presence, so grandfathered
-  // tickets without one are skipped), require ≥1 JTBD whose persona resolves
-  // against personas.md, or a `skip: <reason>` in the Jobs To Be Done section.
+  // spec.md gate (ticket 9EA27P): features fail closed. A `type: feature`
+  // ticket with no spec.md is denied here, rather than silently skipping the
+  // JTBD/AC gates below — without a spec.md those gates have nothing to check,
+  // so a feature could otherwise reach done with no jobs or criteria. Tasks and
+  // patches don't require a spec.md. The CLI scaffolds spec.md for new features,
+  // so this only bites pre-product-layer (epic DZ2NM5) tickets, which pay a lazy
+  // two-line `## Jobs To Be Done` + `skip: <reason>` the next time they advance.
   const specFile = nodePath.join(ticketDirectory, 'spec.md');
+  if (meta.type === 'feature' && !existsSync(specFile)) {
+    deny(
+      'Features require a spec.md before test-definitions.md. Without one the JTBD and Acceptance-Criteria gates have nothing to check.',
+      'Author a Job To Be Done in spec.md under `## Jobs To Be Done` (persona from personas.md, in the "When I…, I want…, so I can…" form), or write `skip: <reason>` there to deliberately omit.',
+    );
+  }
+
+  // JTBD gate (ticket Y2HCNJ): require ≥1 JTBD whose persona resolves against
+  // personas.md, or a `skip: <reason>` in the Jobs To Be Done section. The
+  // existsSync guard below now only spares tasks and patches — a feature with
+  // no spec.md was already denied above.
   if (existsSync(specFile)) {
     const specContent = readFileSync(specFile, 'utf8');
 

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -310,7 +310,8 @@ if (
   // so this only bites pre-product-layer (epic DZ2NM5) tickets, which pay a lazy
   // two-line `## Jobs To Be Done` + `skip: <reason>` the next time they advance.
   const specFile = nodePath.join(ticketDirectory, 'spec.md');
-  if (meta.type === 'feature' && !existsSync(specFile)) {
+  const specExists = existsSync(specFile);
+  if (meta.type === 'feature' && !specExists) {
     deny(
       'Features require a spec.md before test-definitions.md. Without one the JTBD and Acceptance-Criteria gates have nothing to check.',
       'Author a Job To Be Done in spec.md under `## Jobs To Be Done` (persona from personas.md, in the "When I…, I want…, so I can…" form), or write `skip: <reason>` there to deliberately omit.',
@@ -319,9 +320,9 @@ if (
 
   // JTBD gate (ticket Y2HCNJ): require ≥1 JTBD whose persona resolves against
   // personas.md, or a `skip: <reason>` in the Jobs To Be Done section. The
-  // existsSync guard below now only spares tasks and patches — a feature with
-  // no spec.md was already denied above.
-  if (existsSync(specFile)) {
+  // guard below now only spares tasks and patches — a feature with no spec.md
+  // was already denied above.
+  if (specExists) {
     const specContent = readFileSync(specFile, 'utf8');
 
     const jtbdVerdict = evaluateJtbdGate(specContent, readPersonasForGate(ticketDirectory));

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -302,11 +302,25 @@ if (
     }
   }
 
-  // JTBD gate (ticket Y2HCNJ): when the ticket carries a spec.md (new-flow
-  // feature — epic DZ2NM5/D5 routes by spec.md presence, so grandfathered
-  // tickets without one are skipped), require ≥1 JTBD whose persona resolves
-  // against personas.md, or a `skip: <reason>` in the Jobs To Be Done section.
+  // spec.md gate (ticket 9EA27P): features fail closed. A `type: feature`
+  // ticket with no spec.md is denied here, rather than silently skipping the
+  // JTBD/AC gates below — without a spec.md those gates have nothing to check,
+  // so a feature could otherwise reach done with no jobs or criteria. Tasks and
+  // patches don't require a spec.md. The CLI scaffolds spec.md for new features,
+  // so this only bites pre-product-layer (epic DZ2NM5) tickets, which pay a lazy
+  // two-line `## Jobs To Be Done` + `skip: <reason>` the next time they advance.
   const specFile = nodePath.join(ticketDirectory, 'spec.md');
+  if (meta.type === 'feature' && !existsSync(specFile)) {
+    deny(
+      'Features require a spec.md before test-definitions.md. Without one the JTBD and Acceptance-Criteria gates have nothing to check.',
+      'Author a Job To Be Done in spec.md under `## Jobs To Be Done` (persona from personas.md, in the "When I…, I want…, so I can…" form), or write `skip: <reason>` there to deliberately omit.',
+    );
+  }
+
+  // JTBD gate (ticket Y2HCNJ): require ≥1 JTBD whose persona resolves against
+  // personas.md, or a `skip: <reason>` in the Jobs To Be Done section. The
+  // existsSync guard below now only spares tasks and patches — a feature with
+  // no spec.md was already denied above.
   if (existsSync(specFile)) {
     const specContent = readFileSync(specFile, 'utf8');
 

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -310,7 +310,8 @@ if (
   // so this only bites pre-product-layer (epic DZ2NM5) tickets, which pay a lazy
   // two-line `## Jobs To Be Done` + `skip: <reason>` the next time they advance.
   const specFile = nodePath.join(ticketDirectory, 'spec.md');
-  if (meta.type === 'feature' && !existsSync(specFile)) {
+  const specExists = existsSync(specFile);
+  if (meta.type === 'feature' && !specExists) {
     deny(
       'Features require a spec.md before test-definitions.md. Without one the JTBD and Acceptance-Criteria gates have nothing to check.',
       'Author a Job To Be Done in spec.md under `## Jobs To Be Done` (persona from personas.md, in the "When I…, I want…, so I can…" form), or write `skip: <reason>` there to deliberately omit.',
@@ -319,9 +320,9 @@ if (
 
   // JTBD gate (ticket Y2HCNJ): require ≥1 JTBD whose persona resolves against
   // personas.md, or a `skip: <reason>` in the Jobs To Be Done section. The
-  // existsSync guard below now only spares tasks and patches — a feature with
-  // no spec.md was already denied above.
-  if (existsSync(specFile)) {
+  // guard below now only spares tasks and patches — a feature with no spec.md
+  // was already denied above.
+  if (specExists) {
     const specContent = readFileSync(specFile, 'utf8');
 
     const jtbdVerdict = evaluateJtbdGate(specContent, readPersonasForGate(ticketDirectory));

--- a/packages/cli/tests/integration/jtbd-gate.test.ts
+++ b/packages/cli/tests/integration/jtbd-gate.test.ts
@@ -2,7 +2,8 @@
  * Integration test for the intake-exit JTBD gate (ticket Y2HCNJ, slice C,
  * test-definitions.md Rule 7). Spawns the real pre-tool-quality hook and
  * verifies it gates test-definitions.md creation on spec.md JTBD content,
- * and skips the gate when no spec.md is present (D5 routing).
+ * and (ticket 9EA27P) denies a feature that has no spec.md at all — the
+ * transitional no-spec grandfather skip is gone; features fail closed.
  *
  * The hook signals denial the PreToolUse way — a `permissionDecision: deny`
  * JSON object on stdout, exit 0 — so assertions go through the shared
@@ -90,9 +91,11 @@ describe('intake-exit JTBD gate (Rule 7)', () => {
     expectHookAllow(attemptTestDefinitions(ticketDirectory));
   });
 
-  it('skips the JTBD gate when no spec.md is present (grandfathered ticket)', () => {
-    // No spec.md written — old-flow routing; the JTBD gate must not fire.
-    expectHookAllow(attemptTestDefinitions(ticketDirectory));
+  it('denies a feature with no spec.md — the no-spec grandfather skip is gone (9EA27P)', () => {
+    // No spec.md written. Features now fail closed: the JTBD/AC gates no longer
+    // silently skip on spec.md absence — the feature is denied until it carries
+    // a spec.md (real JTBDs, or a `skip:` under `## Jobs To Be Done`).
+    expectHookDeny(attemptTestDefinitions(ticketDirectory), 'spec.md');
   });
 });
 
@@ -129,7 +132,8 @@ describe('intake-exit AC gate (31W8M3)', () => {
     expectHookAllow(attemptTestDefinitions(ticketDirectory));
   });
 
-  it('does not fire the AC gate when no spec.md is present (grandfathered ticket)', () => {
-    expectHookAllow(attemptTestDefinitions(ticketDirectory));
+  it('denies a feature with no spec.md — the no-spec grandfather skip is gone (9EA27P)', () => {
+    // Same fail-closed rule, reached from the AC gate's side: no spec.md ⇒ denied.
+    expectHookDeny(attemptTestDefinitions(ticketDirectory), 'spec.md');
   });
 });

--- a/packages/cli/tests/integration/quality-gates.test.ts
+++ b/packages/cli/tests/integration/quality-gates.test.ts
@@ -1287,6 +1287,13 @@ describe('Quality Gates', () => {
         '.safeword-project/tickets/099-test/dimensions.md',
         '| Dimension | Partitions |\n|---|---|\n| Delivery | email, slack |\n',
       );
+      // ...and a spec.md (ticket 9EA27P). This suite tests the scope/dimensions
+      // prerequisite, not JTBD content, so skip the JTBD enumeration.
+      writeTestFile(
+        projectDirectory,
+        '.safeword-project/tickets/099-test/spec.md',
+        '# Spec\n\n## Jobs To Be Done\n\nskip: prerequisite-gate fixture; JTBD/AC content covered in jtbd-gate.test.ts\n',
+      );
 
       const testDefsPath = nodePath.join(
         projectDirectory,
@@ -1435,6 +1442,12 @@ describe('Quality Gates', () => {
         '.safeword-project/tickets/099-test/dimensions.md',
         '| Dimension | Partitions |\n|---|---|\n| Delivery | email, slack |\n',
       );
+      // Features now require spec.md too (ticket 9EA27P); skip JTBD enumeration.
+      writeTestFile(
+        projectDirectory,
+        '.safeword-project/tickets/099-test/spec.md',
+        '# Spec\n\n## Jobs To Be Done\n\nskip: prerequisite-gate fixture; JTBD/AC content covered in jtbd-gate.test.ts\n',
+      );
 
       const testDefsPath = nodePath.join(
         projectDirectory,
@@ -1519,6 +1532,12 @@ describe('Quality Gates', () => {
         projectDirectory,
         '.safeword-project/tickets/099-test/dimensions.md',
         'skip: single behavioral dimension, no partitioning to enumerate\n',
+      );
+      // Features now require spec.md too (ticket 9EA27P); skip JTBD enumeration.
+      writeTestFile(
+        projectDirectory,
+        '.safeword-project/tickets/099-test/spec.md',
+        '# Spec\n\n## Jobs To Be Done\n\nskip: prerequisite-gate fixture; JTBD/AC content covered in jtbd-gate.test.ts\n',
       );
 
       const testDefsPath = nodePath.join(


### PR DESCRIPTION
## What

Makes the `spec.md` requirement **fail-closed** for features. A `type: feature` ticket that tries to create `test-definitions.md` with no `spec.md` is now **denied** at the gate, instead of silently skipping the JTBD/Acceptance-Criteria checks.

## Why

The JTBD and AC gates in `pre-tool-quality.ts` only ran `if (existsSync(specFile))`, so a feature with no `spec.md` bypassed them entirely — and nothing downstream re-checked. A feature could reach `done` with zero personas, jobs, or criteria (confirmed live: FM5EDA was in exactly that state). The skip was transitional grandfathering for tickets predating the product layer (epic DZ2NM5); the CLI now scaffolds `spec.md` for new features, so the exemption was vestigial.

**Decision (`/figure-it-out`):** no-grandfather over a date cutoff — uniform fail-closed, no magic-date constant. Legacy spec-less features pay a lazy two-line `## Jobs To Be Done` + `skip: <reason>` only when next advanced; no big-bang migration.

## What changed

- `pre-tool-quality.ts` (+ byte-identical `templates/hooks/` mirror): deny a feature creating `test-definitions.md` with no `spec.md`, naming the missing file and the `skip:` valve. Tasks and patches untouched.
- Inverted the two grandfather tests in `jtbd-gate.test.ts` to assert denial.
- Gave `quality-gates.test.ts` fixtures 9.3/9.8/9.11 a `spec.md` (skip) so they reflect the new rule.
- Refactor: hoisted `specExists` to dedup the `existsSync(specFile)` check.

## Verification

- Full suite **2486/2486 green** on a fresh build.
- Baseline diff (clean `main` vs branch) confirmed **zero net regressions** — the only delta was the 3 quality-gates fixtures, now fixed. (Earlier "174 failures" were a stale-`dist` artifact, not environmental.)
- Build ✅, lint ✅, `templates/` ↔ `.safeword/` byte-identical, depcruise/jscpd/knip clean for changed files.

## Out of scope

- Review-gate enablement (`reviewGate: true`) — separate decision.
- Backfilling `spec.md` into the ~54 existing spec-less features — lazy migration, each pays a `skip:` only when next advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)