### PR TITLE
chore(release): v0.45.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.45.0** (minor — strictly additive, auto-upgrade safe).

Rolls up the platform-uplift work merged in #206:

- **Structured ticket relations** — `depends_on` frontmatter, INDEX edge rendering, `safeword check` dangling/cycle advisories (AKZJXC).
- **`/explain` skill** — on-demand plain-English translation of artifacts + state; absorbs catch-me-up (NTT094).
- **Replan blocker-moved advisory** — heads-up when a `depends_on` blocker reaches a terminal status (E11N48).
- **Slug-first ticket references** across hooks / CLI / INDEX (ZRXM6Q).
- **Styled-output glyph fix** — no orphaned `✓` (469YSR).
- **Customer fixes** — managed `.gitignore` ships transient-state paths; `safeword upgrade` untracks pre-committed ones.

Bumps `packages/cli/package.json` + `marketplace.json` to 0.45.0. Tag push after merge triggers `release.yml` → npm publish via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)