### PR TITLE
fix(bdd): give the shell-out acceptance step bounded timeout headroom

### DIFF
--- a/packages/cli/templates/cucumber/shared.steps.ts
+++ b/packages/cli/templates/cucumber/shared.steps.ts
@@ -16,19 +16,27 @@ import type { SafewordWorld } from './world.js';
 
 const execAsync = promisify(exec);
 
-When('I run shell command {string}', async function (this: SafewordWorld, command: string) {
-  try {
-    const { stdout, stderr } = await execAsync(command);
-    this.result = { stdout, stderr, exitCode: 0 };
-  } catch (error: unknown) {
-    const failure = error as { stdout?: string; stderr?: string; code?: number };
-    this.result = {
-      stdout: failure.stdout ?? '',
-      stderr: failure.stderr ?? '',
-      exitCode: failure.code ?? 1,
-    };
-  }
-});
+// Runs arbitrary commands (`go test ./...`, `cargo test`, `curl`) and spawns a
+// shell, so a cold first-spawn under load can exceed cucumber's 5s default step
+// timeout. Give it bounded headroom; the assertion steps below keep the tight
+// default so genuine hangs still surface fast.
+When(
+  'I run shell command {string}',
+  { timeout: 60_000 },
+  async function (this: SafewordWorld, command: string) {
+    try {
+      const { stdout, stderr } = await execAsync(command);
+      this.result = { stdout, stderr, exitCode: 0 };
+    } catch (error: unknown) {
+      const failure = error as { stdout?: string; stderr?: string; code?: number };
+      this.result = {
+        stdout: failure.stdout ?? '',
+        stderr: failure.stderr ?? '',
+        exitCode: failure.code ?? 1,
+      };
+    }
+  },
+);
 
 Then('the shell exit code is {int}', function (this: SafewordWorld, expected: number) {
   assert.equal(this.result.exitCode, expected, `stderr: ${this.result.stderr}`);

--- a/steps/shared.steps.ts
+++ b/steps/shared.steps.ts
@@ -16,19 +16,27 @@ import type { SafewordWorld } from './world.js';
 
 const execAsync = promisify(exec);
 
-When('I run shell command {string}', async function (this: SafewordWorld, command: string) {
-  try {
-    const { stdout, stderr } = await execAsync(command);
-    this.result = { stdout, stderr, exitCode: 0 };
-  } catch (error: unknown) {
-    const failure = error as { stdout?: string; stderr?: string; code?: number };
-    this.result = {
-      stdout: failure.stdout ?? '',
-      stderr: failure.stderr ?? '',
-      exitCode: failure.code ?? 1,
-    };
-  }
-});
+// Runs arbitrary commands (`go test ./...`, `cargo test`, `curl`) and spawns a
+// shell, so a cold first-spawn under load can exceed cucumber's 5s default step
+// timeout. Give it bounded headroom; the assertion steps below keep the tight
+// default so genuine hangs still surface fast.
+When(
+  'I run shell command {string}',
+  { timeout: 60_000 },
+  async function (this: SafewordWorld, command: string) {
+    try {
+      const { stdout, stderr } = await execAsync(command);
+      this.result = { stdout, stderr, exitCode: 0 };
+    } catch (error: unknown) {
+      const failure = error as { stdout?: string; stderr?: string; code?: number };
+      this.result = {
+        stdout: failure.stdout ?? '',
+        stderr: failure.stderr ?? '',
+        exitCode: failure.code ?? 1,
+      };
+    }
+  },
+);
 
 Then('the shell exit code is {int}', function (this: SafewordWorld, expected: number) {
   assert.equal(this.result.exitCode, expected, `stderr: ${this.result.stderr}`);


### PR DESCRIPTION
## Summary

The acceptance-lane step `When('I run shell command {string}')` runs **arbitrary commands** (`go test ./...`, `cargo test`, `curl`) and spawns a shell, but it inherited cucumber's **5000ms default step timeout**. A cold first-spawn under heavy concurrent load flaked it once (`node --version` exceeded 5s, then passed instantly on retry — 59/59).

Because the **done-gate runs `test:bdd`** (`stop-quality.ts` → `runTests` → blocks on Gherkin failure), a flake here can intermittently block legitimate work — for safeword *and* for every customer, since this step ships as a template.

## Fix

Per-step `{ timeout: 60_000 }` on the shell-out step only (12× headroom, still bounded). The assertion steps (`the shell exit code is`, `the shell output contains`) keep cucumber's tight 5s default, so genuine hangs still surface fast.

Considered and rejected a global `setDefaultTimeout` — it's a ceiling, so it would also loosen the instant assertion steps and mask real hangs; only the command-runner needs the room.

## Parity

The step lives in two byte-identical copies bound by a sync contract (`schema.ts:754`): the dogfood `steps/shared.steps.ts` and the shipped template `packages/cli/templates/cucumber/shared.steps.ts`. Both updated identically; pre-commit "contracts in sync" passes.

## Verification

- `bun run test:bdd` → 59 scenarios passed, 576 steps
- `tsc --noEmit` clean
- Both copies confirmed byte-identical post-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)