### PR TITLE
Release v0.48.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump CLI package version to 0.48.0
- Sync marketplace plugin version to 0.48.0
- Sync bun.lock package metadata

## Verification
- node version consistency check
- bun install --frozen-lockfile
- bun run --cwd packages/cli test:release
- bun run --cwd packages/cli build
- bun run lint
- bun run format:check
- bun scripts/check-ticket-ids.ts
- git diff --check