### PR TITLE
fix: fall back to CLAUDE_CODE_SESSION_ID in remote container sessions

### DIFF
--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -12,6 +12,7 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
+  // CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
   sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {

--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -12,7 +12,7 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
-  sessionId = process.env.CLAUDE_SESSION_ID,
+  sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
@@ -33,7 +33,7 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = process.argv[4] ?? process.env.CLAUDE_SESSION_ID;
+  const sessionId = process.argv[4] || process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
 
   try {
     if (skillName === undefined) {

--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -8,12 +8,13 @@ import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
+const ENV_SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
 
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
-  // CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
-  sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
+  sessionId = ENV_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
@@ -34,7 +35,7 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = process.argv[4] || process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
+  const sessionId = process.argv[4] || ENV_SESSION_ID;
 
   try {
     if (skillName === undefined) {

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -29,7 +29,7 @@ import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledge
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+const sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown-session';
 const ticketsDirectory = nodePath.join(resolveNamespaceRoot(projectDirectory), 'tickets');
 
 function fail(message: string): never {

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -29,7 +29,8 @@ import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledge
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-const sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown-session';
+const sessionId =
+  process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown-session';
 const ticketsDirectory = nodePath.join(resolveNamespaceRoot(projectDirectory), 'tickets');
 
 function fail(message: string): never {

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -8,12 +8,13 @@ import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
+const ENV_SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
 
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
-  // CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
-  sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
+  sessionId = ENV_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
@@ -34,8 +35,7 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId =
-    process.argv[4] || process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
+  const sessionId = process.argv[4] || ENV_SESSION_ID;
 
   try {
     if (skillName === undefined) {

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -12,6 +12,7 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
+  // CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
   sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -12,7 +12,7 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 export function recordSkillInvocation(
   projectDirectory: string,
   skillName: string,
-  sessionId = process.env.CLAUDE_SESSION_ID,
+  sessionId = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID,
 ): void {
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
@@ -33,7 +33,8 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = process.argv[4] ?? process.env.CLAUDE_SESSION_ID;
+  const sessionId =
+    process.argv[4] || process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
 
   try {
     if (skillName === undefined) {

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -29,7 +29,8 @@ import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledge
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-const sessionId = process.env.CLAUDE_SESSION_ID ?? 'unknown-session';
+const sessionId =
+  process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown-session';
 const ticketsDirectory = nodePath.join(resolveNamespaceRoot(projectDirectory), 'tickets');
 
 function fail(message: string): never {

--- a/packages/cli/tests/hooks/record-skill-invocation.test.ts
+++ b/packages/cli/tests/hooks/record-skill-invocation.test.ts
@@ -112,10 +112,28 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
     expect(result.stderr).toContain('Invalid skill name "../verify"');
   });
 
+  it('falls back to CLAUDE_CODE_SESSION_ID when CLAUDE_SESSION_ID is empty (remote container)', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.project'), { recursive: true });
+
+    const output = execFileSync('bun', [helperPath, projectDirectory, 'verify'], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_SESSION_ID: '', CLAUDE_CODE_SESSION_ID: 'remote-session-uuid' },
+    });
+
+    expect(output.trim()).toBe('[skill-invocation-log] verify ✓');
+    const logContent = readFileSync(
+      nodePath.join(projectDirectory, '.project', 'skill-invocations.log'),
+      'utf8',
+    );
+    expect(logContent).toMatch(/ remote-session-uuid verify$/m);
+  });
+
   it('fails closed when no session id is available', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
     const env = { ...process.env };
     delete env.CLAUDE_SESSION_ID;
+    delete env.CLAUDE_CODE_SESSION_ID;
 
     const result = spawnSync('bun', [helperPath, projectDirectory, 'verify'], {
       encoding: 'utf8',


### PR DESCRIPTION
## Summary

- In Claude Code remote container sessions (web, GitHub Actions), `CLAUDE_SESSION_ID` is set but **empty** while the real session ID lives in `CLAUDE_CODE_SESSION_ID`. The `??` operator doesn't treat empty string as absent, so the fallback never fired and `record-skill-invocation.ts` threw "Missing session id for skill invocation log", blocking `/verify` and `/audit` at the done gate.
- Switch from `??` to `||` throughout so an empty-string `CLAUDE_SESSION_ID` falls through to `CLAUDE_CODE_SESSION_ID`. Apply the same fix to `write-review-stamp.ts` for correct attribution.
- Extract `ENV_SESSION_ID` module-level constant to eliminate the duplicated env var chain within each file.

**Codex and Cursor are not affected** — neither has a session-scoped stop gate enforcing skill invocation entries.

## Files changed

| File | Change |
|---|---|
| `.safeword/hooks/record-skill-invocation.ts` | `\|\|` fallback chain + `ENV_SESSION_ID` constant (dogfood) |
| `packages/cli/templates/hooks/record-skill-invocation.ts` | same (template) |
| `.safeword/hooks/write-review-stamp.ts` | `\|\|` fallback chain for correct session attribution (dogfood) |
| `packages/cli/templates/hooks/write-review-stamp.ts` | same (template) |
| `packages/cli/tests/hooks/record-skill-invocation.test.ts` | new test: `CLAUDE_SESSION_ID=''` + `CLAUDE_CODE_SESSION_ID=uuid` → success; fail-closed test also deletes `CLAUDE_CODE_SESSION_ID` |

## Test plan

- [ ] `bun run --cwd packages/cli test tests/hooks/record-skill-invocation.test.ts` — 7/7 pass (includes new remote-container fallback case)
- [ ] `bun run --cwd packages/cli test tests/skill-invocation-log.test.ts` — 26/26 pass
- [ ] Gherkin acceptance lane — 31/31 scenarios pass
- [ ] Lint + typecheck clean
- [ ] Verify in a real remote container session: `/verify` and `/audit` invocation log lines now print `✓` instead of `FAILED`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAV9udQMJTos6zGVM8F7S)_