### PR TITLE
Add no-bloat verdict row to quality-review skill

### DIFF
--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -68,6 +68,7 @@ Fetch official documentation for libraries in use.
 **Versions:** [✓/⚠️/❌] [Latest version check]
 **Documentation:** [✓/⚠️/❌] [Current docs check]
 **Security:** [✓/⚠️/❌] [Vulnerability check]
+**No-bloat:** [✓/⚠️/❌] [smallest thing that works, or name the cut]
 
 **Verdict:** [APPROVE / REQUEST CHANGES / NEEDS DISCUSSION]
 

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -68,6 +68,7 @@ Fetch official documentation for libraries in use.
 **Versions:** [✓/⚠️/❌] [Latest version check]
 **Documentation:** [✓/⚠️/❌] [Current docs check]
 **Security:** [✓/⚠️/❌] [Vulnerability check]
+**No-bloat:** [✓/⚠️/❌] [smallest thing that works, or name the cut]
 
 **Verdict:** [APPROVE / REQUEST CHANGES / NEEDS DISCUSSION]
 

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -68,6 +68,7 @@ Fetch official documentation for libraries in use.
 **Versions:** [✓/⚠️/❌] [Latest version check]
 **Documentation:** [✓/⚠️/❌] [Current docs check]
 **Security:** [✓/⚠️/❌] [Vulnerability check]
+**No-bloat:** [✓/⚠️/❌] [smallest thing that works, or name the cut]
 
 **Verdict:** [APPROVE / REQUEST CHANGES / NEEDS DISCUSSION]
 


### PR DESCRIPTION
## What

Adds one verdict row to the `/quality-review` Output Format:

```
**No-bloat:** [✓/⚠️/❌] [smallest thing that works, or name the cut]
```

## Why

A check of the anti-bloat and plain-spoken directives across the prompt hook, quality review, and figure-it-out found one real gap: the `/quality-review` skill surfaced Versions/Docs/Security but never no-bloat. Over-engineering that figure-it-out guards at *design* time had no gate at *review* time.

One verdict row closes it — the reviewer already knows what bloat is (SAFEWORD.md defines it), so no checklist or new section. figure-it-out and plain-spoken coverage were already solid; the prompt hook was left as-is by design (one-anchor minimalism, SAFEWORD.md carries both directives every turn).

Synced across the template (`packages/cli/templates/...`) and the `.claude` / `.agents` dogfood copies for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDG6jLj3yMv6RjBX5rG8ru

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDG6jLj3yMv6RjBX5rG8ru)_