### PR TITLE
chore(release): v0.42.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.42.0

Minor. Largely additive, with two gracefully-degrading behavior changes (noted
below). Auto-upgrade-safe: nothing crashes a setup; both behavior changes fail
loud with a named one/two-line remedy.

Additive

- Review-stamp ledger (NMSD94): two-tier review gates — Tier 1 per-asset stamp
  - Tier 2 phase-advance fork — plus the /self-review skill. Wired default-off
    behind a rollout guard; no effect until a project opts in.
- replan-on-resume (153): the prompt hook flags sibling commits that touched a
  resumed ticket's referenced files and offers an opt-in sub-agent replan.
- Smoke-test tiers (0WQA9V): on-demand test:smoke:fast / test:smoke, a live
  real-model tier, and a hook-drift guard. Dev-only (scripts + tests).
- Tracked Open Questions artifact in intake (V6N5PW).
- effort: low on tool-driven skills — lint, cleanup-zombies (0QTXMB).

Behavior changes (graceful)

- Decomposition phase retired (FSX1PP, W9GPE7): scenario-gate now routes
  straight to implement. DECOMPOSITION.md + the Cursor rule removed, phase enum
  trimmed, ADR recorded. An in-flight `decomposition` ticket degrades to the
  implement guidance via the unknown-phase fallback — no crash.
- spec.md required for features (9EA27P): the JTBD / Acceptance-Criteria gates
  now fail closed for a `type: feature` with no spec.md instead of silently
  skipping. Escape valve: a two-line `## Jobs To Be Done` + `skip: <reason>`.
  Tasks and patches untouched.

Hardening

- Shell-injection closed in hook git calls — execFileSync + sha validation
  (153, 1JMSH6).
- Path-traversal validation on --ticket / artifact names (NMSD94).
- JTBD gate accepts derived persona codes (G9BXE9); intake-exit gate rejects
  empty scope / out_of_scope / done_when lists (9S6600).

Also: ticket triage (13 stale/superseded closed) and a website workflow page
with a mermaid diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
