### PR TITLE
fix(audit): drop knip --fix to prevent working-tree mutation

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -68,11 +68,9 @@ DEPCRUISE_CONFIG=""
 # DEAD CODE DETECTION
 # =========================================================================
 
-# 2a. Dead code - TypeScript/JS (knip with auto-fix + config hints)
+# 2a. Dead code - TypeScript/JS (knip — read-only, reports unused exports/deps/config hints)
 [ -f package.json ] && {
-  bunx knip --fix 2>&1 || true
-  # Capture config hints separately for W005 detection
-  bunx knip --reporter json 2> /dev/null || true
+  bunx knip 2>&1 || true
 }
 
 # 2b. Dead code - Python (deadcode)
@@ -145,7 +143,7 @@ If all packages are up to date, report: `✅ All packages up to date`
 
 #### Knip Configuration Hints (W005)
 
-Check the `bunx knip --fix` output above for "Configuration hints" lines. Hints appear in the default reporter output, NOT in the `--reporter json` output. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
+Check the knip output above for "Configuration hints" lines. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
 
 ```text
 - [W005] Stale config: `knip.json` — `{entry}` can be removed from {list}
@@ -305,7 +303,7 @@ Report findings by severity with codes:
 
 **Dead Code:**
 
-- Fixed by knip: [list of auto-fixed items]
+- Knip findings: [list unused items to review — verify before removing, knip cannot see packages consumed via Astro/Vite/Wrangler config]
 
 **Duplication:**
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -68,11 +68,9 @@ DEPCRUISE_CONFIG=""
 # DEAD CODE DETECTION
 # =========================================================================
 
-# 2a. Dead code - TypeScript/JS (knip with auto-fix + config hints)
+# 2a. Dead code - TypeScript/JS (knip — read-only, reports unused exports/deps/config hints)
 [ -f package.json ] && {
-  bunx knip --fix 2>&1 || true
-  # Capture config hints separately for W005 detection
-  bunx knip --reporter json 2> /dev/null || true
+  bunx knip 2>&1 || true
 }
 
 # 2b. Dead code - Python (deadcode)
@@ -145,7 +143,7 @@ If all packages are up to date, report: `✅ All packages up to date`
 
 #### Knip Configuration Hints (W005)
 
-Check the `bunx knip --fix` output above for "Configuration hints" lines. Hints appear in the default reporter output, NOT in the `--reporter json` output. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
+Check the knip output above for "Configuration hints" lines. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
 
 ```text
 - [W005] Stale config: `knip.json` — `{entry}` can be removed from {list}
@@ -305,7 +303,7 @@ Report findings by severity with codes:
 
 **Dead Code:**
 
-- Fixed by knip: [list of auto-fixed items]
+- Knip findings: [list unused items to review — verify before removing, knip cannot see packages consumed via Astro/Vite/Wrangler config]
 
 **Duplication:**
 

--- a/.cursor/commands/audit.md
+++ b/.cursor/commands/audit.md
@@ -64,11 +64,9 @@ DEPCRUISE_CONFIG=""
 # DEAD CODE DETECTION
 # =========================================================================
 
-# 2a. Dead code - TypeScript/JS (knip with auto-fix + config hints)
+# 2a. Dead code - TypeScript/JS (knip — read-only, reports unused exports/deps/config hints)
 [ -f package.json ] && {
-  bunx knip --fix 2>&1 || true
-  # Capture config hints separately for W005 detection
-  bunx knip --reporter json 2> /dev/null || true
+  bunx knip 2>&1 || true
 }
 
 # 2b. Dead code - Python (deadcode)
@@ -141,7 +139,7 @@ If all packages are up to date, report: `✅ All packages up to date`
 
 #### Knip Configuration Hints (W005)
 
-Check the `bunx knip --fix` output above for "Configuration hints" lines. Hints appear in the default reporter output, NOT in the `--reporter json` output. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
+Check the knip output above for "Configuration hints" lines. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
 
 ```text
 - [W005] Stale config: `knip.json` — `{entry}` can be removed from {list}
@@ -272,7 +270,7 @@ Report findings by severity with codes:
 
 **Dead Code:**
 
-- Fixed by knip: [list of auto-fixed items]
+- Knip findings: [list unused items to review — verify before removing, knip cannot see packages consumed via Astro/Vite/Wrangler config]
 
 **Duplication:**
 

--- a/packages/cli/templates/commands/audit.md
+++ b/packages/cli/templates/commands/audit.md
@@ -64,11 +64,9 @@ DEPCRUISE_CONFIG=""
 # DEAD CODE DETECTION
 # =========================================================================
 
-# 2a. Dead code - TypeScript/JS (knip with auto-fix + config hints)
+# 2a. Dead code - TypeScript/JS (knip — read-only, reports unused exports/deps/config hints)
 [ -f package.json ] && {
-  bunx knip --fix 2>&1 || true
-  # Capture config hints separately for W005 detection
-  bunx knip --reporter json 2> /dev/null || true
+  bunx knip 2>&1 || true
 }
 
 # 2b. Dead code - Python (deadcode)
@@ -141,7 +139,7 @@ If all packages are up to date, report: `✅ All packages up to date`
 
 #### Knip Configuration Hints (W005)
 
-Check the `bunx knip --fix` output above for "Configuration hints" lines. Hints appear in the default reporter output, NOT in the `--reporter json` output. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
+Check the knip output above for "Configuration hints" lines. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
 
 ```text
 - [W005] Stale config: `knip.json` — `{entry}` can be removed from {list}
@@ -272,7 +270,7 @@ Report findings by severity with codes:
 
 **Dead Code:**
 
-- Fixed by knip: [list of auto-fixed items]
+- Knip findings: [list unused items to review — verify before removing, knip cannot see packages consumed via Astro/Vite/Wrangler config]
 
 **Duplication:**
 

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -68,11 +68,9 @@ DEPCRUISE_CONFIG=""
 # DEAD CODE DETECTION
 # =========================================================================
 
-# 2a. Dead code - TypeScript/JS (knip with auto-fix + config hints)
+# 2a. Dead code - TypeScript/JS (knip — read-only, reports unused exports/deps/config hints)
 [ -f package.json ] && {
-  bunx knip --fix 2>&1 || true
-  # Capture config hints separately for W005 detection
-  bunx knip --reporter json 2> /dev/null || true
+  bunx knip 2>&1 || true
 }
 
 # 2b. Dead code - Python (deadcode)
@@ -145,7 +143,7 @@ If all packages are up to date, report: `✅ All packages up to date`
 
 #### Knip Configuration Hints (W005)
 
-Check the `bunx knip --fix` output above for "Configuration hints" lines. Hints appear in the default reporter output, NOT in the `--reporter json` output. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
+Check the knip output above for "Configuration hints" lines. If knip reports **configuration hints** (unused entries in `ignoreDependencies`, `ignoreBinaries`, `ignoreUnresolved`, or `ignoreWorkspaces`), flag each as:
 
 ```text
 - [W005] Stale config: `knip.json` — `{entry}` can be removed from {list}
@@ -305,7 +303,7 @@ Report findings by severity with codes:
 
 **Dead Code:**
 
-- Fixed by knip: [list of auto-fixed items]
+- Knip findings: [list unused items to review — verify before removing, knip cannot see packages consumed via Astro/Vite/Wrangler config]
 
 **Duplication:**
 


### PR DESCRIPTION
## Summary

- `bunx knip --fix` was silently rewriting `package.json`, removing deps consumed via Astro/Vite/Wrangler config that knip can't see (react, husky, wrangler, prettier, etc.)
- The skill already says "/audit must never mutate the working tree" — this enforces it for knip too
- Drops the now-redundant second `--reporter json` run (it existed only to supplement `--fix` output)
- Updates W005 text and the "Dead Code" report label to match read-only mode; notes the Astro/Vite/Wrangler false-positive risk inline so the next person doesn't reach for `knip --fix` blindly

## Scope

All 5 audit surfaces updated identically: `.claude/skills/audit/SKILL.md`, `packages/cli/templates/skills/audit/SKILL.md`, `.agents/skills/audit/SKILL.md`, `packages/cli/templates/commands/audit.md`, `.cursor/commands/audit.md`

## Test plan

- [ ] Run `/audit` in a project with Astro/Vite/Wrangler deps — confirm `package.json` is untouched after the run
- [ ] Confirm knip findings still appear in the report (read-only output unchanged)
- [ ] `bun test` passes (audit-documentation-sources test covers all 5 surfaces)

https://claude.ai/code/session_012DxGD7xZtcHzgfaAzmjJCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012DxGD7xZtcHzgfaAzmjJCj)_