### PR TITLE
fix(#274): tag re-entry brief from the session binding, not a global ticket scan

### DIFF
--- a/.safeword/hooks/stop-reentry.ts
+++ b/.safeword/hooks/stop-reentry.ts
@@ -13,7 +13,8 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getActiveTicket } from './lib/active-ticket';
+import { getTicketInfo } from './lib/active-ticket';
+import { getStateFilePath } from './lib/quality-state.ts';
 import { resolveProjectRoot } from './lib/re-entry';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
@@ -45,25 +46,35 @@ function extractLastNextImperative(text: string): string | null {
   return null;
 }
 
-function readTicketIdFromFrontmatter(projectDirectory: string, folder: string): string | null {
-  const ticketPath = join(resolveNamespaceRoot(projectDirectory), 'tickets', folder, 'ticket.md');
+/**
+ * The session's bound ticket id, from the per-session quality-state
+ * (`quality-state-<sessionId>.json` `activeTicket`) — set when an edit touches a
+ * ticket.md, auto-cleared when the ticket reaches done/backlog. Returns null when
+ * the session never bound a ticket (or state is unreadable).
+ */
+function readSessionTicketId(projectDirectory: string, sessionId: string): string | null {
   try {
-    const content = readFileSync(ticketPath, 'utf8');
-    const idMatch = /^id:\s*(.+)$/m.exec(content);
-    if (!idMatch) return null;
-    // YAML failsafe schema may quote leading-zero ids; strip wrapping quotes.
-    return idMatch[1].trim().replace(/^['"]|['"]$/g, '');
+    const raw = readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8');
+    const state = JSON.parse(raw) as { activeTicket?: string | null };
+    return state.activeTicket ?? null;
   } catch {
     return null;
   }
 }
 
-function resolveTicketField(projectDirectory: string): string {
-  const active = getActiveTicket(projectDirectory);
-  if (!active.folder || !active.phase) return 'ticket=∅/freeform';
-  const id = readTicketIdFromFrontmatter(projectDirectory, active.folder);
-  if (!id) return 'ticket=∅/freeform';
-  return `ticket=${id}/${active.phase}`;
+/**
+ * The re-entry brief records what THIS session worked on, so the ticket tag comes
+ * from the per-session binding — NOT a global "most recent in_progress ticket"
+ * scan, which surfaces an unrelated backlog ticket whenever the session has no
+ * bound ticket (issue #274). There is deliberately no global fallback: an unbound
+ * session is honestly `∅/freeform`.
+ */
+function resolveTicketField(projectDirectory: string, sessionId: string): string {
+  const ticketId = readSessionTicketId(projectDirectory, sessionId);
+  if (!ticketId) return 'ticket=∅/freeform';
+  const { phase } = getTicketInfo(projectDirectory, ticketId);
+  if (!phase) return 'ticket=∅/freeform';
+  return `ticket=${ticketId}/${phase}`;
 }
 
 function readLastAssistantText(transcriptPath: string): string {
@@ -111,7 +122,7 @@ async function main(): Promise<void> {
   const imperative = extractLastNextImperative(assistantText);
   if (!imperative) return;
 
-  const ticketField = resolveTicketField(projectRoot);
+  const ticketField = resolveTicketField(projectRoot, session_id);
 
   const timestamp = new Date().toISOString();
   const line = `${timestamp} ${session_id} ${ticketField} Next: ${imperative}\n`;

--- a/packages/cli/templates/hooks/stop-reentry.ts
+++ b/packages/cli/templates/hooks/stop-reentry.ts
@@ -13,7 +13,8 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getActiveTicket } from './lib/active-ticket';
+import { getTicketInfo } from './lib/active-ticket';
+import { getStateFilePath } from './lib/quality-state.ts';
 import { resolveProjectRoot } from './lib/re-entry';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
@@ -45,25 +46,35 @@ function extractLastNextImperative(text: string): string | null {
   return null;
 }
 
-function readTicketIdFromFrontmatter(projectDirectory: string, folder: string): string | null {
-  const ticketPath = join(resolveNamespaceRoot(projectDirectory), 'tickets', folder, 'ticket.md');
+/**
+ * The session's bound ticket id, from the per-session quality-state
+ * (`quality-state-<sessionId>.json` `activeTicket`) — set when an edit touches a
+ * ticket.md, auto-cleared when the ticket reaches done/backlog. Returns null when
+ * the session never bound a ticket (or state is unreadable).
+ */
+function readSessionTicketId(projectDirectory: string, sessionId: string): string | null {
   try {
-    const content = readFileSync(ticketPath, 'utf8');
-    const idMatch = /^id:\s*(.+)$/m.exec(content);
-    if (!idMatch) return null;
-    // YAML failsafe schema may quote leading-zero ids; strip wrapping quotes.
-    return idMatch[1].trim().replace(/^['"]|['"]$/g, '');
+    const raw = readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8');
+    const state = JSON.parse(raw) as { activeTicket?: string | null };
+    return state.activeTicket ?? null;
   } catch {
     return null;
   }
 }
 
-function resolveTicketField(projectDirectory: string): string {
-  const active = getActiveTicket(projectDirectory);
-  if (!active.folder || !active.phase) return 'ticket=∅/freeform';
-  const id = readTicketIdFromFrontmatter(projectDirectory, active.folder);
-  if (!id) return 'ticket=∅/freeform';
-  return `ticket=${id}/${active.phase}`;
+/**
+ * The re-entry brief records what THIS session worked on, so the ticket tag comes
+ * from the per-session binding — NOT a global "most recent in_progress ticket"
+ * scan, which surfaces an unrelated backlog ticket whenever the session has no
+ * bound ticket (issue #274). There is deliberately no global fallback: an unbound
+ * session is honestly `∅/freeform`.
+ */
+function resolveTicketField(projectDirectory: string, sessionId: string): string {
+  const ticketId = readSessionTicketId(projectDirectory, sessionId);
+  if (!ticketId) return 'ticket=∅/freeform';
+  const { phase } = getTicketInfo(projectDirectory, ticketId);
+  if (!phase) return 'ticket=∅/freeform';
+  return `ticket=${ticketId}/${phase}`;
 }
 
 function readLastAssistantText(transcriptPath: string): string {
@@ -111,7 +122,7 @@ async function main(): Promise<void> {
   const imperative = extractLastNextImperative(assistantText);
   if (!imperative) return;
 
-  const ticketField = resolveTicketField(projectRoot);
+  const ticketField = resolveTicketField(projectRoot, session_id);
 
   const timestamp = new Date().toISOString();
   const line = `${timestamp} ${session_id} ${ticketField} Next: ${imperative}\n`;

--- a/packages/cli/tests/integration/re-entry-stop.test.ts
+++ b/packages/cli/tests/integration/re-entry-stop.test.ts
@@ -229,7 +229,7 @@ describe('stop-reentry hook — Rule 1: records intent when present', () => {
     expect(existsSync(bogus)).toBe(false);
   });
 
-  it('renders ticket=<id>/<phase> when an active ticket exists in this worktree', () => {
+  it('renders ticket=<id>/<phase> for the ticket bound to this session', () => {
     // Create an active ticket in the project directory.
     const ticketsDirectory = nodePath.join(
       projectDirectory,
@@ -253,6 +253,13 @@ describe('stop-reentry hook — Rule 1: records intent when present', () => {
     ].join('\n');
     writeFileSync(nodePath.join(ticketsDirectory, 'ticket.md'), ticketContent);
 
+    // Bind the ticket to THIS session, as post-tool-quality does when an edit
+    // touches a ticket.md. The re-entry tag reads the per-session binding (#274).
+    writeFileSync(
+      nodePath.join(projectDirectory, '.safeword-project', 'quality-state-sess_test_ticket.json'),
+      JSON.stringify({ activeTicket: '645W8H' }),
+    );
+
     const transcriptPath = makeTranscript(
       projectDirectory,
       'Wrapping up.\n\n**Next:** keep going on Slice 1',
@@ -266,5 +273,50 @@ describe('stop-reentry hook — Rule 1: records intent when present', () => {
 
     expect(line).toContain('ticket=645W8H/scenario-gate');
     expect(line).not.toContain('ticket=∅/freeform');
+  });
+
+  it('renders ∅/freeform when a worktree ticket exists but is NOT bound to this session (#274)', () => {
+    // A backlog ticket sits in the worktree, in_progress, freshly modified — but
+    // this session never bound it (no quality-state-<sessionId>.json). The old
+    // global-most-recent scan mislabeled the brief with this unrelated ticket;
+    // the per-session resolver must emit the freeform sentinel instead.
+    const ticketsDirectory = nodePath.join(
+      projectDirectory,
+      '.safeword-project',
+      'tickets',
+      '9E6Q4V',
+    );
+    mkdirSync(ticketsDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(ticketsDirectory, 'ticket.md'),
+      [
+        '---',
+        'id: 9E6Q4V',
+        'slug: unrelated-backlog',
+        'type: task',
+        'phase: intake',
+        'status: in_progress',
+        'last_modified: 2026-06-19T21:44:00.000Z',
+        '---',
+        '',
+        '# Unrelated backlog ticket',
+        '',
+      ].join('\n'),
+    );
+    // Deliberately NO quality-state-<sessionId>.json — this session has no binding.
+
+    const transcriptPath = makeTranscript(
+      projectDirectory,
+      'Did unrelated work.\n\n**Next:** carry on',
+    );
+
+    const result = runStopReentryHook(projectDirectory, transcriptPath, 'sess_unbound');
+    expect(result.status).toBe(0);
+
+    const logPath = nodePath.join(projectDirectory, '.safeword-project', 're-entry.md');
+    const line = readFileSync(logPath, 'utf8').trim();
+
+    expect(line).toContain('ticket=∅/freeform');
+    expect(line).not.toContain('9E6Q4V');
   });
 });


### PR DESCRIPTION
## Summary

Closes #274. The re-entry brief tagged a session's log lines with an **unrelated backlog ticket** whenever the session had no bound ticket. `stop-reentry`'s `resolveTicketField` called `getActiveTicket()` — the global "most-recently-modified `in_progress` non-epic ticket" finder — to label what is meant to be a record of *this session's* work. With a backlog of ~110 perpetually `in_progress` tickets, that surfaced e.g. `ticket=9E6Q4V/intake` on every line, even while the `UserPromptSubmit` hook correctly reported "No active ticket."

## Root cause

Every other session-aware hook (`pre-tool-quality`, `prompt-questions`, `session-compact-context`, `stop-quality`) reads the **per-session** quality-state (`quality-state-${sessionId}.json` `activeTicket`, set when an edit touches a `ticket.md`, auto-cleared on `done`/`backlog`). `stop-reentry` was the lone outlier going straight to the global scan.

## Fix

Point `resolveTicketField` at the per-session binding via `getStateFilePath(projectDirectory, sessionId)` and emit `ticket=∅/freeform` when nothing is bound — **with no global fallback**. The distinction from `stop-quality`: it falls back to a global scan because it hunts for *any* ticket whose done-gate might need enforcing (a global guess is acceptable there); the re-entry brief is a *factual record of this session*, so the global guess **is** the bug. Drops `getActiveTicket` and the now-dead `readTicketIdFromFrontmatter` from this hook.

Decided via `/debug` + `/figure-it-out` (full root-cause and option weighing recorded in #274).

## Tests

- The existing bound-ticket case now seeds per-session state (`quality-state-<sessionId>.json`) and asserts the bound ticket is tagged.
- **New regression guard:** an `in_progress`, freshly-modified, but **unbound** worktree ticket yields `ticket=∅/freeform` (and not the ticket id) — fails against the old global-scan resolver, passes now.

## Verification

- `re-entry-stop` 10/10 (incl. the new #274 guard), re-entry + hook-coverage suites, `schema` 27, **`parity` 18** (template ↔ installed copy in lockstep), typecheck clean.
- Template (`packages/cli/templates/hooks/stop-reentry.ts`) and installed copy (`.safeword/hooks/stop-reentry.ts`) updated byte-identically.

## Follow-up (out of scope)

The ~110 intake-phase tickets carrying `status: in_progress` is a separate data smell (noted in #274) — fixing it would make the global scan return nothing, but the consumer-mismatch fix here is the real correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDaZDtn5mgvu44vcUc7w1R)_