### PR TITLE
Product audit + centralize/harden the test/build resolver (test-plan)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -64,6 +64,10 @@ DEPCRUISE_CONFIG=""
 # Note: Go compiler prevents circular imports between packages at build time.
 # If your Go project builds, it has no circular dependencies.
 
+# 1d. Architecture - Rust
+# Note: Rust's module system and compiler reject circular module dependencies at
+# build time. If your crate builds, it has no circular module dependencies.
+
 # =========================================================================
 # DEAD CODE DETECTION
 # =========================================================================
@@ -83,6 +87,11 @@ DEPCRUISE_CONFIG=""
 # 2c. Dead code - Go (golangci-lint unused)
 [ -f go.mod ] && {
   golangci-lint run --enable unused --out-format colored-line-number 2>&1 || true
+}
+
+# 2d. Dead code - Rust (clippy flags dead_code / unused)
+[ -f Cargo.toml ] && command -v cargo > /dev/null && {
+  cargo clippy --quiet 2>&1 || true
 }
 
 # =========================================================================
@@ -109,6 +118,13 @@ bunx jscpd . --gitignore --min-lines 10 --reporters console 2>&1 || true
 # 4c. Outdated - Go
 [ -f go.mod ] && {
   go list -m -u all 2>&1 | grep '\[' || echo "All Go modules up to date"
+}
+
+# 4d. Outdated - Rust (requires cargo-outdated)
+[ -f Cargo.toml ] && {
+  if command -v cargo-outdated > /dev/null; then
+    cargo outdated 2>&1 || true
+  else echo "Rust outdated check skipped — install with: cargo install cargo-outdated"; fi
 }
 ```
 
@@ -259,7 +275,7 @@ Test Quality:
 
 - If missing → create from `.safeword/templates/architecture-template.md`
 - If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts code (e.g., doc says "Redux", package.json has "zustand")
+  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
   - **Gap (warn):** Major dependencies not documented
 
 **README.md:**

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -55,29 +55,15 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
-Every project has a `package.json` (the BDD lane needs one), so a real `test`
-script — not the file — is the "this is a JS project" signal. Run the first
-matching language's suite; skip gracefully when a toolchain isn't installed.
+Per-language test/build commands come from `safeword test-plan` — one source of
+truth (the same plan the stop-hook gate runs). Eval its shell plan in a child
+shell: an absent toolchain prints a visible skip, and a failing suite exits
+non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
+not a `test-plan` suite).
 
 ```bash
-# --- Test suite (first matching language) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
-  bun run test 2>&1
-elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
-  if [ -f uv.lock ] && command -v uv > /dev/null; then
-    uv run pytest 2>&1
-  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
-    poetry run pytest 2>&1
-  elif command -v pytest > /dev/null; then
-    pytest 2>&1
-  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
-elif [ -f go.mod ]; then
-  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
-elif [ -f Cargo.toml ]; then
-  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
-else
-  echo "Test Suite: ⏭️ Skipped — no test suite detected"
-fi
+# --- Test suite (resolved by safeword test-plan — one source of truth) ---
+bash -c "$(bunx safeword test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -86,16 +72,8 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# --- Build check (JS build script, else native compile) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
-  bun run build 2>&1
-elif [ -f go.mod ] && command -v go > /dev/null; then
-  go build ./... 2>&1
-elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
-  cargo build 2>&1
-else
-  echo "Build: ⏭️ Skipped — no build step for this project"
-fi
+# --- Build check (resolved by safeword test-plan) ---
+bash -c "$(bunx safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -62,8 +62,16 @@ non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
 not a `test-plan` suite).
 
 ```bash
+# Resolve a test-plan-capable safeword CLI — prefer the locally installed one
+# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(bunx safeword test-plan --kind test --format sh)"
+bash -c "$($SW test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -73,7 +81,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(bunx safeword test-plan --kind build --format sh)"
+bash -c "$($SW test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -55,9 +55,29 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
+Every project has a `package.json` (the BDD lane needs one), so a real `test`
+script — not the file — is the "this is a JS project" signal. Run the first
+matching language's suite; skip gracefully when a toolchain isn't installed.
+
 ```bash
-# Full test suite
-bun run test 2>&1
+# --- Test suite (first matching language) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
+  bun run test 2>&1
+elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  if [ -f uv.lock ] && command -v uv > /dev/null; then
+    uv run pytest 2>&1
+  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
+    poetry run pytest 2>&1
+  elif command -v pytest > /dev/null; then
+    pytest 2>&1
+  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
+elif [ -f go.mod ]; then
+  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
+elif [ -f Cargo.toml ]; then
+  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
+else
+  echo "Test Suite: ⏭️ Skipped — no test suite detected"
+fi
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -66,8 +86,16 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# Build check
-bun run build 2>&1
+# --- Build check (JS build script, else native compile) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
+  bun run build 2>&1
+elif [ -f go.mod ] && command -v go > /dev/null; then
+  go build ./... 2>&1
+elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
+  cargo build 2>&1
+else
+  echo "Build: ⏭️ Skipped — no build step for this project"
+fi
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.
@@ -92,20 +120,24 @@ If ticket has `parent:` field:
 
 ### 5. Check Dependency Drift
 
-Compare `package.json` dependencies against `ARCHITECTURE.md`:
+Compare the project's declared dependencies against `ARCHITECTURE.md`:
 
 1. If `ARCHITECTURE.md` does not exist, skip this check
 2. Read `ARCHITECTURE.md` content
-3. Read `package.json` `dependencies` and `devDependencies` keys
+3. Read the project's dependency manifest(s) — whichever exist:
+   - **JS/TS:** `package.json` `dependencies` and `devDependencies`
+   - **Python:** `pyproject.toml` (`[project]` `dependencies`, `[tool.poetry.dependencies]`) or `requirements.txt`
+   - **Go:** the `require` block in `go.mod`
+   - **Rust:** `[dependencies]` (and `[dev-dependencies]`) in `Cargo.toml`
 4. For each dependency name:
-   - Extract the package name (without `@scope/` prefix for matching — but check both full name and short name)
-   - Check if `ARCHITECTURE.md` mentions the package name (case-insensitive)
-5. Flag any dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
+   - Extract the bare name (drop the `@scope/` prefix for JS, version/path specifiers for the others); check both full and short forms
+   - Check if `ARCHITECTURE.md` mentions it (case-insensitive)
+5. Flag any runtime/architectural dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
 
 Do NOT flag:
 
-- `@types/*` packages (type-only, not architectural)
-- Packages in `devDependencies` that are tooling (eslint plugins, prettier plugins, test utils) — only flag deps that represent architectural choices
+- Type-only packages (`@types/*`) and standard-library imports
+- Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
 ### 6. Report Results
 
@@ -118,9 +150,9 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
 **Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
-**Build:** ✅ Success (or ❌ Failed)
+**Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)

--- a/.project/tickets/2FVZ26-language-aware-verify-audit/ticket.md
+++ b/.project/tickets/2FVZ26-language-aware-verify-audit/ticket.md
@@ -1,0 +1,34 @@
+---
+id: 2FVZ26
+slug: language-aware-verify-audit
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-16T13:07:38.959Z
+last_modified: 2026-06-16T13:07:38.959Z
+---
+
+# Make verify and audit work for Python, Go, and Rust projects
+
+**Goal:** `/verify` and `/audit` should run the right test/build/dead-code/drift checks for the project's actual language(s), not just JS.
+
+**Why:** The completion gate is effectively broken on non-JS repos — `/verify` runs `bun run test` / `bun run build` against an empty `scripts: {}`, so it reports nothing useful while appearing to pass. `/audit` skips architecture, dead-code, and dependency-drift entirely for non-JS code.
+
+> Source: `PRODUCT-AUDIT-leakage.md` → Axis 2-B. Note: `/lint` already fans out across Ruff/golangci/clippy via the `post-tool-lint` hook — mirror that pattern.
+
+## Findings (file:line)
+
+- `skills/verify/SKILL.md:56-70`, `commands/verify.md:56-66` — runs `bun run test`, `bun run build`, plus a `node -e` `package.json` script probe; unguarded, JS-only.
+- `skills/verify/SKILL.md:95-108`, `commands/verify.md:91-104` — dependency-drift reads `package.json` deps vs ARCHITECTURE.md; no Cargo/go.mod/pyproject path.
+- `skills/audit/SKILL.md:44-100`, `commands/audit.md:40-96` — `bunx depcruise`/`knip`/`jscpd`/npm `outdated`; only knip+outdated are `[ -f package.json ]`-gated, so architecture + drift are JS-only.
+
+## Acceptance criteria
+
+- [ ] `/verify` detects language and runs the matching test + build commands (e.g. `pytest`/`go test`/`cargo test`); JS path stays behind a `package.json` check.
+- [ ] `/verify` dependency-drift reads the project's actual manifest (pyproject/go.mod/Cargo.toml) when JS is absent.
+- [ ] `/audit` runs dead-code / outdated / architecture checks per language where tools exist, and says so explicitly when a check is skipped (not silent).
+- [ ] Both updated in the SKILL.md and the mirrored commands/*.md.
+
+## Work Log
+
+- 2026-06-16T13:07:38.959Z Started: Created ticket 2FVZ26

--- a/.project/tickets/2FVZ26-language-aware-verify-audit/ticket.md
+++ b/.project/tickets/2FVZ26-language-aware-verify-audit/ticket.md
@@ -2,7 +2,7 @@
 id: 2FVZ26
 slug: language-aware-verify-audit
 type: task
-phase: intake
+phase: implement
 status: in_progress
 created: 2026-06-16T13:07:38.959Z
 last_modified: 2026-06-16T13:07:38.959Z
@@ -24,11 +24,13 @@ last_modified: 2026-06-16T13:07:38.959Z
 
 ## Acceptance criteria
 
-- [ ] `/verify` detects language and runs the matching test + build commands (e.g. `pytest`/`go test`/`cargo test`); JS path stays behind a `package.json` check.
-- [ ] `/verify` dependency-drift reads the project's actual manifest (pyproject/go.mod/Cargo.toml) when JS is absent.
-- [ ] `/audit` runs dead-code / outdated / architecture checks per language where tools exist, and says so explicitly when a check is skipped (not silent).
-- [ ] Both updated in the SKILL.md and the mirrored commands/*.md.
+- [x] `/verify` detects language and runs the matching test + build commands (e.g. `pytest`/`go test`/`cargo test`); JS path stays behind a real `test`-script check.
+- [x] `/verify` dependency-drift reads the project's actual manifest (pyproject/go.mod/Cargo.toml) when JS is absent.
+- [x] `/audit` runs dead-code / outdated / architecture checks per language where tools exist, and says so explicitly when a check is skipped (not silent).
+- [x] Both updated in the SKILL.md and the mirrored commands/\*.md.
+- [x] Bonus: stop-hook `test-runner.ts` extended (native fallback) so the _automatic_ done-gate also verifies non-JS projects — 8 unit tests.
 
 ## Work Log
 
 - 2026-06-16T13:07:38.959Z Started: Created ticket 2FVZ26
+- 2026-06-16 Implemented: language-aware verify/audit skills+commands + test-runner.ts native fallback. 51/51 tests pass (test-runner + verify-skill + parity), tsc clean. Awaiting user confirmation before marking done.

--- a/.project/tickets/4YJV1N-generic-paths-in-shipped-guidance/ticket.md
+++ b/.project/tickets/4YJV1N-generic-paths-in-shipped-guidance/ticket.md
@@ -1,0 +1,32 @@
+---
+id: 4YJV1N
+slug: generic-paths-in-shipped-guidance
+type: patch
+phase: intake
+status: in_progress
+created: 2026-06-16T13:07:39.086Z
+last_modified: 2026-06-16T13:07:39.086Z
+---
+
+# Use generic file paths in shipped guidance examples
+
+**Goal:** Shipped guidance examples should cite generic `src/...` paths, not safeword's own `packages/cli/src/...` monorepo paths.
+
+**Why:** Customer-facing instructions currently teach safeword's internal layout as the citation norm, which is confusing for flat or non-monorepo customer repos.
+
+> Source: `PRODUCT-AUDIT-leakage.md` → Axis 1.
+
+## Findings (file:line)
+
+- `templates/SAFEWORD.md:190` — example: *"`packages/cli/src/auth.ts:42` was swallowing the refresh error."*
+- `templates/SAFEWORD.md:205` — instruction: *"write `packages/cli/src/foo.ts:142` inline."*
+- `templates/skills/tdd-review/SKILL.md:70` — *"implement minimum code in `packages/cli/src/lint.ts`."*
+
+## Acceptance criteria
+
+- [ ] All three replaced with generic placeholders (e.g. `src/auth.ts:42`).
+- [ ] Quick scan confirms no other shipped template cites `packages/cli/...` as a customer example.
+
+## Work Log
+
+- 2026-06-16T13:07:39.086Z Started: Created ticket 4YJV1N

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/dimensions.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/dimensions.md
@@ -1,0 +1,18 @@
+# Behavioral Dimensions: migrate consumers to test-plan
+
+| Dimension                      | Partitions                                                        | Boundary / edge                                 | Covered by scenario                                    |
+| ------------------------------ | ----------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| Output format                  | `json` (TS hook) · **`sh`** (bash skill) · human                  | sh is the new mode                              | sh-cd-command; sh-skip-echo                            |
+| sh entry state                 | available → `( cd <cwd> && <cmd> )` · **unavailable → skip echo** | unavailable must not emit a bare command        | sh-skip-echo                                           |
+| sh runnability                 | the emitted script actually executes                              | eval produces the suite's output                | sh-eval-runs                                           |
+| Languages via consumer         | JS-script · native (go/rust/python) · **polyglot**                | polyglot = all suites                           | sh-polyglot; runner-non-js                             |
+| test-runner suite source       | resolver plan (no inline strings)                                 | structural: zero language commands in the file  | test-runner-no-lang-strings                            |
+| Stop-hook behavior (preserved) | JS test+bdd · non-JS native · **no suite → skip**                 | skip must never block                           | runner-js-preserved; runner-non-js; runner-empty-skips |
+| /verify command source         | `test-plan --format sh` (no inline bash)                          | structural: zero language branches in section 2 | verify-no-inline-lang                                  |
+
+**Notes**
+
+- The load-bearing guarantee is **no language command string appears in two places** — pinned by two structural scenarios (test-runner.ts, /verify) plus the behavioral proof that the migrated paths still run the right suites.
+- `test:bdd` (JS acceptance lane) stays a consumer-side step — _not_ a dimension of `test-plan`; the stop-hook/verify scenarios assert it still runs.
+- Determinism: `--format sh` toolchain availability is driven by the `SAFEWORD_FAKE_TOOLS` seam (BKTTZA), so sh-output scenarios don't depend on the host.
+- Out of scope (no dimension): /audit (dead-code/outdated tooling — different domain).

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/impl-plan.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/impl-plan.md
@@ -1,0 +1,40 @@
+# Impl Plan: migrate consumers to test-plan
+
+**Status:** planned
+
+## Approach
+
+Three slices, build order = dependency order:
+
+| Slice                                    | Owner                                                                                 | Test layer                                              | Order                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------- |
+| `--format sh` emit mode                  | `src/commands/test-plan.ts` + a `renderShellPlan(entries)` helper in `src/test-plan/` | unit (render) + integration (runCli eval)               | 1 — foundation both consumers need |
+| `test-runner.ts` → `test-plan --json`    | `templates/hooks/lib/test-runner.ts` (+ `.safeword` mirror)                           | `runTests` tests via the dogfood CLI                    | 2                                  |
+| `/verify` section 2 → eval `--format sh` | `templates/skills/verify/SKILL.md` + `commands/verify.md` (+ `.claude` mirror)        | structural (file-content) + done-gate phrases preserved | 3                                  |
+
+**`--format sh` semantics:** emit `set -e` once, then `( cd <cwd> && <command> )` per available entry, `echo "⏭️ Skipped — <runner> not installed"` per unavailable entry. `set -e` makes the eval exit non-zero on the first failing suite (matches `test-runner`'s existing first-failure-stop) and an empty plan is a bare (no-op) script → exit 0. Generalize the CLI flag to `--format <human|json|sh>` keeping `--json` as an alias (BKTTZA shipped `--json`; its test must keep passing).
+
+**test-runner.ts:** replace `getTestCommands`/`nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand` with a call to `safeword test-plan --kind test --json` via `safewordCliCommand()` (the installed-or-bunx resolver lint.ts uses), parse `PlanEntry[]`, run each `command` in its `cwd` with the existing execSync+timeout+truncation; still append `test:bdd` (detected from package.json as today).
+
+## Decisions
+
+| Decision                          | Choice                                                                              | Alternatives                | Rejected because                                                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| sh failure propagation            | `set -e` + sequential `( cd && cmd )`                                               | `&&`-chain; run-all-collect | `set -e` is simplest, matches test-runner's first-failure-stop; run-all needs aggregation the gate doesn't require |
+| CLI flag shape                    | `--format <human\|json\|sh>`, `--json` kept as alias                                | new `--sh` boolean          | one enum is cleaner; alias preserves BKTTZA's shipped `--json` + its test                                          |
+| test-runner CLI location in tests | inject a CLI path/seam so `runTests` tests use the local dist, never network `bunx` | rely on `bunx safeword`     | network/non-determinism in unit tests (the spec Open Question)                                                     |
+
+## Arch alignment
+
+- Reuse over duplication — both consumers call the one resolver; `safewordCliCommand()` reused from the lint hook pattern.
+- CLI command structure — `--format` is a standard option on the existing `test-plan` subcommand.
+
+## Known deviations
+
+skip: none planned — behavior-preserving migration onto an existing command.
+
+## Assessment triggers
+
+- A third consumer needing the plan → consider a tiny shared TS client (still CLI-mediated, hooks can't import).
+- If `set -e` first-failure-stop proves wrong for multi-suite repos (users want all suites run) → switch to run-all-and-aggregate.
+- An `audit-plan` resolver (dead-code/outdated) materializes → revisit whether `/audit` joins this consumption pattern.

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/impl-plan.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/impl-plan.md
@@ -1,6 +1,13 @@
 # Impl Plan: migrate consumers to test-plan
 
-**Status:** planned
+**Status:** implemented
+
+## Reconciliation (what shipped vs planned)
+
+- **Decisions held:** `set -e` failure propagation ✓; `--format <human\|json\|sh>` with `--json` kept as alias ✓; `SAFEWORD_CLI` seam for the test-runner CLI location ✓ (the spec Open Question — resolved).
+- **Refinement (deviation from plan):** `/verify` runs `bash -c "$(safeword test-plan … --format sh)"` rather than a bare `eval "$(…)"`. Reason: `set -e` inside `eval` would leak into the rest of the skill's bash block; a child shell (`bash -c`) scopes it. Behaviorally equivalent for the gate (exit code propagates), strictly safer. No follow-up needed.
+- **Arch alignment held:** reuse (`safewordCliCommand` pattern from lint.ts; one resolver), `--format` as a standard option.
+- **Test seam:** `runTests` tests inject `SAFEWORD_CLI` (dogfood source) + `SAFEWORD_FAKE_TOOLS=all` for offline determinism.
 
 ## Approach
 

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
@@ -31,7 +31,7 @@ Make `test-runner.ts` and `/verify` consume the `safeword test-plan` resolver so
 
 #### migrate-consumers.SM1.AC3 — `--format sh` emits an eval-able plan
 
-`safeword test-plan --kind <k> --format sh` prints a runnable script: `( cd <cwd> && <command> )` per available entry, `echo "⏭️ Skipped — <runner> not installed"` for unavailable ones.
+`safeword test-plan --kind <k> --format sh` prints a runnable script: `( cd <cwd> && <command> )` per available entry, `echo "⏭️ Skipped — <runner> not installed"` for unavailable ones. Evaluating it **propagates failure** — exits non-zero if any suite fails (so the gate still blocks) and is a clean no-op (exit 0) for an empty plan. Works for `--kind test` and `--kind build`.
 
 ### migrate-consumers.DEV1 — the done-gate runs my real suite (preserved/upgraded)
 

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
@@ -1,74 +1,53 @@
-# Spec: Route verify, audit, and the stop hook through safeword test-plan
-
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
+# Spec: Route the stop hook and /verify through safeword test-plan
 
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Make `test-runner.ts` and `/verify` consume the `safeword test-plan` resolver so per-language test/build command knowledge lives in exactly one place — removing the duplication 2FVZ26 introduced and keeping the gates from drifting.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- Epic [Q4FX8Y](../Q4FX8Y-extract-shared-test-runner/ticket.md); sibling [BKTTZA](../BKTTZA-test-plan-resolver/ticket.md) (the resolver, done).
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-the configured personas file (e.g., Platform Operator (PO)). Add new
-personas to that file — don't invent them here. -->
-
-## Vocabulary
-
-<!-- Domain terms specific to this feature, consistent with
-the configured glossary file. Optional. -->
+- Safeword Maintainer (SM) — owns the gates; needs one definition of how a language is tested.
+- Agent-Driven Developer (DEV) — relies on the done-gate to run the right suite for their language.
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### migrate-consumers.SM1 — one place to define how a language is tested
 
-Uncomment and customize:
+**Persona:** Safeword Maintainer (SM)
 
-### oauth-flow.PO1 — Rotate credentials without a flag day
+> When I change a language's test/build command, I want to edit one place, so the stop hook and /verify can't drift apart.
 
-**Persona:** Platform Operator (PO)
+#### migrate-consumers.SM1.AC1 — test-runner has no per-language command strings
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
+`test-runner.ts` resolves its suite by calling `safeword test-plan`; `nativeTestCommand`/`getJsTestCommands` are gone.
 
-Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
-in descriptive product language (a guarantee the user can observe), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario will prove a specific AC. If a JTBD has no user-observable capability
-to enumerate, write `skip: <reason>` under it instead of ACs.
+#### migrate-consumers.SM1.AC2 — /verify has no inline per-language test/build bash
 
-#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+`/verify` section 2 obtains its commands from `safeword test-plan --format sh` (eval), not hand-written language branches.
 
-#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
--->
+#### migrate-consumers.SM1.AC3 — `--format sh` emits an eval-able plan
+
+`safeword test-plan --kind <k> --format sh` prints a runnable script: `( cd <cwd> && <command> )` per available entry, `echo "⏭️ Skipped — <runner> not installed"` for unavailable ones.
+
+### migrate-consumers.DEV1 — the done-gate runs my real suite (preserved/upgraded)
+
+**Persona:** Agent-Driven Developer (DEV)
+
+> When my agent hits the done-gate in a Go/Rust/polyglot repo, I want my actual suite(s) run — no regression from the migration.
+
+#### migrate-consumers.DEV1.AC1 — stop-hook behavior preserved, plus polyglot/go.work/nextest
+
+A JS project still runs its `test`/`test:done` + `test:bdd`; non-JS and polyglot repos run the resolver's (more capable) suite. Per-command timeout + truncation + done-gate phrases intact.
 
 ## Outcomes
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+- No language command string appears in both `test-runner.ts` and `/verify`.
+- Full suite + cucumber lane stay green; dogfood parity preserved.
 
 ## Open Questions
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+- **Implementation risk (resolve at implement):** in the dogfood test env, how does `test-runner.ts` locate the CLI for `test-plan`? `safewordCliCommand()` resolves `node_modules/safeword/dist/cli.js` → else `bunx safeword` (network). The runTests unit tests must drive a local CLI deterministically (likely a `SAFEWORD_CLI`/path injection or the installed dist), not hit the network. defer: confirm the seam during TDD.

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
@@ -1,0 +1,74 @@
+# Spec: Route verify, audit, and the stop hook through safeword test-plan
+
+<!--
+Product-framing spec for a feature ticket. The engineering contract
+(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
+file holds the *why and who*. The bdd intake flow authors it before
+engineering scope. Fill each section, then delete the
+guidance comments.
+-->
+
+## Intent
+
+<!-- One or two sentences: what this feature is for and why it matters.
+This is the single source of truth for motivation — ticket.md drops its
+**Why:** line and points here. -->
+
+## References
+
+<!-- Related tickets, prior art, designs, external docs. Optional. -->
+
+## Personas
+
+<!-- The personas this feature serves, referenced by name or code from
+the configured personas file (e.g., Platform Operator (PO)). Add new
+personas to that file — don't invent them here. -->
+
+## Vocabulary
+
+<!-- Domain terms specific to this feature, consistent with
+the configured glossary file. Optional. -->
+
+## Jobs To Be Done
+
+<!--
+One persona per JTBD, in the form "When I …, I want …, so I can …". If two
+personas share a motivation, write two JTBDs. The heading id is
+<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
+feature needs. If there is genuinely no persona-facing job (internal
+plumbing), write `skip: <reason>` here instead.
+
+Uncomment and customize:
+
+### oauth-flow.PO1 — Rotate credentials without a flag day
+
+**Persona:** Platform Operator (PO)
+
+> When I rotate a server's API key, I want the previous key to keep working
+> for a short grace period, so I can roll the change across my fleet without
+> coordinated downtime.
+
+Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
+in descriptive product language (a guarantee the user can observe), NOT
+implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
+scenario will prove a specific AC. If a JTBD has no user-observable capability
+to enumerate, write `skip: <reason>` under it instead of ACs.
+
+#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+
+#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
+-->
+
+## Outcomes
+
+<!-- Observable results that tell us the JTBDs are satisfied — the product
+counterpart to ticket.md's done_when. -->
+
+## Open Questions
+
+<!-- Unresolved questions surfaced during intake — the spec's running list of
+what we don't know yet (the equivalent of Example Mapping's red "question"
+cards). Add one per line as they come up; before advancing to define-behavior,
+resolve each (answer it, then delete the line) or record `defer: <reason>` for
+a deliberate punt. A long unresolved list means intake isn't done — keep
+converging. Delete this comment when you add real questions. -->

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/test-definitions.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/test-definitions.md
@@ -10,76 +10,76 @@ stop-hook behavior via the `runTests` tests.
 
 ### Scenario: An available entry becomes a cd-scoped command
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: An unavailable entry becomes a visible skip line, not a command
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Evaluating the script runs the resolved suite
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Evaluating the script fails when a suite fails
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: An empty plan evals to a clean no-op
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A polyglot repo renders every language's command
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: The shell plan honors --kind build
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: the stop hook resolves its suite via test-plan (no per-language strings)
 
 ### Scenario: test-runner.ts holds no per-language command strings
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A JS project still runs its test script and the acceptance lane
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A project with no runnable suite skips without blocking
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: /verify obtains its commands from test-plan (no inline language bash)
 
 ### Scenario: verify section 2 evals test-plan for both test and build, with no inline language branches
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ---
 
 ## Feature-level cross-scenario refactor
 
-- [ ] cross-scenario
+- [x] cross-scenario — skip: helpers (renderShellPlan, safewordCliCommand, resolvePlanCommands) factored during GREEN; no cross-scenario duplication emerged

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/test-definitions.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/test-definitions.md
@@ -1,0 +1,85 @@
+# Test Definitions: migrate consumers to test-plan
+
+Feature source: `features/migrate-consumers-to-test-plan.feature`
+
+R/G/R ledger. Executable Given/When/Then live in the `.feature`; CLI `--format sh`
+output + eval exit-code via runCli, structural de-dup via file-content assertions,
+stop-hook behavior via the `runTests` tests.
+
+## Rule: test-plan --format sh emits an eval-able plan
+
+### Scenario: An available entry becomes a cd-scoped command
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An unavailable entry becomes a visible skip line, not a command
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Evaluating the script runs the resolved suite
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Evaluating the script fails when a suite fails
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An empty plan evals to a clean no-op
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A polyglot repo renders every language's command
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The shell plan honors --kind build
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: the stop hook resolves its suite via test-plan (no per-language strings)
+
+### Scenario: test-runner.ts holds no per-language command strings
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A JS project still runs its test script and the acceptance lane
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A project with no runnable suite skips without blocking
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: /verify obtains its commands from test-plan (no inline language bash)
+
+### Scenario: verify section 2 evals test-plan for both test and build, with no inline language branches
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+---
+
+## Feature-level cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
@@ -2,7 +2,7 @@
 id: 5FF0ZD
 slug: migrate-consumers-to-test-plan
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 parent: Q4FX8Y
 created: 2026-06-16T15:46:47.057Z

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
@@ -1,19 +1,43 @@
 ---
+
 id: 5FF0ZD
 slug: migrate-consumers-to-test-plan
 type: feature
-phase: intake
+phase: define-behavior
 status: in_progress
+parent: Q4FX8Y
 created: 2026-06-16T15:46:47.057Z
 last_modified: 2026-06-16T15:46:47.057Z
----
+scope:
 
-# Route verify, audit, and the stop hook through safeword test-plan
+- Add a `safeword test-plan --format sh` mode that emits an eval-able script (`( cd <cwd> && <command> )` per entry; `echo "⏭️ Skipped — <runner> not installed"` for unavailable entries)
+- Migrate `templates/hooks/lib/test-runner.ts` to consume `safeword test-plan --kind test --json` (via the `safewordCliCommand()` installed→bunx pattern), executing each entry in its `cwd` with the existing timeout/truncation; still append `test:bdd`
+- Migrate `/verify` (skill + command) section 2 to `eval "$(safeword test-plan --kind test --format sh)"` + build, removing the inline per-language bash; keep its existing `test:bdd` block and done-gate phrasing
+- Delete the now-duplicated `nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand` from `test-runner.ts`
+  out_of_scope:
+- "/audit" migration — its per-language blocks are dead-code/outdated TOOLING, a different domain `test-plan` does not model (revalidated). A parallel `audit-plan` is a fast-follow on the epic, not this ticket.
+- The `test:bdd` gherkin lane (JS-acceptance) stays a consumer-side step; `test-plan` does not emit it
+- Changing resolver behavior (BKTTZA owns it) beyond adding the `--format sh` output mode
+  done_when:
+- `test-runner.ts` contains zero per-language command strings; the stop-hook done-gate runs the resolver's plan (verified: a Go/Rust/polyglot fixture runs the right suites)
+- `/verify` section 2 contains zero inline language bash; it evals `test-plan --format sh`
+- No language command string is duplicated across `test-runner.ts` and `/verify`
+- Done-gate literal phrases preserved; full suite + cucumber lane stay green; dogfood parity preserved
 
-**Goal:** {One sentence: what are we trying to achieve?}
+# Route the stop hook and /verify through safeword test-plan
 
-**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+**Goal:** Make `test-runner.ts` and `/verify` consume the `safeword test-plan` resolver so per-language test/build command knowledge lives in exactly one place — killing the duplication 2FVZ26 introduced.
+
+**See:** epic [Q4FX8Y](../Q4FX8Y-extract-shared-test-runner/ticket.md). [spec.md](./spec.md) for JTBD/AC.
+
+## /figure-it-out decision (2026-06-16)
+
+- **TS hook** (`test-runner.ts`): shell to `safeword test-plan --kind test --json`, parse in TS, execute each `{cwd, command}` with the existing execSync+timeout+truncation. Upgrades it (gains go.work / nextest / tox / unittest from the resolver).
+- **bash skill** (`/verify`): add a `--format sh` emit mode; the skill becomes `eval "$(safeword test-plan --kind test --format sh)"`. No jq (none exists in templates); deterministic; plan-only preserved (resolver formats, caller executes).
+- **Rejected:** parsing `--json` in bash (no jq; inline `node -e` re-duplicates run logic); agent-reads-and-runs (non-deterministic, weakens the gate).
+- **Scope correction:** /audit dropped — dead-code/outdated tooling is a different domain (revalidated). Fast-follow `audit-plan` noted on the epic.
 
 ## Work Log
 
 - 2026-06-16T15:46:47.057Z Started: Created ticket 5FF0ZD
+- 2026-06-16 Intake: revalidated consumers + /figure-it-out; scope corrected (audit out, --format sh for bash, --json for TS). → define-behavior.

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
@@ -1,28 +1,27 @@
 ---
-
 id: 5FF0ZD
 slug: migrate-consumers-to-test-plan
 type: feature
-phase: define-behavior
+phase: implement
 status: in_progress
 parent: Q4FX8Y
 created: 2026-06-16T15:46:47.057Z
 last_modified: 2026-06-16T15:46:47.057Z
 scope:
-
-- Add a `safeword test-plan --format sh` mode that emits an eval-able script (`( cd <cwd> && <command> )` per entry; `echo "⏭️ Skipped — <runner> not installed"` for unavailable entries)
-- Migrate `templates/hooks/lib/test-runner.ts` to consume `safeword test-plan --kind test --json` (via the `safewordCliCommand()` installed→bunx pattern), executing each entry in its `cwd` with the existing timeout/truncation; still append `test:bdd`
-- Migrate `/verify` (skill + command) section 2 to `eval "$(safeword test-plan --kind test --format sh)"` + build, removing the inline per-language bash; keep its existing `test:bdd` block and done-gate phrasing
-- Delete the now-duplicated `nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand` from `test-runner.ts`
-  out_of_scope:
-- "/audit" migration — its per-language blocks are dead-code/outdated TOOLING, a different domain `test-plan` does not model (revalidated). A parallel `audit-plan` is a fast-follow on the epic, not this ticket.
-- The `test:bdd` gherkin lane (JS-acceptance) stays a consumer-side step; `test-plan` does not emit it
-- Changing resolver behavior (BKTTZA owns it) beyond adding the `--format sh` output mode
-  done_when:
-- `test-runner.ts` contains zero per-language command strings; the stop-hook done-gate runs the resolver's plan (verified: a Go/Rust/polyglot fixture runs the right suites)
-- `/verify` section 2 contains zero inline language bash; it evals `test-plan --format sh`
-- No language command string is duplicated across `test-runner.ts` and `/verify`
-- Done-gate literal phrases preserved; full suite + cucumber lane stay green; dogfood parity preserved
+  - Add a `safeword test-plan --format sh` mode emitting an eval-able script (`( cd <cwd> && <command> )` per entry; an `echo` skip line for unavailable entries)
+  - Migrate `templates/hooks/lib/test-runner.ts` to consume `safeword test-plan --kind test --json` (via the `safewordCliCommand()` installed-or-bunx pattern), executing each entry in its `cwd` with the existing timeout/truncation, still appending `test:bdd`
+  - Migrate `/verify` (skill + command) section 2 to eval `safeword test-plan --format sh` for test and build, removing the inline per-language bash; keep its existing `test:bdd` block and done-gate phrasing
+  - Delete the now-duplicated `nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand` from `test-runner.ts`
+out_of_scope:
+  - The /audit migration — its per-language blocks are dead-code/outdated tooling, a different domain `test-plan` does not model (revalidated); a parallel `audit-plan` is an epic fast-follow
+  - The `test:bdd` gherkin lane (JS-acceptance) stays a consumer-side step; `test-plan` does not emit it
+  - Changing resolver behavior (BKTTZA owns it) beyond adding the `--format sh` output mode
+done_when:
+  - `test-runner.ts` contains zero per-language command strings and resolves its suite via the resolver plan
+  - `/verify` section 2 contains zero inline language bash and evals `test-plan --format sh`
+  - No language command string is duplicated across `test-runner.ts` and `/verify`
+  - Done-gate literal phrases preserved; full suite + cucumber lane stay green; dogfood parity preserved
+---
 
 # Route the stop hook and /verify through safeword test-plan
 
@@ -30,14 +29,15 @@ scope:
 
 **See:** epic [Q4FX8Y](../Q4FX8Y-extract-shared-test-runner/ticket.md). [spec.md](./spec.md) for JTBD/AC.
 
-## /figure-it-out decision (2026-06-16)
+## figure-it-out decision (2026-06-16)
 
-- **TS hook** (`test-runner.ts`): shell to `safeword test-plan --kind test --json`, parse in TS, execute each `{cwd, command}` with the existing execSync+timeout+truncation. Upgrades it (gains go.work / nextest / tox / unittest from the resolver).
-- **bash skill** (`/verify`): add a `--format sh` emit mode; the skill becomes `eval "$(safeword test-plan --kind test --format sh)"`. No jq (none exists in templates); deterministic; plan-only preserved (resolver formats, caller executes).
+- **TS hook** (`test-runner.ts`): shell to `safeword test-plan --kind test --json`, parse in TS, execute each `{cwd, command}` with the existing execSync+timeout+truncation. Upgrades it (gains go.work / nextest / tox / unittest).
+- **bash skill** (`/verify`): add a `--format sh` emit mode; the skill becomes `eval "$(safeword test-plan --kind test --format sh)"`. No jq (none exists in templates); deterministic; plan-only preserved.
 - **Rejected:** parsing `--json` in bash (no jq; inline `node -e` re-duplicates run logic); agent-reads-and-runs (non-deterministic, weakens the gate).
 - **Scope correction:** /audit dropped — dead-code/outdated tooling is a different domain (revalidated). Fast-follow `audit-plan` noted on the epic.
 
 ## Work Log
 
 - 2026-06-16T15:46:47.057Z Started: Created ticket 5FF0ZD
-- 2026-06-16 Intake: revalidated consumers + /figure-it-out; scope corrected (audit out, --format sh for bash, --json for TS). → define-behavior.
+- 2026-06-16 Intake: revalidated consumers + figure-it-out; scope corrected (audit out, --format sh for bash, --json for TS). To define-behavior.
+- 2026-06-16 define-behavior: dimensions + 8 scenarios accepted by user.

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
@@ -1,0 +1,19 @@
+---
+id: 5FF0ZD
+slug: migrate-consumers-to-test-plan
+type: feature
+phase: intake
+status: in_progress
+created: 2026-06-16T15:46:47.057Z
+last_modified: 2026-06-16T15:46:47.057Z
+---
+
+# Route verify, audit, and the stop hook through safeword test-plan
+
+**Goal:** {One sentence: what are we trying to achieve?}
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-06-16T15:46:47.057Z Started: Created ticket 5FF0ZD

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/ticket.md
@@ -2,8 +2,8 @@
 id: 5FF0ZD
 slug: migrate-consumers-to-test-plan
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 parent: Q4FX8Y
 created: 2026-06-16T15:46:47.057Z
 last_modified: 2026-06-16T15:46:47.057Z
@@ -41,3 +41,4 @@ done_when:
 - 2026-06-16T15:46:47.057Z Started: Created ticket 5FF0ZD
 - 2026-06-16 Intake: revalidated consumers + figure-it-out; scope corrected (audit out, --format sh for bash, --json for TS). To define-behavior.
 - 2026-06-16 define-behavior: dimensions + 8 scenarios accepted by user.
+- 2026-06-16 Done: full suite 3038/3038 green; security (cwd injection) + CLI-resolution fixes landed + regression-tested; verify.md recorded; audit passed.

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/verify.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/verify.md
@@ -1,0 +1,28 @@
+# Verify: 5FF0ZD — migrate consumers to test-plan
+
+Pinned to branch `claude/safeword-product-audit-115lwo` (post security + CLI-resolution fixes).
+
+## Verify Checklist
+
+**Test Suite:** ✓ 3038/3038 tests pass (5 skipped) — full `bun run test` green
+**Gherkin:** ✅ Acceptance lane passes (cucumber green; migrate-consumers feature incl.)
+**Build:** ⏭️ Skipped — no build step at repo root
+**Lint:** ✅ Clean (eslint + gherkin-lint + repo-wide typecheck)
+**Scenarios:** All 11 scenarios marked complete
+**Dep Drift:** ✅ Clean (no dependencies added)
+**Parent Epic:** Q4FX8Y (siblings: BKTTZA done, 5FF0ZD this) — epic completes with this
+**Reconcile:** ✅ impl-plan reconciled (status implemented); the `bash -c` child-shell refinement recorded
+
+## Audit
+
+- Architecture (depcruise): ✅ no dependency violations (148 modules).
+- Dead code: ✅ none introduced (the migration deleted `nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand`).
+- Duplication: per-language test/build command knowledge now lives only in the resolver — the 2FVZ26 duplication is gone.
+- Audit passed.
+
+## Notes
+
+Two post-implementation fixes from quality-review, both regression-tested:
+
+- **Security (command injection):** `renderShellPlan` now single-quotes `cwd`; a maliciously-named directory can no longer inject via the eval'd `--format sh` script. Empirically reproduced and re-verified fixed.
+- **CLI resolution:** `/verify` resolves a local test-plan-capable safeword (`node_modules/.bin/safeword` → dogfood source → bunx) instead of a bare `bunx safeword` that could hit the published CLI lacking `test-plan`.

--- a/.project/tickets/5RPEMR-clean-shipped-hook-comments/ticket.md
+++ b/.project/tickets/5RPEMR-clean-shipped-hook-comments/ticket.md
@@ -1,0 +1,32 @@
+---
+id: 5RPEMR
+slug: clean-shipped-hook-comments
+type: patch
+phase: intake
+status: in_progress
+created: 2026-06-16T13:07:39.147Z
+last_modified: 2026-06-16T13:07:39.147Z
+---
+
+# Remove safeword release-process narration from shipped hook comments
+
+**Goal:** Comments in shipped hooks should not narrate safeword's own release/dogfood process to customer machines.
+
+**Why:** Low-impact hygiene — the runtime behavior is correct, but the comments describe safeword-internal mechanics (canonical template source, "ahead of published npm") that mean nothing in a customer repo.
+
+> Source: `PRODUCT-AUDIT-leakage.md` → Axis 1 (LOW). The `dogfood.ts` *detection logic* is correct and stays; only the explanatory prose needs trimming to what a consumer needs.
+
+## Findings (file:line)
+
+- `templates/hooks/session-auto-upgrade.ts:23` — *"deployed mirrors of the LOCAL `packages/cli/templates/` source."*
+- `templates/hooks/lib/dogfood.ts:5-13` — *"canonical source at `packages/cli/templates/` — routinely ahead of the published npm package."*
+- `templates/hooks/post-tool-sync-learnings.ts:42` — local-CLI dev/dogfood path check + comment.
+
+## Acceptance criteria
+
+- [ ] Comments reworded to describe consumer-relevant behavior (why the hook skips/branches) without safeword's monorepo/release narrative.
+- [ ] No behavior change; detection logic untouched.
+
+## Work Log
+
+- 2026-06-16T13:07:39.147Z Started: Created ticket 5RPEMR

--- a/.project/tickets/BE7C7B-gate-js-toolchain-by-language/ticket.md
+++ b/.project/tickets/BE7C7B-gate-js-toolchain-by-language/ticket.md
@@ -1,0 +1,37 @@
+---
+id: BE7C7B
+slug: gate-js-toolchain-by-language
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-16T13:07:38.895Z
+last_modified: 2026-06-16T13:07:38.895Z
+---
+
+# Stop installing JS tooling into non-JS projects
+
+**Goal:** A pure Python/Go/Rust/SQL project should not receive a `package.json`, npm dev-deps, or a TypeScript BDD lane it cannot run.
+
+**Why:** This is the deepest JS-coupling in the product. `ensurePackageJson()` forces a manifest into every repo *before* language detection, so `languages.javascript` is always true and the JS toolchain installs unconditionally — the per-file language guards become no-ops.
+
+> Source: `PRODUCT-AUDIT-leakage.md` → Axis 2-A. Decision-bearing: the current behavior is intentional (ticket 102b). This ticket is to **decide and implement** the policy, not assume it.
+
+## Findings (file:line)
+
+- `src/commands/setup.ts:146-159` — `ensurePackageJson()` writes `package.json` into every project. Comment: *"needs a JS home even in pure Go/Rust/Python repos."*
+- `src/commands/setup.ts:460-462` — *"every project is a JS project now"*; `setupJavaScriptProject()` runs unconditionally.
+- `schema.ts` `cucumber/*` managed/owned files (`cucumber.mjs`, `steps/world.ts`, `steps/shared.steps.ts`, `features/safeword-lane.feature`) — installed with no language gate; step defs are TypeScript (`tsx/esm`, `@cucumber/cucumber`).
+- `src/packs/typescript/files.ts` base packages → `schema.ts` `packages` — `eslint`, `prettier`, `knip`, `dependency-cruiser`, `@cucumber/cucumber`, `tsx`, `@types/node` installed unconditionally.
+- `src/packs/typescript/files.ts` generators for `eslint.config.mjs` / `.prettierrc` / `knip.json` guard on `ctx.languages?.javascript`, which is always true post-`ensurePackageJson` → guards never skip.
+- `schema.ts` `.jscpd.json` — owned file, no generator/guard at all.
+
+## Acceptance criteria
+
+- [ ] Decide the policy: either (a) gate the JS toolchain + BDD lane on real JS detection, or (b) consciously keep "every project is a JS project" and document it as a stated product stance.
+- [ ] If (a): a pure-Python/Go/Rust setup produces no `package.json`, no npm deps, no `eslint.config.mjs`/`.prettierrc`/`knip.json`/`.jscpd.json`, and either a language-appropriate BDD lane or none.
+- [ ] Whichever path: the `ctx.languages?.javascript` guards in `typescript/files.ts` actually take effect (no always-true flag).
+- [ ] Golden-path tests for a non-JS-only project assert the absence (or presence) of JS artifacts per the chosen policy.
+
+## Work Log
+
+- 2026-06-16T13:07:38.895Z Started: Created ticket BE7C7B

--- a/.project/tickets/BKTTZA-test-plan-resolver/dimensions.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/dimensions.md
@@ -1,0 +1,26 @@
+# Behavioral Dimensions: test-plan resolver
+
+The resolver's output varies along these independent dimensions. Scenarios in
+`features/test-plan-resolver.feature` pick representative values (equivalence
+classes) and boundaries from each.
+
+| Dimension              | Partitions (equivalence classes)                                            | Boundary / edge                         | Covered by scenario                |
+| ---------------------- | --------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------- |
+| Languages present      | none · one · **polyglot (≥2)**                                              | the ≥2 case is the false-green boundary | JS+Python; Go+Rust                 |
+| JS test signal         | real `test`/`test:done` script · **stub `package.json` (no script)**        | empty `scripts: {}` (102b stub)         | pnpm test script; JS-stub-no-entry |
+| JS package manager     | bun · pnpm · yarn · npm                                                     | lockfile picks PM                       | pnpm run test                      |
+| Python runner          | `tox.ini` → tox · pytest config/installed → pytest · **neither → unittest** | unittest fallback is the floor          | tox; unittest; uv pytest           |
+| Python package manager | uv · poetry · bare                                                          | lockfile picks PM                       | uv run pytest                      |
+| Rust runner            | nextest installed → nextest · **cargo-only → cargo test --workspace**       | absence of nextest                      | rust nextest; rust cargo default   |
+| Go layout              | single module (`go test ./...`) · **`go.work` workspace**                   | workspace needs `go list -m` expansion  | go workspace                       |
+| Toolchain availability | installed (`available:true`) · **absent (`available:false`, still listed)** | absent must not drop the entry          | go-not-installed                   |
+| Manifest location      | root · **nested sub-dir** · vendored/excluded dir                           | `node_modules`/`vendor` excluded        | nested python; vendored ignored    |
+| Plan kind              | test · **build**                                                            | Python has no build entry               | build plan                         |
+| Surface                | in-process resolver · **CLI `safeword test-plan --json`**                   | JSON contract for consumers             | CLI prints JSON                    |
+
+**Partitioning notes**
+
+- The load-bearing boundary is **polyglot (≥2 languages)** — it is the case that produces the false-green bug, so two scenarios exercise it (JS+Python, Go+Rust) across different language pairs.
+- Toolchain-absent is a boundary, not a happy path: the entry must still appear (`available:false`) so a consumer skips loudly.
+- JS detection keys on a **real test script**, not the `package.json` file (every repo has one since ticket 102b) — the stub-no-entry scenario pins that boundary.
+- Not separately scenario'd (lower-risk combinations, covered by unit assertions under GREEN): poetry vs bare-pytest PM variants, bun/yarn/npm PM variants, Rust nextest config-file vs binary detection. The dimension is proven once; PM permutations are table-driven unit cases.

--- a/.project/tickets/BKTTZA-test-plan-resolver/impl-plan.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/impl-plan.md
@@ -1,6 +1,6 @@
 # Impl Plan: test-plan resolver
 
-**Status:** planned
+**Status:** implemented
 
 ## Approach
 

--- a/.project/tickets/BKTTZA-test-plan-resolver/impl-plan.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/impl-plan.md
@@ -1,0 +1,49 @@
+# Impl Plan: test-plan resolver
+
+**Status:** planned
+
+## Approach
+
+One pure module `packages/cli/src/test-plan/resolve.ts` owns all behavior; a thin
+CLI command `packages/cli/src/commands/test-plan.ts` wraps it. Outside-in: the CLI
+JSON contract scenario is the integration boundary; everything else is proven at
+the unit layer against the pure resolver (injected `isToolAvailable` + temp-dir
+fixtures), which is the highest layer that covers each behavior with fast feedback.
+
+| Scenario cluster (rule)                                                             | Owner                                                                           | Test layer           | Build order                        |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------- | ---------------------------------- |
+| Discovery: detect all languages, nested, vendored-excluded, empty plan              | `detectLanguages()` reusing `findInTree`/`SUBDIRECTORY_EXCLUDE` (`utils/fs.ts`) | unit                 | 1 — foundation                     |
+| JS detection via real `test`/`build` script (not the file); PM-aware                | `resolveJs()` (reuse `detectPackageManager` from `test-runner.ts` logic)        | unit                 | 2                                  |
+| Per-language runner (Python tox/pytest/unittest+PM, Rust nextest/cargo, Go go.work) | `resolvePython/Rust/Go()` with injected `isToolAvailable`                       | unit                 | 3 — bulk of AC2                    |
+| Availability flag (`available:false`, never dropped)                                | `PlanEntry.available` set by each resolver                                      | unit                 | 4                                  |
+| `--kind build` commands; Python omitted; JS-no-build omitted                        | `kind` param branch in each resolver                                            | unit                 | 5                                  |
+| CLI emits JSON with field contract                                                  | `commands/test-plan.ts` + commander registration                                | integration (runCli) | 6 — last, wraps the green resolver |
+
+Build order is dependency-first: discovery → JS → other runners → availability → build-kind → CLI wrapper, so each RED builds on green. Cucumber `.feature` steps map onto the same fixtures; the runner-detection cluster may collapse to a `Scenario Outline`/table-driven unit set at GREEN.
+
+## Decisions
+
+| Decision                 | Choice                                             | Alternatives considered     | Rejected because                                                                                                            |
+| ------------------------ | -------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Where the resolver lives | New `src/test-plan/resolve.ts` (CLI src)           | In `templates/hooks/lib/`   | Shipped hooks can't import safeword code (`lint.ts:145`); consumers reach it via the CLI, so it belongs in src.             |
+| Consumer contract        | Plan-only JSON (`safeword test-plan --json`)       | `--run` that executes       | `test-runner.ts` already owns execution/timeout; `/verify` needs to run in bash to emit `✓ X/X tests pass`. (epic decision) |
+| Tree discovery           | Reuse `findInTree`/`SUBDIRECTORY_EXCLUDE`          | New tree-walker             | Already battle-tested with the right excludes + maxDepth; no reason to duplicate.                                           |
+| Availability seam        | Inject `isToolAvailable(tool)`                     | Probe `command -v` directly | Determinism: unit tests assert runner selection without real toolchains installed (mirrors `typecheck-gate.ts`).            |
+| Go workspace command     | `go test $(go list -f '{{.Dir}}/...' -m \| xargs)` | plain `go test ./...`       | `./...` doesn't span sibling workspace modules (contested; verified this session).                                          |
+
+## Arch alignment
+
+- **Schema as Single Source of Truth / CLI command structure** — registers as a standard subcommand alongside `sync-config`, `lint-gherkin` (see `ARCHITECTURE.md` → CLI).
+- **Reuse over duplication** — reuses `utils/fs.ts` discovery and the package-manager detection idiom rather than re-implementing.
+- **Dual-config / language-pack model** — runner detection mirrors `LANGUAGE_PACK_SPEC.md` per-language tool conventions.
+
+## Known deviations
+
+skip: no deviations planned — conforms to existing CLI-command + utils-reuse patterns.
+
+## Assessment triggers
+
+- A 5th language pack (e.g. Java) → revisit whether per-language `resolve*()` functions should become a registry keyed off `LANGUAGE_PACKS`.
+- Real demand for fast feedback on large polyglot repos → add the deferred cross-language `test:done` fast-subset.
+- A consumer needing execution (not just a plan) → revisit the plan-only decision (`--run`).
+- JS workspaces with per-package-only test scripts showing up in practice → add the deferred PM-recursive fallback.

--- a/.project/tickets/BKTTZA-test-plan-resolver/spec.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/spec.md
@@ -1,0 +1,63 @@
+# Spec: safeword test-plan — one resolver for multi-language test/build plans
+
+## Intent
+
+A single pure resolver, exposed as `safeword test-plan`, that emits the correct test/build commands for **every** language present in a repo — the foundation that lets consumers (5FF0ZD) stop duplicating language logic and keeps a polyglot done-gate honest.
+
+## References
+
+- Epic [Q4FX8Y](../Q4FX8Y-extract-shared-test-runner/ticket.md) — full design, decisions, revalidation notes.
+- Sibling [5FF0ZD](../5FF0ZD-migrate-consumers-to-test-plan/ticket.md) — consumes this resolver.
+
+## Personas
+
+- Agent-Driven Developer (DEV)
+- Safeword Maintainer (SM)
+
+## Jobs To Be Done
+
+### test-plan-resolver.DEV1 — trustworthy done-gate across languages
+
+**Persona:** Agent-Driven Developer (DEV)
+
+> When my agent finishes work in a Python/Go/Rust or polyglot repo, I want the gate to run my real suite(s), so "done" means verified — not a silent pass.
+
+#### test-plan-resolver.DEV1.AC1 — every detected language gets a plan entry (no first-match)
+
+A repo with N languages present yields N test entries; adding a second language never hides the first.
+
+#### test-plan-resolver.DEV1.AC2 — the command reflects the detected runner, not a hardcode
+
+Python resolves tox / pytest / unittest (PM-aware); Rust resolves nextest vs `cargo test --workspace`; Go honors `go.work`; JS uses the project's own script (PM-aware).
+
+#### test-plan-resolver.DEV1.AC3 — a missing toolchain is visible, never dropped
+
+An entry whose tool isn't installed is returned with `available:false` (so a consumer skips loudly), not silently omitted.
+
+#### test-plan-resolver.DEV1.AC4 — nested/sub-package manifests are discovered
+
+A manifest in a sub-directory (no root manifest) still produces an entry; vendored/generated dirs are excluded.
+
+#### test-plan-resolver.DEV1.AC5 — `--kind build` emits native build commands
+
+Build plan yields `<pm> run build` (JS), `go build` (Go), `cargo build --workspace` (Rust); Python has no build entry.
+
+### test-plan-resolver.SM1 — one CLI surface as the single definition
+
+**Persona:** Safeword Maintainer (SM)
+
+> When I add or change a language's test/build command, I want a single source of truth, so verify/audit/test-runner can't drift.
+
+#### test-plan-resolver.SM1.AC1 — the resolver is reachable as one CLI surface
+
+`safeword test-plan [--kind test|build] [--json]` emits the plan as machine-readable JSON — the single definition consumers call.
+
+## Outcomes
+
+- `safeword test-plan --kind test --json` on a polyglot fixture lists an entry per detected language.
+- Each command reflects the detected runner; absent toolchains show `available:false`.
+- Nested sub-dir manifests are discovered; no first-match drops a language.
+
+## Open Questions
+
+_None — epic-level decisions resolved (Q4FX8Y → Resolved build decisions). Fast-follows (PM-recursive JS, cross-language fast-subset) are out of scope here._

--- a/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
@@ -15,124 +15,124 @@ runner-detection proof rides on Vitest unit tests (pure resolver, injected
 
 ### Scenario: A JS+Python repo yields exactly a javascript and a python entry
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A Go+Rust repo yields both a go and a rust entry
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A package.json with an empty scripts object contributes no javascript entry
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A malformed manifest is skipped without dropping other languages
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A repo with no recognized manifest yields an empty plan
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: The command reflects the detected runner
 
 ### Scenario: Python with a tox.ini runs tox
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Python with no pytest falls back to unittest
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A uv-locked Python repo runs pytest through uv
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Rust uses nextest when it is installed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Rust falls back to cargo test --workspace without nextest
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A Go workspace expands its modules in the emitted command
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A pnpm JS repo runs its test script through pnpm
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: Missing toolchains stay visible, never dropped
 
 ### Scenario: A Go repo with no go binary still appears, marked unavailable
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: Nested and vendored manifests are handled
 
 ### Scenario: A manifest in a sub-directory is discovered
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: A manifest inside an excluded directory is ignored
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: The build plan emits native build commands
 
 ### Scenario: Build plan emits per-language build commands
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: Build plan omits a JS entry when there is no build script
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: The resolver is reachable as one CLI surface
 
 ### Scenario: The CLI prints the resolved plan as JSON
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ---
 
 ## Feature-level cross-scenario refactor
 
-- [ ] cross-scenario
+- [x] cross-scenario — skip: helpers (entry(), per-language resolvers) factored during GREEN; no cross-scenario duplication emerged

--- a/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
@@ -1,0 +1,138 @@
+# Test Definitions: test-plan resolver
+
+Feature source: `features/test-plan-resolver.feature`
+
+R/G/R ledger. Executable Given/When/Then live in the `.feature`; lower-level
+runner-detection proof rides on Vitest unit tests (pure resolver, injected
+`isToolAvailable` + temp fixtures) under each scenario's GREEN step.
+
+> Scenario count is 18 (above the soft >15 define-behavior split hint). Split
+> **declined**: this is one cohesive journey — a single pure resolver's contract —
+> so "split by user journey" doesn't apply. The runner-detection cluster is
+> table-like and may collapse to a `Scenario Outline` at implementation.
+
+## Rule: Every detected language appears in the plan (no first-match)
+
+### Scenario: A JS+Python repo yields exactly a javascript and a python entry
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A Go+Rust repo yields both a go and a rust entry
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A package.json with an empty scripts object contributes no javascript entry
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A malformed manifest is skipped without dropping other languages
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A repo with no recognized manifest yields an empty plan
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: The command reflects the detected runner
+
+### Scenario: Python with a tox.ini runs tox
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Python with no pytest falls back to unittest
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A uv-locked Python repo runs pytest through uv
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Rust uses nextest when it is installed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Rust falls back to cargo test --workspace without nextest
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A Go workspace expands its modules in the emitted command
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A pnpm JS repo runs its test script through pnpm
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Missing toolchains stay visible, never dropped
+
+### Scenario: A Go repo with no go binary still appears, marked unavailable
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Nested and vendored manifests are handled
+
+### Scenario: A manifest in a sub-directory is discovered
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A manifest inside an excluded directory is ignored
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: The build plan emits native build commands
+
+### Scenario: Build plan emits per-language build commands
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Build plan omits a JS entry when there is no build script
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: The resolver is reachable as one CLI surface
+
+### Scenario: The CLI prints the resolved plan as JSON
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+---
+
+## Feature-level cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
@@ -103,6 +103,12 @@ runner-detection proof rides on Vitest unit tests (pure resolver, injected
 - [x] GREEN
 - [x] REFACTOR
 
+### Scenario: A nested Go module is tested in its own directory
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
 ### Scenario: A manifest inside an excluded directory is ignored
 
 - [x] RED

--- a/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
@@ -1,0 +1,37 @@
+---
+id: BKTTZA
+slug: test-plan-resolver
+type: feature
+phase: implement
+status: in_progress
+parent: Q4FX8Y
+created: 2026-06-16T15:46:47.000Z
+last_modified: 2026-06-16T15:46:47.000Z
+scope:
+  - Pure resolver `resolveTestPlan(root, { kind, isToolAvailable })` → `PlanEntry[]` (language, cwd, command, runner, available)
+  - Detects ALL languages present (polyglot, no first-match); reuses `findInTree`/`SUBDIRECTORY_EXCLUDE` for nested manifests
+  - Per-language runner detection — Python pytest/tox/unittest (PM-aware), Rust nextest/cargo --workspace, Go go.work-aware, JS the project's own script (PM-aware)
+  - `--kind test|build`; missing toolchain → entry flagged `available:false`, never dropped
+  - Exposed as `safeword test-plan [--kind test|build] [--json]`; unit-tested with injected availability + temp fixtures
+out_of_scope:
+  - Wiring test-runner.ts / verify / audit onto the plan (that is 5FF0ZD)
+  - Executing the commands (`--run`) — plan-only; callers execute
+  - JS acceptance lane `test:bdd` (already wired in consumers; not the resolver's primary-suite job v1)
+  - PM-recursive JS fallback for workspaces with no root `test` script (fast-follow); cross-language `test:done` fast-subset (fast-follow)
+done_when:
+  - `safeword test-plan --kind test --json` on a polyglot fixture lists an entry for every detected language
+  - Each language's command reflects the detected runner; absent toolchains show `available:false`
+  - Nested (sub-dir) manifests are discovered; no first-match drops a language
+  - Resolver unit tests pass; tsc + lint clean
+---
+
+# safeword test-plan: one resolver that emits correct multi-language test/build plans
+
+**Goal:** A single pure resolver, exposed as `safeword test-plan`, that emits the correct test/build commands for **every** language present in a repo — so consumers (5FF0ZD) can stop duplicating language logic and a polyglot done-gate can't go green with a language untested.
+
+**See:** epic [Q4FX8Y](../Q4FX8Y-extract-shared-test-runner/ticket.md) for the full design, decisions, and revalidation notes. [spec.md](./spec.md) for JTBD/AC.
+
+## Work Log
+
+- 2026-06-16T15:46:47.000Z Started: Created ticket BKTTZA
+- 2026-06-16 Intake: inherited epic scope (split confirmed); scope/out-of-scope/done-when set. → define-behavior.

--- a/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
@@ -35,3 +35,4 @@ done_when:
 
 - 2026-06-16T15:46:47.000Z Started: Created ticket BKTTZA
 - 2026-06-16 Intake: inherited epic scope (split confirmed); scope/out-of-scope/done-when set. → define-behavior.
+- 2026-06-16 Implemented (outside-in TDD): `src/test-plan/resolve.ts` + `safeword test-plan [dir] --kind --json` CLI, reusing `findInTree`/`detectPackageManager`. 18/18 scenarios green (vitest resolver+CLI + cucumber acceptance lane), tsc + eslint clean, full bdd lane 49/49. Added `SAFEWORD_FAKE_TOOLS` test seam for deterministic acceptance. Awaiting verify phase (/verify + /audit).

--- a/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
@@ -2,7 +2,7 @@
 id: BKTTZA
 slug: test-plan-resolver
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 parent: Q4FX8Y
 created: 2026-06-16T15:46:47.000Z

--- a/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/ticket.md
@@ -2,8 +2,8 @@
 id: BKTTZA
 slug: test-plan-resolver
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 parent: Q4FX8Y
 created: 2026-06-16T15:46:47.000Z
 last_modified: 2026-06-16T15:46:47.000Z
@@ -36,3 +36,4 @@ done_when:
 - 2026-06-16T15:46:47.000Z Started: Created ticket BKTTZA
 - 2026-06-16 Intake: inherited epic scope (split confirmed); scope/out-of-scope/done-when set. → define-behavior.
 - 2026-06-16 Implemented (outside-in TDD): `src/test-plan/resolve.ts` + `safeword test-plan [dir] --kind --json` CLI, reusing `findInTree`/`detectPackageManager`. 18/18 scenarios green (vitest resolver+CLI + cucumber acceptance lane), tsc + eslint clean, full bdd lane 49/49. Added `SAFEWORD_FAKE_TOOLS` test seam for deterministic acceptance. Awaiting verify phase (/verify + /audit).
+- 2026-06-16 Done: /verify green (full suite 3028 passed / 5 skipped / 0 failed after hermetic test-infra fixes), /audit passed (0 errors; doc gap fixed), verify.md recorded. Marked done with user confirmation.

--- a/.project/tickets/BKTTZA-test-plan-resolver/verify.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/verify.md
@@ -1,0 +1,25 @@
+# Verify: BKTTZA — test-plan resolver
+
+Pinned to HEAD `9c4253c` (branch `claude/safeword-product-audit-115lwo`).
+
+## Verify Checklist
+
+**Test Suite:** ✓ 3028/3028 tests pass (5 skipped) — full `bun run test` green
+**Gherkin:** ✅ Acceptance lane passes (50/50 scenarios, incl. BKTTZA's 19)
+**Build:** ⏭️ Skipped — no build step at repo root (per-package `tsup` builds fine)
+**Lint:** ✅ Clean (eslint + gherkin-lint + repo-wide typecheck)
+**Scenarios:** All 19 scenarios marked complete
+**Dep Drift:** ✅ Clean (no dependencies added by this work)
+**Parent Epic:** Q4FX8Y (siblings: 0/2 done — 5FF0ZD still in intake)
+**Reconcile:** ✅ No pattern deviation (conformed to CLI-command + utils-reuse patterns)
+
+## Notes
+
+The full suite was red at the start of verify (139 failures) for reasons **independent of BKTTZA** — the managed environment enforces commit signing and runs as root, breaking git-commit and permission-denial tests across 17 unrelated suites. Two hermetic test-infra fixes (separate commits) brought it green:
+
+- `c047216` — inject `GIT_CONFIG commit.gpgsign=false` for test git invocations (vitest.base).
+- `9c4253c` — `it.skipIf(root)` on two chmod-based permission-denial setup tests.
+
+BKTTZA's own surface (resolver + CLI + `indexFilesInTree`) is green on every dimension: 79 unit/CLI tests, 19 cucumber scenarios, lint, typecheck.
+
+Audit evidence (`Audit passed`) for the feature done-gate is pending a separate `/audit` run.

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -2,8 +2,8 @@
 id: Q4FX8Y
 slug: extract-shared-test-runner
 type: epic
-phase: intake
-status: in_progress
+phase: done
+status: done
 children: [BKTTZA, 5FF0ZD]
 created: 2026-06-16T13:58:31.841Z
 last_modified: 2026-06-16T13:58:31.841Z
@@ -100,3 +100,4 @@ Each revalidated against the code; PM-recursive behavior web-verified.
 - 2026-06-16T13:58:31.841Z Started: Created ticket Q4FX8Y
 - 2026-06-16 Quality-review + revalidation: corrected the per-stop premise (tests are done-gate-only), reused existing `findInTree` ignores, downgraded spawn-cost, kept Go workaround with a build-time caveat. Plan tightened; ready for `/bdd`.
 - 2026-06-16 Resolved the 3 open build decisions (figure-it-out + revalidation): require-root-JS-script (PM-recursive deferred), plan-only, defer cross-language fast-subset. Revalidated that safeword installs `test:bdd` but not `test`/`build`/`test:done`. No open v1 blockers remain.
+- 2026-06-16 Done: both children complete — BKTTZA (resolver + safeword test-plan) and 5FF0ZD (test-runner + /verify consume it; per-language duplication removed). Suite green.

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -36,33 +36,43 @@ safeword test-plan --kind test|build [--json]
 
 ### Resolver correctness rules
 
-| Concern          | Rule                                                                                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Polyglot         | Return **all** detected language suites (JS + Python + Go + Rust), each a plan entry. No first-match.                                                        |
-| JS monorepo      | A real root `test` script is the orchestrator (turbo/nx/make) → use it; PM-aware (bun/pnpm/yarn/npm). Don't also recurse workspaces.                         |
-| Python runner    | `tox.ini`→`tox`; `[tool.pytest.ini_options]`/`pytest.ini`/installed→`pytest` (recurses from root); else `python -m unittest discover`. PM-aware (uv/poetry). |
-| Go               | `go.work` → `go test $(go list -f '{{.Dir}}/...' -m \| xargs)`; else `go test ./...`.                                                                        |
-| Rust             | nextest configured/installed → `cargo nextest run --workspace` (+ `cargo test --doc`); else `cargo test --workspace`.                                        |
-| Nested manifests | Discover via declared workspace members (pnpm/cargo `[workspace]`/go.work) + bounded tree scan — not root-only.                                              |
-| Tool absent      | Entry flagged `available:false` → skipped with a **visible** note, never silently dropped.                                                                   |
-| Timeout/perf     | Per-suite timeout preserved; stop-hook path keeps a fast-subset preference (extend `test:done` cross-language) + total budget; report partial results.       |
+| Concern          | Rule                                                                                                                                                                                                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Polyglot         | Return **all** detected language suites (JS + Python + Go + Rust), each a plan entry. No first-match.                                                                                                                                                                      |
+| JS monorepo      | A real root `test` script is the orchestrator (turbo/nx/make) → use it; PM-aware (bun/pnpm/yarn/npm). Don't also recurse workspaces.                                                                                                                                       |
+| Python runner    | `tox.ini`→`tox`; `[tool.pytest.ini_options]`/`pytest.ini`/installed→`pytest` (recurses from root); else `python -m unittest discover`. PM-aware (uv/poetry).                                                                                                               |
+| Go               | `go.work` → `go test $(go list -f '{{.Dir}}/...' -m \| xargs)`; else `go test ./...`. Behavior depends on module layout (nested vs sibling) — verify against the target Go version at build; respect the Go 1.25 `go.mod ignore` directive.                                |
+| Rust             | nextest configured/installed → `cargo nextest run --workspace` (+ `cargo test --doc`, since nextest skips doctests); else `cargo test --workspace` (which already runs doctests).                                                                                          |
+| Nested manifests | **Reuse** `findInTree` + `SUBDIRECTORY_EXCLUDE` from `src/utils/fs.ts` (already skips `node_modules`/`.git`/`vendor`/`dist`/`build`/`target`/`coverage`, maxDepth 10) — the resolver lives in CLI `src/` so it imports these directly. Do **not** write a new tree-walker. |
+| Tool absent      | Entry flagged `available:false` → skipped with a **visible** note, never silently dropped.                                                                                                                                                                                 |
+| Timeout/perf     | Tests execute only at the **done gate** (see revalidation below), not every stop — so the all-suites cost is bounded to done/`verify`. Keep per-suite timeout + a cross-language `test:done` fast-subset escape hatch + partial-result reporting.                          |
 
 ## Acceptance criteria
 
 - [ ] `safeword test-plan --kind test|build --json` returns **all** detected suites for a repo; pure resolver unit-tested with injected availability + fixtures.
 - [ ] Polyglot monorepo (JS+Python) runs **both** suites — done-gate cannot go green with a language untested (kills the false green).
 - [ ] Python runner detected (pytest vs `tox` vs `unittest`), not hardcoded; Rust uses `--workspace` (+ nextest when present); Go honors `go.work`.
-- [ ] Nested/sub-package manifests are discovered (not root-only).
+- [ ] Nested/sub-package manifests are discovered (not root-only) by **reusing** `findInTree`/`SUBDIRECTORY_EXCLUDE` from `src/utils/fs.ts` — no new tree-walker — plus Go `go.mod ignore` awareness.
 - [ ] `test-runner.ts`, `/verify`, `/audit` all consume `test-plan`; **zero** language command strings duplicated across surfaces.
 - [ ] Tool-absent suites are reported as skipped (visible), never silently passed; per-suite timeout + partial-result reporting intact.
 - [ ] Done-gate literal-phrase contract preserved; existing 2FVZ26 tests + verify-skill/parity stay green; dogfood parity preserved.
 
+## Revalidation notes (quality-review, 2026-06-16)
+
+Each quality-review finding was revalidated against the code before being folded in. Two corrected a wrong assumption — recorded here so they are not "fixed" again:
+
+- **`runTests` is done-phase-only, NOT per-stop.** `stop-quality.ts:489` calls `runTests` only inside `if (currentPhase === 'done')`. The review's "Critical: don't run all suites on every stop" was based on a false premise — there is **no** per-stop test execution to scope down, and no hook-vs-verify policy split is needed. Running all suites at the done gate is correct (same cost as `/verify`). The only real lever is total time on large polyglot repos → the `test:done` fast-subset escape hatch (now cross-language).
+- **Discovery ignores already exist.** `src/utils/fs.ts` `findInTree`/`SUBDIRECTORY_EXCLUDE` already excludes vendored/generated dirs at maxDepth 10. Reuse it; nothing to add except Go's `go.mod ignore`.
+- **Spawn cost is negligible** — the CLI is invoked at the done gate and on manual `/verify`/`/audit`, not on every stop (precedent: `lint.ts` shells out per edit).
+- **Go `./...` across workspace modules is contested** across sources — keep the `go list` workaround; verify against the target Go version at build.
+
 ## Known limitations to decide at build (open)
 
-- Fast-subset vs full-suite in the 60s stop-hook budget for large monorepos — needs a cross-language `test:done` convention.
 - JS workspace with **no** root test script (per-package only) — run per-package, or require a root script? (lean: require root script v1.)
-- Whether `test-plan` only _plans_ (callers execute) or can also _execute_ (`--run`). Lean: plan-only; callers execute so /verify stays transparent and the done-gate sees results.
+- Whether `test-plan` only _plans_ (callers execute) or can also _execute_ (`--run`). Lean: plan-only; callers execute so `/verify` stays transparent and the done-gate sees results.
+- Cross-language `test:done` fast-subset convention for very large polyglot repos (nice-to-have, not v1-blocking).
 
 ## Work Log
 
 - 2026-06-16T13:58:31.841Z Started: Created ticket Q4FX8Y
+- 2026-06-16 Quality-review + revalidation: corrected the per-stop premise (tests are done-gate-only), reused existing `findInTree` ignores, downgraded spawn-cost, kept Go workaround with a build-time caveat. Plan tightened; ready for `/bdd`.

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -1,9 +1,10 @@
 ---
 id: Q4FX8Y
 slug: extract-shared-test-runner
-type: feature
+type: epic
 phase: intake
 status: in_progress
+children: [BKTTZA, 5FF0ZD]
 created: 2026-06-16T13:58:31.841Z
 last_modified: 2026-06-16T13:58:31.841Z
 ---
@@ -15,6 +16,18 @@ last_modified: 2026-06-16T13:58:31.841Z
 **Why:** 2FVZ26 made all three language-aware but (a) the logic is duplicated in three forms (bash in verify/audit skills+commands, TS in `test-runner.ts`) and (b) it is **first-match-wins, root-only, one-runner-per-language**. So a JS+Python monorepo verifies only JS and the done-gate passes with Python untested (**false green**); a `unittest`/`tox` Python project or a `go.work`/Rust-workspace repo is mis- or under-tested. This folds in Option C (centralization) **and** fixes the correctness gaps.
 
 > Source: 2FVZ26 figure-it-out (Option C, deferred) + the polyglot/runner gaps surfaced in review. Reclassified task→**feature**: new CLI surface + behavior change + multiple flows → build with `/bdd`.
+
+## Epic split (Entry checkpoint, user-confirmed 2026-06-16)
+
+Promoted feature→epic; two child features, build A then B:
+
+- **BKTTZA — `safeword test-plan` resolver + CLI.** Pure resolver + CLI verb that emits the JSON plan; polyglot, nested (reuse `findInTree`), multi-runner. Independently valuable + unit-tested. The foundation.
+- **5FF0ZD — route verify/audit/test-runner through `test-plan`.** Migrate the three consumers onto the plan and delete the duplicated language logic. Depends on BKTTZA; this is where the polyglot done-gate + zero-drift behavior lands.
+
+### Jobs To Be Done
+
+- **q4fx8y.DEV1 — trustworthy done-gate across languages.** Persona: Agent-Driven Developer (DEV). _When my agent finishes work in a Python/Go/Rust or polyglot repo, I want the done-gate to actually run my real suite(s), so "done" means verified — not a silent pass._
+- **q4fx8y.SM1 — one place to define how a language is tested.** Persona: Safeword Maintainer (SM). _When I add or change a language's test/build command, I want a single source of truth, so `/verify`, `/audit`, and `test-runner.ts` can't drift._
 
 ## Decisive constraint (from /figure-it-out)
 

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -92,6 +92,8 @@ Each revalidated against the code; PM-recursive behavior web-verified.
 
 - PM-recursive JS fallback for workspaces without a root `test` script (decision 1).
 - Cross-language `test:done` fast-subset convention (decision 3).
+- **Surface skipped (toolchain-absent) suites at the automated done-gate** (5FF0ZD quality-review). `test-runner` drops `available:false` entries; `stop-quality.ts` only prints `runTests().output` when blocking on failure (line 499), not on the skipped/pass path (579). So a missing-toolchain suite is a silent pass at the _automated_ gate. figure-it-out → deferred: delivering it needs a change to the hard done-gate's output protocol, and `/verify` (the user-facing path) already shows the skip echo. Low value vs. churning a green enforcement gate.
+- _Considered + rejected:_ replacing `bunx safeword` in `/verify` with an explicit installed→source→bunx ladder. `bunx safeword` already resolves the locally-installed `safeword` (always a project dep) → no network, project's version. Not worth the markdown-bash complexity.
 
 ## Work Log
 

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -55,24 +55,33 @@ safeword test-plan --kind test|build [--json]
 - [ ] Nested/sub-package manifests are discovered (not root-only) by **reusing** `findInTree`/`SUBDIRECTORY_EXCLUDE` from `src/utils/fs.ts` — no new tree-walker — plus Go `go.mod ignore` awareness.
 - [ ] `test-runner.ts`, `/verify`, `/audit` all consume `test-plan`; **zero** language command strings duplicated across surfaces.
 - [ ] Tool-absent suites are reported as skipped (visible), never silently passed; per-suite timeout + partial-result reporting intact.
+- [ ] JS workspace with no root `test` script → unit tests are a **loud** partial-skip (acceptance lane still runs); `test-plan` is plan-only (no `--run`).
 - [ ] Done-gate literal-phrase contract preserved; existing 2FVZ26 tests + verify-skill/parity stay green; dogfood parity preserved.
 
 ## Revalidation notes (quality-review, 2026-06-16)
 
 Each quality-review finding was revalidated against the code before being folded in. Two corrected a wrong assumption — recorded here so they are not "fixed" again:
 
-- **`runTests` is done-phase-only, NOT per-stop.** `stop-quality.ts:489` calls `runTests` only inside `if (currentPhase === 'done')`. The review's "Critical: don't run all suites on every stop" was based on a false premise — there is **no** per-stop test execution to scope down, and no hook-vs-verify policy split is needed. Running all suites at the done gate is correct (same cost as `/verify`). The only real lever is total time on large polyglot repos → the `test:done` fast-subset escape hatch (now cross-language).
+- **`runTests` is done-phase-only, NOT per-stop.** `stop-quality.ts:489` calls `runTests` only inside `if (currentPhase === 'done')`. The review's "Critical: don't run all suites on every stop" was based on a false premise — there is **no** per-stop test execution to scope down, and no hook-vs-verify policy split is needed. Running all suites at the done gate is correct (same cost as `/verify`). The only real lever is total time on large polyglot repos → the `test:done` fast-subset escape hatch (JS-only today; a cross-language version is deferred — see Resolved build decisions).
 - **Discovery ignores already exist.** `src/utils/fs.ts` `findInTree`/`SUBDIRECTORY_EXCLUDE` already excludes vendored/generated dirs at maxDepth 10. Reuse it; nothing to add except Go's `go.mod ignore`.
 - **Spawn cost is negligible** — the CLI is invoked at the done gate and on manual `/verify`/`/audit`, not on every stop (precedent: `lint.ts` shells out per edit).
 - **Go `./...` across workspace modules is contested** across sources — keep the `go list` workaround; verify against the target Go version at build.
 
-## Known limitations to decide at build (open)
+## Resolved build decisions (figure-it-out, 2026-06-16)
 
-- JS workspace with **no** root test script (per-package only) — run per-package, or require a root script? (lean: require root script v1.)
-- Whether `test-plan` only _plans_ (callers execute) or can also _execute_ (`--run`). Lean: plan-only; callers execute so `/verify` stays transparent and the done-gate sees results.
-- Cross-language `test:done` fast-subset convention for very large polyglot repos (nice-to-have, not v1-blocking).
+Each revalidated against the code; PM-recursive behavior web-verified.
+
+1. **JS workspace with no root `test` script → require a root script; skip-with-visible-note otherwise.** Matches the turbo/nx norm (a root `test` orchestrates the workspace) and is a single code path (`<pm> run test`). The safeword acceptance lane (`test:bdd`, always installed) still runs, so "no root script" is a **loud partial-skip**, never a silent green. _Rejected for v1:_ PM-recursive fallback (`pnpm -r run test` / `npm test --workspaces --if-present` / `yarn workspaces foreach`) — feasible but each PM behaves differently (npm errors without `--if-present`, yarn v1≠berry); deferred as a **fast-follow** if real repos hit it. (web-verified: pnpm.io/cli/recursive — this session)
+2. **`test-plan` is plan-only; callers execute (no `--run`).** `test-runner.ts` already owns execution (execSync + 60s timeout + truncation + first-fail-stop) and `/verify` must run commands in bash to emit `✓ X/X tests pass`. A `--run` mode would duplicate execution semantics into the CLI and hide output from the done-gate. (codebase: `test-runner.ts`)
+3. **Cross-language `test:done` fast-subset → deferred (out of v1).** Tests run only at the done gate (bounded) and the per-suite 60s timeout caps runaway, so there's no v1 need. JS keeps its opt-in `test:done`; a general per-language fast-subset config is a fast-follow only if a large-polyglot repo demands it.
+
+## Remaining open (fast-follow, not v1-blocking)
+
+- PM-recursive JS fallback for workspaces without a root `test` script (decision 1).
+- Cross-language `test:done` fast-subset convention (decision 3).
 
 ## Work Log
 
 - 2026-06-16T13:58:31.841Z Started: Created ticket Q4FX8Y
 - 2026-06-16 Quality-review + revalidation: corrected the per-stop premise (tests are done-gate-only), reused existing `findInTree` ignores, downgraded spawn-cost, kept Go workaround with a build-time caveat. Plan tightened; ready for `/bdd`.
+- 2026-06-16 Resolved the 3 open build decisions (figure-it-out + revalidation): require-root-JS-script (PM-recursive deferred), plan-only, defer cross-language fast-subset. Revalidated that safeword installs `test:bdd` but not `test`/`build`/`test:done`. No open v1 blockers remain.

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -1,37 +1,67 @@
 ---
 id: Q4FX8Y
 slug: extract-shared-test-runner
-type: task
+type: feature
 phase: intake
 status: in_progress
 created: 2026-06-16T13:58:31.841Z
 last_modified: 2026-06-16T13:58:31.841Z
 ---
 
-# Extract one shared test/build resolver for verify, audit, and the stop hook
+# Centralize and harden the test/build resolver (polyglot, nested, multi-runner)
 
-**Goal:** Put the language→test/build command knowledge in one place so `/verify`, `/audit`, and the stop-hook `test-runner.ts` can't drift apart.
+**Goal:** One resolver decides what test/build commands to run for a repo — correct across polyglot monorepos (run **every** detected suite, not first-match), nested/sub-package manifests, and languages with multiple runners — consumed identically by `/verify`, `/audit`, and the stop-hook `test-runner.ts` without drift.
 
-**Why:** 2FVZ26 made all three language-aware but the knowledge now lives in three forms — inline bash in `skills/verify` + `commands/verify` (and audit), and TS in `hooks/lib/test-runner.ts`. Each must be edited in lockstep when a language/tool/PM changes (e.g. a new uv subcommand, golangci v3). This is the deferred "Option C" from 2FVZ26's `/figure-it-out`.
+**Why:** 2FVZ26 made all three language-aware but (a) the logic is duplicated in three forms (bash in verify/audit skills+commands, TS in `test-runner.ts`) and (b) it is **first-match-wins, root-only, one-runner-per-language**. So a JS+Python monorepo verifies only JS and the done-gate passes with Python untested (**false green**); a `unittest`/`tox` Python project or a `go.work`/Rust-workspace repo is mis- or under-tested. This folds in Option C (centralization) **and** fixes the correctness gaps.
 
-> Source: 2FVZ26 figure-it-out (Option C, deferred) and `PRODUCT-AUDIT-leakage.md` → Axis 2-B. This is a **refactor** — behavior must not change (use `/refactor`).
+> Source: 2FVZ26 figure-it-out (Option C, deferred) + the polyglot/runner gaps surfaced in review. Reclassified task→**feature**: new CLI surface + behavior change + multiple flows → build with `/bdd`.
 
-## Current duplication
+## Decisive constraint (from /figure-it-out)
 
-- `templates/hooks/lib/test-runner.ts` — `nativeTestCommand()` (TS): pytest/go test/cargo test + PM-aware Python + graceful tool-absence. Plus the `.safeword/` mirror (parity test enforces byte-identity).
-- `templates/skills/verify/SKILL.md` + `templates/commands/verify.md` — section 2 inline bash (same routing) + section 5 manifest-aware dep-drift.
-- `templates/skills/audit/SKILL.md` + `templates/commands/audit.md` — per-language dead-code/outdated/arch bash blocks.
+Shipped hooks **cannot import safeword package code** — `templates/hooks/lib/lint.ts:145` states this and is why logic is duplicated there. So a shared _import_ between CLI `src/` and `test-runner.ts` is impossible. The single source of truth must therefore be reached by **calling the CLI**, not importing it.
 
-## Sketch
+## Chosen design — `safeword test-plan` (Option A)
 
-A single source of truth the others consume — likely a small CLI subcommand (e.g. `safeword detect-commands --kind=test|build`) backed by `hooks/lib/`, that the skills call instead of inlining bash, and that `test-runner.ts` imports directly. Weigh: CLI subcommand vs exported lib + thin bash shim. Keep graceful degradation (skip when tool absent) and the done-gate literal-phrase contract intact.
+A pure resolver lives once in `packages/cli/src/` and is exposed as a CLI subcommand that emits a machine-readable plan; every surface consumes the CLI (precedent: `lint.ts` already shells to `safewordCliCommand()`; `/audit` calls `bunx safeword sync-config`):
+
+```
+safeword test-plan --kind test|build [--json]
+# → [{ language, cwd, command, available, runner }, ...]  (ALL detected suites)
+```
+
+- **`test-runner.ts`** shells to the CLI for the plan (with the existing installed-CLI → `bunx` fallback), then executes each command with its current timeout/truncation logic. The hook shrinks to a thin caller — no language strings, no `.safeword`/template byte-parity burden for the logic.
+- **`/verify`** runs the planned test+build commands and aggregates the done-gate line (`✓ X/X tests pass` across suites).
+- **`/audit`** uses the same discovery for its per-language dead-code/outdated/arch checks.
+- Resolver is unit-tested in the normal CLI suite with an injected `isToolAvailable` + temp-dir fixtures (no real toolchains needed) — like `typecheck-gate.ts`'s seam.
+
+### Resolver correctness rules
+
+| Concern          | Rule                                                                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Polyglot         | Return **all** detected language suites (JS + Python + Go + Rust), each a plan entry. No first-match.                                                        |
+| JS monorepo      | A real root `test` script is the orchestrator (turbo/nx/make) → use it; PM-aware (bun/pnpm/yarn/npm). Don't also recurse workspaces.                         |
+| Python runner    | `tox.ini`→`tox`; `[tool.pytest.ini_options]`/`pytest.ini`/installed→`pytest` (recurses from root); else `python -m unittest discover`. PM-aware (uv/poetry). |
+| Go               | `go.work` → `go test $(go list -f '{{.Dir}}/...' -m \| xargs)`; else `go test ./...`.                                                                        |
+| Rust             | nextest configured/installed → `cargo nextest run --workspace` (+ `cargo test --doc`); else `cargo test --workspace`.                                        |
+| Nested manifests | Discover via declared workspace members (pnpm/cargo `[workspace]`/go.work) + bounded tree scan — not root-only.                                              |
+| Tool absent      | Entry flagged `available:false` → skipped with a **visible** note, never silently dropped.                                                                   |
+| Timeout/perf     | Per-suite timeout preserved; stop-hook path keeps a fast-subset preference (extend `test:done` cross-language) + total budget; report partial results.       |
 
 ## Acceptance criteria
 
-- [ ] One module/command is the sole definition of per-language test + build commands (incl. Python PM detection).
-- [ ] `test-runner.ts`, `/verify`, and `/audit` all consume it; no language command string is duplicated across surfaces.
-- [ ] No behavior change vs 2FVZ26: same commands run, same graceful skips, same done-gate evidence phrases. Existing tests stay green.
-- [ ] Dogfood parity (`.safeword/` mirror + `.claude/` skills) preserved.
+- [ ] `safeword test-plan --kind test|build --json` returns **all** detected suites for a repo; pure resolver unit-tested with injected availability + fixtures.
+- [ ] Polyglot monorepo (JS+Python) runs **both** suites — done-gate cannot go green with a language untested (kills the false green).
+- [ ] Python runner detected (pytest vs `tox` vs `unittest`), not hardcoded; Rust uses `--workspace` (+ nextest when present); Go honors `go.work`.
+- [ ] Nested/sub-package manifests are discovered (not root-only).
+- [ ] `test-runner.ts`, `/verify`, `/audit` all consume `test-plan`; **zero** language command strings duplicated across surfaces.
+- [ ] Tool-absent suites are reported as skipped (visible), never silently passed; per-suite timeout + partial-result reporting intact.
+- [ ] Done-gate literal-phrase contract preserved; existing 2FVZ26 tests + verify-skill/parity stay green; dogfood parity preserved.
+
+## Known limitations to decide at build (open)
+
+- Fast-subset vs full-suite in the 60s stop-hook budget for large monorepos — needs a cross-language `test:done` convention.
+- JS workspace with **no** root test script (per-package only) — run per-package, or require a root script? (lean: require root script v1.)
+- Whether `test-plan` only _plans_ (callers execute) or can also _execute_ (`--run`). Lean: plan-only; callers execute so /verify stays transparent and the done-gate sees results.
 
 ## Work Log
 

--- a/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
+++ b/.project/tickets/Q4FX8Y-extract-shared-test-runner/ticket.md
@@ -1,0 +1,38 @@
+---
+id: Q4FX8Y
+slug: extract-shared-test-runner
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-16T13:58:31.841Z
+last_modified: 2026-06-16T13:58:31.841Z
+---
+
+# Extract one shared test/build resolver for verify, audit, and the stop hook
+
+**Goal:** Put the language→test/build command knowledge in one place so `/verify`, `/audit`, and the stop-hook `test-runner.ts` can't drift apart.
+
+**Why:** 2FVZ26 made all three language-aware but the knowledge now lives in three forms — inline bash in `skills/verify` + `commands/verify` (and audit), and TS in `hooks/lib/test-runner.ts`. Each must be edited in lockstep when a language/tool/PM changes (e.g. a new uv subcommand, golangci v3). This is the deferred "Option C" from 2FVZ26's `/figure-it-out`.
+
+> Source: 2FVZ26 figure-it-out (Option C, deferred) and `PRODUCT-AUDIT-leakage.md` → Axis 2-B. This is a **refactor** — behavior must not change (use `/refactor`).
+
+## Current duplication
+
+- `templates/hooks/lib/test-runner.ts` — `nativeTestCommand()` (TS): pytest/go test/cargo test + PM-aware Python + graceful tool-absence. Plus the `.safeword/` mirror (parity test enforces byte-identity).
+- `templates/skills/verify/SKILL.md` + `templates/commands/verify.md` — section 2 inline bash (same routing) + section 5 manifest-aware dep-drift.
+- `templates/skills/audit/SKILL.md` + `templates/commands/audit.md` — per-language dead-code/outdated/arch bash blocks.
+
+## Sketch
+
+A single source of truth the others consume — likely a small CLI subcommand (e.g. `safeword detect-commands --kind=test|build`) backed by `hooks/lib/`, that the skills call instead of inlining bash, and that `test-runner.ts` imports directly. Weigh: CLI subcommand vs exported lib + thin bash shim. Keep graceful degradation (skip when tool absent) and the done-gate literal-phrase contract intact.
+
+## Acceptance criteria
+
+- [ ] One module/command is the sole definition of per-language test + build commands (incl. Python PM detection).
+- [ ] `test-runner.ts`, `/verify`, and `/audit` all consume it; no language command string is duplicated across surfaces.
+- [ ] No behavior change vs 2FVZ26: same commands run, same graceful skips, same done-gate evidence phrases. Existing tests stay green.
+- [ ] Dogfood parity (`.safeword/` mirror + `.claude/` skills) preserved.
+
+## Work Log
+
+- 2026-06-16T13:58:31.841Z Started: Created ticket Q4FX8Y

--- a/.project/tickets/QK6NQW-delanguage-teaching-surface/ticket.md
+++ b/.project/tickets/QK6NQW-delanguage-teaching-surface/ticket.md
@@ -1,0 +1,36 @@
+---
+id: QK6NQW
+slug: delanguage-teaching-surface
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-16T13:07:39.023Z
+last_modified: 2026-06-16T13:07:39.023Z
+---
+
+# Show non-JS examples in skills, guides, and doc templates
+
+**Goal:** Skills, guides, and doc-templates should teach with language-neutral or multi-language examples, not TypeScript as the only language.
+
+**Why:** A Python/Go/Rust user reading the shipped teaching material sees only TS examples and JS-only enforcement, signalling they're a second-class citizen on a tool that claims to support them.
+
+> Source: `PRODUCT-AUDIT-leakage.md` → Axis 2-C. Model to follow: `SAFEWORD.md:132-136` already does multi-language dependency guidance well.
+
+## Findings (file:line)
+
+- `guides/testing-guide.md:144-402` — all examples ` ```typescript `; `playwright.config.ts`, `bun run dev:test`, "Vitest/Jest".
+- `guides/architecture-guide.md:340-349` — boundary enforcement is `eslint-plugin-boundaries` + `bun add -D` only; no import-linter (Python) / depguard (Go) equivalent.
+- `doc-templates/architecture-template.md:65` — bakes *"Boundaries enforced via eslint-plugin-boundaries"* into the customer-filled template.
+- `skills/testing/SKILL.md` (10× ` ```typescript `), `skills/refactor/SKILL.md:69/97/115`, `guides/design-doc-guide.md:70`, `doc-templates/design-doc-template.md:25/45/61` — illustrative code is all TS.
+- `guides/context-files-guide.md:240` — *"@package.json for available npm commands."*
+- `skills/bdd/TDD.md:31-33`, `skills/bdd/SCENARIOS.md:207` — BDD RED step prescribes TypeScript step defs + vitest skeleton.
+
+## Acceptance criteria
+
+- [ ] Pervasive TS-only examples replaced with language-neutral pseudocode or paired multi-language examples.
+- [ ] Architecture boundary-enforcement guidance lists import-linter/depguard alongside eslint-plugin-boundaries; doc-template generalized.
+- [ ] No customer-facing guide hard-codes `package.json`/npm as the only manifest.
+
+## Work Log
+
+- 2026-06-16T13:07:39.023Z Started: Created ticket QK6NQW

--- a/.safeword/hooks/lib/test-runner.ts
+++ b/.safeword/hooks/lib/test-runner.ts
@@ -1,6 +1,13 @@
 /**
  * Test runner utilities for the stop hook.
- * Detects and executes the project's test suite directly.
+ *
+ * The per-language test command is resolved by the single source of truth —
+ * `safeword test-plan --kind test --json` — not duplicated here. This hook only
+ * EXECUTES the resolved commands (timeout-safe, no zombies) and appends the JS
+ * acceptance lane (`test:bdd`), which the resolver does not emit.
+ *
+ * Shipped hooks cannot import safeword code, so we reach the resolver via the
+ * CLI (the `safewordCliCommand()` installed→source→bunx pattern, mirroring lint.ts).
  */
 
 import { execSync, spawnSync } from 'node:child_process';
@@ -10,11 +17,22 @@ import nodePath from 'node:path';
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 type TestCommand = {
-  /** package.json script name, e.g. test:done or test:bdd. */
+  /** Label for output/diagnostics (the runner or script name). */
   script: string;
   /** Concrete shell command to execute. */
   command: string;
+  /** Directory to run the command in (the resolved entry's cwd). */
+  cwd: string;
 };
+
+/** One entry of `safeword test-plan --json` output. */
+interface PlanEntry {
+  language: string;
+  cwd: string;
+  command: string;
+  runner: string;
+  available: boolean;
+}
 
 export interface TestResult {
   /** Whether tests passed (exit code 0). */
@@ -34,9 +52,11 @@ const MAX_OUTPUT_LINES = 30;
 /** Maximum characters of test output to inject into the block reason. */
 const MAX_OUTPUT_CHARS = 3000;
 
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
 /**
  * Detect package manager by lockfile presence (bun > pnpm > yarn > npm).
- * Mirrors the logic in packages/cli/src/utils/install.ts.
+ * Used only for the `test:bdd` acceptance lane (the resolver owns the rest).
  */
 function detectPackageManager(cwd: string): PackageManager {
   if (existsSync(nodePath.join(cwd, 'bun.lockb')) || existsSync(nodePath.join(cwd, 'bun.lock')))
@@ -48,103 +68,74 @@ function detectPackageManager(cwd: string): PackageManager {
   return 'npm';
 }
 
-/**
- * Convert a package.json script name into the command for the detected package
- * manager.
- */
+/** Convert a package.json script name into the detected package manager's run command. */
 function formatRunCommand(script: string, packageManager: PackageManager): string {
   if (packageManager === 'npm') return script === 'test' ? 'npm test' : `npm run ${script}`;
   return `${packageManager} run ${script}`;
 }
 
-/** Check whether a CLI tool is on PATH via POSIX `command -v`. */
-function isToolAvailable(tool: string): boolean {
-  const result = spawnSync('command', ['-v', tool], { shell: true, stdio: 'ignore' });
-  return result.status === 0;
+/**
+ * Resolve the safeword CLI invocation. `SAFEWORD_CLI` (a path to cli.js/cli.ts run
+ * via bun) overrides for tests/dev; otherwise the installed package, then the
+ * dogfood source, then `bunx`.
+ */
+function safewordCliCommand(cwd: string): [string, ...string[]] {
+  const override = process.env.SAFEWORD_CLI;
+  if (override) return ['bun', override];
+  const installed = nodePath.join(cwd, 'node_modules', 'safeword', 'dist', 'cli.js');
+  if (existsSync(installed)) return ['bun', installed];
+  const source = nodePath.join(cwd, 'packages', 'cli', 'src', 'cli.ts');
+  if (existsSync(source)) return ['bun', source];
+  return ['bunx', 'safeword'];
 }
 
 /**
- * Resolve the Python test command, package-manager aware (uv > poetry > bare
- * pytest). Returns undefined when no Python test toolchain is installed so the
- * caller skips rather than blocks.
+ * Ask `safeword test-plan` for the project's test commands and keep the runnable
+ * (available) ones. Returns [] on any failure so the caller skips, never blocks.
  */
-function pythonTestCommand(
-  cwd: string,
-  isAvailable: (tool: string) => boolean,
-): TestCommand | undefined {
-  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
-  if (has('uv.lock') && isAvailable('uv')) return { script: 'pytest', command: 'uv run pytest' };
-  if (has('poetry.lock') && isAvailable('poetry'))
-    return { script: 'pytest', command: 'poetry run pytest' };
-  if (isAvailable('pytest')) return { script: 'pytest', command: 'pytest' };
-  return undefined;
-}
-
-/**
- * Resolve the native test command for a non-JS project from its manifest, or
- * undefined when no supported manifest is present OR the toolchain isn't
- * installed (caller skips, never blocks — mirrors the lint hook's graceful
- * degradation). Pure except for the injected `isAvailable` probe, so the
- * language→command decision is unit-testable without the real toolchains.
- */
-export function nativeTestCommand(
-  cwd: string,
-  isAvailable: (tool: string) => boolean = isToolAvailable,
-): TestCommand | undefined {
-  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
-  if (has('pyproject.toml') || has('requirements.txt')) return pythonTestCommand(cwd, isAvailable);
-  if (has('go.mod'))
-    return isAvailable('go') ? { script: 'go test', command: 'go test ./...' } : undefined;
-  if (has('Cargo.toml'))
-    return isAvailable('cargo') ? { script: 'cargo test', command: 'cargo test' } : undefined;
-  return undefined;
-}
-
-/**
- * Detect test commands from package.json scripts. Prefers `test:done` (a
- * gate-tuned fast subset) when present, falling back to `test`, and appends
- * `test:bdd` when present so executable `.feature` scenarios are part of done
- * evidence. Projects whose full test suite exceeds TEST_TIMEOUT_MS should
- * define `test:done` as a meaningful but fast subset — unit tests + drift
- * checks typically work.
- * Returns an empty array if package.json is absent or no runnable test scripts
- * exist.
- */
-function getJsTestCommands(cwd: string): TestCommand[] {
-  const packageJsonPath = nodePath.join(cwd, 'package.json');
+function resolvePlanCommands(cwd: string): TestCommand[] {
+  const cli = safewordCliCommand(cwd);
+  const result = spawnSync(
+    cli[0],
+    [...cli.slice(1), 'test-plan', '--kind', 'test', '--json', cwd],
+    { encoding: 'utf8', timeout: TEST_TIMEOUT_MS },
+  );
+  if (result.status !== 0 || !result.stdout) return [];
   try {
-    const content = readFileSync(packageJsonPath, 'utf8');
-    const pkg = JSON.parse(content) as { scripts?: Record<string, string> };
-    const pm = detectPackageManager(cwd);
-    const scripts = pkg.scripts ?? {};
-    const commands: TestCommand[] = [];
-    const addCommand = (script: string): void => {
-      if (commands.some(command => command.script === script)) return;
-      commands.push({ script, command: formatRunCommand(script, pm) });
-    };
-
-    if (scripts['test:done']) addCommand('test:done');
-    else if (scripts.test) addCommand('test');
-    if (scripts['test:bdd']) addCommand('test:bdd');
-
-    return commands;
+    const entries = JSON.parse(result.stdout) as PlanEntry[];
+    return entries
+      .filter(entry => entry.available)
+      .map(entry => ({ script: entry.runner, command: entry.command, cwd: entry.cwd }));
   } catch {
     return [];
   }
 }
 
-/**
- * Resolve the test commands to run. A configured JS test script wins (it's the
- * project's chosen suite); otherwise fall back to the native language suite
- * detected from the manifest. Every project gets a package.json (ticket 102b),
- * so the presence of a real `test` script — not the file — is the JS signal.
- * Returns an empty array when nothing runnable is found (caller skips).
- */
+/** The JS acceptance lane (`test:bdd`) — consumer-side, not emitted by the resolver. */
+function bddCommand(cwd: string): TestCommand | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(nodePath.join(cwd, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    if (pkg.scripts?.['test:bdd']) {
+      return {
+        script: 'test:bdd',
+        command: formatRunCommand('test:bdd', detectPackageManager(cwd)),
+        cwd,
+      };
+    }
+  } catch {
+    // No package.json — no acceptance lane.
+  }
+  return undefined;
+}
+
+/** Resolved suite (from test-plan) plus the acceptance lane; [] means skip. */
 function getTestCommands(cwd: string): TestCommand[] {
-  const jsCommands = getJsTestCommands(cwd);
-  if (jsCommands.length > 0) return jsCommands;
-  const native = nativeTestCommand(cwd);
-  return native ? [native] : [];
+  const commands = resolvePlanCommands(cwd);
+  const bdd = bddCommand(cwd);
+  if (bdd) commands.push(bdd);
+  return commands;
 }
 
 function formatCommandOutput(testCommand: TestCommand, output: string): string {
@@ -164,13 +155,10 @@ function truncateOutput(output: string): string {
   return '...(truncated)\n' + tail.slice(-MAX_OUTPUT_CHARS);
 }
 
-function runSingleTestCommand(
-  cwd: string,
-  testCommand: TestCommand,
-): { passed: boolean; output: string } {
+function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; output: string } {
   try {
     const output = execSync(testCommand.command, {
-      cwd,
+      cwd: testCommand.cwd,
       timeout: TEST_TIMEOUT_MS,
       stdio: 'pipe',
       encoding: 'utf8',
@@ -204,20 +192,21 @@ function runSingleTestCommand(
 }
 
 /**
- * Run the project's test suite directly and return the result.
+ * Run the project's test suite and return the result.
  *
- * - Detects test commands from package.json scripts
- * - Uses execSync for synchronous, timeout-safe execution (no zombie processes)
- * - Returns skipped=true if no test command found (caller should not block)
+ * - Resolves commands from `safeword test-plan` (single source of truth) + the
+ *   `test:bdd` acceptance lane.
+ * - Uses execSync for synchronous, timeout-safe execution (no zombie processes).
+ * - Returns skipped=true if no runnable command was found (caller should not block).
  */
-export function runTests(cwd: string): TestResult {
+export function runTests(cwd: string = projectDir): TestResult {
   const commands = getTestCommands(cwd);
   if (commands.length === 0) return { passed: true, output: '', skipped: true };
 
   const outputs: string[] = [];
 
   for (const testCommand of commands) {
-    const result = runSingleTestCommand(cwd, testCommand);
+    const result = runSingleTestCommand(testCommand);
     outputs.push(result.output);
     if (!result.passed)
       return { passed: false, output: truncateOutput(outputs.join('\n\n')), skipped: false };

--- a/.safeword/hooks/lib/test-runner.ts
+++ b/.safeword/hooks/lib/test-runner.ts
@@ -3,7 +3,7 @@
  * Detects and executes the project's test suite directly.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -57,6 +57,49 @@ function formatRunCommand(script: string, packageManager: PackageManager): strin
   return `${packageManager} run ${script}`;
 }
 
+/** Check whether a CLI tool is on PATH via POSIX `command -v`. */
+function isToolAvailable(tool: string): boolean {
+  const result = spawnSync('command', ['-v', tool], { shell: true, stdio: 'ignore' });
+  return result.status === 0;
+}
+
+/**
+ * Resolve the Python test command, package-manager aware (uv > poetry > bare
+ * pytest). Returns undefined when no Python test toolchain is installed so the
+ * caller skips rather than blocks.
+ */
+function pythonTestCommand(
+  cwd: string,
+  isAvailable: (tool: string) => boolean,
+): TestCommand | undefined {
+  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
+  if (has('uv.lock') && isAvailable('uv')) return { script: 'pytest', command: 'uv run pytest' };
+  if (has('poetry.lock') && isAvailable('poetry'))
+    return { script: 'pytest', command: 'poetry run pytest' };
+  if (isAvailable('pytest')) return { script: 'pytest', command: 'pytest' };
+  return undefined;
+}
+
+/**
+ * Resolve the native test command for a non-JS project from its manifest, or
+ * undefined when no supported manifest is present OR the toolchain isn't
+ * installed (caller skips, never blocks — mirrors the lint hook's graceful
+ * degradation). Pure except for the injected `isAvailable` probe, so the
+ * language→command decision is unit-testable without the real toolchains.
+ */
+export function nativeTestCommand(
+  cwd: string,
+  isAvailable: (tool: string) => boolean = isToolAvailable,
+): TestCommand | undefined {
+  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
+  if (has('pyproject.toml') || has('requirements.txt')) return pythonTestCommand(cwd, isAvailable);
+  if (has('go.mod'))
+    return isAvailable('go') ? { script: 'go test', command: 'go test ./...' } : undefined;
+  if (has('Cargo.toml'))
+    return isAvailable('cargo') ? { script: 'cargo test', command: 'cargo test' } : undefined;
+  return undefined;
+}
+
 /**
  * Detect test commands from package.json scripts. Prefers `test:done` (a
  * gate-tuned fast subset) when present, falling back to `test`, and appends
@@ -67,7 +110,7 @@ function formatRunCommand(script: string, packageManager: PackageManager): strin
  * Returns an empty array if package.json is absent or no runnable test scripts
  * exist.
  */
-function getTestCommands(cwd: string): TestCommand[] {
+function getJsTestCommands(cwd: string): TestCommand[] {
   const packageJsonPath = nodePath.join(cwd, 'package.json');
   try {
     const content = readFileSync(packageJsonPath, 'utf8');
@@ -88,6 +131,20 @@ function getTestCommands(cwd: string): TestCommand[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Resolve the test commands to run. A configured JS test script wins (it's the
+ * project's chosen suite); otherwise fall back to the native language suite
+ * detected from the manifest. Every project gets a package.json (ticket 102b),
+ * so the presence of a real `test` script — not the file — is the JS signal.
+ * Returns an empty array when nothing runnable is found (caller skips).
+ */
+function getTestCommands(cwd: string): TestCommand[] {
+  const jsCommands = getJsTestCommands(cwd);
+  if (jsCommands.length > 0) return jsCommands;
+  const native = nativeTestCommand(cwd);
+  return native ? [native] : [];
 }
 
 function formatCommandOutput(testCommand: TestCommand, output: string): string {

--- a/.safeword/logs/ticket-2FVZ26-language-aware-verify-audit.md
+++ b/.safeword/logs/ticket-2FVZ26-language-aware-verify-audit.md
@@ -1,0 +1,47 @@
+# Work Log — 2FVZ26 language-aware verify and audit
+
+## Session 2026-06-16
+
+### Revalidation (before coding)
+
+- `/verify` (`skills/verify/SKILL.md` + `commands/verify.md`): **genuinely broken** for non-JS.
+  Section 2 hardcodes `bun run test` / `bun run build`; section 5 dep-drift reads only `package.json`.
+- `/audit` (`skills/audit/SKILL.md` + `commands/audit.md`): **already mostly multi-language**
+  (Python deadcode, Go golangci unused + `go list -u`, outdated for JS/Py/Go, jscpd all langs).
+  Real gaps: **Rust absent**; ARCHITECTURE.md drift check (section 5) reads only package.json.
+  → Report overstated audit's JS-onlyness; corrected.
+- `hooks/lib/test-runner.ts` (stop-hook automated test run): **also JS-only** — reads only
+  package.json scripts; non-JS project returns `skipped:true` → automatic done-gate silently passes.
+- Detection: every project has package.json (102b), so the "is-JS" signal is a **real `test` script**,
+  not the file. Confirmed in `test-runner.ts:83-85`. Forward-compatible with BE7C7B.
+
+### /figure-it-out outcome
+
+- Architecture: **Option A** — inline manifest-gated bash in the skills, mirroring `/audit`'s
+  existing structure. Defer Option C (shared TS runner reused by test-runner.ts) to an uplevel follow-up.
+- Commands (2026, verified): Python PM-aware `uv run pytest` / `poetry run pytest` / `pytest`;
+  Go `go test ./...` + `go build ./...`; Rust `cargo test` + `cargo build`.
+
+### Scope (user delegated — "your call")
+
+verify skill+cmd + audit skill+cmd + `test-runner.ts` (template AND `.safeword/` copy — parity test
+`test-runner.test.ts:65` enforces byte-identity). Defer shared-runner refactor (C) to follow-up.
+
+### Plan
+
+1. [x] test-runner.ts: pure injectable `nativeTestCommand(cwd, isToolAvailable)` + `getJsTestCommands`/`getTestCommands` split; edited template + `.safeword/` copy (parity OK). 8 new unit tests.
+2. [x] verify skill+cmd: section 2 language-aware test+build (JS behind real `test` script; Python PM-aware; Go/Rust); section 5 manifest-aware drift; checklist allows ⏭️ Skipped. Synced `.claude/skills/verify/SKILL.md`.
+3. [x] audit skill+cmd: added Rust architecture note + clippy dead-code (2d) + cargo-outdated (4d); generalized drift example. Synced `.claude/skills/audit/SKILL.md`.
+4. [x] vitest: test-runner + verify-skill + parity = 51/51 pass. tsc clean. eslint clean on test file.
+
+### Result
+
+- Done-gate literal phrases preserved (`✓ X/X tests pass`, `**Gherkin:**`, `Audit passed`, `Ready to mark done.`) — verify-skill.test.ts green.
+- `.claude` skill mirrors synced (commands not installed in dogfood repo; no sync needed).
+- Deferred: Option-C shared runner (extract test-runner logic for reuse) → uplevel follow-up.
+
+### Notes / dead ends
+
+- test-runner runs only TESTS; build stays in the verify skill (keeps hook change small).
+- Tool-absent → skip (don't block) — matches lint.ts graceful degradation; a contributor without the
+  toolchain must not be blocked at the gate.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,7 +65,7 @@ ESLint configs are bundled in the main package and accessed via `import safeword
 ```text
 packages/cli/
 ├── src/
-│   ├── commands/       # CLI commands (setup, upgrade, check, diff, reset, sync-config, sync-learnings)
+│   ├── commands/       # CLI commands (setup, upgrade, check, diff, reset, sync-config, sync-learnings, test-plan)
 │   ├── packs/          # Language packs + registry
 │   │   ├── {lang}/     # index.ts, files.ts, setup.ts per language
 │   │   ├── registry.ts # Central pack registry and detection

--- a/PRODUCT-AUDIT-leakage.md
+++ b/PRODUCT-AUDIT-leakage.md
@@ -1,0 +1,153 @@
+# Safeword Product Audit — Customer-Agnostic & Language-Agnostic Leakage
+
+**Date:** 2026-06-16
+**Branch:** `claude/safeword-product-audit-115lwo`
+**Scope (agreed):** Shippable surface only — what lands in a *customer* project:
+`packages/cli/templates/`, `packages/cli/src/packs/`, `packages/cli/src/presets/`,
+the CLI install logic (`src/commands/setup.ts`, `src/schema.ts`), and customer-facing
+README sections. **Out of scope:** this repo's own dogfood config (`.safeword/`,
+`.claude/`, root `CLAUDE.md`/`AGENTS.md`/`ARCHITECTURE.md`), the website, and
+hooks being written in TypeScript and run via `bun` (accepted infrastructure — the
+hook runtime is language-neutral-by-fiat and explicitly excluded).
+
+**Two axes audited:**
+
+1. **Customer vs. safeword-as-target** — content that assumes the project being
+   worked on *is* safeword itself (its own dev/release workflow, its own monorepo
+   paths) rather than an arbitrary customer project.
+2. **JS/TS vs. language-agnostic** — content that assumes JavaScript/TypeScript
+   when safeword claims to support Python, Go, Rust, and SQL.
+
+> **Deliverable:** findings only — no code changed. Severity reflects customer
+> impact, not effort.
+
+---
+
+## Executive summary
+
+The **language axis is where the real exposure is.** Safeword has a genuine
+multi-language pack architecture (TS/Python/Go/Rust/SQL), but the *generic shared
+surface that every project receives regardless of language* is still JS-first in
+three load-bearing places:
+
+- **Install is JS-ifying by design.** Every project — including a pure
+  Python/Go/Rust repo — gets a `package.json`, the full TS toolchain
+  (ESLint/Prettier/knip/dependency-cruiser/jscpd), and a **TypeScript** Cucumber
+  BDD lane it cannot run. This is deliberate (ticket 102b) but it is the single
+  deepest piece of JS-coupling in the product and it makes the per-file
+  `languages.javascript` guards effectively no-ops.
+- **The core workflow skills hard-code the JS toolchain.** `/verify` runs
+  `bun run test` / `bun run build`; `/audit` runs `knip`/`depcruise`/`jscpd`;
+  `/lint` leads with ESLint/Prettier/tsc. On a non-JS project these degrade to
+  "nothing useful happened" at best, and the verify gate is effectively broken.
+- **Teaching material uses TypeScript as the only example language** across
+  `testing`, `refactor`, the testing-guide, and the doc-templates.
+
+The **customer-vs-safeword axis is mostly clean** — the architecture (template →
+`bunx safeword upgrade`, the `dogfood.ts` repo-detector) correctly separates "what
+we ship" from "what we are." The residue is small: a handful of customer-facing
+examples that cite **safeword's own** `packages/cli/src/...` paths, and a few
+shipped hook comments that describe safeword's release process.
+
+---
+
+## AXIS 2 — JS/TS leakage (primary concern)
+
+### A. Structural: install JS-ifies every project *(HIGH — by design, flag for decision)*
+
+`ensurePackageJson()` creates a `package.json` in **every** project before language
+detection runs, so `languages.javascript` is always `true` and
+`setupJavaScriptProject()` runs unconditionally. The code says so directly:
+
+- `src/commands/setup.ts:146-159` — *"Every safeword project gets one … needs a JS home even in pure Go/Rust/Python repos (ticket 102b)."*
+- `src/commands/setup.ts:460-462` — *"every project is a JS project now."*
+
+Consequences a pure Python/Go/Rust repo inherits:
+
+| What gets installed | Where | Why it's a leak |
+| --- | --- | --- |
+| `package.json` (`private: true`) | `setup.ts:146` | Foreign manifest in a non-JS repo |
+| TS BDD lane: `cucumber.mjs`, `steps/world.ts`, `steps/shared.steps.ts`, `features/safeword-lane.feature` | `schema.ts` managed/owned files (`cucumber/*` templates), no language gate | **TypeScript** step defs (`tsx/esm`, `@cucumber/cucumber`) a Python/Go/Rust team cannot run or maintain |
+| npm packages: `eslint@^9`, `prettier`, `knip`, `dependency-cruiser`, `@cucumber/cucumber`, `tsx`, `@types/node`, `safeword` | `src/packs/typescript/files.ts` base packages → `schema.ts` `packages` | `node_modules/` + 8 dev deps in a repo with no JS |
+| `eslint.config.mjs`, `.prettierrc`, `knip.json` | `src/packs/typescript/files.ts` generators guarded by `ctx.languages?.javascript` | Guard is **always true** post-`ensurePackageJson`, so guards never skip |
+| `.jscpd.json` | `schema.ts` owned file, **no** generator/guard | JS/TS-oriented copy-paste detector config, no value for other langs |
+| `.dependency-cruiser.cjs` / `.safeword/depcruise-config.cjs` | `setup.ts` arch build (`buildArchitecture`) | CommonJS config for a JS module-boundary tool |
+
+**Recommendation (for decision, not done here):** introduce a
+`hasNonJavaScript = python || golang || rust || sql` notion and gate the JS
+toolchain on `javascript && !nonJsOnly`, OR move the BDD lane + JS tooling into the
+TypeScript pack so it's installed only when JS is actually present. The current
+guards can't work while `ensurePackageJson` forces the flag on.
+
+### B. Core workflow skills hard-code the JS toolchain
+
+These ship to every project and are invoked on every language:
+
+| Severity | File:line | Leak |
+| --- | --- | --- |
+| **HIGH** | `skills/verify/SKILL.md:56-70`, `commands/verify.md:56-66` | Verify gate runs `bun run test`, then `bun run build`, plus a `node -e` `package.json` script probe. On a non-JS repo (empty `scripts: {}`) these no-op or fail — the completion gate doesn't actually verify the project. |
+| **HIGH** | `skills/verify/SKILL.md:95-108`, `commands/verify.md:91-104` | Dependency-drift check reads `package.json` `dependencies`/`devDependencies` vs ARCHITECTURE.md — JS-only; Cargo/go.mod/pyproject get no drift check. |
+| **MEDIUM-HIGH** | `skills/audit/SKILL.md:44-100`, `commands/audit.md:40-96` | Audit pipeline = `bunx depcruise`, `bunx knip --fix`, `bunx jscpd`, npm `outdated`. Only knip/outdated are `[ -f package.json ]`-gated; architecture (depcruise) and dep-drift are JS-only. Non-JS projects get no dead-code/architecture/outdated audit. |
+| **MEDIUM** | `skills/lint/SKILL.md:29-58`, `commands/lint.md:25-53` | The inline lint block leads with ESLint/Prettier/`tsc` (guarded by `[ -f package.json ]`, so OK), but the skill is framed JS-first; other linters (Ruff/golangci/mypy) appear only as a trailing mention. The real multilingual path is the `post-tool-lint` hook, not this skill. |
+| **MEDIUM** | `skills/bdd/TDD.md:31-33`, `skills/bdd/SCENARIOS.md:207` | BDD RED step prescribes "thinnest **TypeScript** step definitions" and a "native **vitest** skeleton"; `codify --format gherkin` emits vitest. A Python/Go BDD user is steered into TS/vitest. |
+
+> Note: lines like `bun "$PROJECT_DIR/.safeword/hooks/…"` (audit/verify/explain/
+> self-review SKILLs) are the **accepted bun hook runtime** and are *not* flagged
+> per the agreed scope.
+
+### C. Teaching material / guides assume TypeScript *(MEDIUM/LOW)*
+
+| Severity | File:line | Leak |
+| --- | --- | --- |
+| MEDIUM | `guides/testing-guide.md:144-402` | Examples are all ` ```typescript `, plus `playwright.config.ts`, `bun run dev:test`, "Package.json Scripts", "Vitest/Jest". A non-JS reader gets no examples in their language. |
+| MEDIUM | `guides/architecture-guide.md:340-349` | Boundary enforcement section is `eslint-plugin-boundaries` + `bun add -D` only — no Python (import-linter) / Go (depguard) equivalent, though the pack spec knows them. |
+| MEDIUM | `doc-templates/architecture-template.md:65` | Template a customer fills in bakes in *"Boundaries enforced via `eslint-plugin-boundaries`."* |
+| LOW | `skills/testing/SKILL.md` (10× ` ```typescript `), `skills/refactor/SKILL.md:69/97/115`, `guides/design-doc-guide.md:70`, `doc-templates/design-doc-template.md:25/45/61` | All illustrative code is TypeScript; reads as JS-first to non-JS users. |
+| LOW | `guides/context-files-guide.md:240` | Suggested context line: *"@package.json for available npm commands."* |
+| LOW | `guides/zombie-process-cleanup.md`, `skills/cleanup-zombies/SKILL.md:29` | Node dev-server centric (vite/next, bun/pnpm/yarn/npm) — inherent to the topic, low concern. |
+| LOW | `guides/learning-extraction.md:290/319/441-444` | Examples lean Astro/Electron/`bun run build`. |
+
+---
+
+## AXIS 1 — Safeword-as-target leakage (secondary; mostly clean)
+
+The install/upgrade architecture cleanly separates ship-vs-self
+(`hooks/lib/dogfood.ts` correctly detects the dev repo to skip auto-upgrade — this
+is right and **not** a leak). Residual items:
+
+| Severity | File:line | Leak |
+| --- | --- | --- |
+| MEDIUM | `templates/SAFEWORD.md:190`, `:205` | Code-citation examples instruct customers using **safeword's own** paths: *"`packages/cli/src/auth.ts:42`"* and *"write `packages/cli/src/foo.ts:142` inline."* Teaches customers safeword's monorepo layout as the norm; use a generic `src/...` placeholder. |
+| MEDIUM | `templates/skills/tdd-review/SKILL.md:70` | Worked example: *"implement minimum code in `packages/cli/src/lint.ts`"* — safeword's own source path in shipped guidance. |
+| LOW | `templates/hooks/session-auto-upgrade.ts:23`, `templates/hooks/lib/dogfood.ts:5-13`, `templates/hooks/post-tool-sync-learnings.ts:42` | Shipped hook **comments** describe safeword's own release process (*"deployed mirrors of the LOCAL `packages/cli/templates/`"*, *"ahead of the published npm package"*). Harmless at runtime, but it's safeword-internal narrative shipped to customer machines. Comment hygiene only. |
+| LOW | `templates/cucumber/safeword-lane.feature`, `world.ts`, `cucumber.mjs` | Starter scaffold is branded "Safeword BDD lane" / `SafewordWorld`. It tells the user to replace it, so acceptable — noting only because it ships to every project (see Axis 2-A for the bigger TS-runtime issue). |
+| LOW | `README.md:54`, `:220`, `:406` | Customer-facing README leads JS-first: *"For JS/TS projects: ESLint, Prettier…"* then relegates *"Python, Go, and Rust (beta)"*; hooks described as "TypeScript … Bun runtime". Accurate, but frames JS as the primary citizen. (README:439-514 "Development" is explicitly contributor-facing and correctly out of scope.) |
+
+---
+
+## Prioritized fix list (if/when you act)
+
+1. **Decide the JS-ification policy (Axis 2-A).** Biggest lever. Either gate the JS
+   toolchain + BDD lane behind real JS detection, or consciously accept "every
+   project is a JS project" and document it as a product stance. Everything else
+   downstream depends on this call.
+2. **Make `/verify` and `/audit` language-aware** (verify.md/audit.md + their
+   SKILLs): branch test/build/drift/dead-code on detected language, mirroring how
+   `/lint` and the `post-tool-lint` hook already fan out across Ruff/golangci/clippy.
+3. **De-JS the teaching surface:** add non-TS examples (or language-neutral
+   pseudocode) to `testing-guide`, `architecture-guide`, `testing`/`refactor`
+   skills, and the doc-templates; generalize the boundary-enforcement section to
+   import-linter/depguard alongside eslint-plugin-boundaries.
+4. **Sanitize safeword-own paths in shipped guidance** (SAFEWORD.md:190/205,
+   tdd-review:70) → generic `src/...` placeholders.
+5. **Comment hygiene** on the three shipped hooks that narrate safeword's release
+   process (low priority).
+
+## What is correctly language-/customer-agnostic (don't "fix")
+
+- `SAFEWORD.md:132-136` — the dependency-versioning guidance is exemplary:
+  enumerates `requirements.txt`/`go.mod`/`Cargo.toml` and `uv add`/`cargo add`/
+  `go get`. This is the model the rest of the docs should match.
+- The language-pack architecture (`src/packs/*`, `LANGUAGE_PACK_SPEC.md`) and the
+  `post-tool-lint` hook's multi-language routing.
+- `hooks/lib/dogfood.ts` repo-detection (correct ship-vs-self boundary).

--- a/features/migrate-consumers-to-test-plan.feature
+++ b/features/migrate-consumers-to-test-plan.feature
@@ -2,7 +2,8 @@ Feature: migrate consumers to test-plan
 
   test-runner.ts and /verify must obtain their per-language test/build commands from
   `safeword test-plan` — one source of truth — instead of each carrying its own
-  language logic. The stop-hook done-gate behavior is preserved (and upgraded).
+  language logic. The stop-hook done-gate behavior is preserved (and upgraded):
+  the eval-able plan runs the right suites and still fails when a suite fails.
 
   Rule: test-plan --format sh emits an eval-able plan
 
@@ -14,32 +15,55 @@ Feature: migrate consumers to test-plan
       Then the script contains "( cd" and "go test ./..."
 
     @migrate-consumers.SM1.AC3
-    Scenario: An unavailable entry becomes a visible skip, not a command
+    Scenario: An unavailable entry becomes a visible skip line, not a command
       Given a repo with a "go.mod"
       And the "go" toolchain is not installed
       When I render the test plan as a shell script
-      Then the script reports the go suite as skipped
-      And the script does not run "go test"
+      Then the script contains the line "echo \"⏭️ Skipped — go not installed\""
+      And the script contains no runnable "go test" command outside that echo
 
     @migrate-consumers.SM1.AC3
     Scenario: Evaluating the script runs the resolved suite
       Given a repo with a root "test" script that prints "RAN_SUITE"
       When I eval the rendered shell script
       Then the output contains "RAN_SUITE"
+      And the eval exits zero
+
+    @migrate-consumers.SM1.AC3
+    Scenario: Evaluating the script fails when a suite fails
+      Given a repo with a root "test" script that exits non-zero
+      When I eval the rendered shell script
+      Then the eval exits non-zero
+
+    @migrate-consumers.SM1.AC3
+    Scenario: An empty plan evals to a clean no-op
+      Given a repo with no recognized language manifest and no test script
+      When I eval the rendered shell script
+      Then the eval exits zero
+      And no suite command is run
 
     @migrate-consumers.SM1.AC3
     Scenario: A polyglot repo renders every language's command
       Given a repo with a root "test" script and a "pyproject.toml"
+      And the "pytest" toolchain is installed
       When I render the test plan as a shell script
-      Then the script includes the javascript command
-      And the script includes the python command
+      Then the script contains "run test"
+      And the script contains "pytest"
+
+    @migrate-consumers.SM1.AC3
+    Scenario: The shell plan honors --kind build
+      Given a repo with a "go.mod"
+      And the "go" toolchain is installed
+      When I render the build plan as a shell script
+      Then the script contains "go build"
 
   Rule: the stop hook resolves its suite via test-plan (no per-language strings)
 
     @migrate-consumers.SM1.AC1
     Scenario: test-runner.ts holds no per-language command strings
       When I read templates/hooks/lib/test-runner.ts
-      Then it contains no hardcoded "cargo test --workspace", "go test ./...", or "pytest" command
+      Then it contains no hardcoded "cargo test", "go test", "pytest", or "uv run pytest" command
+      And it does not define "nativeTestCommand", "getJsTestCommands", or "pythonTestCommand"
       And it invokes "test-plan" via the safeword CLI
 
     @migrate-consumers.DEV1.AC1
@@ -57,7 +81,8 @@ Feature: migrate consumers to test-plan
   Rule: /verify obtains its commands from test-plan (no inline language bash)
 
     @migrate-consumers.SM1.AC2
-    Scenario: verify section 2 evals test-plan with no inline language branches
-      When I read the verify skill and command
-      Then section 2 evaluates "test-plan --format sh"
-      And it contains no inline "uv run pytest", "go test", or "cargo test" branch
+    Scenario: verify section 2 evals test-plan for both test and build, with no inline language branches
+      When I read the verify skill and the verify command
+      Then section 2 of each evaluates "test-plan --format sh"
+      And section 2 of each contains no inline language test branch ("uv run pytest", "go test", "cargo test")
+      And section 2 of each contains no inline language build branch ("go build", "cargo build")

--- a/features/migrate-consumers-to-test-plan.feature
+++ b/features/migrate-consumers-to-test-plan.feature
@@ -1,0 +1,63 @@
+Feature: migrate consumers to test-plan
+
+  test-runner.ts and /verify must obtain their per-language test/build commands from
+  `safeword test-plan` — one source of truth — instead of each carrying its own
+  language logic. The stop-hook done-gate behavior is preserved (and upgraded).
+
+  Rule: test-plan --format sh emits an eval-able plan
+
+    @migrate-consumers.SM1.AC3
+    Scenario: An available entry becomes a cd-scoped command
+      Given a repo with a "go.mod"
+      And the "go" toolchain is installed
+      When I render the test plan as a shell script
+      Then the script contains "( cd" and "go test ./..."
+
+    @migrate-consumers.SM1.AC3
+    Scenario: An unavailable entry becomes a visible skip, not a command
+      Given a repo with a "go.mod"
+      And the "go" toolchain is not installed
+      When I render the test plan as a shell script
+      Then the script reports the go suite as skipped
+      And the script does not run "go test"
+
+    @migrate-consumers.SM1.AC3
+    Scenario: Evaluating the script runs the resolved suite
+      Given a repo with a root "test" script that prints "RAN_SUITE"
+      When I eval the rendered shell script
+      Then the output contains "RAN_SUITE"
+
+    @migrate-consumers.SM1.AC3
+    Scenario: A polyglot repo renders every language's command
+      Given a repo with a root "test" script and a "pyproject.toml"
+      When I render the test plan as a shell script
+      Then the script includes the javascript command
+      And the script includes the python command
+
+  Rule: the stop hook resolves its suite via test-plan (no per-language strings)
+
+    @migrate-consumers.SM1.AC1
+    Scenario: test-runner.ts holds no per-language command strings
+      When I read templates/hooks/lib/test-runner.ts
+      Then it contains no hardcoded "cargo test --workspace", "go test ./...", or "pytest" command
+      And it invokes "test-plan" via the safeword CLI
+
+    @migrate-consumers.DEV1.AC1
+    Scenario: A JS project still runs its test script and the acceptance lane
+      Given a project whose package.json has a "test" and a "test:bdd" script
+      When the stop-hook test runner runs
+      Then both the test script and the acceptance lane are executed
+
+    @migrate-consumers.DEV1.AC1
+    Scenario: A project with no runnable suite skips without blocking
+      Given a project with no test script and no language manifest
+      When the stop-hook test runner runs
+      Then it reports skipped and does not block
+
+  Rule: /verify obtains its commands from test-plan (no inline language bash)
+
+    @migrate-consumers.SM1.AC2
+    Scenario: verify section 2 evals test-plan with no inline language branches
+      When I read the verify skill and command
+      Then section 2 evaluates "test-plan --format sh"
+      And it contains no inline "uv run pytest", "go test", or "cargo test" branch

--- a/features/test-plan-resolver.feature
+++ b/features/test-plan-resolver.feature
@@ -24,7 +24,7 @@ Feature: test-plan resolver
 
     @test-plan-resolver.DEV1.AC1
     Scenario: A package.json with an empty scripts object contributes no javascript entry
-      Given a repo with a "go.mod" and a "package.json" whose "scripts" is "{}"
+      Given a repo with a "go.mod" and a "package.json" with an empty scripts object
       When I request the test plan
       Then the plan includes a "go" entry
       And the plan has no "javascript" entry
@@ -136,6 +136,6 @@ Feature: test-plan resolver
     @test-plan-resolver.SM1.AC1
     Scenario: The CLI prints the resolved plan as JSON
       Given a repo with a "go.mod"
-      When I run "safeword test-plan --kind test --json"
+      When I run the test-plan CLI as JSON
       Then the output is a JSON array containing an entry with language "go"
       And that entry has a non-empty "command" and a boolean "available"

--- a/features/test-plan-resolver.feature
+++ b/features/test-plan-resolver.feature
@@ -109,6 +109,12 @@ Feature: test-plan resolver
       Then the plan includes a "python" entry
 
     @test-plan-resolver.DEV1.AC4
+    Scenario: A nested Go module is tested in its own directory
+      Given a repo with a "services/api/go.mod" and no root manifest
+      When I request the test plan
+      Then the "go" entry runs in the "services/api" sub-directory
+
+    @test-plan-resolver.DEV1.AC4
     Scenario: A manifest inside an excluded directory is ignored
       Given a repo with a "Cargo.toml" only under "target"
       When I request the test plan

--- a/features/test-plan-resolver.feature
+++ b/features/test-plan-resolver.feature
@@ -1,0 +1,141 @@
+Feature: test-plan resolver
+
+  safeword needs one resolver that, given a repo, emits the test/build commands
+  for EVERY language present — so consumers stop duplicating language logic and a
+  polyglot done-gate cannot go green with a language untested. The resolver is
+  plan-only: each entry carries the command string it WOULD run, never its result.
+
+  Rule: Every detected language appears in the plan (no first-match)
+
+    @test-plan-resolver.DEV1.AC1
+    Scenario: A JS+Python repo yields exactly a javascript and a python entry
+      Given a repo with a root "test" script and a "pyproject.toml"
+      When I request the test plan
+      Then the plan includes a "javascript" entry
+      And the plan includes a "python" entry
+      And the plan has exactly 2 entries
+
+    @test-plan-resolver.DEV1.AC1
+    Scenario: A Go+Rust repo yields both a go and a rust entry
+      Given a repo with a "go.mod" and a "Cargo.toml"
+      When I request the test plan
+      Then the plan includes a "go" entry
+      And the plan includes a "rust" entry
+
+    @test-plan-resolver.DEV1.AC1
+    Scenario: A package.json with an empty scripts object contributes no javascript entry
+      Given a repo with a "go.mod" and a "package.json" whose "scripts" is "{}"
+      When I request the test plan
+      Then the plan includes a "go" entry
+      And the plan has no "javascript" entry
+
+    @test-plan-resolver.DEV1.AC1
+    Scenario: A malformed manifest is skipped without dropping other languages
+      Given a repo with a "go.mod" and a "package.json" containing invalid JSON
+      When I request the test plan
+      Then the plan includes a "go" entry
+      And the plan has no "javascript" entry
+
+    @test-plan-resolver.DEV1.AC1
+    Scenario: A repo with no recognized manifest yields an empty plan
+      Given a repo with no recognized language manifest
+      When I request the test plan
+      Then the plan is empty
+
+  Rule: The command reflects the detected runner
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: Python with a tox.ini runs tox
+      Given a Python repo with a "tox.ini"
+      When I request the test plan
+      Then the "python" entry command is "tox"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: Python with no pytest falls back to unittest
+      Given a Python repo with no pytest configuration
+      And only the "python" toolchain is installed
+      When I request the test plan
+      Then the "python" entry command is "python -m unittest discover"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: A uv-locked Python repo runs pytest through uv
+      Given a Python repo with a "uv.lock" and pytest configured
+      And the "uv" and "pytest" toolchains are installed
+      When I request the test plan
+      Then the "python" entry command is "uv run pytest"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: Rust uses nextest when it is installed
+      Given a Rust repo
+      And the "cargo" and "cargo-nextest" toolchains are installed
+      When I request the test plan
+      Then the "rust" entry command is "cargo nextest run --workspace"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: Rust falls back to cargo test --workspace without nextest
+      Given a Rust repo
+      And only the "cargo" toolchain is installed
+      When I request the test plan
+      Then the "rust" entry command is "cargo test --workspace"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: A Go workspace expands its modules in the emitted command
+      Given a Go repo with a "go.work"
+      When I request the test plan
+      Then the "go" entry command is "go test $(go list -f '{{.Dir}}/...' -m | xargs)"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: A pnpm JS repo runs its test script through pnpm
+      Given a repo with a root "test" script and a "pnpm-lock.yaml"
+      When I request the test plan
+      Then the "javascript" entry command is "pnpm run test"
+
+  Rule: Missing toolchains stay visible, never dropped
+
+    @test-plan-resolver.DEV1.AC3
+    Scenario: A Go repo with no go binary still appears, marked unavailable
+      Given a repo with a "go.mod"
+      And the "go" toolchain is not installed
+      When I request the test plan
+      Then the plan includes a "go" entry
+      And the "go" entry is marked unavailable
+
+  Rule: Nested and vendored manifests are handled
+
+    @test-plan-resolver.DEV1.AC4
+    Scenario: A manifest in a sub-directory is discovered
+      Given a repo with a "services/api/pyproject.toml" and no root manifest
+      When I request the test plan
+      Then the plan includes a "python" entry
+
+    @test-plan-resolver.DEV1.AC4
+    Scenario: A manifest inside an excluded directory is ignored
+      Given a repo with a "Cargo.toml" only under "target"
+      When I request the test plan
+      Then the plan has no "rust" entry
+
+  Rule: The build plan emits native build commands
+
+    @test-plan-resolver.DEV1.AC5
+    Scenario: Build plan emits per-language build commands
+      Given a repo with a "go.mod", a "Cargo.toml", and a root "build" script
+      When I request the build plan
+      Then the "go" entry command is "go build ./..."
+      And the "rust" entry command is "cargo build --workspace"
+      And the plan has no "python" entry
+
+    @test-plan-resolver.DEV1.AC5
+    Scenario: Build plan omits a JS entry when there is no build script
+      Given a repo with a "go.mod" and a "package.json" with no "build" script
+      When I request the build plan
+      Then the plan includes a "go" entry
+      And the plan has no "javascript" entry
+
+  Rule: The resolver is reachable as one CLI surface
+
+    @test-plan-resolver.SM1.AC1
+    Scenario: The CLI prints the resolved plan as JSON
+      Given a repo with a "go.mod"
+      When I run "safeword test-plan --kind test --json"
+      Then the output is a JSON array containing an entry with language "go"
+      And that entry has a non-empty "command" and a boolean "available"

--- a/features/test-plan-resolver.feature
+++ b/features/test-plan-resolver.feature
@@ -69,7 +69,7 @@ Feature: test-plan resolver
       Given a Rust repo
       And the "cargo" and "cargo-nextest" toolchains are installed
       When I request the test plan
-      Then the "rust" entry command is "cargo nextest run --workspace"
+      Then the "rust" entry command is "cargo nextest run --workspace && cargo test --doc"
 
     @test-plan-resolver.DEV1.AC2
     Scenario: Rust falls back to cargo test --workspace without nextest

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -145,11 +145,17 @@ program
   .description('Emit the test/build commands for every language detected in the repo')
   .argument('[dir]', 'project directory to scan (defaults to the current directory)')
   .option('--kind <kind>', 'test or build', 'test')
-  .option('--json', 'print the plan as JSON')
-  .action(async (dir: string | undefined, options: { kind?: string; json?: boolean }) => {
-    const { testPlan } = await import('./commands/test-plan.js');
-    await testPlan(options, dir);
-  });
+  .option('--format <format>', 'human, json, or sh (eval-able)', 'human')
+  .option('--json', 'alias for --format json')
+  .action(
+    async (
+      dir: string | undefined,
+      options: { kind?: string; json?: boolean; format?: string },
+    ) => {
+      const { testPlan } = await import('./commands/test-plan.js');
+      await testPlan(options, dir);
+    },
+  );
 
 // Show help if no arguments provided
 if (process.argv.length === 2) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -140,6 +140,17 @@ program
     await lintGherkin(files);
   });
 
+program
+  .command('test-plan')
+  .description('Emit the test/build commands for every language detected in the repo')
+  .argument('[dir]', 'project directory to scan (defaults to the current directory)')
+  .option('--kind <kind>', 'test or build', 'test')
+  .option('--json', 'print the plan as JSON')
+  .action(async (dir: string | undefined, options: { kind?: string; json?: boolean }) => {
+    const { testPlan } = await import('./commands/test-plan.js');
+    await testPlan(options, dir);
+  });
+
 // Show help if no arguments provided
 if (process.argv.length === 2) {
   program.help();

--- a/packages/cli/src/commands/test-plan.ts
+++ b/packages/cli/src/commands/test-plan.ts
@@ -7,15 +7,26 @@
 import nodePath from 'node:path';
 import process from 'node:process';
 
+import { renderShellPlan } from '../test-plan/render.js';
 import { type PlanKind, resolveTestPlan } from '../test-plan/resolve.js';
 
-export function testPlan(options: { kind?: string; json?: boolean }, dir?: string): Promise<void> {
+type Format = 'human' | 'json' | 'sh';
+
+export function testPlan(
+  options: { kind?: string; json?: boolean; format?: string },
+  dir?: string,
+): Promise<void> {
   const kind = parseKind(options.kind);
+  const format = parseFormat(options);
   const root = dir === undefined ? process.cwd() : nodePath.resolve(process.cwd(), dir);
   const plan = resolveTestPlan(root, { kind });
 
-  if (options.json) {
+  if (format === 'json') {
     console.log(JSON.stringify(plan));
+    return Promise.resolve();
+  }
+  if (format === 'sh') {
+    process.stdout.write(renderShellPlan(plan));
     return Promise.resolve();
   }
 
@@ -28,6 +39,16 @@ export function testPlan(options: { kind?: string; json?: boolean }, dir?: strin
     console.log(`${planEntry.language}: ${planEntry.command}${suffix}`);
   }
   return Promise.resolve();
+}
+
+/** `--json` is the back-compat alias for `--format json`. */
+function parseFormat(options: { json?: boolean; format?: string }): Format {
+  if (options.json) return 'json';
+  const value = options.format;
+  if (value === undefined || value === 'human') return 'human';
+  if (value === 'json' || value === 'sh') return value;
+  console.error(`Unknown --format "${value}" (expected "human", "json", or "sh")`);
+  process.exit(1);
 }
 
 function parseKind(value: string | undefined): PlanKind {

--- a/packages/cli/src/commands/test-plan.ts
+++ b/packages/cli/src/commands/test-plan.ts
@@ -1,0 +1,38 @@
+/**
+ * `safeword test-plan` — emit the test/build commands for every language present
+ * in the repo, as the single source of truth consumers (verify/audit/test-runner)
+ * call. Plan-only: prints commands, never runs them.
+ */
+
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { type PlanKind, resolveTestPlan } from '../test-plan/resolve.js';
+
+export function testPlan(options: { kind?: string; json?: boolean }, dir?: string): Promise<void> {
+  const kind = parseKind(options.kind);
+  const root = dir === undefined ? process.cwd() : nodePath.resolve(process.cwd(), dir);
+  const plan = resolveTestPlan(root, { kind });
+
+  if (options.json) {
+    console.log(JSON.stringify(plan));
+    return Promise.resolve();
+  }
+
+  if (plan.length === 0) {
+    console.log(`No ${kind} suites detected.`);
+    return Promise.resolve();
+  }
+  for (const planEntry of plan) {
+    const suffix = planEntry.available ? '' : ' (unavailable — skipped)';
+    console.log(`${planEntry.language}: ${planEntry.command}${suffix}`);
+  }
+  return Promise.resolve();
+}
+
+function parseKind(value: string | undefined): PlanKind {
+  if (value === undefined || value === 'test') return 'test';
+  if (value === 'build') return 'build';
+  console.error(`Unknown --kind "${value}" (expected "test" or "build")`);
+  process.exit(1);
+}

--- a/packages/cli/src/test-plan/render.ts
+++ b/packages/cli/src/test-plan/render.ts
@@ -1,0 +1,27 @@
+/**
+ * Render a test/build plan as an eval-able shell script for bash consumers
+ * (e.g. the /verify skill: `eval "$(safeword test-plan --format sh)"`).
+ *
+ * - `set -e` (only when there's something to run) so the eval exits non-zero on
+ *   the first failing suite — preserving the done-gate's block-on-red behavior.
+ * - one `( cd "<cwd>" && <command> )` per available entry (cd-scoped so nested
+ *   modules run in their own directory).
+ * - one `echo "⏭️ Skipped — <runner> not installed"` per unavailable entry, so a
+ *   missing toolchain is visible, never a silently-dropped or failing command.
+ * - an empty plan renders to the empty string — a clean no-op under `eval`.
+ */
+
+import type { PlanEntry } from './resolve.js';
+
+export function renderShellPlan(entries: PlanEntry[]): string {
+  if (entries.length === 0) return '';
+  const lines = ['set -e'];
+  for (const entry of entries) {
+    lines.push(
+      entry.available
+        ? `( cd "${entry.cwd}" && ${entry.command} )`
+        : `echo "⏭️ Skipped — ${entry.runner} not installed"`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/packages/cli/src/test-plan/render.ts
+++ b/packages/cli/src/test-plan/render.ts
@@ -13,13 +13,26 @@
 
 import type { PlanEntry } from './resolve.js';
 
+/**
+ * POSIX single-quote a string so the shell treats it as a literal — no `$()`,
+ * backtick, or variable expansion. Critical for `cwd`, which is filesystem data
+ * (a directory could be maliciously named e.g. `$(rm -rf ~)`); the script is
+ * eval'd by consumers, so an unescaped path would be a command-injection vector.
+ */
+function shellQuote(value: string): string {
+  const escaped = value.replaceAll("'", String.raw`'\''`);
+  return `'${escaped}'`;
+}
+
 export function renderShellPlan(entries: PlanEntry[]): string {
   if (entries.length === 0) return '';
   const lines = ['set -e'];
   for (const entry of entries) {
+    // `entry.cwd` is data → single-quoted. `entry.command` is safeword's own
+    // trusted output (and may legitimately contain `$(go list …)`) → left as-is.
     lines.push(
       entry.available
-        ? `( cd "${entry.cwd}" && ${entry.command} )`
+        ? `( cd ${shellQuote(entry.cwd)} && ${entry.command} )`
         : `echo "⏭️ Skipped — ${entry.runner} not installed"`,
     );
   }

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -113,17 +113,21 @@ function pickTestScript(scripts: Record<string, string>): string | undefined {
   return undefined;
 }
 
-function pytestConfigured(root: string): boolean {
-  if (existsInTree(root, 'pytest.ini')) return true;
-  const dir = findInTree(root, 'pyproject.toml');
+/** True when `file` (found anywhere in the tree) contains `marker`. */
+function configContains(root: string, file: string, marker: string): boolean {
+  const dir = findInTree(root, file);
   if (dir === undefined) return false;
   try {
-    return readFileSync(nodePath.join(dir, 'pyproject.toml'), 'utf8').includes(
-      '[tool.pytest.ini_options]',
-    );
+    return readFileSync(nodePath.join(dir, file), 'utf8').includes(marker);
   } catch {
     return false;
   }
+}
+
+function pytestConfigured(root: string): boolean {
+  if (existsInTree(root, 'pytest.ini') || existsInTree(root, '.pytest.ini')) return true;
+  if (configContains(root, 'pyproject.toml', '[tool.pytest.ini_options]')) return true;
+  return configContains(root, 'setup.cfg', '[tool:pytest]');
 }
 
 /** Package-manager-aware pytest invocation; returns the command, runner, and the tool whose presence gates availability. */
@@ -147,7 +151,15 @@ function resolvePython(
     const { command, tool } = pytestInvocation(root, isAvailable);
     return entry('python', root, command, 'pytest', isAvailable(tool));
   }
-  return entry('python', root, 'python -m unittest discover', 'unittest', isAvailable('python'));
+  // Prefer python3 (the only `python` on macOS/modern distros), fall back to python.
+  const pythonBin = isAvailable('python3') ? 'python3' : 'python';
+  return entry(
+    'python',
+    root,
+    `${pythonBin} -m unittest discover`,
+    'unittest',
+    isAvailable(pythonBin),
+  );
 }
 
 function goCommand(root: string, kind: PlanKind): string {
@@ -168,7 +180,14 @@ function resolveRust(root: string, kind: PlanKind, isAvailable: ToolProbe): Plan
   if (kind === 'build')
     return entry('rust', root, 'cargo build --workspace', 'cargo', isAvailable('cargo'));
   if (isAvailable('cargo-nextest'))
-    return entry('rust', root, 'cargo nextest run --workspace', 'nextest', isAvailable('cargo'));
+    // nextest doesn't run doctests — append `cargo test --doc` so they aren't silently skipped.
+    return entry(
+      'rust',
+      root,
+      'cargo nextest run --workspace && cargo test --doc',
+      'nextest',
+      isAvailable('cargo'),
+    );
   return entry('rust', root, 'cargo test --workspace', 'cargo', isAvailable('cargo'));
 }
 

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -51,14 +51,19 @@ const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'set
  */
 function fakeToolProbe(spec: string): (tool: string) => boolean {
   if (spec.startsWith('only:')) {
-    const set = new Set(spec.slice(5).split(',').filter(Boolean));
+    const set = parseToolList(spec);
     return tool => set.has(tool);
   }
   if (spec.startsWith('none:')) {
-    const set = new Set(spec.slice(5).split(',').filter(Boolean));
+    const set = parseToolList(spec);
     return tool => !set.has(tool);
   }
   return allToolsAvailable; // 'all' or empty
+}
+
+/** Parse the comma-separated tool list after a `only:` / `none:` prefix. */
+function parseToolList(spec: string): Set<string> {
+  return new Set(spec.slice('only:'.length).split(',').filter(Boolean));
 }
 
 function allToolsAvailable(): boolean {

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -1,0 +1,186 @@
+/**
+ * test-plan resolver (ticket BKTTZA).
+ *
+ * Given a repo root, emit the test/build command for EVERY language present —
+ * polyglot, no first-match. Pure except for an injectable `isToolAvailable`
+ * probe, so runner selection is unit-testable without real toolchains. Plan-only:
+ * each entry carries the command it WOULD run; callers execute.
+ *
+ * Reaches the consumers (verify/audit/test-runner) via the `safeword test-plan`
+ * CLI — shipped hooks cannot import safeword code, so the CLI is the seam.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { existsInTree, findInTree } from '../utils/fs.js';
+import { detectPackageManager } from '../utils/install.js';
+
+export type PlanKind = 'test' | 'build';
+export type Language = 'javascript' | 'python' | 'go' | 'rust';
+
+export interface PlanEntry {
+  language: Language;
+  /** Directory the command runs in (repo root for v1). */
+  cwd: string;
+  /** The command string to run. Plan-only — never executed here. */
+  command: string;
+  /** The detected runner (e.g. pytest, tox, unittest, nextest, cargo, go, pnpm). */
+  runner: string;
+  /** Whether the runner's toolchain is installed. Unavailable entries are kept (visible), never dropped. */
+  available: boolean;
+}
+
+export interface ResolveOptions {
+  kind?: PlanKind;
+  /** Injected for tests; defaults to a real `command -v` probe. */
+  isToolAvailable?: (tool: string) => boolean;
+}
+
+type ToolProbe = (tool: string) => boolean;
+
+const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'tox.ini'];
+
+/**
+ * Parse the `SAFEWORD_FAKE_TOOLS` test seam (same spirit as `SAFEWORD_SKIP_INSTALL`):
+ * `all` → everything installed; `only:a,b` → allowlist; `none:a,b` → denylist.
+ * Lets the BDD acceptance lane drive the real CLI deterministically without
+ * depending on the host's actual toolchains.
+ */
+function fakeToolProbe(spec: string): (tool: string) => boolean {
+  if (spec.startsWith('only:')) {
+    const set = new Set(spec.slice(5).split(',').filter(Boolean));
+    return tool => set.has(tool);
+  }
+  if (spec.startsWith('none:')) {
+    const set = new Set(spec.slice(5).split(',').filter(Boolean));
+    return tool => !set.has(tool);
+  }
+  return allToolsAvailable; // 'all' or empty
+}
+
+function allToolsAvailable(): boolean {
+  return true;
+}
+
+function defaultIsToolAvailable(tool: string): boolean {
+  const fake = process.env.SAFEWORD_FAKE_TOOLS;
+  if (fake !== undefined) return fakeToolProbe(fake)(tool);
+  return spawnSync('command', ['-v', tool], { shell: true, stdio: 'ignore' }).status === 0;
+}
+
+function entry(
+  language: Language,
+  cwd: string,
+  command: string,
+  runner: string,
+  available: boolean,
+): PlanEntry {
+  return { language, cwd, command, runner, available };
+}
+
+/** Root package.json scripts, or undefined when absent/unparseable (so a malformed manifest never aborts the plan). */
+function readRootScripts(root: string): Record<string, string> | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(nodePath.join(root, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    return pkg.scripts ?? {};
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveJs(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
+  const scripts = readRootScripts(root);
+  if (!scripts) return undefined;
+  const pm = detectPackageManager(root);
+  if (kind === 'build') {
+    return scripts.build
+      ? entry('javascript', root, `${pm} run build`, pm, isAvailable(pm))
+      : undefined;
+  }
+  const script = pickTestScript(scripts);
+  return script ? entry('javascript', root, `${pm} run ${script}`, pm, isAvailable(pm)) : undefined;
+}
+
+/** Prefer a gate-tuned `test:done` subset, else `test`; undefined when neither exists. */
+function pickTestScript(scripts: Record<string, string>): string | undefined {
+  if (scripts['test:done']) return 'test:done';
+  if (scripts.test) return 'test';
+  return undefined;
+}
+
+function pytestConfigured(root: string): boolean {
+  if (existsInTree(root, 'pytest.ini')) return true;
+  const dir = findInTree(root, 'pyproject.toml');
+  if (dir === undefined) return false;
+  try {
+    return readFileSync(nodePath.join(dir, 'pyproject.toml'), 'utf8').includes(
+      '[tool.pytest.ini_options]',
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Package-manager-aware pytest invocation; returns the command, runner, and the tool whose presence gates availability. */
+function pytestInvocation(root: string, isAvailable: ToolProbe): { command: string; tool: string } {
+  if (existsInTree(root, 'uv.lock') && isAvailable('uv'))
+    return { command: 'uv run pytest', tool: 'uv' };
+  if (existsInTree(root, 'poetry.lock') && isAvailable('poetry'))
+    return { command: 'poetry run pytest', tool: 'poetry' };
+  return { command: 'pytest', tool: 'pytest' };
+}
+
+function resolvePython(
+  root: string,
+  kind: PlanKind,
+  isAvailable: ToolProbe,
+): PlanEntry | undefined {
+  if (kind === 'build') return undefined; // no standard Python build step
+  if (!PYTHON_MANIFESTS.some(manifest => existsInTree(root, manifest))) return undefined;
+  if (existsInTree(root, 'tox.ini')) return entry('python', root, 'tox', 'tox', isAvailable('tox'));
+  if (pytestConfigured(root) || isAvailable('pytest')) {
+    const { command, tool } = pytestInvocation(root, isAvailable);
+    return entry('python', root, command, 'pytest', isAvailable(tool));
+  }
+  return entry('python', root, 'python -m unittest discover', 'unittest', isAvailable('python'));
+}
+
+function goCommand(root: string, kind: PlanKind): string {
+  const verb = kind === 'build' ? 'build' : 'test';
+  if (existsSync(nodePath.join(root, 'go.work'))) {
+    return `go ${verb} $(go list -f '{{.Dir}}/...' -m | xargs)`;
+  }
+  return `go ${verb} ./...`;
+}
+
+function resolveGo(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
+  if (!existsInTree(root, 'go.mod')) return undefined;
+  return entry('go', root, goCommand(root, kind), 'go', isAvailable('go'));
+}
+
+function resolveRust(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
+  if (!existsInTree(root, 'Cargo.toml')) return undefined;
+  if (kind === 'build')
+    return entry('rust', root, 'cargo build --workspace', 'cargo', isAvailable('cargo'));
+  if (isAvailable('cargo-nextest'))
+    return entry('rust', root, 'cargo nextest run --workspace', 'nextest', isAvailable('cargo'));
+  return entry('rust', root, 'cargo test --workspace', 'cargo', isAvailable('cargo'));
+}
+
+/**
+ * Resolve the test (or build) plan for a repo: one entry per detected language.
+ * Languages whose toolchain is missing are still listed (`available:false`).
+ */
+export function resolveTestPlan(root: string, options: ResolveOptions = {}): PlanEntry[] {
+  const kind = options.kind ?? 'test';
+  const isAvailable = options.isToolAvailable ?? defaultIsToolAvailable;
+  const resolvers = [resolveJs, resolvePython, resolveGo, resolveRust];
+  return resolvers
+    .map(resolve => resolve(root, kind, isAvailable))
+    .filter((planEntry): planEntry is PlanEntry => planEntry !== undefined);
+}

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -8,6 +8,10 @@
  *
  * Reaches the consumers (verify/audit/test-runner) via the `safeword test-plan`
  * CLI — shipped hooks cannot import safeword code, so the CLI is the seam.
+ *
+ * Manifest discovery is a single tree walk (`indexFilesInTree`) shared by every
+ * language resolver, so a complex/deep monorepo costs one traversal, not one per
+ * probe.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -15,7 +19,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { existsInTree, findInTree } from '../utils/fs.js';
+import { indexFilesInTree } from '../utils/fs.js';
 import { detectPackageManager } from '../utils/install.js';
 
 export type PlanKind = 'test' | 'build';
@@ -23,7 +27,7 @@ export type Language = 'javascript' | 'python' | 'go' | 'rust';
 
 export interface PlanEntry {
   language: Language;
-  /** Directory the command runs in (repo root for v1). */
+  /** Directory the command runs in (the discovered manifest's directory). */
   cwd: string;
   /** The command string to run. Plan-only — never executed here. */
   command: string;
@@ -40,8 +44,21 @@ export interface ResolveOptions {
 }
 
 type ToolProbe = (tool: string) => boolean;
+/** filename → directory of its shallowest occurrence (from one tree walk). */
+type ManifestIndex = ReadonlyMap<string, string>;
 
 const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'tox.ini'];
+
+/** Every manifest probed via the tree (root-only files like package.json/go.work are checked directly). */
+const TREE_MANIFESTS = new Set<string>([
+  ...PYTHON_MANIFESTS,
+  'pytest.ini',
+  '.pytest.ini',
+  'uv.lock',
+  'poetry.lock',
+  'go.mod',
+  'Cargo.toml',
+]);
 
 /**
  * Parse the `SAFEWORD_FAKE_TOOLS` test seam (same spirit as `SAFEWORD_SKIP_INSTALL`):
@@ -86,6 +103,15 @@ function entry(
   return { language, cwd, command, runner, available };
 }
 
+/** Directory of the first listed manifest present in the index, or root if none. */
+function firstDirectory(root: string, index: ManifestIndex, names: readonly string[]): string {
+  for (const name of names) {
+    const dir = index.get(name);
+    if (dir !== undefined) return dir;
+  }
+  return root;
+}
+
 /** Root package.json scripts, or undefined when absent/unparseable (so a malformed manifest never aborts the plan). */
 function readRootScripts(root: string): Record<string, string> | undefined {
   try {
@@ -98,7 +124,13 @@ function readRootScripts(root: string): Record<string, string> | undefined {
   }
 }
 
-function resolveJs(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
+function resolveJs(
+  root: string,
+  _index: ManifestIndex,
+  kind: PlanKind,
+  isAvailable: ToolProbe,
+): PlanEntry | undefined {
+  // JS is detected root-only: subdirectory package.json is too common to treat as a project root.
   const scripts = readRootScripts(root);
   if (!scripts) return undefined;
   const pm = detectPackageManager(root);
@@ -118,18 +150,9 @@ function pickTestScript(scripts: Record<string, string>): string | undefined {
   return undefined;
 }
 
-/** Directory of the first listed manifest found in the tree, or root if none. The command runs here. */
-function manifestDirectory(root: string, names: readonly string[]): string {
-  for (const name of names) {
-    const dir = findInTree(root, name);
-    if (dir !== undefined) return dir;
-  }
-  return root;
-}
-
-/** True when `file` (found anywhere in the tree) contains `marker`. */
-function configContains(root: string, file: string, marker: string): boolean {
-  const dir = findInTree(root, file);
+/** True when an indexed `file` contains `marker`. */
+function configContains(index: ManifestIndex, file: string, marker: string): boolean {
+  const dir = index.get(file);
   if (dir === undefined) return false;
   try {
     return readFileSync(nodePath.join(dir, file), 'utf8').includes(marker);
@@ -138,32 +161,35 @@ function configContains(root: string, file: string, marker: string): boolean {
   }
 }
 
-function pytestConfigured(root: string): boolean {
-  if (existsInTree(root, 'pytest.ini') || existsInTree(root, '.pytest.ini')) return true;
-  if (configContains(root, 'pyproject.toml', '[tool.pytest.ini_options]')) return true;
-  return configContains(root, 'setup.cfg', '[tool:pytest]');
+function pytestConfigured(index: ManifestIndex): boolean {
+  if (index.has('pytest.ini') || index.has('.pytest.ini')) return true;
+  if (configContains(index, 'pyproject.toml', '[tool.pytest.ini_options]')) return true;
+  return configContains(index, 'setup.cfg', '[tool:pytest]');
 }
 
-/** Package-manager-aware pytest invocation; returns the command, runner, and the tool whose presence gates availability. */
-function pytestInvocation(root: string, isAvailable: ToolProbe): { command: string; tool: string } {
-  if (existsInTree(root, 'uv.lock') && isAvailable('uv'))
-    return { command: 'uv run pytest', tool: 'uv' };
-  if (existsInTree(root, 'poetry.lock') && isAvailable('poetry'))
+/** Package-manager-aware pytest invocation; returns the command and the tool whose presence gates availability. */
+function pytestInvocation(
+  index: ManifestIndex,
+  isAvailable: ToolProbe,
+): { command: string; tool: string } {
+  if (index.has('uv.lock') && isAvailable('uv')) return { command: 'uv run pytest', tool: 'uv' };
+  if (index.has('poetry.lock') && isAvailable('poetry'))
     return { command: 'poetry run pytest', tool: 'poetry' };
   return { command: 'pytest', tool: 'pytest' };
 }
 
 function resolvePython(
   root: string,
+  index: ManifestIndex,
   kind: PlanKind,
   isAvailable: ToolProbe,
 ): PlanEntry | undefined {
   if (kind === 'build') return undefined; // no standard Python build step
-  if (!PYTHON_MANIFESTS.some(manifest => existsInTree(root, manifest))) return undefined;
-  const cwd = manifestDirectory(root, PYTHON_MANIFESTS);
-  if (existsInTree(root, 'tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
-  if (pytestConfigured(root) || isAvailable('pytest')) {
-    const { command, tool } = pytestInvocation(root, isAvailable);
+  if (!PYTHON_MANIFESTS.some(manifest => index.has(manifest))) return undefined;
+  const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
+  if (index.has('tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
+  if (pytestConfigured(index) || isAvailable('pytest')) {
+    const { command, tool } = pytestInvocation(index, isAvailable);
     return entry('python', cwd, command, 'pytest', isAvailable(tool));
   }
   // Prefer python3 (the only `python` on macOS/modern distros), fall back to python.
@@ -177,8 +203,13 @@ function resolvePython(
   );
 }
 
-function resolveGo(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
-  if (!existsInTree(root, 'go.mod')) return undefined;
+function resolveGo(
+  root: string,
+  index: ManifestIndex,
+  kind: PlanKind,
+  isAvailable: ToolProbe,
+): PlanEntry | undefined {
+  if (!index.has('go.mod')) return undefined;
   const verb = kind === 'build' ? 'build' : 'test';
   // A root go.work tests every workspace module — run the expansion from root.
   // Otherwise run `./...` in the module's own directory (supports nested modules).
@@ -186,13 +217,18 @@ function resolveGo(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEn
     const command = `go ${verb} $(go list -f '{{.Dir}}/...' -m | xargs)`;
     return entry('go', root, command, 'go', isAvailable('go'));
   }
-  const cwd = findInTree(root, 'go.mod') ?? root;
+  const cwd = index.get('go.mod') ?? root;
   return entry('go', cwd, `go ${verb} ./...`, 'go', isAvailable('go'));
 }
 
-function resolveRust(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
-  if (!existsInTree(root, 'Cargo.toml')) return undefined;
-  const cwd = findInTree(root, 'Cargo.toml') ?? root;
+function resolveRust(
+  root: string,
+  index: ManifestIndex,
+  kind: PlanKind,
+  isAvailable: ToolProbe,
+): PlanEntry | undefined {
+  if (!index.has('Cargo.toml')) return undefined;
+  const cwd = index.get('Cargo.toml') ?? root;
   if (kind === 'build')
     return entry('rust', cwd, 'cargo build --workspace', 'cargo', isAvailable('cargo'));
   if (isAvailable('cargo-nextest'))
@@ -214,8 +250,9 @@ function resolveRust(root: string, kind: PlanKind, isAvailable: ToolProbe): Plan
 export function resolveTestPlan(root: string, options: ResolveOptions = {}): PlanEntry[] {
   const kind = options.kind ?? 'test';
   const isAvailable = options.isToolAvailable ?? defaultIsToolAvailable;
+  const index = indexFilesInTree(root, TREE_MANIFESTS);
   const resolvers = [resolveJs, resolvePython, resolveGo, resolveRust];
   return resolvers
-    .map(resolve => resolve(root, kind, isAvailable))
+    .map(resolve => resolve(root, index, kind, isAvailable))
     .filter((planEntry): planEntry is PlanEntry => planEntry !== undefined);
 }

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -118,6 +118,15 @@ function pickTestScript(scripts: Record<string, string>): string | undefined {
   return undefined;
 }
 
+/** Directory of the first listed manifest found in the tree, or root if none. The command runs here. */
+function manifestDirectory(root: string, names: readonly string[]): string {
+  for (const name of names) {
+    const dir = findInTree(root, name);
+    if (dir !== undefined) return dir;
+  }
+  return root;
+}
+
 /** True when `file` (found anywhere in the tree) contains `marker`. */
 function configContains(root: string, file: string, marker: string): boolean {
   const dir = findInTree(root, file);
@@ -151,49 +160,51 @@ function resolvePython(
 ): PlanEntry | undefined {
   if (kind === 'build') return undefined; // no standard Python build step
   if (!PYTHON_MANIFESTS.some(manifest => existsInTree(root, manifest))) return undefined;
-  if (existsInTree(root, 'tox.ini')) return entry('python', root, 'tox', 'tox', isAvailable('tox'));
+  const cwd = manifestDirectory(root, PYTHON_MANIFESTS);
+  if (existsInTree(root, 'tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
   if (pytestConfigured(root) || isAvailable('pytest')) {
     const { command, tool } = pytestInvocation(root, isAvailable);
-    return entry('python', root, command, 'pytest', isAvailable(tool));
+    return entry('python', cwd, command, 'pytest', isAvailable(tool));
   }
   // Prefer python3 (the only `python` on macOS/modern distros), fall back to python.
   const pythonBin = isAvailable('python3') ? 'python3' : 'python';
   return entry(
     'python',
-    root,
+    cwd,
     `${pythonBin} -m unittest discover`,
     'unittest',
     isAvailable(pythonBin),
   );
 }
 
-function goCommand(root: string, kind: PlanKind): string {
-  const verb = kind === 'build' ? 'build' : 'test';
-  if (existsSync(nodePath.join(root, 'go.work'))) {
-    return `go ${verb} $(go list -f '{{.Dir}}/...' -m | xargs)`;
-  }
-  return `go ${verb} ./...`;
-}
-
 function resolveGo(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
   if (!existsInTree(root, 'go.mod')) return undefined;
-  return entry('go', root, goCommand(root, kind), 'go', isAvailable('go'));
+  const verb = kind === 'build' ? 'build' : 'test';
+  // A root go.work tests every workspace module — run the expansion from root.
+  // Otherwise run `./...` in the module's own directory (supports nested modules).
+  if (existsSync(nodePath.join(root, 'go.work'))) {
+    const command = `go ${verb} $(go list -f '{{.Dir}}/...' -m | xargs)`;
+    return entry('go', root, command, 'go', isAvailable('go'));
+  }
+  const cwd = findInTree(root, 'go.mod') ?? root;
+  return entry('go', cwd, `go ${verb} ./...`, 'go', isAvailable('go'));
 }
 
 function resolveRust(root: string, kind: PlanKind, isAvailable: ToolProbe): PlanEntry | undefined {
   if (!existsInTree(root, 'Cargo.toml')) return undefined;
+  const cwd = findInTree(root, 'Cargo.toml') ?? root;
   if (kind === 'build')
-    return entry('rust', root, 'cargo build --workspace', 'cargo', isAvailable('cargo'));
+    return entry('rust', cwd, 'cargo build --workspace', 'cargo', isAvailable('cargo'));
   if (isAvailable('cargo-nextest'))
     // nextest doesn't run doctests — append `cargo test --doc` so they aren't silently skipped.
     return entry(
       'rust',
-      root,
+      cwd,
       'cargo nextest run --workspace && cargo test --doc',
       'nextest',
       isAvailable('cargo'),
     );
-  return entry('rust', root, 'cargo test --workspace', 'cargo', isAvailable('cargo'));
+  return entry('rust', cwd, 'cargo test --workspace', 'cargo', isAvailable('cargo'));
 }
 
 /**

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -162,6 +162,40 @@ function scanTreeForFile(
 }
 
 /**
+ * Index multiple files in a single tree walk — the multi-file analogue of
+ * `findInTree`. Returns a Map from each requested filename to the directory of
+ * its **shallowest** occurrence (root-first, level-order — same ordering as
+ * `findInTree`), omitting names not found. One traversal regardless of how many
+ * filenames are requested, so callers that probe many manifests stay O(one walk)
+ * even on large/deep monorepos. Stops early once every name is located.
+ */
+export function indexFilesInTree(
+  cwd: string,
+  filenames: Iterable<string>,
+  maxDepth = 10,
+): Map<string, string> {
+  const wanted = [...filenames];
+  const found = new Map<string, string>();
+  const queue: { directory: string; depth: number }[] = [{ directory: cwd, depth: 0 }];
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (item === undefined) break;
+    for (const name of wanted) {
+      if (!found.has(name) && existsSync(nodePath.join(item.directory, name))) {
+        found.set(name, item.directory);
+      }
+    }
+    if (found.size === wanted.length) break;
+    if (item.depth >= maxDepth) continue;
+    for (const subdirectory of getScannableSubdirectories(item.directory)) {
+      queue.push({ directory: subdirectory, depth: item.depth + 1 });
+    }
+  }
+  return found;
+}
+
+/**
  * Create directory recursively
  * @param path
  */

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -176,10 +176,14 @@ export function indexFilesInTree(
 ): Map<string, string> {
   const wanted = [...filenames];
   const found = new Map<string, string>();
+  // Cursor instead of Array.shift() so the BFS stays O(dirs), not O(dirs²) on
+  // wide/deep monorepos — the very repos this single-walk index exists to serve.
   const queue: { directory: string; depth: number }[] = [{ directory: cwd, depth: 0 }];
 
-  while (queue.length > 0) {
-    const item = queue.shift();
+  let head = 0;
+  while (head < queue.length) {
+    const item = queue[head];
+    head += 1;
     if (item === undefined) break;
     for (const name of wanted) {
       if (!found.has(name) && existsSync(nodePath.join(item.directory, name))) {

--- a/packages/cli/templates/commands/audit.md
+++ b/packages/cli/templates/commands/audit.md
@@ -60,6 +60,10 @@ DEPCRUISE_CONFIG=""
 # Note: Go compiler prevents circular imports between packages at build time.
 # If your Go project builds, it has no circular dependencies.
 
+# 1d. Architecture - Rust
+# Note: Rust's module system and compiler reject circular module dependencies at
+# build time. If your crate builds, it has no circular module dependencies.
+
 # =========================================================================
 # DEAD CODE DETECTION
 # =========================================================================
@@ -79,6 +83,11 @@ DEPCRUISE_CONFIG=""
 # 2c. Dead code - Go (golangci-lint unused)
 [ -f go.mod ] && {
   golangci-lint run --enable unused --out-format colored-line-number 2>&1 || true
+}
+
+# 2d. Dead code - Rust (clippy flags dead_code / unused)
+[ -f Cargo.toml ] && command -v cargo > /dev/null && {
+  cargo clippy --quiet 2>&1 || true
 }
 
 # =========================================================================
@@ -105,6 +114,13 @@ bunx jscpd . --gitignore --min-lines 10 --reporters console 2>&1 || true
 # 4c. Outdated - Go
 [ -f go.mod ] && {
   go list -m -u all 2>&1 | grep '\[' || echo "All Go modules up to date"
+}
+
+# 4d. Outdated - Rust (requires cargo-outdated)
+[ -f Cargo.toml ] && {
+  if command -v cargo-outdated > /dev/null; then
+    cargo outdated 2>&1 || true
+  else echo "Rust outdated check skipped — install with: cargo install cargo-outdated"; fi
 }
 ```
 
@@ -227,7 +243,7 @@ Test Quality:
 
 - If missing → create from `.safeword/templates/architecture-template.md`
 - If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts code (e.g., doc says "Redux", package.json has "zustand")
+  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
   - **Gap (warn):** Major dependencies not documented
 
 **README.md:**

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -51,9 +51,29 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
+Every project has a `package.json` (the BDD lane needs one), so a real `test`
+script — not the file — is the "this is a JS project" signal. Run the first
+matching language's suite; skip gracefully when a toolchain isn't installed.
+
 ```bash
-# Full test suite
-bun run test 2>&1
+# --- Test suite (first matching language) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
+  bun run test 2>&1
+elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  if [ -f uv.lock ] && command -v uv > /dev/null; then
+    uv run pytest 2>&1
+  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
+    poetry run pytest 2>&1
+  elif command -v pytest > /dev/null; then
+    pytest 2>&1
+  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
+elif [ -f go.mod ]; then
+  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
+elif [ -f Cargo.toml ]; then
+  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
+else
+  echo "Test Suite: ⏭️ Skipped — no test suite detected"
+fi
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -62,8 +82,16 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# Build check
-bun run build 2>&1
+# --- Build check (JS build script, else native compile) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
+  bun run build 2>&1
+elif [ -f go.mod ] && command -v go > /dev/null; then
+  go build ./... 2>&1
+elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
+  cargo build 2>&1
+else
+  echo "Build: ⏭️ Skipped — no build step for this project"
+fi
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.
@@ -88,20 +116,24 @@ If ticket has `parent:` field:
 
 ### 5. Check Dependency Drift
 
-Compare `package.json` dependencies against `ARCHITECTURE.md`:
+Compare the project's declared dependencies against `ARCHITECTURE.md`:
 
 1. If `ARCHITECTURE.md` does not exist, skip this check
 2. Read `ARCHITECTURE.md` content
-3. Read `package.json` `dependencies` and `devDependencies` keys
+3. Read the project's dependency manifest(s) — whichever exist:
+   - **JS/TS:** `package.json` `dependencies` and `devDependencies`
+   - **Python:** `pyproject.toml` (`[project]` `dependencies`, `[tool.poetry.dependencies]`) or `requirements.txt`
+   - **Go:** the `require` block in `go.mod`
+   - **Rust:** `[dependencies]` (and `[dev-dependencies]`) in `Cargo.toml`
 4. For each dependency name:
-   - Extract the package name (without `@scope/` prefix for matching — but check both full name and short name)
-   - Check if `ARCHITECTURE.md` mentions the package name (case-insensitive)
-5. Flag any dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
+   - Extract the bare name (drop the `@scope/` prefix for JS, version/path specifiers for the others); check both full and short forms
+   - Check if `ARCHITECTURE.md` mentions it (case-insensitive)
+5. Flag any runtime/architectural dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
 
 Do NOT flag:
 
-- `@types/*` packages (type-only, not architectural)
-- Packages in `devDependencies` that are tooling (eslint plugins, prettier plugins, test utils) — only flag deps that represent architectural choices
+- Type-only packages (`@types/*`) and standard-library imports
+- Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
 ### 6. Report Results
 
@@ -114,9 +146,9 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
 **Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
-**Build:** ✅ Success (or ❌ Failed)
+**Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -58,8 +58,16 @@ non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
 not a `test-plan` suite).
 
 ```bash
+# Resolve a test-plan-capable safeword CLI — prefer the locally installed one
+# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(bunx safeword test-plan --kind test --format sh)"
+bash -c "$($SW test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -69,7 +77,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(bunx safeword test-plan --kind build --format sh)"
+bash -c "$($SW test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -51,29 +51,15 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
-Every project has a `package.json` (the BDD lane needs one), so a real `test`
-script — not the file — is the "this is a JS project" signal. Run the first
-matching language's suite; skip gracefully when a toolchain isn't installed.
+Per-language test/build commands come from `safeword test-plan` — one source of
+truth (the same plan the stop-hook gate runs). Eval its shell plan in a child
+shell: an absent toolchain prints a visible skip, and a failing suite exits
+non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
+not a `test-plan` suite).
 
 ```bash
-# --- Test suite (first matching language) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
-  bun run test 2>&1
-elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
-  if [ -f uv.lock ] && command -v uv > /dev/null; then
-    uv run pytest 2>&1
-  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
-    poetry run pytest 2>&1
-  elif command -v pytest > /dev/null; then
-    pytest 2>&1
-  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
-elif [ -f go.mod ]; then
-  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
-elif [ -f Cargo.toml ]; then
-  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
-else
-  echo "Test Suite: ⏭️ Skipped — no test suite detected"
-fi
+# --- Test suite (resolved by safeword test-plan — one source of truth) ---
+bash -c "$(bunx safeword test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -82,16 +68,8 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# --- Build check (JS build script, else native compile) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
-  bun run build 2>&1
-elif [ -f go.mod ] && command -v go > /dev/null; then
-  go build ./... 2>&1
-elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
-  cargo build 2>&1
-else
-  echo "Build: ⏭️ Skipped — no build step for this project"
-fi
+# --- Build check (resolved by safeword test-plan) ---
+bash -c "$(bunx safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/templates/hooks/lib/test-runner.ts
+++ b/packages/cli/templates/hooks/lib/test-runner.ts
@@ -1,6 +1,13 @@
 /**
  * Test runner utilities for the stop hook.
- * Detects and executes the project's test suite directly.
+ *
+ * The per-language test command is resolved by the single source of truth —
+ * `safeword test-plan --kind test --json` — not duplicated here. This hook only
+ * EXECUTES the resolved commands (timeout-safe, no zombies) and appends the JS
+ * acceptance lane (`test:bdd`), which the resolver does not emit.
+ *
+ * Shipped hooks cannot import safeword code, so we reach the resolver via the
+ * CLI (the `safewordCliCommand()` installed→source→bunx pattern, mirroring lint.ts).
  */
 
 import { execSync, spawnSync } from 'node:child_process';
@@ -10,11 +17,22 @@ import nodePath from 'node:path';
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 type TestCommand = {
-  /** package.json script name, e.g. test:done or test:bdd. */
+  /** Label for output/diagnostics (the runner or script name). */
   script: string;
   /** Concrete shell command to execute. */
   command: string;
+  /** Directory to run the command in (the resolved entry's cwd). */
+  cwd: string;
 };
+
+/** One entry of `safeword test-plan --json` output. */
+interface PlanEntry {
+  language: string;
+  cwd: string;
+  command: string;
+  runner: string;
+  available: boolean;
+}
 
 export interface TestResult {
   /** Whether tests passed (exit code 0). */
@@ -34,9 +52,11 @@ const MAX_OUTPUT_LINES = 30;
 /** Maximum characters of test output to inject into the block reason. */
 const MAX_OUTPUT_CHARS = 3000;
 
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
 /**
  * Detect package manager by lockfile presence (bun > pnpm > yarn > npm).
- * Mirrors the logic in packages/cli/src/utils/install.ts.
+ * Used only for the `test:bdd` acceptance lane (the resolver owns the rest).
  */
 function detectPackageManager(cwd: string): PackageManager {
   if (existsSync(nodePath.join(cwd, 'bun.lockb')) || existsSync(nodePath.join(cwd, 'bun.lock')))
@@ -48,103 +68,74 @@ function detectPackageManager(cwd: string): PackageManager {
   return 'npm';
 }
 
-/**
- * Convert a package.json script name into the command for the detected package
- * manager.
- */
+/** Convert a package.json script name into the detected package manager's run command. */
 function formatRunCommand(script: string, packageManager: PackageManager): string {
   if (packageManager === 'npm') return script === 'test' ? 'npm test' : `npm run ${script}`;
   return `${packageManager} run ${script}`;
 }
 
-/** Check whether a CLI tool is on PATH via POSIX `command -v`. */
-function isToolAvailable(tool: string): boolean {
-  const result = spawnSync('command', ['-v', tool], { shell: true, stdio: 'ignore' });
-  return result.status === 0;
+/**
+ * Resolve the safeword CLI invocation. `SAFEWORD_CLI` (a path to cli.js/cli.ts run
+ * via bun) overrides for tests/dev; otherwise the installed package, then the
+ * dogfood source, then `bunx`.
+ */
+function safewordCliCommand(cwd: string): [string, ...string[]] {
+  const override = process.env.SAFEWORD_CLI;
+  if (override) return ['bun', override];
+  const installed = nodePath.join(cwd, 'node_modules', 'safeword', 'dist', 'cli.js');
+  if (existsSync(installed)) return ['bun', installed];
+  const source = nodePath.join(cwd, 'packages', 'cli', 'src', 'cli.ts');
+  if (existsSync(source)) return ['bun', source];
+  return ['bunx', 'safeword'];
 }
 
 /**
- * Resolve the Python test command, package-manager aware (uv > poetry > bare
- * pytest). Returns undefined when no Python test toolchain is installed so the
- * caller skips rather than blocks.
+ * Ask `safeword test-plan` for the project's test commands and keep the runnable
+ * (available) ones. Returns [] on any failure so the caller skips, never blocks.
  */
-function pythonTestCommand(
-  cwd: string,
-  isAvailable: (tool: string) => boolean,
-): TestCommand | undefined {
-  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
-  if (has('uv.lock') && isAvailable('uv')) return { script: 'pytest', command: 'uv run pytest' };
-  if (has('poetry.lock') && isAvailable('poetry'))
-    return { script: 'pytest', command: 'poetry run pytest' };
-  if (isAvailable('pytest')) return { script: 'pytest', command: 'pytest' };
-  return undefined;
-}
-
-/**
- * Resolve the native test command for a non-JS project from its manifest, or
- * undefined when no supported manifest is present OR the toolchain isn't
- * installed (caller skips, never blocks — mirrors the lint hook's graceful
- * degradation). Pure except for the injected `isAvailable` probe, so the
- * language→command decision is unit-testable without the real toolchains.
- */
-export function nativeTestCommand(
-  cwd: string,
-  isAvailable: (tool: string) => boolean = isToolAvailable,
-): TestCommand | undefined {
-  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
-  if (has('pyproject.toml') || has('requirements.txt')) return pythonTestCommand(cwd, isAvailable);
-  if (has('go.mod'))
-    return isAvailable('go') ? { script: 'go test', command: 'go test ./...' } : undefined;
-  if (has('Cargo.toml'))
-    return isAvailable('cargo') ? { script: 'cargo test', command: 'cargo test' } : undefined;
-  return undefined;
-}
-
-/**
- * Detect test commands from package.json scripts. Prefers `test:done` (a
- * gate-tuned fast subset) when present, falling back to `test`, and appends
- * `test:bdd` when present so executable `.feature` scenarios are part of done
- * evidence. Projects whose full test suite exceeds TEST_TIMEOUT_MS should
- * define `test:done` as a meaningful but fast subset — unit tests + drift
- * checks typically work.
- * Returns an empty array if package.json is absent or no runnable test scripts
- * exist.
- */
-function getJsTestCommands(cwd: string): TestCommand[] {
-  const packageJsonPath = nodePath.join(cwd, 'package.json');
+function resolvePlanCommands(cwd: string): TestCommand[] {
+  const cli = safewordCliCommand(cwd);
+  const result = spawnSync(
+    cli[0],
+    [...cli.slice(1), 'test-plan', '--kind', 'test', '--json', cwd],
+    { encoding: 'utf8', timeout: TEST_TIMEOUT_MS },
+  );
+  if (result.status !== 0 || !result.stdout) return [];
   try {
-    const content = readFileSync(packageJsonPath, 'utf8');
-    const pkg = JSON.parse(content) as { scripts?: Record<string, string> };
-    const pm = detectPackageManager(cwd);
-    const scripts = pkg.scripts ?? {};
-    const commands: TestCommand[] = [];
-    const addCommand = (script: string): void => {
-      if (commands.some(command => command.script === script)) return;
-      commands.push({ script, command: formatRunCommand(script, pm) });
-    };
-
-    if (scripts['test:done']) addCommand('test:done');
-    else if (scripts.test) addCommand('test');
-    if (scripts['test:bdd']) addCommand('test:bdd');
-
-    return commands;
+    const entries = JSON.parse(result.stdout) as PlanEntry[];
+    return entries
+      .filter(entry => entry.available)
+      .map(entry => ({ script: entry.runner, command: entry.command, cwd: entry.cwd }));
   } catch {
     return [];
   }
 }
 
-/**
- * Resolve the test commands to run. A configured JS test script wins (it's the
- * project's chosen suite); otherwise fall back to the native language suite
- * detected from the manifest. Every project gets a package.json (ticket 102b),
- * so the presence of a real `test` script — not the file — is the JS signal.
- * Returns an empty array when nothing runnable is found (caller skips).
- */
+/** The JS acceptance lane (`test:bdd`) — consumer-side, not emitted by the resolver. */
+function bddCommand(cwd: string): TestCommand | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(nodePath.join(cwd, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    if (pkg.scripts?.['test:bdd']) {
+      return {
+        script: 'test:bdd',
+        command: formatRunCommand('test:bdd', detectPackageManager(cwd)),
+        cwd,
+      };
+    }
+  } catch {
+    // No package.json — no acceptance lane.
+  }
+  return undefined;
+}
+
+/** Resolved suite (from test-plan) plus the acceptance lane; [] means skip. */
 function getTestCommands(cwd: string): TestCommand[] {
-  const jsCommands = getJsTestCommands(cwd);
-  if (jsCommands.length > 0) return jsCommands;
-  const native = nativeTestCommand(cwd);
-  return native ? [native] : [];
+  const commands = resolvePlanCommands(cwd);
+  const bdd = bddCommand(cwd);
+  if (bdd) commands.push(bdd);
+  return commands;
 }
 
 function formatCommandOutput(testCommand: TestCommand, output: string): string {
@@ -164,13 +155,10 @@ function truncateOutput(output: string): string {
   return '...(truncated)\n' + tail.slice(-MAX_OUTPUT_CHARS);
 }
 
-function runSingleTestCommand(
-  cwd: string,
-  testCommand: TestCommand,
-): { passed: boolean; output: string } {
+function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; output: string } {
   try {
     const output = execSync(testCommand.command, {
-      cwd,
+      cwd: testCommand.cwd,
       timeout: TEST_TIMEOUT_MS,
       stdio: 'pipe',
       encoding: 'utf8',
@@ -204,20 +192,21 @@ function runSingleTestCommand(
 }
 
 /**
- * Run the project's test suite directly and return the result.
+ * Run the project's test suite and return the result.
  *
- * - Detects test commands from package.json scripts
- * - Uses execSync for synchronous, timeout-safe execution (no zombie processes)
- * - Returns skipped=true if no test command found (caller should not block)
+ * - Resolves commands from `safeword test-plan` (single source of truth) + the
+ *   `test:bdd` acceptance lane.
+ * - Uses execSync for synchronous, timeout-safe execution (no zombie processes).
+ * - Returns skipped=true if no runnable command was found (caller should not block).
  */
-export function runTests(cwd: string): TestResult {
+export function runTests(cwd: string = projectDir): TestResult {
   const commands = getTestCommands(cwd);
   if (commands.length === 0) return { passed: true, output: '', skipped: true };
 
   const outputs: string[] = [];
 
   for (const testCommand of commands) {
-    const result = runSingleTestCommand(cwd, testCommand);
+    const result = runSingleTestCommand(testCommand);
     outputs.push(result.output);
     if (!result.passed)
       return { passed: false, output: truncateOutput(outputs.join('\n\n')), skipped: false };

--- a/packages/cli/templates/hooks/lib/test-runner.ts
+++ b/packages/cli/templates/hooks/lib/test-runner.ts
@@ -3,7 +3,7 @@
  * Detects and executes the project's test suite directly.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -57,6 +57,49 @@ function formatRunCommand(script: string, packageManager: PackageManager): strin
   return `${packageManager} run ${script}`;
 }
 
+/** Check whether a CLI tool is on PATH via POSIX `command -v`. */
+function isToolAvailable(tool: string): boolean {
+  const result = spawnSync('command', ['-v', tool], { shell: true, stdio: 'ignore' });
+  return result.status === 0;
+}
+
+/**
+ * Resolve the Python test command, package-manager aware (uv > poetry > bare
+ * pytest). Returns undefined when no Python test toolchain is installed so the
+ * caller skips rather than blocks.
+ */
+function pythonTestCommand(
+  cwd: string,
+  isAvailable: (tool: string) => boolean,
+): TestCommand | undefined {
+  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
+  if (has('uv.lock') && isAvailable('uv')) return { script: 'pytest', command: 'uv run pytest' };
+  if (has('poetry.lock') && isAvailable('poetry'))
+    return { script: 'pytest', command: 'poetry run pytest' };
+  if (isAvailable('pytest')) return { script: 'pytest', command: 'pytest' };
+  return undefined;
+}
+
+/**
+ * Resolve the native test command for a non-JS project from its manifest, or
+ * undefined when no supported manifest is present OR the toolchain isn't
+ * installed (caller skips, never blocks — mirrors the lint hook's graceful
+ * degradation). Pure except for the injected `isAvailable` probe, so the
+ * language→command decision is unit-testable without the real toolchains.
+ */
+export function nativeTestCommand(
+  cwd: string,
+  isAvailable: (tool: string) => boolean = isToolAvailable,
+): TestCommand | undefined {
+  const has = (file: string): boolean => existsSync(nodePath.join(cwd, file));
+  if (has('pyproject.toml') || has('requirements.txt')) return pythonTestCommand(cwd, isAvailable);
+  if (has('go.mod'))
+    return isAvailable('go') ? { script: 'go test', command: 'go test ./...' } : undefined;
+  if (has('Cargo.toml'))
+    return isAvailable('cargo') ? { script: 'cargo test', command: 'cargo test' } : undefined;
+  return undefined;
+}
+
 /**
  * Detect test commands from package.json scripts. Prefers `test:done` (a
  * gate-tuned fast subset) when present, falling back to `test`, and appends
@@ -67,7 +110,7 @@ function formatRunCommand(script: string, packageManager: PackageManager): strin
  * Returns an empty array if package.json is absent or no runnable test scripts
  * exist.
  */
-function getTestCommands(cwd: string): TestCommand[] {
+function getJsTestCommands(cwd: string): TestCommand[] {
   const packageJsonPath = nodePath.join(cwd, 'package.json');
   try {
     const content = readFileSync(packageJsonPath, 'utf8');
@@ -88,6 +131,20 @@ function getTestCommands(cwd: string): TestCommand[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Resolve the test commands to run. A configured JS test script wins (it's the
+ * project's chosen suite); otherwise fall back to the native language suite
+ * detected from the manifest. Every project gets a package.json (ticket 102b),
+ * so the presence of a real `test` script — not the file — is the JS signal.
+ * Returns an empty array when nothing runnable is found (caller skips).
+ */
+function getTestCommands(cwd: string): TestCommand[] {
+  const jsCommands = getJsTestCommands(cwd);
+  if (jsCommands.length > 0) return jsCommands;
+  const native = nativeTestCommand(cwd);
+  return native ? [native] : [];
 }
 
 function formatCommandOutput(testCommand: TestCommand, output: string): string {

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -64,6 +64,10 @@ DEPCRUISE_CONFIG=""
 # Note: Go compiler prevents circular imports between packages at build time.
 # If your Go project builds, it has no circular dependencies.
 
+# 1d. Architecture - Rust
+# Note: Rust's module system and compiler reject circular module dependencies at
+# build time. If your crate builds, it has no circular module dependencies.
+
 # =========================================================================
 # DEAD CODE DETECTION
 # =========================================================================
@@ -83,6 +87,11 @@ DEPCRUISE_CONFIG=""
 # 2c. Dead code - Go (golangci-lint unused)
 [ -f go.mod ] && {
   golangci-lint run --enable unused --out-format colored-line-number 2>&1 || true
+}
+
+# 2d. Dead code - Rust (clippy flags dead_code / unused)
+[ -f Cargo.toml ] && command -v cargo > /dev/null && {
+  cargo clippy --quiet 2>&1 || true
 }
 
 # =========================================================================
@@ -109,6 +118,13 @@ bunx jscpd . --gitignore --min-lines 10 --reporters console 2>&1 || true
 # 4c. Outdated - Go
 [ -f go.mod ] && {
   go list -m -u all 2>&1 | grep '\[' || echo "All Go modules up to date"
+}
+
+# 4d. Outdated - Rust (requires cargo-outdated)
+[ -f Cargo.toml ] && {
+  if command -v cargo-outdated > /dev/null; then
+    cargo outdated 2>&1 || true
+  else echo "Rust outdated check skipped — install with: cargo install cargo-outdated"; fi
 }
 ```
 
@@ -259,7 +275,7 @@ Test Quality:
 
 - If missing → create from `.safeword/templates/architecture-template.md`
 - If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts code (e.g., doc says "Redux", package.json has "zustand")
+  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
   - **Gap (warn):** Major dependencies not documented
 
 **README.md:**

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -55,29 +55,15 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
-Every project has a `package.json` (the BDD lane needs one), so a real `test`
-script — not the file — is the "this is a JS project" signal. Run the first
-matching language's suite; skip gracefully when a toolchain isn't installed.
+Per-language test/build commands come from `safeword test-plan` — one source of
+truth (the same plan the stop-hook gate runs). Eval its shell plan in a child
+shell: an absent toolchain prints a visible skip, and a failing suite exits
+non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
+not a `test-plan` suite).
 
 ```bash
-# --- Test suite (first matching language) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
-  bun run test 2>&1
-elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
-  if [ -f uv.lock ] && command -v uv > /dev/null; then
-    uv run pytest 2>&1
-  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
-    poetry run pytest 2>&1
-  elif command -v pytest > /dev/null; then
-    pytest 2>&1
-  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
-elif [ -f go.mod ]; then
-  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
-elif [ -f Cargo.toml ]; then
-  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
-else
-  echo "Test Suite: ⏭️ Skipped — no test suite detected"
-fi
+# --- Test suite (resolved by safeword test-plan — one source of truth) ---
+bash -c "$(bunx safeword test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -86,16 +72,8 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# --- Build check (JS build script, else native compile) ---
-if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
-  bun run build 2>&1
-elif [ -f go.mod ] && command -v go > /dev/null; then
-  go build ./... 2>&1
-elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
-  cargo build 2>&1
-else
-  echo "Build: ⏭️ Skipped — no build step for this project"
-fi
+# --- Build check (resolved by safeword test-plan) ---
+bash -c "$(bunx safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -62,8 +62,16 @@ non-zero so the gate blocks. The Gherkin acceptance lane runs separately (it is
 not a `test-plan` suite).
 
 ```bash
+# Resolve a test-plan-capable safeword CLI — prefer the locally installed one
+# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(bunx safeword test-plan --kind test --format sh)"
+bash -c "$($SW test-plan --kind test --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -73,7 +81,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(bunx safeword test-plan --kind build --format sh)"
+bash -c "$($SW test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -55,9 +55,29 @@ Run these in sequence, reporting each result:
 1. **Run `/lint`** to auto-fix style issues first
 2. Then run verification:
 
+Every project has a `package.json` (the BDD lane needs one), so a real `test`
+script — not the file — is the "this is a JS project" signal. Run the first
+matching language's suite; skip gracefully when a toolchain isn't installed.
+
 ```bash
-# Full test suite
-bun run test 2>&1
+# --- Test suite (first matching language) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.test||s["test:done"]?0:1)' 2> /dev/null; then
+  bun run test 2>&1
+elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  if [ -f uv.lock ] && command -v uv > /dev/null; then
+    uv run pytest 2>&1
+  elif [ -f poetry.lock ] && command -v poetry > /dev/null; then
+    poetry run pytest 2>&1
+  elif command -v pytest > /dev/null; then
+    pytest 2>&1
+  else echo "Test Suite: ⏭️ Skipped — pytest not installed"; fi
+elif [ -f go.mod ]; then
+  command -v go > /dev/null && go test ./... 2>&1 || echo "Test Suite: ⏭️ Skipped — go not installed"
+elif [ -f Cargo.toml ]; then
+  command -v cargo > /dev/null && cargo test 2>&1 || echo "Test Suite: ⏭️ Skipped — cargo not installed"
+else
+  echo "Test Suite: ⏭️ Skipped — no test suite detected"
+fi
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -66,8 +86,16 @@ else
   echo "Gherkin acceptance lane skipped: Skipped — no test:bdd script"
 fi
 
-# Build check
-bun run build 2>&1
+# --- Build check (JS build script, else native compile) ---
+if node -e 'const s=(require("./package.json").scripts)||{};process.exit(s.build?0:1)' 2> /dev/null; then
+  bun run build 2>&1
+elif [ -f go.mod ] && command -v go > /dev/null; then
+  go build ./... 2>&1
+elif [ -f Cargo.toml ] && command -v cargo > /dev/null; then
+  cargo build 2>&1
+else
+  echo "Build: ⏭️ Skipped — no build step for this project"
+fi
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.
@@ -92,20 +120,24 @@ If ticket has `parent:` field:
 
 ### 5. Check Dependency Drift
 
-Compare `package.json` dependencies against `ARCHITECTURE.md`:
+Compare the project's declared dependencies against `ARCHITECTURE.md`:
 
 1. If `ARCHITECTURE.md` does not exist, skip this check
 2. Read `ARCHITECTURE.md` content
-3. Read `package.json` `dependencies` and `devDependencies` keys
+3. Read the project's dependency manifest(s) — whichever exist:
+   - **JS/TS:** `package.json` `dependencies` and `devDependencies`
+   - **Python:** `pyproject.toml` (`[project]` `dependencies`, `[tool.poetry.dependencies]`) or `requirements.txt`
+   - **Go:** the `require` block in `go.mod`
+   - **Rust:** `[dependencies]` (and `[dev-dependencies]`) in `Cargo.toml`
 4. For each dependency name:
-   - Extract the package name (without `@scope/` prefix for matching — but check both full name and short name)
-   - Check if `ARCHITECTURE.md` mentions the package name (case-insensitive)
-5. Flag any dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
+   - Extract the bare name (drop the `@scope/` prefix for JS, version/path specifiers for the others); check both full and short forms
+   - Check if `ARCHITECTURE.md` mentions it (case-insensitive)
+5. Flag any runtime/architectural dependency NOT mentioned: `"Dependency \`{name}\` not documented in ARCHITECTURE.md"`
 
 Do NOT flag:
 
-- `@types/*` packages (type-only, not architectural)
-- Packages in `devDependencies` that are tooling (eslint plugins, prettier plugins, test utils) — only flag deps that represent architectural choices
+- Type-only packages (`@types/*`) and standard-library imports
+- Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
 ### 6. Report Results
 
@@ -118,9 +150,9 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
 **Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
-**Build:** ✅ Success (or ❌ Failed)
+**Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)

--- a/packages/cli/tests/commands/setup-hooks.test.ts
+++ b/packages/cli/tests/commands/setup-hooks.test.ts
@@ -231,24 +231,29 @@ describe('Test Suite 3: Setup - Hooks and Skills', () => {
   });
 
   describe('Test 3.5: Exit 1 if hook registration fails', () => {
-    it('should fail with exit 1 when settings.json is not writable', async () => {
-      createTypeScriptPackageJson(temporaryDirectory);
-      initGitRepo(temporaryDirectory);
+    // Skipped as root: root ignores chmod 0o444, so the write succeeds and setup
+    // exits 0 — the permission-denial path can't be exercised as the superuser.
+    it.skipIf(process.getuid?.() === 0)(
+      'should fail with exit 1 when settings.json is not writable',
+      async () => {
+        createTypeScriptPackageJson(temporaryDirectory);
+        initGitRepo(temporaryDirectory);
 
-      // Create .claude directory with read-only settings.json
-      writeTestFile(temporaryDirectory, '.claude/settings.json', '{}');
-      chmodSync(nodePath.join(temporaryDirectory, '.claude/settings.json'), 0o444);
+        // Create .claude directory with read-only settings.json
+        writeTestFile(temporaryDirectory, '.claude/settings.json', '{}');
+        chmodSync(nodePath.join(temporaryDirectory, '.claude/settings.json'), 0o444);
 
-      const result = await runCli(['setup'], {
-        cwd: temporaryDirectory,
-      });
+        const result = await runCli(['setup'], {
+          cwd: temporaryDirectory,
+        });
 
-      // Restore permissions for cleanup
-      chmodSync(nodePath.join(temporaryDirectory, '.claude/settings.json'), 0o644);
+        // Restore permissions for cleanup
+        chmodSync(nodePath.join(temporaryDirectory, '.claude/settings.json'), 0o644);
 
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr.toLowerCase()).toMatch(/hook|permission|write|failed/i);
-    });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr.toLowerCase()).toMatch(/hook|permission|write|failed/i);
+      },
+    );
   });
 
   describe('Test 3.7: Installs lib scripts', () => {

--- a/packages/cli/tests/commands/setup-linting.test.ts
+++ b/packages/cli/tests/commands/setup-linting.test.ts
@@ -131,23 +131,28 @@ describe('Test Suite 4: Setup - Linting (Integration)', () => {
   });
 
   describe('Test 4.8: Exit 1 if linting setup fails', () => {
-    it('should fail with exit 1 when package.json is not writable', async () => {
-      createTypeScriptPackageJson(temporaryDirectory);
-      initGitRepo(temporaryDirectory);
+    // Skipped as root: root ignores chmod 0o444, so the write succeeds and setup
+    // exits 0 — the permission-denial path can't be exercised as the superuser.
+    it.skipIf(process.getuid?.() === 0)(
+      'should fail with exit 1 when package.json is not writable',
+      async () => {
+        createTypeScriptPackageJson(temporaryDirectory);
+        initGitRepo(temporaryDirectory);
 
-      // Make package.json read-only
-      chmodSync(nodePath.join(temporaryDirectory, 'package.json'), 0o444);
+        // Make package.json read-only
+        chmodSync(nodePath.join(temporaryDirectory, 'package.json'), 0o444);
 
-      const result = await runCli(['setup'], {
-        cwd: temporaryDirectory,
-      });
+        const result = await runCli(['setup'], {
+          cwd: temporaryDirectory,
+        });
 
-      // Restore permissions for cleanup
-      chmodSync(nodePath.join(temporaryDirectory, 'package.json'), 0o644);
+        // Restore permissions for cleanup
+        chmodSync(nodePath.join(temporaryDirectory, 'package.json'), 0o644);
 
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr.toLowerCase()).toMatch(/lint|permission|write|failed|package/i);
-    });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr.toLowerCase()).toMatch(/lint|permission|write|failed|package/i);
+      },
+    );
   });
 
   describe('Test 4.9: Adds format:check script', () => {

--- a/packages/cli/tests/hooks/test-runner.test.ts
+++ b/packages/cli/tests/hooks/test-runner.test.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { runTests } from '../../../../.safeword/hooks/lib/test-runner';
+import { nativeTestCommand, runTests } from '../../../../.safeword/hooks/lib/test-runner';
 
 const temporaryDirectories: string[] = [];
 
@@ -18,6 +18,19 @@ function makeProject(scripts: Record<string, string>): string {
   );
   return directory;
 }
+
+/** Make a temp project with the given manifest files (and no package.json). */
+function makeManifestProject(files: Record<string, string>): string {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-native-test-'));
+  temporaryDirectories.push(directory);
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(nodePath.join(directory, name), content);
+  }
+  return directory;
+}
+
+const allAvailable = (): boolean => true;
+const noneAvailable = (): boolean => false;
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -74,5 +87,74 @@ describe('runTests', () => {
     );
 
     expect(dogfood).toBe(template);
+  });
+});
+
+describe('nativeTestCommand', () => {
+  it('routes go.mod to `go test ./...` when go is available', () => {
+    const project = makeManifestProject({ 'go.mod': 'module example\n' });
+    expect(nativeTestCommand(project, allAvailable)).toEqual({
+      script: 'go test',
+      command: 'go test ./...',
+    });
+  });
+
+  it('routes Cargo.toml to `cargo test` when cargo is available', () => {
+    const project = makeManifestProject({ 'Cargo.toml': '[package]\nname = "x"\n' });
+    expect(nativeTestCommand(project, allAvailable)).toEqual({
+      script: 'cargo test',
+      command: 'cargo test',
+    });
+  });
+
+  it('prefers `uv run pytest` for a uv-locked Python project', () => {
+    const project = makeManifestProject({ 'pyproject.toml': '', 'uv.lock': '' });
+    expect(nativeTestCommand(project, allAvailable)).toEqual({
+      script: 'pytest',
+      command: 'uv run pytest',
+    });
+  });
+
+  it('prefers `poetry run pytest` for a poetry-locked Python project', () => {
+    const project = makeManifestProject({ 'pyproject.toml': '', 'poetry.lock': '' });
+    expect(nativeTestCommand(project, allAvailable)).toEqual({
+      script: 'pytest',
+      command: 'poetry run pytest',
+    });
+  });
+
+  it('falls back to bare `pytest` when the lock PM runner is unavailable', () => {
+    const project = makeManifestProject({ 'pyproject.toml': '', 'uv.lock': '' });
+    const onlyPytest = (tool: string): boolean => tool === 'pytest';
+    expect(nativeTestCommand(project, onlyPytest)).toEqual({ script: 'pytest', command: 'pytest' });
+  });
+
+  it('skips (undefined) when a manifest is present but its toolchain is absent', () => {
+    const goProject = makeManifestProject({ 'go.mod': 'module example\n' });
+    const pyProject = makeManifestProject({ 'pyproject.toml': '' });
+    expect(nativeTestCommand(goProject, noneAvailable)).toBeUndefined();
+    expect(nativeTestCommand(pyProject, noneAvailable)).toBeUndefined();
+  });
+
+  it('returns undefined when no supported manifest is present', () => {
+    const project = makeManifestProject({ 'README.md': '# hi\n' });
+    expect(nativeTestCommand(project, allAvailable)).toBeUndefined();
+  });
+});
+
+describe('runTests native fallback', () => {
+  it('never blocks a non-JS project: skips when toolchain absent, else runs it', () => {
+    // pyproject present, no JS test script. The done gate must never block on a
+    // missing toolchain — so this either skips, or (if pytest is installed in
+    // this environment) actually runs pytest.
+    const project = makeManifestProject({ 'pyproject.toml': '' });
+
+    const result = runTests(project);
+
+    if (result.skipped) {
+      expect(result).toEqual({ passed: true, output: '', skipped: true });
+    } else {
+      expect(result.output).toContain('pytest');
+    }
   });
 });

--- a/packages/cli/tests/hooks/test-runner.test.ts
+++ b/packages/cli/tests/hooks/test-runner.test.ts
@@ -2,11 +2,28 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { nativeTestCommand, runTests } from '../../../../.safeword/hooks/lib/test-runner';
+import { runTests } from '../../../../.safeword/hooks/lib/test-runner';
 
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const temporaryDirectories: string[] = [];
+const savedEnvironment: Record<string, string | undefined> = {};
+
+// Drive the real resolver offline + deterministically: point the hook at the
+// dogfood CLI source (no installed dist / no network bunx) and fake all tools
+// present so JS availability doesn't depend on the host.
+beforeAll(() => {
+  savedEnvironment.SAFEWORD_CLI = process.env.SAFEWORD_CLI;
+  savedEnvironment.SAFEWORD_FAKE_TOOLS = process.env.SAFEWORD_FAKE_TOOLS;
+  process.env.SAFEWORD_CLI = nodePath.join(repoRoot, 'packages/cli/src/cli.ts');
+  process.env.SAFEWORD_FAKE_TOOLS = 'all';
+});
+
+afterAll(() => {
+  process.env.SAFEWORD_CLI = savedEnvironment.SAFEWORD_CLI;
+  process.env.SAFEWORD_FAKE_TOOLS = savedEnvironment.SAFEWORD_FAKE_TOOLS;
+});
 
 function makeProject(scripts: Record<string, string>): string {
   const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-test-runner-'));
@@ -19,26 +36,13 @@ function makeProject(scripts: Record<string, string>): string {
   return directory;
 }
 
-/** Make a temp project with the given manifest files (and no package.json). */
-function makeManifestProject(files: Record<string, string>): string {
-  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-native-test-'));
-  temporaryDirectories.push(directory);
-  for (const [name, content] of Object.entries(files)) {
-    writeFileSync(nodePath.join(directory, name), content);
-  }
-  return directory;
-}
-
-const allAvailable = (): boolean => true;
-const noneAvailable = (): boolean => false;
-
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { force: true, recursive: true });
   }
 });
 
-describe('runTests', () => {
+describe('runTests (resolves its suite via safeword test-plan)', () => {
   it('blocks when the Gherkin acceptance lane fails after primary tests pass', () => {
     const project = makeProject({
       'test:done': 'node -e "console.log(\'PRIMARY_OK\')"',
@@ -63,7 +67,6 @@ describe('runTests', () => {
 
     expect(result.skipped).toBe(false);
     expect(result.passed).toBe(true);
-    expect(result.output).toContain('test');
     expect(result.output).toContain('test:bdd');
   });
 
@@ -75,8 +78,19 @@ describe('runTests', () => {
     expect(result).toEqual({ passed: true, output: '', skipped: true });
   });
 
+  it('holds no per-language command strings and resolves via test-plan', () => {
+    const source = readFileSync(
+      nodePath.join(repoRoot, 'packages/cli/templates/hooks/lib/test-runner.ts'),
+      'utf8',
+    );
+    expect(source).not.toMatch(/cargo test|go test|uv run pytest|\bpytest\b/);
+    expect(source).not.toContain('nativeTestCommand');
+    expect(source).not.toContain('getJsTestCommands');
+    expect(source).not.toContain('pythonTestCommand');
+    expect(source).toContain('test-plan');
+  });
+
   it('keeps the template and dogfood runner aligned', () => {
-    const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
     const template = readFileSync(
       nodePath.join(repoRoot, 'packages/cli/templates/hooks/lib/test-runner.ts'),
       'utf8',
@@ -87,74 +101,5 @@ describe('runTests', () => {
     );
 
     expect(dogfood).toBe(template);
-  });
-});
-
-describe('nativeTestCommand', () => {
-  it('routes go.mod to `go test ./...` when go is available', () => {
-    const project = makeManifestProject({ 'go.mod': 'module example\n' });
-    expect(nativeTestCommand(project, allAvailable)).toEqual({
-      script: 'go test',
-      command: 'go test ./...',
-    });
-  });
-
-  it('routes Cargo.toml to `cargo test` when cargo is available', () => {
-    const project = makeManifestProject({ 'Cargo.toml': '[package]\nname = "x"\n' });
-    expect(nativeTestCommand(project, allAvailable)).toEqual({
-      script: 'cargo test',
-      command: 'cargo test',
-    });
-  });
-
-  it('prefers `uv run pytest` for a uv-locked Python project', () => {
-    const project = makeManifestProject({ 'pyproject.toml': '', 'uv.lock': '' });
-    expect(nativeTestCommand(project, allAvailable)).toEqual({
-      script: 'pytest',
-      command: 'uv run pytest',
-    });
-  });
-
-  it('prefers `poetry run pytest` for a poetry-locked Python project', () => {
-    const project = makeManifestProject({ 'pyproject.toml': '', 'poetry.lock': '' });
-    expect(nativeTestCommand(project, allAvailable)).toEqual({
-      script: 'pytest',
-      command: 'poetry run pytest',
-    });
-  });
-
-  it('falls back to bare `pytest` when the lock PM runner is unavailable', () => {
-    const project = makeManifestProject({ 'pyproject.toml': '', 'uv.lock': '' });
-    const onlyPytest = (tool: string): boolean => tool === 'pytest';
-    expect(nativeTestCommand(project, onlyPytest)).toEqual({ script: 'pytest', command: 'pytest' });
-  });
-
-  it('skips (undefined) when a manifest is present but its toolchain is absent', () => {
-    const goProject = makeManifestProject({ 'go.mod': 'module example\n' });
-    const pyProject = makeManifestProject({ 'pyproject.toml': '' });
-    expect(nativeTestCommand(goProject, noneAvailable)).toBeUndefined();
-    expect(nativeTestCommand(pyProject, noneAvailable)).toBeUndefined();
-  });
-
-  it('returns undefined when no supported manifest is present', () => {
-    const project = makeManifestProject({ 'README.md': '# hi\n' });
-    expect(nativeTestCommand(project, allAvailable)).toBeUndefined();
-  });
-});
-
-describe('runTests native fallback', () => {
-  it('never blocks a non-JS project: skips when toolchain absent, else runs it', () => {
-    // pyproject present, no JS test script. The done gate must never block on a
-    // missing toolchain — so this either skips, or (if pytest is installed in
-    // this environment) actually runs pytest.
-    const project = makeManifestProject({ 'pyproject.toml': '' });
-
-    const result = runTests(project);
-
-    if (result.skipped) {
-      expect(result).toEqual({ passed: true, output: '', skipped: true });
-    } else {
-      expect(result.output).toContain('pytest');
-    }
   });
 });

--- a/packages/cli/tests/test-plan/cli-sh.test.ts
+++ b/packages/cli/tests/test-plan/cli-sh.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -68,6 +68,17 @@ describe('safeword test-plan --format sh', () => {
     const root = makeRepo({ 'package.json': JSON.stringify({ scripts: { test: 'exit 1' } }) });
     const { code } = evalScript(await renderSh(root), root);
     expect(code).not.toBe(0);
+  });
+
+  it('does not execute a command substitution in a maliciously-named directory', async () => {
+    // A nested Go module under a dir named with $(...). Eval must NOT run it.
+    const root = makeRepo({ 'm$(touch INJECTED)d/go.mod': 'module x\n' });
+    const sh = await renderSh(root);
+    const { code } = evalScript(sh, root);
+    // cd may fail (the literal dir name won't match a shell-expanded one), but
+    // the injection must not have fired.
+    expect(existsSync(nodePath.join(root, 'INJECTED'))).toBe(false);
+    expect(typeof code).toBe('number');
   });
 
   it('eval of an empty plan is a clean no-op (exit zero)', async () => {

--- a/packages/cli/tests/test-plan/cli-sh.test.ts
+++ b/packages/cli/tests/test-plan/cli-sh.test.ts
@@ -1,0 +1,79 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runCli } from '../helpers.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+function makeRepo(files: Record<string, string>): string {
+  const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-sh-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const abs = nodePath.join(root, relativePath);
+    mkdirSync(nodePath.dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return root;
+}
+
+async function renderSh(root: string, kind: 'test' | 'build' = 'test'): Promise<string> {
+  const result = await runCli(['test-plan', '--kind', kind, '--format', 'sh'], {
+    cwd: root,
+    env: { SAFEWORD_FAKE_TOOLS: 'all' },
+  });
+  expect(result.exitCode).toBe(0);
+  return result.stdout;
+}
+
+/** Eval a rendered script in bash; return { stdout, code }. */
+function evalScript(script: string, cwd: string): { stdout: string; code: number } {
+  try {
+    const stdout = execSync('bash', { input: script, cwd, encoding: 'utf8' });
+    return { stdout, code: 0 };
+  } catch (error) {
+    const err = error as { stdout?: string; status?: number };
+    return { stdout: err.stdout ?? '', code: err.status ?? 1 };
+  }
+}
+
+describe('safeword test-plan --format sh', () => {
+  it('renders a Go repo as a runnable go test command', async () => {
+    const sh = await renderSh(makeRepo({ 'go.mod': 'module x\n' }));
+    expect(sh).toContain('go test ./...');
+  });
+
+  it('renders --kind build as a go build command', async () => {
+    const sh = await renderSh(makeRepo({ 'go.mod': 'module x\n' }), 'build');
+    expect(sh).toContain('go build');
+  });
+
+  it('eval runs the resolved suite and exits zero on success', async () => {
+    const root = makeRepo({
+      'package.json': JSON.stringify({ scripts: { test: 'echo RAN_SUITE' } }),
+    });
+    const { stdout, code } = evalScript(await renderSh(root), root);
+    expect(stdout).toContain('RAN_SUITE');
+    expect(code).toBe(0);
+  });
+
+  it('eval exits non-zero when a suite fails', async () => {
+    const root = makeRepo({ 'package.json': JSON.stringify({ scripts: { test: 'exit 1' } }) });
+    const { code } = evalScript(await renderSh(root), root);
+    expect(code).not.toBe(0);
+  });
+
+  it('eval of an empty plan is a clean no-op (exit zero)', async () => {
+    const root = makeRepo({ 'README.md': '# hi\n' });
+    const sh = await renderSh(root);
+    expect(sh).toBe('');
+    expect(evalScript(sh, root).code).toBe(0);
+  });
+});

--- a/packages/cli/tests/test-plan/cli.test.ts
+++ b/packages/cli/tests/test-plan/cli.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runCli } from '../helpers.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+function makeGoRepo(): string {
+  const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-test-plan-cli-'));
+  temporaryDirectories.push(root);
+  writeFileSync(nodePath.join(root, 'go.mod'), 'module x\n');
+  return root;
+}
+
+describe('safeword test-plan --json', () => {
+  it('prints the resolved plan as a JSON array with the entry contract', async () => {
+    const root = makeGoRepo();
+
+    const result = await runCli(['test-plan', '--kind', 'test', '--json'], { cwd: root });
+
+    expect(result.exitCode).toBe(0);
+    const plan = JSON.parse(result.stdout) as {
+      language: string;
+      command: string;
+      available: unknown;
+    }[];
+    expect(Array.isArray(plan)).toBe(true);
+    const go = plan.find(entry => entry.language === 'go');
+    expect(go).toBeDefined();
+    expect(go?.command).not.toBe('');
+    expect(typeof go?.available).toBe('boolean');
+  });
+});

--- a/packages/cli/tests/test-plan/render.test.ts
+++ b/packages/cli/tests/test-plan/render.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderShellPlan } from '../../src/test-plan/render';
+import type { PlanEntry } from '../../src/test-plan/resolve';
+
+function entry(over: Partial<PlanEntry>): PlanEntry {
+  return {
+    language: 'go',
+    cwd: '/repo',
+    command: 'go test ./...',
+    runner: 'go',
+    available: true,
+    ...over,
+  };
+}
+
+describe('renderShellPlan', () => {
+  it('renders an available entry as a cd-scoped command', () => {
+    const sh = renderShellPlan([entry({ cwd: '/repo', command: 'go test ./...' })]);
+    expect(sh).toContain('( cd "/repo" && go test ./... )');
+  });
+
+  it('starts a non-empty script with set -e (fails the eval on a failing suite)', () => {
+    expect(renderShellPlan([entry({})]).startsWith('set -e\n')).toBe(true);
+  });
+
+  it('renders an unavailable entry as a visible skip echo, not a command', () => {
+    const sh = renderShellPlan([entry({ available: false, runner: 'go' })]);
+    expect(sh).toContain('echo "⏭️ Skipped — go not installed"');
+    expect(sh).not.toContain('( cd');
+  });
+
+  it('renders an empty plan as an empty string (a no-op under eval)', () => {
+    expect(renderShellPlan([])).toBe('');
+  });
+
+  it('renders every entry for a polyglot plan', () => {
+    const sh = renderShellPlan([
+      entry({ language: 'javascript', command: 'bun run test', runner: 'bun' }),
+      entry({ language: 'python', command: 'pytest', runner: 'pytest' }),
+    ]);
+    expect(sh).toContain('bun run test');
+    expect(sh).toContain('pytest');
+  });
+});

--- a/packages/cli/tests/test-plan/render.test.ts
+++ b/packages/cli/tests/test-plan/render.test.ts
@@ -17,7 +17,19 @@ function entry(over: Partial<PlanEntry>): PlanEntry {
 describe('renderShellPlan', () => {
   it('renders an available entry as a cd-scoped command', () => {
     const sh = renderShellPlan([entry({ cwd: '/repo', command: 'go test ./...' })]);
-    expect(sh).toContain('( cd "/repo" && go test ./... )');
+    expect(sh).toContain("( cd '/repo' && go test ./... )");
+  });
+
+  it('single-quotes the cwd so a maliciously-named directory cannot inject commands', () => {
+    const sh = renderShellPlan([entry({ cwd: '/repo/$(touch PWNED)', command: 'go test ./...' })]);
+    // The cwd is single-quoted verbatim — the $(...) is literal, never expanded.
+    expect(sh).toContain("cd '/repo/$(touch PWNED)'");
+    expect(sh).not.toContain('cd "');
+  });
+
+  it('escapes an embedded single quote in the cwd', () => {
+    const sh = renderShellPlan([entry({ cwd: "/re'po", command: 'go test ./...' })]);
+    expect(sh).toContain(String.raw`cd '/re'\''po'`);
   });
 
   it('starts a non-empty script with set -e (fails the eval on a failing suite)', () => {

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -91,6 +91,21 @@ describe('resolveTestPlan — the command reflects the detected runner', () => {
     expect(entryFor(plan, 'python')?.command).toBe('python -m unittest discover');
   });
 
+  it('prefers python3 for the unittest fallback when available', () => {
+    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python3') });
+    expect(entryFor(plan, 'python')?.command).toBe('python3 -m unittest discover');
+  });
+
+  it('detects pytest configured via setup.cfg [tool:pytest]', () => {
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'setup.cfg': '[tool:pytest]\naddopts = -q\n',
+    });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python', 'python3') });
+    expect(entryFor(plan, 'python')?.command).toBe('pytest');
+  });
+
   it('a uv-locked python repo runs pytest through uv', () => {
     const root = makeRepo({
       'pyproject.toml': '[tool.pytest.ini_options]\n',
@@ -103,7 +118,9 @@ describe('resolveTestPlan — the command reflects the detected runner', () => {
   it('rust uses nextest when it is installed', () => {
     const root = makeRepo({ 'Cargo.toml': '[package]\nname="x"\n' });
     const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('cargo', 'cargo-nextest') });
-    expect(entryFor(plan, 'rust')?.command).toBe('cargo nextest run --workspace');
+    expect(entryFor(plan, 'rust')?.command).toBe(
+      'cargo nextest run --workspace && cargo test --doc',
+    );
   });
 
   it('rust falls back to cargo test --workspace without nextest', () => {

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -1,0 +1,177 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { type Language, type PlanEntry, resolveTestPlan } from '../../src/test-plan/resolve';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+/** Build a temp repo from a map of relative path → file contents. */
+function makeRepo(files: Record<string, string>): string {
+  const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-test-plan-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const abs = nodePath.join(root, relativePath);
+    mkdirSync(nodePath.dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return root;
+}
+
+const allTools = (): boolean => true;
+const onlyTools =
+  (...names: string[]) =>
+  (tool: string): boolean =>
+    names.includes(tool);
+
+function entryFor(plan: PlanEntry[], language: Language): PlanEntry | undefined {
+  return plan.find(planEntry => planEntry.language === language);
+}
+function languages(plan: PlanEntry[]): Language[] {
+  return plan.map(planEntry => planEntry.language);
+}
+
+describe('resolveTestPlan — every detected language appears (no first-match)', () => {
+  it('a JS+Python repo yields exactly a javascript and a python entry', () => {
+    const root = makeRepo({
+      'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+      'pyproject.toml': '[project]\nname = "x"\n',
+    });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(languages(plan).toSorted()).toEqual(['javascript', 'python']);
+    expect(plan).toHaveLength(2);
+  });
+
+  it('a Go+Rust repo yields both a go and a rust entry', () => {
+    const root = makeRepo({ 'go.mod': 'module x\n', 'Cargo.toml': '[package]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')).toBeDefined();
+    expect(entryFor(plan, 'rust')).toBeDefined();
+  });
+
+  it('a package.json with an empty scripts object contributes no javascript entry', () => {
+    const root = makeRepo({
+      'go.mod': 'module x\n',
+      'package.json': JSON.stringify({ scripts: {} }),
+    });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')).toBeDefined();
+    expect(entryFor(plan, 'javascript')).toBeUndefined();
+  });
+
+  it('a malformed manifest is skipped without dropping other languages', () => {
+    const root = makeRepo({ 'go.mod': 'module x\n', 'package.json': '{ this is not json' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')).toBeDefined();
+    expect(entryFor(plan, 'javascript')).toBeUndefined();
+  });
+
+  it('a repo with no recognized manifest yields an empty plan', () => {
+    const root = makeRepo({ 'README.md': '# hi\n' });
+    expect(resolveTestPlan(root, { isToolAvailable: allTools })).toEqual([]);
+  });
+});
+
+describe('resolveTestPlan — the command reflects the detected runner', () => {
+  it('python with a tox.ini runs tox', () => {
+    const root = makeRepo({ 'pyproject.toml': '[project]\n', 'tox.ini': '[tox]\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')?.command).toBe('tox');
+  });
+
+  it('python with no pytest falls back to unittest', () => {
+    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python') });
+    expect(entryFor(plan, 'python')?.command).toBe('python -m unittest discover');
+  });
+
+  it('a uv-locked python repo runs pytest through uv', () => {
+    const root = makeRepo({
+      'pyproject.toml': '[tool.pytest.ini_options]\n',
+      'uv.lock': '',
+    });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('uv', 'pytest') });
+    expect(entryFor(plan, 'python')?.command).toBe('uv run pytest');
+  });
+
+  it('rust uses nextest when it is installed', () => {
+    const root = makeRepo({ 'Cargo.toml': '[package]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('cargo', 'cargo-nextest') });
+    expect(entryFor(plan, 'rust')?.command).toBe('cargo nextest run --workspace');
+  });
+
+  it('rust falls back to cargo test --workspace without nextest', () => {
+    const root = makeRepo({ 'Cargo.toml': '[package]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('cargo') });
+    expect(entryFor(plan, 'rust')?.command).toBe('cargo test --workspace');
+  });
+
+  it('a go workspace expands its modules in the emitted command', () => {
+    const root = makeRepo({ 'go.mod': 'module x\n', 'go.work': 'go 1.22\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')?.command).toBe("go test $(go list -f '{{.Dir}}/...' -m | xargs)");
+  });
+
+  it('a pnpm JS repo runs its test script through pnpm', () => {
+    const root = makeRepo({
+      'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+      'pnpm-lock.yaml': '',
+    });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'javascript')?.command).toBe('pnpm run test');
+  });
+});
+
+describe('resolveTestPlan — missing toolchains stay visible', () => {
+  it('a go repo with no go binary still appears, marked unavailable', () => {
+    const root = makeRepo({ 'go.mod': 'module x\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools() });
+    const go = entryFor(plan, 'go');
+    expect(go).toBeDefined();
+    expect(go?.available).toBe(false);
+  });
+});
+
+describe('resolveTestPlan — nested and vendored manifests', () => {
+  it('a manifest in a sub-directory is discovered', () => {
+    const root = makeRepo({ 'services/api/pyproject.toml': '[project]\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')).toBeDefined();
+  });
+
+  it('a manifest inside an excluded directory is ignored', () => {
+    const root = makeRepo({ 'target/dep/Cargo.toml': '[package]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'rust')).toBeUndefined();
+  });
+});
+
+describe('resolveTestPlan — build plan', () => {
+  it('emits per-language build commands', () => {
+    const root = makeRepo({
+      'go.mod': 'module x\n',
+      'Cargo.toml': '[package]\nname="x"\n',
+      'package.json': JSON.stringify({ scripts: { build: 'tsup' } }),
+    });
+    const plan = resolveTestPlan(root, { kind: 'build', isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')?.command).toBe('go build ./...');
+    expect(entryFor(plan, 'rust')?.command).toBe('cargo build --workspace');
+    expect(entryFor(plan, 'python')).toBeUndefined();
+  });
+
+  it('omits a JS entry when there is no build script', () => {
+    const root = makeRepo({
+      'go.mod': 'module x\n',
+      'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+    });
+    const plan = resolveTestPlan(root, { kind: 'build', isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')).toBeDefined();
+    expect(entryFor(plan, 'javascript')).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -167,6 +167,26 @@ describe('resolveTestPlan — nested and vendored manifests', () => {
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
     expect(entryFor(plan, 'rust')).toBeUndefined();
   });
+
+  it('runs a nested Go module in its own directory, not the repo root', () => {
+    const root = makeRepo({ 'services/api/go.mod': 'module example\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    const go = entryFor(plan, 'go');
+    expect(go?.cwd).toBe(nodePath.join(root, 'services/api'));
+    expect(go?.command).toBe('go test ./...');
+  });
+
+  it('runs a nested Rust crate in its own directory', () => {
+    const root = makeRepo({ 'crates/core/Cargo.toml': '[package]\nname="x"\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('cargo') });
+    expect(entryFor(plan, 'rust')?.cwd).toBe(nodePath.join(root, 'crates/core'));
+  });
+
+  it('keeps cwd at the repo root for a root-level manifest', () => {
+    const root = makeRepo({ 'go.mod': 'module x\n' });
+    const plan = resolveTestPlan(root, { isToolAvailable: allTools });
+    expect(entryFor(plan, 'go')?.cwd).toBe(root);
+  });
 });
 
 describe('resolveTestPlan — build plan', () => {

--- a/packages/cli/tests/utils/index-files-in-tree.test.ts
+++ b/packages/cli/tests/utils/index-files-in-tree.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { indexFilesInTree } from '../../src/utils/fs';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+function makeRepo(files: Record<string, string>): string {
+  const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-index-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const abs = nodePath.join(root, relativePath);
+    mkdirSync(nodePath.dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return root;
+}
+
+describe('indexFilesInTree', () => {
+  it('finds requested files at root and in sub-directories in one walk', () => {
+    const root = makeRepo({ 'go.mod': '', 'services/api/Cargo.toml': '' });
+    const index = indexFilesInTree(root, ['go.mod', 'Cargo.toml']);
+    expect(index.get('go.mod')).toBe(root);
+    expect(index.get('Cargo.toml')).toBe(nodePath.join(root, 'services/api'));
+  });
+
+  it('omits names that are not present', () => {
+    const root = makeRepo({ 'go.mod': '' });
+    const index = indexFilesInTree(root, ['go.mod', 'Cargo.toml']);
+    expect(index.has('Cargo.toml')).toBe(false);
+  });
+
+  it('prefers the shallowest occurrence (root over nested)', () => {
+    const root = makeRepo({ 'pyproject.toml': '', 'pkg/pyproject.toml': '' });
+    expect(indexFilesInTree(root, ['pyproject.toml']).get('pyproject.toml')).toBe(root);
+  });
+
+  it('skips excluded directories like node_modules', () => {
+    const root = makeRepo({ 'node_modules/dep/Cargo.toml': '' });
+    expect(indexFilesInTree(root, ['Cargo.toml']).has('Cargo.toml')).toBe(false);
+  });
+
+  it('respects maxDepth', () => {
+    const root = makeRepo({ 'a/b/c/go.mod': '' });
+    expect(indexFilesInTree(root, ['go.mod'], 1).has('go.mod')).toBe(false);
+    expect(indexFilesInTree(root, ['go.mod'], 3).get('go.mod')).toBe(nodePath.join(root, 'a/b/c'));
+  });
+});

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -118,4 +118,15 @@ describe('verify report structure (146)', () => {
       expect(content.toLowerCase()).toContain('empty sections are hidden');
     });
   });
+
+  describe('Rule: section 2 consumes safeword test-plan (5FF0ZD)', () => {
+    it.each(surfaces)('%s evals the test and build plans from test-plan', (_name, content) => {
+      expect(content).toContain('test-plan --kind test --format sh');
+      expect(content).toContain('test-plan --kind build --format sh');
+    });
+
+    it.each(surfaces)('%s carries no inline per-language test/build branch', (_name, content) => {
+      expect(content).not.toMatch(/uv run pytest|go test|cargo test|go build|cargo build/);
+    });
+  });
 });

--- a/packages/cli/vitest.base.ts
+++ b/packages/cli/vitest.base.ts
@@ -11,9 +11,16 @@ export const baseConfig = defineConfig({
     globals: true,
     environment: 'node',
     // Ensure the runtime binary directory is in PATH for child processes
-    // (e.g. bunx, bun) so execSync calls in tests can find them
+    // (e.g. bunx, bun) so execSync calls in tests can find them.
+    // Also force commit.gpgsign=false for every git invocation: tests create
+    // throwaway repos in /tmp and must be hermetic — they must not inherit a
+    // host that enforces commit signing (e.g. a managed env that signs via a
+    // server), which otherwise fails every test `git commit` with a signing error.
     env: {
       PATH: `${path.dirname(process.execPath)}:${process.env.PATH}`,
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'commit.gpgsign',
+      GIT_CONFIG_VALUE_0: 'false',
     },
     // Increase hook timeout for afterEach cleanup (rmSync with retries)
     // Default 10s isn't enough when bun has locked files

--- a/steps/test-plan-resolver.steps.ts
+++ b/steps/test-plan-resolver.steps.ts
@@ -1,0 +1,258 @@
+import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import nodeOs from 'node:os';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { After, Given, Then, When } from '@cucumber/cucumber';
+
+import type { SafewordWorld } from './world.js';
+
+/** Mirror of the resolver's PlanEntry shape (kept local so this step file has no runtime src import). */
+interface PlanEntry {
+  language: string;
+  cwd: string;
+  command: string;
+  runner: string;
+  available: boolean;
+}
+
+interface TestPlanWorld extends SafewordWorld {
+  root?: string;
+  /** `SAFEWORD_FAKE_TOOLS` value; defaults to "all". */
+  fakeTools?: string;
+  plan?: PlanEntry[];
+  cliStdout?: string;
+}
+
+const DEFAULT_CONTENT: Record<string, string> = {
+  'go.mod': 'module example\n',
+  'go.work': 'go 1.22\n',
+  'Cargo.toml': '[package]\nname = "x"\nversion = "0.1.0"\n',
+  'pyproject.toml': '[project]\nname = "x"\n',
+  'tox.ini': '[tox]\nenvlist = py3\n',
+  'uv.lock': '',
+  'poetry.lock': '',
+  'pnpm-lock.yaml': '',
+  'requirements.txt': '',
+};
+
+function ensureRoot(world: TestPlanWorld): string {
+  world.root ??= mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'safeword-test-plan-bdd-'));
+  return world.root;
+}
+
+function write(world: TestPlanWorld, rel: string, content: string): void {
+  const abs = nodePath.join(ensureRoot(world), rel);
+  mkdirSync(nodePath.dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+/** Write a manifest by name using sensible default content. */
+function seed(world: TestPlanWorld, name: string): void {
+  write(world, name, DEFAULT_CONTENT[name] ?? '');
+}
+
+/** Run the real CLI from source via bun, capturing its JSON plan deterministically. */
+function runPlan(world: TestPlanWorld, kind: 'test' | 'build'): void {
+  const cliPath = nodePath.join(process.cwd(), 'packages/cli/src/cli.ts');
+  const target = ensureRoot(world);
+  // Run from the repo root (valid package.json) and point the CLI at the temp
+  // repo via the [dir] arg — so a malformed temp package.json can't trip the
+  // bun runtime before the CLI's own (catching) resolver reads it.
+  world.cliStdout = execFileSync('bun', [cliPath, 'test-plan', target, '--kind', kind, '--json'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, SAFEWORD_FAKE_TOOLS: world.fakeTools ?? 'all' },
+  });
+  world.plan = JSON.parse(world.cliStdout) as PlanEntry[];
+}
+
+function findEntry(world: TestPlanWorld, language: string): PlanEntry | undefined {
+  return world.plan?.find(planEntry => planEntry.language === language);
+}
+
+After(function (this: TestPlanWorld) {
+  if (this.root !== undefined) rmSync(this.root, { force: true, recursive: true });
+});
+
+// --- Given: repo shapes ---
+
+Given(
+  'a repo with a root {string} script and a {string}',
+  function (this: TestPlanWorld, script: string, file: string) {
+    write(this, 'package.json', JSON.stringify({ scripts: { [script]: 'echo run' } }));
+    seed(this, file);
+  },
+);
+
+Given(
+  'a repo with a {string} and a {string}',
+  function (this: TestPlanWorld, a: string, b: string) {
+    seed(this, a);
+    seed(this, b);
+  },
+);
+
+Given(
+  'a repo with a {string} and a {string} with an empty scripts object',
+  function (this: TestPlanWorld, manifest: string, _pkg: string) {
+    seed(this, manifest);
+    write(this, 'package.json', JSON.stringify({ scripts: {} }));
+  },
+);
+
+Given(
+  'a repo with a {string} and a {string} containing invalid JSON',
+  function (this: TestPlanWorld, manifest: string, _pkg: string) {
+    seed(this, manifest);
+    write(this, 'package.json', '{ this is not valid json');
+  },
+);
+
+Given('a repo with no recognized language manifest', function (this: TestPlanWorld) {
+  write(this, 'README.md', '# hi\n');
+});
+
+Given('a Python repo with a {string}', function (this: TestPlanWorld, file: string) {
+  seed(this, 'pyproject.toml');
+  seed(this, file);
+});
+
+Given('a Python repo with no pytest configuration', function (this: TestPlanWorld) {
+  write(this, 'pyproject.toml', '[project]\nname = "x"\n');
+});
+
+Given(
+  'a Python repo with a {string} and pytest configured',
+  function (this: TestPlanWorld, file: string) {
+    write(this, 'pyproject.toml', '[tool.pytest.ini_options]\nminversion = "7.0"\n');
+    seed(this, file);
+  },
+);
+
+Given('a Rust repo', function (this: TestPlanWorld) {
+  seed(this, 'Cargo.toml');
+});
+
+Given('a Go repo with a {string}', function (this: TestPlanWorld, file: string) {
+  seed(this, 'go.mod');
+  seed(this, file);
+});
+
+Given('a repo with a {string}', function (this: TestPlanWorld, file: string) {
+  seed(this, file);
+});
+
+Given(
+  'a repo with a {string} and no root manifest',
+  function (this: TestPlanWorld, nestedPath: string) {
+    write(this, nestedPath, DEFAULT_CONTENT[nodePath.basename(nestedPath)] ?? '[project]\n');
+  },
+);
+
+Given(
+  'a repo with a {string} only under {string}',
+  function (this: TestPlanWorld, file: string, dir: string) {
+    write(this, nodePath.join(dir, 'dep', file), DEFAULT_CONTENT[file] ?? '');
+  },
+);
+
+Given(
+  'a repo with a {string}, a {string}, and a root "build" script',
+  function (this: TestPlanWorld, a: string, b: string) {
+    seed(this, a);
+    seed(this, b);
+    write(this, 'package.json', JSON.stringify({ scripts: { build: 'tsup' } }));
+  },
+);
+
+Given(
+  'a repo with a {string} and a {string} with no "build" script',
+  function (this: TestPlanWorld, manifest: string, _pkg: string) {
+    seed(this, manifest);
+    write(this, 'package.json', JSON.stringify({ scripts: { test: 'vitest' } }));
+  },
+);
+
+// --- Given: toolchain availability (drives the SAFEWORD_FAKE_TOOLS seam) ---
+
+Given('only the {string} toolchain is installed', function (this: TestPlanWorld, tool: string) {
+  this.fakeTools = `only:${tool}`;
+});
+
+Given(
+  'the {string} and {string} toolchains are installed',
+  function (this: TestPlanWorld, a: string, b: string) {
+    this.fakeTools = `only:${a},${b}`;
+  },
+);
+
+Given('the {string} toolchain is not installed', function (this: TestPlanWorld, tool: string) {
+  this.fakeTools = `none:${tool}`;
+});
+
+// --- When ---
+
+When('I request the test plan', function (this: TestPlanWorld) {
+  runPlan(this, 'test');
+});
+
+When('I request the build plan', function (this: TestPlanWorld) {
+  runPlan(this, 'build');
+});
+
+When('I run the test-plan CLI as JSON', function (this: TestPlanWorld) {
+  runPlan(this, 'test');
+});
+
+// --- Then ---
+
+Then('the plan includes a {string} entry', function (this: TestPlanWorld, language: string) {
+  assert.ok(findEntry(this, language), `expected a ${language} entry`);
+});
+
+Then('the plan has no {string} entry', function (this: TestPlanWorld, language: string) {
+  assert.equal(findEntry(this, language), undefined, `unexpected ${language} entry`);
+});
+
+Then('the plan has exactly {int} entries', function (this: TestPlanWorld, count: number) {
+  assert.equal(this.plan?.length, count);
+});
+
+Then('the plan is empty', function (this: TestPlanWorld) {
+  assert.deepEqual(this.plan, []);
+});
+
+Then(
+  'the {string} entry command is {string}',
+  function (this: TestPlanWorld, language: string, command: string) {
+    assert.equal(findEntry(this, language)?.command, command);
+  },
+);
+
+Then('the {string} entry is marked unavailable', function (this: TestPlanWorld, language: string) {
+  assert.equal(findEntry(this, language)?.available, false);
+});
+
+Then(
+  'the output is a JSON array containing an entry with language {string}',
+  function (this: TestPlanWorld, language: string) {
+    const parsed = JSON.parse(this.cliStdout ?? '') as PlanEntry[];
+    assert.ok(Array.isArray(parsed), 'output is not a JSON array');
+    assert.ok(
+      parsed.some(planEntry => planEntry.language === language),
+      `no ${language} entry in CLI output`,
+    );
+  },
+);
+
+Then(
+  'that entry has a non-empty "command" and a boolean "available"',
+  function (this: TestPlanWorld) {
+    const planEntry = (JSON.parse(this.cliStdout ?? '') as PlanEntry[])[0];
+    assert.ok(planEntry && planEntry.command.length > 0, 'command is empty');
+    assert.equal(typeof planEntry.available, 'boolean');
+  },
+);

--- a/steps/test-plan-resolver.steps.ts
+++ b/steps/test-plan-resolver.steps.ts
@@ -237,6 +237,13 @@ Then('the {string} entry is marked unavailable', function (this: TestPlanWorld, 
 });
 
 Then(
+  'the {string} entry runs in the {string} sub-directory',
+  function (this: TestPlanWorld, language: string, subdir: string) {
+    assert.equal(findEntry(this, language)?.cwd, nodePath.join(ensureRoot(this), subdir));
+  },
+);
+
+Then(
   'the output is a JSON array containing an entry with language {string}',
   function (this: TestPlanWorld, language: string) {
     const parsed = JSON.parse(this.cliStdout ?? '') as PlanEntry[];


### PR DESCRIPTION
## Summary

Started as a product audit for customer-agnostic & language-agnostic leakage; landed the highest-value fixes plus a full epic that removes per-language test/build duplication.

**Audit + report**
- `PRODUCT-AUDIT-leakage.md` — findings across two axes (safeword-as-target vs. any customer; JS-specific vs. any language) with prioritized fixes. Filed follow-up tickets.

**2FVZ26 — language-aware `/verify` & `/audit`** (shipped earlier in branch)
- `/verify` and `/audit` run the right test/build/dead-code checks per language (Python/Go/Rust), not just JS; `test-runner.ts` got a native fallback.

**Epic Q4FX8Y — one resolver, consumed everywhere**
- **BKTTZA** — new `safeword test-plan [--kind test|build] [--json|--format sh]`: a pure resolver emitting per-language commands for **every** detected language (polyglot, no first-match), nested-manifest aware (single `indexFilesInTree` walk), multi-runner (Python tox/pytest/unittest, Rust nextest/`--workspace`, Go `go.work`, JS via its own script), tool-absence visible.
- **5FF0ZD** — `test-runner.ts` (stop-hook gate) and `/verify` now consume `test-plan` (`--json` for the TS hook, eval'd `--format sh` for the bash skill); deleted the duplicated `nativeTestCommand`/`getJsTestCommands`/`pythonTestCommand`. `/audit` left as-is (its dead-code/outdated tooling is a different domain — documented).

**Hardening (from quality/security review)**
- Security: single-quote `cwd` in `--format sh` — fixes a command-injection via a maliciously-named directory (reproduced + regression-tested).
- `/verify` resolves a local `test-plan`-capable CLI (not a bare `bunx safeword` that could hit the published CLI lacking the command).
- Test infra: hermetic test git repos (`commit.gpgsign=false`) and skip-as-root permission tests — these fixed a pre-existing red baseline (139 env-only failures) unrelated to the feature.

## Verification
- Full suite green: **3038 passed / 5 skipped / 0 failed** (205 files).
- BDD: both features passed independent scenario-gate reviews; cucumber lane green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf4Lq3E1o3LAtFfmJBqkrR)_