### PR TITLE
fix(quality-review): add missing `verify` phase to the Detect Phase table

### DIFF
--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -28,6 +28,7 @@ If in BDD workflow, read the current ticket from `<namespace-root>/tickets/` and
 | define-behavior | Testing patterns, BDD research and patterns     |
 | scenario-gate   | Architecture patterns, test layer strategy      |
 | implement       | **Library versions, deprecated APIs, security** |
+| verify          | Flaky-test & regression patterns, coverage gaps |
 | done            | CI/CD patterns, release checklists              |
 
 ## 2. Research Angles (Primary Value)

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -28,6 +28,7 @@ If in BDD workflow, read the current ticket from `<namespace-root>/tickets/` and
 | define-behavior | Testing patterns, BDD research and patterns     |
 | scenario-gate   | Architecture patterns, test layer strategy      |
 | implement       | **Library versions, deprecated APIs, security** |
+| verify          | Flaky-test & regression patterns, coverage gaps |
 | done            | CI/CD patterns, release checklists              |
 
 ## 2. Research Angles (Primary Value)

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -28,6 +28,7 @@ If in BDD workflow, read the current ticket from `<namespace-root>/tickets/` and
 | define-behavior | Testing patterns, BDD research and patterns     |
 | scenario-gate   | Architecture patterns, test layer strategy      |
 | implement       | **Library versions, deprecated APIs, security** |
+| verify          | Flaky-test & regression patterns, coverage gaps |
 | done            | CI/CD patterns, release checklists              |
 
 ## 2. Research Angles (Primary Value)


### PR DESCRIPTION
## What

Adds the missing `verify` row to the quality-review skill's **Detect Phase** table.

## Why

The phase→research-focus table jumped `implement → done`, skipping the `verify` phase that sits between them in the canonical workflow:

```
intake → define-behavior → scenario-gate → implement → verify → done
```

Source of truth: `BddPhase` in `packages/cli/templates/hooks/lib/quality.ts`, plus the verify transition guidance in `prompt-questions.ts`.

When a ticket was in the `verify` phase, the skill's "Detect Phase" step found no matching row and fell through to **no phase-specific research focus** — going phase-blind exactly at the verify gate. The omission predates #266 (which added the provenance gate above this table but didn't touch it).

## Change

One row — `verify | Flaky-test & regression patterns, coverage gaps` — byte-synced across the `.md` trio (template + `.claude` + `.agents`). The Cursor rule is a thin `@reference` and needs no change.

## Verification

- `parity-check --mode=all`: **157 pairs + 3 contracts in sync**
- `prettier --check` on all 3 copies: clean (no commit-time drift)
- `dependency-freshness-prompt.test.ts` + `schema.test.ts`: **36 pass**
- No test asserts the table content (checked before editing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)