### PR TITLE
Track recursive Bun workspace manifests

### DIFF
--- a/.project/tickets/B8GCC1-protect-advanced-workspace-glob-fallback/ticket.md
+++ b/.project/tickets/B8GCC1-protect-advanced-workspace-glob-fallback/ticket.md
@@ -1,0 +1,48 @@
+---
+id: B8GCC1
+slug: protect-advanced-workspace-glob-fallback
+type: task
+phase: implement
+status: in_progress
+created: 2026-06-15T20:50:56.371Z
+last_modified: 2026-06-15T20:55:46Z
+---
+
+# Protect advanced workspace glob fallback
+
+**Goal:** Lock in the dependency readiness hook's conservative fallback for unsupported advanced Bun workspace glob syntax.
+
+**Why:** Future refactors should not accidentally narrow tracked workspace manifests and falsely report dependencies ready when Bun supports a broader glob language than this hook implements.
+
+**Type:** Improvement
+
+**Scope:** Add targeted regression coverage for unsupported advanced Bun workspace glob patterns such as `{}` and `[]`, proving the hook over-tracks package manifests instead of under-tracking them. Keep the test in the existing dependency-readiness test suite.
+
+**Out of Scope:** Implementing full Bun glob syntax, adding a runtime glob dependency to hook code, changing recursive `**` or simple negative workspace behavior, or modifying dependency bootstrap user-facing messages.
+
+**Done When:**
+
+- [x] Unsupported advanced positive workspace patterns include all package manifests under the static scan base.
+- [x] Unsupported advanced negative workspace patterns do not exclude manifests, preserving the no-false-ready bias.
+- [x] Dependency readiness tests pass.
+
+**Tests:**
+
+- [x] CHARACTERIZATION: Add a unit test proving unsupported advanced positive and negative workspace globs are conservatively over-tracked.
+- [x] GREEN: Existing implementation satisfies the test; no production code change needed.
+- [x] REFACTOR: Keep the test readable and local to related workspace glob coverage.
+
+## Figure-It-Out Decision
+
+Recommend adding a table-driven regression test only. Current Bun docs support full workspace glob syntax, including `?`, `[]`, `{}`, `!`, `*`, and `**`, but this PR intentionally implements a no-dependency common subset for a hot hook and defaults unsupported positive patterns to match-all within their scan base. Implementing full advanced glob support now would add complexity without improving the original safety property.
+
+**Next:** Add the regression test in `packages/cli/tests/hooks/dependency-readiness.test.ts`.
+
+## Work Log
+
+- 2026-06-15T20:50:56.371Z Started: Created ticket B8GCC1
+- 2026-06-15T20:51:06Z Scoped: Rebased PR branch onto `origin/main`; revalidated that main has no unsupported advanced glob fallback coverage.
+- 2026-06-15T20:51:06Z Figure-it-out: Current Bun docs confirm advanced glob syntax; chose coverage-only follow-up to lock the conservative over-tracking contract without adding hook runtime dependencies.
+- 2026-06-15T20:55:46Z Implemented: Added regression coverage for unsupported brace positive and character-class negative workspace patterns.
+- 2026-06-15T20:55:46Z Verified: `bun run --cwd packages/cli test tests/hooks/dependency-readiness.test.ts` passed 49/49, adjacent hook/schema suite passed 84/84, `bun run --cwd packages/cli lint` clean, and `bun run --cwd packages/cli test:release` passed 7/7.
+- 2026-06-15T20:55:46Z Verify blocked: `/verify` invocation recorder fallback failed with `Missing CLAUDE_SESSION_ID` in Codex, so `verify.md` was not hand-written and ticket status remains `in_progress`.

--- a/.project/tickets/E0J9N2-agent-worktree-dependency-bootstrap/ticket.md
+++ b/.project/tickets/E0J9N2-agent-worktree-dependency-bootstrap/ticket.md
@@ -7,7 +7,7 @@ status: done
 epic: cc-changelog-alignment
 relates_to: 8R54HV
 created: 2026-06-13T21:34:07.157Z
-last_modified: 2026-06-15T13:59:34Z
+last_modified: 2026-06-15T19:58:05Z
 ---
 
 # Bootstrap dependencies in Claude-created worktrees
@@ -113,3 +113,4 @@ For Bun projects with a committed `bun.lock`, prefer `bun ci` over bare `bun ins
 - 2026-06-14T01:01:27.000Z Implemented dependency-readiness hook library, SessionStart context/auto-bootstrap hook, PreToolUse Bash guard, schema/settings registration, transient-state ignore rules, and verification coverage. Full package suite passed: 2866/2866 tests, 1 skipped.
 - 2026-06-15T04:17:45Z Figure-it-out follow-up: broadened the dependency-backed command detector for `bun --cwd`, `env` wrappers, `npx`/`npm exec`, `pnpm exec`, `corepack pnpm`, and naked local-bin forms for pnpm/yarn. Kept nested shell parsing out of scope to avoid brittle full-shell emulation in a hot PreToolUse hook.
 - 2026-06-15T13:59:34Z Quality-review fix: synced the three new hook templates into the dogfood `.safeword/` tree so release parity passes.
+- 2026-06-15T19:58:05Z Figure-it-out follow-up: fixed Bun recursive workspace manifest tracking for `packages/**` and negative patterns such as `!packages/**/test/**`, using a no-dependency recursive scanner that over-tracks unsupported advanced glob syntax rather than falsely reporting dependencies ready.

--- a/.project/tickets/E0J9N2-agent-worktree-dependency-bootstrap/verify.md
+++ b/.project/tickets/E0J9N2-agent-worktree-dependency-bootstrap/verify.md
@@ -15,6 +15,7 @@
 **Hook coverage drift guard:** ✅ `tests/smoke/hook-coverage.test.ts` passes; dependency readiness hooks are covered by deterministic hook tests and listed with justification.
 **Schema/install surface:** ✅ `setup-hooks` and schema tests pass; new templates are registered and installed.
 **Command detector follow-up:** ✅ Broadened coverage for `bun --cwd`, `env` wrappers, `npx`/`npm exec`, `pnpm exec`, `corepack pnpm`, and naked pnpm/yarn local-bin commands without adding dependencies.
+**Recursive workspace follow-up:** ✅ Bun workspace tracking now includes recursive `packages/**` manifests and honors simple negative patterns such as `!packages/**/test/**` without adding hook-time dependencies.
 **Dogfood parity:** ✅ New hook templates are synced into `.safeword/` and release parity passes.
 **Audit passed** — no findings attributable to this change.
 
@@ -24,7 +25,7 @@
 - ✅ Default mode is detect-and-guard: SessionStart injects `bun ci` recovery context, and PreToolUse blocks dependency-backed Bash commands until install artifacts exist.
 - ✅ Explicit auto-install mode runs `bun ci` and writes ready state when `.safeword/config.json` opts into `dependencyBootstrap.autoInstall`.
 - ✅ Bootstrap uses `bun ci` for Bun lockfile projects and records failure instead of rewriting dependency metadata when install fails.
-- ✅ Ready installs are skipped when `node_modules` is current; stale/missing artifacts are detected from lockfile and package manifest inputs.
+- ✅ Ready installs are skipped when `node_modules` is current; stale/missing artifacts are detected from lockfile and package manifest inputs, including recursive Bun workspace manifests.
 - ✅ Non-dependency Bash commands such as `git status`, install commands, and quoted text containing dependency commands are allowed without output.
 - ✅ Unsupported projects skip silently.
 
@@ -42,3 +43,7 @@
 - `bun run --cwd packages/cli lint` — clean after command-detector follow-up.
 - `bun run --cwd packages/cli test -- dependency-readiness src/templates/config.test.ts tests/smoke/hook-coverage.test.ts setup-hooks` — 81/81 passed after command-detector follow-up.
 - `bun run --cwd packages/cli test:release` — 7/7 passed after syncing dogfood `.safeword/` hook files.
+- `bun run --cwd packages/cli test -- dependency-readiness` — RED confirmed recursive and negative Bun workspace glob tests failed before implementation; GREEN passed 48/48 after implementation.
+- `bun run --cwd packages/cli test -- dependency-readiness src/templates/config.test.ts tests/smoke/hook-coverage.test.ts setup-hooks` — 83/83 passed after recursive workspace follow-up.
+- `bun run --cwd packages/cli lint` — clean after recursive workspace follow-up.
+- `bun run --cwd packages/cli test:release` — 7/7 passed after recursive workspace follow-up and dogfood sync.

--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  type Dirent,
+} from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
@@ -48,6 +56,13 @@ export interface DependencyReadinessState {
 const INSTALL_ARTIFACT = 'node_modules';
 const DEPENDENCY_STATE_FILENAME = 'dependency-readiness.json';
 const BUN_LOCKFILES = ['bun.lock', 'bun.lockb'];
+const WORKSPACE_SCAN_EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.project',
+  '.safeword',
+  '.safeword-project',
+  'node_modules',
+]);
 const BUN_OPTIONS_WITH_VALUES = new Set([
   '--config',
   '--conditions',
@@ -261,14 +276,7 @@ function collectWorkspacePackageJsonPaths(
   projectDirectory: string,
   rootPackageJson: Record<string, unknown>,
 ): string[] {
-  const patterns = readWorkspacePatterns(rootPackageJson);
-  const packageJsonPaths: string[] = [];
-
-  for (const pattern of patterns) {
-    packageJsonPaths.push(...expandWorkspacePattern(projectDirectory, pattern));
-  }
-
-  return packageJsonPaths;
+  return expandWorkspacePatterns(projectDirectory, readWorkspacePatterns(rootPackageJson));
 }
 
 function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string[] {
@@ -291,34 +299,177 @@ function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string
   return [];
 }
 
-function expandWorkspacePattern(projectDirectory: string, pattern: string): string[] {
-  const normalizedPattern = pattern.replaceAll('\\', '/').replace(/^\.?\//, '');
-  if (normalizedPattern.includes('**')) return [];
+interface WorkspacePattern {
+  pattern: string;
+  negated: boolean;
+}
 
-  const starIndex = normalizedPattern.indexOf('*');
-  if (starIndex === -1) {
-    const packageJsonPath = normalizedPattern.endsWith('/package.json')
-      ? normalizedPattern
-      : `${normalizedPattern.replace(/\/$/, '')}/package.json`;
+function expandWorkspacePatterns(projectDirectory: string, rawPatterns: string[]): string[] {
+  const patterns = rawPatterns
+    .map(normalizeWorkspacePattern)
+    .filter((pattern): pattern is WorkspacePattern => pattern !== undefined);
+  const positivePatterns = patterns.filter(pattern => !pattern.negated);
+  const negativePatterns = patterns.filter(pattern => pattern.negated);
+  const packageJsonPaths = new Set<string>();
+
+  for (const { pattern } of positivePatterns) {
+    for (const packageJsonPath of expandPositiveWorkspacePattern(projectDirectory, pattern)) {
+      if (!isExcludedWorkspacePackage(packageJsonPath, negativePatterns)) {
+        packageJsonPaths.add(packageJsonPath);
+      }
+    }
+  }
+
+  return [...packageJsonPaths];
+}
+
+function normalizeWorkspacePattern(rawPattern: string): WorkspacePattern | undefined {
+  let pattern = rawPattern.trim().replaceAll('\\', '/');
+  const negated = pattern.startsWith('!');
+  if (negated) pattern = pattern.slice(1);
+
+  pattern = pattern.replace(/^\.?\//, '').replace(/\/+$/, '');
+  if (pattern.length === 0) return undefined;
+
+  return { pattern, negated };
+}
+
+function expandPositiveWorkspacePattern(projectDirectory: string, pattern: string): string[] {
+  if (!hasGlobSyntax(pattern)) {
+    const packageJsonPath = pattern.endsWith('/package.json') ? pattern : `${pattern}/package.json`;
     return existsSync(nodePath.join(projectDirectory, packageJsonPath)) ? [packageJsonPath] : [];
   }
 
-  const prefix = normalizedPattern.slice(0, starIndex);
-  const suffix = normalizedPattern.slice(starIndex + 1);
-  if (suffix.includes('*')) return [];
+  return collectPackageJsonPathsUnder(
+    projectDirectory,
+    workspacePatternBaseDirectory(pattern),
+  ).filter(packageJsonPath => matchesWorkspacePattern(pattern, packageJsonPath, true));
+}
 
-  const baseDirectory = nodePath.join(projectDirectory, prefix);
+function collectPackageJsonPathsUnder(
+  projectDirectory: string,
+  relativeBaseDirectory: string,
+): string[] {
+  const baseDirectory = nodePath.join(projectDirectory, relativeBaseDirectory);
   if (!isDirectory(baseDirectory)) return [];
 
-  return readdirSync(baseDirectory, { withFileTypes: true })
-    .filter(entry => entry.isDirectory())
-    .map(entry => {
-      const expanded = `${prefix}${entry.name}${suffix}`;
-      return expanded.endsWith('/package.json')
-        ? expanded
-        : `${expanded.replace(/\/$/, '')}/package.json`;
-    })
-    .filter(relativePath => existsSync(nodePath.join(projectDirectory, relativePath)));
+  const packageJsonPaths: string[] = [];
+  const pendingDirectories = [baseDirectory];
+
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop();
+    if (directory === undefined) continue;
+
+    const relativeDirectory = normalizeRelativePath(nodePath.relative(projectDirectory, directory));
+    const packageJsonPath =
+      relativeDirectory.length > 0 ? `${relativeDirectory}/package.json` : 'package.json';
+    if (existsSync(nodePath.join(directory, 'package.json'))) {
+      packageJsonPaths.push(packageJsonPath);
+    }
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || WORKSPACE_SCAN_EXCLUDED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      pendingDirectories.push(nodePath.join(directory, entry.name));
+    }
+  }
+
+  return packageJsonPaths;
+}
+
+function isExcludedWorkspacePackage(
+  packageJsonPath: string,
+  negativePatterns: WorkspacePattern[],
+): boolean {
+  return negativePatterns.some(({ pattern }) =>
+    matchesWorkspacePattern(pattern, packageJsonPath, false),
+  );
+}
+
+function matchesWorkspacePattern(
+  pattern: string,
+  packageJsonPath: string,
+  unsupportedGlobDefault: boolean,
+): boolean {
+  const target = pattern.endsWith('/package.json')
+    ? packageJsonPath
+    : packageJsonPath.replace(/\/package\.json$/, '');
+  const matcher = workspacePatternMatcher(pattern);
+  if (matcher === undefined) return unsupportedGlobDefault;
+  return matcher.test(target);
+}
+
+function workspacePatternMatcher(pattern: string): RegExp | undefined {
+  if (/[?[\]{}]/.test(pattern)) return undefined;
+
+  let source = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+    const afterNext = pattern[index + 2];
+    if (char === undefined) continue;
+
+    if (char === '*' && next === '*' && afterNext === '/') {
+      source += '(?:.*/)?';
+      index += 2;
+      continue;
+    }
+
+    if (char === '*' && next === '*') {
+      source += '.*';
+      index += 1;
+      continue;
+    }
+
+    if (char === '*') {
+      source += '[^/]*';
+      continue;
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  return new RegExp(`${source}$`);
+}
+
+function workspacePatternBaseDirectory(pattern: string): string {
+  const globIndex = firstGlobSyntaxIndex(pattern);
+  if (globIndex === -1) {
+    return pattern.endsWith('/package.json')
+      ? normalizeRelativePath(nodePath.dirname(pattern))
+      : pattern;
+  }
+
+  const staticPrefix = pattern.slice(0, globIndex);
+  const slashIndex = staticPrefix.lastIndexOf('/');
+  return slashIndex === -1 ? '' : staticPrefix.slice(0, slashIndex);
+}
+
+function firstGlobSyntaxIndex(pattern: string): number {
+  const indexes = ['*', '?', '[', '{']
+    .map(char => pattern.indexOf(char))
+    .filter(index => index !== -1);
+  return indexes.length === 0 ? -1 : Math.min(...indexes);
+}
+
+function hasGlobSyntax(pattern: string): boolean {
+  return firstGlobSyntaxIndex(pattern) !== -1;
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isDependencyBackedSegment(segment: string): boolean {

--- a/.safeword/logs/ticket-B8GCC1-protect-advanced-workspace-glob-fallback.md
+++ b/.safeword/logs/ticket-B8GCC1-protect-advanced-workspace-glob-fallback.md
@@ -1,0 +1,14 @@
+# Work Log: Protect advanced workspace glob fallback
+
+**Anchored to:** `.project/tickets/B8GCC1-protect-advanced-workspace-glob-fallback/ticket.md`
+
+---
+
+## Session: 2026-06-15
+
+- [20:51] Started after rebasing `codex/recursive-bun-workspaces` onto `origin/main`.
+- [20:51] Revalidated: existing tests cover recursive `packages/**` and simple negative `!packages/**/test/**`, but not unsupported advanced `{}` or `[]` fallback semantics.
+- [20:51] Figure-it-out: Bun's current workspace docs point to full glob syntax, but the implementation's safety contract is conservative over-tracking for unsupported advanced forms. Smallest useful work is a unit regression test, not full matcher support.
+- [20:55] Added `over-tracks package manifests for unsupported advanced workspace globs` covering brace positive and character-class negative patterns.
+- [20:55] Verification passed: focused dependency-readiness suite 49/49, adjacent hook/schema suite 84/84, package lint clean, release parity 7/7.
+- [20:55] `/verify` recorder fallback failed with `Missing CLAUDE_SESSION_ID`; per skill instructions, did not hand-write `verify.md` or mark ticket done.

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  type Dirent,
+} from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
@@ -48,6 +56,13 @@ export interface DependencyReadinessState {
 const INSTALL_ARTIFACT = 'node_modules';
 const DEPENDENCY_STATE_FILENAME = 'dependency-readiness.json';
 const BUN_LOCKFILES = ['bun.lock', 'bun.lockb'];
+const WORKSPACE_SCAN_EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.project',
+  '.safeword',
+  '.safeword-project',
+  'node_modules',
+]);
 const BUN_OPTIONS_WITH_VALUES = new Set([
   '--config',
   '--conditions',
@@ -261,14 +276,7 @@ function collectWorkspacePackageJsonPaths(
   projectDirectory: string,
   rootPackageJson: Record<string, unknown>,
 ): string[] {
-  const patterns = readWorkspacePatterns(rootPackageJson);
-  const packageJsonPaths: string[] = [];
-
-  for (const pattern of patterns) {
-    packageJsonPaths.push(...expandWorkspacePattern(projectDirectory, pattern));
-  }
-
-  return packageJsonPaths;
+  return expandWorkspacePatterns(projectDirectory, readWorkspacePatterns(rootPackageJson));
 }
 
 function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string[] {
@@ -291,34 +299,177 @@ function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string
   return [];
 }
 
-function expandWorkspacePattern(projectDirectory: string, pattern: string): string[] {
-  const normalizedPattern = pattern.replaceAll('\\', '/').replace(/^\.?\//, '');
-  if (normalizedPattern.includes('**')) return [];
+interface WorkspacePattern {
+  pattern: string;
+  negated: boolean;
+}
 
-  const starIndex = normalizedPattern.indexOf('*');
-  if (starIndex === -1) {
-    const packageJsonPath = normalizedPattern.endsWith('/package.json')
-      ? normalizedPattern
-      : `${normalizedPattern.replace(/\/$/, '')}/package.json`;
+function expandWorkspacePatterns(projectDirectory: string, rawPatterns: string[]): string[] {
+  const patterns = rawPatterns
+    .map(normalizeWorkspacePattern)
+    .filter((pattern): pattern is WorkspacePattern => pattern !== undefined);
+  const positivePatterns = patterns.filter(pattern => !pattern.negated);
+  const negativePatterns = patterns.filter(pattern => pattern.negated);
+  const packageJsonPaths = new Set<string>();
+
+  for (const { pattern } of positivePatterns) {
+    for (const packageJsonPath of expandPositiveWorkspacePattern(projectDirectory, pattern)) {
+      if (!isExcludedWorkspacePackage(packageJsonPath, negativePatterns)) {
+        packageJsonPaths.add(packageJsonPath);
+      }
+    }
+  }
+
+  return [...packageJsonPaths];
+}
+
+function normalizeWorkspacePattern(rawPattern: string): WorkspacePattern | undefined {
+  let pattern = rawPattern.trim().replaceAll('\\', '/');
+  const negated = pattern.startsWith('!');
+  if (negated) pattern = pattern.slice(1);
+
+  pattern = pattern.replace(/^\.?\//, '').replace(/\/+$/, '');
+  if (pattern.length === 0) return undefined;
+
+  return { pattern, negated };
+}
+
+function expandPositiveWorkspacePattern(projectDirectory: string, pattern: string): string[] {
+  if (!hasGlobSyntax(pattern)) {
+    const packageJsonPath = pattern.endsWith('/package.json') ? pattern : `${pattern}/package.json`;
     return existsSync(nodePath.join(projectDirectory, packageJsonPath)) ? [packageJsonPath] : [];
   }
 
-  const prefix = normalizedPattern.slice(0, starIndex);
-  const suffix = normalizedPattern.slice(starIndex + 1);
-  if (suffix.includes('*')) return [];
+  return collectPackageJsonPathsUnder(
+    projectDirectory,
+    workspacePatternBaseDirectory(pattern),
+  ).filter(packageJsonPath => matchesWorkspacePattern(pattern, packageJsonPath, true));
+}
 
-  const baseDirectory = nodePath.join(projectDirectory, prefix);
+function collectPackageJsonPathsUnder(
+  projectDirectory: string,
+  relativeBaseDirectory: string,
+): string[] {
+  const baseDirectory = nodePath.join(projectDirectory, relativeBaseDirectory);
   if (!isDirectory(baseDirectory)) return [];
 
-  return readdirSync(baseDirectory, { withFileTypes: true })
-    .filter(entry => entry.isDirectory())
-    .map(entry => {
-      const expanded = `${prefix}${entry.name}${suffix}`;
-      return expanded.endsWith('/package.json')
-        ? expanded
-        : `${expanded.replace(/\/$/, '')}/package.json`;
-    })
-    .filter(relativePath => existsSync(nodePath.join(projectDirectory, relativePath)));
+  const packageJsonPaths: string[] = [];
+  const pendingDirectories = [baseDirectory];
+
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop();
+    if (directory === undefined) continue;
+
+    const relativeDirectory = normalizeRelativePath(nodePath.relative(projectDirectory, directory));
+    const packageJsonPath =
+      relativeDirectory.length > 0 ? `${relativeDirectory}/package.json` : 'package.json';
+    if (existsSync(nodePath.join(directory, 'package.json'))) {
+      packageJsonPaths.push(packageJsonPath);
+    }
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || WORKSPACE_SCAN_EXCLUDED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      pendingDirectories.push(nodePath.join(directory, entry.name));
+    }
+  }
+
+  return packageJsonPaths;
+}
+
+function isExcludedWorkspacePackage(
+  packageJsonPath: string,
+  negativePatterns: WorkspacePattern[],
+): boolean {
+  return negativePatterns.some(({ pattern }) =>
+    matchesWorkspacePattern(pattern, packageJsonPath, false),
+  );
+}
+
+function matchesWorkspacePattern(
+  pattern: string,
+  packageJsonPath: string,
+  unsupportedGlobDefault: boolean,
+): boolean {
+  const target = pattern.endsWith('/package.json')
+    ? packageJsonPath
+    : packageJsonPath.replace(/\/package\.json$/, '');
+  const matcher = workspacePatternMatcher(pattern);
+  if (matcher === undefined) return unsupportedGlobDefault;
+  return matcher.test(target);
+}
+
+function workspacePatternMatcher(pattern: string): RegExp | undefined {
+  if (/[?[\]{}]/.test(pattern)) return undefined;
+
+  let source = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+    const afterNext = pattern[index + 2];
+    if (char === undefined) continue;
+
+    if (char === '*' && next === '*' && afterNext === '/') {
+      source += '(?:.*/)?';
+      index += 2;
+      continue;
+    }
+
+    if (char === '*' && next === '*') {
+      source += '.*';
+      index += 1;
+      continue;
+    }
+
+    if (char === '*') {
+      source += '[^/]*';
+      continue;
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  return new RegExp(`${source}$`);
+}
+
+function workspacePatternBaseDirectory(pattern: string): string {
+  const globIndex = firstGlobSyntaxIndex(pattern);
+  if (globIndex === -1) {
+    return pattern.endsWith('/package.json')
+      ? normalizeRelativePath(nodePath.dirname(pattern))
+      : pattern;
+  }
+
+  const staticPrefix = pattern.slice(0, globIndex);
+  const slashIndex = staticPrefix.lastIndexOf('/');
+  return slashIndex === -1 ? '' : staticPrefix.slice(0, slashIndex);
+}
+
+function firstGlobSyntaxIndex(pattern: string): number {
+  const indexes = ['*', '?', '[', '{']
+    .map(char => pattern.indexOf(char))
+    .filter(index => index !== -1);
+  return indexes.length === 0 ? -1 : Math.min(...indexes);
+}
+
+function hasGlobSyntax(pattern: string): boolean {
+  return firstGlobSyntaxIndex(pattern) !== -1;
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isDependencyBackedSegment(segment: string): boolean {

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -116,6 +116,57 @@ describe('dependency readiness hook support', () => {
     ]);
   });
 
+  it('tracks package manifests matched by recursive workspace globs', () => {
+    writeJson('package.json', {
+      name: 'recursive-workspace-project',
+      packageManager: 'bun@1.3.14',
+      workspaces: ['packages/**'],
+    });
+    writeTestFile(projectDirectory, 'bun.lock', '# lockfile');
+    writeJson('packages/cli/package.json', {
+      name: '@test/cli',
+    });
+    writeJson('packages/features/plugin/package.json', {
+      name: '@test/plugin',
+    });
+
+    const plan = detectDependencyPlan(projectDirectory);
+
+    expect(plan?.inputPaths.toSorted()).toEqual([
+      'bun.lock',
+      'package.json',
+      'packages/cli/package.json',
+      'packages/features/plugin/package.json',
+    ]);
+  });
+
+  it('excludes package manifests matched by negative workspace globs', () => {
+    writeJson('package.json', {
+      name: 'excluded-workspace-project',
+      packageManager: 'bun@1.3.14',
+      workspaces: ['packages/**', '!packages/**/test/**'],
+    });
+    writeTestFile(projectDirectory, 'bun.lock', '# lockfile');
+    writeJson('packages/app/package.json', {
+      name: '@test/app',
+    });
+    writeJson('packages/app/test/fixture/package.json', {
+      name: '@test/fixture',
+    });
+    writeJson('packages/plugins/auth/package.json', {
+      name: '@test/auth-plugin',
+    });
+
+    const plan = detectDependencyPlan(projectDirectory);
+
+    expect(plan?.inputPaths.toSorted()).toEqual([
+      'bun.lock',
+      'package.json',
+      'packages/app/package.json',
+      'packages/plugins/auth/package.json',
+    ]);
+  });
+
   it('changes the dependency fingerprint when tracked inputs change', () => {
     writeBunProject();
     const plan = detectDependencyPlan(projectDirectory);

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -167,6 +167,37 @@ describe('dependency readiness hook support', () => {
     ]);
   });
 
+  it('over-tracks package manifests for unsupported advanced workspace globs', () => {
+    writeJson('package.json', {
+      name: 'advanced-workspace-project',
+      packageManager: 'bun@1.3.14',
+      workspaces: ['packages/{app,plugins/*}', '!packages/[a]*/test/**'],
+    });
+    writeTestFile(projectDirectory, 'bun.lock', '# lockfile');
+    writeJson('packages/app/package.json', {
+      name: '@test/app',
+    });
+    writeJson('packages/app/test/fixture/package.json', {
+      name: '@test/fixture',
+    });
+    writeJson('packages/plugins/auth/package.json', {
+      name: '@test/auth-plugin',
+    });
+    writeJson('examples/tool/package.json', {
+      name: '@test/example-tool',
+    });
+
+    const plan = detectDependencyPlan(projectDirectory);
+
+    expect(plan?.inputPaths.toSorted()).toEqual([
+      'bun.lock',
+      'package.json',
+      'packages/app/package.json',
+      'packages/app/test/fixture/package.json',
+      'packages/plugins/auth/package.json',
+    ]);
+  });
+
   it('changes the dependency fingerprint when tracked inputs change', () => {
     writeBunProject();
     const plan = detectDependencyPlan(projectDirectory);


### PR DESCRIPTION
## Summary
- track Bun workspace package manifests matched by recursive patterns like `packages/**`
- honor simple negative workspace patterns like `!packages/**/test/**`
- keep hook-time dependency readiness self-contained with no new package dependency and sync dogfood hook copy

## Verification
- `bun run --cwd packages/cli test -- dependency-readiness` — RED before implementation, GREEN 48/48 after implementation
- `bun run --cwd packages/cli test -- dependency-readiness src/templates/config.test.ts tests/smoke/hook-coverage.test.ts setup-hooks` — 83/83 passed on fresh `origin/main` branch
- `bun run --cwd packages/cli lint` — passed
- `bun run --cwd packages/cli test:release` — 7/7 passed
- `git diff --check origin/main...HEAD` — passed