### PR TITLE
feat(0QTXMB): effort: low on tool-driven skills (lint, cleanup-zombies)

### DIFF
--- a/.claude/skills/cleanup-zombies/SKILL.md
+++ b/.claude/skills/cleanup-zombies/SKILL.md
@@ -3,6 +3,7 @@ name: cleanup-zombies
 description: Kill zombie dev servers and test processes. Use when ports are
   blocked, processes are hanging, or test runners won't start.
 allowed-tools: '*'
+effort: low
 ---
 
 # Cleanup Zombies

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -4,6 +4,7 @@ description: Run linters and formatters to fix code style issues. Use when
   cleaning up style violations, formatting code, or after implementation to
   ensure code meets project standards.
 allowed-tools: '*'
+effort: low
 ---
 
 # Lint

--- a/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/ticket.md
+++ b/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/ticket.md
@@ -2,12 +2,12 @@
 id: 0QTXMB
 slug: effort-frontmatter-skills
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 epic: cc-changelog-alignment
 relates_to: 8R54HV
 created: 2026-05-31T21:05:09.536Z
-last_modified: 2026-06-05T17:18:00.000Z
+last_modified: 2026-06-05T17:34:00.000Z
 ---
 
 # Per-skill `effort: low` on tool-driven skills
@@ -54,3 +54,4 @@ This invalidates the original 3-tier mapping. Rescoped below (via `/figure-it-ou
 - 2026-05-31T21:05:09.536Z Started: Created ticket 0QTXMB
 - 2026-05-31 Confirmed no skill sets effort and no hook reads $CLAUDE_EFFORT.
 - 2026-06-05T17:18:00.000Z Revalidated (CC 2.1.161) + rescoped via `/figure-it-out`. Mechanism still current, but frontmatter is an absolute override (not a floor): the original 3-tier mapping was a no-op (high/default tiers) and harmful (capping reasoning skills below `/effort xhigh`). Rescoped to the one real lever — `effort: low` on the two tool-driven skills (`lint`, `cleanup-zombies`); reasoning skills left unset; hook-scaling rejected. Implemented the 4 frontmatter edits (both copies; parity test green).
+- 2026-06-05T17:34:00.000Z Verified + done. `/verify`: full suite **2488/2488 green**, build ✅, lint ✅, dep-drift clean, parity green (630 skill/reconcile/schema tests accept the new field). `/quality-review` APPROVE (change is a no-op-if-wrong, zero downside). verify.md written. PR #195. Status → done.

--- a/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/ticket.md
+++ b/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/ticket.md
@@ -2,51 +2,55 @@
 id: 0QTXMB
 slug: effort-frontmatter-skills
 type: task
-phase: intake
+phase: implement
 status: in_progress
 epic: cc-changelog-alignment
 relates_to: 8R54HV
 created: 2026-05-31T21:05:09.536Z
-last_modified: 2026-05-31T21:05:09.536Z
+last_modified: 2026-06-05T17:18:00.000Z
 ---
 
-# Per-skill effort frontmatter + $CLAUDE_EFFORT gate scaling
+# Per-skill `effort: low` on tool-driven skills
 
-**Goal:** Tune reasoning effort per skill (high for hard reasoning, low for mechanical work) and let hooks read effort to scale gate strictness.
+**Goal:** Lower reasoning effort on safeword's genuinely tool-driven skills (`lint`, `cleanup-zombies`) so they don't burn reasoning the linters / kill-commands do anyway. Leave reasoning skills unset so the user's session `/effort` controls them.
 
-**Why:** CC now exposes effort as skill/agent frontmatter and to hooks/bash. Safeword can spend reasoning where it pays off (debug, decisions, review) and save it where it doesn't (lint), and gates could adapt to the session's effort level.
+**Why:** Claude Code exposes per-skill `effort:` frontmatter. On tool-driven skills the model only orchestrates deterministic tools, so `effort: low` saves tokens with no quality loss. (The original ambition — a "high" tier to _boost_ reasoning skills — is a no-op-or-harmful on a default-high session; see revalidation.)
 
-## Findings
+## Revalidation (2026-06-05, CC 2.1.161 — was planned against 2.1.120–2.1.154)
 
-- CC `2.1.120`: "Skills reference `${CLAUDE_EFFORT}`."
-- CC `2.1.133`: "Hooks receive `effort.level` and `$CLAUDE_EFFORT`; Bash commands read `$CLAUDE_EFFORT`."
-- CC `2.1.149`: status bar respects skill/agent `effort:` frontmatter; `/usage` per-category.
-- CC `2.1.154`: Opus 4.8 defaults to high effort; `/effort xhigh` available.
+Mechanism re-verified current against CC docs:
 
-## Evidence in safeword
+- Skill `effort:` frontmatter exists; values `low/medium/high/xhigh/max` on Opus 4.8. ([skills.md](https://code.claude.com/docs/en/skills.md#frontmatter-reference))
+- Hooks receive `effort.level` + `$CLAUDE_EFFORT`; Bash commands get `$CLAUDE_EFFORT`. ([hooks.md](https://code.claude.com/docs/en/hooks.md))
+- **Precedence (the decisive finding):** env var > frontmatter `effort:` > session/`/effort` > model default. Frontmatter is an **absolute override** of the session level, **not a floor**. ([model-config.md](https://code.claude.com/docs/en/model-config.md#adjust-effort-level))
 
-- Grep confirms no skill sets `effort:` and no hook reads `$CLAUDE_EFFORT` today.
-- Effort mapping (proposed):
-  - High: `debug`, `figure-it-out`, `quality-review`, `audit`, `tdd-review`.
-  - Default: `bdd`, `refactor`, `testing`, `verify`, `ticket-system`, `versioning`.
-  - Low: `lint`, `cleanup-zombies` (mechanical).
+**Consequence on a default-high (Opus 4.8) session:**
 
-## Approach
+- `effort: low` → genuinely lowers reasoning (cost saving). ✓ the only useful lever.
+- `effort: high`/`medium` → no-op (session is already ≥ that).
+- `effort: high` on a **reasoning** skill → **harmful**: caps it below a user's `/effort xhigh`, stealing their control.
 
-- Add `effort:` to skill frontmatter per the mapping; confirm valid values and behavior on Opus 4.8 (already high by default — does per-skill `effort:` still differentiate?) against current CC docs.
-- Optional, smaller: have a gate hook read `$CLAUDE_EFFORT` to scale strictness (e.g., be terser in low-effort sessions). Keep this minimal — only if it earns its complexity.
+This invalidates the original 3-tier mapping. Rescoped below (via `/figure-it-out`).
 
-## Done when
+## Scope
 
-- Skills carry an `effort:` value matching the mapping (or a reasoned subset), verified against current CC docs.
-- Decision recorded on whether hook-side `$CLAUDE_EFFORT` scaling is worth adding (yes → implemented; no → noted why).
-- Templates + dogfood copies in parity.
+- Add `effort: low` to the frontmatter of **`lint`** and **`cleanup-zombies`** — both tool-driven (linters / kill-commands do the work; the model only orchestrates). Mirror across `packages/cli/templates/skills/` ↔ `.claude/skills/` (byte-identical).
+- Leave **all reasoning skills unset** (`debug`, `figure-it-out`, `quality-review`, `audit`, `tdd-review`, `bdd`, `refactor`, `testing`, `verify`, `ticket-system`, `versioning`) → they inherit the session effort, so the user's `/effort` (incl. `xhigh`) controls them.
 
 ## Out of scope
 
-- Reworking which model runs (effort ≠ model selection).
+- The 3-tier mapping's "High"/"Default" tiers — no-op or reasoning-capping; rejected.
+- Hook-side `$CLAUDE_EFFORT` gate-scaling — scaling gate strictness by effort is niche behavior for real complexity; doesn't earn its keep. **Decision: no.**
+- Model selection (effort ≠ model).
+
+## Done when
+
+- `lint` and `cleanup-zombies` SKILL.md carry `effort: low` in both copies (template + dogfood), byte-identical (parity green).
+- No reasoning skill has `effort:` set (user `/effort` retains control).
+- Hook-scaling decision recorded (no). Full suite + lint green.
 
 ## Work Log
 
 - 2026-05-31T21:05:09.536Z Started: Created ticket 0QTXMB
 - 2026-05-31 Confirmed no skill sets effort and no hook reads $CLAUDE_EFFORT.
+- 2026-06-05T17:18:00.000Z Revalidated (CC 2.1.161) + rescoped via `/figure-it-out`. Mechanism still current, but frontmatter is an absolute override (not a floor): the original 3-tier mapping was a no-op (high/default tiers) and harmful (capping reasoning skills below `/effort xhigh`). Rescoped to the one real lever — `effort: low` on the two tool-driven skills (`lint`, `cleanup-zombies`); reasoning skills left unset; hook-scaling rejected. Implemented the 4 frontmatter edits (both copies; parity test green).

--- a/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/verify.md
+++ b/.safeword-project/tickets/0QTXMB-effort-frontmatter-skills/verify.md
@@ -1,0 +1,26 @@
+# Verify — 0QTXMB (effort: low on tool-driven skills)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 2488/2488 tests pass (1 skipped — the live smoke tier) — full suite on fresh dist (`bun run test`, includes `pretest: tsup`)
+**Build:** ✅ Success — tsup ESM + DTS
+**Lint:** ✅ Clean — `eslint . && tsc --noEmit`, exit 0
+**Scenarios:** ⏭️ N/A — task (no test-definitions.md; tasks carry no scenarios)
+**Dep Drift:** ✅ Clean — no dependency changes (frontmatter only; `package.json` deps untouched)
+**Parent Epic:** cc-changelog-alignment (epic-tagged; no `parent:`/children array — not a blocking dependency)
+**Reconcile:** ✅ No pattern deviation — adds a documented Claude Code frontmatter field (`effort:`) to existing skill files; no new pattern introduced.
+
+Audit: not gate-required for tasks (feature-only); `/quality-review` ran instead — APPROVE, with the key finding that the change is a harmless no-op even if CC ignored `effort:` (safeword validators accept the field; unrecognized frontmatter keys don't break skill loading).
+
+## Done-when evidence
+
+- **`lint` + `cleanup-zombies` carry `effort: low` in both copies, byte-identical** — `dogfood-parity.release.test.ts` green; manual `diff` IDENTICAL on both pairs. ✓
+- **No reasoning skill has `effort:` set** — only the two tool-driven skills changed (grep-confirmed); reasoning skills inherit the session `/effort`. ✓
+- **Hook-scaling decision recorded (no)** — in ticket scope/out-of-scope, with rationale. ✓
+- **Full suite + lint green** — 2488/2488; 630 skill/reconcile/schema tests accept the new field. ✓
+
+## Revalidation note
+
+Mechanism re-verified against CC 2.1.161 (was planned 2.1.120–2.1.154): `effort:` is an absolute override of the session level (env > frontmatter > `/effort` > model default), not a floor — which invalidated the original 3-tier mapping and rescoped this to `low`-on-tool-driven-skills only. Doc-verified, not empirically observed to take effect; safe either way (no-op if wrong).
+
+Ready to mark done.

--- a/packages/cli/templates/skills/cleanup-zombies/SKILL.md
+++ b/packages/cli/templates/skills/cleanup-zombies/SKILL.md
@@ -3,6 +3,7 @@ name: cleanup-zombies
 description: Kill zombie dev servers and test processes. Use when ports are
   blocked, processes are hanging, or test runners won't start.
 allowed-tools: '*'
+effort: low
 ---
 
 # Cleanup Zombies

--- a/packages/cli/templates/skills/lint/SKILL.md
+++ b/packages/cli/templates/skills/lint/SKILL.md
@@ -4,6 +4,7 @@ description: Run linters and formatters to fix code style issues. Use when
   cleaning up style violations, formatting code, or after implementation to
   ensure code meets project standards.
 allowed-tools: '*'
+effort: low
 ---
 
 # Lint


### PR DESCRIPTION
## What

Adds `effort: low` to the frontmatter of the `lint` and `cleanup-zombies` skills (both the `templates/` source and the `.claude/` dogfood mirror). Rewrites ticket **0QTXMB** to its revalidated, narrower scope.

## Why (revalidation changed the plan)

The ticket was planned against CC 2.1.120–2.1.154 with a 3-tier `effort:` mapping. Revalidating against **CC 2.1.161** surfaced the decisive fact: per-skill `effort:` is an **absolute override** of the session level (precedence: env var > frontmatter > `/effort` > model default), **not a floor**. On a default-`high` (Opus 4.8) session that means:

- `effort: low` → genuinely lowers reasoning (saves tokens) — the *only* useful lever.
- `effort: high`/`medium` → no-op (already ≥ that).
- `effort: high` on a **reasoning** skill → **harmful**: caps it below a user's `/effort xhigh`, stealing their control.

So the original "High" tier was no-op-or-harmful. Rescoped (via `/figure-it-out`) to just `effort: low` on the two genuinely **tool-driven** skills — the linters / kill-commands do the work, the model only orchestrates, so lower reasoning is free savings. All reasoning skills left **unset** so the session `/effort` controls them. Hook-side `$CLAUDE_EFFORT` gate-scaling **rejected** (niche behavior, complexity > value).

Citations (verified 2.1.161): [skills frontmatter](https://code.claude.com/docs/en/skills.md#frontmatter-reference), [hooks effort](https://code.claude.com/docs/en/hooks.md), [precedence](https://code.claude.com/docs/en/model-config.md#adjust-effort-level).

## Verification

- Dogfood-parity test green; both pairs byte-identical.
- 630 skill/reconcile/schema tests pass with the new field (no allowlist rejects `effort:`).
- `eslint`/`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)