### PR TITLE
chore(release): v0.51.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.49.0",
+      "version": "0.51.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## chore(release): v0.51.0

Isolated version-bump PR (the canonical release flow). Bumps `package.json`, `marketplace.json`, and `bun.lock` from 0.50.0 → 0.51.0.

**Why 0.51.0 and not 0.50.0:** 0.50.0 was committed to main (folded into #247) but never tagged/published — npm is still on 0.49.0. This PR isolates the bump so the release is auditable and the tag points at a clean release commit. 0.50.0 is a skipped intermediate.

**Rollup since v0.49.0 (the last published tag):**
- feat: `safeword test-plan` resolver CLI — per-language test/build commands as `--json` or eval-able `--format sh` (one source of truth for the stop-hook gate, `/verify`, `/audit`)
- feat: language-aware `/verify`, `/audit`, and `test-runner.ts` — Python/Go/Rust/SQL
- BE7C7B: gate `knip` + `dependency-cruiser` on real JS source (non-JS repos no longer carry JS-app tooling)
- security: `test-plan --format sh` single-quotes `cwd` (command-injection fix)

**Classification:** minor (additive features + the BE7C7B non-JS cleanup), per the maintainer's call recorded on #247.

## Test plan

- [x] `bun install --frozen-lockfile` clean (lockfile valid)
- [x] Version files match (pre-commit hook enforced)
- [ ] CI (test + lint) green → merge → push annotated `v0.51.0` tag to trigger `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf4Lq3E1o3LAtFfmJBqkrR)_