### PR TITLE
fix(reconcile): preserve user-customized MCP servers on upgrade (#255)

### DIFF
--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -11,6 +11,7 @@
 
 import { SAFEWORD_IGNORE_DIRS } from '../../owned-paths.js';
 import { getEslintConfig, getSafewordEslintConfig } from '../../templates/config.js';
+import { assignOrPrune } from '../../utils/json-merge.js';
 import type {
   FileDefinition,
   JsonMergeDefinition,
@@ -419,12 +420,7 @@ export const typescriptJsonMerges: Record<string, JsonMergeDefinition> = {
       delete scripts.publint;
       delete scripts['test:bdd'];
 
-      if (Object.keys(scripts).length > 0) {
-        result.scripts = scripts;
-      } else {
-        delete result.scripts;
-      }
-
+      assignOrPrune(result, 'scripts', scripts);
       return result;
     },
   },

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -76,25 +76,28 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
   keys: ['mcpServers.context7', 'mcpServers.playwright'],
   removeFileIfEmpty: true,
   merge: existing => {
-    const mcpServers = (existing.mcpServers as Record<string, unknown>) ?? {};
-    return {
-      ...existing,
-      mcpServers: {
-        // Add-if-missing: seed our defaults first, then let any user-authored
-        // entry win by spreading existing servers last. This keeps `upgrade`
-        // from clobbering a customized context7/playwright definition (e.g. a
-        // hosted HTTP transport) while still injecting the default when the
-        // key is absent. (#255)
-        context7: MCP_SERVERS.context7,
-        playwright: MCP_SERVERS.playwright,
-        ...mcpServers,
-      },
-    };
+    const mcpServers = { ...(existing.mcpServers as Record<string, unknown>) };
+    // Add-if-missing: preserve any user-authored entry — including its key
+    // ordering — and inject safeword's default only when the server key is
+    // absent. This keeps `upgrade` from clobbering a customized
+    // context7/playwright definition (e.g. a hosted HTTP transport), and
+    // spreading existing first means an already-correct file produces an
+    // identical merge (no write churn). (#255)
+    mcpServers.context7 ??= MCP_SERVERS.context7;
+    mcpServers.playwright ??= MCP_SERVERS.playwright;
+    return { ...existing, mcpServers };
   },
   unmerge: existing => {
     const result = { ...existing };
     const mcpServers = { ...(existing.mcpServers as Record<string, unknown>) };
 
+    // Blind-delete on uninstall: removing the server names safeword introduced
+    // is the predictable inverse of install and matches the package.json /
+    // .cursor/hooks.json unmerges. A value-match "delete-if-ours" was
+    // considered but rejected — it can't tell a user customization from a
+    // server installed by an older safeword version (different default value),
+    // so it would orphan stale entries. uninstall is an explicit destructive
+    // action; #255 is about upgrade not clobbering, which the merge handles.
     delete mcpServers.context7;
     delete mcpServers.playwright;
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -30,6 +30,7 @@ import { CURSOR_HOOKS, SETTINGS_HOOKS } from './templates/config.js';
 import { AGENTS_MD_LINK, CLAUDE_MD_IMPORT_BLOCK } from './templates/content.js';
 import { filterOutSafewordHooks } from './utils/hooks.js';
 import { MCP_SERVERS } from './utils/install.js';
+import { assignOrPrune } from './utils/json-merge.js';
 import { VERSION } from './version.js';
 
 export interface TextPatchDefinition {
@@ -101,12 +102,7 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
     delete mcpServers.context7;
     delete mcpServers.playwright;
 
-    if (Object.keys(mcpServers).length > 0) {
-      result.mcpServers = mcpServers;
-    } else {
-      delete result.mcpServers;
-    }
-
+    assignOrPrune(result, 'mcpServers', mcpServers);
     return result;
   },
 };
@@ -841,11 +837,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
         }
 
         const result = { ...existing };
-        if (Object.keys(cleanedHooks).length > 0) {
-          result.hooks = cleanedHooks;
-        } else {
-          delete result.hooks;
-        }
+        assignOrPrune(result, 'hooks', cleanedHooks);
         return result;
       },
     },
@@ -875,10 +867,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
         delete hooks.afterFileEdit;
         delete hooks.stop;
 
-        if (Object.keys(hooks).length > 0) {
-          result.hooks = hooks;
-        } else {
-          delete result.hooks;
+        // `version` is only meaningful while safeword's hooks remain; drop it
+        // alongside an emptied hooks container.
+        if (!assignOrPrune(result, 'hooks', hooks)) {
           delete result.version;
         }
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -80,9 +80,14 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
     return {
       ...existing,
       mcpServers: {
-        ...mcpServers,
+        // Add-if-missing: seed our defaults first, then let any user-authored
+        // entry win by spreading existing servers last. This keeps `upgrade`
+        // from clobbering a customized context7/playwright definition (e.g. a
+        // hosted HTTP transport) while still injecting the default when the
+        // key is absent. (#255)
         context7: MCP_SERVERS.context7,
         playwright: MCP_SERVERS.playwright,
+        ...mcpServers,
       },
     };
   },

--- a/packages/cli/src/utils/json-merge.test.ts
+++ b/packages/cli/src/utils/json-merge.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { assignOrPrune } from './json-merge.js';
+
+describe('assignOrPrune', () => {
+  it('assigns the value and returns true when it has entries', () => {
+    const target: Record<string, unknown> = { keep: 1 };
+    const value = { a: 1 };
+
+    const kept = assignOrPrune(target, 'nested', value);
+
+    expect(kept).toBe(true);
+    expect(target).toEqual({ keep: 1, nested: { a: 1 } });
+  });
+
+  it('deletes an existing key and returns false when the value is empty', () => {
+    const target: Record<string, unknown> = { keep: 1, nested: { old: 1 } };
+
+    const kept = assignOrPrune(target, 'nested', {});
+
+    expect(kept).toBe(false);
+    expect(target).toEqual({ keep: 1 });
+    expect('nested' in target).toBe(false);
+  });
+
+  it('is a no-op (returns false) when pruning an absent key', () => {
+    const target: Record<string, unknown> = { keep: 1 };
+
+    const kept = assignOrPrune(target, 'missing', {});
+
+    expect(kept).toBe(false);
+    expect(target).toEqual({ keep: 1 });
+  });
+});

--- a/packages/cli/src/utils/json-merge.ts
+++ b/packages/cli/src/utils/json-merge.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers shared by `JsonMergeDefinition.unmerge` implementations.
+ */
+
+/**
+ * Assign `value` to `target[key]`, or delete the key when `value` has no
+ * remaining entries. Unmerge functions strip safeword's managed keys out of a
+ * nested object (scripts, hooks, mcpServers, …) and then must either write the
+ * trimmed object back or drop the now-empty container entirely. Returns whether
+ * the key was kept, so callers can prune sibling keys that only make sense when
+ * the container survives (e.g. `.cursor/hooks.json`'s `version`).
+ */
+export function assignOrPrune(
+  target: Record<string, unknown>,
+  key: string,
+  value: Record<string, unknown>,
+): boolean {
+  if (Object.keys(value).length > 0) {
+    target[key] = value;
+    return true;
+  }
+  Reflect.deleteProperty(target, key);
+  return false;
+}

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -977,6 +977,74 @@ describe('Reconcile - Reconciliation Engine', () => {
       // .mcp.json should be removed (was only our content)
       expect(existsSync(nodePath.join(temporaryDirectory, '.mcp.json'))).toBe(false);
     });
+
+    // Regression: #255 — MCP reconcile must not clobber user-customized servers.
+    it('should preserve a user-customized context7 entry on upgrade (#255)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      const mcpPath = nodePath.join(temporaryDirectory, '.mcp.json');
+      // User authored a custom context7 transport with headers.
+      const customContext7 = {
+        url: 'https://mcp.context7.com/mcp',
+        headers: { Authorization: 'Bearer user-token' },
+      };
+      writeFileSync(
+        mcpPath,
+        JSON.stringify({ mcpServers: { context7: customContext7 } }, undefined, 2),
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const result = JSON.parse(readFileSync(mcpPath, 'utf8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      // User's customization survives reconcile/upgrade...
+      expect(result.mcpServers.context7).toEqual(customContext7);
+      // ...and the missing default (playwright) is still injected.
+      expect(result.mcpServers.playwright).toBeDefined();
+    });
+
+    it('should preserve unrelated user MCP servers on upgrade (#255)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      const mcpPath = nodePath.join(temporaryDirectory, '.mcp.json');
+      const customServer = { command: 'bunx', args: ['@acme/custom-mcp@latest'] };
+      writeFileSync(mcpPath, JSON.stringify({ mcpServers: { acme: customServer } }, undefined, 2));
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const result = JSON.parse(readFileSync(mcpPath, 'utf8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(result.mcpServers.acme).toEqual(customServer);
+      expect(result.mcpServers.context7).toBeDefined();
+      expect(result.mcpServers.playwright).toBeDefined();
+    });
+
+    it('should seed default MCP servers when none are present (#255)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+      const { MCP_SERVERS } = await import('../src/utils/install.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const result = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, '.mcp.json'), 'utf8'),
+      ) as { mcpServers: Record<string, unknown> };
+      expect(result.mcpServers.context7).toEqual(MCP_SERVERS.context7);
+      expect(result.mcpServers.playwright).toEqual(MCP_SERVERS.playwright);
+    });
   });
 
   describe('reconcile() - dryRun option', () => {

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -977,7 +977,9 @@ describe('Reconcile - Reconciliation Engine', () => {
       // .mcp.json should be removed (was only our content)
       expect(existsSync(nodePath.join(temporaryDirectory, '.mcp.json'))).toBe(false);
     });
+  });
 
+  describe('reconcile() - MCP server merge (#255)', () => {
     // Regression: #255 — MCP reconcile must not clobber user-customized servers.
     it('should preserve a user-customized context7 entry on upgrade (#255)', async () => {
       const { reconcile } = await import('../src/reconcile.js');

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1045,6 +1045,34 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(result.mcpServers.context7).toEqual(MCP_SERVERS.context7);
       expect(result.mcpServers.playwright).toEqual(MCP_SERVERS.playwright);
     });
+
+    it('should not rewrite .mcp.json when servers are already correct (#255)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      const mcpPath = nodePath.join(temporaryDirectory, '.mcp.json');
+      // A user-authored server ordered before our managed ones; both defaults present.
+      const onDisk = `${JSON.stringify(
+        {
+          mcpServers: {
+            acme: { command: 'bunx', args: ['@acme/custom-mcp@latest'] },
+            context7: { url: 'https://mcp.context7.com/mcp' },
+            playwright: { command: 'bunx', args: ['@playwright/mcp@latest'] },
+          },
+        },
+        undefined,
+        2,
+      )}\n`;
+      writeFileSync(mcpPath, onDisk);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      // Idempotent: byte-identical, no key reordering churn.
+      expect(readFileSync(mcpPath, 'utf8')).toBe(onDisk);
+    });
   });
 
   describe('reconcile() - dryRun option', () => {


### PR DESCRIPTION
## Summary

Fixes #255. `safeword upgrade` (and the auto-upgrade session hook) was silently reverting any user customization of the `context7`/`playwright` MCP servers in both `.mcp.json` and `.cursor/mcp.json`, because `MCP_JSON_MERGE` spread the user's existing `mcpServers` **first** and then overwrote those two keys with the built-in defaults.

> Note: the other half of the original report — context7 pinned to the legacy stdio transport (`bunx @upstash/context7-mcp@latest`) — was already fixed independently. `MCP_SERVERS.context7` is now the hosted `{ url: "https://mcp.context7.com/mcp" }` form, so the remaining live defect was just the clobbering.

## What changed

- **Add-if-missing merge** (`packages/cli/src/schema.ts`): spread the existing servers first, then `??=` safeword's defaults. A user-authored entry wins; the default is still injected only when the key is absent. Because existing key order is preserved, an already-correct file produces an identical merge and reconcile skips the write — no formatting/key-reorder churn. This matches the `addScriptIfMissing` / `.claude/settings.json` convention used by the other merges. Both `.mcp.json` and `.cursor/mcp.json` share `MCP_JSON_MERGE`, so both paths are fixed.
- **`unmerge` (uninstall) keeps blind-delete, now documented.** A value-match "delete-if-ours" was evaluated and rejected: it cannot distinguish a user customization from a server installed by an *older* safeword version (whose default value differs), so it would orphan stale entries on uninstall. uninstall is an explicit destructive action; #255 is specifically about `upgrade` not clobbering, which the merge now handles.
- **Refactor:** the "write the trimmed object back, or delete the key when empty" idiom was duplicated across four `unmerge` functions (mcpServers, two hooks maps, package.json scripts). Extracted into `utils/json-merge.ts` `assignOrPrune`, which returns whether the key survived so `.cursor/hooks.json` can still drop its `version` sibling when hooks empty. Behavior unchanged.

## Tests

- Regression tests in a dedicated `reconcile() - MCP server merge (#255)` block: customized `context7` survives upgrade (the real regression guard — fails against pre-fix code), unrelated user servers survive, defaults are seeded on fresh install, and an already-correct file is left byte-identical (no churn).
- Unit test for `assignOrPrune` covering assign / prune-existing / prune-absent branches.

## Verification

- `tsc --noEmit`, eslint, and `depcruise`/`deps:validate` clean (incl. the new `packs → utils` edge)
- Full test suite green (610+ via the pre-push schema-drift gate); reconcile/reset/configured-paths/setup-cursor/setup-hooks suites pass
- `/audit` clean: no dead code (`assignOrPrune` resolved as used), no new duplication (the refactor removed 4 duplicated sites), no cycles or boundary violations, config in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KxNsZG64tV2EgNb47hrPm)_