### PR TITLE
fix(upgrade): capture safeword package version

### DIFF
--- a/.project/tickets/72VX8K-upgrade-captures-package-version/ticket.md
+++ b/.project/tickets/72VX8K-upgrade-captures-package-version/ticket.md
@@ -1,0 +1,53 @@
+---
+id: 72VX8K
+slug: upgrade-captures-package-version
+title: Capture upgraded safeword version in package.json
+type: task
+phase: done
+status: done
+priority: medium
+created: 2026-06-13T00:00:00Z
+last_modified: 2026-06-13T18:27:56Z
+scope:
+  - Update `safeword upgrade` so a root `package.json` that depends on safeword records the current CLI version after upgrade.
+  - Preserve local-only dependency specs such as `file:` and `workspace:` so development and dogfood installs keep working.
+  - Route stale registry-style safeword bumps through the detected package manager using the exact running CLI version so lockfiles can stay in sync.
+out_of_scope:
+  - Changing install-time package manager behavior.
+  - Hand-editing lockfiles or changing non-safeword dependency semantics.
+  - Adding safeword to package.json when the project intentionally relies on a workspace member package instead.
+done_when:
+  - `safeword upgrade` changes an older registry-style safeword devDependency to the running CLI version.
+  - Upgrade leaves local `file:` or `workspace:` safeword specs unchanged.
+  - npm-lock projects update stale registry-style safeword specs via the package manager path.
+  - Existing upgrade behavior for `.safeword/version` still passes.
+---
+
+# Task: Capture upgraded safeword version in package.json
+
+**Type:** Improvement
+
+**Scope:** Keep package.json aligned with the safeword version installed by an upgrade. This records the new version in the project manifest instead of relying only on `.safeword/version`.
+
+**Out of Scope:** Direct lockfile editing, package-manager install strategy changes, and dogfood/workspace self-install behavior.
+
+**Done When:**
+
+- [x] Older registry-style safeword dependency specs update to the current CLI version.
+- [x] Local `file:` and `workspace:` safeword specs are preserved.
+- [x] npm-lock projects use the package-manager path for stale registry-style safeword bumps.
+- [x] Existing upgrade tests remain green.
+
+**Tests:**
+
+- [x] CLI integration: upgrade rewrites an old registry-style `devDependencies.safeword` spec.
+- [x] CLI integration: upgrade preserves a local `file:` safeword spec.
+- [x] CLI integration: upgrade delegates stale npm-lock safeword bumps to npm so package-lock can update.
+
+## Work Log
+
+- 2026-06-13T08:33:00Z Complete: added upgrade-side package.json sync for existing registry-style safeword dependency specs while preserving local specs. Verified with upgrade command tests and package lint/typecheck.
+- 2026-06-13T09:23:00Z Quality-review fix: changed stale registry-spec sync to call the detected package manager instead of editing `package.json` directly. Added an npm-lock regression using a fake npm binary to prove package-lock can be updated by the package-manager path.
+- 2026-06-13T17:38:20Z Refactor pass: separated exact install target (`safeword@${VERSION}`) from saved manifest specs (`^${VERSION}` / `${VERSION}` / `~${VERSION}`), after a focused regression exposed that installing `safeword@^${VERSION}` can resolve a newer compatible package version. Extracted local package.json helpers in the upgrade test.
+- 2026-06-13T18:10:21Z Audit pass: rebased the uncommitted work onto `origin/main` (`0fb014ac`, CLI `0.46.2`) and reran audit/verification checks before commit.
+- 2026-06-13T18:27:56Z CI-stability fix: reused the fake npm fixture for registry-spec package.json assertions so tests verify package-manager delegation without depending on live npm registry latency.

--- a/.project/tickets/72VX8K-upgrade-captures-package-version/verify.md
+++ b/.project/tickets/72VX8K-upgrade-captures-package-version/verify.md
@@ -1,0 +1,25 @@
+# Verify: Capture upgraded safeword version in package.json
+
+## Commands
+
+- `bun run --cwd packages/cli test tests/commands/upgrade.test.ts -t "package.json safeword|local safeword"` — 2 passed, 14 skipped.
+- `bun run --cwd packages/cli test tests/commands/upgrade.test.ts -t "package-lock stays in sync"` — 1 passed, 16 skipped.
+- `bun run --cwd packages/cli test tests/commands/upgrade.test.ts -t "package.json safeword|local safeword|package-lock stays in sync"` — 3 passed, 14 skipped.
+- `bun run --cwd packages/cli lint` — passed (`eslint src tests && tsc --noEmit`).
+- `bun run --cwd packages/cli test tests/commands/upgrade.test.ts` — 17 passed.
+- `bunx prettier --check packages/cli/src/commands/upgrade.ts packages/cli/tests/commands/upgrade.test.ts .project/tickets/72VX8K-upgrade-captures-package-version/ticket.md .project/tickets/72VX8K-upgrade-captures-package-version/verify.md` — passed.
+- `git diff --check` — passed.
+- `bunx safeword@latest sync-config --check` — passed (`✓ Config in sync`).
+- `bunx depcruise --output-type err --config .dependency-cruiser.cjs .` — 0 errors, 3 pre-existing warnings.
+- `bunx knip --reporter json` — reported pre-existing unused/unresolved items outside this change.
+- `bunx jscpd . --min-lines 10 --reporters console` — reported pre-existing duplicate blocks; no new duplicate in the upgrade change.
+- `bun outdated` — reported `eslint` current `9.39.4`, latest `10.5.0`.
+
+## Evidence
+
+- Branch verification ran after rebasing onto `origin/main` at `0fb014ac` with `packages/cli` version `0.46.2`.
+- RED: before implementation, `should update package.json safeword dependency to the CLI version` failed with `Received: "^0.1.0"` and `Expected: "^0.46.1"`.
+- RED: quality-review lockfile regression failed because `npm-args.log` was not created, proving upgrade did not delegate the stale safeword bump to npm.
+- RED: refactor regression caught npm range drift: installing `safeword@^0.46.1` wrote `^0.46.2`, so upgrade now installs the exact running CLI version while accepting npm's saved manifest prefix.
+- GREEN: final full upgrade command test file passed after the package-manager-backed refactor.
+- CI-stability: registry-spec tests use a fake npm binary, avoiding live registry installs while still asserting that `upgrade` delegates `safeword@${VERSION}` to the package manager.

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -19,7 +19,7 @@ import { reconcile, type ReconcileResult } from '../reconcile.js';
 import { SAFEWORD_SCHEMA, SAFEWORD_TRANSIENT_PATHS } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
 import { getEslintPeerMismatchWarning } from '../utils/eslint-peer-check.js';
-import { exists, findInTree, readFileSafe, writeFile } from '../utils/fs.js';
+import { exists, findInTree, readFileSafe, readJson, writeFile } from '../utils/fs.js';
 import { untrackIgnoredFiles } from '../utils/git.js';
 import { detectPackageManager, installDependencies } from '../utils/install.js';
 import {
@@ -33,6 +33,28 @@ import { scanStaleNamespaceConfigs } from '../utils/stale-config-scan.js';
 import { maybeAutoPatchOrNudge } from '../utils/vendored-ignores-nudge.js';
 import { compareVersions } from '../utils/version.js';
 import { VERSION } from '../version.js';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+const DEPENDENCY_FIELDS = ['devDependencies', 'dependencies', 'optionalDependencies'] as const;
+const SAFEWORD_REGISTRY_SPEC = `^${VERSION}`;
+const SAFEWORD_INSTALL_SPEC = VERSION;
+const NON_REGISTRY_SPEC_PREFIXES = [
+  'file:',
+  'link:',
+  'portal:',
+  'workspace:',
+  'git+',
+  'github:',
+  'gitlab:',
+  'bitbucket:',
+  'http:',
+  'https:',
+] as const;
 
 function getProjectVersion(safewordDirectory: string): string {
   const versionPath = nodePath.join(safewordDirectory, 'version');
@@ -52,6 +74,54 @@ function stripDeadConfigVersion(safewordDirectory: string): void {
   if (!('version' in parsed)) return;
   delete parsed.version;
   writeFile(configPath, JSON.stringify(parsed, undefined, 2));
+}
+
+function isNonRegistryPackageSpec(spec: string): boolean {
+  return (
+    NON_REGISTRY_SPEC_PREFIXES.some(prefix => spec.startsWith(prefix)) ||
+    spec.startsWith('.') ||
+    spec.startsWith('/')
+  );
+}
+
+function isCurrentSafewordRegistrySpec(spec: string): boolean {
+  return spec === VERSION || spec === SAFEWORD_REGISTRY_SPEC || spec === `~${VERSION}`;
+}
+
+function syncPackageJsonSafewordVersion(cwd: string): boolean {
+  const packageJson = readPackageJson(cwd);
+  if (!packageJson) return false;
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const dependencies = packageJson[field];
+    const currentSpec = dependencies?.safeword;
+    if (!dependencies || currentSpec === undefined || isNonRegistryPackageSpec(currentSpec))
+      continue;
+
+    if (isCurrentSafewordRegistrySpec(currentSpec)) continue;
+    installDependencies(cwd, [`safeword@${SAFEWORD_INSTALL_SPEC}`], 'safeword package');
+    return packageJsonReferencesCurrentSafewordVersion(cwd);
+  }
+
+  return false;
+}
+
+function readPackageJson(cwd: string): PackageJson | undefined {
+  const packageJsonPath = nodePath.join(cwd, 'package.json');
+  return readJson(packageJsonPath) as PackageJson | undefined;
+}
+
+function packageJsonReferencesCurrentSafewordVersion(cwd: string): boolean {
+  const packageJson = readPackageJson(cwd);
+  return DEPENDENCY_FIELDS.some(field => {
+    const spec = packageJson?.[field]?.safeword;
+    return spec !== undefined && isCurrentSafewordRegistrySpec(spec);
+  });
+}
+
+function syncAndRecordPackageJsonSafewordVersion(cwd: string, result: ReconcileResult): void {
+  if (!syncPackageJsonSafewordVersion(cwd)) return;
+  if (!result.updated.includes('package.json')) result.updated.push('package.json');
 }
 
 function printUpgradeSummary(result: ReconcileResult, projectVersion: string, cwd: string): void {
@@ -276,6 +346,7 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
     const ctx = createProjectContext(cwd);
     const result = await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
     installDependencies(cwd, result.packagesToInstall, 'missing packages');
+    syncAndRecordPackageJsonSafewordVersion(cwd, result);
 
     // Migrate renamed pack IDs (dbt → sql)
     migratePackId(cwd, 'dbt', 'sql');

--- a/packages/cli/tests/commands/upgrade.test.ts
+++ b/packages/cli/tests/commands/upgrade.test.ts
@@ -4,8 +4,12 @@
  * Tests for `safeword upgrade` command.
  */
 
+import { chmodSync, mkdirSync } from 'node:fs';
+import nodePath from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { VERSION } from '../../src/version.js';
 import {
   createConfiguredProject,
   createTemporaryDirectory,
@@ -20,6 +24,12 @@ import {
 } from '../helpers';
 
 describe('Test Suite 9: Upgrade', () => {
+  interface TestPackageJson {
+    devDependencies: Record<string, string>;
+    name: string;
+    version: string;
+  }
+
   let temporaryDirectory: string;
 
   beforeEach(() => {
@@ -29,6 +39,118 @@ describe('Test Suite 9: Upgrade', () => {
   afterEach(() => {
     removeTemporaryDirectory(temporaryDirectory);
   });
+
+  function readPackageJson(): TestPackageJson {
+    return JSON.parse(readTestFile(temporaryDirectory, 'package.json')) as TestPackageJson;
+  }
+
+  function writePackageJson(packageJson: TestPackageJson): void {
+    writeTestFile(temporaryDirectory, 'package.json', JSON.stringify(packageJson, undefined, 2));
+  }
+
+  function createNpmLockedProjectWithStaleSafeword(): void {
+    createTypeScriptPackageJson(temporaryDirectory, {
+      devDependencies: {
+        '@cucumber/cucumber': '^13.0.0',
+        '@types/node': '^25.0.0',
+        'dependency-cruiser': '^17.0.0',
+        eslint: '^9.22.0',
+        knip: '^6.0.0',
+        prettier: '^3.0.0',
+        safeword: '^0.1.0',
+        tsx: '^4.0.0',
+        typescript: '^5.0.0',
+      },
+    });
+
+    const packageJson = readPackageJson();
+
+    writeTestFile(temporaryDirectory, '.safeword/version', '0.0.1');
+    writeTestFile(temporaryDirectory, '.safeword/SAFEWORD.md', '# Old content\n');
+    writeSafewordConfig(temporaryDirectory, { installedPacks: ['typescript'] });
+    writeTestFile(
+      temporaryDirectory,
+      'package-lock.json',
+      JSON.stringify(
+        {
+          name: packageJson.name,
+          version: packageJson.version,
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            '': {
+              name: packageJson.name,
+              version: packageJson.version,
+              devDependencies: packageJson.devDependencies,
+            },
+            'node_modules/safeword': {
+              version: '0.1.0',
+              resolved: 'https://registry.npmjs.org/safeword/-/safeword-0.1.0.tgz',
+              integrity: 'sha512-test',
+            },
+          },
+        },
+        undefined,
+        2,
+      ),
+    );
+  }
+
+  function installFakeNpm(): string {
+    const fakeBin = nodePath.join(temporaryDirectory, 'fake-bin');
+    mkdirSync(fakeBin, { recursive: true });
+    const fakeNpmPath = nodePath.join(fakeBin, 'npm');
+    writeTestFile(
+      temporaryDirectory,
+      'fake-bin/npm',
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(args) + '\\n');
+
+const version = process.env.FAKE_SAFEWORD_VERSION;
+if (args.includes(\`safeword@\${version}\`)) {
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  packageJson.devDependencies ||= {};
+  packageJson.devDependencies.safeword = \`^\${version}\`;
+	  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\\n');
+
+	  const packageLockPath = path.join(process.cwd(), 'package-lock.json');
+	  if (!fs.existsSync(packageLockPath)) process.exit(0);
+	  const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+  packageLock.packages ||= {};
+  packageLock.packages[''] ||= {};
+  packageLock.packages[''].devDependencies ||= {};
+  packageLock.packages[''].devDependencies.safeword = \`^\${version}\`;
+  packageLock.packages['node_modules/safeword'] = {
+    version,
+    resolved: \`https://registry.npmjs.org/safeword/-/safeword-\${version}.tgz\`,
+    integrity: 'sha512-test',
+  };
+  fs.writeFileSync(packageLockPath, JSON.stringify(packageLock, null, 2) + '\\n');
+}
+`,
+    );
+    chmodSync(fakeNpmPath, 0o755);
+    return fakeBin;
+  }
+
+  async function runUpgradeWithFakeNpm(): Promise<Awaited<ReturnType<typeof runCli>>> {
+    const fakeBin = installFakeNpm();
+    const fakeNpmLog = nodePath.join(temporaryDirectory, 'npm-args.log');
+
+    return runCli(['upgrade'], {
+      cwd: temporaryDirectory,
+      env: {
+        FAKE_NPM_LOG: fakeNpmLog,
+        FAKE_SAFEWORD_VERSION: VERSION,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+      },
+    });
+  }
 
   describe('Test 9.1: Overwrites .safeword files', () => {
     it('should restore modified files to CLI version', async () => {
@@ -55,6 +177,49 @@ describe('Test Suite 9: Upgrade', () => {
       const version = readTestFile(temporaryDirectory, '.safeword/version').trim();
       expect(version).not.toBe('0.0.1');
       expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it('should update package.json safeword dependency to the CLI version', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      const packageJson = readPackageJson();
+      packageJson.devDependencies.safeword = '^0.1.0';
+      writePackageJson(packageJson);
+
+      const result = await runUpgradeWithFakeNpm();
+
+      expect(result.exitCode).toBe(0);
+      expect(readTestFile(temporaryDirectory, 'npm-args.log')).toContain(`safeword@${VERSION}`);
+      const updatedPackageJson = readPackageJson();
+      expect(updatedPackageJson.devDependencies.safeword).toBe(`^${VERSION}`);
+    });
+
+    it('should preserve local safeword dependency specs', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      const packageJson = readPackageJson();
+      const originalSpec = packageJson.devDependencies.safeword;
+
+      await runCli(['upgrade'], { cwd: temporaryDirectory });
+
+      const updatedPackageJson = readPackageJson();
+      expect(updatedPackageJson.devDependencies.safeword).toBe(originalSpec);
+    });
+
+    it('should update stale registry specs through npm so package-lock stays in sync', async () => {
+      createNpmLockedProjectWithStaleSafeword();
+      const result = await runUpgradeWithFakeNpm();
+
+      expect(result.exitCode).toBe(0);
+      expect(fileExists(temporaryDirectory, 'npm-args.log')).toBe(true);
+      expect(readTestFile(temporaryDirectory, 'npm-args.log')).toContain(`safeword@${VERSION}`);
+
+      const packageLock = JSON.parse(readTestFile(temporaryDirectory, 'package-lock.json')) as {
+        packages: {
+          '': { devDependencies: Record<string, string> };
+          'node_modules/safeword': { version: string };
+        };
+      };
+      expect(packageLock.packages[''].devDependencies.safeword).toBe(`^${VERSION}`);
+      expect(packageLock.packages['node_modules/safeword'].version).toBe(VERSION);
     });
   });
 


### PR DESCRIPTION
## Summary
- Update `safeword upgrade` to sync stale registry-style `safeword` package specs through the detected package manager.
- Install the exact running CLI version so package.json captures the CLI version instead of a newer compatible release.
- Preserve local/non-registry specs and add npm lockfile regression coverage.

## Verification
- `bun run --cwd packages/cli test tests/commands/upgrade.test.ts` — 17 passed
- `bun run --cwd packages/cli lint`
- `bunx prettier --check ...`
- `git diff --check`
- `bunx safeword@latest sync-config --check`
- audit checks run; only pre-existing depcruise/knip/jscpd warnings found