### PR TITLE
Release v0.49.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump safeword CLI package version to `0.49.0`.
- Bump marketplace plugin version to `0.49.0`.
- Sync the workspace package version in `bun.lock`.

## Validation

- `bun install --frozen-lockfile`
- `bun run --cwd packages/cli test:release`
- `bun run --cwd packages/cli build`
- `bun pm pack --cwd packages/cli --destination /tmp/safeword-release-0.49.0`
- `bun run lint`
- `git diff --check`