### PR TITLE
feat(codex): MCP server parity for .codex/config.toml (#269)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -22,3 +22,10 @@ type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-quality.ts"'
 timeout = 30
 statusMessage = "Checking safeword PreToolUse gates"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.playwright]
+command = "bunx"
+args = ["@playwright/mcp@latest"]

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -123,16 +123,23 @@ function planMissingDirectories(
  * upgrade` reaches the heal path on pre-fix installs, which is what commit
  * a304af8 promised.
  */
+function asPatchList(entry: TextPatchDefinition | TextPatchDefinition[]): TextPatchDefinition[] {
+  return Array.isArray(entry) ? entry : [entry];
+}
+
 function planTextPatches(
-  patches: Record<string, TextPatchDefinition>,
+  patches: Record<string, TextPatchDefinition | TextPatchDefinition[]>,
   cwd: string,
   isGitRepo: boolean,
 ): Action[] {
   const actions: Action[] = [];
-  for (const [filePath, definition] of Object.entries(patches)) {
+  for (const [filePath, entry] of Object.entries(patches)) {
     if (shouldSkipForNonGit(filePath, isGitRepo)) continue;
-    if (!passesTextPatchContentGuard(cwd, filePath, definition)) continue;
-    actions.push({ type: 'text-patch', path: filePath, definition });
+    // Apply in list order so later patches land beneath earlier ones.
+    for (const definition of asPatchList(entry)) {
+      if (!passesTextPatchContentGuard(cwd, filePath, definition)) continue;
+      actions.push({ type: 'text-patch', path: filePath, definition });
+    }
   }
   return actions;
 }
@@ -152,7 +159,7 @@ function passesTextPatchContentGuard(
 }
 
 function planTextUnpatches(
-  patches: Record<string, TextPatchDefinition>,
+  patches: Record<string, TextPatchDefinition | TextPatchDefinition[]>,
   cwd: string,
   isGitRepo: boolean,
 ): Action[] {
@@ -162,15 +169,19 @@ function planTextUnpatches(
   };
 
   const actions: Action[] = [];
-  for (const [filePath, definition] of Object.entries(patches)) {
+  for (const [filePath, entry] of Object.entries(patches)) {
     if (shouldSkipForNonGit(filePath, isGitRepo)) continue;
 
     const fullPath = nodePath.join(cwd, filePath);
     if (!exists(fullPath)) continue;
 
     const content = readFileSafe(fullPath) ?? '';
-    if (hasLegacyPreamble(content, definition)) {
-      actions.push({ type: 'text-unpatch', path: filePath, definition });
+    // Unpatch in reverse list order so the patch that owns file removal
+    // (removeFileIfContentEquals) runs last, after siblings strip their blocks.
+    for (const definition of asPatchList(entry).toReversed()) {
+      if (hasLegacyPreamble(content, definition)) {
+        actions.push({ type: 'text-unpatch', path: filePath, definition });
+      }
     }
   }
   return actions;

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -57,7 +57,11 @@ export interface SafewordSchema {
   ownedFiles: Record<string, FileDefinition>; // Overwrite on upgrade (if changed)
   managedFiles: Record<string, ManagedFileDefinition>; // Create if missing, update if safeword content
   jsonMerges: Record<string, JsonMergeDefinition>;
-  textPatches: Record<string, TextPatchDefinition>;
+  // A file may carry an ordered list of patches (e.g. .codex/config.toml's hook
+  // retrofit + MCP-server retrofit). Patches apply in list order and unpatch in
+  // reverse, so the patch that owns file removal (removeFileIfContentEquals)
+  // runs last on uninstall. See #269.
+  textPatches: Record<string, TextPatchDefinition | TextPatchDefinition[]>;
   legacyTextPatches: Record<string, TextPatchDefinition>; // Remove old managed text patches without installing them
   contracts: Record<string, ContractDefinition>; // Files that must contain specific strings (predicate parity)
   packages: {
@@ -137,6 +141,20 @@ type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-quality.ts"'
 timeout = 30
 statusMessage = "Checking safeword PreToolUse gates"
+`;
+
+// MCP servers for Codex parity with .mcp.json / .cursor/mcp.json (#269).
+// context7 uses the hosted streamable-HTTP transport (url); playwright uses
+// stdio (command/args) — matching MCP_SERVERS. Shipped via the codex/config.toml
+// template and re-applied as a retrofit text-patch on upgrade. Must byte-match
+// the block appended to that template (exported so tests strip it exactly).
+export const CODEX_MCP_SERVERS_BLOCK = `
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.playwright]
+command = "bunx"
+args = ["@playwright/mcp@latest"]
 `;
 
 const CODEX_CONFIG_SCAFFOLD_WITHOUT_HOOKS = `
@@ -907,17 +925,38 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       content: `\n# Safeword - managed prettier exclusions (owned dirs)\n${MANAGED_PRETTIER_PATHS.join('\n')}\n`,
       marker: '# Safeword - managed prettier exclusions (owned dirs)',
     },
-    '.codex/config.toml': {
-      operation: 'append',
-      content: CODEX_PROMPT_TIMESTAMP_HOOK_PATCH,
-      marker: '.safeword/hooks/prompt-timestamp.ts',
-      applyWhenContentIncludes: [
-        '# Safeword Codex project configuration.',
-        '.safeword/hooks/codex/pre-tool-quality.ts',
-      ],
-      unpatchContent: [CODEX_SESSION_START_HOOK_PATCH, CODEX_PRE_TOOL_QUALITY_HOOK_PATCH],
-      removeFileIfContentEquals: [CODEX_CONFIG_SCAFFOLD_WITHOUT_HOOKS],
-    },
+    '.codex/config.toml': [
+      // Primary patch: retrofits the prompt-timestamp hook onto pre-existing
+      // configs and owns file removal on uninstall (runs LAST on unpatch).
+      {
+        operation: 'append',
+        content: CODEX_PROMPT_TIMESTAMP_HOOK_PATCH,
+        marker: '.safeword/hooks/prompt-timestamp.ts',
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
+        unpatchContent: [CODEX_SESSION_START_HOOK_PATCH, CODEX_PRE_TOOL_QUALITY_HOOK_PATCH],
+        removeFileIfContentEquals: [CODEX_CONFIG_SCAFFOLD_WITHOUT_HOOKS],
+      },
+      // MCP-server retrofit (#269): add-if-missing parity with .mcp.json /
+      // .cursor/mcp.json. Marker is the context7 table header, so an existing
+      // (safeword- or user-authored) [mcp_servers.context7] suppresses the
+      // append — never clobbering or duplicating a user's entry. Guarded to
+      // safeword-scaffolded configs only.
+      {
+        operation: 'append',
+        content: CODEX_MCP_SERVERS_BLOCK,
+        marker: '[mcp_servers.context7]',
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
+        // No unpatchContent/removeFileIfContentEquals by design: unpatch removes
+        // this patch's `content` (the MCP block), and the primary patch above —
+        // running last on the reversed unpatch — owns file removal.
+      },
+    ],
   },
 
   // Cleanup-only text patches. Safeword used to prepend these blocks to

--- a/packages/cli/templates/codex/config.toml
+++ b/packages/cli/templates/codex/config.toml
@@ -31,3 +31,10 @@ type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-quality.ts"'
 timeout = 30
 statusMessage = "Checking safeword PreToolUse gates"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.playwright]
+command = "bunx"
+args = ["@playwright/mcp@latest"]

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1077,6 +1077,98 @@ describe('Reconcile - Reconciliation Engine', () => {
     });
   });
 
+  describe('reconcile() - Codex MCP parity (#269)', () => {
+    it('configures context7 and playwright MCP servers in Codex config on install', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      // context7 over the hosted streamable-HTTP transport (parity with MCP_SERVERS).
+      expect(content).toContain('[mcp_servers.context7]');
+      expect(content).toContain('url = "https://mcp.context7.com/mcp"');
+      // playwright over stdio.
+      expect(content).toContain('[mcp_servers.playwright]');
+      expect(content).toContain('command = "bunx"');
+      expect(content).toContain('args = ["@playwright/mcp@latest"]');
+    });
+
+    it('strips safeword MCP servers from a user-extended Codex config on uninstall', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+      // User appends their own config below safeword's managed content.
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.codex/config.toml'),
+        `${readCodexConfigTemplate()}\nmodel = "gpt-5-codex"\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'uninstall', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      // User content survives; safeword's MCP servers are removed.
+      expect(content).toContain('model = "gpt-5-codex"');
+      expect(content).not.toContain('[mcp_servers.context7]');
+      expect(content).not.toContain('[mcp_servers.playwright]');
+    });
+
+    it('retrofits MCP servers into an existing pre-MCP Codex config on upgrade', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      // Simulate a config from a safeword version that predates MCP parity:
+      // the hooks scaffold, but no [mcp_servers.*] tables. Strip the exact MCP
+      // block so this stays correct regardless of template section ordering.
+      const { CODEX_MCP_SERVERS_BLOCK } = await import('../src/schema.js');
+      const preMcp = readCodexConfigTemplate().replace(CODEX_MCP_SERVERS_BLOCK, '');
+      mkdirSync(nodePath.join(temporaryDirectory, '.codex'), { recursive: true });
+      writeFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), preMcp);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(content).toContain('[mcp_servers.context7]');
+      expect(content).toContain('url = "https://mcp.context7.com/mcp"');
+      expect(content).toContain('[mcp_servers.playwright]');
+      // Idempotent: retrofit appends exactly one context7 table, not a duplicate.
+      expect(content.match(/\[mcp_servers\.context7\]/g)).toHaveLength(1);
+    });
+
+    it('does not overwrite or duplicate a user-authored context7 on upgrade', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      // User already has a customized context7 in their Codex config.
+      const { CODEX_MCP_SERVERS_BLOCK } = await import('../src/schema.js');
+      const base = readCodexConfigTemplate().replace(CODEX_MCP_SERVERS_BLOCK, '').trimEnd();
+      const customized = `${base}\n[mcp_servers.context7]\nurl = "https://example.test/custom"\n`;
+      mkdirSync(nodePath.join(temporaryDirectory, '.codex'), { recursive: true });
+      writeFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), customized);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      // User's customization survives; no duplicate table injected.
+      expect(content).toContain('url = "https://example.test/custom"');
+      expect(content).not.toContain('url = "https://mcp.context7.com/mcp"');
+      expect(content.match(/\[mcp_servers\.context7\]/g)).toHaveLength(1);
+    });
+  });
+
   describe('reconcile() - dryRun option', () => {
     it('should not make any changes in dryRun mode', async () => {
       const { reconcile } = await import('../src/reconcile.js');

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -169,7 +169,10 @@ describe('Schema - Single Source of Truth', () => {
     // ignored in safeword's own repo but missing from the shipped textPatch.
     it('ignores all generated transient files', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
-      const content = SAFEWORD_SCHEMA.textPatches['.gitignore']?.content ?? '';
+      const gitignorePatch = SAFEWORD_SCHEMA.textPatches['.gitignore'];
+      const content =
+        (Array.isArray(gitignorePatch) ? gitignorePatch[0]?.content : gitignorePatch?.content) ??
+        '';
       for (const entry of [
         '.safeword/.update-cache.json',
         '.safeword-project/quality-state*.json',


### PR DESCRIPTION
## Summary

Closes #269. safeword configured the `context7` and `playwright` MCP servers for Claude Code (`.mcp.json`) and Cursor (`.cursor/mcp.json`) but **not** for Codex. This adds the same two servers to Codex's `.codex/config.toml`, achieving cross-agent MCP parity.

Uses the verified Codex schema ([docs](https://developers.openai.com/codex/config-reference)): context7 over the hosted **streamable-HTTP `url`** transport, playwright over **stdio** `command`/`args` — matching `MCP_SERVERS`. The hosted `url` form also means safeword never emits the legacy stdio context7 that triggered the Codex `url is not supported for stdio` error noted in #255.

## Mechanism

- **Template** (`templates/codex/config.toml`) gains the `[mcp_servers.*]` tables, so **fresh installs** get parity. Managed files are create-if-missing (`reconcile.ts` — they're not rewritten on upgrade), so the template alone doesn't reach existing configs.
- **Generalized `textPatches` to an ordered list per file.** Added a second, marker-gated (`[mcp_servers.context7]`) retrofit patch that appends the servers to an existing safeword-scaffolded config on **upgrade** — **add-if-missing**, so a user-authored or already-present context7 is never overwritten or duplicated. Patches apply in list order and unpatch in **reverse**, so the primary patch's `removeFileIfContentEquals` (file removal) runs last on uninstall.

## Why this design (not a structured TOML merge)

A structured `mcp_servers` merge would need a TOML library: `smol-toml`/`@iarna` strip comments on re-serialize, and the only comment-preserving option is a WASM port (`@rainbowatcher/toml-edit-js`) — a heavy runtime dep for a published CLI, plus it would double-manage one file alongside the text-patch hooks. The text-patch retrofit stays within safeword's existing, dependency-free, comment-preserving config mechanism.

## Tests

- Install writes both server tables (correct transports).
- Upgrade retrofits a pre-MCP config — idempotent, exactly one `[mcp_servers.context7]` table.
- Upgrade preserves a user-customized context7 (no overwrite, no duplicate).
- Uninstall strips the servers while preserving user content.

## Verification

- Full suite: **3091 passed, 5 skipped**
- typecheck, eslint, `deps:validate` (no boundary violations), pre-push schema-drift gate — all green

## Notes

- Independent of #255 / PR #268 (that's the JSON side of the same parity surface).
- A config a user has fully diverged from safeword's scaffold (guard strings removed) is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KxNsZG64tV2EgNb47hrPm)_