### PR TITLE
test(smoke): fold phase0-walkthrough into test:smoke + fix stale comment

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "test:done": "vitest run tests/hooks/ tests/schema.test.ts",
     "test:integration": "vitest run tests/integration/",
     "test:smoke:fast": "vitest run tests/hooks/ tests/schema.test.ts tests/integration/quality-gates.test.ts tests/integration/jtbd-gate.test.ts tests/smoke/hook-coverage.test.ts",
-    "test:smoke": "tsup && vitest run tests/hooks/ tests/schema.test.ts tests/integration/quality-gates.test.ts tests/integration/jtbd-gate.test.ts tests/smoke/hook-coverage.test.ts tests/integration/golden-path.test.ts",
+    "test:smoke": "tsup && vitest run tests/hooks/ tests/schema.test.ts tests/integration/quality-gates.test.ts tests/integration/jtbd-gate.test.ts tests/smoke/hook-coverage.test.ts tests/integration/phase0-walkthrough.test.ts tests/integration/golden-path.test.ts",
     "test:smoke:live": "vitest run --config vitest.live.config.ts",
     "test:release": "vitest run --config vitest.release.config.ts",
     "test:slow": "vitest run --config vitest.slow.config.ts",

--- a/packages/cli/tests/smoke/steering.live.test.ts
+++ b/packages/cli/tests/smoke/steering.live.test.ts
@@ -11,8 +11,10 @@
  * Costs ~1.5¢/run (pinned Haiku); `--max-budget-usd` is the hard ceiling.
  *
  * Why these choices (all verified against claude 2.1.161 this session):
- * - intake-phase gate, NOT the 9EA27P spec.md gate — intake is a stable, long-
- *   standing invariant; 9EA27P isn't on main yet and would silently allow.
+ * - intake-phase gate as the canary — it's safeword's most stable, long-standing
+ *   invariant (you can't write scenarios before leaving intake), so it's the
+ *   least likely gate to churn out from under this test. (The 9EA27P spec.md gate
+ *   also works now that it's merged, but intake is the safer long-term anchor.)
  * - point the project's hook at the real source hook (no `safeword setup`) —
  *   same shipping code, no 180s install (golden-path already covers install).
  * - `--allowedTools Write` lets the permission layer ALLOW the write, so the


### PR DESCRIPTION
## What

Two small smoke-test refinements:

1. **Fold `phase0-walkthrough.test.ts` into the `test:smoke` e2e tier.** It's the existing deterministic test (E1K5ZW) that drives the real `pre-tool-quality` hook + `safeword check --offline` over one ticket — spec scaffold → JTBD/AC gates → numbered scenarios → coverage clears — proving the four product layers compose.
2. **Fix a stale comment** in `steering.live.test.ts` (the "9EA27P isn't on main yet" rationale — it's merged now).

## Why

The on-demand smoke attested *gate logic* (fast tier) and *a real install lints* (golden-path), but **not** that the Phase-0 product pipeline composes — a core thing, with a cheap (~8s), deterministic, already-existing test for it, and the e2e tier already builds the `dist` its `runCli` needs. Folding it in makes the smoke story coherent:

| Tier | Attests |
|---|---|
| `test:smoke:fast` | gate logic + schema + hook-coverage drift guard |
| `test:smoke` | the above **+ Phase-0 composition (`phase0-walkthrough`)** + real install (`golden-path`) |
| `test:smoke:live` | a real Claude agent gets steered (intake gate) |

Decided via `/figure-it-out`: chosen over adding a *live-agent* phase-0 walkthrough (flaky by construction — a multi-turn agent authoring valid JTBDs/ACs/scenarios) and over leaving the smoke steering-only (omits a core, cheap, available signal). The live harness stays steering-only by design. Not added to `test:smoke:fast` — that tier is build-free and `phase0-walkthrough` needs `dist`.

## Verification

`bun run test:smoke` green — 26 files, 409 tests. Lint clean. Two-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)