### PR TITLE
chore(099): close ESLint 10 migration ticket (shipped in v0.52.0)

### DIFF
--- a/.project/tickets/099-eslint-10-migration/ticket.md
+++ b/.project/tickets/099-eslint-10-migration/ticket.md
@@ -1,10 +1,10 @@
 ---
 id: '099'
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-04-11
-last_modified: 2026-06-18T03:20:00Z
+last_modified: 2026-06-18T15:00:00Z
 ---
 
 # Task: ESLint 10 Migration


### PR DESCRIPTION
Marks ticket 099 done/done — ESLint 10 additive support shipped in v0.52.0 (PR #254; npm latest = 0.52.0). Doc-only ticket status flip.