### PR TITLE
feat(namespace): wire a custom paths.projectRoot into formatter ignores + auto-upgrade staging (#273)

### DIFF
--- a/.project/tickets/1QNPCF-custom-projectroot-wiring/ticket.md
+++ b/.project/tickets/1QNPCF-custom-projectroot-wiring/ticket.md
@@ -1,0 +1,30 @@
+---
+id: 1QNPCF
+slug: custom-projectroot-wiring
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-20T15:28:05.112Z
+last_modified: 2026-06-20T15:28:05.112Z
+---
+
+# Custom paths.projectRoot: wire formatter ignores + auto-upgrade staging
+
+**Goal:** Make the namespace-root contribution to formatter ignore-lists and the auto-upgrade owned-paths prefixes follow the _resolved_ `paths.projectRoot`, not just the static `.project/`/`.safeword-project/`.
+
+**Why:** A custom `projectRoot` (e.g. `team-ns`) is invisible to `SAFEWORD_IGNORE_DIRS` and `generateOwnedPathsModule`, so its scaffolded files aren't auto-staged on upgrade (breaks the clean-tree gate — functional) and its markdown gets reformatted by prettier/dprint (cosmetic churn). Issue #273.
+
+## Decision (figure-it-out)
+
+Option A: replace static `SAFEWORD_IGNORE_DIRS` with a resolved-root-aware `safewordIgnoreDirs(ctx)` applied at the ctx-bearing seams. jsonMerge `merge`/`unmerge` and generators already receive `ctx`; jsonMerges re-apply every upgrade (no marker-skip). Guard `projectRoot:'.'` (must add no repo-root dir, else formatters skip the whole repo).
+
+- **Slice 1 (this pass):** `safewordIgnoreDirs(ctx)` → owned-paths generator (Facet 2) + Biome/dprint/oxfmt merges (Facet 1, the formatters that touch markdown).
+- **Slice 2 (deferred):** `.prettierignore` textPatch — needs the textPatch system extended to pass ctx + content factory; only helps fresh installs (marker-skip). Lower value, higher plumbing.
+
+## Work Log
+
+- 2026-06-20T15:28:05.112Z Started: Created ticket 1QNPCF
+- 2026-06-20T15:28Z Revalidated #273: confirmed SAFEWORD_IGNORE_DIRS feeds Biome(:141)/dprint+oxfmt(:199)/eslint and MANAGED_PRETTIER_PATHS; generateOwnedPathsModule(:84) hardcodes .project/+.safeword-project/. Verified merge/unmerge + generators receive ctx; textPatch does not.
+- 2026-06-20T15:28Z figure-it-out → Option A, sliced (owned-paths + jsonMerge formatters now; prettier deferred).
+- 2026-06-20T15:42Z Slice 1 GREEN (commit 5df2830): safewordIgnoreDirectories(label) + resolvedNamespaceDirectory(ctx) in owned-paths.ts; wired owned-paths generator + Biome/dprint/oxfmt merges (merge+unmerge). Guards projectRoot:'.'. 101 targeted tests pass, lint+typecheck clean. On branch claude/issue-273-projectroot-wiring (kept off the #272 PR #276 branch). NOT pushed yet.
+- TODO slice 2: .prettierignore ctx-awareness (textPatch system needs ctx + content factory). Knip ignore (files.ts:86) + eslint also static but near-moot (non-JS/markdown). Full suite + push pending.

--- a/.project/tickets/1QNPCF-custom-projectroot-wiring/ticket.md
+++ b/.project/tickets/1QNPCF-custom-projectroot-wiring/ticket.md
@@ -2,10 +2,10 @@
 id: 1QNPCF
 slug: custom-projectroot-wiring
 type: task
-phase: intake
-status: in_progress
+phase: done
+status: done
 created: 2026-06-20T15:28:05.112Z
-last_modified: 2026-06-20T15:28:05.112Z
+last_modified: 2026-06-20T18:58:00.000Z
 ---
 
 # Custom paths.projectRoot: wire formatter ignores + auto-upgrade staging

--- a/packages/cli/src/owned-paths.ts
+++ b/packages/cli/src/owned-paths.ts
@@ -12,8 +12,11 @@
  * semantics.
  */
 
-import type { JsonMergeDefinition } from './packs/types.js';
+import nodePath from 'node:path';
+
+import type { JsonMergeDefinition, ProjectContext } from './packs/types.js';
 import type { SafewordSchema } from './schema.js';
+import { resolveNamespaceRoot } from './utils/configured-paths.js';
 
 /**
  * Safeword-owned top-level directories a customer's OWN formatter must skip, so
@@ -21,6 +24,10 @@ import type { SafewordSchema } from './schema.js';
  * for every formatter's ignore wiring — `.prettierignore`, Biome excludes, ruff
  * `extend-exclude`, etc. — so adding an owned dir updates all of them in one
  * place. Bare names (no trailing slash); each tool maps to its own syntax.
+ *
+ * Covers the two well-known namespace roots; a *custom* `paths.projectRoot` is
+ * layered on at apply time via `safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx))`
+ * (issue #273), since this static list can't name an arbitrary root.
  *
  * `features/` and `steps/` are intentionally absent: the customer authors the
  * BDD feature files and step definitions there and wants them formatted. A drift
@@ -37,10 +44,41 @@ export const SAFEWORD_IGNORE_DIRS: readonly string[] = [
 ];
 
 /**
+ * Safeword-owned dirs a formatter must skip, including a custom `paths.projectRoot`
+ * (issue #273). `namespaceRootLabel` is the repo-relative resolved root from
+ * `resolvedNamespaceDirectory`; undefined (default/legacy/repo-root) leaves the static
+ * base list untouched.
+ */
+export function safewordIgnoreDirectories(namespaceRootLabel?: string): readonly string[] {
+  return namespaceRootLabel !== undefined && !SAFEWORD_IGNORE_DIRS.includes(namespaceRootLabel)
+    ? [...SAFEWORD_IGNORE_DIRS, namespaceRootLabel]
+    : SAFEWORD_IGNORE_DIRS;
+}
+
+/**
+ * The resolved namespace root as a repo-relative dir label, returned only when it
+ * is a custom root the static lists don't already cover. Returns undefined for the
+ * default `.project`/legacy `.safeword-project` roots, for `paths.projectRoot:'.'`
+ * (the repo root — excluding or staging it would match the whole repo), and for any
+ * root resolved OUTSIDE the repo ('../…' would leak nonsensical entries).
+ */
+export function resolvedNamespaceDirectory(ctx: ProjectContext): string | undefined {
+  const root = ctx.namespaceRoot ?? resolveNamespaceRoot(ctx.cwd);
+  const label = nodePath.relative(ctx.cwd, root) || '.';
+  // Skip the repo root ('.'), the well-known roots (already in the static lists),
+  // and any root resolved OUTSIDE the repo ('../…') — a traversal label would leak
+  // nonsensical ignore/prefix entries that match nothing under the repo.
+  if (label === '.' || label.startsWith('..') || SAFEWORD_IGNORE_DIRS.includes(label)) {
+    return undefined;
+  }
+  return label;
+}
+
+/**
  * Build a JSON-merge that adds safeword-owned dirs to a customer formatter's
  * string-array exclude/ignore field so the tool skips them (ticket EYRK34).
- * Sourced from the single SAFEWORD_IGNORE_DIRS list; `skipIfMissing` → only ever
- * touches a config the customer already has.
+ * Resolved at apply time from `ctx`, so a custom `paths.projectRoot` is excluded
+ * too (issue #273); `skipIfMissing` → only ever touches a config the customer has.
  *
  * `globForDir` controls the per-dir glob and defaults to the bare trailing-globstar
  * form used by dprint (`excludes`) and oxfmt (`ignorePatterns`). markdownlint-cli2
@@ -51,11 +89,13 @@ export function dirGlobExcludeMerge(
   field: string,
   globForDirectory: (dir: string) => string = dir => `${dir}/**`,
 ): JsonMergeDefinition {
-  const safewordGlobs = SAFEWORD_IGNORE_DIRS.map(dir => globForDirectory(dir));
   return {
     keys: [field],
     skipIfMissing: true,
-    merge: existing => {
+    merge: (existing, ctx) => {
+      const safewordGlobs = safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir =>
+        globForDirectory(dir),
+      );
       const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
       const merged = [...current];
       for (const glob of safewordGlobs) {
@@ -63,9 +103,14 @@ export function dirGlobExcludeMerge(
       }
       return { ...existing, [field]: merged };
     },
-    unmerge: existing => {
+    unmerge: (existing, ctx) => {
+      const safewordGlobs = new Set(
+        safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir =>
+          globForDirectory(dir),
+        ),
+      );
       const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
-      const cleaned = current.filter(entry => !safewordGlobs.includes(entry));
+      const cleaned = current.filter(entry => !safewordGlobs.has(entry));
       // Drop the field without a dynamic `delete` or unused binding, re-adding it
       // only when entries remain.
       const rest = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== field));
@@ -120,15 +165,22 @@ export function referenceFilterSafewordFiles(
   return [...changedFiles, ...untrackedFiles].filter(f => matchesSafewordPath(f, prefixes));
 }
 
-export function generateOwnedPathsModule(schema: SafewordSchema): string {
+export function generateOwnedPathsModule(
+  schema: SafewordSchema,
+  namespaceRootLabel?: string,
+): string {
   // The schema manifest carries legacy-prefixed namespace entries; installed
-  // projects may run either root (AQJ95G), so emit both prefixes.
+  // projects may run either well-known root (AQJ95G), so emit both prefixes —
+  // plus the resolved custom root (issue #273) so the auto-upgrade hook stages
+  // files scaffolded under a custom `paths.projectRoot`.
+  const customPrefix = namespaceRootLabel === undefined ? [] : [`${namespaceRootLabel}/`];
   const prefixes = [
-    ...new Set(
-      computeSafewordPathPrefixes(schema).flatMap(prefix =>
+    ...new Set([
+      ...computeSafewordPathPrefixes(schema).flatMap(prefix =>
         prefix === '.safeword-project/' ? ['.safeword-project/', '.project/'] : [prefix],
       ),
-    ),
+      ...customPrefix,
+    ]),
   ];
   const entries = prefixes.map(prefix => `  '${prefix}',`).join('\n');
 

--- a/packages/cli/src/owned-paths.ts
+++ b/packages/cli/src/owned-paths.ts
@@ -75,6 +75,15 @@ export function resolvedNamespaceDirectory(ctx: ProjectContext): string | undefi
 }
 
 /**
+ * The safeword-owned ignore directories for a context — the static base list plus
+ * the resolved custom `paths.projectRoot` (issue #273). Composition used by the
+ * formatter merges so the two-step resolution lives in one place.
+ */
+export function resolvedIgnoreDirectories(ctx: ProjectContext): readonly string[] {
+  return safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx));
+}
+
+/**
  * Build a JSON-merge that adds safeword-owned dirs to a customer formatter's
  * string-array exclude/ignore field so the tool skips them (ticket EYRK34).
  * Resolved at apply time from `ctx`, so a custom `paths.projectRoot` is excluded
@@ -93,9 +102,7 @@ export function dirGlobExcludeMerge(
     keys: [field],
     skipIfMissing: true,
     merge: (existing, ctx) => {
-      const safewordGlobs = safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir =>
-        globForDirectory(dir),
-      );
+      const safewordGlobs = resolvedIgnoreDirectories(ctx).map(dir => globForDirectory(dir));
       const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
       const merged = [...current];
       for (const glob of safewordGlobs) {
@@ -105,9 +112,7 @@ export function dirGlobExcludeMerge(
     },
     unmerge: (existing, ctx) => {
       const safewordGlobs = new Set(
-        safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir =>
-          globForDirectory(dir),
-        ),
+        resolvedIgnoreDirectories(ctx).map(dir => globForDirectory(dir)),
       );
       const current = Array.isArray(existing[field]) ? (existing[field] as string[]) : [];
       const cleaned = current.filter(entry => !safewordGlobs.has(entry));

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -88,6 +88,9 @@ function addKnipIgnoreDependencies(
 function getKnipConfig(ctx: ProjectContext): object {
   // A custom paths.projectRoot is added alongside the two well-known roots so
   // Knip doesn't scan (and false-positive on) the custom namespace dir (#273).
+  // NB: Knip's ignore is intentionally just the namespace roots, not the full
+  // safewordIgnoreDirectories/resolvedIgnoreDirectories list — so resolve the
+  // custom root directly here rather than reusing that composer.
   const customRoot = resolvedNamespaceDirectory(ctx);
   const config = {
     ignore: [

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -11,8 +11,8 @@
 
 import {
   dirGlobExcludeMerge,
+  resolvedIgnoreDirectories,
   resolvedNamespaceDirectory,
-  safewordIgnoreDirectories,
 } from '../../owned-paths.js';
 import { getEslintConfig, getSafewordEslintConfig } from '../../templates/config.js';
 import { assignOrPrune } from '../../utils/json-merge.js';
@@ -153,7 +153,7 @@ const BIOME_JSON_MERGE: JsonMergeDefinition = {
     // (issue #273). Biome v2.2.0+ doesn't need /**.
     const safewordExcludes = [
       '!eslint.config.mjs',
-      ...safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir => `!${dir}`),
+      ...resolvedIgnoreDirectories(ctx).map(dir => `!${dir}`),
     ];
     const newIncludes = [...existingIncludes];
     for (const exclude of safewordExcludes) {
@@ -180,7 +180,7 @@ const BIOME_JSON_MERGE: JsonMergeDefinition = {
     const safewordExcludes = new Set([
       '!eslint.config.mjs',
       '!.safeword/**',
-      ...safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir => `!${dir}`),
+      ...resolvedIgnoreDirectories(ctx).map(dir => `!${dir}`),
     ]);
     const cleanedIncludes = existingIncludes.filter(
       (entry: string) => !safewordExcludes.has(entry),

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -9,7 +9,11 @@
  * Inline disables target only generator arrow functions, not regular functions in this file.
  */
 
-import { dirGlobExcludeMerge, SAFEWORD_IGNORE_DIRS } from '../../owned-paths.js';
+import {
+  dirGlobExcludeMerge,
+  resolvedNamespaceDirectory,
+  safewordIgnoreDirectories,
+} from '../../owned-paths.js';
 import { getEslintConfig, getSafewordEslintConfig } from '../../templates/config.js';
 import { assignOrPrune } from '../../utils/json-merge.js';
 import type {
@@ -82,8 +86,16 @@ function addKnipIgnoreDependencies(
  * Knip plugins auto-enable based on deps, so we just configure ignore patterns.
  */
 function getKnipConfig(ctx: ProjectContext): object {
+  // A custom paths.projectRoot is added alongside the two well-known roots so
+  // Knip doesn't scan (and false-positive on) the custom namespace dir (#273).
+  const customRoot = resolvedNamespaceDirectory(ctx);
   const config = {
-    ignore: ['.safeword/**', '.project/**', '.safeword-project/**'],
+    ignore: [
+      '.safeword/**',
+      '.project/**',
+      '.safeword-project/**',
+      ...(customRoot === undefined ? [] : [`${customRoot}/**`]),
+    ],
     ignoreDependencies: ['safeword', 'dependency-cruiser'],
   };
 
@@ -131,14 +143,18 @@ function getPrettierPlugins(projectType: {
 const BIOME_JSON_MERGE: JsonMergeDefinition = {
   keys: ['files.includes'],
   skipIfMissing: true, // Only modify if project already uses Biome
-  merge: existing => {
+  merge: (existing, ctx) => {
     const files = (existing.files as Record<string, unknown>) ?? {};
     const existingIncludes = Array.isArray(files.includes) ? files.includes : [];
 
     // Add safeword exclusions (! prefix) if not already present, sourced from
     // the single SAFEWORD_IGNORE_DIRS list (ticket EYRK34) so Biome skips every
-    // safeword-owned dir, not just .safeword/. Biome v2.2.0+ doesn't need /**.
-    const safewordExcludes = ['!eslint.config.mjs', ...SAFEWORD_IGNORE_DIRS.map(dir => `!${dir}`)];
+    // safeword-owned dir, not just .safeword/ — including a custom paths.projectRoot
+    // (issue #273). Biome v2.2.0+ doesn't need /**.
+    const safewordExcludes = [
+      '!eslint.config.mjs',
+      ...safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir => `!${dir}`),
+    ];
     const newIncludes = [...existingIncludes];
     for (const exclude of safewordExcludes) {
       if (!newIncludes.includes(exclude)) {
@@ -154,16 +170,17 @@ const BIOME_JSON_MERGE: JsonMergeDefinition = {
       },
     };
   },
-  unmerge: (existing, _ctx) => {
+  unmerge: (existing, ctx) => {
     const files = (existing.files as Record<string, unknown>) ?? {};
     const existingIncludes = Array.isArray(files.includes) ? files.includes : [];
 
     // Remove safeword exclusions from includes list (current set + the legacy
-    // '!.safeword/**' folder form, cleaned up on unmerge).
+    // '!.safeword/**' folder form, cleaned up on unmerge). Mirrors merge, so a
+    // custom paths.projectRoot exclusion is also removed (issue #273).
     const safewordExcludes = new Set([
       '!eslint.config.mjs',
       '!.safeword/**',
-      ...SAFEWORD_IGNORE_DIRS.map(dir => `!${dir}`),
+      ...safewordIgnoreDirectories(resolvedNamespaceDirectory(ctx)).map(dir => `!${dir}`),
     ]);
     const cleanedIncludes = existingIncludes.filter(
       (entry: string) => !safewordExcludes.has(entry),

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -27,6 +27,7 @@ export type {
 import {
   dirGlobExcludeMerge,
   generateOwnedPathsModule,
+  resolvedNamespaceDirectory,
   SAFEWORD_IGNORE_DIRS,
 } from './owned-paths.js';
 import type { FileDefinition, JsonMergeDefinition, ManagedFileDefinition } from './packs/types.js';
@@ -545,7 +546,8 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     // Generated at setup/upgrade from SAFEWORD_SCHEMA itself — the prefix list
     // the auto-upgrade hook uses to decide which files to stage. See owned-paths.ts.
     '.safeword/hooks/lib/owned-paths.ts': {
-      generator: (): string => generateOwnedPathsModule(SAFEWORD_SCHEMA),
+      generator: (ctx): string =>
+        generateOwnedPathsModule(SAFEWORD_SCHEMA, resolvedNamespaceDirectory(ctx)),
     },
 
     // Hooks - TypeScript with Bun runtime

--- a/packages/cli/tests/owned-paths.test.ts
+++ b/packages/cli/tests/owned-paths.test.ts
@@ -14,9 +14,24 @@ import {
   generateOwnedPathsModule,
   matchesSafewordPath,
   referenceFilterSafewordFiles,
+  resolvedNamespaceDirectory,
+  SAFEWORD_IGNORE_DIRS,
+  safewordIgnoreDirectories,
 } from '../src/owned-paths.js';
+import type { ProjectContext } from '../src/packs/types.js';
 import type { SafewordSchema } from '../src/schema.js';
 import { SAFEWORD_SCHEMA } from '../src/schema.js';
+
+// Minimal context for resolvedNamespaceDirectory: it only reads cwd + namespaceRoot.
+const ctxWith = (cwd: string, namespaceRoot?: string): ProjectContext =>
+  ({
+    cwd,
+    namespaceRoot,
+    projectType: {},
+    developmentDeps: {},
+    productionDeps: {},
+    isGitRepo: true,
+  }) as unknown as ProjectContext;
 
 describe('computeSafewordPathPrefixes', () => {
   it('returns first-segment-with-slash for nested paths', () => {
@@ -121,6 +136,50 @@ describe('generateOwnedPathsModule', () => {
   it('emits a filterSafewordFiles helper for the auto-upgrade hook to consume', () => {
     const source = generateOwnedPathsModule(stubSchema({ ownedFiles: ['.safeword/x.ts'] }));
     expect(source).toContain('export function filterSafewordFiles');
+  });
+});
+
+describe('namespace-root awareness (issue #273)', () => {
+  it('safewordIgnoreDirectories appends a custom namespace root to the base list', () => {
+    const directories = safewordIgnoreDirectories('team-ns');
+    expect(directories).toContain('team-ns');
+    expect(directories).toContain('.safeword'); // base dirs preserved
+  });
+
+  it('safewordIgnoreDirectories leaves the base list unchanged for no/known roots', () => {
+    expect(safewordIgnoreDirectories()).toEqual(SAFEWORD_IGNORE_DIRS);
+    // '.project' and '.safeword-project' are already in the base list — no dupes.
+    expect(safewordIgnoreDirectories('.project')).toEqual(SAFEWORD_IGNORE_DIRS);
+    expect(safewordIgnoreDirectories('.safeword-project')).toEqual(SAFEWORD_IGNORE_DIRS);
+  });
+
+  it('resolvedNamespaceDirectory returns the label for a custom in-repo root', () => {
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/repo/team-ns'))).toBe('team-ns');
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/repo/config/team-ns'))).toBe(
+      'config/team-ns',
+    );
+  });
+
+  it('resolvedNamespaceDirectory returns undefined for repo-root and the well-known roots', () => {
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/repo'))).toBeUndefined();
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/repo/.project'))).toBeUndefined();
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/repo/.safeword-project'))).toBeUndefined();
+  });
+
+  it('resolvedNamespaceDirectory returns undefined for a root resolved outside the repo', () => {
+    // A '../…' traversal label would leak nonsensical ignore/prefix entries.
+    expect(resolvedNamespaceDirectory(ctxWith('/repo', '/external/ns'))).toBeUndefined();
+  });
+
+  it('generateOwnedPathsModule emits a resolved custom root prefix', () => {
+    // So the auto-upgrade hook stages files under the custom root (Facet 2).
+    expect(generateOwnedPathsModule(SAFEWORD_SCHEMA, 'team-ns')).toContain("'team-ns/'");
+  });
+
+  it('generateOwnedPathsModule still emits both well-known roots with no custom label', () => {
+    const source = generateOwnedPathsModule(SAFEWORD_SCHEMA);
+    expect(source).toContain("'.project/'");
+    expect(source).toContain("'.safeword-project/'");
   });
 });
 

--- a/packages/cli/tests/reconcile-namespace-root.test.ts
+++ b/packages/cli/tests/reconcile-namespace-root.test.ts
@@ -237,6 +237,44 @@ describe('reconcile scaffolds at the resolved namespace root (N9S5XG)', () => {
     }
   });
 
+  // Issue #273 Facet 2: the generated owned-paths module drives which files the
+  // auto-upgrade hook stages. A custom root must appear there, or its scaffolded
+  // files surface as untracked churn and block the clean-tree gate on upgrade.
+  it('DEV1.AC4.configured_root_listed_in_owned_paths_module', async () => {
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+    );
+
+    await runInstall();
+
+    const ownedPaths = readFileSync(
+      nodePath.join(cwd, '.safeword', 'hooks', 'lib', 'owned-paths.ts'),
+      'utf8',
+    );
+    expect(ownedPaths).toContain("'team-ns/'");
+  });
+
+  it('DEV1.AC4.repo_root_namespace_adds_no_bare_prefix', async () => {
+    // projectRoot '.' must NOT inject a repo-root prefix — a bare './' or '' would
+    // make the auto-upgrade hook match (and stage) every file in the repo.
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: '.' } }),
+    );
+
+    await runInstall();
+
+    const ownedPaths = readFileSync(
+      nodePath.join(cwd, '.safeword', 'hooks', 'lib', 'owned-paths.ts'),
+      'utf8',
+    );
+    expect(ownedPaths).not.toContain("'./'");
+    expect(ownedPaths).not.toMatch(/^\s*'',?\s*$/m);
+  });
+
   it('DEV1.AC4.upgrade_on_project_repo_stays_project', async () => {
     await runInstall();
     const glossaryPath = nodePath.join(cwd, '.project', 'glossary.md');

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -80,6 +80,15 @@ describe('Reconcile - Reconciliation Engine', () => {
     return defaultContent;
   }
 
+  // Write .safeword/config.json with a custom paths.projectRoot (issue #273 tests).
+  function writeProjectRootConfig(projectRoot: string) {
+    mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot } }),
+    );
+  }
+
   // Helper to create project context
   /**
    *
@@ -298,11 +307,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
 
       createPackageJson();
-      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
-      writeFileSync(
-        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
-        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
-      );
+      writeProjectRootConfig('team-ns');
       writeFileSync(
         nodePath.join(temporaryDirectory, 'biome.json'),
         `${JSON.stringify({ files: { includes: ['**'] } }, undefined, 2)}\n`,
@@ -322,11 +327,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
 
       createPackageJson();
-      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
-      writeFileSync(
-        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
-        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
-      );
+      writeProjectRootConfig('team-ns');
       writeFileSync(
         nodePath.join(temporaryDirectory, 'dprint.json'),
         `${JSON.stringify({ excludes: ['node_modules'] }, undefined, 2)}\n`,
@@ -346,11 +347,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
 
       createPackageJson();
-      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
-      writeFileSync(
-        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
-        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
-      );
+      writeProjectRootConfig('team-ns');
       writeFileSync(
         nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'),
         `${JSON.stringify({ config: { default: true }, ignores: ['dist/**'] }, undefined, 2)}\n`,
@@ -370,11 +367,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
 
       createPackageJson();
-      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
-      writeFileSync(
-        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
-        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
-      );
+      writeProjectRootConfig('team-ns');
 
       await reconcile(
         SAFEWORD_SCHEMA,
@@ -398,11 +391,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const { createProjectContext } = await import('../src/utils/context.js');
 
       createPackageJson();
-      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
-      writeFileSync(
-        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
-        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
-      );
+      writeProjectRootConfig('team-ns');
       writeFileSync(
         nodePath.join(temporaryDirectory, 'dprint.json'),
         `${JSON.stringify({ excludes: ['node_modules'] }, undefined, 2)}\n`,

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -293,6 +293,135 @@ describe('Reconcile - Reconciliation Engine', () => {
       }
     });
 
+    it('excludes a custom paths.projectRoot from an existing biome.json (#273)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+      );
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'biome.json'),
+        `${JSON.stringify({ files: { includes: ['**'] } }, undefined, 2)}\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const biome = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, 'biome.json'), 'utf8'),
+      ) as { files: { includes: string[] } };
+      expect(biome.files.includes).toContain('!team-ns'); // custom root excluded
+      expect(biome.files.includes).toContain('!.safeword'); // base dirs preserved
+    });
+
+    it('excludes a custom paths.projectRoot from an existing dprint.json (#273)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+      );
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'dprint.json'),
+        `${JSON.stringify({ excludes: ['node_modules'] }, undefined, 2)}\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const dprint = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, 'dprint.json'), 'utf8'),
+      ) as { excludes: string[] };
+      expect(dprint.excludes).toContain('team-ns/**'); // custom root excluded
+      expect(dprint.excludes).toContain('.safeword/**'); // base dirs preserved
+    });
+
+    it('ignores a custom paths.projectRoot in an existing .markdownlint-cli2.jsonc (#273)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+      );
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'),
+        `${JSON.stringify({ config: { default: true }, ignores: ['dist/**'] }, undefined, 2)}\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const cli2 = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, '.markdownlint-cli2.jsonc'), 'utf8'),
+      ) as { ignores: string[] };
+      expect(cli2.ignores).toContain('**/team-ns/**'); // custom root, leading-globstar form
+      expect(cli2.ignores).toContain('**/.safeword/**'); // base dirs preserved
+    });
+
+    it('adds a custom paths.projectRoot to knip.json ignore (#273)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+      );
+
+      await reconcile(
+        SAFEWORD_SCHEMA,
+        'install',
+        createContext({ projectType: { hasJsSource: true } }),
+      );
+
+      const knip = JSON.parse(
+        readFileSync(nodePath.join(temporaryDirectory, 'knip.json'), 'utf8'),
+      ) as { ignore: string[] };
+      expect(knip.ignore).toContain('team-ns/**'); // custom root ignored by knip
+      expect(knip.ignore).toContain('.project/**'); // well-known roots preserved
+    });
+
+    it('removes a custom paths.projectRoot from dprint.json on uninstall (#273 symmetry)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+      // Use the real context builder: it resolves namespaceRoot up front (the CLI
+      // does this before uninstall removes .safeword/config.json), which is what
+      // lets unmerge clean up the custom root rather than orphan it.
+      const { createProjectContext } = await import('../src/utils/context.js');
+
+      createPackageJson();
+      mkdirSync(nodePath.join(temporaryDirectory, '.safeword'), { recursive: true });
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.safeword', 'config.json'),
+        JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+      );
+      writeFileSync(
+        nodePath.join(temporaryDirectory, 'dprint.json'),
+        `${JSON.stringify({ excludes: ['node_modules'] }, undefined, 2)}\n`,
+      );
+
+      const dprintPath = nodePath.join(temporaryDirectory, 'dprint.json');
+      const excludesAfter = (): string[] =>
+        (JSON.parse(readFileSync(dprintPath, 'utf8')) as { excludes?: string[] }).excludes ?? [];
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(temporaryDirectory));
+      expect(excludesAfter()).toContain('team-ns/**'); // added on install
+
+      await reconcile(SAFEWORD_SCHEMA, 'uninstall', createProjectContext(temporaryDirectory));
+      // unmerge removes exactly what merge added — including the custom root.
+      expect(excludesAfter()).not.toContain('team-ns/**');
+      expect(excludesAfter()).not.toContain('.safeword/**');
+      expect(excludesAfter()).toContain('node_modules'); // user entry preserved
+    });
+
     it('SAFEWORD_IGNORE_DIRS covers every safeword-owned dot-directory the schema manages (no drift)', async () => {
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
       const { SAFEWORD_IGNORE_DIRS, computeSafewordPathPrefixes } =


### PR DESCRIPTION
Closes #273.

## Problem

A custom `paths.projectRoot` (e.g. `team-ns` instead of the default `.project/`) was invisible to two namespace-blind static lists:

- **Auto-upgrade staging (Facet 2, functional):** `generateOwnedPathsModule` hardcoded only `.project/` + `.safeword-project/`, so files scaffolded under `team-ns/` weren't auto-staged on upgrade — they surfaced as untracked churn and blocked the clean-tree gate.
- **Formatter ignores (Facet 1, cosmetic):** `SAFEWORD_IGNORE_DIRS` fed Biome / dprint / oxfmt / markdownlint-cli2, none of which named a custom root, so those tools reformatted the generated ticket/learning markdown under `team-ns/` on every run.

(The sibling `.gitignore` transient-leak facet was fixed separately in #276.)

## Fix

Resolve the namespace root at apply time and feed it to both surfaces — riding seams that already receive `ctx`, so there's no new plumbing and `jsonMerge`s self-heal on upgrade:

- `resolvedNamespaceDirectory(ctx)` — repo-relative custom-root label, or `undefined` for the default/legacy roots, repo-root `'.'` (would match the whole repo), and any root resolved outside the repo (`../…`).
- `safewordIgnoreDirectories(label)` — base dirs + the custom root.
- `resolvedIgnoreDirectories(ctx)` — composes the two; single call site for the formatter merges.

Wired through: the Biome merge, the shared `dirGlobExcludeMerge` (so dprint/oxfmt/**markdownlint** all get the custom root via one seam, preserving each tool's glob form), `getKnipConfig`, and the `owned-paths.ts` generator (emits the custom-root prefix).

## Safety

- **Zero churn for default/legacy installs:** `undefined` label returns the exact static `SAFEWORD_IGNORE_DIRS` reference → byte-identical output.
- **Symmetric merge/unmerge:** uninstall removes exactly what install added (production resolves `namespaceRoot` up front via `createProjectContext`, before config removal — verified by a round-trip test).
- **`projectRoot:'.'` guarded:** never emits a bare `'./'` prefix that would match the whole repo.
- **Orthogonal to #279** auto-upgrade hardening (the `startsWith`/exact-match predicate is unchanged).

## Deferred → still tracked in #273

`.prettierignore` is a static textPatch (can't take `ctx`), so its custom-root coverage is the one remaining formatter surface — noted in the issue.

## Verification

- Full suite: **3141 passed / 5 skipped** (209 files), Gherkin **69/69**, build + lint + tsc clean.
- `/audit`: no architecture violations, no new dead code, duplication net-reduced.
- New tests: custom-root coverage for Biome/dprint/markdownlint/knip + owned-paths module, `projectRoot:'.'` guards, external-root guard, and an uninstall round-trip.

> [!NOTE]
> Commits are attributed to `Claude <noreply@anthropic.com>` but are **unsigned** (this environment's signing key is a 0-byte placeholder), so GitHub will mark them Unverified. Environment limitation, not a committer-email issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F)_