### PR TITLE
chore(release): v0.44.0

### DIFF
--- a/.safeword-project/tickets/AQJ95G-project-namespace-default/spec.md
+++ b/.safeword-project/tickets/AQJ95G-project-namespace-default/spec.md
@@ -1,0 +1,74 @@
+# Spec: Epic: default namespace .safeword-project/ → .project/ (configurable root, legacy detection)
+
+<!--
+Product-framing spec for a feature ticket. The engineering contract
+(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
+file holds the *why and who*. The bdd intake flow authors it before
+engineering scope. Fill each section, then delete the
+guidance comments.
+-->
+
+## Intent
+
+<!-- One or two sentences: what this feature is for and why it matters.
+This is the single source of truth for motivation — ticket.md drops its
+**Why:** line and points here. -->
+
+## References
+
+<!-- Related tickets, prior art, designs, external docs. Optional. -->
+
+## Personas
+
+<!-- The personas this feature serves, referenced by name or code from
+.safeword-project/personas.md (e.g., Platform Operator (PO)). Add new
+personas to that file — don't invent them here. -->
+
+## Vocabulary
+
+<!-- Domain terms specific to this feature, consistent with
+.safeword-project/glossary.md. Optional. -->
+
+## Jobs To Be Done
+
+<!--
+One persona per JTBD, in the form "When I …, I want …, so I can …". If two
+personas share a motivation, write two JTBDs. The heading id is
+<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
+feature needs. If there is genuinely no persona-facing job (internal
+plumbing), write `skip: <reason>` here instead.
+
+Uncomment and customize:
+
+### oauth-flow.PO1 — Rotate credentials without a flag day
+
+**Persona:** Platform Operator (PO)
+
+> When I rotate a server's API key, I want the previous key to keep working
+> for a short grace period, so I can roll the change across my fleet without
+> coordinated downtime.
+
+Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
+in descriptive product language (a guarantee the user can observe), NOT
+implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
+scenario will prove a specific AC. If a JTBD has no user-observable capability
+to enumerate, write `skip: <reason>` under it instead of ACs.
+
+#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+
+#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
+-->
+
+## Outcomes
+
+<!-- Observable results that tell us the JTBDs are satisfied — the product
+counterpart to ticket.md's done_when. -->
+
+## Open Questions
+
+<!-- Unresolved questions surfaced during intake — the spec's running list of
+what we don't know yet (the equivalent of Example Mapping's red "question"
+cards). Add one per line as they come up; before advancing to define-behavior,
+resolve each (answer it, then delete the line) or record `defer: <reason>` for
+a deliberate punt. A long unresolved list means intake isn't done — keep
+converging. Delete this comment when you add real questions. -->

--- a/.safeword-project/tickets/AQJ95G-project-namespace-default/ticket.md
+++ b/.safeword-project/tickets/AQJ95G-project-namespace-default/ticket.md
@@ -1,0 +1,38 @@
+---
+id: AQJ95G
+slug: project-namespace-default
+type: feature
+phase: intake
+status: in_progress
+created: 2026-06-12T04:08:06.464Z
+last_modified: 2026-06-12T04:08:06.464Z
+---
+
+# Epic: default namespace .safeword-project/ → .project/ (configurable root, legacy detection)
+
+**Goal:** Make `.project/` the default safeword namespace root (replacing `.safeword-project/`), with a configurable root override and automatic legacy detection — converging safeword and arcade on one convention instead of bridging two.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Decisions (locked at intake, driver-confirmed 2026-06-12)
+
+1. **Name: `.project/` (singular)** — byte-for-byte match with arcade's existing convention; safeword reads arcade's real personas/glossary/specs with zero config. Driver confirmed.
+2. **Configurable root** — users can point the namespace elsewhere. Extend the K7N2QM `paths.*` machinery with a root-level key (e.g. `paths.projectRoot`); per-file `paths.personas`/`paths.glossary`/`paths.architecture` overrides keep working and resolve against the root. Driver-required.
+3. **Back-compat: detect, don't force** — resolution precedence per project: explicit config → `.project/` → legacy `.safeword-project/`. Existing installs untouched; fresh `safeword setup` scaffolds `.project/`; optional `safeword migrate-namespace` command (git-aware move + config check) for converging old installs.
+4. **Supersedes P8RJ4M** — the cross-tool coexistence bridge is cancelled-by-convergence once this ships; arcade's temporary `paths.*` overrides (decommission checklist) become removable.
+
+## Scope notes (for intake refinement)
+
+- Pervasive-token sweep: `.safeword-project` appears across packages/cli src (TICKETS_SUBPATH, schema, setup, check, ticket-sync), templates/hooks (quality-state, active-ticket, stop-quality, write-review-stamp, jtbd), skills docs (bdd/\*, SAFEWORD.md), website docs + glossary, and tests — apply the exhaustive-grep discipline (all surfaces, fresh build, subprocess tests can lie on stale dist).
+- The resolution precedence must be computed once and shared (single resolver), not re-derived per call site — that's the design center of the epic.
+- Both-dirs-present is the ambiguous cell: define it (config wins; otherwise warn via `safeword check` advisory and prefer `.project/`? settle at /figure-it-out).
+- Sequencing: ships as 0.45.0; 0.44.0 (M6D315 capabilities) releases first so the arcade decommission isn't blocked on this epic.
+
+## Work Log
+
+- 2026-06-12T04:08:06.464Z Started: Created ticket AQJ95G
+- 2026-06-12T04:09:00.000Z Drafted: epic shell with 4 locked decisions (driver-confirmed: .project/ singular + configurable root), scope notes, sequencing after 0.44.0. Supersedes P8RJ4M.
+
+## Work Log
+
+- 2026-06-12T04:08:06.464Z Started: Created ticket AQJ95G

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,14 +1,18 @@
 {
   "name": "safeword",
   "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-  "owner": { "name": "safeword" },
+  "owner": {
+    "name": "safeword"
+  },
   "plugins": [
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "source": "./plugin",
-      "author": { "name": "safeword" }
+      "author": {
+        "name": "safeword"
+      }
     }
   ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release carrying epic M6D315 (merged in #204): impl-plan artifact + stop-hook gates, ADR consultation (`paths.architecture` file-or-directory), plan-vs-actual reconciliation gate, harness degraded path. Also includes the AQJ95G namespace-epic draft (docs-only, slated for 0.45.0).

**Semver check (minor, strictly additive):** new quality gates/checks per the versioning contract — new-flow features gain the impl-plan gates with self-service unblocks (skip-annotated sections; block messages name the template + procedure). No removals, renames, or behavior changes to existing capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)