### PR TITLE
feat(quality-review): bounded review→fix loop with independent reviewer

### DIFF
--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -79,6 +79,32 @@ Fetch official documentation for libraries in use.
 
 The `**Next:**` line is required. On APPROVE, name what to do now (proceed, commit, run /verify). On REQUEST CHANGES, name the specific edit and re-review trigger. On NEEDS DISCUSSION, name the question to ask. A verdict that doesn't tell the reader what to do next is incomplete.
 
+## Loop: review → fix → re-review
+
+Run the review in passes (MAX_PASSES = 3), not one-and-done.
+
+Each pass:
+
+1. **Review with a fresh, independent reviewer.** Spawn a sub-agent on a
+   _different model than yours_ when your harness supports it — a same-model,
+   same-context reviewer shares your blind spots, and ungrounded self-correction
+   can _degrade_ code rather than improve it. Hand it only the diff and the
+   ticket scope, have it apply §1–3, and return the Output Format above.
+   - Claude Code: Agent/Task tool. Codex: ask in your prompt — subagents never
+     auto-spawn, and `/agent` only switches between existing threads. Cursor:
+     subagents.
+   - No sub-agent available? Do a fresh-context pass and switch models manually —
+     independence is the point, not the mechanism.
+2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
+   improvements** worth the change; list the rest — don't chase them.
+3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
+   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
+   if you edited code this pass.
+
+A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
+objective signal — not the reviewer running out of suggestions — is the real
+stop condition; tests are the ground truth.
+
 ## Reminders
 
 1. **Primary value: Web research** - Verify versions, docs, security

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -79,6 +79,32 @@ Fetch official documentation for libraries in use.
 
 The `**Next:**` line is required. On APPROVE, name what to do now (proceed, commit, run /verify). On REQUEST CHANGES, name the specific edit and re-review trigger. On NEEDS DISCUSSION, name the question to ask. A verdict that doesn't tell the reader what to do next is incomplete.
 
+## Loop: review → fix → re-review
+
+Run the review in passes (MAX_PASSES = 3), not one-and-done.
+
+Each pass:
+
+1. **Review with a fresh, independent reviewer.** Spawn a sub-agent on a
+   _different model than yours_ when your harness supports it — a same-model,
+   same-context reviewer shares your blind spots, and ungrounded self-correction
+   can _degrade_ code rather than improve it. Hand it only the diff and the
+   ticket scope, have it apply §1–3, and return the Output Format above.
+   - Claude Code: Agent/Task tool. Codex: ask in your prompt — subagents never
+     auto-spawn, and `/agent` only switches between existing threads. Cursor:
+     subagents.
+   - No sub-agent available? Do a fresh-context pass and switch models manually —
+     independence is the point, not the mechanism.
+2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
+   improvements** worth the change; list the rest — don't chase them.
+3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
+   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
+   if you edited code this pass.
+
+A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
+objective signal — not the reviewer running out of suggestions — is the real
+stop condition; tests are the ground truth.
+
 ## Reminders
 
 1. **Primary value: Web research** - Verify versions, docs, security

--- a/.cursor/rules/safeword-quality-reviewing.mdc
+++ b/.cursor/rules/safeword-quality-reviewing.mdc
@@ -147,6 +147,33 @@ Fetch documentation from official sources:
 **Suggested improvements:** [List or "None"]
 ```
 
+## Loop: review → fix → re-review
+
+Run the review in passes (MAX_PASSES = 3), not one-and-done.
+
+Each pass:
+
+1. **Review with a fresh, independent reviewer.** Spawn a sub-agent on a
+   _different model than yours_ when your harness supports it — a same-model,
+   same-context reviewer shares your blind spots, and ungrounded self-correction
+   can _degrade_ code rather than improve it. Hand it only the diff and the
+   project standards, have it apply the Review Protocol above, and return the
+   Output Format above.
+   - Claude Code: Agent/Task tool. Codex: ask in your prompt — subagents never
+     auto-spawn, and `/agent` only switches between existing threads. Cursor:
+     subagents.
+   - No sub-agent available? Do a fresh-context pass and switch models manually —
+     independence is the point, not the mechanism.
+2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
+   improvements** worth the change; list the rest — don't chase them.
+3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
+   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
+   if you edited code this pass.
+
+A pass isn't done until the project's tests, lint, and typecheck are green. That
+objective signal — not the reviewer running out of suggestions — is the real
+stop condition; tests are the ground truth.
+
 ## Critical Reminders
 
 1. **Primary value: Web research** - Verify against current ecosystem (versions, docs, security)

--- a/.project/tickets/151-migrate-cursor-rules-to-reference-pattern/ticket.md
+++ b/.project/tickets/151-migrate-cursor-rules-to-reference-pattern/ticket.md
@@ -4,7 +4,7 @@ type: task
 phase: intake
 status: pending
 created: 2026-05-17T19:35:00Z
-last_modified: 2026-05-17T19:35:00Z
+last_modified: 2026-06-18T11:54:00Z
 ---
 
 # Migrate Cursor Rules to @reference Pattern
@@ -14,7 +14,7 @@ last_modified: 2026-05-17T19:35:00Z
 **Why:** Cursor rules currently use two inconsistent patterns:
 
 - `@reference` (newer): `safeword-core.mdc` (5 lines), `safeword-ticket-system.mdc` (9 lines), and now `safeword-brainstorming.mdc`, `safeword-elicitation.mdc`, `safeword-tdd-review.mdc` (from ticket 150 / PR #103)
-- **Duplicate content** (older): `safeword-debugging.mdc` (209 lines), `safeword-quality-reviewing.mdc` (157), `safeword-refactoring.mdc` (175), `safeword-testing.mdc` (276) — each independently authored alongside its Claude skill
+- **Duplicate content** (older): `safeword-debugging.mdc` (209 lines), `safeword-quality-reviewing.mdc` (186), `safeword-refactoring.mdc` (175), `safeword-testing.mdc` (276) — each independently authored alongside its Claude skill
 
 Parity-check only validates template ↔ dogfood within the same toolchain. It does NOT validate Claude-skill ↔ Cursor-rule content equivalence. So the four duplicate-content rules can silently drift from their Claude counterparts (and may already have).
 
@@ -26,7 +26,7 @@ Parity-check only validates template ↔ dogfood within the same toolchain. It d
 | safeword-brainstorming     | 7     | brainstorm     | 42    | `@reference` (new) |
 | safeword-debugging         | 209   | debug          | 226   | duplicate          |
 | safeword-elicitation       | 7     | elicit         | 84    | `@reference` (new) |
-| safeword-quality-reviewing | 157   | quality-review | ~     | duplicate          |
+| safeword-quality-reviewing | 186   | quality-review | 115   | duplicate          |
 | safeword-refactoring       | 175   | refactor       | ~     | duplicate          |
 | safeword-tdd-review        | 7     | tdd-review     | 75    | `@reference` (new) |
 | safeword-testing           | 276   | testing        | ~     | duplicate          |
@@ -41,22 +41,23 @@ Parity-check only validates template ↔ dogfood within the same toolchain. It d
 ## Scope
 
 - Convert 4 Cursor rules to the `@reference` pattern matching `safeword-ticket-system.mdc`
-- Add a parity-check contract or test enforcing Claude-skill ↔ Cursor-rule content equivalence (so future divergence is caught)
+- Add a **structural** guard (lint/contract) that skill Cursor-rules must be `@reference` pointers — prevents NEW duplicate-content rules. (Content-_equivalence_ checking is moot once a rule is a thin pointer: the reference **is** the single source, so there is no rule body left to drift.)
 - Update any contributor docs that describe the duplicate-content convention
 
 ## Out of Scope
 
 - Changing the content of the underlying Claude skills
-- Migrating BDD-split rules (`bdd-core`, `bdd-discovery`, etc.) — they reference phase-specific files inside the bdd skill folder; conversion is a separate question
+- BDD-split rules (`bdd-core`, `bdd-discovery`, etc.) — **already migrated** to `@reference` (ticket `G1A6BS-bdd-cursor-rules-reference`); no longer applicable here
 - Migrating skill rules to a different format entirely
 
 ## Done When
 
 - Four rules converted to `@reference` pattern
 - Pre-conversion content diffs documented in this ticket if any drift was found
-- A test or contract enforces Claude-skill ↔ Cursor-rule content equivalence going forward
+- A **structural** guard prevents new duplicate-content skill-rules (rules must be `@reference` pointers) — content-equivalence is then auto-satisfied by the pointer
 - `bun scripts/parity-check.ts --mode=all` clean
 
 ## Work Log
 
 - 2026-05-17 19:35 UTC — Ticket created as follow-up from ticket 150 / PR #103. While porting three new Cursor rules I noticed the duplicate-content pattern in 4 older rules creates silent drift risk; the project already supports `@reference` pattern, so migration is mechanical once drift is audited.
+- 2026-06-18 11:54 UTC — Refresh during a quality-review pass. (1) `safeword-quality-reviewing.mdc` grew 157→186 lines: commit `bb429c40` added a shared "Loop" block to both the `.md` skill and this `.mdc`. On conversion, the `.mdc`'s 8-step protocol is intentionally dropped and the Loop survives via the `@reference` to the skill — audit accordingly. (2) The 7 `bdd-*` rules are already `@reference` (ticket `G1A6BS`), so the BDD out-of-scope note is resolved. (3) `@reference` mechanic confirmed current in Cursor docs; large-file (150–300 line) expansion depth still unverified — investigation item 2 stands. (4) Reframed the equivalence guard as a structural "must-be-pointer" check.

--- a/packages/cli/templates/cursor/rules/safeword-quality-reviewing.mdc
+++ b/packages/cli/templates/cursor/rules/safeword-quality-reviewing.mdc
@@ -147,6 +147,33 @@ Fetch documentation from official sources:
 **Suggested improvements:** [List or "None"]
 ```
 
+## Loop: review → fix → re-review
+
+Run the review in passes (MAX_PASSES = 3), not one-and-done.
+
+Each pass:
+
+1. **Review with a fresh, independent reviewer.** Spawn a sub-agent on a
+   _different model than yours_ when your harness supports it — a same-model,
+   same-context reviewer shares your blind spots, and ungrounded self-correction
+   can _degrade_ code rather than improve it. Hand it only the diff and the
+   project standards, have it apply the Review Protocol above, and return the
+   Output Format above.
+   - Claude Code: Agent/Task tool. Codex: ask in your prompt — subagents never
+     auto-spawn, and `/agent` only switches between existing threads. Cursor:
+     subagents.
+   - No sub-agent available? Do a fresh-context pass and switch models manually —
+     independence is the point, not the mechanism.
+2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
+   improvements** worth the change; list the rest — don't chase them.
+3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
+   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
+   if you edited code this pass.
+
+A pass isn't done until the project's tests, lint, and typecheck are green. That
+objective signal — not the reviewer running out of suggestions — is the real
+stop condition; tests are the ground truth.
+
 ## Critical Reminders
 
 1. **Primary value: Web research** - Verify against current ecosystem (versions, docs, security)

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -79,6 +79,32 @@ Fetch official documentation for libraries in use.
 
 The `**Next:**` line is required. On APPROVE, name what to do now (proceed, commit, run /verify). On REQUEST CHANGES, name the specific edit and re-review trigger. On NEEDS DISCUSSION, name the question to ask. A verdict that doesn't tell the reader what to do next is incomplete.
 
+## Loop: review → fix → re-review
+
+Run the review in passes (MAX_PASSES = 3), not one-and-done.
+
+Each pass:
+
+1. **Review with a fresh, independent reviewer.** Spawn a sub-agent on a
+   _different model than yours_ when your harness supports it — a same-model,
+   same-context reviewer shares your blind spots, and ungrounded self-correction
+   can _degrade_ code rather than improve it. Hand it only the diff and the
+   ticket scope, have it apply §1–3, and return the Output Format above.
+   - Claude Code: Agent/Task tool. Codex: ask in your prompt — subagents never
+     auto-spawn, and `/agent` only switches between existing threads. Cursor:
+     subagents.
+   - No sub-agent available? Do a fresh-context pass and switch models manually —
+     independence is the point, not the mechanism.
+2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
+   improvements** worth the change; list the rest — don't chase them.
+3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
+   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
+   if you edited code this pass.
+
+A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
+objective signal — not the reviewer running out of suggestions — is the real
+stop condition; tests are the ground truth.
+
 ## Reminders
 
 1. **Primary value: Web research** - Verify versions, docs, security


### PR DESCRIPTION
## What

Adds a **Loop** section to the `quality-review` skill: run review→fix→re-review in bounded passes (`MAX_PASSES = 3`), each pass using a fresh, ideally **different-model** sub-agent reviewer; stop when **Critical issues = None**, anchored to an objective signal (`/verify` — tests/lint/typecheck). Harness-neutral (Claude / Codex / Cursor) with a no-sub-agent fallback.

## Why

"Loop until no more suggestions" doesn't converge. Intrinsic same-model self-correction can _degrade_ output ([Huang et al., ICLR 2024](https://arxiv.org/abs/2310.01798)), and iterative self-refinement has no convergence guarantee ([Self-Refine](https://selfrefine.info/)). The remedy baked into the loop: an independent (ideally different-model) reviewer each pass to break correlated blind spots, a severity gate (loop on Critical, not on taste), a hard pass cap, and an external stop signal.

## Surfaces (parity-enforced)

- **`.md` trio:** `packages/cli/templates/skills/quality-review/SKILL.md` → `.claude/skills/...` (Claude) + `.agents/skills/...` (Codex)
- **Cursor `.mdc` pair:** template + `.cursor/rules/safeword-quality-reviewing.mdc`

On Codex/Cursor the loop is advisory prose (those harnesses have sub-agents, but the cross-model _enforcement_ ledger is Claude-only).

## Version

Joins the in-development **0.52.0** (the version `main` opened in #254) — rebased onto current main, no separate bump.

## Also in this PR

- `chore(ticket-151)`: refreshed the cursor-rule-migration ticket — stale line counts, bdd rules marked already-migrated (G1A6BS), the equivalence guard reframed as a structural "must-be-pointer" check, and a note that the Loop block is absorbed on conversion. (The actual `@reference` migration that would dissolve the `.md`/`.mdc` duplication remains ticket 151's own work.)

## Verification

- `bun scripts/parity-check.ts` — 157 pairs + 3 contracts in sync
- markdownlint + prettier clean (lint-staged, on commit)
- **Dogfooded:** the loop was run on itself and on the proposal via independent Sonnet reviewers, which caught a real factual error (Codex `/agent` mis-described as a spawn command) — fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
