### PR TITLE
chore(release): v0.46.2

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.46.1",
+      "version": "0.46.2",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump safeword CLI and Claude Code marketplace versions to 0.46.2.

## Verification
- bun install --frozen-lockfile
- bun audit
- bun run --cwd packages/cli test:release