### PR TITLE
fix(test): raise golang-golden-path timeout to 120s (golangci-lint cold-start flake)

### DIFF
--- a/packages/cli/tests/integration/golang-golden-path.test.ts
+++ b/packages/cli/tests/integration/golang-golden-path.test.ts
@@ -16,7 +16,7 @@ import { execSync, spawnSync } from 'node:child_process';
 import { unlinkSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
   createGoProject,
@@ -33,6 +33,15 @@ import {
 } from '../helpers';
 
 const GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
+
+// golangci-lint's FIRST run cold-starts (~62s: type-checks the code, compiling
+// stdlib deps, then initializes the curated linter set and builds its cache),
+// which sits right on vitest's default 60s testTimeout and flakes on cold CI
+// runners (every CI run cold-starts — setup-go uses cache:false). Later runs
+// reuse the warm cache and finish in seconds, so only the first invocation is
+// slow; give the whole file 2× headroom rather than caching (the golangci-lint
+// GH-Action cache is slow and grows unbounded — see ticket discussion).
+vi.setConfig({ testTimeout: 120_000 });
 
 describe('E2E: Go Golden Path', () => {
   let projectDirectory: string;


### PR DESCRIPTION
## What

`vi.setConfig({ testTimeout: 120_000 })` at the top of `golang-golden-path.test.ts`, raising its tests from vitest's default 60s to 120s.

## Why

The first `golangci-lint run` in the suite **cold-starts** — it type-checks the Go code (compiling stdlib deps), initializes safeword's curated linter set, and builds golangci-lint's cache — which clocks ~62s. That sits right on the 60s default `testTimeout`, and every CI run cold-starts (`setup-go` uses `cache: false`, and there's no golangci-lint cache), so it flaked at the edge — **observed 61.96s on PR #189's CI** (`golangci-lint runs on valid code` > "Test timed out in 60000ms"). Later golangci-lint tests reuse the warm cache and finish in seconds.

## Why this fix (not the alternatives — via `/figure-it-out`)

- **Bump the timeout (this):** the ~62s cold-start is a *legitimate* cost, not a regression, so a realistic timeout is the correct fix. 120s is ~2× the observed worst case; eliminates the flake everywhere (local + CI, including cache-miss). `vi.setConfig` verified to apply file-wide.
- **Not `actions/cache` the golangci-lint cache:** the official action's cache is [documented to be slow and grow unbounded](https://github.com/golangci/golangci-lint-action/issues/465) (fetch/upload can exceed the 62s it'd save), and cache-miss runs still cold-start — net negative.
- **Not warm in `beforeAll`:** would just relocate the 62s into the already-loaded 180s setup hook, trading the flake for a `beforeAll` flake.

## Verification

- `vi.setConfig({ testTimeout })` confirmed to apply at file scope (probe test timed out exactly at the configured value).
- Full file passes locally (11/11; golangci-lint warm here). Lint clean. Single-file change.
- The real cold-start fix is confirmed by the existing CI data point (61.96s < 120s).

Unrelated to (but unblocks recurrence on) the spec.md gate PR #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)