### PR TITLE
Release v0.47.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.46.2",
+      "version": "0.47.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.46.2",
+      "version": "0.47.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump safeword CLI and marketplace metadata to v0.47.0
- Update bun.lock package metadata for the release

## Verification
- bun install --frozen-lockfile
- bun run lint
- bun run test
- bun run --cwd packages/cli test:release
- bun run --cwd packages/cli build
- bun pm pack --cwd packages/cli --destination <tmpdir>