### PR TITLE
fix(schema): ignore transient session state under a custom paths.projectRoot (#272)

### DIFF
--- a/.project/.gitignore
+++ b/.project/.gitignore
@@ -1,6 +1,6 @@
 # Safeword - transient session state (auto-managed)
-quality-state*.json
-failure-counts.json
-skill-invocations.log
-re-entry.md
-dependency-readiness.json
+/quality-state*.json
+/failure-counts.json
+/skill-invocations.log
+/re-entry.md
+/dependency-readiness.json

--- a/.project/.gitignore
+++ b/.project/.gitignore
@@ -1,0 +1,6 @@
+# Safeword - transient session state (auto-managed)
+quality-state*.json
+failure-counts.json
+skill-invocations.log
+re-entry.md
+dependency-readiness.json

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -342,10 +342,14 @@ function withResolvedNamespaceRoot(schema: SafewordSchema, ctx: ProjectContext):
     ...schema,
     preservedDirs: schema.preservedDirs.map(path => translate(path)),
     managedFiles: Object.fromEntries(
-      Object.entries(schema.managedFiles).map(([path, definition]) => [
-        translate(path),
-        definition,
-      ]),
+      Object.entries(schema.managedFiles)
+        .map(([path, definition]) => [translate(path), definition] as const)
+        // A per-root `.gitignore` (issue #272) translated onto the repo root
+        // (paths.projectRoot: '.') would BE the user's own root `.gitignore` —
+        // owned by the textPatch, never created by us (create-if-missing skips
+        // an existing file). Drop it there so a full uninstall can't delete a
+        // file we didn't write.
+        .filter(([translatedPath]) => translatedPath !== '.gitignore'),
     ),
   };
 }

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -237,10 +237,15 @@ export const SAFEWORD_TRANSIENT_PATHS: readonly string[] = [
  * root resolves, and git applies each pattern relative to that directory. The
  * legacy-prefixed managed-file key is remapped to the resolved root by
  * `withResolvedNamespaceRoot`.
+ *
+ * Patterns are leading-slash-anchored so they match only the transient files at
+ * the namespace root — where the hooks write them — and never a same-named file
+ * deeper in the tree (e.g. a `tickets/.../re-entry.md`). This mirrors the
+ * repo-root block, whose `.project/re-entry.md` entries are likewise anchored.
  */
-const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-managed)\n${NAMESPACE_TRANSIENT_BASENAMES.join(
-  '\n',
-)}\n`;
+const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-managed)\n${NAMESPACE_TRANSIENT_BASENAMES.map(
+  name => `/${name}`,
+).join('\n')}\n`;
 
 /**
  * Top-level dirs a customer's prettier must skip so safeword's files don't dirty

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -243,9 +243,10 @@ export const SAFEWORD_TRANSIENT_PATHS: readonly string[] = [
  * deeper in the tree (e.g. a `tickets/.../re-entry.md`). This mirrors the
  * repo-root block, whose `.project/re-entry.md` entries are likewise anchored.
  */
-const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-managed)\n${NAMESPACE_TRANSIENT_BASENAMES.map(
-  name => `/${name}`,
-).join('\n')}\n`;
+const NAMESPACE_GITIGNORE_PATTERNS = NAMESPACE_TRANSIENT_BASENAMES.map(name => `/${name}`).join(
+  '\n',
+);
+const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-managed)\n${NAMESPACE_GITIGNORE_PATTERNS}\n`;
 
 /**
  * Top-level dirs a customer's prettier must skip so safeword's files don't dirty

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -193,29 +193,54 @@ const CODEX_SKILL_OWNED_FILES: Record<string, FileDefinition> = Object.fromEntri
 // ============================================================================
 
 /**
- * Runtime/transient state files safeword's hooks write to the working tree
- * every turn (update-cache, quality-state, failure-counts, skill-invocations,
- * re-entry, dependency-readiness). They must be gitignored — and untracked on upgrade if a customer
- * committed them before the ignore rule existed — because the hooks read/write
- * these paths directly, so git tracking is never consulted. Single source for
- * the managed `.gitignore` block (below) and the upgrade-time untrack.
+ * Transient state files safeword's hooks write under the *resolved namespace
+ * root* every turn, as root-relative names (quality-state, failure-counts,
+ * skill-invocations, re-entry, dependency-readiness). Single source for both
+ * the per-root `.gitignore` managed file (`NAMESPACE_GITIGNORE_CONTENT`) and the
+ * repo-root `.gitignore` block (`SAFEWORD_TRANSIENT_PATHS`). Patterns are exact
+ * filenames plus the one `quality-state*` glob — never a bare `*` — so durable
+ * siblings (tickets/, learnings/, personas.md, glossary.md) stay tracked.
  */
-// Both namespace roots are listed: hooks write transient state under the
-// resolved root (TAGWZ8), which is `.project/` on fresh installs and
-// `.safeword-project/` on legacy ones.
+const NAMESPACE_TRANSIENT_BASENAMES: readonly string[] = [
+  'quality-state*.json',
+  'failure-counts.json',
+  'skill-invocations.log',
+  're-entry.md',
+  'dependency-readiness.json',
+];
+
+/**
+ * Runtime/transient state files safeword's hooks write to the working tree
+ * every turn (update-cache plus the namespace-root state above). They must be
+ * gitignored — and untracked on upgrade if a customer committed them before the
+ * ignore rule existed — because the hooks read/write these paths directly, so
+ * git tracking is never consulted. Single source for the repo-root managed
+ * `.gitignore` block (below) and the upgrade-time untrack.
+ *
+ * Both well-known namespace roots are listed: hooks write transient state under
+ * the resolved root (TAGWZ8), which is `.project/` on fresh installs and
+ * `.safeword-project/` on legacy ones. A *custom* `paths.projectRoot` is covered
+ * by the per-root `.gitignore` (`NAMESPACE_GITIGNORE_CONTENT`) instead, since a
+ * static repo-root block cannot name an arbitrary root (issue #272).
+ */
 export const SAFEWORD_TRANSIENT_PATHS: readonly string[] = [
   '.safeword/.update-cache.json',
-  '.project/quality-state*.json',
-  '.project/failure-counts.json',
-  '.project/skill-invocations.log',
-  '.project/re-entry.md',
-  '.project/dependency-readiness.json',
-  '.safeword-project/quality-state*.json',
-  '.safeword-project/failure-counts.json',
-  '.safeword-project/skill-invocations.log',
-  '.safeword-project/re-entry.md',
-  '.safeword-project/dependency-readiness.json',
+  ...['.project', '.safeword-project'].flatMap(root =>
+    NAMESPACE_TRANSIENT_BASENAMES.map(name => `${root}/${name}`),
+  ),
 ];
+
+/**
+ * Content of the `.gitignore` written *inside* the resolved namespace root
+ * (issue #272). Because the ignore rules live with the files they describe, a
+ * custom `paths.projectRoot` is handled for free — the file lands wherever the
+ * root resolves, and git applies each pattern relative to that directory. The
+ * legacy-prefixed managed-file key is remapped to the resolved root by
+ * `withResolvedNamespaceRoot`.
+ */
+const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-managed)\n${NAMESPACE_TRANSIENT_BASENAMES.join(
+  '\n',
+)}\n`;
 
 /**
  * Top-level dirs a customer's prettier must skip so safeword's files don't dirty
@@ -800,6 +825,15 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword-project/glossary.md': {
       template: 'glossary-template.md',
       configKey: 'glossary',
+    },
+
+    // Per-root `.gitignore` for hook-written transient state. The legacy-prefixed
+    // key is remapped to the resolved namespace root by withResolvedNamespaceRoot,
+    // so a custom `paths.projectRoot` ignores its own transient files even though
+    // the static repo-root block can't name that root (issue #272). Created once;
+    // the repo-root block stays the belt-and-suspenders for `.project/`/legacy.
+    '.safeword-project/.gitignore': {
+      content: NAMESPACE_GITIGNORE_CONTENT,
     },
   },
 

--- a/packages/cli/tests/reconcile-namespace-root.test.ts
+++ b/packages/cli/tests/reconcile-namespace-root.test.ts
@@ -142,6 +142,41 @@ describe('reconcile scaffolds at the resolved namespace root (N9S5XG)', () => {
     expect(existsSync(nodePath.join(cwd, '.safeword-project'))).toBe(false);
   });
 
+  // Issue #272: the static repo-root .gitignore block names only `.project/` and
+  // `.safeword-project/`, so a custom paths.projectRoot's transient files would
+  // leak into `git status`. The per-root .gitignore (written into the resolved
+  // root) covers it — and never ignores durable knowledge files.
+  it('DEV1.AC4.configured_root_gets_transient_gitignore', async () => {
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+    );
+
+    await runInstall();
+
+    const gitignore = readFileSync(nodePath.join(cwd, 'team-ns', '.gitignore'), 'utf8');
+    for (const name of [
+      'quality-state*.json',
+      'failure-counts.json',
+      'skill-invocations.log',
+      're-entry.md',
+      'dependency-readiness.json',
+    ]) {
+      expect(gitignore).toContain(name);
+    }
+    // Durable siblings must stay tracked — no bare wildcard that would swallow them.
+    expect(gitignore).not.toMatch(/^\*\s*$/m);
+    expect(gitignore).not.toContain('tickets');
+  });
+
+  it('DEV1.AC4.default_root_gets_transient_gitignore', async () => {
+    await runInstall();
+
+    expect(existsSync(nodePath.join(cwd, '.project', '.gitignore'))).toBe(true);
+    expect(existsSync(nodePath.join(cwd, '.safeword-project'))).toBe(false);
+  });
+
   it('DEV1.AC4.upgrade_on_project_repo_stays_project', async () => {
     await runInstall();
     const glossaryPath = nodePath.join(cwd, '.project', 'glossary.md');

--- a/packages/cli/tests/reconcile-namespace-root.test.ts
+++ b/packages/cli/tests/reconcile-namespace-root.test.ts
@@ -20,6 +20,30 @@ import { createTemporaryDirectory, removeTemporaryDirectory } from './helpers.js
 
 const NAMESPACE_DIRECTORIES = ['learnings', 'tickets', 'tickets/completed', 'tmp'];
 
+// The transient patterns the per-root .gitignore must carry, leading-slash-anchored
+// so they match only the namespace-root file (not e.g. tickets/.../re-entry.md).
+const ANCHORED_TRANSIENT_PATTERNS = [
+  '/quality-state*.json',
+  '/failure-counts.json',
+  '/skill-invocations.log',
+  '/re-entry.md',
+  '/dependency-readiness.json',
+];
+
+// Assert a per-root .gitignore carries every transient pattern, root-anchored,
+// and never a bare wildcard or a durable-dir name (#272).
+function expectAnchoredTransientGitignore(contents: string): void {
+  for (const pattern of ANCHORED_TRANSIENT_PATTERNS) {
+    expect(contents).toContain(pattern);
+  }
+  expect(contents).not.toMatch(/^\*\s*$/m);
+  expect(contents).not.toContain('tickets');
+  for (const line of contents.split('\n')) {
+    if (line === '' || line.startsWith('#')) continue;
+    expect(line.startsWith('/'), `pattern must be root-anchored: ${line}`).toBe(true);
+  }
+}
+
 function listTree(root: string): string[] {
   return existsSync(root) ? readdirSync(root, { recursive: true }).map(String) : [];
 }
@@ -155,34 +179,20 @@ describe('reconcile scaffolds at the resolved namespace root (N9S5XG)', () => {
 
     await runInstall();
 
-    const gitignore = readFileSync(nodePath.join(cwd, 'team-ns', '.gitignore'), 'utf8');
-    // Leading-slash-anchored so they match only the root-level transient files,
-    // not a same-named file deeper in the tree (e.g. tickets/.../re-entry.md).
-    for (const name of [
-      '/quality-state*.json',
-      '/failure-counts.json',
-      '/skill-invocations.log',
-      '/re-entry.md',
-      '/dependency-readiness.json',
-    ]) {
-      expect(gitignore).toContain(name);
-    }
-    // Durable siblings must stay tracked — no bare wildcard, and every pattern
-    // is root-anchored (starts with `/`) so it can't recurse into tickets/.
-    expect(gitignore).not.toMatch(/^\*\s*$/m);
-    expect(gitignore).not.toContain('tickets');
-    for (const line of gitignore.split('\n')) {
-      if (line === '' || line.startsWith('#')) continue;
-      expect(line.startsWith('/'), `pattern must be root-anchored: ${line}`).toBe(true);
-    }
+    expectAnchoredTransientGitignore(
+      readFileSync(nodePath.join(cwd, 'team-ns', '.gitignore'), 'utf8'),
+    );
+    // The legacy-prefixed key must be remapped, not also written at the legacy
+    // root — a broken translate/filter would leak a stale .safeword-project copy.
+    expect(existsSync(nodePath.join(cwd, '.safeword-project', '.gitignore'))).toBe(false);
   });
 
   it('DEV1.AC4.default_root_gets_transient_gitignore', async () => {
     await runInstall();
 
-    const gitignore = readFileSync(nodePath.join(cwd, '.project', '.gitignore'), 'utf8');
-    expect(gitignore).toContain('/re-entry.md');
-    expect(gitignore).toContain('/quality-state*.json');
+    expectAnchoredTransientGitignore(
+      readFileSync(nodePath.join(cwd, '.project', '.gitignore'), 'utf8'),
+    );
     expect(existsSync(nodePath.join(cwd, '.safeword-project'))).toBe(false);
   });
 
@@ -199,13 +209,32 @@ describe('reconcile scaffolds at the resolved namespace root (N9S5XG)', () => {
     writeFileSync(rootGitignore, 'node_modules/\nmy-secret.env\n');
 
     await runInstall();
-    // Our managed transient block is never appended as a per-root file here, and
-    // the user's content survives untouched.
+    // The per-root managed .gitignore is dropped for projectRoot:'.'; the
+    // repo-root textPatch still runs as normal, but the user's content survives.
     expect(readFileSync(rootGitignore, 'utf8')).toContain('my-secret.env');
 
     await reconcile(SAFEWORD_SCHEMA, 'uninstall-full', createProjectContext(cwd));
     expect(existsSync(rootGitignore), 'root .gitignore must survive full uninstall').toBe(true);
     expect(readFileSync(rootGitignore, 'utf8')).toContain('my-secret.env');
+  });
+
+  // The exists-guard masks the filter when a .gitignore is pre-created, so prove
+  // the filter directly: with no pre-existing root .gitignore, install must never
+  // write our managed per-root block (distinct `(auto-managed)` header) at the
+  // repo root — that file is the repo-root textPatch's domain, not a managed file.
+  it('DEV1.AC4.repo_root_namespace_skips_managed_root_gitignore', async () => {
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: '.' } }),
+    );
+
+    await runInstall();
+
+    const rootGitignore = nodePath.join(cwd, '.gitignore');
+    if (existsSync(rootGitignore)) {
+      expect(readFileSync(rootGitignore, 'utf8')).not.toContain('(auto-managed)');
+    }
   });
 
   it('DEV1.AC4.upgrade_on_project_repo_stays_project', async () => {

--- a/packages/cli/tests/reconcile-namespace-root.test.ts
+++ b/packages/cli/tests/reconcile-namespace-root.test.ts
@@ -156,25 +156,56 @@ describe('reconcile scaffolds at the resolved namespace root (N9S5XG)', () => {
     await runInstall();
 
     const gitignore = readFileSync(nodePath.join(cwd, 'team-ns', '.gitignore'), 'utf8');
+    // Leading-slash-anchored so they match only the root-level transient files,
+    // not a same-named file deeper in the tree (e.g. tickets/.../re-entry.md).
     for (const name of [
-      'quality-state*.json',
-      'failure-counts.json',
-      'skill-invocations.log',
-      're-entry.md',
-      'dependency-readiness.json',
+      '/quality-state*.json',
+      '/failure-counts.json',
+      '/skill-invocations.log',
+      '/re-entry.md',
+      '/dependency-readiness.json',
     ]) {
       expect(gitignore).toContain(name);
     }
-    // Durable siblings must stay tracked — no bare wildcard that would swallow them.
+    // Durable siblings must stay tracked — no bare wildcard, and every pattern
+    // is root-anchored (starts with `/`) so it can't recurse into tickets/.
     expect(gitignore).not.toMatch(/^\*\s*$/m);
     expect(gitignore).not.toContain('tickets');
+    for (const line of gitignore.split('\n')) {
+      if (line === '' || line.startsWith('#')) continue;
+      expect(line.startsWith('/'), `pattern must be root-anchored: ${line}`).toBe(true);
+    }
   });
 
   it('DEV1.AC4.default_root_gets_transient_gitignore', async () => {
     await runInstall();
 
-    expect(existsSync(nodePath.join(cwd, '.project', '.gitignore'))).toBe(true);
+    const gitignore = readFileSync(nodePath.join(cwd, '.project', '.gitignore'), 'utf8');
+    expect(gitignore).toContain('/re-entry.md');
+    expect(gitignore).toContain('/quality-state*.json');
     expect(existsSync(nodePath.join(cwd, '.safeword-project'))).toBe(false);
+  });
+
+  // paths.projectRoot: '.' resolves the namespace to the repo root, where a
+  // per-root .gitignore would BE the user's own root .gitignore. Install must
+  // not clobber it, and a full uninstall must not delete it (issue #272 review).
+  it('DEV1.AC4.repo_root_namespace_never_manages_root_gitignore', async () => {
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: '.' } }),
+    );
+    const rootGitignore = nodePath.join(cwd, '.gitignore');
+    writeFileSync(rootGitignore, 'node_modules/\nmy-secret.env\n');
+
+    await runInstall();
+    // Our managed transient block is never appended as a per-root file here, and
+    // the user's content survives untouched.
+    expect(readFileSync(rootGitignore, 'utf8')).toContain('my-secret.env');
+
+    await reconcile(SAFEWORD_SCHEMA, 'uninstall-full', createProjectContext(cwd));
+    expect(existsSync(rootGitignore), 'root .gitignore must survive full uninstall').toBe(true);
+    expect(readFileSync(rootGitignore, 'utf8')).toContain('my-secret.env');
   });
 
   it('DEV1.AC4.upgrade_on_project_repo_stays_project', async () => {


### PR DESCRIPTION
Closes #272 (the one open acceptance criterion). Follow-up: #273.

## Context — what was already fixed

The leak #272 reports (transient files surfacing in `git status` on the default `.project/` namespace) was **already fixed on `main`** by epic 2H2XKH: `SAFEWORD_TRANSIENT_PATHS` lists all five transient files under both `.project/` and `.safeword-project/`, with deliberate `.gitignore`/`.prettierignore` marker bumps so existing installs re-apply on upgrade. Revalidated: `git status` is clean and `git check-ignore` returns IGNORED for all five `.project/...` files.

The **one open acceptance criterion was #2 — a custom `paths.projectRoot`.** The static repo-root block can only name the two well-known roots, so a repo with e.g. `paths.projectRoot: "team-ns"` still leaked `team-ns/quality-state*.json`, `re-entry.md`, etc.

## The fix (Option C)

Write a per-root `.gitignore` **inside the resolved namespace root**, as a managed file keyed `.safeword-project/.gitignore` that rides the existing `withResolvedNamespaceRoot` translation. The ignore rules live with the files they describe, so any root — default, legacy, or custom — is covered for free, with **no marker-skip exposure** (managed files aren't marker-gated) and **no change to the verified-working repo-root block**.

Both the repo-root block and the per-root file derive from one `NAMESPACE_TRANSIENT_BASENAMES` source; `SAFEWORD_TRANSIENT_PATHS` output is byte-identical.

## Hardening from review (commit 2)

A quality review (independent reviewer + empirical `git check-ignore` probes) caught two bugs in the first commit, both fixed and tested:

1. **Pattern over-match** — unanchored patterns (`re-entry.md`) matched recursively in a nested `.gitignore`, so a durable `tickets/.../re-entry.md` would silently drop from tracking. Fixed: leading-slash anchoring (`/re-entry.md`), mirroring the repo-root block. Verified: root transients ignored, subtree same-named files stay tracked.
2. **Data loss on `uninstall --full` when `paths.projectRoot: '.'`** — the key translates to a bare repo-root `.gitignore`, which install never creates (the user already has one) yet full-uninstall would delete. Fixed: drop the entry when it resolves to the repo-root `.gitignore`.

## Scope deliberately deferred → #273

The custom-root **formatter-ignore** gap (prettier/biome/eslint/dprint/oxfmt reformatting a custom root's markdown) is broader — 5 formatters sharing the static `SAFEWORD_IGNORE_DIRS` — and is #272's secondary "compounding wrinkle," not the named git-status symptom. Tracked separately to keep this change small and regression-free.

## Verification

- `safeword test-plan --kind verify`: **3097 passed / 5 skipped** (208 files)
- Gherkin acceptance lane: **69/69 scenarios**
- Lint (eslint + gherkin-lint) + `tsc --noEmit`: clean
- New regression tests: custom-root coverage + anchoring, default-root content, and a `paths.projectRoot: '.'` full-uninstall data-loss guard
- Dogfooded: `.project/.gitignore` added to this repo

> [!NOTE]
> Commits are attributed to `Claude <noreply@anthropic.com>` but are **unsigned** (this environment's signing key is a 0-byte placeholder), so GitHub marks them Unverified. Environment limitation, not a committer-email issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F)_