### PR TITLE
chore(release): v0.46.1

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.46.0",
+      "version": "0.46.1",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release: JYWZG1 — after `safeword upgrade --migrate-namespace` moves a repo to .project/, warn (never edit) on customer tooling configs still referencing the old namespace. Additive + read-only; auto-upgrade safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)