### PR TITLE
refactor skill: split discovery (fan-out) from execution (linear)

### DIFF
--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -36,7 +36,7 @@ Answer IN ORDER. Stop at first match:
 
 **Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
 
-Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `quality-review`'s independent reviewer passes.
 
 Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
@@ -90,7 +90,7 @@ it('processOrder returns current behavior', () => {
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
 
-**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -34,7 +34,11 @@ Answer IN ORDER. Stop at first match:
 - Poor naming (unclear what something does)
 - Wrong level of abstraction (special cases piled on shared infrastructure instead of a generalized mechanism; detect via _shotgun surgery_ — one logical change forces edits in many places)
 
-**Scout first (optional).** When the target is "clean this up" with no named smell, surface candidates before diving in: run `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), then apply judgment for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Produce a _prioritized_ list and work it one smell at a time (never in parallel). If you cap the list, say what you dropped — a scout that reads as "nothing else" when it truncated is a bug.
+**Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
+
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+
+Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
 ---
 
@@ -85,6 +89,8 @@ it('processOrder returns current behavior', () => {
 ## Phase 3: REFACTOR
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+
+**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -187,13 +193,17 @@ git checkout -- <changed-files>
 
 ## Phase 5: ITERATE
 
+Walk the scout ledger **leaf-first**. Each entry gets its own Phase 3 → Phase 4 cycle; mark it done (or struck, with a reason) before starting the next. The ledger is the completeness contract — you stop when every entry is resolved or explicitly deferred, not when you're tired of the diff. Don't let an unfinished ledger read as "nothing left."
+
 ```text
-More refactoring needed?
-├─ Yes → Return to Phase 3 (one more refactoring)
+Ledger entries remaining?
+├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Changes: [summary]"
+    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
 ```
+
+A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 **Audit catches:** Dead code left behind, new duplication (should decrease!), architecture violations.
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -36,7 +36,7 @@ Answer IN ORDER. Stop at first match:
 
 **Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
 
-Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `quality-review`'s independent reviewer passes.
 
 Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
@@ -90,7 +90,7 @@ it('processOrder returns current behavior', () => {
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
 
-**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -34,7 +34,11 @@ Answer IN ORDER. Stop at first match:
 - Poor naming (unclear what something does)
 - Wrong level of abstraction (special cases piled on shared infrastructure instead of a generalized mechanism; detect via _shotgun surgery_ — one logical change forces edits in many places)
 
-**Scout first (optional).** When the target is "clean this up" with no named smell, surface candidates before diving in: run `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), then apply judgment for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Produce a _prioritized_ list and work it one smell at a time (never in parallel). If you cap the list, say what you dropped — a scout that reads as "nothing else" when it truncated is a bug.
+**Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
+
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+
+Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
 ---
 
@@ -85,6 +89,8 @@ it('processOrder returns current behavior', () => {
 ## Phase 3: REFACTOR
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+
+**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -187,13 +193,17 @@ git checkout -- <changed-files>
 
 ## Phase 5: ITERATE
 
+Walk the scout ledger **leaf-first**. Each entry gets its own Phase 3 → Phase 4 cycle; mark it done (or struck, with a reason) before starting the next. The ledger is the completeness contract — you stop when every entry is resolved or explicitly deferred, not when you're tired of the diff. Don't let an unfinished ledger read as "nothing left."
+
 ```text
-More refactoring needed?
-├─ Yes → Return to Phase 3 (one more refactoring)
+Ledger entries remaining?
+├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Changes: [summary]"
+    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
 ```
+
+A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 **Audit catches:** Dead code left behind, new duplication (should decrease!), architecture violations.
 

--- a/packages/cli/templates/skills/refactor/SKILL.md
+++ b/packages/cli/templates/skills/refactor/SKILL.md
@@ -36,7 +36,7 @@ Answer IN ORDER. Stop at first match:
 
 **Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
 
-Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `quality-review`'s independent reviewer passes.
 
 Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
@@ -90,7 +90,7 @@ it('processOrder returns current behavior', () => {
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
 
-**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 

--- a/packages/cli/templates/skills/refactor/SKILL.md
+++ b/packages/cli/templates/skills/refactor/SKILL.md
@@ -34,7 +34,11 @@ Answer IN ORDER. Stop at first match:
 - Poor naming (unclear what something does)
 - Wrong level of abstraction (special cases piled on shared infrastructure instead of a generalized mechanism; detect via _shotgun surgery_ — one logical change forces edits in many places)
 
-**Scout first (optional).** When the target is "clean this up" with no named smell, surface candidates before diving in: run `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), then apply judgment for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Produce a _prioritized_ list and work it one smell at a time (never in parallel). If you cap the list, say what you dropped — a scout that reads as "nothing else" when it truncated is a bug.
+**Scout first.** Default for any multi-smell or unnamed request ("clean this up", "tidy this module"). Skip it only when the user named one specific smell — then go straight to Phase 3 with a one-entry ledger.
+
+Discovery is the one phase that may **fan out**. Sweep in independent read-only passes — `/lint` + `/audit` for the mechanical smells (long function, deep nesting, magic literals, duplication, dead code — already detected there), plus separate judgment passes for the semantic ones (reuse / duplicated intent, wrong level of abstraction). Per smell category or per module these passes are independent, so run them concurrently (sub-agents where your harness supports it) and merge the findings — the same fan-out-then-merge shape as `deep-research` and `quality-review`.
+
+Merge into a **ledger**, not a loose list: each entry is a smell + location, ordered _prioritized and dependency-aware_ — leaf-first, so no fix lands before the change it depends on (the Mikado ordering). Persist it as the Phase 5 checklist and never silently truncate — if you cap it, say what you dropped. A scout that reads as "nothing else" when it truncated is a bug.
 
 ---
 
@@ -85,6 +89,8 @@ it('processOrder returns current behavior', () => {
 ## Phase 3: REFACTOR
 
 **Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+
+**Discovery fans out; mutation never does.** The scout (Phase 1) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -187,13 +193,17 @@ git checkout -- <changed-files>
 
 ## Phase 5: ITERATE
 
+Walk the scout ledger **leaf-first**. Each entry gets its own Phase 3 → Phase 4 cycle; mark it done (or struck, with a reason) before starting the next. The ledger is the completeness contract — you stop when every entry is resolved or explicitly deferred, not when you're tired of the diff. Don't let an unfinished ledger read as "nothing left."
+
 ```text
-More refactoring needed?
-├─ Yes → Return to Phase 3 (one more refactoring)
+Ledger entries remaining?
+├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Changes: [summary]"
+    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
 ```
+
+A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 **Audit catches:** Dead code left behind, new duplication (should decrease!), architecture violations.
 


### PR DESCRIPTION
## What

Clarifies that the `refactor` skill **fans out for discovery but stays strictly linear for execution**, and makes it more thorough so identified fixes can't be silently dropped. Prose-only change to the three in-sync `refactor/SKILL.md` copies (template + `.claude` + `.agents`).

## Why

The skill's Iron Law ("ONE REFACTORING → TEST → COMMIT") only governs *execution*, but the text didn't say so — leaving it ambiguous whether the skill stops at one fix or works through all of them, and whether discovery could be parallelized. The split resolves both.

## Changes

1. **Scout promoted** from optional → default for multi-smell/unnamed requests; skips to Phase 3 only when one specific smell is named.
2. **Discovery may fan out** — parallel read-only passes per smell category/module, merged the same fan-out-then-merge way as `quality-review`'s reviewer passes.
3. **Output is a ledger** — prioritized *and* dependency-aware (leaf-first / Mikado ordering), persisted as the Phase 5 checklist, no silent truncation.
4. **Phase 3 states the asymmetry** — discovery fans out, mutation never does, with the *why* (revert protocol, `git bisect`, single-change test attribution) and the Iron Law clarified as **per-edit, not per-session**.
5. **Phase 5 ITERATE rewritten** as a leaf-first ledger walk with a Resolved/Deferred report.

A `/quality-review` pass (independent Sonnet reviewer) caught and fixed two issues before this PR: a mislabeled "Phase 1" scout reference and a dangling `deep-research` citation (no `SKILL.md` ships for it).

## Verification

- Parity: ✅ all 157 pairs + 3 contracts in sync (three copies byte-identical)
- Tests: ✅ 3087 passed / 5 skipped (207 files)
- Gherkin: ✅ 69 scenarios / 741 steps
- Build: ✅ success
- Lint: ✅ ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsX8UqTfWiTFvsWipjDGfz)_