### PR TITLE
feat(prettier): exclude a custom paths.projectRoot via ctx-aware, re-rendered .prettierignore (#293)

### DIFF
--- a/.project/tickets/EXP1PE-prettierignore-ctx-rerender/ticket.md
+++ b/.project/tickets/EXP1PE-prettierignore-ctx-rerender/ticket.md
@@ -1,0 +1,26 @@
+---
+id: EXP1PE
+slug: prettierignore-ctx-rerender
+type: task
+phase: implement
+status: in_progress
+created: 2026-06-20T22:30:00.000Z
+last_modified: 2026-06-20T22:50:00.000Z
+---
+
+# ctx-aware + re-rendered .prettierignore for a custom projectRoot (#293)
+
+**Goal:** Make `.prettierignore` exclude a custom `paths.projectRoot` (the last formatter #273 left uncovered).
+
+**Why:** Prettier reads only the root `.prettierignore`/`.gitignore` (verified) and the custom root's markdown is tracked, so the root `.prettierignore` is the only lever. Its text-patch was static/ctx-blind and append-once.
+
+## Approach (figure-it-out → Option A)
+
+- Generalize the text-patch engine: `TextPatchDefinition.content` may be `(ctx) => string`, resolved at plan time (`resolveTextPatch`) so executors still see a string.
+- Add opt-in `rerender`: when the marker is present but the resolved block has drifted, replace the managed block in place (`stripRerenderBlock` consumes only safeword's own lines, derived from the fresh content, so customer lines after the block are preserved). No-op when current → default installs never churn.
+- `.prettierignore` patch → `content: ctx => …managedPrettierPaths(ctx)`, `rerender: true`. Default/legacy output byte-identical.
+
+## Work Log
+
+- 2026-06-20T22:30Z Revalidated engine (append-once, marker-skip; content string-only; no ctx in executeTextPatch). Verified prettier ignore behavior vs docs.
+- 2026-06-20T22:50Z Implemented ctx-factory + rerender; 6 prettier tests (fresh custom, in-place re-render w/ customer-after preserved + one block, default no-churn, projectRoot '.'); typecheck + lint clean; 102 reconcile+schema tests green. Branch claude/issue-293-prettierignore-rerender off main.

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -970,26 +970,38 @@ function executeJsonUnmerge(
 }
 
 /**
+ * The safeword-owned body lines of a re-renderable block, in order, taken from
+ * the freshly-resolved content (the header/marker line excluded).
+ */
+function rerenderBlockLines(definition: ResolvedTextPatch): string[] {
+  return definition.content
+    .split('\n')
+    .filter(line => line !== '' && !line.includes(definition.marker));
+}
+
+/**
  * Remove a re-renderable managed block so a fresh, ctx-resolved version can be
- * re-appended (#293). Consumes the `marker` header plus the contiguous run after
- * it of lines that are blank OR appear in the freshly-resolved block content —
- * so only safeword's own lines are removed (an on-disk block only ever has a
- * subset of the new lines, since the owned-dir set grows), and a customer entry
- * that happens to follow the block is preserved.
+ * re-appended (#293). Consumes the `marker` header plus the contiguous run of
+ * disk lines that match the fresh block's body lines *in order* — an on-disk
+ * block is always a prefix of the new one (the owned-dir set only grows and its
+ * order is fixed), so a customer line that breaks the sequence (even one that
+ * coincidentally equals an owned dir) is never consumed.
  */
 function stripRerenderBlock(content: string, definition: ResolvedTextPatch): string {
   const lines = content.split('\n');
   const startIndex = lines.findIndex(line => line.includes(definition.marker));
   if (startIndex === -1) return content;
 
-  const ownLines = new Set(
-    definition.content.split('\n').filter(line => line !== '' && !line.includes(definition.marker)),
-  );
+  const blockLines = rerenderBlockLines(definition);
   let endIndex = startIndex;
-  while (endIndex + 1 < lines.length) {
-    const next = lines[endIndex + 1] ?? '';
-    if (next !== '' && !ownLines.has(next)) break;
+  let expected = 0;
+  while (
+    endIndex + 1 < lines.length &&
+    expected < blockLines.length &&
+    lines[endIndex + 1] === blockLines[expected]
+  ) {
     endIndex += 1;
+    expected += 1;
   }
 
   // Also drop a single blank separator line immediately before the header.
@@ -999,6 +1011,11 @@ function stripRerenderBlock(content: string, definition: ResolvedTextPatch): str
 }
 
 function executeTextPatch(cwd: string, path: string, definition: ResolvedTextPatch): void {
+  // rerender re-appends the block at EOF, so it only makes sense for `append`.
+  if (definition.rerender && definition.operation !== 'append') {
+    throw new Error(`rerender text patch ${path} must use operation: 'append'`);
+  }
+
   const fullPath = nodePath.join(cwd, path);
   let content = readFileSafe(fullPath) ?? '';
 
@@ -1036,12 +1053,16 @@ function executeTextPatch(cwd: string, path: string, definition: ResolvedTextPat
   writeFile(fullPath, content);
 }
 
-function executeTextUnpatch(cwd: string, path: string, definition: ResolvedTextPatch): void {
-  const fullPath = nodePath.join(cwd, path);
-  const content = readFileSafe(fullPath);
-  if (!content) return;
-
+function computeUnpatchedContent(content: string, definition: ResolvedTextPatch): string {
   let unpatched = removeExactTextPatchContent(content, definition);
+
+  // Re-render patches (#293): the on-disk block can differ from the ctx-resolved
+  // content (e.g. paths.projectRoot changed since install), so an exact removal
+  // misses it. Fall back to the marker-anchored, sequence-bounded strip — which
+  // never consumes a customer line that follows the block.
+  if (unpatched === content && definition.rerender) {
+    unpatched = stripRerenderBlock(content, definition);
+  }
 
   // Legacy prepend blocks may have a malformed separator (`---# Heading`) from
   // safeword <=0.30.1. If the file starts with our managed marker, remove the
@@ -1049,18 +1070,25 @@ function executeTextUnpatch(cwd: string, path: string, definition: ResolvedTextP
   if (unpatched === content && content.startsWith(definition.marker)) {
     const separatorIndex = content.indexOf('\n---');
     if (separatorIndex !== -1) {
-      const afterSeparator = content.slice(separatorIndex + '\n---'.length).replace(/^\n+/, '');
-      unpatched = afterSeparator;
+      unpatched = content.slice(separatorIndex + '\n---'.length).replace(/^\n+/, '');
     }
   }
 
   const firstLine = content.split('\n', 1)[0] ?? '';
   if (unpatched === content && firstLine.includes(definition.marker)) {
-    const lines = content.split('\n');
-    const filtered = lines.slice(1);
-    unpatched = filtered.join('\n').replace(/^\n+/, ''); // Remove leading empty lines
+    unpatched = content.split('\n').slice(1).join('\n').replace(/^\n+/, ''); // drop leading blanks
     unpatched = stripLeadingSafewordSeparator(unpatched);
   }
+
+  return unpatched;
+}
+
+function executeTextUnpatch(cwd: string, path: string, definition: ResolvedTextPatch): void {
+  const fullPath = nodePath.join(cwd, path);
+  const content = readFileSafe(fullPath);
+  if (!content) return;
+
+  const unpatched = computeUnpatchedContent(content, definition);
 
   if (shouldRemoveTextPatchTarget(unpatched, definition)) {
     remove(fullPath);

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -129,16 +129,19 @@ function asPatchList(entry: TextPatchDefinition | TextPatchDefinition[]): TextPa
 
 function planTextPatches(
   patches: Record<string, TextPatchDefinition | TextPatchDefinition[]>,
-  cwd: string,
-  isGitRepo: boolean,
+  ctx: ProjectContext,
 ): Action[] {
   const actions: Action[] = [];
   for (const [filePath, entry] of Object.entries(patches)) {
-    if (shouldSkipForNonGit(filePath, isGitRepo)) continue;
+    if (shouldSkipForNonGit(filePath, ctx.isGitRepo)) continue;
     // Apply in list order so later patches land beneath earlier ones.
     for (const definition of asPatchList(entry)) {
-      if (!passesTextPatchContentGuard(cwd, filePath, definition)) continue;
-      actions.push({ type: 'text-patch', path: filePath, definition });
+      if (!passesTextPatchContentGuard(ctx.cwd, filePath, definition)) continue;
+      actions.push({
+        type: 'text-patch',
+        path: filePath,
+        definition: resolveTextPatch(definition, ctx),
+      });
     }
   }
   return actions;
@@ -160,8 +163,7 @@ function passesTextPatchContentGuard(
 
 function planTextUnpatches(
   patches: Record<string, TextPatchDefinition | TextPatchDefinition[]>,
-  cwd: string,
-  isGitRepo: boolean,
+  ctx: ProjectContext,
 ): Action[] {
   const hasLegacyPreamble = (content: string, definition: TextPatchDefinition): boolean => {
     const firstLine = content.split('\n', 1)[0] ?? '';
@@ -170,9 +172,9 @@ function planTextUnpatches(
 
   const actions: Action[] = [];
   for (const [filePath, entry] of Object.entries(patches)) {
-    if (shouldSkipForNonGit(filePath, isGitRepo)) continue;
+    if (shouldSkipForNonGit(filePath, ctx.isGitRepo)) continue;
 
-    const fullPath = nodePath.join(cwd, filePath);
+    const fullPath = nodePath.join(ctx.cwd, filePath);
     if (!exists(fullPath)) continue;
 
     const content = readFileSafe(fullPath) ?? '';
@@ -180,7 +182,11 @@ function planTextUnpatches(
     // (removeFileIfContentEquals) runs last, after siblings strip their blocks.
     for (const definition of asPatchList(entry).toReversed()) {
       if (hasLegacyPreamble(content, definition)) {
-        actions.push({ type: 'text-unpatch', path: filePath, definition });
+        actions.push({
+          type: 'text-unpatch',
+          path: filePath,
+          definition: resolveTextPatch(definition, ctx),
+        });
       }
     }
   }
@@ -303,8 +309,20 @@ export type Action =
   | { type: 'chmod'; paths: string[] }
   | { type: 'json-merge'; path: string; definition: JsonMergeDefinition }
   | { type: 'json-unmerge'; path: string; definition: JsonMergeDefinition }
-  | { type: 'text-patch'; path: string; definition: TextPatchDefinition }
-  | { type: 'text-unpatch'; path: string; definition: TextPatchDefinition };
+  | { type: 'text-patch'; path: string; definition: ResolvedTextPatch }
+  | { type: 'text-unpatch'; path: string; definition: ResolvedTextPatch };
+
+// A TextPatchDefinition whose ctx-factory `content` has been resolved to a string
+// at plan time, so executors never see a function (#293).
+type ResolvedTextPatch = Omit<TextPatchDefinition, 'content'> & { content: string };
+
+function resolveTextPatch(definition: TextPatchDefinition, ctx: ProjectContext): ResolvedTextPatch {
+  return {
+    ...definition,
+    content:
+      typeof definition.content === 'function' ? definition.content(ctx) : definition.content,
+  };
+}
 
 export interface ReconcileResult {
   actions: Action[];
@@ -481,8 +499,8 @@ function computeInstallPlan(schema: SafewordSchema, ctx: ProjectContext): Reconc
 
   // 6. Text patches — unguarded patches create absent target files; guarded
   // patches only run when the current file proves it is safe to touch.
-  actions.push(...planTextUnpatches(schema.legacyTextPatches, ctx.cwd, ctx.isGitRepo));
-  const textPatchActions = planTextPatches(schema.textPatches, ctx.cwd, ctx.isGitRepo);
+  actions.push(...planTextUnpatches(schema.legacyTextPatches, ctx));
+  const textPatchActions = planTextPatches(schema.textPatches, ctx);
   actions.push(...textPatchActions);
   for (const action of textPatchActions) {
     if (action.type === 'text-patch' && !exists(nodePath.join(ctx.cwd, action.path))) {
@@ -629,8 +647,8 @@ function computeUpgradePlan(schema: SafewordSchema, ctx: ProjectContext): Reconc
 
   // 7. Text patches
   actions.push(
-    ...planTextUnpatches(schema.legacyTextPatches, ctx.cwd, ctx.isGitRepo),
-    ...planTextPatches(schema.textPatches, ctx.cwd, ctx.isGitRepo),
+    ...planTextUnpatches(schema.legacyTextPatches, ctx),
+    ...planTextPatches(schema.textPatches, ctx),
   );
 
   // 8. Compute packages to install
@@ -684,8 +702,8 @@ function computeUninstallPlan(
 
   // 3. Text unpatches
   actions.push(
-    ...planTextUnpatches(schema.textPatches, ctx.cwd, ctx.isGitRepo),
-    ...planTextUnpatches(schema.legacyTextPatches, ctx.cwd, ctx.isGitRepo),
+    ...planTextUnpatches(schema.textPatches, ctx),
+    ...planTextUnpatches(schema.legacyTextPatches, ctx),
   );
 
   // 4. Remove preserved directories first (reverse order, only if empty)
@@ -951,12 +969,50 @@ function executeJsonUnmerge(
   writeJson(fullPath, unmerged);
 }
 
-function executeTextPatch(cwd: string, path: string, definition: TextPatchDefinition): void {
+/**
+ * Remove a re-renderable managed block so a fresh, ctx-resolved version can be
+ * re-appended (#293). Consumes the `marker` header plus the contiguous run after
+ * it of lines that are blank OR appear in the freshly-resolved block content —
+ * so only safeword's own lines are removed (an on-disk block only ever has a
+ * subset of the new lines, since the owned-dir set grows), and a customer entry
+ * that happens to follow the block is preserved.
+ */
+function stripRerenderBlock(content: string, definition: ResolvedTextPatch): string {
+  const lines = content.split('\n');
+  const startIndex = lines.findIndex(line => line.includes(definition.marker));
+  if (startIndex === -1) return content;
+
+  const ownLines = new Set(
+    definition.content.split('\n').filter(line => line !== '' && !line.includes(definition.marker)),
+  );
+  let endIndex = startIndex;
+  while (endIndex + 1 < lines.length) {
+    const next = lines[endIndex + 1] ?? '';
+    if (next !== '' && !ownLines.has(next)) break;
+    endIndex += 1;
+  }
+
+  // Also drop a single blank separator line immediately before the header.
+  const blockStart = startIndex > 0 && lines[startIndex - 1] === '' ? startIndex - 1 : startIndex;
+  lines.splice(blockStart, endIndex - blockStart + 1);
+  return lines.join('\n').replaceAll(/\n{3,}/g, '\n\n');
+}
+
+function executeTextPatch(cwd: string, path: string, definition: ResolvedTextPatch): void {
   const fullPath = nodePath.join(cwd, path);
   let content = readFileSafe(fullPath) ?? '';
 
   // Check if already patched
   if (content.includes(definition.marker)) {
+    // Re-renderable block (#293): when the resolved content has drifted from
+    // what's on disk (e.g. a custom paths.projectRoot was added), replace the
+    // managed block in place so existing installs heal on upgrade. A no-op when
+    // the block is already current, so default installs never churn.
+    if (definition.rerender && !content.includes(definition.content)) {
+      const stripped = stripRerenderBlock(content, definition);
+      writeFile(fullPath, stripped + definition.content);
+      return;
+    }
     // Heal legacy artifact from safeword <=0.30.1: the prepend templates
     // (CLAUDE_MD_IMPORT_BLOCK, AGENTS_MD_LINK) ended with bare `---` and no
     // trailing newline, so the `---` separator glued to the user's first
@@ -980,7 +1036,7 @@ function executeTextPatch(cwd: string, path: string, definition: TextPatchDefini
   writeFile(fullPath, content);
 }
 
-function executeTextUnpatch(cwd: string, path: string, definition: TextPatchDefinition): void {
+function executeTextUnpatch(cwd: string, path: string, definition: ResolvedTextPatch): void {
   const fullPath = nodePath.join(cwd, path);
   const content = readFileSafe(fullPath);
   if (!content) return;
@@ -1014,7 +1070,7 @@ function executeTextUnpatch(cwd: string, path: string, definition: TextPatchDefi
   writeFile(fullPath, unpatched);
 }
 
-function removeExactTextPatchContent(content: string, definition: TextPatchDefinition): string {
+function removeExactTextPatchContent(content: string, definition: ResolvedTextPatch): string {
   let unpatched = content.replace(definition.content, '');
   for (const extraContent of definition.unpatchContent ?? []) {
     unpatched = unpatched.replace(extraContent, '');

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -27,10 +27,15 @@ export type {
 import {
   dirGlobExcludeMerge,
   generateOwnedPathsModule,
+  resolvedIgnoreDirectories,
   resolvedNamespaceDirectory,
-  SAFEWORD_IGNORE_DIRS,
 } from './owned-paths.js';
-import type { FileDefinition, JsonMergeDefinition, ManagedFileDefinition } from './packs/types.js';
+import type {
+  FileDefinition,
+  JsonMergeDefinition,
+  ManagedFileDefinition,
+  ProjectContext,
+} from './packs/types.js';
 import { CURSOR_HOOKS, SETTINGS_HOOKS } from './templates/config.js';
 import { AGENTS_MD_LINK, CLAUDE_MD_IMPORT_BLOCK } from './templates/content.js';
 import { filterOutSafewordHooks } from './utils/hooks.js';
@@ -40,11 +45,18 @@ import { VERSION } from './version.js';
 
 export interface TextPatchDefinition {
   operation: 'prepend' | 'append';
-  content: string;
+  // Static string, or a factory resolved with ctx at plan time so the block can
+  // depend on the resolved namespace root (e.g. a custom paths.projectRoot, #293).
+  content: string | ((ctx: ProjectContext) => string);
   marker: string; // Used to detect if already applied & for removal
   applyWhenContentIncludes?: string[]; // Optional guard for semi-owned config files
   unpatchContent?: string[]; // Additional exact blocks to remove on uninstall/reset
   removeFileIfContentEquals?: string[]; // Delete file only when remaining content is known scaffold
+  // When set (append patches only), re-render the managed block in place on
+  // upgrade instead of skip-on-marker — so a ctx-dependent block (e.g. a custom
+  // projectRoot added to .prettierignore) heals on existing installs. A no-op
+  // when the block is already current, so unchanged installs never churn (#293).
+  rerender?: boolean;
 }
 
 export interface ContractDefinition {
@@ -311,8 +323,14 @@ const NAMESPACE_GITIGNORE_CONTENT = `# Safeword - transient session state (auto-
  * roots are covered — plus husky's generated `_` dir. Previously this listed only
  * the INDEX markdown under each root (TAGWZ8/1GGD28); the whole `.project/` is
  * safeword-generated, so excluding it wholesale also covers tickets and learnings.
+ *
+ * Resolved per-ctx (issue #293) so a custom `paths.projectRoot` is excluded too —
+ * for the two well-known roots this is identical to the old static list, so a
+ * default/legacy install's `.prettierignore` block is byte-identical (no churn).
  */
-const MANAGED_PRETTIER_PATHS = ['.husky/_', ...SAFEWORD_IGNORE_DIRS.map(dir => `${dir}/`)];
+function managedPrettierPaths(ctx: ProjectContext): string[] {
+  return ['.husky/_', ...resolvedIgnoreDirectories(ctx).map(dir => `${dir}/`)];
+}
 
 export const SAFEWORD_SCHEMA: SafewordSchema = {
   version: VERSION,
@@ -1004,7 +1022,12 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     // stale-config-scan still detects the block.
     '.prettierignore': {
       operation: 'append',
-      content: `\n# Safeword - managed prettier exclusions (owned dirs)\n${MANAGED_PRETTIER_PATHS.join('\n')}\n`,
+      // ctx factory + rerender (issue #293): a custom paths.projectRoot is excluded,
+      // and the block re-renders in place on upgrade for an existing custom-root
+      // install. Default/legacy output is byte-identical, so those installs no-op.
+      content: ctx =>
+        `\n# Safeword - managed prettier exclusions (owned dirs)\n${managedPrettierPaths(ctx).join('\n')}\n`,
+      rerender: true,
       marker: '# Safeword - managed prettier exclusions (owned dirs)',
     },
     '.codex/config.toml': [

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -332,6 +332,11 @@ function managedPrettierPaths(ctx: ProjectContext): string[] {
   return ['.husky/_', ...resolvedIgnoreDirectories(ctx).map(dir => `${dir}/`)];
 }
 
+// Header line of the managed .prettierignore block — also its marker (re-applied
+// and re-rendered against this exact string). The "(owned dirs)" suffix marks the
+// post-EYRK34 format; the stable prefix is what stale-config-scan detects.
+const PRETTIER_EXCLUSIONS_HEADER = '# Safeword - managed prettier exclusions (owned dirs)';
+
 export const SAFEWORD_SCHEMA: SafewordSchema = {
   version: VERSION,
 
@@ -1025,10 +1030,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       // ctx factory + rerender (issue #293): a custom paths.projectRoot is excluded,
       // and the block re-renders in place on upgrade for an existing custom-root
       // install. Default/legacy output is byte-identical, so those installs no-op.
-      content: ctx =>
-        `\n# Safeword - managed prettier exclusions (owned dirs)\n${managedPrettierPaths(ctx).join('\n')}\n`,
+      content: ctx => `\n${PRETTIER_EXCLUSIONS_HEADER}\n${managedPrettierPaths(ctx).join('\n')}\n`,
       rerender: true,
-      marker: '# Safeword - managed prettier exclusions (owned dirs)',
+      marker: PRETTIER_EXCLUSIONS_HEADER,
     },
     '.codex/config.toml': [
       // Primary patch: retrofits the prompt-timestamp hook onto pre-existing

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -555,6 +555,45 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).not.toMatch(/^\/$/m);
     });
 
+    it('prettierignore re-render preserves a customer line after the block even if it equals an owned dir (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeProjectRootConfig('team-ns');
+      // Customer manually duplicated `.claude/` (an owned dir) right AFTER the block.
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.prettierignore'),
+        `dist/${currentPrettierBlock}.claude/\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', createContext());
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'utf8');
+      expect(content).toContain('team-ns/'); // re-rendered with the custom root
+      expect(countHeaders(content)).toBe(1);
+      // The block has one `.claude/`; the customer's trailing one must survive → two total.
+      expect(content.split('.claude/').length - 1).toBe(2);
+    });
+
+    it('prettierignore block is removed on uninstall, customer content preserved (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+      const { createProjectContext } = await import('../src/utils/context.js');
+
+      createPackageJson();
+      writeProjectRootConfig('team-ns');
+      writeFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'dist/\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(temporaryDirectory));
+      await reconcile(SAFEWORD_SCHEMA, 'uninstall', createProjectContext(temporaryDirectory));
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'utf8');
+      expect(content).not.toContain(PRETTIER_HEADER); // managed block gone
+      expect(content).not.toContain('team-ns/');
+      expect(content).toContain('dist/'); // customer content preserved
+    });
+
     it('excludes every safeword-owned dir from an existing dprint.json', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -465,6 +465,96 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).toContain('# Safeword - managed prettier exclusions (owned dirs)');
     });
 
+    const PRETTIER_HEADER = '# Safeword - managed prettier exclusions (owned dirs)';
+    const prettierDirectories = [
+      '.husky/_',
+      '.safeword/',
+      '.claude/',
+      '.cursor/',
+      '.codex/',
+      '.agents/',
+      '.project/',
+      '.safeword-project/',
+    ].join('\n');
+    const currentPrettierBlock = `\n${PRETTIER_HEADER}\n${prettierDirectories}\n`;
+    const countHeaders = (content: string): number => content.split(PRETTIER_HEADER).length - 1;
+
+    it('prettierignore excludes a custom paths.projectRoot on fresh install (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeProjectRootConfig('team-ns');
+      writeFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'dist/\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'utf8');
+      expect(content).toContain('team-ns/'); // custom root excluded
+      expect(content).toContain('dist/'); // customer content preserved
+    });
+
+    it('prettierignore re-renders in place to add a custom root on upgrade — exactly one block (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeProjectRootConfig('team-ns');
+      // Existing custom-root install: current block WITHOUT the custom root yet,
+      // and a customer ignore line AFTER the managed block.
+      writeFileSync(
+        nodePath.join(temporaryDirectory, '.prettierignore'),
+        `dist/${currentPrettierBlock}coverage/\n`,
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', createContext());
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'utf8');
+      expect(content).toContain('team-ns/'); // custom root now excluded
+      expect(content).toContain('dist/'); // customer content before preserved
+      expect(content).toContain('coverage/'); // customer line AFTER the block preserved
+      expect(countHeaders(content)).toBe(1); // re-rendered in place, not appended
+    });
+
+    it('prettierignore does not churn a default install on upgrade (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'dist/\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+      const afterInstall = readFileSync(
+        nodePath.join(temporaryDirectory, '.prettierignore'),
+        'utf8',
+      );
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', createContext());
+      const afterUpgrade = readFileSync(
+        nodePath.join(temporaryDirectory, '.prettierignore'),
+        'utf8',
+      );
+
+      expect(afterUpgrade).toBe(afterInstall); // byte-identical — no churn, one block
+      expect(countHeaders(afterUpgrade)).toBe(1);
+    });
+
+    it('prettierignore adds no bare repo-root entry for projectRoot "." (#293)', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      writeProjectRootConfig('.');
+      writeFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'dist/\n');
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', createContext());
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.prettierignore'), 'utf8');
+      // No bare './' or empty entry that would exclude the whole repo.
+      expect(content).not.toMatch(/^\.\/$/m);
+      expect(content).not.toMatch(/^\/$/m);
+    });
+
     it('excludes every safeword-owned dir from an existing dprint.json', async () => {
       const { reconcile } = await import('../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../src/schema.js');


### PR DESCRIPTION
Closes #293. Final follow-up to the #272/#273 epic — closes the last formatter gap.

## Problem

After #273, four formatters (Biome, dprint, oxfmt, markdownlint) follow a custom `paths.projectRoot`, but **prettier** didn't: its `.prettierignore` block was a **static, append-once** text-patch with no `ctx`. Prettier reads only the root `.prettierignore`/`.gitignore` (no nested files — verified), and the custom root's markdown is tracked, so the root `.prettierignore` is the only lever.

## Fix

- **Generalize the text-patch engine** — `TextPatchDefinition.content` may now be a `(ctx) => string` factory, resolved at plan time (`resolveTextPatch`) so executors still receive a string. This was the last namespace-blind config seam.
- **Opt-in `rerender`** — when the marker is present but the resolved block has drifted (e.g. a custom root was added), replace the managed block in place instead of skip-on-marker. It's a **no-op when already current**, so default/legacy installs never churn (their block is byte-identical to before).
- `.prettierignore` → ctx factory + `rerender: true`, sourced from `resolvedIgnoreDirectories(ctx)`.

## Safety / correctness

- **Block boundary by ordered sequence** — `stripRerenderBlock` consumes the marker header plus the contiguous run matching the fresh block's body lines *in order* (an on-disk block is always a prefix of the new one, since dirs only grow and order is fixed). A customer line after the block — even one that coincidentally equals an owned dir — breaks the sequence and is preserved.
- **Uninstall** uses a marker-anchored sequence-strip fallback so the block is removed even if `projectRoot` changed since install (no orphan).
- **Append-only guard** on `rerender`; `executeTextUnpatch` complexity kept in budget via `computeUnpatchedContent`.

## Review

An independent same-tier review flagged the two correctness edges above (customer-line deletion; uninstall orphan) — both fixed and regression-tested before this PR.

## Verification

- Full suite **3178 passed / 5 skipped** (210 files) — exercises every other text patch (codex config, gitignore, legacy prepends), so the engine change is regression-clean.
- Gherkin **69/69**; build + lint + tsc clean; `/audit` clean (no cycles, no new dead code, duplication reduced).
- 8 prettier-specific tests: fresh custom-root exclusion; in-place re-render (custom root added, exactly one block, customer lines before AND after preserved); default-upgrade byte-identical (no churn); `projectRoot:'.'` adds no bare entry; a coincidental owned-dir customer line survives; uninstall removes the block.

> [!NOTE]
> Commits are attributed to `Claude <noreply@anthropic.com>` but are **unsigned** (this environment's signing key is a 0-byte placeholder) → GitHub will mark them Unverified. Environment limitation, not a committer-email issue.
>
> Branch is a few commits behind `main` (dependency bumps that don't touch these files) — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F)_