### PR TITLE
chore(EXP1PE): mark ticket done (shipped in #296)

### DIFF
--- a/.project/tickets/EXP1PE-prettierignore-ctx-rerender/ticket.md
+++ b/.project/tickets/EXP1PE-prettierignore-ctx-rerender/ticket.md
@@ -2,10 +2,10 @@
 id: EXP1PE
 slug: prettierignore-ctx-rerender
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-06-20T22:30:00.000Z
-last_modified: 2026-06-20T22:50:00.000Z
+last_modified: 2026-06-21T00:44:00.000Z
 ---
 
 # ctx-aware + re-rendered .prettierignore for a custom projectRoot (#293)


### PR DESCRIPTION
Bookkeeping only — flips ticket `EXP1PE` to `status: done` / `phase: done`. The work it tracks (ctx-aware, re-rendered `.prettierignore` for a custom `paths.projectRoot`) shipped in #296. The ticket was merged still marked `in_progress` because the status flip wasn't committed before merge.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dd8WVLHJwahV9R7mYu64F)_