### PR TITLE
chore(setup): default new installs to ESLint 10 (v0.52.1)

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -455,9 +455,12 @@ export const typescriptJsonMerges: Record<string, JsonMergeDefinition> = {
 // Packages
 // ============================================================================
 
-// Pin to v9 until ESLint plugin ecosystem supports v10 (released Feb 2026).
-// Minimum 9.22 for `eslint/config` defineConfig helper used in generated configs.
-export const ESLINT_PACKAGE = 'eslint@^9.22.0';
+// Default new installs to ESLint 10 — safeword's peer range is `^9.22.0 || ^10.0.0`
+// since v0.52.0, and the plugin-ecosystem blocker that pinned this to v9 is resolved.
+// Existing customers are NOT bumped: reconcile skips packages already installed, so
+// this only affects fresh setups. v10 keeps the `eslint/config` defineConfig helper
+// used in generated configs.
+export const ESLINT_PACKAGE = 'eslint@^10.0.0';
 
 export const typescriptPackages = {
   base: [


### PR DESCRIPTION
## What

`safeword setup` now installs `eslint@^10.0.0` for fresh projects (was `^9.22.0`). The old comment's condition — *"pin to v9 until the ESLint plugin ecosystem supports v10"* — is satisfied as of v0.52.0 (peer range `^9.22.0 || ^10.0.0`, React-plugin blocker resolved).

## Why it's non-breaking for existing customers

Reconcile detects installed packages by **name**, not version spec (`stripVersionSpecifier` in `reconcile.ts:835` — `eslint@^9` → `eslint`). So any project that already has `eslint` installed is skipped; `ESLINT_PACKAGE` is only added to `packagesToInstall` for projects with **no eslint yet**. Existing v9 users are **not** bumped on `safeword upgrade`.

## Version

Patch bump `0.52.0` → `0.52.1`. Existing users' working setups are unaffected, so it passes the "auto-upgrade at SessionStart — does anything break?" test in the negative.

## Edge note (not bumped)

`engines.node` stays `>=22.12`. A *new* project on exactly Node 22.12 installing eslint 10 would see eslint's own engine warning (it wants `^22.13`); that's eslint's self-enforced floor, trivially resolved, and bumping safeword's own floor would narrow support for existing users — so it's intentionally left alone.

## Verification

- Reconcile tests 49/49 (the 2 transient failures on first run were flaky heavy-integration noise — green on re-run)
- `tsc --noEmit` clean
- Tests reference the `ESLINT_PACKAGE` constant, so they move with the value (no test edits needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)