### PR TITLE
feat(eslint): support ESLint 10 additively (peer ^9.22.0 || ^10.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Lint (ESLint 10 forward-compat)
+        # Ticket 099: safeword's peerDependencies.eslint is "^9.22.0 || ^10.0.0".
+        # The Lint step above runs ESLint 9 (the primary dev dep); this proves the
+        # same shipped config also lints clean under ESLint 10 via the eslint-v10
+        # alias, keeping the dual-major peer range honest as plugins/deps change.
+        run: bun run --cwd packages/cli lint:eslint:v10
+
       - name: Type check
         run: bun run --cwd packages/cli typecheck
 

--- a/.project/tickets/099-eslint-10-migration/ticket.md
+++ b/.project/tickets/099-eslint-10-migration/ticket.md
@@ -4,7 +4,7 @@ type: task
 phase: implement
 status: in_progress
 created: 2026-04-11
-last_modified: 2026-06-15T21:52:44Z
+last_modified: 2026-06-18T03:20:00Z
 ---
 
 # Task: ESLint 10 Migration
@@ -173,3 +173,59 @@ Audited all 24 packages safeword ships against npm: latest version, latest-relea
 - `eslint-plugin-react@7.37.5` — release stale (13mo) but **repo is very active** (5 commits in the last week as of 2026-05-18, including ESLint-v10 RuleTester work). Slow to release, not abandoned. Already tracked above as the Phase 3 upstream blocker.
 
 Everything else: active maintenance within 3 months. `eslint-config-prettier` (10mo) and `eslint-import-resolver-typescript` (11mo) are quiet but stable — a pure rule-disabler and a resolver respectively, both genuinely "done."
+
+## Status refresh 2026-06-18 — UNBLOCKED; reframed to an additive minor
+
+### The blocker is gone
+
+Ticket [71Q4DV](../71Q4DV-eslint-10-react-plugin-path/ticket.md) landed on `main` (commit `762be9c3`), replacing `eslint-plugin-react` with `@eslint-react/eslint-plugin@5.9.0`. Safeword no longer depends on `eslint-plugin-react`, so the upstream chain (`eslint-plugin-react` → `eslint-plugin-import` → ESLint 10) that froze this ticket since April no longer gates us. `eslint-plugin-react` is now in `deprecatedPackages` (`schema.ts`), telling customers to uninstall it.
+
+### ESLint 10 is a clean drop-in (empirical)
+
+Ran both majors against the real codebase via the `eslint-v10` alias:
+
+| target                                   | eslint 9.39.4 | eslint 10.5.0   |
+| ---------------------------------------- | ------------- | --------------- |
+| `eslint src tests` (canonical CI target) | exit 0        | exit 0          |
+| `eslint .`                               | 137 problems  | 137 — identical |
+
+The 137 are pre-existing `templates/**` issues present under both majors (not in the CI lint target). ESLint 10 introduces **zero** new problems. All 105 preset/schema tests pass, including the in-process ESLint-10 `Linter` load test.
+
+### Decision: additive minor, not semver-major (supersedes the 2026-04-11 "semver-major" assumption)
+
+The original framing assumed ESLint 10 forces a major because it changes the shipped peer-dependency range. That held only under the abandoned "drop v9, install v10 as the sole version" plan. Revalidation shows safeword's shipped config works under **both** majors, so the honest move is **additive**:
+
+- `peerDependencies.eslint`: `^9.22.0` → **`^9.22.0 || ^10.0.0`**. Widening a peer range forbids nothing and permits more — strictly additive, so this ships as a **minor** (auto-upgradeable, strands no v9 customer). Matches the `typescript-eslint` precedent (`^8.57.0 || ^9.0.0 || ^10.0.0`).
+- `engines.node`: **unchanged at `>=22.12`.** ESLint 10's higher Node floor (`^20.19.0 || ^22.13.0 || >=24`) is self-enforced by eslint's own `package.json` when a customer installs v10. Safeword's `engines` can't express "22.13 only if on eslint 10," and a v9 customer doesn't need 22.13 — so the floor stays. Node 20 is EOL as of 2026-04-30, so we do not widen toward eslint's `^20.19.0`.
+- `@eslint/js`: **kept at `^9.39.4`** (bundled dependency). Its v9 recommended ruleset is valid under both runtimes; bundling v10's recommended could surface rules a v9 customer's engine lacks.
+- **Legacy `.eslintrc` template (`getSafewordEslintConfigLegacy`): kept.** `@eslint/eslintrc`/`FlatCompat` still functions under v10 (per the ESLint 10 migrate guide), and v9 customers with legacy configs still rely on it. Deleting it removes support — belongs in the future major.
+
+The legacy-template deletion, `@eslint/js` bump, and engines bump are all **deferred to the eventual major that drops ESLint 9** — each with a concrete changelog reason then, rather than smuggled into this additive release. Concrete trigger for scheduling that major: **ESLint v9 EOL is 2026-08-06** (per eslint.org/version-support, verified 2026-06-18). Until then v9 is still upstream-maintained and widely deployed, so additive support strands no one; after it, the v9-drop major has a real reason to point at.
+
+### Implemented 2026-06-18 (v0.52.0)
+
+- `packages/cli/package.json`: peer range → `^9.22.0 || ^10.0.0`; version `0.51.0` → `0.52.0`; added `lint:eslint:v10` script (`node ./node_modules/eslint-v10/bin/eslint.js src tests`).
+- `marketplace.json`: plugin version → `0.52.0`.
+- `.github/workflows/ci.yml`: added a "Lint (ESLint 10 forward-compat)" step running `lint:eslint:v10`, so the dual-major claim is enforced in CI, not just one in-process test. The ticket's history of "verified but actually wasn't" misses (e.g. the 2026-05-18 vitest entry) is exactly why this gate exists.
+- `bun.lock`: resynced (only the cli eslint peer-range line changed).
+
+Verified: `eslint src tests` exit 0 under both 9.39.4 and 10.5.0; 105/105 preset+schema tests; DTS build clean; lockfile synced. Full `/verify` (whole suite, scenarios, dep drift) still owed before merge.
+
+### Revised Done-When (additive minor)
+
+- [x] Compatible plugins at ESLint-10-ready versions (dependabot + 71Q4DV)
+- [x] `typescript-eslint` supports ESLint 10 (8.61.0)
+- [x] All preset configs load without errors under ESLint 10
+- [x] `peerDependencies.eslint` includes v10 (`^9.22.0 || ^10.0.0`)
+- [x] ESLint 10 lints the CI target clean (dual-major CI gate added)
+- [x] Preset + schema tests pass under the change
+- [x] `engines.node` decision recorded (intentionally unchanged — see above)
+- [ ] Full `/verify` (whole suite, scenarios, dep drift) before merge
+- [ ] Merge + minor release (0.52.0)
+
+~~Promise rules vendored~~ — obsolete; `eslint-plugin-promise@7.3.0` supports v10, no vendoring.
+
+### Sequencing
+
+- **7JDZFF** (optional peer-deps, in_progress) also rewrites `packages/cli/package.json` dependency structure and is where ESLint 10's "move plugins from peerDeps to deps" guidance belongs. This ticket lands first (smaller, unblocks the freeze); 7JDZFF rebases on the new peer range.
+- **051 / 087** were superseded prior attempts — this additive framing is deliberately narrower than their "replace the version outright" approach.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "bin": {
         "safeword": "dist/cli.js",
       },
@@ -74,7 +74,7 @@
         "vitest": "^4.1.9",
       },
       "peerDependencies": {
-        "eslint": "^9.22.0",
+        "eslint": "^9.22.0 || ^10.0.0",
       },
     },
     "packages/website": {

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",
@@ -51,6 +51,7 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "node scripts/check-bun-publish.js && bun run test:release && bun run build",
     "lint:eslint": "eslint .",
+    "lint:eslint:v10": "node ./node_modules/eslint-v10/bin/eslint.js src tests",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "knip": "knip",
@@ -103,7 +104,7 @@
     "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "eslint": "^9.22.0"
+    "eslint": "^9.22.0 || ^10.0.0"
   },
   "keywords": [
     "cli",

--- a/packages/cli/src/utils/eslint-peer-check.test.ts
+++ b/packages/cli/src/utils/eslint-peer-check.test.ts
@@ -59,25 +59,34 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('returns a warning for pinned eslint 10.0.0 (above safeword supported range)', () => {
-    writeTestFile(
-      temporaryDirectory,
-      'package.json',
-      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '10.0.0' } }),
-    );
-    const warning = getEslintPeerMismatchWarning(temporaryDirectory);
-    expect(warning).not.toBeUndefined();
-    expect(warning).toContain('eslint');
-    expect(warning).toContain('10');
-  });
-
-  it('returns a warning for eslint ^10 caret range', () => {
+  it('returns undefined when eslint is in the supported major (10.x as caret range)', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
       JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^10.4.0' } }),
     );
-    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns undefined for a pinned 10.x version', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '10.0.0' } }),
+    );
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+  });
+
+  it('returns a warning for pinned eslint 11.0.0 (above safeword supported range)', () => {
+    writeTestFile(
+      temporaryDirectory,
+      'package.json',
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '11.0.0' } }),
+    );
+    const warning = getEslintPeerMismatchWarning(temporaryDirectory);
+    expect(warning).not.toBeUndefined();
+    expect(warning).toContain('eslint');
+    expect(warning).toContain('11');
   });
 
   it('returns a warning for eslint below supported range (8.x)', () => {
@@ -93,7 +102,7 @@ describe('getEslintPeerMismatchWarning', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
-      JSON.stringify({ name: 'x', version: '0.0.0', dependencies: { eslint: '10.0.0' } }),
+      JSON.stringify({ name: 'x', version: '0.0.0', dependencies: { eslint: '11.0.0' } }),
     );
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
   });
@@ -107,13 +116,14 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('warning message names the safeword supported major (9) and the conflict', () => {
+  it('warning message names the safeword supported majors (9 and 10) and the conflict', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
-      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^10.0.0' } }),
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^11.0.0' } }),
     );
     const warning = getEslintPeerMismatchWarning(temporaryDirectory);
     expect(warning).toContain('9');
+    expect(warning).toContain('10');
   });
 });


### PR DESCRIPTION
## Summary

Adds ESLint 10 support to safeword **additively** — widens `peerDependencies.eslint` to `^9.22.0 || ^10.0.0` so the shipped config works under both ESLint 9 and 10. Ships as a **minor** (`0.52.0`), not the semver-major ticket 099 originally assumed: widening a peer range forbids nothing and permits more, so it's strictly additive — no v9 customer is stranded and auto-upgrade stays silent.

The long-standing blocker (`eslint-plugin-react` crashing under v10 via removed `context.getFilename()`) is gone — it was replaced by `@eslint-react/eslint-plugin` in ticket 71Q4DV (commit 762be9c3). Revalidation shows v10 is a clean drop-in: `eslint src tests` exits 0 under **both** 9.39.4 and 10.5.0, with byte-identical results (`eslint .` = 137 pre-existing template problems on each).

## Changes

- **`packages/cli/package.json`** — peer range → `^9.22.0 || ^10.0.0`; version `0.51.0` → `0.52.0`; add `lint:eslint:v10` script
- **`marketplace.json`** — plugin version → `0.52.0`
- **`.github/workflows/ci.yml`** — new "ESLint 10 forward-compat" lint step running the shipped config under v10 via the `eslint-v10` alias, so the dual-major claim is enforced every CI run (not just one in-process test)
- **ticket 099** — reframed to additive-minor with full decision record

## Intentionally unchanged — deferred to the future v9-drop major

- `engines.node` stays `>=22.12` — ESLint 10's higher Node floor (`^20.19.0 || ^22.13.0 || >=24`) is self-enforced by eslint's own package.json; Node 20 is EOL (2026-04-30) so we don't widen toward it
- `@eslint/js` stays `^9.39.4` — its v9 recommended ruleset is valid under both runtimes; bundling v10's could surface rules a v9 customer's engine lacks
- legacy `.eslintrc` `FlatCompat` template kept — still functions under v10, and v9 customers with legacy configs rely on it

**Trigger for the eventual v9-drop major: ESLint v9 EOL 2026-08-06.**

## Verification

- `eslint src tests` (canonical CI target) exits 0 under both ESLint 9.39.4 and 10.5.0
- 461/461 done-gate tests pass; build (tsup DTS) clean; lint + typecheck clean
- Security: CVE-2025-54313 (`eslint-config-prettier` malware) doesn't apply — pinned `^10.1.8` is above the compromised 10.1.6/10.1.7
- `bun.lock` resynced (only the peer-range line changed)

Refs: ticket 099 (eslint-10-migration), ticket 71Q4DV (eslint-react replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)