### PR TITLE
chore(release): v0.43.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "source": "./plugin",
       "author": { "name": "safeword" }
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release — strictly additive (auto-upgradeable per the versioning contract).

Rolls up PR #200 (BDD Phase 1 + executable Gherkin):

- **New:** `safeword codify <ticket>` — emit runnable test stubs from a ticket's scenarios (native vitest skeletons; `--format gherkin` for tagged `.feature` files)
- **New:** `/review-spec` skill — the re-invokable adversarial scenario gate (vacuous-pass, AODI, determinism, negative-case, cross-cutting)
- **New:** scenario-construction rules + gate upgrades in the bdd skill
- **New:** cucumber-js acceptance lane scaffolded by `safeword setup` in every project — `cucumber.mjs` (owned), `features/` + `steps/` starters (customer-owned), `@cucumber/cucumber`/`tsx`/`@types/node` base deps, `test:bdd` script (add-if-absent). Repos with no `package.json` (pure Go/Rust/Python) get a minimal private one created to host the lane.
- **Fix:** Gherkin `features/` dirs no longer trip architecture detection; scaffolded TS steps pass typecheck hooks

**Headline for upgraders:** existing non-JS safeword projects gain the BDD lane (incl. a `package.json` + JS dev-tooling) — additive; nothing existing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)