### PR TITLE
refactor: extract shared readSessionState for the quality hooks

### DIFF
--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -85,8 +85,9 @@ export function getStateFilePath(projectDirectory: string, sessionId: string): s
  */
 export function readSessionState(
   projectDirectory: string,
-  sessionId: string,
+  sessionId: string | undefined,
 ): QualityState | null {
+  if (!sessionId) return null;
   try {
     return JSON.parse(
       readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8'),
@@ -158,7 +159,7 @@ export function recordFailure(
         const counters = readCounters(projectDirectory);
         const entry = counters[pattern] ?? { count: 0, lastSeen: '', countAtLastSuggestion: null };
         entry.count += 1;
-        entry.lastSeen = new Date().toISOString().split('T')[0];
+        entry.lastSeen = new Date().toISOString().slice(0, 10);
         counters[pattern] = entry;
         writeCounters(projectDirectory, counters);
       }

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -76,6 +76,26 @@ export function getStateFilePath(projectDirectory: string, sessionId: string): s
   return nodePath.join(resolveNamespaceRoot(projectDirectory), `quality-state-${sessionId}.json`);
 }
 
+/**
+ * Read and parse the per-session quality-state file, or `null` when it is absent
+ * or unreadable/unparseable. Centralizes the read+parse+tolerate-failure idiom the
+ * quality hooks share; read-only callers use this directly, while read-modify-write
+ * callers (post-tool, prompt-questions, the stop-quality writer) still own their
+ * own read+write so the write half stays explicit.
+ */
+export function readSessionState(
+  projectDirectory: string,
+  sessionId: string,
+): QualityState | null {
+  try {
+    return JSON.parse(
+      readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8'),
+    ) as QualityState;
+  } catch {
+    return null;
+  }
+}
+
 /** Counter file for cross-session failure pattern tracking. */
 export function getCounterFilePath(projectDirectory: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), 'failure-counts.json');

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -25,10 +25,9 @@ import {
 } from './lib/review-ledger.ts';
 import {
   EXPLAIN_HINT,
-  getStateFilePath,
   LOC_THRESHOLD,
   META_PATHS,
-  type QualityState,
+  readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
 import { isNamespacePath, resolveNamespaceRoot } from './lib/namespace-root.ts';
@@ -149,16 +148,8 @@ function readReviewStamps(): ReviewStamp[] {
  * wrong step, or unreachable git all silently allow.
  */
 function enforceRefactorCommitGate(sessionId?: string): void {
-  const stateFile = getStateFilePath(projectDirectory, sessionId);
-  if (!existsSync(stateFile)) return;
-
-  let state: QualityState;
-  try {
-    state = JSON.parse(readFileSync(stateFile, 'utf8'));
-  } catch {
-    return;
-  }
-  if (!state.activeTicket) return;
+  const state = readSessionState(projectDirectory, sessionId);
+  if (!state?.activeTicket) return;
 
   const ticket = getTicketInfo(projectDirectory, state.activeTicket);
   if (ticket.phase !== 'implement' || !ticket.folder) return;
@@ -445,16 +436,9 @@ if (META_PATHS.some(p => editedFile.includes(p))) {
 // Shared state read — used by both implement phase gate and LOC gate below.
 // ---------------------------------------------------------------------------
 
-const stateFile = getStateFilePath(projectDirectory, input.session_id);
+const state = readSessionState(projectDirectory, input.session_id);
 
-if (!existsSync(stateFile)) {
-  process.exit(0);
-}
-
-let state: QualityState;
-try {
-  state = JSON.parse(readFileSync(stateFile, 'utf8'));
-} catch {
+if (!state) {
   process.exit(0);
 }
 

--- a/.safeword/hooks/session-compact-context.ts
+++ b/.safeword/hooks/session-compact-context.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { getTicketInfo } from './lib/active-ticket.ts';
-import { getStateFilePath } from './lib/quality-state.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 interface HookInput {
@@ -36,21 +36,10 @@ if (existsSync(learningsIndex)) {
   );
 }
 
-// Read per-session state file (not legacy shared file)
-const stateFile = getStateFilePath(projectDir, input.session_id);
+// Read the per-session state to find the ticket bound to this session.
+const state = readSessionState(projectDir, input.session_id);
 
-if (!existsSync(stateFile)) {
-  process.exit(0);
-}
-
-let state: { activeTicket: string | null; gate: string | null };
-try {
-  state = JSON.parse(readFileSync(stateFile, 'utf8'));
-} catch {
-  process.exit(0);
-}
-
-if (!state.activeTicket) {
+if (!state?.activeTicket) {
   process.exit(0);
 }
 

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -31,6 +31,7 @@ import {
   type FailureEntry,
   getStateFilePath,
   type QualityState,
+  readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
 import { shouldReviewPhase, shouldReviewStep } from './lib/review-trigger.ts';
@@ -89,15 +90,8 @@ function getCurrentTicketInfo(sessionId?: string): TicketInfo {
 
   // Try session-scoped resolution first
   if (sessionId) {
-    const stateFile = getStateFilePath(projectDir, sessionId);
-    if (!existsSync(stateFile)) return fallbackGlobalScan();
-
-    let state: QualityState;
-    try {
-      state = JSON.parse(readFileSync(stateFile, 'utf8'));
-    } catch {
-      return fallbackGlobalScan();
-    }
+    const state = readSessionState(projectDir, sessionId);
+    if (!state) return fallbackGlobalScan();
 
     if (!state.activeTicket) return empty;
 
@@ -118,18 +112,6 @@ function getCurrentTicketInfo(sessionId?: string): TicketInfo {
   }
 
   return fallbackGlobalScan();
-}
-
-/** Read session state file once. Returns null if unavailable. */
-function readSessionState(sessionId?: string): QualityState | null {
-  if (!sessionId) return null;
-  const stateFile = getStateFilePath(projectDir, sessionId);
-  if (!existsSync(stateFile)) return null;
-  try {
-    return JSON.parse(readFileSync(stateFile, 'utf8'));
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -655,7 +637,7 @@ if (typecheckAdvice.advice !== null) {
 // this Stop path catches a boundary PostToolUse didn't see (e.g. a non-edit
 // phase bump) and the ordinary interactive stop. Dedup via lastReviewedStep /
 // lastReviewedPhase so each boundary is reviewed once across both triggers.
-const sessionState = readSessionState(input.session_id);
+const sessionState = readSessionState(projectDir, input.session_id);
 
 // Derive TDD step from test-definitions.md (not cache)
 const tddStep =

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -30,7 +30,6 @@ import {
   EXPLAIN_HINT,
   type FailureEntry,
   getStateFilePath,
-  type QualityState,
   readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';

--- a/.safeword/hooks/stop-reentry.ts
+++ b/.safeword/hooks/stop-reentry.ts
@@ -14,7 +14,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getTicketInfo } from './lib/active-ticket';
-import { getStateFilePath } from './lib/quality-state.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { resolveProjectRoot } from './lib/re-entry';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
@@ -53,13 +53,7 @@ function extractLastNextImperative(text: string): string | null {
  * the session never bound a ticket (or state is unreadable).
  */
 function readSessionTicketId(projectDirectory: string, sessionId: string): string | null {
-  try {
-    const raw = readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8');
-    const state = JSON.parse(raw) as { activeTicket?: string | null };
-    return state.activeTicket ?? null;
-  } catch {
-    return null;
-  }
+  return readSessionState(projectDirectory, sessionId)?.activeTicket ?? null;
 }
 
 /**

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -83,7 +83,11 @@ export function getStateFilePath(projectDirectory: string, sessionId: string): s
  * callers (post-tool, prompt-questions, the stop-quality writer) still own their
  * own read+write so the write half stays explicit.
  */
-export function readSessionState(projectDirectory: string, sessionId: string): QualityState | null {
+export function readSessionState(
+  projectDirectory: string,
+  sessionId: string | undefined,
+): QualityState | null {
+  if (!sessionId) return null;
   try {
     return JSON.parse(
       readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8'),
@@ -155,7 +159,7 @@ export function recordFailure(
         const counters = readCounters(projectDirectory);
         const entry = counters[pattern] ?? { count: 0, lastSeen: '', countAtLastSuggestion: null };
         entry.count += 1;
-        entry.lastSeen = new Date().toISOString().split('T')[0];
+        entry.lastSeen = new Date().toISOString().slice(0, 10);
         counters[pattern] = entry;
         writeCounters(projectDirectory, counters);
       }

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -76,6 +76,23 @@ export function getStateFilePath(projectDirectory: string, sessionId: string): s
   return nodePath.join(resolveNamespaceRoot(projectDirectory), `quality-state-${sessionId}.json`);
 }
 
+/**
+ * Read and parse the per-session quality-state file, or `null` when it is absent
+ * or unreadable/unparseable. Centralizes the read+parse+tolerate-failure idiom the
+ * quality hooks share; read-only callers use this directly, while read-modify-write
+ * callers (post-tool, prompt-questions, the stop-quality writer) still own their
+ * own read+write so the write half stays explicit.
+ */
+export function readSessionState(projectDirectory: string, sessionId: string): QualityState | null {
+  try {
+    return JSON.parse(
+      readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8'),
+    ) as QualityState;
+  } catch {
+    return null;
+  }
+}
+
 /** Counter file for cross-session failure pattern tracking. */
 export function getCounterFilePath(projectDirectory: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), 'failure-counts.json');

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -25,10 +25,9 @@ import {
 } from './lib/review-ledger.ts';
 import {
   EXPLAIN_HINT,
-  getStateFilePath,
   LOC_THRESHOLD,
   META_PATHS,
-  type QualityState,
+  readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
 import { isNamespacePath, resolveNamespaceRoot } from './lib/namespace-root.ts';
@@ -149,16 +148,8 @@ function readReviewStamps(): ReviewStamp[] {
  * wrong step, or unreachable git all silently allow.
  */
 function enforceRefactorCommitGate(sessionId?: string): void {
-  const stateFile = getStateFilePath(projectDirectory, sessionId);
-  if (!existsSync(stateFile)) return;
-
-  let state: QualityState;
-  try {
-    state = JSON.parse(readFileSync(stateFile, 'utf8'));
-  } catch {
-    return;
-  }
-  if (!state.activeTicket) return;
+  const state = readSessionState(projectDirectory, sessionId);
+  if (!state?.activeTicket) return;
 
   const ticket = getTicketInfo(projectDirectory, state.activeTicket);
   if (ticket.phase !== 'implement' || !ticket.folder) return;
@@ -445,16 +436,9 @@ if (META_PATHS.some(p => editedFile.includes(p))) {
 // Shared state read — used by both implement phase gate and LOC gate below.
 // ---------------------------------------------------------------------------
 
-const stateFile = getStateFilePath(projectDirectory, input.session_id);
+const state = readSessionState(projectDirectory, input.session_id);
 
-if (!existsSync(stateFile)) {
-  process.exit(0);
-}
-
-let state: QualityState;
-try {
-  state = JSON.parse(readFileSync(stateFile, 'utf8'));
-} catch {
+if (!state) {
   process.exit(0);
 }
 

--- a/packages/cli/templates/hooks/session-compact-context.ts
+++ b/packages/cli/templates/hooks/session-compact-context.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { getTicketInfo } from './lib/active-ticket.ts';
-import { getStateFilePath } from './lib/quality-state.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 interface HookInput {
@@ -36,21 +36,10 @@ if (existsSync(learningsIndex)) {
   );
 }
 
-// Read per-session state file (not legacy shared file)
-const stateFile = getStateFilePath(projectDir, input.session_id);
+// Read the per-session state to find the ticket bound to this session.
+const state = readSessionState(projectDir, input.session_id);
 
-if (!existsSync(stateFile)) {
-  process.exit(0);
-}
-
-let state: { activeTicket: string | null; gate: string | null };
-try {
-  state = JSON.parse(readFileSync(stateFile, 'utf8'));
-} catch {
-  process.exit(0);
-}
-
-if (!state.activeTicket) {
+if (!state?.activeTicket) {
   process.exit(0);
 }
 

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -31,6 +31,7 @@ import {
   type FailureEntry,
   getStateFilePath,
   type QualityState,
+  readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
 import { shouldReviewPhase, shouldReviewStep } from './lib/review-trigger.ts';
@@ -89,15 +90,8 @@ function getCurrentTicketInfo(sessionId?: string): TicketInfo {
 
   // Try session-scoped resolution first
   if (sessionId) {
-    const stateFile = getStateFilePath(projectDir, sessionId);
-    if (!existsSync(stateFile)) return fallbackGlobalScan();
-
-    let state: QualityState;
-    try {
-      state = JSON.parse(readFileSync(stateFile, 'utf8'));
-    } catch {
-      return fallbackGlobalScan();
-    }
+    const state = readSessionState(projectDir, sessionId);
+    if (!state) return fallbackGlobalScan();
 
     if (!state.activeTicket) return empty;
 
@@ -118,18 +112,6 @@ function getCurrentTicketInfo(sessionId?: string): TicketInfo {
   }
 
   return fallbackGlobalScan();
-}
-
-/** Read session state file once. Returns null if unavailable. */
-function readSessionState(sessionId?: string): QualityState | null {
-  if (!sessionId) return null;
-  const stateFile = getStateFilePath(projectDir, sessionId);
-  if (!existsSync(stateFile)) return null;
-  try {
-    return JSON.parse(readFileSync(stateFile, 'utf8'));
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -655,7 +637,7 @@ if (typecheckAdvice.advice !== null) {
 // this Stop path catches a boundary PostToolUse didn't see (e.g. a non-edit
 // phase bump) and the ordinary interactive stop. Dedup via lastReviewedStep /
 // lastReviewedPhase so each boundary is reviewed once across both triggers.
-const sessionState = readSessionState(input.session_id);
+const sessionState = readSessionState(projectDir, input.session_id);
 
 // Derive TDD step from test-definitions.md (not cache)
 const tddStep =

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -30,7 +30,6 @@ import {
   EXPLAIN_HINT,
   type FailureEntry,
   getStateFilePath,
-  type QualityState,
   readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';

--- a/packages/cli/templates/hooks/stop-reentry.ts
+++ b/packages/cli/templates/hooks/stop-reentry.ts
@@ -14,7 +14,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getTicketInfo } from './lib/active-ticket';
-import { getStateFilePath } from './lib/quality-state.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { resolveProjectRoot } from './lib/re-entry';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
@@ -53,13 +53,7 @@ function extractLastNextImperative(text: string): string | null {
  * the session never bound a ticket (or state is unreadable).
  */
 function readSessionTicketId(projectDirectory: string, sessionId: string): string | null {
-  try {
-    const raw = readFileSync(getStateFilePath(projectDirectory, sessionId), 'utf8');
-    const state = JSON.parse(raw) as { activeTicket?: string | null };
-    return state.activeTicket ?? null;
-  } catch {
-    return null;
-  }
+  return readSessionState(projectDirectory, sessionId)?.activeTicket ?? null;
 }
 
 /**

--- a/packages/cli/tests/hooks/quality-state-read.test.ts
+++ b/packages/cli/tests/hooks/quality-state-read.test.ts
@@ -14,38 +14,38 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readSessionState } from '../../../../.safeword/hooks/lib/quality-state';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
 
-let projectDirectory: string;
+const context = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  context.projectDirectory = createTemporaryDirectory();
   // resolveNamespaceRoot defaults to .project/ when neither namespace dir exists.
-  mkdirSync(nodePath.join(projectDirectory, '.project'), { recursive: true });
+  mkdirSync(nodePath.join(context.projectDirectory, '.project'), { recursive: true });
 });
 
 afterEach(() => {
-  removeTemporaryDirectory(projectDirectory);
+  removeTemporaryDirectory(context.projectDirectory);
 });
 
 const stateFile = (sessionId: string): string =>
-  nodePath.join(projectDirectory, '.project', `quality-state-${sessionId}.json`);
+  nodePath.join(context.projectDirectory, '.project', `quality-state-${sessionId}.json`);
 
 describe('readSessionState', () => {
   it('returns the parsed state when the per-session file exists', () => {
     writeFileSync(stateFile('s1'), JSON.stringify({ activeTicket: 'ABC123' }));
 
-    const state = readSessionState(projectDirectory, 's1');
+    const state = readSessionState(context.projectDirectory, 's1');
 
     expect(state?.activeTicket).toBe('ABC123');
   });
 
   it('returns null when no per-session state file exists', () => {
-    expect(readSessionState(projectDirectory, 'missing')).toBeNull();
+    expect(readSessionState(context.projectDirectory, 'missing')).toBeNull();
   });
 
   it('returns null (no throw) when the state file is malformed JSON', () => {
     writeFileSync(stateFile('s2'), '{ not valid json');
 
-    expect(() => readSessionState(projectDirectory, 's2')).not.toThrow();
-    expect(readSessionState(projectDirectory, 's2')).toBeNull();
+    expect(() => readSessionState(context.projectDirectory, 's2')).not.toThrow();
+    expect(readSessionState(context.projectDirectory, 's2')).toBeNull();
   });
 });

--- a/packages/cli/tests/hooks/quality-state-read.test.ts
+++ b/packages/cli/tests/hooks/quality-state-read.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for readSessionState — the shared per-session quality-state reader.
+ *
+ * Read-only hooks (stop-reentry, pre-tool, session-compact, stop-quality readers)
+ * rely on this returning the parsed state or `null` (absent / unreadable /
+ * unparseable) without throwing.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readSessionState } from '../../../../.safeword/hooks/lib/quality-state';
+import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
+
+let projectDirectory: string;
+
+beforeEach(() => {
+  projectDirectory = createTemporaryDirectory();
+  // resolveNamespaceRoot defaults to .project/ when neither namespace dir exists.
+  mkdirSync(nodePath.join(projectDirectory, '.project'), { recursive: true });
+});
+
+afterEach(() => {
+  removeTemporaryDirectory(projectDirectory);
+});
+
+const stateFile = (sessionId: string): string =>
+  nodePath.join(projectDirectory, '.project', `quality-state-${sessionId}.json`);
+
+describe('readSessionState', () => {
+  it('returns the parsed state when the per-session file exists', () => {
+    writeFileSync(stateFile('s1'), JSON.stringify({ activeTicket: 'ABC123' }));
+
+    const state = readSessionState(projectDirectory, 's1');
+
+    expect(state?.activeTicket).toBe('ABC123');
+  });
+
+  it('returns null when no per-session state file exists', () => {
+    expect(readSessionState(projectDirectory, 'missing')).toBeNull();
+  });
+
+  it('returns null (no throw) when the state file is malformed JSON', () => {
+    writeFileSync(stateFile('s2'), '{ not valid json');
+
+    expect(() => readSessionState(projectDirectory, 's2')).not.toThrow();
+    expect(readSessionState(projectDirectory, 's2')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Dedup of the "read the per-session quality-state JSON, tolerate failure" idiom that was inlined across the quality hooks (surfaced during the #274 work). Adds one shared `readSessionState(projectDirectory, sessionId): QualityState | null` to `lib/quality-state.ts` and migrates the **pure-read** call sites to it. **Behavior-preserving** — no gate/resolution logic changes.

## Commits (one refactoring each, tests green at every step)

1. **Add `readSessionState`** to `lib/quality-state.ts` + unit test. No callers changed.
2. **stop-reentry** — `readSessionTicketId` collapses to a one-liner over the helper.
3. **stop-quality** — replaces its *own local* `readSessionState` copy **and** the inline read in the session-scoped ticket resolver. Widens the shared helper's `sessionId` to `string | undefined` (matching the local one it replaced). Incidental: `recordFailure`'s date uses `.slice(0, 10)` instead of `.split('T')[0]` (the latter is `string | undefined` under `noUncheckedIndexedAccess`, surfaced once the unit test pulled the module into typecheck scope) — behavior identical.
4. **pre-tool-quality + session-compact-context** — the remaining pure-read sites; drops now-unused `getStateFilePath`/`QualityState` imports from pre-tool.

## Deliberately left inline (read-modify-write)

`post-tool-quality`, `prompt-questions`, and `stop-quality`'s `recordReviewMarker` read **and write back** the state object — they keep their own read+write so the write half stays explicit. The shared helper is a read-only convenience, not a state manager.

## Verification

- Full suite: **3130 passed, 5 skipped** (210 files); typecheck, eslint, depcruise (no violations, 152 modules), **parity** (template ↔ installed in lockstep), knip (no new dead code) — all green.
- New unit test: `readSessionState` returns parsed state / `null` (absent) / `null` (malformed, no throw).
- Per-hook suites re-run green at each commit (re-entry-stop, quality-gates, refactor-commit-gate, status-close-gate, phase-derivation, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDaZDtn5mgvu44vcUc7w1R)_