### PR TITLE
fix(#262): exclude generated agent docs from consuming-repo markdownlint (+ merge-engine hardening)

### DIFF
--- a/.project/tickets/TIA4M8-merge-warn-unparseable/ticket.md
+++ b/.project/tickets/TIA4M8-merge-warn-unparseable/ticket.md
@@ -1,0 +1,69 @@
+---
+id: TIA4M8
+slug: merge-warn-unparseable
+type: task
+phase: done
+status: done
+created: 2026-06-20T07:48:00.000Z
+last_modified: 2026-06-20T07:55:00.000Z
+---
+
+> **Done (2026-06-20):** Added a `warnings: string[]` channel to `ReconcileResult`,
+> threaded through `executePlan` → `executeJsonMerge`. A merge target that exists
+> but fails to parse now pushes one actionable warning (file + cause + the keys
+> safeword wanted to add) instead of silently skipping; a genuinely-absent
+> `skipIfMissing` target stays silent. `setup`/`upgrade` print the warnings. Tests:
+> exists+unparseable → warning, absent → silent, valid → no warning. Full command
+> suites (279) + reconcile (58) green.
+
+# Merge engine: warn when a JSON-merge target exists but won't parse
+
+**Goal:** When `safeword setup`/`upgrade` reconciles a `jsonMerge` target that
+exists on disk but fails to parse (e.g. a `.markdownlint-cli2.jsonc` with
+comments, or a malformed `package.json`), surface an actionable warning instead
+of silently skipping the merge. The skip itself stays — fail-safe, no churn — but
+it stops being invisible.
+
+**Origin:** Follow-up from issue #262 (markdownlint-cli2 `ignores` merge) and the
+`/figure-it-out` decision recorded there. `executeJsonMerge` calls `readJson`
+(plain `JSON.parse`), which returns `undefined` on parse failure; combined with
+`skipIfMissing`, "file absent" and "file present-but-unparseable" collapse into
+one silent no-op. The defect is the silence, and it spans all jsonMerge targets,
+not just markdownlint.
+
+## Decision (from #262 figure-it-out)
+
+Chose **Option A — keep the safe no-op, make it loud** over:
+
+- **B (strip-and-rewrite):** destroys the user's JSONC comments on upgrade —
+  violates the EYRK34 no-churn ethos. Rejected.
+- **C (comment-preserving surgical edit via jsonc-parser `modify`/`applyEdits`):**
+  the elegant ideal, but a second, text-based write path used by only one merge
+  family makes the engine inconsistent (the single `writeJson` reformatting path
+  is shared by ~156 merge targets) and is speculative without real-world signal.
+  Deferred, gated on evidence that commented configs are common in the wild.
+
+## Scope
+
+- Thread a `warnings: string[]` channel through `executePlan` → `executeJsonMerge`
+  and expose it on `ReconcileResult` (backward-compatible, optional/empty default).
+- In `executeJsonMerge`: when the target **exists** but `readJson` returns
+  `undefined`, push one actionable warning (name the file, name the likely cause —
+  invalid JSON / JSONC comments — and the keys safeword wanted to add). Keep the
+  early-return skip.
+- Print collected warnings from the `setup`/`upgrade` commands.
+
+## Out of scope
+
+- Comment-preserving JSONC editing (Option C) — separate, evidence-gated.
+- Changing any merge OUTCOME — this only adds observability.
+
+## Done when
+
+- A jsonMerge target that exists but doesn't parse yields a `ReconcileResult`
+  warning naming the file and cause; an absent target stays silent (no warning).
+- A valid target merges exactly as before (no behavior change).
+- `setup`/`upgrade` print the warnings.
+- Unit tests cover: exists+unparseable → warning; absent → no warning; valid →
+  no warning + correct merge.
+- Full suite + lint + typecheck green.

--- a/.project/tickets/TIA4M8-merge-warn-unparseable/ticket.md
+++ b/.project/tickets/TIA4M8-merge-warn-unparseable/ticket.md
@@ -5,8 +5,21 @@ type: task
 phase: done
 status: done
 created: 2026-06-20T07:48:00.000Z
-last_modified: 2026-06-20T07:55:00.000Z
+last_modified: 2026-06-20T11:55:00.000Z
 ---
+
+> **Follow-up hardening (2026-06-20, from quality-review):** `readJson` performed
+> its `readFileSafe` read _outside_ its `try`, so a directory at a config path
+> (`EISDIR`) or an unreadable file (`EACCES`) threw uncaught and crashed reconcile
+> (empirically reproduced). `/figure-it-out` chose **option A** — wrap the read
+> inside `readJson`'s existing `try/catch` — over hardening `readFileSafe` (25-caller
+> blast radius, masks real read errors) or an `isDirectory` guard in
+> `executeJsonMerge` (partial: misses `EACCES`, leaves the other 8 `readJson`
+> callers crashable). All 9 `readJson` callers already handle `undefined`. Now a
+> directory/unreadable merge target degrades to the same actionable warning (message
+> generalized beyond "JSONC comments"). Added `tests/utils/fs.test.ts` (valid /
+> missing / JSONC-comment / directory-EISDIR) and made the valid-target reconcile
+> test assert per-file rather than global-empty warnings.
 
 > **Done (2026-06-20):** Added a `warnings: string[]` channel to `ReconcileResult`,
 > threaded through `executePlan` → `executeJsonMerge`. A merge target that exists

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.52.1",
+      "version": "0.52.2",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -295,6 +295,11 @@ function printSetupSummary(options: SetupSummaryOptions): void {
   ];
   printModifiedFiles(modifiedFiles);
 
+  if (result.warnings.length > 0) {
+    warn(`\n${result.warnings.length} config(s) could not be updated:`);
+    for (const message of result.warnings) listItem(message);
+  }
+
   // Next steps
   info('\nNext steps:');
   listItem('Run `safeword check` to verify setup');

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -30,7 +30,15 @@ import { createProjectContext } from '../utils/context.js';
 import { getEslintPeerMismatchWarning } from '../utils/eslint-peer-check.js';
 import { exists, readJson, writeJson } from '../utils/fs.js';
 import { installDependencies } from '../utils/install.js';
-import { error, header, info, listItem, success, warn } from '../utils/output.js';
+import {
+  error,
+  header,
+  info,
+  listItem,
+  printReconcileWarnings,
+  success,
+  warn,
+} from '../utils/output.js';
 import { type Languages } from '../utils/project-detector.js';
 import { maybeAutoPatchOrNudge } from '../utils/vendored-ignores-nudge.js';
 import { getWorkspacePatterns } from '../utils/workspaces.js';
@@ -295,10 +303,7 @@ function printSetupSummary(options: SetupSummaryOptions): void {
   ];
   printModifiedFiles(modifiedFiles);
 
-  if (result.warnings.length > 0) {
-    warn(`\n${result.warnings.length} config(s) could not be updated:`);
-    for (const message of result.warnings) listItem(message);
-  }
+  printReconcileWarnings(result.warnings);
 
   // Next steps
   info('\nNext steps:');

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -160,6 +160,11 @@ function printUpgradeSummary(result: ReconcileResult, projectVersion: string, cw
     listItem(CODEX_TRUST_NEXT_STEP);
   }
 
+  if (result.warnings.length > 0) {
+    warn(`\n${result.warnings.length} config(s) could not be updated:`);
+    for (const message of result.warnings) listItem(message);
+  }
+
   success(`\nSafeword upgraded to v${VERSION}`);
 }
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -38,7 +38,15 @@ import {
   type MigrationResult,
   planNamespaceMigration,
 } from '../utils/namespace-migration.js';
-import { error, header, info, listItem, success, warn } from '../utils/output.js';
+import {
+  error,
+  header,
+  info,
+  listItem,
+  printReconcileWarnings,
+  success,
+  warn,
+} from '../utils/output.js';
 import { scanStaleNamespaceConfigs } from '../utils/stale-config-scan.js';
 import { maybeAutoPatchOrNudge } from '../utils/vendored-ignores-nudge.js';
 import { compareVersions } from '../utils/version.js';
@@ -160,10 +168,7 @@ function printUpgradeSummary(result: ReconcileResult, projectVersion: string, cw
     listItem(CODEX_TRUST_NEXT_STEP);
   }
 
-  if (result.warnings.length > 0) {
-    warn(`\n${result.warnings.length} config(s) could not be updated:`);
-    for (const message of result.warnings) listItem(message);
-  }
+  printReconcileWarnings(result.warnings);
 
   success(`\nSafeword upgraded to v${VERSION}`);
 }

--- a/packages/cli/src/owned-paths.ts
+++ b/packages/cli/src/owned-paths.ts
@@ -12,6 +12,7 @@
  * semantics.
  */
 
+import type { JsonMergeDefinition } from './packs/types.js';
 import type { SafewordSchema } from './schema.js';
 
 /**
@@ -34,6 +35,44 @@ export const SAFEWORD_IGNORE_DIRS: readonly string[] = [
   '.project',
   '.safeword-project',
 ];
+
+/**
+ * Build a JSON-merge that adds safeword-owned dirs to a customer formatter's
+ * string-array exclude/ignore field so the tool skips them (ticket EYRK34).
+ * Sourced from the single SAFEWORD_IGNORE_DIRS list; `skipIfMissing` → only ever
+ * touches a config the customer already has.
+ *
+ * `globForDir` controls the per-dir glob and defaults to the bare trailing-globstar
+ * form used by dprint (`excludes`) and oxfmt (`ignorePatterns`). markdownlint-cli2
+ * (`ignores`) overrides it with a leading-globstar form so the glob also matches
+ * the absolute paths lint-staged passes (ticket #262).
+ */
+export function dirGlobExcludeMerge(
+  field: string,
+  globForDirectory: (dir: string) => string = dir => `${dir}/**`,
+): JsonMergeDefinition {
+  const safewordGlobs = SAFEWORD_IGNORE_DIRS.map(dir => globForDirectory(dir));
+  return {
+    keys: [field],
+    skipIfMissing: true,
+    merge: existing => {
+      const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
+      const merged = [...current];
+      for (const glob of safewordGlobs) {
+        if (!merged.includes(glob)) merged.push(glob);
+      }
+      return { ...existing, [field]: merged };
+    },
+    unmerge: existing => {
+      const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
+      const cleaned = current.filter(entry => !safewordGlobs.includes(entry));
+      // Drop the field without a dynamic `delete` or unused binding, re-adding it
+      // only when entries remain.
+      const rest = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== field));
+      return cleaned.length > 0 ? { ...rest, [field]: cleaned } : rest;
+    },
+  };
+}
 
 export function computeSafewordPathPrefixes(schema: SafewordSchema): readonly string[] {
   const allPaths = [

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -9,7 +9,7 @@
  * Inline disables target only generator arrow functions, not regular functions in this file.
  */
 
-import { SAFEWORD_IGNORE_DIRS } from '../../owned-paths.js';
+import { dirGlobExcludeMerge, SAFEWORD_IGNORE_DIRS } from '../../owned-paths.js';
 import { getEslintConfig, getSafewordEslintConfig } from '../../templates/config.js';
 import type {
   FileDefinition,
@@ -186,37 +186,6 @@ const BIOME_JSON_MERGE: JsonMergeDefinition = {
     return { ...existing, files: cleanedFiles };
   },
 };
-
-/**
- * Build a JSON-merge that adds safeword-owned dirs (as `<dir>/**` globs) to a
- * customer formatter's string-array exclude field so the formatter skips them
- * (ticket EYRK34). Sourced from the single SAFEWORD_IGNORE_DIRS list; used for
- * dprint (`excludes`) and oxfmt (`ignorePatterns`). `skipIfMissing` → only ever
- * touches a config the customer already has.
- */
-function dirGlobExcludeMerge(field: string): JsonMergeDefinition {
-  const safewordGlobs = SAFEWORD_IGNORE_DIRS.map(dir => `${dir}/**`);
-  return {
-    keys: [field],
-    skipIfMissing: true,
-    merge: existing => {
-      const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
-      const merged = [...current];
-      for (const glob of safewordGlobs) {
-        if (!merged.includes(glob)) merged.push(glob);
-      }
-      return { ...existing, [field]: merged };
-    },
-    unmerge: existing => {
-      const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
-      const cleaned = current.filter(entry => !safewordGlobs.includes(entry));
-      // Drop the field without a dynamic `delete` or unused binding, re-adding it
-      // only when entries remain.
-      const rest = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== field));
-      return cleaned.length > 0 ? { ...rest, [field]: cleaned } : rest;
-    },
-  };
-}
 
 // dprint's `excludes` and oxfmt's `ignorePatterns` both take a glob list (EYRK34).
 const DPRINT_JSON_MERGE = dirGlobExcludeMerge('excludes');

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -303,6 +303,10 @@ export interface ReconcileResult {
   removed: string[];
   packagesToInstall: string[];
   packagesToRemove: string[];
+  // Non-fatal issues surfaced during execution (e.g. a jsonMerge target that
+  // exists but doesn't parse, so the merge was skipped rather than silently lost).
+  // Empty on a dry run, which never executes merges.
+  warnings: string[];
 }
 
 interface ReconcileOptions {
@@ -373,6 +377,7 @@ export async function reconcile(
       removed: plan.wouldRemove,
       packagesToInstall: plan.packagesToInstall,
       packagesToRemove: plan.packagesToRemove,
+      warnings: [],
     };
   }
 
@@ -386,6 +391,7 @@ export async function reconcile(
     removed: result.removed,
     packagesToInstall: plan.packagesToInstall,
     packagesToRemove: plan.packagesToRemove,
+    warnings: result.warnings,
   };
 }
 
@@ -713,13 +719,15 @@ interface ExecutionResult {
   created: string[];
   updated: string[];
   removed: string[];
+  warnings: string[];
 }
 
 function executePlan(plan: ReconcilePlan, ctx: ProjectContext): ExecutionResult {
   const created: string[] = [];
   const updated: string[] = [];
   const removed: string[] = [];
-  const result = { created, updated, removed };
+  const warnings: string[] = [];
+  const result = { created, updated, removed, warnings };
 
   for (const action of plan.actions) {
     executeAction(action, ctx, result);
@@ -764,7 +772,7 @@ function executeAction(action: Action, ctx: ProjectContext, result: ExecutionRes
       break;
     }
     case 'json-merge': {
-      executeJsonMerge(ctx.cwd, action.path, action.definition, ctx);
+      executeJsonMerge(ctx.cwd, action.path, action.definition, ctx, result);
       break;
     }
     case 'json-unmerge': {
@@ -869,12 +877,29 @@ function executeJsonMerge(
   path: string,
   definition: JsonMergeDefinition,
   ctx: ProjectContext,
+  result: ExecutionResult,
 ): void {
   const fullPath = nodePath.join(cwd, path);
   const rawExisting = readJson(fullPath) as Record<string, unknown> | undefined;
 
-  // Skip if file doesn't exist and skipIfMissing is set
-  if (!rawExisting && definition.skipIfMissing) return;
+  if (!rawExisting) {
+    // A present-but-unparseable target (JSONC comments, a trailing comma, or genuine
+    // malformation) reads as undefined just like an absent file. Skipping is correct —
+    // overwriting would clobber the customer's config — but doing it silently hides the
+    // merge that never landed (the #262 commented-`.markdownlint-cli2.jsonc` case, and the
+    // same trap for any jsonMerge target). Distinguish the two: warn when the file exists,
+    // stay silent when it's genuinely absent.
+    if (exists(fullPath)) {
+      result.warnings.push(
+        `Skipped merging safeword config into ${path}: the file exists but is not valid JSON ` +
+          `(JSONC comments are not supported by the merge engine). ` +
+          `Add these keys manually if you need them: ${definition.keys.join(', ')}.`,
+      );
+      return;
+    }
+    // Genuinely absent: honor skipIfMissing; otherwise fall through and create it.
+    if (definition.skipIfMissing) return;
+  }
 
   const existing = rawExisting ?? {};
   const merged = definition.merge(existing, ctx);

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -891,8 +891,8 @@ function executeJsonMerge(
     // stay silent when it's genuinely absent.
     if (exists(fullPath)) {
       result.warnings.push(
-        `Skipped merging safeword config into ${path}: the file exists but is not valid JSON ` +
-          `(JSONC comments are not supported by the merge engine). ` +
+        `Skipped merging safeword config into ${path}: the file exists but could not be read as JSON ` +
+          `(it may contain JSONC comments, which the merge engine does not support, or otherwise not be valid JSON). ` +
           `Add these keys manually if you need them: ${definition.keys.join(', ')}.`,
       );
       return;

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -124,6 +124,14 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
  * `ignores` is a cli2-only option, so it lives solely in `.markdownlint-cli2.jsonc`
  * (the standard `.markdownlint.*` rule files have no `ignores` field). `skipIfMissing`
  * → only ever touches a config the customer already has, never imposes markdownlint.
+ *
+ * Limitation (shared by the sibling biome/dprint/oxfmt `.jsonc` merges): the merge
+ * engine parses with `JSON.parse`, so a `.markdownlint-cli2.jsonc` that actually
+ * uses comments parses as undefined and `skipIfMissing` makes this a safe no-op —
+ * the ignores aren't added, but the customer's commented config is never clobbered.
+ * Stripping comments to parse would round-trip the file through `JSON.stringify` and
+ * destroy those comments, which is worse than the no-op; comment-preserving JSONC
+ * editing is a future improvement for the whole merge engine, not this ticket.
  */
 const MARKDOWNLINT_IGNORE_GLOBS = SAFEWORD_IGNORE_DIRS.map(dir => `**/${dir}/**`);
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -103,6 +103,49 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
   },
 };
 
+/**
+ * markdownlint-cli2 `ignores` merge — add safeword-owned dirs so a consuming
+ * repo's markdownlint never flags safeword's generated agent docs (ticket #262,
+ * extends the EYRK34 formatter-ignore family alongside prettier/biome/dprint/oxfmt).
+ *
+ * Why this and not `.markdownlintignore`: markdownlint-cli2 does NOT read
+ * `.markdownlintignore` at all (it's a markdownlint-cli v1 file), and even when a
+ * tool honors it, lint-staged passes explicit absolute file paths that bypass
+ * ignore-file globbing entirely. The cli2 `ignores` array is the one mechanism
+ * that filters files even when passed explicitly — verified against lint-staged's
+ * default absolute-path invocation.
+ *
+ * Glob form prefixes each dir with a leading globstar segment (see
+ * MARKDOWNLINT_IGNORE_GLOBS below), unlike the bare `<dir>/` form used by
+ * dprint/oxfmt: lint-staged passes absolute paths by default, and the leading
+ * globstar is required for the glob to match `/abs/repo/.claude/...`. It also
+ * still matches the relative tree-glob and relative-explicit invocations.
+ *
+ * `ignores` is a cli2-only option, so it lives solely in `.markdownlint-cli2.jsonc`
+ * (the standard `.markdownlint.*` rule files have no `ignores` field). `skipIfMissing`
+ * → only ever touches a config the customer already has, never imposes markdownlint.
+ */
+const MARKDOWNLINT_IGNORE_GLOBS = SAFEWORD_IGNORE_DIRS.map(dir => `**/${dir}/**`);
+
+const MARKDOWNLINT_CLI2_IGNORES_MERGE: JsonMergeDefinition = {
+  keys: ['ignores'],
+  skipIfMissing: true,
+  merge: existing => {
+    const current = Array.isArray(existing.ignores) ? (existing.ignores as string[]) : [];
+    const merged = [...current];
+    for (const glob of MARKDOWNLINT_IGNORE_GLOBS) {
+      if (!merged.includes(glob)) merged.push(glob);
+    }
+    return { ...existing, ignores: merged };
+  },
+  unmerge: existing => {
+    const current = Array.isArray(existing.ignores) ? (existing.ignores as string[]) : [];
+    const cleaned = current.filter(entry => !MARKDOWNLINT_IGNORE_GLOBS.includes(entry));
+    const rest = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== 'ignores'));
+    return cleaned.length > 0 ? { ...rest, ignores: cleaned } : rest;
+  },
+};
+
 const CODEX_PROMPT_TIMESTAMP_HOOK_PATCH = `
 [[hooks.UserPromptSubmit]]
 
@@ -844,6 +887,11 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
 
     '.mcp.json': MCP_JSON_MERGE,
     '.cursor/mcp.json': MCP_JSON_MERGE,
+
+    // markdownlint-cli2 ignores - hide safeword's generated agent docs from a
+    // consuming repo's markdown lint hooks (ticket #262). cli2's only JSON config
+    // form is `.jsonc`; yaml/cjs/mjs variants fall back to manual wiring.
+    '.markdownlint-cli2.jsonc': MARKDOWNLINT_CLI2_IGNORES_MERGE,
 
     '.cursor/hooks.json': {
       keys: ['version', 'hooks.sessionStart', 'hooks.afterFileEdit', 'hooks.stop'],

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -24,7 +24,11 @@ export type {
   ManagedFileDefinition,
   ProjectContext,
 } from './packs/types.js';
-import { generateOwnedPathsModule, SAFEWORD_IGNORE_DIRS } from './owned-paths.js';
+import {
+  dirGlobExcludeMerge,
+  generateOwnedPathsModule,
+  SAFEWORD_IGNORE_DIRS,
+} from './owned-paths.js';
 import type { FileDefinition, JsonMergeDefinition, ManagedFileDefinition } from './packs/types.js';
 import { CURSOR_HOOKS, SETTINGS_HOOKS } from './templates/config.js';
 import { AGENTS_MD_LINK, CLAUDE_MD_IMPORT_BLOCK } from './templates/content.js';
@@ -115,11 +119,11 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
  * that filters files even when passed explicitly — verified against lint-staged's
  * default absolute-path invocation.
  *
- * Glob form prefixes each dir with a leading globstar segment (see
- * MARKDOWNLINT_IGNORE_GLOBS below), unlike the bare `<dir>/` form used by
- * dprint/oxfmt: lint-staged passes absolute paths by default, and the leading
- * globstar is required for the glob to match `/abs/repo/.claude/...`. It also
- * still matches the relative tree-glob and relative-explicit invocations.
+ * Glob form (see the call below) prefixes each dir with a leading globstar,
+ * unlike the bare trailing-globstar form used by dprint/oxfmt: lint-staged passes
+ * absolute paths by default, and the leading globstar is required for the glob to
+ * match `/abs/repo/.claude/...`. It also still matches the relative tree-glob and
+ * relative-explicit invocations.
  *
  * `ignores` is a cli2-only option, so it lives solely in `.markdownlint-cli2.jsonc`
  * (the standard `.markdownlint.*` rule files have no `ignores` field). `skipIfMissing`
@@ -133,26 +137,7 @@ const MCP_JSON_MERGE: JsonMergeDefinition = {
  * destroy those comments, which is worse than the no-op; comment-preserving JSONC
  * editing is a future improvement for the whole merge engine, not this ticket.
  */
-const MARKDOWNLINT_IGNORE_GLOBS = SAFEWORD_IGNORE_DIRS.map(dir => `**/${dir}/**`);
-
-const MARKDOWNLINT_CLI2_IGNORES_MERGE: JsonMergeDefinition = {
-  keys: ['ignores'],
-  skipIfMissing: true,
-  merge: existing => {
-    const current = Array.isArray(existing.ignores) ? (existing.ignores as string[]) : [];
-    const merged = [...current];
-    for (const glob of MARKDOWNLINT_IGNORE_GLOBS) {
-      if (!merged.includes(glob)) merged.push(glob);
-    }
-    return { ...existing, ignores: merged };
-  },
-  unmerge: existing => {
-    const current = Array.isArray(existing.ignores) ? (existing.ignores as string[]) : [];
-    const cleaned = current.filter(entry => !MARKDOWNLINT_IGNORE_GLOBS.includes(entry));
-    const rest = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== 'ignores'));
-    return cleaned.length > 0 ? { ...rest, ignores: cleaned } : rest;
-  },
-};
+const MARKDOWNLINT_CLI2_IGNORES_MERGE = dirGlobExcludeMerge('ignores', dir => `**/${dir}/**`);
 
 const CODEX_PROMPT_TIMESTAMP_HOOK_PATCH = `
 [[hooks.UserPromptSubmit]]

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -274,13 +274,19 @@ export function makeScriptsExecutable(dirPath: string): void {
 }
 
 /**
- * Read JSON file
+ * Read and parse a JSON file, best-effort: returns `undefined` when no JSON
+ * value can be obtained from the path — whether it is absent, empty, unparseable
+ * (e.g. JSONC comments or malformed), or unreadable as a file at all. The read is
+ * inside the `try` so a directory at the path (`EISDIR`) or a permission error
+ * (`EACCES`) degrades to `undefined` like a parse failure, instead of throwing
+ * uncaught and crashing callers (e.g. reconcile's jsonMerge). All callers already
+ * treat the result as `T | undefined`.
  * @param path
  */
 export function readJson(path: string): unknown {
-  const content = readFileSafe(path);
-  if (!content) return undefined;
   try {
+    const content = readFileSafe(path);
+    if (!content) return undefined;
     return JSON.parse(content) as unknown;
   } catch {
     return undefined;

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -65,6 +65,18 @@ export function listItem(item: string, indent = 2): void {
 }
 
 /**
+ * Print the non-fatal config-merge warnings collected during reconcile (e.g. a
+ * jsonMerge target that exists but does not parse, so the merge was skipped).
+ * No-op when empty. Shared by `setup` and `upgrade` so the heading stays in sync.
+ * @param warnings
+ */
+export function printReconcileWarnings(warnings: string[]): void {
+  if (warnings.length === 0) return;
+  warn(`\n${warnings.length} config(s) could not be updated:`);
+  for (const message of warnings) listItem(message);
+}
+
+/**
  * Print key-value pair
  * @param key
  * @param value

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -391,6 +391,61 @@ describe('Reconcile - Reconciliation Engine', () => {
       }
     });
 
+    it('ignores every safeword-owned dir in an existing .markdownlint-cli2.jsonc (ticket #262)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+      const { SAFEWORD_IGNORE_DIRS } = await import('../src/owned-paths.js');
+
+      createPackageJson();
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'),
+        `${JSON.stringify({ config: { default: true }, ignores: ['dist/**'] }, undefined, 2)}\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const cli2 = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'), 'utf8'),
+      ) as { config: unknown; ignores: string[] };
+      expect(cli2.ignores).toContain('dist/**'); // customer entry preserved
+      expect(cli2.config).toEqual({ default: true }); // rule config untouched
+      // Leading-globstar form (not a bare dir glob): lint-staged passes absolute
+      // paths, and the leading globstar is required to match them.
+      for (const dir of SAFEWORD_IGNORE_DIRS) {
+        expect(cli2.ignores).toContain(`**/${dir}/**`);
+      }
+    });
+
+    it('does not create .markdownlint-cli2.jsonc when the repo has no markdownlint config (skipIfMissing)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      expect(existsSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'))).toBe(false);
+    });
+
+    it('removes safeword ignore globs from .markdownlint-cli2.jsonc on uninstall, preserving customer entries', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'),
+        `${JSON.stringify({ ignores: ['dist/**'] }, undefined, 2)}\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+      await reconcile(SAFEWORD_SCHEMA, 'uninstall', createContext());
+
+      const cli2 = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'), 'utf8'),
+      ) as { ignores: string[] };
+      expect(cli2.ignores).toEqual(['dist/**']); // safeword globs gone, customer entry kept
+    });
+
     it('should merge JSON files', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -489,7 +489,7 @@ describe('Reconcile - Reconciliation Engine', () => {
 
       const result = await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
 
-      expect(result.warnings).toEqual([]);
+      expect(result.warnings.some(w => w.includes('.markdownlint-cli2.jsonc'))).toBe(false);
     });
 
     it('should merge JSON files', async () => {

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -446,6 +446,52 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(cli2.ignores).toEqual(['dist/**']); // safeword globs gone, customer entry kept
     });
 
+    it('warns (instead of silently skipping) when a jsonMerge target exists but does not parse', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      // A real-world commented .markdownlint-cli2.jsonc (JSONC). JSON.parse fails on
+      // the comment, so the merge is skipped — but it must not be skipped silently.
+      const commented = '{\n  // my markdownlint config\n  "ignores": ["dist/**"]\n}\n';
+      writeFileSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'), commented);
+
+      const result = await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      expect(result.warnings.some(w => w.includes('.markdownlint-cli2.jsonc'))).toBe(true);
+      expect(result.warnings.some(w => w.includes('ignores'))).toBe(true);
+      // The customer's commented file is left untouched (never clobbered).
+      expect(
+        readFileSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'), 'utf8'),
+      ).toBe(commented);
+    });
+
+    it('stays silent (no warning) when a skipIfMissing jsonMerge target is genuinely absent', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+
+      const result = await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      expect(result.warnings.some(w => w.includes('.markdownlint-cli2.jsonc'))).toBe(false);
+    });
+
+    it('does not warn when a jsonMerge target parses cleanly', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'),
+        `${JSON.stringify({ ignores: ['dist/**'] }, undefined, 2)}\n`,
+      );
+
+      const result = await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      expect(result.warnings).toEqual([]);
+    });
+
     it('should merge JSON files', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');

--- a/packages/cli/tests/utils/fs.test.ts
+++ b/packages/cli/tests/utils/fs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit Tests: readJson robustness
+ *
+ * readJson is best-effort: it returns `undefined` when no JSON value can be
+ * obtained from a path, and must never throw — callers all treat the result as
+ * `T | undefined`. A directory at the path (EISDIR) or an unreadable file
+ * previously threw uncaught and crashed callers like reconcile's jsonMerge.
+ */
+
+import { mkdirSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readJson } from '../../src/utils/fs.js';
+import { createTemporaryDirectory, removeTemporaryDirectory, writeTestFile } from '../helpers';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = createTemporaryDirectory();
+});
+
+afterEach(() => {
+  if (dir) removeTemporaryDirectory(dir);
+});
+
+describe('readJson', () => {
+  it('parses a valid JSON file', () => {
+    writeTestFile(dir, 'config.json', JSON.stringify({ a: 1 }));
+    expect(readJson(nodePath.join(dir, 'config.json'))).toEqual({ a: 1 });
+  });
+
+  it('returns undefined for a missing file', () => {
+    expect(readJson(nodePath.join(dir, 'nope.json'))).toBeUndefined();
+  });
+
+  it('returns undefined (no throw) for a file with JSONC comments', () => {
+    writeTestFile(dir, 'config.jsonc', '{\n  // a comment\n  "a": 1\n}\n');
+    expect(readJson(nodePath.join(dir, 'config.jsonc'))).toBeUndefined();
+  });
+
+  it('returns undefined (no throw) when a directory sits at the path (EISDIR)', () => {
+    mkdirSync(nodePath.join(dir, 'config.json'));
+    expect(() => readJson(nodePath.join(dir, 'config.json'))).not.toThrow();
+    expect(readJson(nodePath.join(dir, 'config.json'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #262. Safeword-generated agent docs (`.claude/`, `.agents/`, `.cursor/`, `.codex/`, `.safeword/`, `.project/`) could fail a consuming repo's markdownlint pre-commit hook. `lint-staged` passes explicit **absolute** file paths to `markdownlint-cli2`, which bypasses `.markdownlintignore` globbing — and `markdownlint-cli2` doesn't read `.markdownlintignore` at all (it's a markdownlint-cli v1 file). The cli2 `ignores` array is the only mechanism that filters files even when passed explicitly.

This extends the existing **EYRK34 formatter-ignore family** (prettier/biome/dprint/oxfmt) to markdownlint, then hardens and refactors the surrounding merge engine.

## What changed

1. **`fix(#262)`** — JSON-merge safeword's owned dirs into an existing `.markdownlint-cli2.jsonc` `ignores` array, sourced from the single `SAFEWORD_IGNORE_DIRS` list. Globs use a leading-globstar form (`**/{dir}/**`) so they match lint-staged's default absolute paths; `skipIfMissing` keeps it non-intrusive (never imposes markdownlint). Covers the dominant `.jsonc` config form; yaml/cjs/mjs fall back to manual wiring.
2. **`refactor`** — consolidate the dir-glob exclude-merge factory (`dirGlobExcludeMerge`, previously dprint/oxfmt-only) into `owned-paths.ts` beside `SAFEWORD_IGNORE_DIRS`, generalized with an optional per-dir glob builder. Removes duplicated merge/unmerge boilerplate and a cross-pack coupling. Behavior-preserving.
3. **`feat(TIA4M8)`** — add a `warnings` channel to `ReconcileResult`, threaded `executePlan` → `executeJsonMerge`. A merge target that **exists but won't parse** (JSONC comments, malformation) now emits one actionable warning instead of silently skipping; a genuinely-absent `skipIfMissing` target stays silent. `setup`/`upgrade` print the warnings. This closes a latent silent-skip across **all** jsonMerge targets, not just markdownlint.
4. **`fix(TIA4M8)`** — make `readJson` degrade to `undefined` on `EISDIR`/`EACCES` (the read sat outside its existing `try/catch`, so a directory or unreadable file at a config path crashed reconcile). Chosen via `/figure-it-out` over hardening `readFileSafe` (25-caller blast radius) or a local `isDirectory` guard (partial). All 9 `readJson` callers already handle `undefined`.

## Design notes

- **Why exclusion, not "make generated docs markdownlint-clean":** generated docs can never be guaranteed clean against an arbitrary consuming-repo ruleset (MD013 line-length alone is ~1.5k hits; MD033 inline HTML is sometimes semantically required). Exclusion is the bounded fix; complements #22 (MD040 cleanliness).
- **Deferred (gated on real-world signal):** comment-preserving JSONC editing (jsonc-parser `modify`/`applyEdits`) so the merge lands on commented configs instead of safe-no-op'ing — rejected for now as a second, inconsistent write path on the shared engine. Documented in-code and in ticket `TIA4M8`.

## Verification

- Full suite: **3097 passed, 5 skipped** (208 files); typecheck, eslint, markdownlint (951 files), pre-push schema-drift gate — all green.
- New tests: markdownlint `ignores` merge (preserve customer entries / skipIfMissing / uninstall); warnings channel (exists+unparseable → warning, absent → silent, valid → no warning); `readJson` robustness (valid / missing / JSONC-comment / directory-EISDIR).
- Version bumped `0.52.1 → 0.52.2` (both `packages/cli/package.json` and `marketplace.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)