### PR TITLE
ESLint 10 + eslint-plugin-unicorn 68 (breaking: drop ESLint 9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,6 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Lint (ESLint 10 forward-compat)
-        # Ticket 099: safeword's peerDependencies.eslint is "^9.22.0 || ^10.0.0".
-        # The Lint step above runs ESLint 9 (the primary dev dep); this proves the
-        # same shipped config also lints clean under ESLint 10 via the eslint-v10
-        # alias, keeping the dual-major peer range honest as plugins/deps change.
-        run: bun run --cwd packages/cli lint:eslint:v10
-
       - name: Type check
         run: bun run --cwd packages/cli typecheck
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@cucumber/messages": "^33.0.2",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint-react/eslint-plugin": "5.9.0",
-        "@eslint/js": "^9.39.4",
+        "@eslint/js": "^10.0.1",
         "@next/eslint-plugin-next": "16.2.9",
         "@tanstack/eslint-plugin-query": "5.101.0",
         "@vitest/eslint-plugin": "^1.6.20",
@@ -54,7 +54,7 @@
         "eslint-plugin-sonarjs": "4.0.3",
         "eslint-plugin-storybook": "10.4.5",
         "eslint-plugin-turbo": "2.9.18",
-        "eslint-plugin-unicorn": "64.0.0",
+        "eslint-plugin-unicorn": "68.0.0",
         "typescript-eslint": "8.61.0",
         "yaml": "^2.9.0",
       },
@@ -63,8 +63,7 @@
         "@types/estree": "^1.0.9",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "^9.39.4",
-        "eslint-v10": "npm:eslint@^10.5.0",
+        "eslint": "^10.5.0",
         "knip": "6.17.1",
         "prettier": "^3.8.4",
         "publint": "^0.3.21",
@@ -74,7 +73,7 @@
         "vitest": "^4.1.9",
       },
       "peerDependencies": {
-        "eslint": "^9.22.0 || ^10.0.0",
+        "eslint": "^10.4.0",
       },
     },
     "packages/website": {
@@ -147,7 +146,7 @@
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
 
@@ -313,7 +312,7 @@
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
 
-    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -1001,8 +1000,6 @@
 
     "class-transformer": ["class-transformer@0.5.1", "", {}, "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="],
 
-    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
-
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
@@ -1185,6 +1182,8 @@
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
+    "detect-indent": ["detect-indent@7.0.2", "", {}, "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
@@ -1313,11 +1312,9 @@
 
     "eslint-plugin-turbo": ["eslint-plugin-turbo@2.9.18", "", { "dependencies": { "dotenv": "16.0.3" }, "peerDependencies": { "eslint": ">6.6.0", "turbo": ">2.0.0" } }, "sha512-WbvNDtwxyNQnX6ODtWs39EutD8a2Eoh25EgGkSqbqRpw8llHG/waCgBUwUUG7i1yh73d6p4HNBWEk+C+mvx9Xw=="],
 
-    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@64.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.1", "change-case": "^5.4.4", "ci-info": "^4.4.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.49.0", "find-up-simple": "^1.0.1", "globals": "^17.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA=="],
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@68.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
-
-    "eslint-v10": ["eslint@10.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -2621,6 +2618,8 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
+    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2628,6 +2627,10 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@cucumber/cucumber/@cucumber/gherkin": ["@cucumber/gherkin@39.1.0", "", { "dependencies": { "@cucumber/messages": ">=31.0.0 <33" } }, "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ=="],
 
@@ -2749,8 +2752,6 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -2780,6 +2781,8 @@
     "decompress-unzip/yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "dependency-cruiser/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "eslint/@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -2833,25 +2836,7 @@
 
     "eslint-plugin-unicorn/globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
-    "eslint-plugin-unicorn/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
-
-    "eslint-v10/@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
-
-    "eslint-v10/@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
-
-    "eslint-v10/@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
-
-    "eslint-v10/@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
-
-    "eslint-v10/eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
-
-    "eslint-v10/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "eslint-v10/espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
-
-    "eslint-v10/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "eslint-v10/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "eslint-plugin-unicorn/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -2916,6 +2901,8 @@
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "safeword/eslint": ["eslint@10.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ=="],
 
     "safeword/knip": ["knip@6.17.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.135.0", "oxc-resolver": "^11.20.0", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.1", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ=="],
 
@@ -3059,10 +3046,6 @@
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
 
-    "eslint-v10/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
-
-    "eslint-v10/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
-
     "globby/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "istanbul-lib-report/make-dir/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
@@ -3078,6 +3061,24 @@
     "markdownlint/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "safeword/eslint/@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "safeword/eslint/@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "safeword/eslint/@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "safeword/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "safeword/eslint/eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "safeword/eslint/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "safeword/eslint/espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "safeword/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "safeword/eslint/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "safeword/knip/oxc-parser": ["oxc-parser@0.135.0", "", { "dependencies": { "@oxc-project/types": "^0.135.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.135.0", "@oxc-parser/binding-android-arm64": "0.135.0", "@oxc-parser/binding-darwin-arm64": "0.135.0", "@oxc-parser/binding-darwin-x64": "0.135.0", "@oxc-parser/binding-freebsd-x64": "0.135.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0", "@oxc-parser/binding-linux-arm64-gnu": "0.135.0", "@oxc-parser/binding-linux-arm64-musl": "0.135.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0", "@oxc-parser/binding-linux-riscv64-musl": "0.135.0", "@oxc-parser/binding-linux-s390x-gnu": "0.135.0", "@oxc-parser/binding-linux-x64-gnu": "0.135.0", "@oxc-parser/binding-linux-x64-musl": "0.135.0", "@oxc-parser/binding-openharmony-arm64": "0.135.0", "@oxc-parser/binding-wasm32-wasi": "0.135.0", "@oxc-parser/binding-win32-arm64-msvc": "0.135.0", "@oxc-parser/binding-win32-ia32-msvc": "0.135.0", "@oxc-parser/binding-win32-x64-msvc": "0.135.0" } }, "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA=="],
 
@@ -3181,9 +3182,11 @@
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ=="],
 
-    "eslint-v10/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "safeword/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "safeword/eslint/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "safeword/knip/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.135.0", "", { "os": "android", "cpu": "arm" }, "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ=="],
 
@@ -3258,6 +3261,8 @@
     "eslint-plugin-react-web-api/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "safeword/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
   }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -83,6 +83,22 @@ export default defineConfig([
     },
   },
 
+  // Cucumber step definitions — the Cucumber API binds `this` to the World in
+  // `function () {}` step callbacks (arrow functions break that binding), and
+  // setWorldConstructor/Given/When/Then/Before/After are top-level registration
+  // side effects by design. unicorn 68's no-this-outside-of-class and
+  // no-top-level-side-effects are fundamentally incompatible with that idiom.
+  // (The scaffolded root `features/` lane is ignored above; this covers our own
+  // packages/cli/features/ suite, which is typechecked and stays linted.)
+  {
+    name: 'cucumber-steps-override',
+    files: ['**/features/**/*.ts'],
+    rules: {
+      'unicorn/no-this-outside-of-class': 'off',
+      'unicorn/no-top-level-side-effects': 'off',
+    },
+  },
+
   // Website package overrides - Astro has virtual modules and special patterns
   {
     name: 'website-package-override',

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.52.2",
+      "version": "0.53.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/eslint.config.ts
+++ b/packages/cli/eslint.config.ts
@@ -11,8 +11,8 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 import safeword from './src/presets/typescript/index.js';
 
 const { detect, configs } = safeword;
-const deps = detect.collectAllDeps(import.meta.dirname);
-const framework = detect.detectFramework(deps);
+const dependencies = detect.collectAllDeps(import.meta.dirname);
+const framework = detect.detectFramework(dependencies);
 
 // Map framework to base config
 // Note: Astro config only lints .astro files, so we combine it with TypeScript config
@@ -29,10 +29,10 @@ export default defineConfig([
   { ignores: detect.getIgnores() },
 
   ...baseConfigs[framework],
-  ...(detect.hasVitest(deps) ? configs.vitest : []),
-  ...(detect.hasPlaywright(deps) ? configs.playwright : []),
-  ...(detect.hasTailwind(deps) ? configs.tailwind : []),
-  ...(detect.hasTanstackQuery(deps) ? configs.tanstackQuery : []),
+  ...(detect.hasVitest(dependencies) ? configs.vitest : []),
+  ...(detect.hasPlaywright(dependencies) ? configs.playwright : []),
+  ...(detect.hasTailwind(dependencies) ? configs.tailwind : []),
+  ...(detect.hasTanstackQuery(dependencies) ? configs.tanstackQuery : []),
   configs.cli,
   configs.relaxedTypes,
   eslintConfigPrettier,

--- a/packages/cli/features/steps/codex.steps.ts
+++ b/packages/cli/features/steps/codex.steps.ts
@@ -89,9 +89,9 @@ function runSafeword(projectRoot: string, args: string[], options: { fakeCodexBi
     encoding: 'utf8',
     env: {
       ...process.env,
-      ...(options.fakeCodexBin
-        ? { PATH: `${options.fakeCodexBin}${nodePath.delimiter}${process.env.PATH ?? ''}` }
-        : {}),
+      ...(options.fakeCodexBin && {
+        PATH: `${options.fakeCodexBin}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      }),
       SAFEWORD_NO_MODIFY: '1',
       SAFEWORD_SKIP_INSTALL: '1',
     },
@@ -176,7 +176,7 @@ function runCodexHook(
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: projectRoot,
-      ...(options.fallbackMode ? { SAFEWORD_CODEX_DENY_MODE: 'exit-code' } : {}),
+      ...(options.fallbackMode && { SAFEWORD_CODEX_DENY_MODE: 'exit-code' }),
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,6 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "node scripts/check-bun-publish.js && bun run test:release && bun run build",
     "lint:eslint": "eslint .",
-    "lint:eslint:v10": "node ./node_modules/eslint-v10/bin/eslint.js src tests",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "knip": "knip",
@@ -63,7 +62,7 @@
     "@cucumber/messages": "^33.0.2",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint-react/eslint-plugin": "5.9.0",
-    "@eslint/js": "^9.39.4",
+    "@eslint/js": "^10.0.1",
     "@next/eslint-plugin-next": "16.2.9",
     "@tanstack/eslint-plugin-query": "5.101.0",
     "@vitest/eslint-plugin": "^1.6.20",
@@ -84,7 +83,7 @@
     "eslint-plugin-sonarjs": "4.0.3",
     "eslint-plugin-storybook": "10.4.5",
     "eslint-plugin-turbo": "2.9.18",
-    "eslint-plugin-unicorn": "64.0.0",
+    "eslint-plugin-unicorn": "68.0.0",
     "typescript-eslint": "8.61.0",
     "yaml": "^2.9.0"
   },
@@ -93,8 +92,7 @@
     "@types/estree": "^1.0.9",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "^4.1.9",
-    "eslint": "^9.39.4",
-    "eslint-v10": "npm:eslint@^10.5.0",
+    "eslint": "^10.5.0",
     "knip": "6.17.1",
     "prettier": "^3.8.4",
     "publint": "^0.3.21",
@@ -104,7 +102,7 @@
     "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "eslint": "^9.22.0 || ^10.0.0"
+    "eslint": "^10.4.0"
   },
   "keywords": [
     "cli",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.52.2",
+  "version": "0.53.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/src/commands/codify.ts
+++ b/packages/cli/src/commands/codify.ts
@@ -61,9 +61,8 @@ function codifySync(ticket: string, options: CodifyOptions): void {
 
 function parseCodifyScenarios(source: CodifySource): ParsedScenario[] {
   try {
-    return source.kind === 'feature'
-      ? parseFeatureScenarios(source.content)
-      : parseScenarios(source.content);
+    const parse = source.kind === 'feature' ? parseFeatureScenarios : parseScenarios;
+    return parse(source.content);
   } catch (parseError: unknown) {
     if (parseError instanceof FeatureParseError) {
       fail(`${source.displayPath}: invalid Gherkin feature: ${parseError.message}`);

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -137,34 +137,36 @@ function actionsToDiffs(actions: Action[], cwd: string): FileDiff[] {
   const seenPaths = new Set<string>();
 
   for (const action of actions) {
-    if (action.type === 'write') {
-      if (seenPaths.has(action.path)) continue;
-      seenPaths.add(action.path);
+    if (action.type !== 'write') {
+    	continue;
+    }
 
-      const fullPath = nodePath.join(cwd, action.path);
-      const currentContent = readFileSafe(fullPath);
+    if (seenPaths.has(action.path)) continue;
+    seenPaths.add(action.path);
 
-      if (currentContent === undefined) {
-        diffs.push({
-          path: action.path,
-          status: 'added',
-          newContent: action.content,
-        });
-      } else if (currentContent.trim() === action.content.trim()) {
-        diffs.push({
-          path: action.path,
-          status: 'unchanged',
-          currentContent,
-          newContent: action.content,
-        });
-      } else {
-        diffs.push({
-          path: action.path,
-          status: 'modified',
-          currentContent,
-          newContent: action.content,
-        });
-      }
+    const fullPath = nodePath.join(cwd, action.path);
+    const currentContent = readFileSafe(fullPath);
+
+    if (currentContent === undefined) {
+      diffs.push({
+        path: action.path,
+        status: 'added',
+        newContent: action.content,
+      });
+    } else if (currentContent.trim() === action.content.trim()) {
+      diffs.push({
+        path: action.path,
+        status: 'unchanged',
+        currentContent,
+        newContent: action.content,
+      });
+    } else {
+      diffs.push({
+        path: action.path,
+        status: 'modified',
+        currentContent,
+        newContent: action.content,
+      });
     }
   }
 

--- a/packages/cli/src/commands/reset.ts
+++ b/packages/cli/src/commands/reset.ts
@@ -25,17 +25,17 @@ interface ResetOptions {
 function uninstallPackages(cwd: string, packages: string[]): void {
   if (packages.length === 0) return;
 
-  const uninstallCmd = getUninstallCommand(packages, cwd);
+  const uninstallCommand = getUninstallCommand(packages, cwd);
 
   info('\nUninstalling devDependencies...');
-  info(`Running: ${uninstallCmd}`);
+  info(`Running: ${uninstallCommand}`);
 
   try {
-    execSync(uninstallCmd, { cwd, stdio: 'inherit' });
+    execSync(uninstallCommand, { cwd, stdio: 'inherit' });
     success('Uninstalled safeword devDependencies');
   } catch {
     warn('Failed to uninstall some packages. Run manually:');
-    listItem(uninstallCmd);
+    listItem(uninstallCommand);
   }
 }
 
@@ -69,12 +69,12 @@ export async function reset(options: ResetOptions): Promise<void> {
     return;
   }
 
-  const fullReset = options.full ?? false;
-  const mode = fullReset ? 'uninstall-full' : 'uninstall';
+  const isFullReset = options.full ?? false;
+  const mode = isFullReset ? 'uninstall-full' : 'uninstall';
 
   header('Safeword Reset');
   info(
-    fullReset
+    isFullReset
       ? 'Performing full reset (including linting configuration)...'
       : 'Removing safeword configuration...',
   );
@@ -83,8 +83,8 @@ export async function reset(options: ResetOptions): Promise<void> {
     const ctx = createProjectContext(cwd);
     const result = await reconcile(SAFEWORD_SCHEMA, mode, ctx);
 
-    if (fullReset) uninstallPackages(cwd, result.packagesToRemove);
-    printResetSummary(result, fullReset);
+    if (isFullReset) uninstallPackages(cwd, result.packagesToRemove);
+    printResetSummary(result, isFullReset);
   } catch (error_) {
     error(`Reset failed: ${error_ instanceof Error ? error_.message : 'Unknown error'}`);
     process.exit(1);

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -111,9 +111,10 @@ function setupWorkspaceFormatScripts(cwd: string, ctx: ProjectContext): string[]
     const isGlobPattern = pattern.endsWith('/*');
     const workspacePath = isGlobPattern ? pattern.slice(0, -2) : pattern;
 
-    const patternUpdates = isGlobPattern
-      ? processGlobWorkspacePattern(cwd, workspacePath)
-      : processExplicitWorkspacePath(cwd, workspacePath);
+    const processWorkspacePattern = isGlobPattern
+      ? processGlobWorkspacePattern
+      : processExplicitWorkspacePath;
+    const patternUpdates = processWorkspacePattern(cwd, workspacePath);
 
     updated.push(...patternUpdates);
   }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -185,7 +185,7 @@ function getPythonTools(includeImportLinter: boolean): string[] {
  * This function handles dependency installation.
  */
 function setupPython(cwd: string): PythonSetupStatus {
-  let installFailed = false;
+  let isInstallFailed = false;
 
   // Detect layers for import-linter
   const layers = detectPythonLayers(cwd);
@@ -196,20 +196,20 @@ function setupPython(cwd: string): PythonSetupStatus {
     const tools = getPythonTools(hasLayers);
     const pm = detectPythonPackageManager(cwd);
     if (pm === 'pip') {
-      installFailed = true;
+      isInstallFailed = true;
     } else {
       info(`\nInstalling Python tools (${tools.join(', ')})...`);
-      const installed = installPythonDependencies(cwd, tools);
-      if (installed) {
+      const isInstalled = installPythonDependencies(cwd, tools);
+      if (isInstalled) {
         success('Python tools installed');
       } else {
-        installFailed = true;
+        isInstallFailed = true;
       }
     }
   }
 
   // Note: files are now created by reconciliation, not returned here
-  return { files: [], installFailed, importLinter: hasLayers };
+  return { files: [], installFailed: isInstallFailed, importLinter: hasLayers };
 }
 
 interface SetupSummaryOptions {
@@ -448,11 +448,11 @@ export async function setup(options: SetupOptions): Promise<void> {
     process.exit(1);
   }
 
-  const packageJsonCreated = ensurePackageJson(cwd);
+  const isPackageJsonCreated = ensurePackageJson(cwd);
 
   header('Safeword Setup');
   info(`Version: ${VERSION}`);
-  if (packageJsonCreated) info('Created package.json (none found)');
+  if (isPackageJsonCreated) info('Created package.json (none found)');
   warnIfBunMissing();
   warnIfCodexBelowHookFloor();
 
@@ -484,7 +484,7 @@ export async function setup(options: SetupOptions): Promise<void> {
     printSetupSummary({
       cwd,
       result,
-      packageJsonCreated,
+      packageJsonCreated: isPackageJsonCreated,
       languages,
       archFiles,
       workspaceUpdates,

--- a/packages/cli/src/commands/sync-config.ts
+++ b/packages/cli/src/commands/sync-config.ts
@@ -10,10 +10,10 @@ import nodePath from 'node:path';
 
 import { detectArchitecture } from '../utils/boundaries.js';
 import {
-  type DepCruiseArchitecture,
+  type DepCruiseArchitecture as DependencyCruiseArchitecture,
   detectWorkspaces,
-  generateDepCruiseConfigFile,
-  generateDepCruiseMainConfig,
+  generateDepCruiseConfigFile as generateDependencyCruiseConfigFile,
+  generateDepCruiseMainConfig as generateDependencyCruiseMainConfig,
 } from '../utils/depcruise-config.js';
 import { exists } from '../utils/fs.js';
 import { error, info, success } from '../utils/output.js';
@@ -27,7 +27,7 @@ interface SyncConfigResult {
  * Core sync logic - writes depcruise configs to disk
  * Can be called from setup or as standalone command
  */
-export function syncConfigCore(cwd: string, arch: DepCruiseArchitecture): SyncConfigResult {
+export function syncConfigCore(cwd: string, arch: DependencyCruiseArchitecture): SyncConfigResult {
   const safewordDirectory = nodePath.join(cwd, '.safeword');
   const result: SyncConfigResult = {
     generatedConfig: false,
@@ -36,7 +36,7 @@ export function syncConfigCore(cwd: string, arch: DepCruiseArchitecture): SyncCo
 
   // Generate and write .safeword/depcruise-config.cjs (CJS for compatibility)
   const generatedConfigPath = nodePath.join(safewordDirectory, 'depcruise-config.cjs');
-  const generatedConfig = generateDepCruiseConfigFile(arch);
+  const generatedConfig = generateDependencyCruiseConfigFile(arch);
   writeFileSync(generatedConfigPath, generatedConfig);
   result.generatedConfig = true;
 
@@ -44,7 +44,7 @@ export function syncConfigCore(cwd: string, arch: DepCruiseArchitecture): SyncCo
   // Use .cjs extension to work in ESM projects (type: "module")
   const mainConfigPath = nodePath.join(cwd, '.dependency-cruiser.cjs');
   if (!exists(mainConfigPath)) {
-    const mainConfig = generateDepCruiseMainConfig();
+    const mainConfig = generateDependencyCruiseMainConfig();
     writeFileSync(mainConfigPath, mainConfig);
     result.createdMainConfig = true;
   }
@@ -55,7 +55,7 @@ export function syncConfigCore(cwd: string, arch: DepCruiseArchitecture): SyncCo
 /**
  * Build full architecture info by combining detected layers with workspaces
  */
-export function buildArchitecture(cwd: string): DepCruiseArchitecture {
+export function buildArchitecture(cwd: string): DependencyCruiseArchitecture {
   const arch = detectArchitecture(cwd);
   const workspaces = detectWorkspaces(cwd);
   return { ...arch, workspaces };
@@ -64,7 +64,7 @@ export function buildArchitecture(cwd: string): DepCruiseArchitecture {
 /**
  * Check if architecture was detected (layers, monorepo structure, or workspaces)
  */
-export function hasArchitectureDetected(arch: DepCruiseArchitecture): boolean {
+export function hasArchitectureDetected(arch: DependencyCruiseArchitecture): boolean {
   return arch.elements.length > 0 || arch.isMonorepo || (arch.workspaces?.length ?? 0) > 0;
 }
 
@@ -75,13 +75,13 @@ export function hasArchitectureDetected(arch: DepCruiseArchitecture): boolean {
  */
 function checkConfig(
   cwd: string,
-  arch: DepCruiseArchitecture,
+  arch: DependencyCruiseArchitecture,
 ): { matches: true } | { matches: false; reason: 'missing' | 'drifted' } {
   const generatedConfigPath = nodePath.join(cwd, '.safeword', 'depcruise-config.cjs');
   if (!exists(generatedConfigPath)) {
     return { matches: false, reason: 'missing' };
   }
-  const generated = generateDepCruiseConfigFile(arch);
+  const generated = generateDependencyCruiseConfigFile(arch);
   const onDisk = readFileSync(generatedConfigPath, 'utf8');
   return generated === onDisk ? { matches: true } : { matches: false, reason: 'drifted' };
 }

--- a/packages/cli/src/commands/sync-config.ts
+++ b/packages/cli/src/commands/sync-config.ts
@@ -10,10 +10,10 @@ import nodePath from 'node:path';
 
 import { detectArchitecture } from '../utils/boundaries.js';
 import {
-  type DepCruiseArchitecture as DependencyCruiseArchitecture,
+  type DependencyCruiseArchitecture,
   detectWorkspaces,
-  generateDepCruiseConfigFile as generateDependencyCruiseConfigFile,
-  generateDepCruiseMainConfig as generateDependencyCruiseMainConfig,
+  generateDependencyCruiseConfigFile,
+  generateDependencyCruiseMainConfig,
 } from '../utils/depcruise-config.js';
 import { exists } from '../utils/fs.js';
 import { error, info, success } from '../utils/output.js';

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -156,11 +156,11 @@ function printUpgradeSummary(result: ReconcileResult, projectVersion: string, cw
   }
 
   if (result.packagesToRemove.length > 0) {
-    const uninstallCmd = getUninstallCommand(result.packagesToRemove, cwd);
+    const uninstallCommand = getUninstallCommand(result.packagesToRemove, cwd);
     warn(`\n${result.packagesToRemove.length} package(s) are now bundled in safeword:`);
     for (const pkg of result.packagesToRemove) listItem(pkg);
     info("\nIf you don't use these elsewhere, you can remove them:");
-    listItem(uninstallCmd);
+    listItem(uninstallCommand);
   }
 
   if (reconciledCodexConfig(result)) {
@@ -181,8 +181,8 @@ function installPythonBasedTools(pythonDirectory: string, packages: string[], la
     return;
   }
   info(`\nInstalling ${label} (${packages.join(', ')})...`);
-  const installed = installPythonDependencies(pythonDirectory, packages);
-  if (installed) {
+  const isInstalled = installPythonDependencies(pythonDirectory, packages);
+  if (isInstalled) {
     success(`${label} installed`);
   } else {
     warn(`${label} install failed. Install manually:`);
@@ -266,10 +266,10 @@ async function resolveMigrationConsent(options: UpgradeOptions): Promise<boolean
   if (options.migrateNamespace !== undefined) return options.migrateNamespace;
 
   // An injected confirm seam counts as interactive — it IS the TTY stand-in.
-  const interactive =
+  const isInteractive =
     options.confirmMigration !== undefined ||
-    (process.stdin.isTTY === true && process.stdout.isTTY === true);
-  if (!interactive) {
+    (process.stdin.isTTY && process.stdout.isTTY);
+  if (!isInteractive) {
     info(
       'Namespace: this project uses the legacy .safeword-project/ — run `safeword upgrade --migrate-namespace` to converge on .project/ (recommended).',
     );

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -102,7 +102,7 @@ function isNonRegistryPackageSpec(spec: string): boolean {
 }
 
 function isCurrentSafewordRegistrySpec(spec: string): boolean {
-  return spec === VERSION || spec === SAFEWORD_REGISTRY_SPEC || spec === `~${VERSION}`;
+  return [VERSION, SAFEWORD_REGISTRY_SPEC, `~${VERSION}`].includes(spec);
 }
 
 function syncPackageJsonSafewordVersion(cwd: string): boolean {
@@ -267,8 +267,7 @@ async function resolveMigrationConsent(options: UpgradeOptions): Promise<boolean
 
   // An injected confirm seam counts as interactive — it IS the TTY stand-in.
   const isInteractive =
-    options.confirmMigration !== undefined ||
-    (process.stdin.isTTY && process.stdout.isTTY);
+    options.confirmMigration !== undefined || (process.stdin.isTTY && process.stdout.isTTY);
   if (!isInteractive) {
     info(
       'Namespace: this project uses the legacy .safeword-project/ — run `safeword upgrade --migrate-namespace` to converge on .project/ (recommended).',

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -219,15 +219,15 @@ function findArchitectureAdvisories(cwd: string): string[] {
 /** Whether the impl plan's `## Arch alignment` section carries real content
  * (non-empty, not a `skip:` annotation). */
 function archAlignmentHasContent(implPlanContent: string): boolean {
-  let inSection = false;
+  let isInSection = false;
   const body: string[] = [];
   for (const raw of implPlanContent.split('\n')) {
     const line = raw.trim();
     if (line.startsWith('## ')) {
-      inSection = line.slice(3).trim().toLowerCase() === 'arch alignment';
+      isInSection = line.slice(3).trim().toLowerCase() === 'arch alignment';
       continue;
     }
-    if (inSection && line !== '') body.push(line);
+    if (isInSection && line !== '') body.push(line);
   }
   if (body.length === 0) return false;
   return !(body.length === 1 && (body[0] ?? '').toLowerCase().startsWith('skip:'));

--- a/packages/cli/src/packs/golang/files.ts
+++ b/packages/cli/src/packs/golang/files.ts
@@ -128,9 +128,9 @@ function generateSafewordGolangciConfig(existingConfig: string | undefined, cwd:
       return getSafewordGolangciStandalone();
     }
 
-    return projectConfig.version === '2'
-      ? getSafewordGolangciMergedV2(projectConfig)
-      : getSafewordGolangciMergedV1(projectConfig);
+    const merge =
+      projectConfig.version === '2' ? getSafewordGolangciMergedV2 : getSafewordGolangciMergedV1;
+    return merge(projectConfig);
   } catch {
     console.warn(`Safeword: Could not parse ${existingConfig}, using standalone config`);
     return getSafewordGolangciStandalone();
@@ -258,20 +258,23 @@ function fillGapMerge(
   const result: Record<string, unknown> = { ...base };
 
   for (const [key, defaultValue] of Object.entries(defaults)) {
-    if (!(key in result)) {
+    if (Object.hasOwn(result, key)) {
+      const existingValue = result[key];
+      if (
+        defaultValue &&
+        typeof defaultValue === 'object' &&
+        !Array.isArray(defaultValue) &&
+        existingValue &&
+        typeof existingValue === 'object' &&
+        !Array.isArray(existingValue)
+      ) {
+        result[key] = fillGapMerge(
+          existingValue as Record<string, unknown>,
+          defaultValue as Record<string, unknown>,
+        );
+      }
+    } else {
       result[key] = defaultValue;
-    } else if (
-      defaultValue &&
-      typeof defaultValue === 'object' &&
-      !Array.isArray(defaultValue) &&
-      result[key] &&
-      typeof result[key] === 'object' &&
-      !Array.isArray(result[key])
-    ) {
-      result[key] = fillGapMerge(
-        result[key] as Record<string, unknown>,
-        defaultValue as Record<string, unknown>,
-      );
     }
   }
 

--- a/packages/cli/src/packs/python/setup.ts
+++ b/packages/cli/src/packs/python/setup.ts
@@ -35,19 +35,28 @@ const PYTHON_LAYERS: Record<string, string[]> = {
  * @param cwd - Project root directory
  * @returns Array of detected layer names in dependency order (domain first)
  */
+/**
+ * Whether any of the given layer patterns exists under `cwd` (either at
+ * `src/{pattern}` or `{pattern}`).
+ */
+function hasAnyLayerPattern(cwd: string, patterns: readonly string[]): boolean {
+  for (const pattern of patterns) {
+    // Check common locations: src/{pattern}, {pattern}
+    const srcPath = nodePath.join(cwd, 'src', pattern);
+    const rootPath = nodePath.join(cwd, pattern);
+    if (exists(srcPath) || exists(rootPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function detectPythonLayers(cwd: string): string[] {
   const detected: string[] = [];
 
   for (const [layer, patterns] of Object.entries(PYTHON_LAYERS)) {
-    for (const pattern of patterns) {
-      // Check common locations: src/{pattern}, {pattern}
-      const srcPath = nodePath.join(cwd, 'src', pattern);
-      const rootPath = nodePath.join(cwd, pattern);
-
-      if (exists(srcPath) || exists(rootPath)) {
-        detected.push(layer);
-        break; // Only add layer once
-      }
+    if (hasAnyLayerPattern(cwd, patterns)) {
+      detected.push(layer);
     }
   }
 

--- a/packages/cli/src/packs/sql/dialect.ts
+++ b/packages/cli/src/packs/sql/dialect.ts
@@ -172,9 +172,9 @@ function detectFromPythonDependencies(cwd: string): string | undefined {
     // Match dbt-{adapter} packages, skipping dbt-core (framework, not adapter)
     const adapters = content
       .matchAll(/dbt-(\w+)/g)
-      .toArray()
       .map(m => m[1])
-      .filter((a): a is string => a !== undefined && a !== 'core');
+      .filter((a): a is string => a !== undefined && a !== 'core')
+      .toArray();
     for (const adapter of adapters) {
       const dialect = ADAPTER_TO_DIALECT[adapter];
       if (dialect) return dialect;

--- a/packages/cli/src/packs/sql/dialect.ts
+++ b/packages/cli/src/packs/sql/dialect.ts
@@ -170,7 +170,9 @@ function detectFromPythonDependencies(cwd: string): string | undefined {
     if (!content) return undefined;
 
     // Match dbt-{adapter} packages, skipping dbt-core (framework, not adapter)
-    const adapters = [...content.matchAll(/dbt-(\w+)/g)]
+    const adapters = content
+      .matchAll(/dbt-(\w+)/g)
+      .toArray()
       .map(m => m[1])
       .filter((a): a is string => a !== undefined && a !== 'core');
     for (const adapter of adapters) {

--- a/packages/cli/src/packs/sql/dialect.ts
+++ b/packages/cli/src/packs/sql/dialect.ts
@@ -96,7 +96,7 @@ const PROVIDER_TO_DIALECT: Record<string, string> = {
 export function detectSqlDialect(cwd: string): string | undefined {
   return (
     detectFromProfiles(cwd) ??
-    detectFromPythonDeps(cwd) ??
+    detectFromPythonDependencies(cwd) ??
     detectFromSqlcConfig(cwd) ??
     detectFromPrismaSchema(cwd) ??
     detectFromDrizzleConfig(cwd) ??
@@ -153,7 +153,7 @@ function detectFromProfiles(cwd: string): string | undefined {
 }
 
 /** Signal 2: dbt-{adapter} packages in Python dependency files. */
-function detectFromPythonDeps(cwd: string): string | undefined {
+function detectFromPythonDependencies(cwd: string): string | undefined {
   const directory = findInTree(cwd, 'requirements.txt') ?? findInTree(cwd, 'pyproject.toml');
   if (!directory) return undefined;
 

--- a/packages/cli/src/packs/sql/index.ts
+++ b/packages/cli/src/packs/sql/index.ts
@@ -37,10 +37,12 @@ function directoryHasSqlFiles(directory: string): boolean {
     if (entries.some(entry => entry.isFile() && entry.name.endsWith('.sql'))) return true;
     // Check subdirectories for .sql files (prisma/migrations/20210313_init/migration.sql)
     for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const subEntries = readdirSync(nodePath.join(directory, entry.name));
-        if (subEntries.some(f => f.endsWith('.sql'))) return true;
+      if (!entry.isDirectory()) {
+      	continue;
       }
+
+      const subEntries = readdirSync(nodePath.join(directory, entry.name));
+      if (subEntries.some(f => f.endsWith('.sql'))) return true;
     }
     return false;
   } catch {

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -30,10 +30,7 @@ import type {
 /**
  * Add framework-specific ignores to Knip config.
  */
-function addKnipIgnores(
-  config: { ignore: string[]; ignoreDependencies: string[] },
-  ctx: ProjectContext,
-): void {
+function addKnipIgnores(config: { ignore: string[] }, ctx: ProjectContext): void {
   const allDependencies = ctx.developmentDeps;
 
   // Framework build/cache directories
@@ -54,7 +51,7 @@ function addKnipIgnores(
  * Add framework-specific ignoreDependencies to Knip config.
  */
 function addKnipIgnoreDependencies(
-  config: { ignore: string[]; ignoreDependencies: string[] },
+  config: { ignoreDependencies: string[] },
   ctx: ProjectContext,
 ): void {
   const allDependencies = ctx.developmentDeps;
@@ -324,7 +321,8 @@ export const typescriptManagedFiles: Record<string, ManagedFileDefinition> = {
  * Add a script if it doesn't exist.
  */
 function addScriptIfMissing(scripts: Record<string, string>, name: string, command: string): void {
-  if (!scripts[name]) scripts[name] = command;
+  const existing = scripts[name];
+  if (!existing) scripts[name] = command;
 }
 
 const GHERKIN_LINT_SCRIPT = 'safeword lint-gherkin';

--- a/packages/cli/src/packs/typescript/files.ts
+++ b/packages/cli/src/packs/typescript/files.ts
@@ -34,18 +34,18 @@ function addKnipIgnores(
   config: { ignore: string[]; ignoreDependencies: string[] },
   ctx: ProjectContext,
 ): void {
-  const allDeps = ctx.developmentDeps;
+  const allDependencies = ctx.developmentDeps;
 
   // Framework build/cache directories
   if (ctx.projectType.nextjs) config.ignore.push('.next/**');
   if (ctx.projectType.astro) config.ignore.push('.astro/**');
-  if ('storybook' in allDeps || '@storybook/react' in allDeps) {
+  if ('storybook' in allDependencies || '@storybook/react' in allDependencies) {
     config.ignore.push('.storybook/**', 'storybook-static/**');
   }
-  if ('turbo' in allDeps) config.ignore.push('.turbo/**');
+  if ('turbo' in allDependencies) config.ignore.push('.turbo/**');
 
   // Electron - Knip has no Electron plugin
-  if ('electron' in allDeps || 'electron' in ctx.productionDeps) {
+  if ('electron' in allDependencies || 'electron' in ctx.productionDeps) {
     config.ignore.push('electron/**', 'dist-electron/**', 'out/**');
   }
 }
@@ -57,18 +57,18 @@ function addKnipIgnoreDependencies(
   config: { ignore: string[]; ignoreDependencies: string[] },
   ctx: ProjectContext,
 ): void {
-  const allDeps = ctx.developmentDeps;
+  const allDependencies = ctx.developmentDeps;
 
   // Dependencies used via config files, not imports
   if (ctx.projectType.tailwind) {
     config.ignoreDependencies.push('tailwindcss', '@tailwindcss/typography', '@tailwindcss/forms');
   }
   if (ctx.projectType.playwright) config.ignoreDependencies.push('@playwright/test');
-  if ('husky' in allDeps) config.ignoreDependencies.push('husky');
-  if ('lint-staged' in allDeps) config.ignoreDependencies.push('lint-staged');
+  if ('husky' in allDependencies) config.ignoreDependencies.push('husky');
+  if ('lint-staged' in allDependencies) config.ignoreDependencies.push('lint-staged');
 
   // Electron ecosystem packages
-  if ('electron' in allDeps || 'electron' in ctx.productionDeps) {
+  if ('electron' in allDependencies || 'electron' in ctx.productionDeps) {
     config.ignoreDependencies.push(
       'electron',
       'electron-builder',

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -36,13 +36,13 @@ function checkPair(
 ): ParityFailure | undefined {
   const templateFile = nodePath.join(templatesDirectory, template);
   const dogfoodFile = nodePath.join(rootDirectory, destinationPath);
-  const templateExists = existsSync(templateFile);
-  const dogfoodExists = existsSync(dogfoodFile);
+  const isTemplateExists = existsSync(templateFile);
+  const isDogfoodExists = existsSync(dogfoodFile);
 
-  if (!templateExists || !dogfoodExists) {
+  if (!isTemplateExists || !isDogfoodExists) {
     const missing: string[] = [];
-    if (!templateExists) missing.push(template);
-    if (!dogfoodExists) missing.push(destinationPath);
+    if (!isTemplateExists) missing.push(template);
+    if (!isDogfoodExists) missing.push(destinationPath);
     return { kind: 'pair', message: `[PAIR] Missing file(s): ${missing.join(', ')}` };
   }
 

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -75,7 +75,8 @@ function checkContract(
 function collectTemplateFiles(directory: string, prefix = ''): string[] {
   if (!existsSync(directory)) return [];
   const files: string[] = [];
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  for (const entry of entries) {
     const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
       if (entry.name.startsWith('_')) continue;
@@ -114,7 +115,8 @@ function checkCursorRulesThin(templatesDirectory: string): ParityFailure[] {
   const rulesDirectory = nodePath.join(templatesDirectory, 'cursor', 'rules');
   if (!existsSync(rulesDirectory)) return [];
   const failures: ParityFailure[] = [];
-  for (const entry of readdirSync(rulesDirectory, { withFileTypes: true })) {
+  const ruleEntries = readdirSync(rulesDirectory, { withFileTypes: true });
+  for (const entry of ruleEntries) {
     if (!entry.isFile() || !entry.name.endsWith('.mdc')) continue;
     // Split on \r?\n so a CRLF-saved rule isn't misread as frontmatter-less
     // (which would flag a valid thin rule as fat).

--- a/packages/cli/src/presets/typescript/detect.ts
+++ b/packages/cli/src/presets/typescript/detect.ts
@@ -96,13 +96,13 @@ const ALTERNATIVE_FORMATTER_FILES = [
   'deno.jsonc',
 ] as const;
 
-type DepsRecord = Record<string, string | undefined>;
+type DependenciesRecord = Record<string, string | undefined>;
 type ScriptsRecord = Record<string, string | undefined>;
 
 /**
  * Read dependencies from a package.json file.
  */
-function readPackageDeps(pkgPath: string): DepsRecord {
+function readPackageDependencies(pkgPath: string): DependenciesRecord {
   try {
     if (!existsSync(pkgPath)) return {};
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
@@ -124,85 +124,85 @@ function getMonorepoPatterns(rootDirectory: string): string[] {
 /**
  * Scan a workspace directory for package.json files.
  */
-function scanWorkspaceDirectory(rootDirectory: string, pattern: string): DepsRecord {
+function scanWorkspaceDirectory(rootDirectory: string, pattern: string): DependenciesRecord {
   if (!pattern.endsWith('/*')) return {};
 
   const baseDirectory = path.join(rootDirectory, pattern.slice(0, -2));
   if (!existsSync(baseDirectory)) return {};
 
-  const allDeps: DepsRecord = {};
+  const allDependencies: DependenciesRecord = {};
   try {
     const entries = readdirSync(baseDirectory, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.isDirectory()) {
         Object.assign(
-          allDeps,
-          readPackageDeps(path.join(baseDirectory, entry.name, 'package.json')),
+          allDependencies,
+          readPackageDependencies(path.join(baseDirectory, entry.name, 'package.json')),
         );
       }
     }
   } catch {
     // Ignore read errors
   }
-  return allDeps;
+  return allDependencies;
 }
 
 /**
  * Collect all dependencies from root and workspace package.json files.
  * Supports npm/yarn workspaces and common monorepo patterns.
  */
-function collectAllDeps(rootDirectory: string): DepsRecord {
+function collectAllDependencies(rootDirectory: string): DependenciesRecord {
   const rootPackagePath = path.join(rootDirectory, 'package.json');
-  const allDeps = readPackageDeps(rootPackagePath);
+  const allDependencies = readPackageDependencies(rootPackagePath);
 
   // Scan each workspace pattern
   for (const pattern of getMonorepoPatterns(rootDirectory)) {
-    Object.assign(allDeps, scanWorkspaceDirectory(rootDirectory, pattern));
+    Object.assign(allDependencies, scanWorkspaceDirectory(rootDirectory, pattern));
   }
 
-  return allDeps;
+  return allDependencies;
 }
 
 /**
  * Check if Tailwind CSS is installed.
  */
-function hasTailwind(deps: DepsRecord): boolean {
-  return TAILWIND_PACKAGES.some(pkg => pkg in deps);
+function hasTailwind(dependencies: DependenciesRecord): boolean {
+  return TAILWIND_PACKAGES.some(pkg => pkg in dependencies);
 }
 
 /**
  * Check if TanStack Query is installed.
  */
-function hasTanstackQuery(deps: DepsRecord): boolean {
-  return TANSTACK_QUERY_PACKAGES.some(pkg => pkg in deps);
+function hasTanstackQuery(dependencies: DependenciesRecord): boolean {
+  return TANSTACK_QUERY_PACKAGES.some(pkg => pkg in dependencies);
 }
 
 /**
  * Check if Vitest is installed.
  */
-function hasVitest(deps: DepsRecord): boolean {
-  return 'vitest' in deps;
+function hasVitest(dependencies: DependenciesRecord): boolean {
+  return 'vitest' in dependencies;
 }
 
 /**
  * Check if Playwright is installed.
  */
-function hasPlaywright(deps: DepsRecord): boolean {
-  return PLAYWRIGHT_PACKAGES.some(pkg => pkg in deps);
+function hasPlaywright(dependencies: DependenciesRecord): boolean {
+  return PLAYWRIGHT_PACKAGES.some(pkg => pkg in dependencies);
 }
 
 /**
  * Check if Turborepo is installed.
  */
-function hasTurbo(deps: DepsRecord): boolean {
-  return 'turbo' in deps;
+function hasTurbo(dependencies: DependenciesRecord): boolean {
+  return 'turbo' in dependencies;
 }
 
 /**
  * Check if Storybook is installed.
  */
-function hasStorybook(deps: DepsRecord): boolean {
-  return STORYBOOK_PACKAGES.some(pkg => pkg in deps);
+function hasStorybook(dependencies: DependenciesRecord): boolean {
+  return STORYBOOK_PACKAGES.some(pkg => pkg in dependencies);
 }
 
 /**
@@ -210,12 +210,12 @@ function hasStorybook(deps: DepsRecord): boolean {
  * Returns the most specific framework detected.
  */
 function detectFramework(
-  deps: DepsRecord,
+  dependencies: DependenciesRecord,
 ): 'next' | 'react' | 'astro' | 'typescript' | 'javascript' {
-  if ('next' in deps) return 'next';
-  if ('astro' in deps) return 'astro'; // Check before React (Astro+React has both)
-  if ('react' in deps) return 'react';
-  if ('typescript' in deps || 'typescript-eslint' in deps) return 'typescript';
+  if ('next' in dependencies) return 'next';
+  if ('astro' in dependencies) return 'astro'; // Check before React (Astro+React has both)
+  if ('react' in dependencies) return 'react';
+  if ('typescript' in dependencies || 'typescript-eslint' in dependencies) return 'typescript';
   return 'javascript';
 }
 
@@ -400,7 +400,7 @@ export const detect = {
   NEXT_CONFIG_FILES,
 
   // Core utilities
-  collectAllDeps,
+  collectAllDeps: collectAllDependencies,
   detectFramework,
   getIgnores,
 

--- a/packages/cli/src/presets/typescript/detect.ts
+++ b/packages/cli/src/presets/typescript/detect.ts
@@ -167,14 +167,14 @@ function collectAllDependencies(rootDirectory: string): DependenciesRecord {
  * Check if Tailwind CSS is installed.
  */
 function hasTailwind(dependencies: DependenciesRecord): boolean {
-  return TAILWIND_PACKAGES.some(pkg => pkg in dependencies);
+  return TAILWIND_PACKAGES.some(pkg => Object.hasOwn(dependencies, pkg));
 }
 
 /**
  * Check if TanStack Query is installed.
  */
 function hasTanstackQuery(dependencies: DependenciesRecord): boolean {
-  return TANSTACK_QUERY_PACKAGES.some(pkg => pkg in dependencies);
+  return TANSTACK_QUERY_PACKAGES.some(pkg => Object.hasOwn(dependencies, pkg));
 }
 
 /**
@@ -188,7 +188,7 @@ function hasVitest(dependencies: DependenciesRecord): boolean {
  * Check if Playwright is installed.
  */
 function hasPlaywright(dependencies: DependenciesRecord): boolean {
-  return PLAYWRIGHT_PACKAGES.some(pkg => pkg in dependencies);
+  return PLAYWRIGHT_PACKAGES.some(pkg => Object.hasOwn(dependencies, pkg));
 }
 
 /**
@@ -202,7 +202,7 @@ function hasTurbo(dependencies: DependenciesRecord): boolean {
  * Check if Storybook is installed.
  */
 function hasStorybook(dependencies: DependenciesRecord): boolean {
-  return STORYBOOK_PACKAGES.some(pkg => pkg in dependencies);
+  return STORYBOOK_PACKAGES.some(pkg => Object.hasOwn(dependencies, pkg));
 }
 
 /**

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/configs.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/configs.test.ts
@@ -386,14 +386,14 @@ describe('file scoping', () => {
     });
 
     // All Astro configs with astro/ rules should have .astro file scope
-    const allAstroScoped = astroRulesConfigs.every(config => {
+    const isAllAstroScoped = astroRulesConfigs.every(config => {
       if ('files' in config && Array.isArray(config.files)) {
         return config.files.some((f: string) => f.includes('.astro'));
       }
       // Astro plugin may set files via a different mechanism
       return true;
     });
-    expect(allAstroScoped).toBe(true);
+    expect(isAllAstroScoped).toBe(true);
   });
 
   it('combined config lints .ts files without errors', () => {

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/errors-on-bugs.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/errors-on-bugs.test.ts
@@ -54,7 +54,7 @@ function matchesTypeScript(files: unknown): boolean {
     }
     // Check for global patterns that match all files (not extension-specific)
     // e.g., "**/*" but not "**/*.js"
-    return p === '**/*' || p === '*' || p === '**';
+    return ['**/*', '*', '**'].includes(p);
   });
 }
 
@@ -68,7 +68,7 @@ function matchesTypeScript(files: unknown): boolean {
 function getRuleConfigForTs(config: any[], ruleId: string): unknown {
   for (let i = config.length - 1; i >= 0; i--) {
     const c = config[i];
-    if (c && typeof c === 'object' && 'rules' in c && c.rules && ruleId in c.rules) {
+    if (c && typeof c === 'object' && 'rules' in c && c.rules && Object.hasOwn(c.rules, ruleId)) {
       // Skip if this config only applies to JS files
       if (!matchesTypeScript(c.files)) {
         continue;

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/errors-on-bugs.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/errors-on-bugs.test.ts
@@ -54,10 +54,7 @@ function matchesTypeScript(files: unknown): boolean {
     }
     // Check for global patterns that match all files (not extension-specific)
     // e.g., "**/*" but not "**/*.js"
-    if (p === '**/*' || p === '*' || p === '**') {
-      return true;
-    }
-    return false;
+    return p === '**/*' || p === '*' || p === '**';
   });
 }
 
@@ -204,14 +201,15 @@ export { grouped };
       expectLintError(errors);
     });
 
-    it('unicorn/prevent-abbreviations errors on non-standard abbreviations', () => {
+    it('unicorn/name-replacements errors on non-standard abbreviations', () => {
       // ctx, dir, err, etc. are allowed - but uncommon ones like 'str', 'num' are not
+      // (renamed from unicorn/prevent-abbreviations in eslint-plugin-unicorn 68)
       const code = `function process(str, num) {
   return str + num;
 }
 export { process };
 `;
-      const errors = lintJs(code, 'unicorn/prevent-abbreviations');
+      const errors = lintJs(code, 'unicorn/name-replacements');
       expectLintError(errors);
     });
 
@@ -223,11 +221,12 @@ export { value };
       expectLintError(errors);
     });
 
-    it('unicorn/no-array-for-each errors on forEach', () => {
+    it('unicorn/no-for-each errors on forEach', () => {
+      // renamed from unicorn/no-array-for-each in eslint-plugin-unicorn 68
       const code = `const items = [1, 2, 3];
 items.forEach(item => console.log(item));
 `;
-      const errors = lintJs(code, 'unicorn/no-array-for-each');
+      const errors = lintJs(code, 'unicorn/no-for-each');
       expectLintError(errors);
     });
 

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
@@ -203,7 +203,7 @@ describe('React JSX rules (lint behavior)', () => {
       `
 const items = [{ id: 'a' }];
 export function List() {
-  return <ul>{items.map(item => <li>${'{'}item.id}</li>)}</ul>;
+  return <ul>{items.map(item => <li>\{item.id}</li>)}</ul>;
 }
 `,
     );
@@ -239,7 +239,7 @@ export class Counter extends React.Component<object, { count: number }> {
   }
 
   render() {
-    return <button onClick={() => this.increment()}>${'{'}this.state.count}</button>;
+    return <button onClick={() => this.increment()}>{this.state.count}</button>;
   }
 }
 `,
@@ -251,7 +251,7 @@ export class Counter extends React.Component<object, { count: number }> {
       '@eslint-react/jsx-no-children-prop',
       `
 export function Panel({ children }: { children: unknown }) {
-  return <div children=${'{'}children} />;
+  return <div children={children} />;
 }
 `,
     );

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
@@ -55,7 +55,7 @@ function hasPlugin(pluginName: string): boolean {
       config !== null &&
       'plugins' in config &&
       config.plugins &&
-      pluginName in config.plugins,
+      Object.hasOwn(config.plugins, pluginName),
   );
 }
 
@@ -203,7 +203,7 @@ describe('React JSX rules (lint behavior)', () => {
       `
 const items = [{ id: 'a' }];
 export function List() {
-  return <ul>{items.map(item => <li>{item.id}</li>)}</ul>;
+  return <ul>{items.map(item => <li>${'{'}item.id}</li>)}</ul>;
 }
 `,
     );
@@ -239,7 +239,7 @@ export class Counter extends React.Component<object, { count: number }> {
   }
 
   render() {
-    return <button onClick={() => this.increment()}>{this.state.count}</button>;
+    return <button onClick={() => this.increment()}>${'{'}this.state.count}</button>;
   }
 }
 `,
@@ -251,7 +251,7 @@ export class Counter extends React.Component<object, { count: number }> {
       '@eslint-react/jsx-no-children-prop',
       `
 export function Panel({ children }: { children: unknown }) {
-  return <div children={children} />;
+  return <div children=${'{'}children} />;
 }
 `,
     );

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
@@ -16,6 +16,12 @@ import { describe, expect, it } from 'vitest';
 import { recommendedTypeScriptReact } from '../recommended-react.js';
 import { getAllRules, getRuleConfig, getSeverityNumber } from './test-utilities.js';
 
+// JSX fixtures below embed `{expr}` JSX braces inside template-literal source
+// strings. unicorn/no-incorrect-template-string-interpolation reads these as
+// missed `${expr}` interpolation, but they are intentional React source under
+// test — interpolating them would change the fixtures and break the assertions.
+/* eslint-disable unicorn/no-incorrect-template-string-interpolation -- JSX braces in fixture source, not interpolation */
+
 const ERROR = 2;
 const WARN = 1;
 const REACT_SAMPLE_FILENAME = fileURLToPath(new URL('react-sample.tsx', import.meta.url));
@@ -203,7 +209,7 @@ describe('React JSX rules (lint behavior)', () => {
       `
 const items = [{ id: 'a' }];
 export function List() {
-  return <ul>{items.map(item => <li>\{item.id}</li>)}</ul>;
+  return <ul>{items.map(item => <li>{item.id}</li>)}</ul>;
 }
 `,
     );
@@ -342,3 +348,5 @@ describe('No warnings allowed for React guardrails', () => {
     expect(rulesAtWarn).toEqual([]);
   });
 });
+
+/* eslint-enable unicorn/no-incorrect-template-string-interpolation -- end JSX fixture region */

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
@@ -300,34 +300,6 @@ describe('React JSX parity gaps', () => {
   });
 });
 
-describe('React rules under ESLint 10', () => {
-  it('loads and reports replacement React rules without RuleContext API crashes', async () => {
-    const eslint10PackageName = 'eslint-v10';
-    const { Linter: ESLint10Linter } = (await import(eslint10PackageName)) as {
-      Linter: typeof Linter;
-    };
-
-    const messages = lintReactCode(
-      `
-const items = [{ id: 'a' }];
-export function List() {
-  return <ul>{items.map(item => <li>{item.id}</li>)}</ul>;
-}
-`,
-      new ESLint10Linter({ configType: 'flat' }),
-    );
-
-    expect(messages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          ruleId: '@eslint-react/no-missing-key',
-          severity: ERROR,
-        }),
-      ]),
-    );
-  });
-});
-
 describe('Accessibility rules (jsx-a11y)', () => {
   it('includes jsx-a11y plugin', () => {
     expect(hasPlugin('jsx-a11y')).toBe(true);

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/tailwind.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/tailwind.test.ts
@@ -41,9 +41,9 @@ describe('Tailwind config', () => {
       expect(severity).toBe('error');
     });
 
-    it('better-tailwindcss/no-unregistered-classes is error', () => {
+    it('better-tailwindcss/no-unknown-classes is error', () => {
       const severity = getSeverity(
-        getRuleConfig(tailwindConfig, 'better-tailwindcss/no-unregistered-classes'),
+        getRuleConfig(tailwindConfig, 'better-tailwindcss/no-unknown-classes'),
       );
       expect(severity).toBe('error');
     });
@@ -139,6 +139,30 @@ describe('Tailwind config', () => {
 
       // 3 correctness + 8 stylistic = 11 total
       expect(tailwindRules.length).toBe(11);
+    });
+  });
+
+  describe('referenced rules exist in the plugin (no dead rule names)', () => {
+    it('every better-tailwindcss rule we configure is exported by the loaded plugin', () => {
+      // Pull the actual plugin instance out of the config so the check is
+      // grounded in what ESLint loads at runtime — a config-shape assertion
+      // alone cannot catch a rule that was renamed/removed upstream (e.g.
+      // no-unregistered-classes → no-unknown-classes in better-tailwindcss 4.6).
+      const configWithPlugin = tailwindConfig.find(
+        (config: any) => config.plugins?.['better-tailwindcss'],
+      );
+      expect(configWithPlugin).toBeDefined();
+      const plugin = configWithPlugin.plugins['better-tailwindcss'];
+      const exportedRules = new Set(Object.keys(plugin.rules ?? {}));
+      expect(exportedRules.size).toBeGreaterThan(0);
+
+      const referenced = Object.keys(getAllRules(tailwindConfig)).filter(name =>
+        name.startsWith('better-tailwindcss/'),
+      );
+      const dead = referenced.filter(
+        name => !exportedRules.has(name.replace('better-tailwindcss/', '')),
+      );
+      expect(dead).toEqual([]);
     });
   });
 });

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-utilities.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-utilities.ts
@@ -12,7 +12,7 @@
 export function getRuleConfig(config: any[], ruleId: string): any {
   let result: any;
   for (const configObject of config) {
-    if (configObject.rules && ruleId in configObject.rules) {
+    if (configObject.rules && Object.hasOwn(configObject.rules, ruleId)) {
       result = configObject.rules[ruleId];
     }
   }
@@ -38,14 +38,15 @@ export function getSeverity(ruleConfig: any): number | string | undefined {
  * Normalizes string severities to their numeric equivalents.
  */
 export function getSeverityNumber(ruleConfig: unknown): number {
-  if (typeof ruleConfig === 'number') return ruleConfig;
-  if (typeof ruleConfig === 'string') {
-    if (ruleConfig === 'error') return 2;
-    if (ruleConfig === 'warn') return 1;
-    return 0;
+  let current: unknown = ruleConfig;
+  while (Array.isArray(current) && current.length > 0) {
+    current = current[0];
   }
-  if (Array.isArray(ruleConfig) && ruleConfig.length > 0) {
-    return getSeverityNumber(ruleConfig[0]);
+  if (typeof current === 'number') return current;
+  if (typeof current === 'string') {
+    if (current === 'error') return 2;
+    if (current === 'warn') return 1;
+    return 0;
   }
   return 0;
 }

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/warns-on-suspicious.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/warns-on-suspicious.test.ts
@@ -44,7 +44,7 @@ function expectLintError(errors: Linter.LintMessage[], severity: number = ERROR)
 function getRuleConfig(config: any[], ruleId: string): unknown {
   for (let i = config.length - 1; i >= 0; i--) {
     const c = config[i];
-    if (c && typeof c === 'object' && 'rules' in c && c.rules && ruleId in c.rules) {
+    if (c && typeof c === 'object' && 'rules' in c && c.rules && Object.hasOwn(c.rules, ruleId)) {
       return c.rules[ruleId];
     }
   }

--- a/packages/cli/src/presets/typescript/eslint-configs/base.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/base.ts
@@ -216,7 +216,8 @@ const basePluginsUnscoped: any[] = [
       'unicorn/switch-case-braces': 'error',
       'unicorn/catch-error-name': 'error',
       'unicorn/no-array-reduce': 'error', // LLMs write confusing reduce
-      'unicorn/prevent-abbreviations': [
+      // Renamed from unicorn/prevent-abbreviations in eslint-plugin-unicorn 68.
+      'unicorn/name-replacements': [
         'error',
         {
           allowList: {
@@ -246,7 +247,7 @@ const basePluginsUnscoped: any[] = [
         },
       ],
       'unicorn/no-null': 'error', // Use undefined
-      'unicorn/no-array-for-each': 'error', // Use for...of
+      'unicorn/no-for-each': 'error', // Use for...of (renamed from no-array-for-each in unicorn 68)
       'unicorn/no-negated-condition': 'error', // Clearer conditionals
       // Cherry-picked from 'all' config - high value for LLM code
       'unicorn/no-unused-properties': 'error', // Dead code in enum-like objects

--- a/packages/cli/src/presets/typescript/eslint-configs/base.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/base.ts
@@ -212,6 +212,25 @@ const basePluginsUnscoped: any[] = [
       //   - Packages with CJS-only dependencies
       //   - Gradual ESM migration in progress
       'unicorn/prefer-module': 'off',
+      //
+      // consistent-boolean-name (new in unicorn 68's recommended set): demands an
+      // is/has/can/should/was/did/will prefix on every boolean identifier —
+      // including function declarations that return a status boolean. It cannot
+      // distinguish a boolean *state variable* (where the prefix helps) from an
+      // *action function that returns success/changed* (where it corrupts the
+      // name): installPythonDependencies -> isInstallPythonDependencies,
+      // writeIfChanged -> isWriteIfChanged, exists -> isExisting. Even the JS
+      // stdlib rejects the premise (Array.includes, String.startsWith, Map.has all
+      // return boolean with no prefix). The rule offers no checkFunctions/allowList
+      // knob to scope it, and we ship at error-level into customer agent code, so
+      // the overreach is unfixable by config. Re-enable scoped to variables if
+      // unicorn ever adds a checkFunctions:false option.
+      'unicorn/consistent-boolean-name': 'off',
+      //
+      // filename-case: unicorn 68 began checking directory names too. Dunder
+      // dirs (__tests__, __mocks__, __snapshots__) are an ecosystem convention,
+      // not kebab-case violations — ignore that segment, keep the rule otherwise.
+      'unicorn/filename-case': ['error', { case: 'kebabCase', ignore: [/^__\w+__$/] }],
       // Escalated to error for LLM code
       'unicorn/switch-case-braces': 'error',
       'unicorn/catch-error-name': 'error',

--- a/packages/cli/src/presets/typescript/eslint-configs/recommended-react.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/recommended-react.ts
@@ -66,7 +66,8 @@ function withSeverity(ruleConfig: unknown, severity: 'error' | 'off'): unknown {
 function normalizeEslintReactRulesToError(config: { rules?: Record<string, unknown> }) {
   const overrides: Record<string, unknown> = {};
 
-  for (const [ruleId, ruleConfig] of Object.entries(config.rules ?? {})) {
+  const ruleEntries = Object.entries(config.rules ?? {});
+  for (const [ruleId, ruleConfig] of ruleEntries) {
     if (ruleId.startsWith('@eslint-react/')) {
       overrides[ruleId] = withSeverity(ruleConfig, 'error');
     }

--- a/packages/cli/src/presets/typescript/eslint-configs/tailwind.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/tailwind.ts
@@ -5,7 +5,7 @@
  * All rules enabled at error level (LLMs ignore warnings).
  *
  * Includes 11 rules:
- * - Correctness: no-conflicting-classes, no-unregistered-classes, no-restricted-classes
+ * - Correctness: no-conflicting-classes, no-unknown-classes, no-restricted-classes
  * - Stylistic: enforce-consistent-class-order, enforce-shorthand-classes, no-duplicate-classes,
  *   no-deprecated-classes, enforce-consistent-line-wrapping, no-unnecessary-whitespace,
  *   enforce-consistent-variable-syntax, enforce-consistent-important-position
@@ -39,7 +39,7 @@ export const tailwindConfig: any[] = lazyConfigArray(() => {
       rules: {
         // Correctness rules - catch LLM mistakes
         'better-tailwindcss/no-conflicting-classes': 'error',
-        'better-tailwindcss/no-unregistered-classes': 'error',
+        'better-tailwindcss/no-unknown-classes': 'error',
         'better-tailwindcss/no-restricted-classes': 'error', // no-op by default, configurable
 
         // Stylistic rules - enforce consistency

--- a/packages/cli/src/presets/typescript/eslint-rules/no-accumulating-spread.ts
+++ b/packages/cli/src/presets/typescript/eslint-rules/no-accumulating-spread.ts
@@ -145,11 +145,13 @@ function checkArrowBody(
 
   // Block body - check return statements
   if (body.type === 'BlockStatement') {
-    for (const stmt of body.body) {
-      if (stmt.type === 'ReturnStatement' && stmt.argument) {
-        const found = containsAccumulatorSpread(stmt.argument, accName);
-        if (found) return found;
+    for (const statement of body.body) {
+      if (!(statement.type === 'ReturnStatement' && statement.argument)) {
+      	continue;
       }
+
+      const found = containsAccumulatorSpread(statement.argument, accName);
+      if (found) return found;
     }
   }
 

--- a/packages/cli/src/presets/typescript/eslint-rules/no-incomplete-error-handling.ts
+++ b/packages/cli/src/presets/typescript/eslint-rules/no-incomplete-error-handling.ts
@@ -44,12 +44,12 @@ function isLoggingCall(node: CallExpression): boolean {
 /**
  * Check if a single statement terminates control flow.
  */
-function isTerminatingBranch(stmt: Statement): boolean {
-  if (stmt.type === 'ThrowStatement' || stmt.type === 'ReturnStatement') {
+function isTerminatingBranch(statement: Statement): boolean {
+  if (statement.type === 'ThrowStatement' || statement.type === 'ReturnStatement') {
     return true;
   }
-  if (stmt.type === 'BlockStatement') {
-    return hasTerminatingStatement(stmt.body);
+  if (statement.type === 'BlockStatement') {
+    return hasTerminatingStatement(statement.body);
   }
   return false;
 }
@@ -57,10 +57,10 @@ function isTerminatingBranch(stmt: Statement): boolean {
 /**
  * Check if an if statement terminates (both branches must terminate).
  */
-function ifStatementTerminates(stmt: Statement & { type: 'IfStatement' }): boolean {
-  const consequentTerminates = isTerminatingBranch(stmt.consequent);
-  const alternateTerminates = stmt.alternate ? isTerminatingBranch(stmt.alternate) : false;
-  return consequentTerminates && alternateTerminates;
+function ifStatementTerminates(statement: Statement & { type: 'IfStatement' }): boolean {
+  const isConsequentTerminates = isTerminatingBranch(statement.consequent);
+  const isAlternateTerminates = statement.alternate ? isTerminatingBranch(statement.alternate) : false;
+  return isConsequentTerminates && isAlternateTerminates;
 }
 
 /**
@@ -68,11 +68,11 @@ function ifStatementTerminates(stmt: Statement & { type: 'IfStatement' }): boole
  * @param statements
  */
 function hasTerminatingStatement(statements: Statement[]): boolean {
-  for (const stmt of statements) {
-    if (stmt.type === 'ThrowStatement' || stmt.type === 'ReturnStatement') {
+  for (const statement of statements) {
+    if (statement.type === 'ThrowStatement' || statement.type === 'ReturnStatement') {
       return true;
     }
-    if (stmt.type === 'IfStatement' && ifStatementTerminates(stmt)) {
+    if (statement.type === 'IfStatement' && ifStatementTerminates(statement)) {
       return true;
     }
   }
@@ -82,24 +82,24 @@ function hasTerminatingStatement(statements: Statement[]): boolean {
 /**
  * Check if a single statement is a logging call.
  */
-function isLoggingStatement(stmt: Statement): boolean {
+function isLoggingStatement(statement: Statement): boolean {
   return (
-    stmt.type === 'ExpressionStatement' &&
-    stmt.expression.type === 'CallExpression' &&
-    isLoggingCall(stmt.expression)
+    statement.type === 'ExpressionStatement' &&
+    statement.expression.type === 'CallExpression' &&
+    isLoggingCall(statement.expression)
   );
 }
 
 /**
  * Get nested statements from a statement (for recursive search).
  */
-function getNestedStatements(stmt: Statement): Statement[] {
-  if (stmt.type === 'BlockStatement') {
-    return stmt.body;
+function getNestedStatements(statement: Statement): Statement[] {
+  if (statement.type === 'BlockStatement') {
+    return statement.body;
   }
-  if (stmt.type === 'IfStatement') {
-    const nested = [stmt.consequent];
-    if (stmt.alternate) nested.push(stmt.alternate);
+  if (statement.type === 'IfStatement') {
+    const nested = [statement.consequent];
+    if (statement.alternate) nested.push(statement.alternate);
     return nested;
   }
   return [];
@@ -110,10 +110,10 @@ function getNestedStatements(stmt: Statement): Statement[] {
  * @param statements
  */
 function containsLoggingCall(statements: Statement[]): boolean {
-  for (const stmt of statements) {
-    if (isLoggingStatement(stmt)) return true;
+  for (const statement of statements) {
+    if (isLoggingStatement(statement)) return true;
 
-    const nested = getNestedStatements(stmt);
+    const nested = getNestedStatements(statement);
     if (nested.length > 0 && containsLoggingCall(nested)) return true;
   }
   return false;

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -78,7 +78,8 @@ function getConditionalPackages(
     }
 
     // Check if this condition is met
-    if (projectType[key as keyof ProjectType]) {
+    const conditionMet = projectType[key as keyof ProjectType];
+    if (conditionMet) {
       // For projects with existing formatter, skip prettier-related packages
       if (projectType.existingFormatter) {
         packages.push(...dependencies.filter(pkg => !PRETTIER_PACKAGES.has(pkg)));
@@ -135,14 +136,24 @@ function planTextPatches(
   for (const [filePath, entry] of Object.entries(patches)) {
     if (shouldSkipForNonGit(filePath, ctx.isGitRepo)) continue;
     // Apply in list order so later patches land beneath earlier ones.
-    for (const definition of asPatchList(entry)) {
-      if (!passesTextPatchContentGuard(ctx.cwd, filePath, definition)) continue;
-      actions.push({
-        type: 'text-patch',
-        path: filePath,
-        definition: resolveTextPatch(definition, ctx),
-      });
-    }
+    actions.push(...planTextPatchesForFile(filePath, entry, ctx));
+  }
+  return actions;
+}
+
+function planTextPatchesForFile(
+  filePath: string,
+  entry: TextPatchDefinition | TextPatchDefinition[],
+  ctx: ProjectContext,
+): Action[] {
+  const actions: Action[] = [];
+  for (const definition of asPatchList(entry)) {
+    if (!passesTextPatchContentGuard(ctx.cwd, filePath, definition)) continue;
+    actions.push({
+      type: 'text-patch',
+      path: filePath,
+      definition: resolveTextPatch(definition, ctx),
+    });
   }
   return actions;
 }
@@ -257,7 +268,7 @@ function planExistingDirectoriesRemoval(
   const removed: string[] = [];
   for (const dir of directories) {
     if (!exists(nodePath.join(cwd, dir))) {
-    	continue;
+      continue;
     }
 
     actions.push({ type: 'rmdir', path: dir });
@@ -275,7 +286,7 @@ function planExistingFilesRemoval(
   const removed: string[] = [];
   for (const filePath of files) {
     if (!exists(nodePath.join(cwd, filePath))) {
-    	continue;
+      continue;
     }
 
     actions.push({ type: 'rm', path: filePath });
@@ -664,7 +675,9 @@ function computeUpgradePlan(schema: SafewordSchema, ctx: ProjectContext): Reconc
   );
 
   // 9. Compute deprecated packages to remove (only those actually installed)
-  const packagesToRemove = schema.deprecatedPackages.filter(pkg => pkg in ctx.developmentDeps);
+  const packagesToRemove = schema.deprecatedPackages.filter(pkg =>
+    Object.hasOwn(ctx.developmentDeps, pkg),
+  );
 
   return {
     actions,
@@ -880,7 +893,7 @@ export function computePackagesToInstall(
   // Strip version specifier (e.g. 'eslint@^9' → 'eslint') when checking installed deps
   return needed.filter(pkg => {
     const name = stripVersionSpecifier(pkg);
-    return !workspaceMembers.has(name) && !(name in installedDevelopmentDependencies);
+    return !workspaceMembers.has(name) && !Object.hasOwn(installedDevelopmentDependencies, name);
   });
 }
 
@@ -896,7 +909,9 @@ function computePackagesToRemove(
 
   // Only remove packages that are actually installed
   // Strip version specifier (e.g. 'eslint@^9' → 'eslint') when checking installed deps
-  return safewordPackages.filter(pkg => stripVersionSpecifier(pkg) in installedDevelopmentDependencies);
+  return safewordPackages.filter(pkg =>
+    Object.hasOwn(installedDevelopmentDependencies, stripVersionSpecifier(pkg)),
+  );
 }
 
 /**
@@ -1104,7 +1119,8 @@ function executeTextUnpatch(cwd: string, path: string, definition: ResolvedTextP
 
 function removeExactTextPatchContent(content: string, definition: ResolvedTextPatch): string {
   let unpatched = content.replace(definition.content, '');
-  for (const extraContent of definition.unpatchContent ?? []) {
+  const extraContents = definition.unpatchContent ?? [];
+  for (const extraContent of extraContents) {
     unpatched = unpatched.replace(extraContent, '');
   }
   return unpatched;

--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -68,11 +68,11 @@ function getConditionalPackages(
 ): string[] {
   const packages: string[] = [];
 
-  for (const [key, deps] of Object.entries(conditionalPackages)) {
+  for (const [key, dependencies] of Object.entries(conditionalPackages)) {
     // "standard" means !existingFormatter - only for projects without existing formatter
     if (key === 'standard') {
       if (!projectType.existingFormatter) {
-        packages.push(...deps);
+        packages.push(...dependencies);
       }
       continue;
     }
@@ -81,9 +81,9 @@ function getConditionalPackages(
     if (projectType[key as keyof ProjectType]) {
       // For projects with existing formatter, skip prettier-related packages
       if (projectType.existingFormatter) {
-        packages.push(...deps.filter(pkg => !PRETTIER_PACKAGES.has(pkg)));
+        packages.push(...dependencies.filter(pkg => !PRETTIER_PACKAGES.has(pkg)));
       } else {
-        packages.push(...deps);
+        packages.push(...dependencies);
       }
     }
   }
@@ -256,10 +256,12 @@ function planExistingDirectoriesRemoval(
   const actions: Action[] = [];
   const removed: string[] = [];
   for (const dir of directories) {
-    if (exists(nodePath.join(cwd, dir))) {
-      actions.push({ type: 'rmdir', path: dir });
-      removed.push(dir);
+    if (!exists(nodePath.join(cwd, dir))) {
+    	continue;
     }
+
+    actions.push({ type: 'rmdir', path: dir });
+    removed.push(dir);
   }
   return { actions, removed };
 }
@@ -272,10 +274,12 @@ function planExistingFilesRemoval(
   const actions: Action[] = [];
   const removed: string[] = [];
   for (const filePath of files) {
-    if (exists(nodePath.join(cwd, filePath))) {
-      actions.push({ type: 'rm', path: filePath });
-      removed.push(filePath);
+    if (!exists(nodePath.join(cwd, filePath))) {
+    	continue;
     }
+
+    actions.push({ type: 'rm', path: filePath });
+    removed.push(filePath);
   }
   return { actions, removed };
 }
@@ -397,11 +401,11 @@ export async function reconcile(
   // sync today, but the signature reserves room for async I/O without
   // breaking callers. Token await keeps the contract honest.
   await Promise.resolve();
-  const dryRun = options?.dryRun ?? false;
+  const isDryRun = options?.dryRun ?? false;
 
   const plan = computePlan(withResolvedNamespaceRoot(schema, ctx), mode, ctx);
 
-  if (dryRun) {
+  if (isDryRun) {
     return {
       actions: plan.actions,
       applied: false,
@@ -825,9 +829,9 @@ function executeAction(action: Action, ctx: ProjectContext, result: ExecutionRes
 
 function executeWrite(cwd: string, path: string, content: string, result: ExecutionResult): void {
   const fullPath = nodePath.join(cwd, path);
-  const existed = exists(fullPath);
+  const isExisted = exists(fullPath);
   writeFile(fullPath, content);
-  (existed ? result.updated : result.created).push(path);
+  (isExisted ? result.updated : result.created).push(path);
 }
 
 // ============================================================================
@@ -861,7 +865,7 @@ function fileNeedsUpdate(installedPath: string, newContent: string): boolean {
 export function computePackagesToInstall(
   schema: SafewordSchema,
   projectType: ProjectType,
-  installedDevelopmentDeps: Record<string, string>,
+  installedDevelopmentDependencies: Record<string, string>,
   cwd?: string,
 ): string[] {
   // Combine base packages with conditional packages
@@ -876,14 +880,14 @@ export function computePackagesToInstall(
   // Strip version specifier (e.g. 'eslint@^9' → 'eslint') when checking installed deps
   return needed.filter(pkg => {
     const name = stripVersionSpecifier(pkg);
-    return !workspaceMembers.has(name) && !(name in installedDevelopmentDeps);
+    return !workspaceMembers.has(name) && !(name in installedDevelopmentDependencies);
   });
 }
 
 function computePackagesToRemove(
   schema: SafewordSchema,
   projectType: ProjectType,
-  installedDevelopmentDeps: Record<string, string>,
+  installedDevelopmentDependencies: Record<string, string>,
 ): string[] {
   const safewordPackages = [
     ...schema.packages.base,
@@ -892,7 +896,7 @@ function computePackagesToRemove(
 
   // Only remove packages that are actually installed
   // Strip version specifier (e.g. 'eslint@^9' → 'eslint') when checking installed deps
-  return safewordPackages.filter(pkg => stripVersionSpecifier(pkg) in installedDevelopmentDeps);
+  return safewordPackages.filter(pkg => stripVersionSpecifier(pkg) in installedDevelopmentDependencies);
 }
 
 /**

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -244,7 +244,7 @@ const CODEX_SKILL_TEMPLATE_FILES = [
 
 const CODEX_SKILL_DIRS = [
   ...new Set(
-    CODEX_SKILL_TEMPLATE_FILES.map(([target]) => `.agents/skills/${target.split('/')[0]}`),
+    CODEX_SKILL_TEMPLATE_FILES.map(([target]) => `.agents/skills/${target.split('/', 1)[0]}`),
   ),
 ];
 

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -196,7 +196,7 @@ function resolvePython(
   isAvailable: ToolProbe,
 ): PlanEntry | undefined {
   if (kind === 'build') return undefined; // no standard Python build step
-  if (!PYTHON_MANIFESTS.some(manifest => index.has(manifest))) return undefined;
+  if (PYTHON_MANIFESTS.every(manifest => !index.has(manifest))) return undefined;
   const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
   if (index.has('tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
   if (pytestConfigured(index) || isAvailable('pytest')) {

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -139,7 +139,8 @@ function resolveJs(
       ? entry('javascript', root, `${pm} run build`, pm, isAvailable(pm))
       : undefined;
   }
-  const script = kind === 'verify' ? pickVerifyScript(scripts) : pickTestScript(scripts);
+  const pickScript = kind === 'verify' ? pickVerifyScript : pickTestScript;
+  const script = pickScript(scripts);
   return script ? entry('javascript', root, `${pm} run ${script}`, pm, isAvailable(pm)) : undefined;
 }
 
@@ -148,7 +149,7 @@ function firstScript(
   scripts: Record<string, string>,
   priority: readonly string[],
 ): string | undefined {
-  return priority.find(name => name in scripts);
+  return priority.find(name => Object.hasOwn(scripts, name));
 }
 
 /** Prefer a gate-tuned `test:done` subset, else `test`; undefined when neither exists. */

--- a/packages/cli/src/ticket-sync/index.ts
+++ b/packages/cli/src/ticket-sync/index.ts
@@ -228,7 +228,7 @@ function groupByEpic(entries: TicketEntry[]): [string, TicketEntry[]][] {
     if (bucket) bucket.push(entry);
     else groups.set(key, [entry]);
   }
-  return [...groups.entries()].toSorted(([a], [b]) => {
+  return [...groups].toSorted(([a], [b]) => {
     if (a === NO_EPIC_GROUP) return 1;
     if (b === NO_EPIC_GROUP) return -1;
     return a.localeCompare(b);
@@ -295,16 +295,16 @@ export function syncTickets(cwd: string): TicketSyncResult {
 
   const { active, completed, skipped } = readTickets(ticketsDirectory, relativeLabel);
 
-  const wroteActive = writeIfChanged(indexPath, buildIndexContent(active, { variant: 'active' }));
+  const isWroteActive = writeIfChanged(indexPath, buildIndexContent(active, { variant: 'active' }));
 
   const completedDirectory = nodePath.join(ticketsDirectory, COMPLETED_DIRNAME);
-  const wroteCompleted =
+  const isWroteCompleted =
     completed.length > 0 || existsSync(completedDirectory)
       ? writeIfChanged(completedIndexPath, buildIndexContent(completed, { variant: 'completed' }))
       : false;
 
   return {
-    wrote: wroteActive || wroteCompleted,
+    wrote: isWroteActive || isWroteCompleted,
     active,
     completed,
     skipped,

--- a/packages/cli/src/utils/codex.ts
+++ b/packages/cli/src/utils/codex.ts
@@ -39,7 +39,7 @@ function parseVersionCore(core: string): [number, number, number] | undefined {
 function parseSemver(version: string): ParsedSemver | undefined {
   const trimmed = version.trim();
   const normalized = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
-  const withoutBuildMetadata = normalized.split('+')[0] ?? '';
+  const withoutBuildMetadata = normalized.split('+', 1)[0] ?? '';
   const [core = '', prerelease] = withoutBuildMetadata.split('-', 2);
   const parsedCore = parseVersionCore(core);
   if (!parsedCore) return undefined;
@@ -70,7 +70,7 @@ function compareSemver(a: string, b: string): -1 | 0 | 1 {
 }
 
 function parseCodexVersion(output: string): string | undefined {
-  const tokens = output.replaceAll('\n', ' ').replaceAll('\t', ' ').split(' ');
+  const tokens = output.replaceAll(/[\n\t]/g, ' ').split(' ');
   for (const token of tokens) {
     const trimmed = token.trim();
     const normalized = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;

--- a/packages/cli/src/utils/codex.ts
+++ b/packages/cli/src/utils/codex.ts
@@ -17,7 +17,7 @@ interface ParsedSemver {
 function parseVersionPart(part: string): number | undefined {
   if (part.length === 0) return undefined;
   const parsed = Number(part);
-  if (!Number.isInteger(parsed) || parsed < 0) return undefined;
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return undefined;
   return parsed;
 }
 
@@ -26,11 +26,10 @@ function parseVersionCore(core: string): [number, number, number] | undefined {
   if (parts.length !== 3) return undefined;
 
   const major = parseVersionPart(parts[0] ?? '');
-  const minor = parseVersionPart(parts[1] ?? '');
-  const patch = parseVersionPart(parts[2] ?? '');
-
   if (major === undefined) return undefined;
+  const minor = parseVersionPart(parts[1] ?? '');
   if (minor === undefined) return undefined;
+  const patch = parseVersionPart(parts[2] ?? '');
   if (patch === undefined) return undefined;
 
   return [major, minor, patch];

--- a/packages/cli/src/utils/depcruise-config.ts
+++ b/packages/cli/src/utils/depcruise-config.ts
@@ -10,7 +10,7 @@ import nodePath from 'node:path';
 import type { DetectedArchitecture } from './boundaries.js';
 import { readJson } from './fs.js';
 
-export interface DepCruiseArchitecture extends DetectedArchitecture {
+export interface DependencyCruiseArchitecture extends DetectedArchitecture {
   workspaces?: string[];
 }
 
@@ -72,7 +72,7 @@ function generateMonorepoRules(workspaces: string[]): string {
 /**
  * Generate .safeword/depcruise-config.cjs content (forbidden rules + options)
  */
-export function generateDepCruiseConfigFile(arch: DepCruiseArchitecture): string {
+export function generateDependencyCruiseConfigFile(arch: DependencyCruiseArchitecture): string {
   const monorepoRules = arch.workspaces ? generateMonorepoRules(arch.workspaces) : '';
   const hasMonorepoRules = monorepoRules.length > 0;
 
@@ -161,7 +161,7 @@ export function generateDepCruiseConfigFile(arch: DepCruiseArchitecture): string
 /**
  * Generate .dependency-cruiser.js (main config that imports generated)
  */
-export function generateDepCruiseMainConfig(): string {
+export function generateDependencyCruiseMainConfig(): string {
   return `/**
  * Dependency Cruiser Configuration
  *

--- a/packages/cli/src/utils/duplicate-ids.test.ts
+++ b/packages/cli/src/utils/duplicate-ids.test.ts
@@ -58,7 +58,7 @@ describe('findDuplicateTicketIds', () => {
     const duplicates = findDuplicateTicketIds(cwd);
     expect(duplicates).toHaveLength(1);
     expect(duplicates[0]?.id).toBe('7K9M3P');
-    expect(duplicates[0]?.folders.toSorted()).toEqual(['7K9M3P', '7K9M3Q']);
+    expect(duplicates[0]?.folders.toSorted((a, b) => a.localeCompare(b))).toEqual(['7K9M3P', '7K9M3Q']);
   });
 
   it('flags two LEGACY-format folders sharing the same id (reads frontmatter, not folder name)', () => {

--- a/packages/cli/src/utils/eslint-auto-patch.test.ts
+++ b/packages/cli/src/utils/eslint-auto-patch.test.ts
@@ -16,20 +16,20 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { autoPatchEslintConfig } from './eslint-auto-patch.js';
 
-let temporaryDirectory: string;
+const shared: { temporaryDirectory: string } = { temporaryDirectory: '' };
 
 beforeEach(() => {
-  temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-patch-'));
+  shared.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-patch-'));
 });
 
 afterEach(() => {
-  if (existsSync(temporaryDirectory)) {
-    rmSync(temporaryDirectory, { recursive: true, force: true });
+  if (existsSync(shared.temporaryDirectory)) {
+    rmSync(shared.temporaryDirectory, { recursive: true, force: true });
   }
 });
 
 function writeConfig(filename: string, body: string): string {
-  const fullPath = nodePath.join(temporaryDirectory, filename);
+  const fullPath = nodePath.join(shared.temporaryDirectory, filename);
   writeFileSync(fullPath, body, 'utf8');
   return fullPath;
 }
@@ -201,7 +201,7 @@ describe('Rule 4 — bail-to-print on unrecognized shapes', () => {
   });
 
   it('5.3: read failure on the config bails (file does not exist)', () => {
-    const configPath = nodePath.join(temporaryDirectory, 'missing.mjs');
+    const configPath = nodePath.join(shared.temporaryDirectory, 'missing.mjs');
 
     const result = autoPatchEslintConfig({ configPath });
 

--- a/packages/cli/src/utils/eslint-auto-patch.ts
+++ b/packages/cli/src/utils/eslint-auto-patch.ts
@@ -91,7 +91,7 @@ function skipNonContent(source: string, i: number): number {
     const close = source.indexOf('*/', i + 2);
     return close === -1 ? -1 : close + 2;
   }
-  if (["'", '"', '`'].includes(ch)) {
+  if (ch !== undefined && ["'", '"', '`'].includes(ch)) {
     return skipStringLiteral(source, i);
   }
   return i;

--- a/packages/cli/src/utils/eslint-auto-patch.ts
+++ b/packages/cli/src/utils/eslint-auto-patch.ts
@@ -241,11 +241,11 @@ export function autoPatchEslintConfig(options: AutoPatchOptions): AutoPatchResul
   // one before our spread.
   const probe = lastNonWhitespaceIndex(sourceWithImport, finalClose - 1);
   const charBefore = sourceWithImport[probe];
-  const needsLeadingComma = charBefore !== '[' && charBefore !== ',';
+  const isNeedsLeadingComma = charBefore !== '[' && charBefore !== ',';
 
   const before = sourceWithImport.slice(0, finalClose);
   const after = sourceWithImport.slice(finalClose);
-  const prefix = `${needsLeadingComma ? ',' : ''}${eol}  `;
+  const prefix = `${isNeedsLeadingComma ? ',' : ''}${eol}  `;
   const patched = `${before}${prefix}${SPREAD}${eol}${after}`;
 
   const writeResult = writeAndValidate(configPath, patched, !isTypeScriptConfig(configPath));

--- a/packages/cli/src/utils/eslint-auto-patch.ts
+++ b/packages/cli/src/utils/eslint-auto-patch.ts
@@ -91,7 +91,7 @@ function skipNonContent(source: string, i: number): number {
     const close = source.indexOf('*/', i + 2);
     return close === -1 ? -1 : close + 2;
   }
-  if (ch === "'" || ch === '"' || ch === '`') {
+  if (["'", '"', '`'].includes(ch)) {
     return skipStringLiteral(source, i);
   }
   return i;

--- a/packages/cli/src/utils/eslint-peer-check.test.ts
+++ b/packages/cli/src/utils/eslint-peer-check.test.ts
@@ -41,22 +41,22 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('returns undefined when eslint is in the supported major (9.x as caret range)', () => {
+  it('returns a warning for eslint 9.x (dropped when safeword moved to ESLint 10)', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
       JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^9.39.4' } }),
     );
-    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
   });
 
-  it('returns undefined for a pinned 9.x version', () => {
+  it('returns a warning for a pinned 9.x version', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
       JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '9.39.4' } }),
     );
-    expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
+    expect(getEslintPeerMismatchWarning(temporaryDirectory)).not.toBeUndefined();
   });
 
   it('returns undefined when eslint is in the supported major (10.x as caret range)', () => {
@@ -116,14 +116,14 @@ describe('getEslintPeerMismatchWarning', () => {
     expect(getEslintPeerMismatchWarning(temporaryDirectory)).toBeUndefined();
   });
 
-  it('warning message names the safeword supported majors (9 and 10) and the conflict', () => {
+  it('warning message names the safeword supported major (10) and the conflict', () => {
     writeTestFile(
       temporaryDirectory,
       'package.json',
-      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^11.0.0' } }),
+      JSON.stringify({ name: 'x', version: '0.0.0', devDependencies: { eslint: '^9.0.0' } }),
     );
     const warning = getEslintPeerMismatchWarning(temporaryDirectory);
-    expect(warning).toContain('9');
-    expect(warning).toContain('10');
+    expect(warning).toContain('10'); // supported major
+    expect(warning).toContain('9'); // the conflicting declared major
   });
 });

--- a/packages/cli/src/utils/eslint-peer-check.ts
+++ b/packages/cli/src/utils/eslint-peer-check.ts
@@ -50,7 +50,7 @@ function extractMajorFromComparator(comparator: string): number | undefined {
   const match = /^(\d+)\./.exec(cleaned) ?? /^(\d+)(?:\.x|\.\*|$)/.exec(cleaned);
   const majorString = match?.[1];
   if (majorString === undefined) return undefined;
-  const major = Number.parseInt(majorString, 10);
+  const major = Number(majorString);
   return Number.isNaN(major) ? undefined : major;
 }
 

--- a/packages/cli/src/utils/gherkin-feature.test.ts
+++ b/packages/cli/src/utils/gherkin-feature.test.ts
@@ -206,18 +206,21 @@ describe('findGherkinLintIssues', () => {
       { filePath: 'features/demo.feature' },
     );
 
+    const usesMissing = expect.stringContaining('uses <missing>');
+    const usesOwner = expect.stringContaining('uses <owner>');
+    const definesUnused = expect.stringContaining('defines <unused>');
     expect(issues).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          message: expect.stringContaining('uses <missing>'),
+          message: usesMissing,
           rule: 'no-unused-variables',
         }),
         expect.objectContaining({
-          message: expect.stringContaining('uses <owner>'),
+          message: usesOwner,
           rule: 'no-unused-variables',
         }),
         expect.objectContaining({
-          message: expect.stringContaining('defines <unused>'),
+          message: definesUnused,
           rule: 'no-unused-variables',
         }),
       ]),

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -286,19 +286,19 @@ function findTextLintIssues(content: string, filePath: string | undefined): Gher
     issues.push(issue('new-line-at-eof', 'Feature file should end with a newline.'));
   }
 
-  let previousBlank = false;
+  let isPreviousBlank = false;
   for (const [index, line] of content.split('\n').entries()) {
     const lineNumber = index + 1;
     if (/[ \t]$/.test(line)) {
       issues.push(issue('no-trailing-spaces', 'Line has trailing whitespace.', lineNumber));
     }
-    const blank = line.trim() === '';
-    if (blank && previousBlank) {
+    const isBlank = line.trim() === '';
+    if (isBlank && isPreviousBlank) {
       issues.push(
         issue('no-multiple-empty-lines', 'Avoid multiple consecutive blank lines.', lineNumber),
       );
     }
-    previousBlank = blank;
+    isPreviousBlank = isBlank;
   }
   return issues;
 }

--- a/packages/cli/src/utils/glossary.test.ts
+++ b/packages/cli/src/utils/glossary.test.ts
@@ -25,14 +25,11 @@ describe('validateGlossary — structural errors', () => {
 
       const errors = validateGlossary(parsed);
 
-      expect(errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            line: 1,
-            message: expect.stringContaining('missing Definition'),
-          }),
-        ]),
-      );
+      const expectedError = expect.objectContaining({
+        line: 1,
+        message: expect.stringContaining('missing Definition'),
+      });
+      expect(errors).toEqual(expect.arrayContaining([expectedError]));
     });
   });
 
@@ -43,14 +40,11 @@ describe('validateGlossary — structural errors', () => {
 
       const errors = validateGlossary(parsed);
 
-      expect(errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            line: 1,
-            message: expect.stringContaining('missing term name'),
-          }),
-        ]),
-      );
+      const expectedError = expect.objectContaining({
+        line: 1,
+        message: expect.stringContaining('missing term name'),
+      });
+      expect(errors).toEqual(expect.arrayContaining([expectedError]));
     });
   });
 

--- a/packages/cli/src/utils/glossary.ts
+++ b/packages/cli/src/utils/glossary.ts
@@ -120,14 +120,18 @@ export function lookupGlossaryReference(
 function groupAliasesByLine(entries: readonly ParsedGlossaryEntry[]): Map<string, number[]> {
   const grouped = new Map<string, number[]>();
   for (const entry of entries) {
-    for (const alias of entry.aliases) {
-      if (alias.length === 0) continue;
-      const lines = grouped.get(alias) ?? [];
-      lines.push(entry.lineNumber);
-      grouped.set(alias, lines);
-    }
+    addEntryAliasesToGroup(entry, grouped);
   }
   return grouped;
+}
+
+function addEntryAliasesToGroup(entry: ParsedGlossaryEntry, grouped: Map<string, number[]>): void {
+  for (const alias of entry.aliases) {
+    if (alias.length === 0) continue;
+    const lines = grouped.get(alias) ?? [];
+    lines.push(entry.lineNumber);
+    grouped.set(alias, lines);
+  }
 }
 
 /**
@@ -362,7 +366,7 @@ export function parseGlossary(content: string): ParsedGlossaryEntry[] {
   let activeField: StringFieldKey | undefined;
 
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    if (skip[index] === true) continue;
     const headerName = parseTermHeader(line);
     if (headerName !== undefined) {
       if (current) entries.push(current);

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -28,7 +28,7 @@ function isHookEntry(h: unknown): h is HookEntry {
  */
 function isSafewordHook(h: unknown): boolean {
   if (!isHookEntry(h)) return false;
-  return h.hooks.some(cmd => typeof cmd.command === 'string' && cmd.command.includes('.safeword'));
+  return h.hooks.some(command => typeof command.command === 'string' && command.command.includes('.safeword'));
 }
 
 /**

--- a/packages/cli/src/utils/json-merge.test.ts
+++ b/packages/cli/src/utils/json-merge.test.ts
@@ -7,18 +7,18 @@ describe('assignOrPrune', () => {
     const target: Record<string, unknown> = { keep: 1 };
     const value = { a: 1 };
 
-    const kept = assignOrPrune(target, 'nested', value);
+    const isKept = assignOrPrune(target, 'nested', value);
 
-    expect(kept).toBe(true);
+    expect(isKept).toBe(true);
     expect(target).toEqual({ keep: 1, nested: { a: 1 } });
   });
 
   it('deletes an existing key and returns false when the value is empty', () => {
     const target: Record<string, unknown> = { keep: 1, nested: { old: 1 } };
 
-    const kept = assignOrPrune(target, 'nested', {});
+    const isKept = assignOrPrune(target, 'nested', {});
 
-    expect(kept).toBe(false);
+    expect(isKept).toBe(false);
     expect(target).toEqual({ keep: 1 });
     expect('nested' in target).toBe(false);
   });
@@ -26,9 +26,9 @@ describe('assignOrPrune', () => {
   it('is a no-op (returns false) when pruning an absent key', () => {
     const target: Record<string, unknown> = { keep: 1 };
 
-    const kept = assignOrPrune(target, 'missing', {});
+    const isKept = assignOrPrune(target, 'missing', {});
 
-    expect(kept).toBe(false);
+    expect(isKept).toBe(false);
     expect(target).toEqual({ keep: 1 });
   });
 });

--- a/packages/cli/src/utils/markdown-sections.ts
+++ b/packages/cli/src/utils/markdown-sections.ts
@@ -21,22 +21,22 @@
  */
 export function computeSkipMask(lines: readonly string[]): boolean[] {
   const skip: boolean[] = [];
-  let insideCodeFence = false;
-  let insideComment = false;
+  let isInsideCodeFence = false;
+  let isInsideComment = false;
   for (const line of lines) {
     if (line.trimStart().startsWith('```')) {
       skip.push(true);
-      insideCodeFence = !insideCodeFence;
+      isInsideCodeFence = !isInsideCodeFence;
       continue;
     }
-    if (insideCodeFence) {
+    if (isInsideCodeFence) {
       skip.push(true);
       continue;
     }
-    if (!insideComment && line.trimStart().startsWith('<!--')) insideComment = true;
-    if (insideComment) {
+    if (!isInsideComment && line.trimStart().startsWith('<!--')) isInsideComment = true;
+    if (isInsideComment) {
       skip.push(true);
-      if (line.includes('-->')) insideComment = false;
+      if (line.includes('-->')) isInsideComment = false;
       continue;
     }
     skip.push(false);

--- a/packages/cli/src/utils/namespace-migration.ts
+++ b/packages/cli/src/utils/namespace-migration.ts
@@ -78,10 +78,12 @@ function rewriteLegacyPathOverrides(cwd: string): string[] {
 
   const rewritten: string[] = [];
   for (const [key, value] of Object.entries(parsed.paths)) {
-    if (typeof value === 'string' && value.startsWith(`${LEGACY_ROOT}/`)) {
-      parsed.paths[key] = `${DEFAULT_ROOT}${value.slice(LEGACY_ROOT.length)}`;
-      rewritten.push(key);
+    if (!(typeof value === 'string' && value.startsWith(`${LEGACY_ROOT}/`))) {
+    	continue;
     }
+
+    parsed.paths[key] = `${DEFAULT_ROOT}${value.slice(LEGACY_ROOT.length)}`;
+    rewritten.push(key);
   }
   if (rewritten.length > 0) {
     writeFileSync(configPath, `${JSON.stringify(parsed, undefined, 2)}\n`);

--- a/packages/cli/src/utils/personas.test.ts
+++ b/packages/cli/src/utils/personas.test.ts
@@ -106,7 +106,7 @@ describe('derivePersonaCode', () => {
     });
 
     it('whitespace-only returns empty', () => {
-      expect(derivePersonaCode('   ')).toBe('');
+      expect(derivePersonaCode(' '.repeat(3))).toBe('');
     });
 
     it('punctuation-only returns empty', () => {

--- a/packages/cli/src/utils/personas.ts
+++ b/packages/cli/src/utils/personas.ts
@@ -153,7 +153,7 @@ export function parsePersonas(content: string): ParsedPersona[] {
   let current: ParsedPersona | undefined;
 
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    if (skip[index] === true) continue;
     const header = parseHeaderLine(line);
     if (header) {
       if (current) personas.push(current);

--- a/packages/cli/src/utils/project-detector.ts
+++ b/packages/cli/src/utils/project-detector.ts
@@ -114,9 +114,12 @@ export function detectPythonType(cwd: string): PythonProjectType | undefined {
   }
 
   // Read project file for dependency/tool detection
-  const content = pyprojectDirectory
-    ? readFileSync(nodePath.join(pyprojectDirectory, PYPROJECT_TOML), 'utf8')
-    : readFileSync(nodePath.join(manifestDirectory, REQUIREMENTS_TXT), 'utf8');
+  const content = readFileSync(
+    pyprojectDirectory
+      ? nodePath.join(pyprojectDirectory, PYPROJECT_TOML)
+      : nodePath.join(manifestDirectory, REQUIREMENTS_TXT),
+    'utf8',
+  );
 
   // Detect package manager (priority: poetry > uv > pip)
   let packageManager: PythonProjectType['packageManager'] = 'pip';
@@ -276,8 +279,8 @@ function detectFrameworks(
     astro: 'astro' in dependencies || 'astro' in developmentDependencies,
     vitest: 'vitest' in developmentDependencies,
     playwright: '@playwright/test' in developmentDependencies,
-    tailwind: TAILWIND_PACKAGES.some(pkg => pkg in allDependencies),
-    tanstackQuery: TANSTACK_QUERY_PACKAGES.some(pkg => pkg in allDependencies),
+    tailwind: TAILWIND_PACKAGES.some(pkg => Object.hasOwn(allDependencies, pkg)),
+    tanstackQuery: TANSTACK_QUERY_PACKAGES.some(pkg => Object.hasOwn(allDependencies, pkg)),
   };
 }
 

--- a/packages/cli/src/utils/project-detector.ts
+++ b/packages/cli/src/utils/project-detector.ts
@@ -254,9 +254,9 @@ const SQLFLUFF_CONFIG_FILES = ['.sqlfluff', 'setup.cfg'];
  * Detect JavaScript framework dependencies from package.json.
  */
 function detectFrameworks(
-  deps: Record<string, string>,
-  developmentDeps: Record<string, string>,
-  allDeps: Record<string, string>,
+  dependencies: Record<string, string>,
+  developmentDependencies: Record<string, string>,
+  allDependencies: Record<string, string>,
 ): Pick<
   ProjectType,
   | 'typescript'
@@ -268,16 +268,16 @@ function detectFrameworks(
   | 'tailwind'
   | 'tanstackQuery'
 > {
-  const hasNextJs = 'next' in deps;
+  const hasNextJs = 'next' in dependencies;
   return {
-    typescript: 'typescript' in allDeps,
-    react: 'react' in deps || 'react' in developmentDeps || hasNextJs,
+    typescript: 'typescript' in allDependencies,
+    react: 'react' in dependencies || 'react' in developmentDependencies || hasNextJs,
     nextjs: hasNextJs,
-    astro: 'astro' in deps || 'astro' in developmentDeps,
-    vitest: 'vitest' in developmentDeps,
-    playwright: '@playwright/test' in developmentDeps,
-    tailwind: TAILWIND_PACKAGES.some(pkg => pkg in allDeps),
-    tanstackQuery: TANSTACK_QUERY_PACKAGES.some(pkg => pkg in allDeps),
+    astro: 'astro' in dependencies || 'astro' in developmentDependencies,
+    vitest: 'vitest' in developmentDependencies,
+    playwright: '@playwright/test' in developmentDependencies,
+    tailwind: TAILWIND_PACKAGES.some(pkg => pkg in allDependencies),
+    tanstackQuery: TANSTACK_QUERY_PACKAGES.some(pkg => pkg in allDependencies),
   };
 }
 
@@ -439,13 +439,13 @@ export function hasJsSource(cwd: string, maxDepth = 6): boolean {
 }
 
 export function detectProjectType(packageJson: PackageJsonWithScripts, cwd?: string): ProjectType {
-  const deps = packageJson.dependencies ?? {};
-  const developmentDeps = packageJson.devDependencies ?? {};
-  const allDeps = { ...deps, ...developmentDeps };
+  const dependencies = packageJson.dependencies ?? {};
+  const developmentDependencies = packageJson.devDependencies ?? {};
+  const allDependencies = { ...dependencies, ...developmentDependencies };
   const scripts = packageJson.scripts ?? {};
 
   return {
-    ...detectFrameworks(deps, developmentDeps, allDeps),
+    ...detectFrameworks(dependencies, developmentDependencies, allDependencies),
     publishableLibrary: detectPublishable(packageJson),
     shell: cwd ? hasShellScripts(cwd) : false,
     hasJsSource: cwd ? hasJsSource(cwd) : false,

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -193,5 +193,5 @@ function parseScenarioTitles(content: string): string[] {
 
 /** First whitespace-delimited token of a heading's text (its id). */
 function firstToken(text: string): string {
-  return text.split(/\s+/)[0] ?? '';
+  return text.split(/\s+/, 1)[0] ?? '';
 }

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -67,7 +67,8 @@ export function parseAcIdsByJtbd(specContent: string): Map<string, string[]> {
   let state: WalkState = { inSection: false, currentJtbd: undefined };
 
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    const isSkipped = skip[index];
+    if (isSkipped) continue;
     const heading = parseHeading(line);
     if (heading !== undefined) state = advance(state, heading, byJtbd);
   }
@@ -182,7 +183,8 @@ function parseScenarioTitles(content: string): string[] {
   const skip = computeSkipMask(lines);
   const titles: string[] = [];
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    const isSkipped = skip[index];
+    if (isSkipped) continue;
     const trimmed = line.trim();
     if (trimmed.startsWith(SCENARIO_PREFIX)) {
       titles.push(trimmed.slice(SCENARIO_PREFIX.length).trim());

--- a/packages/cli/src/utils/stale-config-scan.ts
+++ b/packages/cli/src/utils/stale-config-scan.ts
@@ -64,18 +64,18 @@ const CURATED_ROOT_CONFIGS: readonly string[] = [
 
 /** True when any line outside the managed prettier block references the legacy root. */
 function prettierignoreHasCustomerReference(content: string): boolean {
-  let insideManagedBlock = false;
+  let isInsideManagedBlock = false;
   for (const line of content.split('\n')) {
     if (line.includes(MANAGED_PRETTIER_MARKER)) {
-      insideManagedBlock = true;
+      isInsideManagedBlock = true;
       continue;
     }
     // The managed block is safeword-written and contiguous; a blank line ends it.
-    if (insideManagedBlock && line.trim() === '') {
-      insideManagedBlock = false;
+    if (isInsideManagedBlock && line.trim() === '') {
+      isInsideManagedBlock = false;
       continue;
     }
-    if (!insideManagedBlock && line.includes(LEGACY_REFERENCE)) return true;
+    if (!isInsideManagedBlock && line.includes(LEGACY_REFERENCE)) return true;
   }
   return false;
 }

--- a/packages/cli/src/utils/test-skeleton-gherkin.test.ts
+++ b/packages/cli/src/utils/test-skeleton-gherkin.test.ts
@@ -71,13 +71,9 @@ function definitions(title: string, ...blocks: string[]): string {
 
 describe('emitGherkinFeature — AC1: faithful Gherkin emission', () => {
   it('gherkin-typescript.DEV1.AC1.doc_becomes_a_feature_with_rules', () => {
-    const out = emitGherkinFeature(
-      definitions(
-        'My Feature',
-        rule('first rule', scenario('demo.DEV1.AC1.one')),
-        rule('second rule', scenario('demo.DEV1.AC1.two')),
-      ),
-    );
+    const firstRule = rule('first rule', scenario('demo.DEV1.AC1.one'));
+    const secondRule = rule('second rule', scenario('demo.DEV1.AC1.two'));
+    const out = emitGherkinFeature(definitions('My Feature', firstRule, secondRule));
     const parsed = parseFeature(out);
     expect(parsed.feature?.name).toBe('My Feature');
     const ruleNames = (parsed.feature?.children ?? [])
@@ -87,32 +83,25 @@ describe('emitGherkinFeature — AC1: faithful Gherkin emission', () => {
   });
 
   it('gherkin-typescript.DEV1.AC1.scenario_becomes_a_named_scenario', () => {
-    const out = emitGherkinFeature(definitions('F', rule('r', scenario('demo.DEV1.AC1.example'))));
+    const oneRule = rule('r', scenario('demo.DEV1.AC1.example'));
+    const out = emitGherkinFeature(definitions('F', oneRule));
     expect(scenariosOf(out).map(s => s.name)).toContain('demo.DEV1.AC1.example');
   });
 
   it('gherkin-typescript.DEV1.AC1.steps_render_as_given_when_then_and', () => {
-    const out = emitGherkinFeature(
-      definitions(
-        'F',
-        rule(
-          'r',
-          scenario(
-            'demo.DEV1.AC1.s',
-            'Given a cart\nWhen I pay\nThen it clears\nAnd a receipt prints',
-          ),
-        ),
-      ),
+    const stepScenario = scenario(
+      'demo.DEV1.AC1.s',
+      'Given a cart\nWhen I pay\nThen it clears\nAnd a receipt prints',
     );
+    const out = emitGherkinFeature(definitions('F', rule('r', stepScenario)));
     const [s] = scenariosOf(out);
     expect(s?.stepKeywords).toEqual(['Given', 'When', 'Then', 'And']);
     expect(s?.stepTexts).toEqual(['a cart', 'I pay', 'it clears', 'a receipt prints']);
   });
 
   it('gherkin-typescript.DEV1.AC1.lineage_becomes_a_tag', () => {
-    const out = emitGherkinFeature(
-      definitions('F', rule('r', scenario('gherkin-typescript.DEV1.AC1.example'))),
-    );
+    const taggedRule = rule('r', scenario('gherkin-typescript.DEV1.AC1.example'));
+    const out = emitGherkinFeature(definitions('F', taggedRule));
     expect(scenariosOf(out)[0]?.tags).toEqual(['@gherkin-typescript.DEV1.AC1']);
     // Placement: the line directly above `Scenario:` is exactly the tag token.
     const lines = out.split('\n');
@@ -121,7 +110,8 @@ describe('emitGherkinFeature — AC1: faithful Gherkin emission', () => {
   });
 
   it('gherkin-typescript.DEV1.AC1.free_text_scenario_emits_untagged', () => {
-    const out = emitGherkinFeature(definitions('F', rule('r', scenario('plain words here'))));
+    const plainRule = rule('r', scenario('plain words here'));
+    const out = emitGherkinFeature(definitions('F', plainRule));
     const [s] = scenariosOf(out);
     expect(s?.name).toBe('plain words here');
     expect(s?.tags).toEqual([]);
@@ -129,7 +119,8 @@ describe('emitGherkinFeature — AC1: faithful Gherkin emission', () => {
 
   it('gherkin-typescript.DEV1.AC1.hostile_title_emits_a_valid_feature', () => {
     const hostile = 'gherkin-typescript.DEV1.AC1.has spaces (parens) and @at';
-    const out = emitGherkinFeature(definitions('F', rule('r', scenario(hostile))));
+    const hostileRule = rule('r', scenario(hostile));
+    const out = emitGherkinFeature(definitions('F', hostileRule));
     expect(parsesAsGherkin(out)).toBe(true);
     const [s] = scenariosOf(out);
     // Tag comes from the parsed AC ref (whitespace-free), never the raw title.
@@ -138,17 +129,15 @@ describe('emitGherkinFeature — AC1: faithful Gherkin emission', () => {
   });
 
   it('gherkin-typescript.DEV1.AC1.bodyless_scenario_emits_a_stepless_scenario', () => {
-    const out = emitGherkinFeature(
-      definitions('F', rule('r', scenario('demo.DEV1.AC1.bodyless', ''))),
-    );
+    const bodylessRule = rule('r', scenario('demo.DEV1.AC1.bodyless', ''));
+    const out = emitGherkinFeature(definitions('F', bodylessRule));
     expect(parsesAsGherkin(out)).toBe(true);
     expect(scenariosOf(out)[0]?.stepKeywords).toEqual([]);
   });
 
   it('gherkin-typescript.DEV1.AC1.emitted_feature_parses_with_official_parser', () => {
-    const out = emitGherkinFeature(
-      definitions('F', rule('r', scenario('demo.DEV1.AC1.one'), scenario('demo.DEV1.AC1.two'))),
-    );
+    const twoScenarioRule = rule('r', scenario('demo.DEV1.AC1.one'), scenario('demo.DEV1.AC1.two'));
+    const out = emitGherkinFeature(definitions('F', twoScenarioRule));
     expect(parsesAsGherkin(out)).toBe(true);
   });
 });

--- a/packages/cli/src/utils/test-skeleton.test.ts
+++ b/packages/cli/src/utils/test-skeleton.test.ts
@@ -39,25 +39,23 @@ function countDescribes(emitted: string): number {
 
 describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
   it('codify.DEV1.AC1.scenario_emits_one_named_it', () => {
-    const out = emitVitestSkeleton(
-      definitions(rule('a rule', scenario('codify.DEV1.AC1.example'))),
-    );
+    const defs = definitions(rule('a rule', scenario('codify.DEV1.AC1.example')));
+    const out = emitVitestSkeleton(defs);
     expect(countTests(out)).toBe(1);
     expect(out).toContain('"codify.DEV1.AC1.example"');
   });
 
   it('codify.DEV1.AC1.given_when_then_and_render_as_comments', () => {
-    const out = emitVitestSkeleton(
-      definitions(
-        rule(
-          'a rule',
-          scenario(
-            'codify.DEV1.AC1.commented',
-            'Given a cart\nWhen I pay\nThen it clears\nAnd a receipt prints',
-          ),
+    const defs = definitions(
+      rule(
+        'a rule',
+        scenario(
+          'codify.DEV1.AC1.commented',
+          'Given a cart\nWhen I pay\nThen it clears\nAnd a receipt prints',
         ),
       ),
     );
+    const out = emitVitestSkeleton(defs);
     const gIndex = out.indexOf('// Given a cart');
     const wIndex = out.indexOf('// When I pay');
     const tIndex = out.indexOf('// Then it clears');
@@ -69,9 +67,8 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
   });
 
   it('codify.DEV1.AC1.scenario_without_body_still_emits_a_stub', () => {
-    const out = emitVitestSkeleton(
-      definitions(rule('a rule', scenario('codify.DEV1.AC1.bodyless', ''))),
-    );
+    const defs = definitions(rule('a rule', scenario('codify.DEV1.AC1.bodyless', '')));
+    const out = emitVitestSkeleton(defs);
     expect(countTests(out)).toBe(1);
     expect(out).toContain('"codify.DEV1.AC1.bodyless"');
     // No step comments in the generated body (the only `//` is the file header).
@@ -80,15 +77,14 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
   });
 
   it('codify.DEV1.AC1.scenarios_group_under_their_rule_describe', () => {
-    const out = emitVitestSkeleton(
-      definitions(
-        rule(
-          'emits one test per scenario',
-          scenario('codify.DEV1.AC1.one'),
-          scenario('codify.DEV1.AC1.two'),
-        ),
+    const defs = definitions(
+      rule(
+        'emits one test per scenario',
+        scenario('codify.DEV1.AC1.one'),
+        scenario('codify.DEV1.AC1.two'),
       ),
     );
+    const out = emitVitestSkeleton(defs);
     expect(countDescribes(out)).toBe(1);
     expect(out).toContain('describe("emits one test per scenario"');
     expect(countTests(out)).toBe(2);
@@ -96,27 +92,26 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
 
   it('codify.DEV1.AC1.rule_heading_with_special_chars_emits_valid_module', () => {
     const heading = "`check` reports gaps (three buckets) — don't break";
-    const out = emitVitestSkeleton(definitions(rule(heading, scenario('codify.DEV1.AC1.special'))));
+    const defs = definitions(rule(heading, scenario('codify.DEV1.AC1.special')));
+    const out = emitVitestSkeleton(defs);
     // The describe name is JSON-encoded, so any heading — backticks, quotes,
     // parens — becomes a valid JS string literal and the module parses.
     expect(out).toContain(`describe(${JSON.stringify(heading)}`);
   });
 
   it('codify.DEV1.AC1.rules_and_scenarios_map_one_to_one', () => {
-    const out = emitVitestSkeleton(
-      definitions(
-        rule('first rule', scenario('codify.DEV1.AC1.r1s1'), scenario('codify.DEV1.AC1.r1s2')),
-        rule('second rule', scenario('codify.DEV1.AC1.r2s1')),
-      ),
+    const defs = definitions(
+      rule('first rule', scenario('codify.DEV1.AC1.r1s1'), scenario('codify.DEV1.AC1.r1s2')),
+      rule('second rule', scenario('codify.DEV1.AC1.r2s1')),
     );
+    const out = emitVitestSkeleton(defs);
     expect(countDescribes(out)).toBe(2);
     expect(countTests(out)).toBe(3);
   });
 
   it('codify.DEV1.AC1.free_text_scenario_still_emits_a_test', () => {
-    const out = emitVitestSkeleton(
-      definitions(rule('a rule', scenario('plain words with no lineage'))),
-    );
+    const defs = definitions(rule('a rule', scenario('plain words with no lineage')));
+    const out = emitVitestSkeleton(defs);
     expect(countTests(out)).toBe(1);
     expect(out).toContain('"plain words with no lineage"');
   });
@@ -124,9 +119,10 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
   it('codify.DEV1.AC1.fenced_and_commented_scenarios_are_skipped', () => {
     const fenced = '```\n### Scenario: codify.DEV1.AC1.fenced\n```';
     const commented = '<!--\n### Scenario: codify.DEV1.AC1.commented_out\n-->';
-    const out = emitVitestSkeleton(
-      definitions(rule('a rule', scenario('codify.DEV1.AC1.real'), `${fenced}\n\n${commented}`)),
+    const defs = definitions(
+      rule('a rule', scenario('codify.DEV1.AC1.real'), `${fenced}\n\n${commented}`),
     );
+    const out = emitVitestSkeleton(defs);
     expect(countTests(out)).toBe(1);
     expect(out).not.toContain('fenced');
     expect(out).not.toContain('commented_out');
@@ -143,15 +139,15 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
 
 describe('emitVitestSkeleton — AC2: pending by default, --red throws', () => {
   it('codify.DEV1.AC2.default_emits_pending_it_todo', () => {
-    const out = emitVitestSkeleton(
-      definitions(rule('a rule', scenario('codify.DEV1.AC2.pending'))),
-    );
+    const defs = definitions(rule('a rule', scenario('codify.DEV1.AC2.pending')));
+    const out = emitVitestSkeleton(defs);
     expect(out).toContain('it.todo("codify.DEV1.AC2.pending")');
     expect(out).not.toContain('throw new Error');
   });
 
   it('codify.DEV1.AC2.red_flag_emits_throwing_body', () => {
-    const out = emitVitestSkeleton(definitions(rule('a rule', scenario('codify.DEV1.AC2.red'))), {
+    const defs = definitions(rule('a rule', scenario('codify.DEV1.AC2.red')));
+    const out = emitVitestSkeleton(defs, {
       red: true,
     });
     expect(out).toContain('it("codify.DEV1.AC2.red"');

--- a/packages/cli/src/utils/test-skeleton.test.ts
+++ b/packages/cli/src/utils/test-skeleton.test.ts
@@ -75,7 +75,7 @@ describe('emitVitestSkeleton — AC1: faithful scenario→test mapping', () => {
     expect(countTests(out)).toBe(1);
     expect(out).toContain('"codify.DEV1.AC1.bodyless"');
     // No step comments in the generated body (the only `//` is the file header).
-    const generatedBody = out.split("from 'vitest';")[1] ?? '';
+    const generatedBody = out.split("from 'vitest';", 2)[1] ?? '';
     expect(generatedBody).not.toContain('//');
   });
 

--- a/packages/cli/src/utils/test-skeleton.ts
+++ b/packages/cli/src/utils/test-skeleton.ts
@@ -66,7 +66,8 @@ export function parseScenarios(testDefinitionsContent: string): ParsedScenario[]
   };
 
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    const isSkipped = skip[index];
+    if (isSkipped) continue;
     const heading = classifyHeading(line);
     if (heading !== undefined) {
       flush();

--- a/packages/cli/src/utils/test-skeleton.ts
+++ b/packages/cli/src/utils/test-skeleton.ts
@@ -57,12 +57,12 @@ export function parseScenarios(testDefinitionsContent: string): ParsedScenario[]
   const scenarios: ParsedScenario[] = [];
   let currentRule: string | undefined;
   let current: ParsedScenario | undefined;
-  let collectingSteps = false;
+  let isCollectingSteps = false;
 
   const flush = (): void => {
     if (current !== undefined) scenarios.push(current);
     current = undefined;
-    collectingSteps = false;
+    isCollectingSteps = false;
   };
 
   for (const [index, line] of lines.entries()) {
@@ -74,10 +74,10 @@ export function parseScenarios(testDefinitionsContent: string): ParsedScenario[]
       else if (heading.kind === 'other') currentRule = undefined;
       else if (currentRule !== undefined) {
         current = { rule: currentRule, title: heading.title, steps: [] };
-        collectingSteps = true;
+        isCollectingSteps = true;
       }
-    } else if (collectingSteps && current !== undefined) {
-      collectingSteps = appendStep(current, line);
+    } else if (isCollectingSteps && current !== undefined) {
+      isCollectingSteps = appendStep(current, line);
     }
   }
   flush();

--- a/packages/cli/src/utils/ticket-relations.ts
+++ b/packages/cli/src/utils/ticket-relations.ts
@@ -76,21 +76,28 @@ export function findTicketsInCycles(nodes: TicketNode[]): string[] {
   const inCycle = new Set<string>();
 
   for (const start of edges.keys()) {
-    // DFS along depends_on edges; reaching `start` again means it's on a cycle.
-    const stack = [...(edges.get(start) ?? [])];
-    const seen = new Set<string>();
-    while (stack.length > 0) {
-      const next = stack.pop();
-      if (next === undefined) continue;
-      if (next === start) {
-        inCycle.add(start);
-        break;
-      }
-      if (seen.has(next)) continue;
-      seen.add(next);
-      stack.push(...(edges.get(next) ?? []));
-    }
+    if (reachesSelf(start, edges)) inCycle.add(start);
   }
 
   return [...inCycle].toSorted((a, b) => a.localeCompare(b));
+}
+
+/**
+ * DFS along depends_on edges from `start`; returns true when `start` is
+ * reachable from itself (it lies on a cycle, including via a self-edge).
+ */
+function reachesSelf(start: string, edges: Map<string, string[]>): boolean {
+  const stack = [...(edges.get(start) ?? [])];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const next = stack.pop();
+    if (next === undefined) continue;
+    if (next === start) {
+      return true;
+    }
+    if (seen.has(next)) continue;
+    seen.add(next);
+    stack.push(...(edges.get(next) ?? []));
+  }
+  return false;
 }

--- a/packages/cli/src/utils/ticket-writer.ts
+++ b/packages/cli/src/utils/ticket-writer.ts
@@ -82,7 +82,7 @@ export function createTicket(
 
 function renderSpecMarkdown(title: string): string {
   const template = readFileSync(nodePath.join(getTemplatesDirectory(), 'spec-template.md'), 'utf8');
-  return template.replace('{title}', title);
+  return template.replace('{title}', () => title);
 }
 
 function mintAndClaim(

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -39,7 +39,7 @@ export function groupByLine<T extends { lineNumber: number }>(
  */
 export function findDuplicates(grouped: Map<string, number[]>, kind: string): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  for (const [value, lines] of grouped.entries()) {
+  for (const [value, lines] of grouped) {
     if (lines.length <= 1) continue;
     for (const line of lines) {
       const others = lines.filter(other => other !== line).join(', ');

--- a/packages/cli/src/utils/vendored-ignores-nudge.test.ts
+++ b/packages/cli/src/utils/vendored-ignores-nudge.test.ts
@@ -36,8 +36,8 @@ afterEach(() => {
 
 describe('shouldEmitVendoredIgnoresNudge', () => {
   it('emits when existing JS eslint config does not reference .safeword/', () => {
-    const cfg = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
-    writeFileSync(cfg, "export default [{ files: ['**/*.ts'] }];\n", 'utf8');
+    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    writeFileSync(config, "export default [{ files: ['**/*.ts'] }];\n", 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
         cwd: temporaryDirectory,
@@ -48,8 +48,8 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent when existing eslint config already references .safeword/', () => {
-    const cfg = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
-    writeFileSync(cfg, "export default [{ ignores: ['.safeword/**'] }];\n", 'utf8');
+    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    writeFileSync(config, "export default [{ ignores: ['.safeword/**'] }];\n", 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
         cwd: temporaryDirectory,
@@ -60,9 +60,9 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent when existing eslint config already mentions vendoredIgnores (manual 153 application)', () => {
-    const cfg = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
     writeFileSync(
-      cfg,
+      config,
       "import s from 'safeword/eslint';\nexport default [...s.configs.vendoredIgnores];\n",
       'utf8',
     );
@@ -86,8 +86,8 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent on non-JS projects regardless of stray eslint config', () => {
-    const cfg = nodePath.join(temporaryDirectory, '.eslintrc');
-    writeFileSync(cfg, '{}', 'utf8');
+    const config = nodePath.join(temporaryDirectory, '.eslintrc');
+    writeFileSync(config, '{}', 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
         cwd: temporaryDirectory,

--- a/packages/cli/src/utils/vendored-ignores-nudge.test.ts
+++ b/packages/cli/src/utils/vendored-ignores-nudge.test.ts
@@ -16,31 +16,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { maybeAutoPatchOrNudge, shouldEmitVendoredIgnoresNudge } from './vendored-ignores-nudge.js';
 
-let temporaryDirectory: string;
+const state: { temporaryDirectory: string } = { temporaryDirectory: '' };
 
 function setupConfig(filename: string, body: string): string {
-  const fullPath = nodePath.join(temporaryDirectory, filename);
+  const fullPath = nodePath.join(state.temporaryDirectory, filename);
   writeFileSync(fullPath, body, 'utf8');
   return fullPath;
 }
 
 beforeEach(() => {
-  temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-nudge-'));
+  state.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-nudge-'));
 });
 
 afterEach(() => {
-  if (existsSync(temporaryDirectory)) {
-    rmSync(temporaryDirectory, { recursive: true, force: true });
+  if (existsSync(state.temporaryDirectory)) {
+    rmSync(state.temporaryDirectory, { recursive: true, force: true });
   }
 });
 
 describe('shouldEmitVendoredIgnoresNudge', () => {
   it('emits when existing JS eslint config does not reference .safeword/', () => {
-    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    const config = nodePath.join(state.temporaryDirectory, 'eslint.config.mjs');
     writeFileSync(config, "export default [{ files: ['**/*.ts'] }];\n", 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
-        cwd: temporaryDirectory,
+        cwd: state.temporaryDirectory,
         existingEslintConfig: 'eslint.config.mjs',
         hasJavaScript: true,
       }),
@@ -48,11 +48,11 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent when existing eslint config already references .safeword/', () => {
-    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    const config = nodePath.join(state.temporaryDirectory, 'eslint.config.mjs');
     writeFileSync(config, "export default [{ ignores: ['.safeword/**'] }];\n", 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
-        cwd: temporaryDirectory,
+        cwd: state.temporaryDirectory,
         existingEslintConfig: 'eslint.config.mjs',
         hasJavaScript: true,
       }),
@@ -60,7 +60,7 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent when existing eslint config already mentions vendoredIgnores (manual 153 application)', () => {
-    const config = nodePath.join(temporaryDirectory, 'eslint.config.mjs');
+    const config = nodePath.join(state.temporaryDirectory, 'eslint.config.mjs');
     writeFileSync(
       config,
       "import s from 'safeword/eslint';\nexport default [...s.configs.vendoredIgnores];\n",
@@ -68,7 +68,7 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
     );
     expect(
       shouldEmitVendoredIgnoresNudge({
-        cwd: temporaryDirectory,
+        cwd: state.temporaryDirectory,
         existingEslintConfig: 'eslint.config.mjs',
         hasJavaScript: true,
       }),
@@ -78,7 +78,7 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   it('stays silent when no existing eslint config (fresh project)', () => {
     expect(
       shouldEmitVendoredIgnoresNudge({
-        cwd: temporaryDirectory,
+        cwd: state.temporaryDirectory,
         existingEslintConfig: undefined,
         hasJavaScript: true,
       }),
@@ -86,11 +86,11 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
   });
 
   it('stays silent on non-JS projects regardless of stray eslint config', () => {
-    const config = nodePath.join(temporaryDirectory, '.eslintrc');
+    const config = nodePath.join(state.temporaryDirectory, '.eslintrc');
     writeFileSync(config, '{}', 'utf8');
     expect(
       shouldEmitVendoredIgnoresNudge({
-        cwd: temporaryDirectory,
+        cwd: state.temporaryDirectory,
         existingEslintConfig: '.eslintrc',
         hasJavaScript: false,
       }),
@@ -102,7 +102,7 @@ describe('shouldEmitVendoredIgnoresNudge', () => {
     try {
       expect(
         shouldEmitVendoredIgnoresNudge({
-          cwd: temporaryDirectory,
+          cwd: state.temporaryDirectory,
           existingEslintConfig: 'does-not-exist.mjs',
           hasJavaScript: true,
         }),
@@ -131,18 +131,18 @@ describe('maybeAutoPatchOrNudge', () => {
     setupConfig('eslint.config.mjs', original);
 
     maybeAutoPatchOrNudge({
-      cwd: temporaryDirectory,
+      cwd: state.temporaryDirectory,
       existingEslintConfig: 'eslint.config.mjs',
       hasJavaScript: true,
       noModify: true,
     });
 
-    expect(readFileSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
+    expect(readFileSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
       original,
     );
-    expect(existsSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs.safeword-bak'))).toBe(
-      false,
-    );
+    expect(
+      existsSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs.safeword-bak')),
+    ).toBe(false);
     const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(output).toContain('...safeword.configs.vendoredIgnores,');
   });
@@ -153,18 +153,18 @@ describe('maybeAutoPatchOrNudge', () => {
     process.env.SAFEWORD_NO_MODIFY = '1';
 
     maybeAutoPatchOrNudge({
-      cwd: temporaryDirectory,
+      cwd: state.temporaryDirectory,
       existingEslintConfig: 'eslint.config.mjs',
       hasJavaScript: true,
       noModify: false,
     });
 
-    expect(readFileSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
+    expect(readFileSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
       original,
     );
-    expect(existsSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs.safeword-bak'))).toBe(
-      false,
-    );
+    expect(
+      existsSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs.safeword-bak')),
+    ).toBe(false);
     const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(output).toContain('...safeword.configs.vendoredIgnores,');
   });
@@ -175,13 +175,13 @@ describe('maybeAutoPatchOrNudge', () => {
     setupConfig('eslint.config.mjs', original);
 
     maybeAutoPatchOrNudge({
-      cwd: temporaryDirectory,
+      cwd: state.temporaryDirectory,
       existingEslintConfig: 'eslint.config.mjs',
       hasJavaScript: true,
       noModify: true,
     });
 
-    expect(readFileSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
+    expect(readFileSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
       original,
     );
     const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
@@ -192,17 +192,20 @@ describe('maybeAutoPatchOrNudge', () => {
     setupConfig('eslint.config.mjs', "export default [{ files: ['**/*.ts'] }];\n");
 
     maybeAutoPatchOrNudge({
-      cwd: temporaryDirectory,
+      cwd: state.temporaryDirectory,
       existingEslintConfig: 'eslint.config.mjs',
       hasJavaScript: true,
       noModify: false,
     });
 
-    const patched = readFileSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs'), 'utf8');
-    expect(patched).toContain('...safeword.configs.vendoredIgnores,');
-    expect(existsSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs.safeword-bak'))).toBe(
-      true,
+    const patched = readFileSync(
+      nodePath.join(state.temporaryDirectory, 'eslint.config.mjs'),
+      'utf8',
     );
+    expect(patched).toContain('...safeword.configs.vendoredIgnores,');
+    expect(
+      existsSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs.safeword-bak')),
+    ).toBe(true);
     const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(output).toContain('eslint.config.mjs');
     expect(output).toContain('.safeword-bak');
@@ -213,18 +216,18 @@ describe('maybeAutoPatchOrNudge', () => {
     setupConfig('eslint.config.mjs', original);
 
     maybeAutoPatchOrNudge({
-      cwd: temporaryDirectory,
+      cwd: state.temporaryDirectory,
       existingEslintConfig: 'eslint.config.mjs',
       hasJavaScript: true,
       noModify: false,
     });
 
-    expect(readFileSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
+    expect(readFileSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs'), 'utf8')).toBe(
       original,
     );
-    expect(existsSync(nodePath.join(temporaryDirectory, 'eslint.config.mjs.safeword-bak'))).toBe(
-      false,
-    );
+    expect(
+      existsSync(nodePath.join(state.temporaryDirectory, 'eslint.config.mjs.safeword-bak')),
+    ).toBe(false);
     const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(output).toContain("Couldn't auto-patch");
     expect(output).toContain('...safeword.configs.vendoredIgnores,');

--- a/packages/cli/tests/commands/reset.test.ts
+++ b/packages/cli/tests/commands/reset.test.ts
@@ -126,7 +126,7 @@ describe('Test Suite 11: Reset', () => {
       await createConfiguredProject(temporaryDirectory);
 
       // Verify skills exist after setup
-      const skillsExist = fileExists(temporaryDirectory, '.claude/skills');
+      const isSkillsExist = fileExists(temporaryDirectory, '.claude/skills');
 
       const result = await runCli(['reset', '--yes'], {
         cwd: temporaryDirectory,
@@ -137,7 +137,7 @@ describe('Test Suite 11: Reset', () => {
 
       // After reset, safeword skills should be gone
       // but .claude/skills directory may remain if empty or have other skills
-      if (skillsExist) {
+      if (isSkillsExist) {
         // Check no safeword-* directories remain
         // This would require listing directory contents
       }

--- a/packages/cli/tests/commands/setup-golang.test.ts
+++ b/packages/cli/tests/commands/setup-golang.test.ts
@@ -19,18 +19,6 @@ import {
   writeTestFile,
 } from '../helpers';
 
-let projectDirectory: string;
-
-beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
-});
-
-afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
-  }
-});
-
 /**
  * Helper to create a polyglot project (JS + Go)
  */
@@ -57,6 +45,18 @@ function createJsGoProject(dir: string): void {
 }
 
 describe('Test Suite: Conditional Setup for Go Projects', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    if (projectDirectory) {
+      removeTemporaryDirectory(projectDirectory);
+    }
+  });
+
   describe('Test: Installs the JS toolchain for Go-only projects (BDD lane, ticket 102b)', () => {
     it.skipIf(process.env.SAFEWORD_RUN_INSTALL_TESTS !== '1')(
       'should install eslint and cucumber for Go-only project (the lane ships TS step files)',

--- a/packages/cli/tests/commands/setup-hooks.test.ts
+++ b/packages/cli/tests/commands/setup-hooks.test.ts
@@ -6,6 +6,7 @@
 
 import { chmodSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
+import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/packages/cli/tests/commands/setup-linting.test.ts
+++ b/packages/cli/tests/commands/setup-linting.test.ts
@@ -10,6 +10,7 @@
 
 import { chmodSync } from 'node:fs';
 import nodePath from 'node:path';
+import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/packages/cli/tests/commands/setup-python-phase2.test.ts
+++ b/packages/cli/tests/commands/setup-python-phase2.test.ts
@@ -331,7 +331,7 @@ strict = true
 // Test Suite 6: Auto-Install Python Tools
 // =============================================================================
 
-const UV_AVAILABLE = isUvInstalled();
+const IS_UV_AVAILABLE = isUvInstalled();
 
 describe('Suite 6: Auto-Install Python Tools', () => {
   it(
@@ -354,7 +354,7 @@ describe('Suite 6: Auto-Install Python Tools', () => {
     TIMEOUT_SETUP,
   );
 
-  it.skipIf(!UV_AVAILABLE)(
+  it.skipIf(!IS_UV_AVAILABLE)(
     'Test 6.2: Auto-installs tools for uv projects',
     async () => {
       // Arrange - uv project with uv.lock

--- a/packages/cli/tests/commands/setup-python-phase2.test.ts
+++ b/packages/cli/tests/commands/setup-python-phase2.test.ts
@@ -26,15 +26,15 @@ import {
 
 const __dirname = import.meta.dirname;
 
-let projectDirectory: string;
+let state.projectDirectory: string;
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  state.projectDirectory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
+  if (state.projectDirectory) {
+    removeTemporaryDirectory(state.projectDirectory);
   }
 });
 
@@ -88,23 +88,23 @@ describe('Suite 1: Ruff Config Generation', () => {
     'Test 1.1: Generates ruff.toml at project root',
     async () => {
       // Arrange
-      createPythonProjectReadyForSetup(projectDirectory);
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
       // Ticket 138: customer's ruff.toml is bare/customer-owned; safeword's .safeword/ruff.toml extends it.
-      expect(fileExists(projectDirectory, 'ruff.toml')).toBe(true);
-      const ruffToml = readTestFile(projectDirectory, 'ruff.toml');
+      expect(fileExists(state.projectDirectory, 'ruff.toml')).toBe(true);
+      const ruffToml = readTestFile(state.projectDirectory, 'ruff.toml');
       expect(ruffToml).toContain('customer-owned');
 
       // Actual rules are in .safeword/ruff.toml, which extends customer's ruff.toml.
-      const safewordRuffToml = readTestFile(projectDirectory, '.safeword/ruff.toml');
+      const safewordRuffToml = readTestFile(state.projectDirectory, '.safeword/ruff.toml');
       expect(safewordRuffToml).toContain('[lint]');
       expect(safewordRuffToml).toContain('extend = "../ruff.toml"');
       expect(safewordRuffToml).toContain('extend-select = [');
@@ -114,7 +114,7 @@ describe('Suite 1: Ruff Config Generation', () => {
       expect(safewordRuffToml).toContain('"B"');
 
       // pyproject.toml should NOT be modified for ruff
-      const pyprojectContent = readPyprojectToml(projectDirectory);
+      const pyprojectContent = readPyprojectToml(state.projectDirectory);
       expect(pyprojectContent).not.toContain('[tool.ruff]');
     },
     TIMEOUT_SETUP,
@@ -125,7 +125,7 @@ describe('Suite 1: Ruff Config Generation', () => {
     async () => {
       // Arrange - project with existing [tool.ruff] in pyproject.toml
       writeTestFile(
-        projectDirectory,
+        state.projectDirectory,
         'pyproject.toml',
         `[project]
 name = "existing-project"
@@ -139,24 +139,24 @@ line-length = 120
 testpaths = ["tests"]
 `,
       );
-      createSafewordBasePackageJson(projectDirectory);
-      initGitRepo(projectDirectory);
+      createSafewordBasePackageJson(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
       // Assert - ruff.toml should NOT be created (project has existing config)
-      expect(fileExists(projectDirectory, 'ruff.toml')).toBe(false);
+      expect(fileExists(state.projectDirectory, 'ruff.toml')).toBe(false);
 
       // .safeword/ruff.toml should still be created (for hooks)
-      expect(fileExists(projectDirectory, '.safeword/ruff.toml')).toBe(true);
+      expect(fileExists(state.projectDirectory, '.safeword/ruff.toml')).toBe(true);
 
       // Original pyproject.toml content preserved
-      const pyprojectContent = readPyprojectToml(projectDirectory);
+      const pyprojectContent = readPyprojectToml(state.projectDirectory);
       expect(pyprojectContent).toContain('name = "existing-project"');
       expect(pyprojectContent).toContain('description = "An existing project"');
       expect(pyprojectContent).toContain('[tool.pytest.ini_options]');
@@ -175,24 +175,24 @@ describe('Suite 2: Architecture Validation', () => {
     'Test 2.1: Generates .importlinter config file',
     async () => {
       // Arrange
-      createPythonProjectWithLayers(projectDirectory);
-      initGitRepo(projectDirectory);
+      createPythonProjectWithLayers(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
       });
 
       // Assert - .importlinter file created at project root
-      expect(fileExists(projectDirectory, '.importlinter')).toBe(true);
-      const importLinterConfig = readTestFile(projectDirectory, '.importlinter');
+      expect(fileExists(state.projectDirectory, '.importlinter')).toBe(true);
+      const importLinterConfig = readTestFile(state.projectDirectory, '.importlinter');
       expect(importLinterConfig).toContain('[importlinter]');
       // Should have layer contracts
       expect(importLinterConfig).toContain('[importlinter:contract:layers]');
 
       // pyproject.toml should NOT be modified
-      const pyprojectContent = readPyprojectToml(projectDirectory);
+      const pyprojectContent = readPyprojectToml(state.projectDirectory);
       expect(pyprojectContent).not.toContain('[tool.importlinter]');
     },
     TIMEOUT_SETUP,
@@ -202,18 +202,18 @@ describe('Suite 2: Architecture Validation', () => {
     'Test 2.1b: Does not generate .importlinter without layer structure',
     async () => {
       // Arrange
-      createPythonProjectReadyForSetup(projectDirectory); // No layers
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory); // No layers
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
       // Assert - .importlinter file should NOT exist
-      expect(fileExists(projectDirectory, '.importlinter')).toBe(false);
+      expect(fileExists(state.projectDirectory, '.importlinter')).toBe(false);
     },
     TIMEOUT_SETUP,
   );
@@ -264,19 +264,19 @@ describe('Suite 5: mypy Configuration', () => {
     'Test 5.1: Generates mypy.ini at project root',
     async () => {
       // Arrange
-      createPythonProjectReadyForSetup(projectDirectory);
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
       // Assert - mypy.ini file created at project root
-      expect(fileExists(projectDirectory, 'mypy.ini')).toBe(true);
-      const mypyConfig = readTestFile(projectDirectory, 'mypy.ini');
+      expect(fileExists(state.projectDirectory, 'mypy.ini')).toBe(true);
+      const mypyConfig = readTestFile(state.projectDirectory, 'mypy.ini');
       expect(mypyConfig).toContain('[mypy]');
       // Strict mode for LLM agents
       expect(mypyConfig).toContain('strict = True');
@@ -286,7 +286,7 @@ describe('Suite 5: mypy Configuration', () => {
       expect(mypyConfig).toContain('pretty = True');
 
       // pyproject.toml should NOT be modified
-      const pyprojectContent = readPyprojectToml(projectDirectory);
+      const pyprojectContent = readPyprojectToml(state.projectDirectory);
       expect(pyprojectContent).not.toContain('[tool.mypy]');
     },
     TIMEOUT_SETUP,
@@ -297,7 +297,7 @@ describe('Suite 5: mypy Configuration', () => {
     async () => {
       // Arrange - project with existing [tool.mypy] in pyproject.toml
       writeTestFile(
-        projectDirectory,
+        state.projectDirectory,
         'pyproject.toml',
         `[project]
 name = "test"
@@ -306,21 +306,21 @@ name = "test"
 strict = true
 `,
       );
-      createSafewordBasePackageJson(projectDirectory);
-      initGitRepo(projectDirectory);
+      createSafewordBasePackageJson(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
       // Assert - mypy.ini should NOT be created (project has existing config)
-      expect(fileExists(projectDirectory, 'mypy.ini')).toBe(false);
+      expect(fileExists(state.projectDirectory, 'mypy.ini')).toBe(false);
 
       // Original pyproject.toml preserved
-      const pyprojectContent = readPyprojectToml(projectDirectory);
+      const pyprojectContent = readPyprojectToml(state.projectDirectory);
       expect(pyprojectContent).toContain('strict = true');
     },
     TIMEOUT_SETUP,
@@ -338,12 +338,12 @@ describe('Suite 6: Auto-Install Python Tools', () => {
     'Test 6.1: Shows install message for pip projects (no auto-install)',
     async () => {
       // Arrange - pip project (default, no lockfile)
-      createPythonProjectReadyForSetup(projectDirectory);
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       const result = await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
       });
 
@@ -358,12 +358,12 @@ describe('Suite 6: Auto-Install Python Tools', () => {
     'Test 6.2: Auto-installs tools for uv projects',
     async () => {
       // Arrange - uv project with uv.lock
-      createPythonProjectReadyForSetup(projectDirectory, { manager: 'uv' });
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory, { manager: 'uv' });
+      initGitRepo(state.projectDirectory);
 
       // Act
       const result = await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
         env: { SAFEWORD_SKIP_INSTALL: '1' },
       });
@@ -381,7 +381,7 @@ describe('Suite 6: Auto-Install Python Tools', () => {
     async () => {
       // Arrange - project with ruff already declared
       writeTestFile(
-        projectDirectory,
+        state.projectDirectory,
         'pyproject.toml',
         `[project]
 name = "test"
@@ -391,12 +391,12 @@ version = "0.1.0"
 dev = ["ruff>=0.8.0"]
 `,
       );
-      createSafewordBasePackageJson(projectDirectory);
-      initGitRepo(projectDirectory);
+      createSafewordBasePackageJson(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       const result = await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
       });
 
@@ -413,7 +413,7 @@ dev = ["ruff>=0.8.0"]
       // Arrange - poetry project with invalid config (python key not allowed)
       // This makes poetry fail immediately with "Additional properties are not allowed"
       writeTestFile(
-        projectDirectory,
+        state.projectDirectory,
         'pyproject.toml',
         `[project]
 name = "test"
@@ -425,12 +425,12 @@ python = "^3.12"
 `,
       );
       // Note: Invalid poetry config ensures immediate failure (no network calls)
-      createSafewordBasePackageJson(projectDirectory);
-      initGitRepo(projectDirectory);
+      createSafewordBasePackageJson(state.projectDirectory);
+      initGitRepo(state.projectDirectory);
 
       // Act
       const result = await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
       });
 
@@ -445,13 +445,13 @@ python = "^3.12"
     'Test 6.5: Shows pipenv install command for pipenv projects',
     async () => {
       // Arrange - pipenv project
-      createPythonProjectReadyForSetup(projectDirectory, { manager: 'pipenv' });
-      writeTestFile(projectDirectory, 'Pipfile', '[invalid\n');
-      initGitRepo(projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory, { manager: 'pipenv' });
+      writeTestFile(state.projectDirectory, 'Pipfile', '[invalid\n');
+      initGitRepo(state.projectDirectory);
 
       // Act
       const result = await runCli(['setup'], {
-        cwd: projectDirectory,
+        cwd: state.projectDirectory,
         timeout: TIMEOUT_SETUP,
       });
 

--- a/packages/cli/tests/commands/setup-python-phase2.test.ts
+++ b/packages/cli/tests/commands/setup-python-phase2.test.ts
@@ -26,7 +26,7 @@ import {
 
 const __dirname = import.meta.dirname;
 
-let state.projectDirectory: string;
+const state: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
   state.projectDirectory = createTemporaryDirectory();

--- a/packages/cli/tests/commands/setup-python.test.ts
+++ b/packages/cli/tests/commands/setup-python.test.ts
@@ -19,18 +19,6 @@ import {
   writeTestFile,
 } from '../helpers';
 
-let projectDirectory: string;
-
-beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
-});
-
-afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
-  }
-});
-
 /**
  * Helper to create a polyglot project (JS + Python)
  */
@@ -57,6 +45,18 @@ function createPolyglotProject(dir: string): void {
 }
 
 describe('Test Suite 3: Conditional Setup for Python Projects', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    if (projectDirectory) {
+      removeTemporaryDirectory(projectDirectory);
+    }
+  });
+
   describe('Test 3.1: Installs the JS toolchain for Python-only projects (BDD lane, ticket 102b)', () => {
     it.skipIf(process.env.SAFEWORD_RUN_INSTALL_TESTS !== '1')(
       'should install eslint and cucumber for Python-only project (the lane ships TS step files)',

--- a/packages/cli/tests/commands/setup-templates.test.ts
+++ b/packages/cli/tests/commands/setup-templates.test.ts
@@ -164,11 +164,11 @@ describe('Setup - Template Bundling (Story 1)', () => {
       /learnings\//, // Example learning file paths in documentation
     ];
 
-    for (const mdFile of allMdFiles) {
-      const content = readFileSync(mdFile, 'utf8');
-      const links = content.match(linkPattern) || [];
-      totalLinks += links.length;
-
+    const collectBrokenLinksForFile = (
+      mdFile: string,
+      links: string[],
+    ): { file: string; link: string }[] => {
+      const broken: { file: string; link: string }[] = [];
       for (const link of links) {
         // Skip example/placeholder links
         if (examplePatterns.some(p => p.test(link))) {
@@ -179,12 +179,21 @@ describe('Setup - Template Bundling (Story 1)', () => {
         const relativePath = link;
 
         if (!fileExists(temporaryDirectory, relativePath)) {
-          brokenLinks.push({
+          broken.push({
             file: mdFile.replace(`${temporaryDirectory}/`, ''),
             link,
           });
         }
       }
+      return broken;
+    };
+
+    for (const mdFile of allMdFiles) {
+      const content = readFileSync(mdFile, 'utf8');
+      const links = content.match(linkPattern) || [];
+      totalLinks += links.length;
+
+      brokenLinks.push(...collectBrokenLinksForFile(mdFile, links));
     }
 
     // Report all broken links

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -32,8 +32,10 @@ function readOnlyTicketFolderName(ticketsDirectory: string): string {
 function extractIdFromFolder(folderName: string): string {
   const match = FOLDER_PATTERN.exec(folderName);
   const id = match?.[1];
-  if (id === undefined)
-    throw new Error(`folder "${folderName}" did not match ${'{'}ID}-${'{'}slug} shape`);
+  if (id === undefined) {
+    // eslint-disable-next-line unicorn/no-incorrect-template-string-interpolation -- {ID}-{slug} is literal placeholder text in the message, not interpolation
+    throw new Error(`folder "${folderName}" did not match {ID}-{slug} shape`);
+  }
   return id;
 }
 

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -32,7 +32,8 @@ function readOnlyTicketFolderName(ticketsDirectory: string): string {
 function extractIdFromFolder(folderName: string): string {
   const match = FOLDER_PATTERN.exec(folderName);
   const id = match?.[1];
-  if (id === undefined) throw new Error(`folder "${folderName}" did not match {ID}-{slug} shape`);
+  if (id === undefined)
+    throw new Error(`folder "${folderName}" did not match ${'{'}ID}-${'{'}slug} shape`);
   return id;
 }
 

--- a/packages/cli/tests/commands/upgrade-reconcile.test.ts
+++ b/packages/cli/tests/commands/upgrade-reconcile.test.ts
@@ -260,7 +260,7 @@ describe('Upgrade Command - Reconcile Integration', () => {
       // Safeword hooks should be added (they have structure { hooks: [{ command: '...' }] })
       const hasSafeword = settings.hooks?.SessionStart?.some(
         (h: { hooks?: { command?: string }[] }) =>
-          h.hooks?.some((cmd: { command?: string }) => cmd.command?.includes('.safeword')),
+          h.hooks?.some((command: { command?: string }) => command.command?.includes('.safeword')),
       );
       expect(hasSafeword).toBe(true);
     });

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -107,14 +107,14 @@ export function removeTemporaryDirectory(dir: string): void {
  */
 export function createPackageJson(dir: string, overrides: Record<string, unknown> = {}): void {
   // Merge devDependencies to ensure local safeword is always included
-  const existingDevelopmentDeps = (overrides.devDependencies as Record<string, string>) ?? {};
+  const existingDevelopmentDependencies = (overrides.devDependencies as Record<string, string>) ?? {};
   const pkg = {
     name: 'test-project',
     version: '1.0.0',
     ...overrides,
     devDependencies: {
       safeword: SAFEWORD_VERSION,
-      ...existingDevelopmentDeps,
+      ...existingDevelopmentDependencies,
     },
   };
   writeFileSync(nodePath.join(dir, 'package.json'), JSON.stringify(pkg, undefined, 2));
@@ -130,12 +130,12 @@ export function createSafewordBasePackageJson(
   dir: string,
   overrides: Record<string, unknown> = {},
 ): void {
-  const existingDevelopmentDeps = (overrides.devDependencies as Record<string, string>) ?? {};
+  const existingDevelopmentDependencies = (overrides.devDependencies as Record<string, string>) ?? {};
   createPackageJson(dir, {
     ...overrides,
     devDependencies: {
       ...SAFEWORD_BASE_DEV_DEPENDENCIES,
-      ...existingDevelopmentDeps,
+      ...existingDevelopmentDependencies,
     },
   });
 }

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -109,7 +109,7 @@ describe('dependency readiness hook support', () => {
       },
       installArtifact: 'node_modules',
     });
-    expect(plan?.inputPaths.toSorted()).toEqual([
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
       'bun.lock',
       'package.json',
       'packages/cli/package.json',
@@ -132,7 +132,7 @@ describe('dependency readiness hook support', () => {
 
     const plan = detectDependencyPlan(projectDirectory);
 
-    expect(plan?.inputPaths.toSorted()).toEqual([
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
       'bun.lock',
       'package.json',
       'packages/cli/package.json',
@@ -159,7 +159,7 @@ describe('dependency readiness hook support', () => {
 
     const plan = detectDependencyPlan(projectDirectory);
 
-    expect(plan?.inputPaths.toSorted()).toEqual([
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
       'bun.lock',
       'package.json',
       'packages/app/package.json',
@@ -189,7 +189,7 @@ describe('dependency readiness hook support', () => {
 
     const plan = detectDependencyPlan(projectDirectory);
 
-    expect(plan?.inputPaths.toSorted()).toEqual([
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
       'bun.lock',
       'package.json',
       'packages/app/package.json',

--- a/packages/cli/tests/hooks/dogfood.test.ts
+++ b/packages/cli/tests/hooks/dogfood.test.ts
@@ -21,7 +21,9 @@ describe('isDogfoodRepo', () => {
     return directory;
   }
   afterEach(() => {
-    for (const directory of created.splice(0)) rmSync(directory, { recursive: true, force: true });
+    const directories = [...created];
+    created.length = 0;
+    for (const directory of directories) rmSync(directory, { recursive: true, force: true });
   });
 
   it('detects the dogfood repo by the canonical templates directory', () => {

--- a/packages/cli/tests/hooks/hierarchy.test.ts
+++ b/packages/cli/tests/hooks/hierarchy.test.ts
@@ -31,12 +31,12 @@ import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers';
 
 /** Create a ticket directory with frontmatter */
 function createTicket(
-  ticketsDirectory: string,
+  directories.tickets: string,
   slug: string,
   frontmatter: Record<string, unknown>,
   body = '',
 ): string {
-  const directory = nodePath.join(ticketsDirectory, slug);
+  const directory = nodePath.join(directories.tickets, slug);
   mkdirSync(directory, { recursive: true });
   const lines = ['---'];
   for (const [key, value] of Object.entries(frontmatter)) {
@@ -59,22 +59,21 @@ function createTicket(
 // Tests
 // ---------------------------------------------------------------------------
 
-let temporaryDirectory: string;
-let ticketsDirectory: string;
+const directories: { temporary: string; tickets: string } = { temporary: '', tickets: '' };
 
 beforeEach(() => {
-  temporaryDirectory = createTemporaryDirectory();
-  ticketsDirectory = nodePath.join(temporaryDirectory, '.safeword-project', 'tickets');
-  mkdirSync(ticketsDirectory, { recursive: true });
+  directories.temporary = createTemporaryDirectory();
+  directories.tickets = nodePath.join(directories.temporary, '.safeword-project', 'tickets');
+  mkdirSync(directories.tickets, { recursive: true });
 });
 
 afterEach(() => {
-  removeTemporaryDirectory(temporaryDirectory);
+  removeTemporaryDirectory(directories.temporary);
 });
 
 describe('readTicketFrontmatter', () => {
   it('parses quoted string parent and children', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '013a-bdd-compression', {
+    const ticketDirectory = createTicket(directories.tickets, '013a-bdd-compression', {
       id: "'013a'",
       type: 'feature',
       status: 'done',
@@ -90,7 +89,7 @@ describe('readTicketFrontmatter', () => {
   });
 
   it('parses unquoted number parent and children array', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '001-epic', {
+    const ticketDirectory = createTicket(directories.tickets, '001-epic', {
       id: '001',
       type: 'epic',
       status: 'in_progress',
@@ -103,7 +102,7 @@ describe('readTicketFrontmatter', () => {
   });
 
   it('handles null parent', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '025-hierarchy', {
+    const ticketDirectory = createTicket(directories.tickets, '025-hierarchy', {
       id: '025',
       type: 'feature',
       parent: null,
@@ -114,7 +113,7 @@ describe('readTicketFrontmatter', () => {
   });
 
   it('handles missing parent field', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '030-standalone', {
+    const ticketDirectory = createTicket(directories.tickets, '030-standalone', {
       id: '030',
       type: 'task',
     });
@@ -124,7 +123,7 @@ describe('readTicketFrontmatter', () => {
   });
 
   it('handles missing children field', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '016-epic', {
+    const ticketDirectory = createTicket(directories.tickets, '016-epic', {
       id: '016',
       type: 'epic',
     });
@@ -136,29 +135,29 @@ describe('readTicketFrontmatter', () => {
 
 describe('resolveTicketDirectory', () => {
   it('resolves ticket ID to directory path', () => {
-    createTicket(ticketsDirectory, '013a-bdd-compression', { id: "'013a'" });
+    createTicket(directories.tickets, '013a-bdd-compression', { id: "'013a'" });
 
-    const resolved = resolveTicketDirectory('013a', ticketsDirectory);
-    expect(resolved).toBe(nodePath.join(ticketsDirectory, '013a-bdd-compression'));
+    const resolved = resolveTicketDirectory('013a', directories.tickets);
+    expect(resolved).toBe(nodePath.join(directories.tickets, '013a-bdd-compression'));
   });
 
   it('returns null for non-existent ticket', () => {
-    const resolved = resolveTicketDirectory('999', ticketsDirectory);
+    const resolved = resolveTicketDirectory('999', directories.tickets);
     expect(resolved).toBeNull();
   });
 
   it('returns null when multiple directories match', () => {
-    createTicket(ticketsDirectory, '013-epic-a', { id: '013' });
-    createTicket(ticketsDirectory, '013-epic-b', { id: '013' });
+    createTicket(directories.tickets, '013-epic-a', { id: '013' });
+    createTicket(directories.tickets, '013-epic-b', { id: '013' });
 
-    const resolved = resolveTicketDirectory('013', ticketsDirectory);
+    const resolved = resolveTicketDirectory('013', directories.tickets);
     expect(resolved).toBeNull();
   });
 });
 
 describe('updateTicketStatus', () => {
   it('updates status, phase, and last_modified', () => {
-    const ticketDirectory = createTicket(ticketsDirectory, '013a-bdd', {
+    const ticketDirectory = createTicket(directories.tickets, '013a-bdd', {
       id: "'013a'",
       status: 'in_progress',
       phase: 'done',
@@ -178,7 +177,7 @@ describe('updateTicketStatus', () => {
 describe('findNextWork', () => {
   // Scenario 1: Navigate to next undone sibling
   it('navigates to next undone sibling', () => {
-    createTicket(ticketsDirectory, '001-epic', {
+    createTicket(directories.tickets, '001-epic', {
       id: '001',
       type: 'epic',
       status: 'in_progress',
@@ -187,26 +186,26 @@ describe('findNextWork', () => {
 
     // Children are unquoted numbers [6, 7, 8] — YAML failsafe keeps as strings
     // Directory names use the same unpadded format to match
-    const currentDirectory = createTicket(ticketsDirectory, '6-feature-a', {
+    const currentDirectory = createTicket(directories.tickets, '6-feature-a', {
       id: 6,
       status: 'done',
       phase: 'done',
       parent: '001',
     });
 
-    createTicket(ticketsDirectory, '7-feature-b', {
+    createTicket(directories.tickets, '7-feature-b', {
       id: 7,
       status: 'in_progress',
       parent: '001',
     });
 
-    createTicket(ticketsDirectory, '8-feature-c', {
+    createTicket(directories.tickets, '8-feature-c', {
       id: 8,
       status: 'ready',
       parent: '001',
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('navigate');
     if (result.type !== 'navigate') throw new Error('Expected navigate');
     expect(result.ticketId).toBe('7');
@@ -215,38 +214,38 @@ describe('findNextWork', () => {
 
   // Scenario 2: Skip done siblings, find next undone
   it('skips done siblings and finds next undone', () => {
-    createTicket(ticketsDirectory, '013-epic', {
+    createTicket(directories.tickets, '013-epic', {
       id: "'013'",
       type: 'epic',
       status: 'in_progress',
       children: ['013a', '013b', '013c', '013d'],
     });
 
-    createTicket(ticketsDirectory, '013a-feat', {
+    createTicket(directories.tickets, '013a-feat', {
       id: "'013a'",
       status: 'done',
       parent: "'013'",
     });
 
-    const currentDirectory = createTicket(ticketsDirectory, '013b-feat', {
+    const currentDirectory = createTicket(directories.tickets, '013b-feat', {
       id: "'013b'",
       status: 'done',
       parent: "'013'",
     });
 
-    createTicket(ticketsDirectory, '013c-feat', {
+    createTicket(directories.tickets, '013c-feat', {
       id: "'013c'",
       status: 'done',
       parent: "'013'",
     });
 
-    createTicket(ticketsDirectory, '013d-feat', {
+    createTicket(directories.tickets, '013d-feat', {
       id: "'013d'",
       status: 'in_progress',
       parent: "'013'",
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('navigate');
     if (result.type !== 'navigate') throw new Error('Expected navigate');
     expect(result.ticketId).toBe('013d');
@@ -254,26 +253,26 @@ describe('findNextWork', () => {
 
   // Scenario 3: All siblings done — cascade parent to done
   it('returns cascade-done when all siblings are done', () => {
-    createTicket(ticketsDirectory, '013-epic', {
+    createTicket(directories.tickets, '013-epic', {
       id: "'013'",
       type: 'epic',
       status: 'in_progress',
       children: ['013a', '013b'],
     });
 
-    createTicket(ticketsDirectory, '013a-feat', {
+    createTicket(directories.tickets, '013a-feat', {
       id: "'013a'",
       status: 'done',
       parent: "'013'",
     });
 
-    const currentDirectory = createTicket(ticketsDirectory, '013b-feat', {
+    const currentDirectory = createTicket(directories.tickets, '013b-feat', {
       id: "'013b'",
       status: 'done',
       parent: "'013'",
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('cascade-done');
     if (result.type !== 'cascade-done') throw new Error('Expected cascade-done');
     expect(result.parentId).toBe('013');
@@ -282,45 +281,45 @@ describe('findNextWork', () => {
 
   // Scenario 5: Standalone ticket (no parent) — allow stop
   it('returns all-done for standalone ticket with no parent', () => {
-    const currentDirectory = createTicket(ticketsDirectory, '025-standalone', {
+    const currentDirectory = createTicket(directories.tickets, '025-standalone', {
       id: '025',
       status: 'done',
       phase: 'done',
       parent: null,
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('all-done');
   });
 
   // Scenario 6: Broken hierarchy — parent directory missing
   it('returns all-done when parent directory is missing', () => {
-    const currentDirectory = createTicket(ticketsDirectory, '050-orphan', {
+    const currentDirectory = createTicket(directories.tickets, '050-orphan', {
       id: '050',
       status: 'done',
       phase: 'done',
       parent: "'999'",
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('all-done');
   });
 
   // Scenario 7: Children field empty or missing
   it('returns all-done when parent has no children field', () => {
-    createTicket(ticketsDirectory, '016-epic', {
+    createTicket(directories.tickets, '016-epic', {
       id: '016',
       type: 'epic',
       status: 'in_progress',
     });
 
-    const currentDirectory = createTicket(ticketsDirectory, '016a-feat', {
+    const currentDirectory = createTicket(directories.tickets, '016a-feat', {
       id: "'016a'",
       status: 'done',
       parent: '016',
     });
 
-    const result = findNextWork(currentDirectory, ticketsDirectory);
+    const result = findNextWork(currentDirectory, directories.tickets);
     expect(result.type).toBe('all-done');
   });
 });

--- a/packages/cli/tests/hooks/hierarchy.test.ts
+++ b/packages/cli/tests/hooks/hierarchy.test.ts
@@ -31,12 +31,12 @@ import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers';
 
 /** Create a ticket directory with frontmatter */
 function createTicket(
-  directories.tickets: string,
+  ticketsDirectory: string,
   slug: string,
   frontmatter: Record<string, unknown>,
   body = '',
 ): string {
-  const directory = nodePath.join(directories.tickets, slug);
+  const directory = nodePath.join(ticketsDirectory, slug);
   mkdirSync(directory, { recursive: true });
   const lines = ['---'];
   for (const [key, value] of Object.entries(frontmatter)) {

--- a/packages/cli/tests/hooks/ledger-validation.test.ts
+++ b/packages/cli/tests/hooks/ledger-validation.test.ts
@@ -375,13 +375,13 @@ describe('validateLedger — W610WW annotated-loop gating', () => {
 
 describe('wholeTicketPassApplies — unified trigger for row + review (W610WW)', () => {
   it('two annotated loops → applies', () => {
-    expect(
-      wholeTicketPassApplies(ledgerWith([annotatedScenario('a'), annotatedScenario('b')])),
-    ).toBe(true);
+    const scenarios = [annotatedScenario('a'), annotatedScenario('b')];
+    expect(wholeTicketPassApplies(ledgerWith(scenarios))).toBe(true);
   });
 
   it('a single annotated loop → does not apply', () => {
-    expect(wholeTicketPassApplies(ledgerWith([annotatedScenario('only')]))).toBe(false);
+    const scenarios = [annotatedScenario('only')];
+    expect(wholeTicketPassApplies(ledgerWith(scenarios))).toBe(false);
   });
 
   it('zero scenarios → does not apply', () => {
@@ -393,11 +393,8 @@ describe('wholeTicketPassApplies — unified trigger for row + review (W610WW)',
     // not trigger the whole-ticket pass — neither the row nor the /quality-review
     // requirement. A naive loop count (>=2) would wrongly trigger the review
     // half; wholeTicketPassApplies must gate on annotations, not raw count.
-    expect(
-      wholeTicketPassApplies(
-        ledgerWith([legacyScenario('a'), legacyScenario('b'), legacyScenario('c')]),
-      ),
-    ).toBe(false);
+    const scenarios = [legacyScenario('a'), legacyScenario('b'), legacyScenario('c')];
+    expect(wholeTicketPassApplies(ledgerWith(scenarios))).toBe(false);
   });
 });
 

--- a/packages/cli/tests/hooks/models-match.test.ts
+++ b/packages/cli/tests/hooks/models-match.test.ts
@@ -27,7 +27,7 @@ describe('modelsMatch — cross-model independence', () => {
   });
 
   it('matches (fails closed) when the author tag is empty', () => {
-    expect(modelsMatch('claude-opus-4-8', '   ')).toBe(true);
+    expect(modelsMatch('claude-opus-4-8', ' '.repeat(3))).toBe(true);
   });
 
   it('matches (fails closed) when the reviewer tag is absent', () => {

--- a/packages/cli/tests/hooks/parse-annotation.test.ts
+++ b/packages/cli/tests/hooks/parse-annotation.test.ts
@@ -167,7 +167,7 @@ describe('isValidSkipReason', () => {
   });
 
   it('rejects a whitespace-only string', () => {
-    expect(isValidSkipReason('    ')).toBe(false);
+    expect(isValidSkipReason(' '.repeat(4))).toBe(false);
   });
 
   it('rejects a tab-only string', () => {

--- a/packages/cli/tests/hooks/parser-parity.test.ts
+++ b/packages/cli/tests/hooks/parser-parity.test.ts
@@ -27,7 +27,7 @@ function cliActiveLines(content: string): { index: number; text: string }[] {
   const skip = computeSkipMask(lines);
   const out: { index: number; text: string }[] = [];
   for (const [index, line] of lines.entries()) {
-    if (skip[index]) continue;
+    if (skip[index] === true) continue;
     const text = stripInlineComments(line).trim();
     if (text !== '') out.push({ index, text });
   }

--- a/packages/cli/tests/hooks/replan-relevance.test.ts
+++ b/packages/cli/tests/hooks/replan-relevance.test.ts
@@ -198,26 +198,22 @@ describe('detectMovedBlockers (E11N48)', () => {
   const commitTouching = (path: string) => ({ changedPaths: [path, 'README.md'] });
 
   it('fires when a terminal blocker ticket.md is in the window', () => {
-    expect(detectMovedBlockers([target()], [commitTouching(target().ticketPath)])).toEqual([
+    const commit = commitTouching(target().ticketPath);
+    expect(detectMovedBlockers([target()], [commit])).toEqual([
       { id: 'AKZJXC', slug: 'ticket-relations', status: 'done' },
     ]);
   });
 
   it('treats superseded / cancelled / wontfix as terminal', () => {
     for (const status of ['superseded', 'cancelled', 'wontfix']) {
-      expect(
-        detectMovedBlockers([target({ status })], [commitTouching(target().ticketPath)]),
-      ).toHaveLength(1);
+      const commit = commitTouching(target().ticketPath);
+      expect(detectMovedBlockers([target({ status })], [commit])).toHaveLength(1);
     }
   });
 
   it('stays silent when the blocker is not terminal', () => {
-    expect(
-      detectMovedBlockers(
-        [target({ status: 'in_progress' })],
-        [commitTouching(target().ticketPath)],
-      ),
-    ).toEqual([]);
+    const commit = commitTouching(target().ticketPath);
+    expect(detectMovedBlockers([target({ status: 'in_progress' })], [commit])).toEqual([]);
   });
 
   it('stays silent when the terminal blocker ticket.md is not in the window', () => {

--- a/packages/cli/tests/hooks/review-ledger.test.ts
+++ b/packages/cli/tests/hooks/review-ledger.test.ts
@@ -45,7 +45,7 @@ describe('reviewGateForNextAsset (DEV1.AC1 — per-asset stamp gates the next as
   });
 
   it('empty_skip_reason_rejected (SM1.AC2): an empty skip reason does not satisfy the gate', () => {
-    const stamps: ReviewStamp[] = [{ scope: 'jtbd', skipReason: '   ' }];
+    const stamps: ReviewStamp[] = [{ scope: 'jtbd', skipReason: ' '.repeat(3) }];
     expect(reviewGateForNextAsset('jtbd', stamps).ok).toBe(false);
   });
 });

--- a/packages/cli/tests/hooks/session-author-model.test.ts
+++ b/packages/cli/tests/hooks/session-author-model.test.ts
@@ -23,18 +23,6 @@ const HOOK = nodePath.join(
   'session-author-model.ts',
 );
 
-let dir: string;
-let envFile: string;
-
-beforeEach(() => {
-  dir = mkdtempSync(nodePath.join(tmpdir(), 'sw-author-model-'));
-  envFile = nodePath.join(dir, 'env');
-});
-
-afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
-});
-
 function run(stdin: object, env: Record<string, string>): void {
   spawnSync('bun', [HOOK], {
     input: JSON.stringify(stdin),
@@ -44,6 +32,18 @@ function run(stdin: object, env: Record<string, string>): void {
 }
 
 describe('session-author-model capture', () => {
+  let dir: string;
+  let envFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(nodePath.join(tmpdir(), 'sw-author-model-'));
+    envFile = nodePath.join(dir, 'env');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it('writes SAFEWORD_AUTHOR_MODEL from the SessionStart model field', () => {
     run(
       { model: 'claude-opus-4-8', hook_event_name: 'SessionStart' },

--- a/packages/cli/tests/hooks/test-runner.test.ts
+++ b/packages/cli/tests/hooks/test-runner.test.ts
@@ -37,9 +37,10 @@ function makeProject(scripts: Record<string, string>): string {
 }
 
 afterEach(() => {
-  for (const directory of temporaryDirectories.splice(0)) {
+  for (const directory of temporaryDirectories) {
     rmSync(directory, { force: true, recursive: true });
   }
+  temporaryDirectories.length = 0;
 });
 
 describe('runTests (resolves its suite via safeword test-plan)', () => {

--- a/packages/cli/tests/hooks/typecheck-gate.test.ts
+++ b/packages/cli/tests/hooks/typecheck-gate.test.ts
@@ -172,9 +172,9 @@ describe('evaluateImplementStopTypecheck (Rules 2 + 4 — surface as advice)', (
   it('does not run tsc and returns no advice at done phase (Rule 4)', () => {
     const projectDirectory = makeProject();
     touch(nodePath.join(projectDirectory, 'tsconfig.json'));
-    let ran = false;
+    let isRan = false;
     const runner = (): TypecheckRunResult => {
-      ran = true;
+      isRan = true;
       return { available: true, ok: false, output: 'should not be called' };
     };
 
@@ -184,7 +184,7 @@ describe('evaluateImplementStopTypecheck (Rules 2 + 4 — surface as advice)', (
     );
 
     expect(advice).toBeNull();
-    expect(ran).toBe(false);
+    expect(isRan).toBe(false);
   });
 
   it('returns no advice when no tsc binary is available', () => {

--- a/packages/cli/tests/integration/add-language-golang.test.ts
+++ b/packages/cli/tests/integration/add-language-golang.test.ts
@@ -29,7 +29,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
+const IS_GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
 
 describe('E2E: Add Go to Existing TypeScript Project', () => {
   let projectDirectory: string;
@@ -106,7 +106,7 @@ func main() {
       expect(goConfig).toContain('linters:');
     });
 
-    it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint works on Go files', () => {
+    it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint works on Go files', () => {
       const result = spawnSync('golangci-lint', ['run', 'main.go'], {
         cwd: projectDirectory,
         encoding: 'utf8',

--- a/packages/cli/tests/integration/add-language.test.ts
+++ b/packages/cli/tests/integration/add-language.test.ts
@@ -29,7 +29,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const RUFF_AVAILABLE = isRuffInstalled();
+const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 describe('E2E: Add Language to Existing Project', () => {
   let projectDirectory: string;
@@ -91,7 +91,7 @@ version = "0.1.0"
       expect(safewordRuff).toContain('extend = "../ruff.toml"');
     });
 
-    it.skipIf(!RUFF_AVAILABLE)('Ruff works on Python files', () => {
+    it.skipIf(!IS_RUFF_AVAILABLE)('Ruff works on Python files', () => {
       writeTestFile(projectDirectory, 'test.py', 'x = 1\n');
 
       const result = spawnSync('ruff', ['check', 'test.py'], {

--- a/packages/cli/tests/integration/architecture-review-gate.test.ts
+++ b/packages/cli/tests/integration/architecture-review-gate.test.ts
@@ -28,17 +28,17 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let projectDirectory: string;
+const shared: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
+  shared.projectDirectory = createTemporaryDirectory();
+  createTypeScriptPackageJson(shared.projectDirectory);
+  initGitRepo(shared.projectDirectory);
+  await setupOrThrow(shared.projectDirectory);
 });
 
 afterAll(() => {
-  if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  if (shared.projectDirectory) removeTemporaryDirectory(shared.projectDirectory);
 });
 
 function plan(decisions: string, status = 'implemented'): string {
@@ -73,7 +73,7 @@ const UNCITED = plan('We chose a file store because it is simpler than a databas
 
 function setConfig(flags: Record<string, unknown>): void {
   writeTestFile(
-    projectDirectory,
+    shared.projectDirectory,
     '.safeword/config.json',
     JSON.stringify({ installedPacks: ['typescript'], ...flags }),
   );
@@ -81,27 +81,27 @@ function setConfig(flags: Record<string, unknown>): void {
 
 function writeTicket(id: string, type: 'feature' | 'task', implPlan?: string, spec = true): void {
   const folder = `.project/tickets/${id}`;
-  mkdirSync(nodePath.join(projectDirectory, folder), { recursive: true });
+  mkdirSync(nodePath.join(shared.projectDirectory, folder), { recursive: true });
   writeTestFile(
-    projectDirectory,
+    shared.projectDirectory,
     `${folder}/ticket.md`,
     `---\nid: ${id}\ntype: ${type}\nphase: verify\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
   );
   if (type === 'feature') {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       `${folder}/test-definitions.md`,
       '# Test Definitions\n\n## Rule: r\n\n### Scenario: s\n\n- [x] RED abc1234\n',
     );
   }
   if (spec) {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       `${folder}/spec.md`,
       '# Spec\n\n## Jobs To Be Done\n\nskip: fixture\n',
     );
   }
-  if (implPlan !== undefined) writeTestFile(projectDirectory, `${folder}/impl-plan.md`, implPlan);
+  if (implPlan !== undefined) writeTestFile(shared.projectDirectory, `${folder}/impl-plan.md`, implPlan);
 }
 
 /** Append a design-review stamp for the impl-plan to the invocation log. */
@@ -116,7 +116,7 @@ function writeStamp(
     hashArtifact(options.hashOf ?? planContent),
   );
   const line = `2026-06-12T00:00:00Z sess ${formatReviewStamp(scope, options.skip, options.model)}`;
-  appendFileSync(nodePath.join(projectDirectory, '.project', 'skill-invocations.log'), `${line}\n`);
+  appendFileSync(nodePath.join(shared.projectDirectory, '.project', 'skill-invocations.log'), `${line}\n`);
 }
 
 function runStopHook(
@@ -125,7 +125,7 @@ function runStopHook(
   options: { noEdit?: boolean } = {},
 ): string {
   const sessionId = `session-${id}`;
-  const transcriptPath = nodePath.join(projectDirectory, `transcript-${id}.jsonl`);
+  const transcriptPath = nodePath.join(shared.projectDirectory, `transcript-${id}.jsonl`);
   // opts.noEdit → a conversational stop with no recent edit tool, proving the gate enforces on
   // phase/state rather than edit activity (the hoist above the edit-tools early-exit).
   const content = options.noEdit
@@ -139,20 +139,20 @@ function runStopHook(
     `${JSON.stringify({ type: 'assistant', message: { role: 'assistant', content } })}\n`,
   );
   writeFileSync(
-    nodePath.join(projectDirectory, '.project', `quality-state-${sessionId}.json`),
+    nodePath.join(shared.projectDirectory, '.project', `quality-state-${sessionId}.json`),
     JSON.stringify({ activeTicket: id }),
   );
   // Default the ambient author model to unset so cross-model fail-closed cases are deterministic;
   // tests that exercise a known author model pass it explicitly in `env`.
   const childEnvironment: Record<string, string | undefined> = {
     ...process.env,
-    CLAUDE_PROJECT_DIR: projectDirectory,
+    CLAUDE_PROJECT_DIR: shared.projectDirectory,
     ...env,
   };
   if (!('SAFEWORD_AUTHOR_MODEL' in env)) delete childEnvironment.SAFEWORD_AUTHOR_MODEL;
   const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
     input: JSON.stringify({ transcript_path: transcriptPath, session_id: sessionId }),
-    cwd: projectDirectory,
+    cwd: shared.projectDirectory,
     env: childEnvironment,
     encoding: 'utf8',
   });

--- a/packages/cli/tests/integration/claude-code-simulation.test.ts
+++ b/packages/cli/tests/integration/claude-code-simulation.test.ts
@@ -46,7 +46,8 @@ describe('E2E: Claude Code Hook Path Resolution', () => {
     const commands: string[] = [];
 
     // Extract all hook commands
-    for (const entries of Object.values(settings.hooks || {})) {
+    const hookGroups = Object.values(settings.hooks || {});
+    for (const entries of hookGroups) {
       for (const entry of entries as {
         hooks: { type: string; command: string }[];
       }[]) {

--- a/packages/cli/tests/integration/codex-pretooluse-spike.test.ts
+++ b/packages/cli/tests/integration/codex-pretooluse-spike.test.ts
@@ -79,7 +79,7 @@ function runCodexHook(
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: projectRoot,
-      ...(options.fallbackMode ? { SAFEWORD_CODEX_DENY_MODE: 'exit-code' } : {}),
+      ...(options.fallbackMode && { SAFEWORD_CODEX_DENY_MODE: 'exit-code' }),
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/packages/cli/tests/integration/cross-branch-tickets.test.ts
+++ b/packages/cli/tests/integration/cross-branch-tickets.test.ts
@@ -182,7 +182,7 @@ describe('cross-branch ticket creation (real git fixture)', () => {
       expect(secondMerge.status).toBe(0);
 
       const ticketsDirectory = nodePath.join(projectDirectory, '.project', 'tickets');
-      const folders = readdirSync(ticketsDirectory).toSorted();
+      const folders = readdirSync(ticketsDirectory).toSorted((a, b) => a.localeCompare(b));
       expect(folders).toEqual(['COLLID-bar', 'COLLID-foo']);
 
       const scriptPath = nodePath.join(

--- a/packages/cli/tests/integration/golang-golden-path.test.ts
+++ b/packages/cli/tests/integration/golang-golden-path.test.ts
@@ -32,7 +32,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
+const IS_GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
 
 // golangci-lint's FIRST run cold-starts (~62s: type-checks the code, compiling
 // stdlib deps, then initializes the curated linter set and builds its cache),
@@ -73,7 +73,7 @@ describe('E2E: Go Golden Path', () => {
     expect(config).toContain('gofumpt');
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint runs on valid code', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint runs on valid code', () => {
     // main.go from createGoProject should be valid
     const result = spawnSync('golangci-lint', ['run', 'main.go'], {
       cwd: projectDirectory,
@@ -83,7 +83,7 @@ describe('E2E: Go Golden Path', () => {
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint detects violations', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint detects violations', () => {
     // Create a file with an unused import (caught by 'unused' linter in standard set)
     writeTestFile(
       projectDirectory,
@@ -108,7 +108,7 @@ func bad() {
     expect(result.stdout + result.stderr).toMatch(/unused|import/i);
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint fmt formats files', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint fmt formats files', () => {
     // Create a badly formatted Go file
     writeTestFile(
       projectDirectory,
@@ -125,7 +125,7 @@ func main(){println("no spaces")}`,
     expect(formatted).toContain('func main() {');
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('post-tool-lint hook processes Go files', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('post-tool-lint hook processes Go files', () => {
     const filePath = nodePath.join(projectDirectory, 'hook-test.go');
     // Intentionally badly formatted
     writeTestFile(
@@ -191,7 +191,7 @@ describe('E2E: Go Setup Idempotency', () => {
     expect(config).toContain('linters:');
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint still works after running setup twice', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint still works after running setup twice', () => {
     // main.go from createGoProject should still be valid
     const result = spawnSync('golangci-lint', ['run', 'main.go'], {
       cwd: projectDirectory,
@@ -232,7 +232,7 @@ describe('E2E: Go Lint Hook Fallback', () => {
     }
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('lint hook formats files without safeword config', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('lint hook formats files without safeword config', () => {
     writeTestFile(
       projectDirectory,
       'fallback.go',

--- a/packages/cli/tests/integration/hierarchy-navigation.test.ts
+++ b/packages/cli/tests/integration/hierarchy-navigation.test.ts
@@ -97,17 +97,16 @@ function createTestProject(): string {
 // Tests
 // ---------------------------------------------------------------------------
 
-let projectDirectory: string;
-
-beforeEach(() => {
-  projectDirectory = createTestProject();
-});
-
-afterEach(() => {
-  removeTemporaryDirectory(projectDirectory);
-});
-
 describe('hierarchy navigation in stop hook', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTestProject();
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(projectDirectory);
+  });
   // Evidence that passes the done gate for features
   const featureEvidence = '✓ 15/15 tests pass\nAll 8 scenarios marked complete\nAudit passed';
   // Evidence that passes the done gate for tasks

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -34,7 +34,7 @@ const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 // Single setup for all hook tests - sharing avoids 3 separate bun installs
 // Tests must be idempotent or restore state after modification (see try/finally blocks)
-let shared.projectDirectory: string;
+const shared: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeAll(async () => {
   shared.projectDirectory = createTemporaryDirectory();
@@ -147,7 +147,7 @@ function runStopHook(
 }
 
 /** Parse JSON output from stop hook */
-function parseStopOutput(result: { stdout: string; stderr: string; exitCode: number }): {
+function parseStopOutput(result: { stdout: string }): {
   decision?: string;
   reason?: string;
 } {
@@ -1070,7 +1070,10 @@ describe('E2E: Python Lint Hook', () => {
       writeTestFile(shared.projectDirectory, 'format-test.py', badCode);
 
       // Run lint hook on the file
-      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/format-test.py`);
+      const result = runPostToolLint(
+        shared.projectDirectory,
+        `${shared.projectDirectory}/format-test.py`,
+      );
       expect(result.status).toBe(0);
 
       // File should now be formatted
@@ -1085,7 +1088,10 @@ describe('E2E: Python Lint Hook', () => {
       writeTestFile(shared.projectDirectory, 'fix-test.py', codeWithUnusedImport);
 
       // Run lint hook on the file
-      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/fix-test.py`);
+      const result = runPostToolLint(
+        shared.projectDirectory,
+        `${shared.projectDirectory}/fix-test.py`,
+      );
       expect(result.status).toBe(0);
 
       // Unused import should be removed
@@ -1101,7 +1107,10 @@ describe('E2E: Python Lint Hook', () => {
         const codeWithUnfixable = 'def foo():\n    return\n    x = 1\n';
         writeTestFile(shared.projectDirectory, 'unfixable-test.py', codeWithUnfixable);
 
-        const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/unfixable-test.py`);
+        const result = runPostToolLint(
+          shared.projectDirectory,
+          `${shared.projectDirectory}/unfixable-test.py`,
+        );
         expect(result.status).toBe(0);
 
         // Hook should output additionalContext JSON for remaining errors
@@ -1119,7 +1128,10 @@ describe('E2E: Python Lint Hook', () => {
       const autoFixable = 'import os\nx = 1\n';
       writeTestFile(shared.projectDirectory, 'clean-after-fix.py', autoFixable);
 
-      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/clean-after-fix.py`);
+      const result = runPostToolLint(
+        shared.projectDirectory,
+        `${shared.projectDirectory}/clean-after-fix.py`,
+      );
       expect(result.status).toBe(0);
 
       // No additionalContext should be output (file is clean after fix)

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -30,7 +30,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const RUFF_AVAILABLE = isRuffInstalled();
+const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 // Single setup for all hook tests - sharing avoids 3 separate bun installs
 // Tests must be idempotent or restore state after modification (see try/finally blocks)
@@ -1064,7 +1064,7 @@ describe('E2E: Python Lint Hook', () => {
   });
 
   describe('Test 2.4: Ruff fixes Python files via lint hook', () => {
-    it.skipIf(!RUFF_AVAILABLE)('should format Python files when run through lint hook', () => {
+    it.skipIf(!IS_RUFF_AVAILABLE)('should format Python files when run through lint hook', () => {
       // Create badly formatted Python file
       const badCode = 'x=1;y=2';
       writeTestFile(projectDirectory, 'format-test.py', badCode);
@@ -1079,7 +1079,7 @@ describe('E2E: Python Lint Hook', () => {
       expect(formatted).toContain('y = 2');
     });
 
-    it.skipIf(!RUFF_AVAILABLE)('should fix auto-fixable lint issues', () => {
+    it.skipIf(!IS_RUFF_AVAILABLE)('should fix auto-fixable lint issues', () => {
       // Create file with unused import (auto-fixable with --fix)
       const codeWithUnusedImport = 'import os\nx = 1\n';
       writeTestFile(projectDirectory, 'fix-test.py', codeWithUnusedImport);
@@ -1094,7 +1094,7 @@ describe('E2E: Python Lint Hook', () => {
       expect(fixed).toContain('x = 1');
     });
 
-    it.skipIf(!RUFF_AVAILABLE)(
+    it.skipIf(!IS_RUFF_AVAILABLE)(
       'should output additionalContext JSON when unfixable errors remain',
       () => {
         // F841 (unused variable after return) is not auto-fixable without --unsafe-fixes
@@ -1114,7 +1114,7 @@ describe('E2E: Python Lint Hook', () => {
       },
     );
 
-    it.skipIf(!RUFF_AVAILABLE)('should output no JSON when all errors are auto-fixed', () => {
+    it.skipIf(!IS_RUFF_AVAILABLE)('should output no JSON when all errors are auto-fixed', () => {
       // Unused import is fully auto-fixable — no remaining errors
       const autoFixable = 'import os\nx = 1\n';
       writeTestFile(projectDirectory, 'clean-after-fix.py', autoFixable);

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -34,18 +34,18 @@ const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 // Single setup for all hook tests - sharing avoids 3 separate bun installs
 // Tests must be idempotent or restore state after modification (see try/finally blocks)
-let projectDirectory: string;
+let shared.projectDirectory: string;
 
 beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
+  shared.projectDirectory = createTemporaryDirectory();
+  createTypeScriptPackageJson(shared.projectDirectory);
+  initGitRepo(shared.projectDirectory);
+  await setupOrThrow(shared.projectDirectory);
 }, 180_000);
 
 afterAll(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
+  if (shared.projectDirectory) {
+    removeTemporaryDirectory(shared.projectDirectory);
   }
 });
 
@@ -241,8 +241,8 @@ describe('E2E: SessionStart Hooks', () => {
   describe('session-bun-check.sh', () => {
     it('exits silently when bun is available', () => {
       const result = spawnSync('bash', ['.safeword/hooks/session-bun-check.sh'], {
-        cwd: projectDirectory,
-        env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+        cwd: shared.projectDirectory,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
         encoding: 'utf8',
       });
 
@@ -255,7 +255,7 @@ describe('E2E: SessionStart Hooks', () => {
       try {
         const result = spawnSync(
           'bash',
-          [nodePath.join(projectDirectory, '.safeword/hooks/session-bun-check.sh')],
+          [nodePath.join(shared.projectDirectory, '.safeword/hooks/session-bun-check.sh')],
           {
             cwd: nonSafewordDirectory,
             env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory },
@@ -271,10 +271,10 @@ describe('E2E: SessionStart Hooks', () => {
 
     it('hard-blocks with exit 2 when bun is not in PATH', () => {
       const result = spawnSync('bash', ['.safeword/hooks/session-bun-check.sh'], {
-        cwd: projectDirectory,
+        cwd: shared.projectDirectory,
         env: {
           ...process.env,
-          CLAUDE_PROJECT_DIR: projectDirectory,
+          CLAUDE_PROJECT_DIR: shared.projectDirectory,
           // Override PATH to exclude bun
           PATH: '/usr/bin:/bin',
         },
@@ -291,8 +291,8 @@ describe('E2E: SessionStart Hooks', () => {
   describe('session-version.ts', () => {
     it('outputs version message for safeword project', () => {
       const output = execSync('bun .safeword/hooks/session-version.ts', {
-        cwd: projectDirectory,
-        env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+        cwd: shared.projectDirectory,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
         encoding: 'utf8',
       });
 
@@ -306,7 +306,7 @@ describe('E2E: SessionStart Hooks', () => {
       try {
         // Run in a directory without .safeword
         const output = execSync('bun .safeword/hooks/session-version.ts', {
-          cwd: projectDirectory, // Script is here
+          cwd: shared.projectDirectory, // Script is here
           env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory }, // But points to non-safeword dir
           encoding: 'utf8',
         });
@@ -322,12 +322,12 @@ describe('E2E: SessionStart Hooks', () => {
   describe('session-lint-check.ts', () => {
     it('outputs no warnings when lint configs exist', () => {
       // Project should have eslint and prettier after setup
-      expect(fileExists(projectDirectory, 'eslint.config.mjs')).toBe(true);
-      expect(fileExists(projectDirectory, '.prettierrc')).toBe(true);
+      expect(fileExists(shared.projectDirectory, 'eslint.config.mjs')).toBe(true);
+      expect(fileExists(shared.projectDirectory, '.prettierrc')).toBe(true);
 
       const output = execSync('bun .safeword/hooks/session-lint-check.ts', {
-        cwd: projectDirectory,
-        env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+        cwd: shared.projectDirectory,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
         encoding: 'utf8',
       });
 
@@ -338,13 +338,13 @@ describe('E2E: SessionStart Hooks', () => {
     it('warns when ESLint config is missing', () => {
       // Temporarily remove ESLint config
       execSync('mv eslint.config.mjs eslint.config.mjs.bak', {
-        cwd: projectDirectory,
+        cwd: shared.projectDirectory,
       });
 
       try {
         const output = execSync('bun .safeword/hooks/session-lint-check.ts', {
-          cwd: projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
           encoding: 'utf8',
         });
 
@@ -352,26 +352,26 @@ describe('E2E: SessionStart Hooks', () => {
       } finally {
         // Restore ESLint config
         execSync('mv eslint.config.mjs.bak eslint.config.mjs', {
-          cwd: projectDirectory,
+          cwd: shared.projectDirectory,
         });
       }
     });
 
     it('warns when Prettier config is missing', () => {
       // Temporarily remove Prettier config
-      execSync('mv .prettierrc .prettierrc.bak', { cwd: projectDirectory });
+      execSync('mv .prettierrc .prettierrc.bak', { cwd: shared.projectDirectory });
 
       try {
         const output = execSync('bun .safeword/hooks/session-lint-check.ts', {
-          cwd: projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
           encoding: 'utf8',
         });
 
         expect(output).toContain('Prettier config not found');
       } finally {
         // Restore Prettier config
-        execSync('mv .prettierrc.bak .prettierrc', { cwd: projectDirectory });
+        execSync('mv .prettierrc.bak .prettierrc', { cwd: shared.projectDirectory });
       }
     });
 
@@ -379,7 +379,7 @@ describe('E2E: SessionStart Hooks', () => {
       const nonSafewordDirectory = createTemporaryDirectory();
       try {
         const output = execSync('bun .safeword/hooks/session-lint-check.ts', {
-          cwd: projectDirectory,
+          cwd: shared.projectDirectory,
           env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory },
           encoding: 'utf8',
         });
@@ -396,7 +396,7 @@ describe('E2E: UserPromptSubmit Hooks', () => {
   describe('prompt-timestamp.ts', () => {
     it('outputs current timestamp in expected format', () => {
       const output = execSync('bun .safeword/hooks/prompt-timestamp.ts', {
-        cwd: projectDirectory,
+        cwd: shared.projectDirectory,
         encoding: 'utf8',
       });
 
@@ -415,8 +415,8 @@ describe('E2E: UserPromptSubmit Hooks', () => {
       const output = execSync(
         'echo "Help me implement a new feature for user authentication" | bun .safeword/hooks/prompt-questions.ts',
         {
-          cwd: projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
           encoding: 'utf8',
         },
       );
@@ -430,7 +430,7 @@ describe('E2E: UserPromptSubmit Hooks', () => {
         const output = execSync(
           'echo "Help me implement a new feature for user authentication" | bun .safeword/hooks/prompt-questions.ts',
           {
-            cwd: projectDirectory,
+            cwd: shared.projectDirectory,
             env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory },
             encoding: 'utf8',
           },
@@ -447,7 +447,7 @@ describe('E2E: UserPromptSubmit Hooks', () => {
 describe('E2E: Phase-Aware Quality Review', () => {
   describe('Happy Path - Phase Detection', () => {
     it('Scenario 1: Shows intake prompts during discovery phase', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -457,14 +457,14 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.reason).toContain('Phase: intake');
       expect(result.reason).toContain('CONFIDENT');
     });
 
     it('Scenario 2: Shows scenario prompts during define-behavior phase', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -474,7 +474,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.reason).toContain('Phase: define-behavior');
       expect(result.reason).toContain('CONFIDENT');
@@ -482,7 +482,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
     });
 
     it('Scenario 3: Shows implementation prompts during implement phase', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -493,12 +493,12 @@ describe('E2E: Phase-Aware Quality Review', () => {
       ]);
       // Create test-definitions.md (required artifact for features at implement phase)
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.reason).toContain('Phase: implement');
       expect(result.reason).toContain('CONFIDENT');
@@ -506,7 +506,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
     });
 
     it('Scenario 4: Hard blocks done phase without verify.md', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -516,20 +516,20 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
       // No verify.md — should block
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toContain('verify');
     });
 
     it('Scenario 4b: Allows done phase with verify.md present', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -539,17 +539,17 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 10/10 tests pass\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('');
@@ -558,7 +558,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
   describe('Edge Cases - Fallbacks', () => {
     it('Scenario 5: Falls back to implement when no phase field', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -567,7 +567,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Default implementation review (binary form)
       expect(result.reason).toContain('CONFIDENT');
@@ -575,7 +575,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
     });
 
     it('Scenario 6: Falls back to implement for unknown phase', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -585,7 +585,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Default implementation review (binary form)
       expect(result.reason).toContain('CONFIDENT');
@@ -595,7 +595,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
   describe('Edge Cases - Ticket Filtering', () => {
     it('Scenario 7: Ignores backlog tickets (status filtering)', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         // Older but in_progress - should be used
         {
           id: '001',
@@ -614,14 +614,14 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Should use intake from ticket 001, not implement from ticket 002
       expect(result.reason).toContain('Phase: intake');
     });
 
     it('Scenario 8: Ignores epic tickets (type filtering)', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         // Epic with newest timestamp - should be ignored
         {
           id: '001',
@@ -640,14 +640,14 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Should use intake from feature, not implement from epic
       expect(result.reason).toContain('Phase: intake');
     });
 
     it('Scenario 9: Falls back when no in_progress tickets', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -664,16 +664,16 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Default implementation review (fallback)
       expect(result.reason).toContain('CONFIDENT');
     });
 
     it('Scenario 10: Falls back when issues directory empty', () => {
-      clearIssuesDirectory(projectDirectory);
+      clearIssuesDirectory(shared.projectDirectory);
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Default implementation review (fallback)
       expect(result.reason).toContain('CONFIDENT');
@@ -682,7 +682,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
   describe('Cumulative Artifact Checks', () => {
     it('Scenario 11: Soft blocks feature at scenario-gate without test-definitions.md', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -693,7 +693,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       ]);
       // No test-definitions.md file exists
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Should soft block with artifact requirement message
       expect(result.exitCode).toBe(0); // Soft block uses exit 0
@@ -701,7 +701,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
     });
 
     it('Scenario 12: Allows feature at scenario-gate with test-definitions.md', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -712,12 +712,12 @@ describe('E2E: Phase-Aware Quality Review', () => {
       ]);
       // Create test-definitions.md
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [ ] Scenario one\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Should show normal phase review, not artifact block
       expect(result.reason).toContain('Phase: scenario-gate');
@@ -725,7 +725,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
     });
 
     it('Scenario 13: Tasks skip artifact checks (no test-definitions required)', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'task',
@@ -736,7 +736,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       ]);
       // No test-definitions.md - should be fine for tasks
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // Should show normal implementation review, not artifact block
       expect(result.reason).toContain('CONFIDENT');
@@ -746,7 +746,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
   describe('Type-Aware Done Gate', () => {
     it('Scenario 14: Feature done blocks without verify.md even with complete scenarios', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -756,20 +756,20 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
       // No verify.md — blocks on missing artifact before checking scenarios
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toContain('verify');
     });
 
     it('Scenario 15: Task done requires verify.md', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'task',
@@ -779,20 +779,20 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\n',
       );
 
       const evidenceText = '## Done Checklist\n\n**Test Suite:** ✓ 42/42 tests pass';
-      const result = runStopHookForPhase(projectDirectory, evidenceText);
+      const result = runStopHookForPhase(shared.projectDirectory, evidenceText);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('');
     });
 
     it('Scenario 16: Feature done with verify.md and complete scenarios passes', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -802,24 +802,24 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('');
     });
 
     it('T7: Feature done blocks with incomplete scenarios even with verify.md', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -829,24 +829,24 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [ ] Scenario one\n',
       );
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toContain('scenarios');
     });
 
     it('T8: Feature done passes with verify.md and complete scenarios', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -856,24 +856,24 @@ describe('E2E: Phase-Aware Quality Review', () => {
         },
       ]);
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
       );
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('');
     });
 
     it('T9: Feature done hard-blocks when test-definitions.md has content but no GFM checkboxes', () => {
-      setupIssuesDirectory(projectDirectory, [
+      setupIssuesDirectory(shared.projectDirectory, [
         {
           id: '001',
           type: 'feature',
@@ -884,7 +884,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       ]);
       // Legacy / unrecognized format — has content but no GFM task list items.
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/test-definitions.md',
         [
           '# Test Definitions',
@@ -898,12 +898,12 @@ describe('E2E: Phase-Aware Quality Review', () => {
         ].join('\n'),
       );
       writeTestFile(
-        projectDirectory,
+        shared.projectDirectory,
         '.project/tickets/001/verify.md',
         'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
       );
 
-      const result = runStopHookForPhase(projectDirectory);
+      const result = runStopHookForPhase(shared.projectDirectory);
 
       // checkCumulativeArtifacts fires first for features and rejects zero-checkbox files
       // with "no scenarios defined". The GFM-specific hard-block (checkScenariosComplete)
@@ -915,18 +915,18 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
   // Cleanup after all phase tests
   afterAll(() => {
-    clearIssuesDirectory(projectDirectory);
+    clearIssuesDirectory(shared.projectDirectory);
   });
 });
 
 describe('E2E: Stop Hook', () => {
   describe('stop-quality.ts', () => {
     it('triggers quality review when edit tools are used', () => {
-      const transcriptPath = createMultiMessageTranscript(projectDirectory, [
+      const transcriptPath = createMultiMessageTranscript(shared.projectDirectory, [
         { text: 'Let me edit that file.', toolUse: 'Edit' },
       ]);
 
-      const result = runStopHook(projectDirectory, transcriptPath);
+      const result = runStopHook(shared.projectDirectory, transcriptPath);
       const output = parseStopOutput(result);
 
       expect(result.exitCode).toBe(0);
@@ -936,9 +936,9 @@ describe('E2E: Stop Hook', () => {
 
     it('exits silently when no edit tools are used', () => {
       const text = 'I answered a question without making any changes.';
-      const transcriptPath = createMockTranscript(projectDirectory, text);
+      const transcriptPath = createMockTranscript(shared.projectDirectory, text);
 
-      const result = runStopHook(projectDirectory, transcriptPath);
+      const result = runStopHook(shared.projectDirectory, transcriptPath);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -951,7 +951,7 @@ describe('E2E: Stop Hook', () => {
           input: JSON.stringify({
             transcript_path: nodePath.join(nonSafewordDirectory, 'fake.jsonl'),
           }),
-          cwd: projectDirectory,
+          cwd: shared.projectDirectory,
           env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory },
           encoding: 'utf8',
         });
@@ -964,12 +964,12 @@ describe('E2E: Stop Hook', () => {
 
     it('detects edit tools from older messages within scan window', () => {
       // Edit tool in first message, text-only in second
-      const transcriptPath = createMultiMessageTranscript(projectDirectory, [
+      const transcriptPath = createMultiMessageTranscript(shared.projectDirectory, [
         { text: 'Let me edit that file.', toolUse: 'Edit' },
         { text: 'Done with the changes.' },
       ]);
 
-      const result = runStopHook(projectDirectory, transcriptPath);
+      const result = runStopHook(shared.projectDirectory, transcriptPath);
       const output = parseStopOutput(result);
 
       expect(result.exitCode).toBe(0);
@@ -979,9 +979,9 @@ describe('E2E: Stop Hook', () => {
 
     it('exits with error when usage limit reached in last message', () => {
       const text = '5-hour limit reached - resets in 2 hours';
-      const transcriptPath = createMockTranscript(projectDirectory, text);
+      const transcriptPath = createMockTranscript(shared.projectDirectory, text);
 
-      const result = runStopHook(projectDirectory, transcriptPath);
+      const result = runStopHook(shared.projectDirectory, transcriptPath);
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('usage limit reached');
@@ -997,9 +997,9 @@ describe('E2E: Stop Hook', () => {
         '  throw new Error("5-hour limit reached");\n' +
         '}\n' +
         '```';
-      const transcriptPath = createMockTranscript(projectDirectory, text);
+      const transcriptPath = createMockTranscript(shared.projectDirectory, text);
 
-      const result = runStopHook(projectDirectory, transcriptPath);
+      const result = runStopHook(shared.projectDirectory, transcriptPath);
 
       // No edit tools → silent exit, no usage limit error (text is long)
       expect(result.exitCode).toBe(0);
@@ -1015,22 +1015,22 @@ describe('E2E: Stop Hook', () => {
 describe('E2E: Python Lint Hook', () => {
   describe('Test 2.1: Routes .py files to Ruff', () => {
     it('should handle Python files without error', () => {
-      writeTestFile(projectDirectory, 'test.py', 'x = 1\n');
-      const result = runLintHook(projectDirectory, `${projectDirectory}/test.py`);
+      writeTestFile(shared.projectDirectory, 'test.py', 'x = 1\n');
+      const result = runLintHook(shared.projectDirectory, `${shared.projectDirectory}/test.py`);
       expect(result.status).toBe(0);
     });
 
     it('should handle .pyi stub files', () => {
-      writeTestFile(projectDirectory, 'test.pyi', 'def foo() -> int: ...\n');
-      const result = runLintHook(projectDirectory, `${projectDirectory}/test.pyi`);
+      writeTestFile(shared.projectDirectory, 'test.pyi', 'def foo() -> int: ...\n');
+      const result = runLintHook(shared.projectDirectory, `${shared.projectDirectory}/test.pyi`);
       expect(result.status).toBe(0);
     });
   });
 
   describe('Test 2.2: Continues running ESLint for JS/TS files', () => {
     it('should run ESLint for TypeScript files', () => {
-      writeTestFile(projectDirectory, 'test.ts', 'const x = 1\n');
-      const result = runLintHook(projectDirectory, `${projectDirectory}/test.ts`);
+      writeTestFile(shared.projectDirectory, 'test.ts', 'const x = 1\n');
+      const result = runLintHook(shared.projectDirectory, `${shared.projectDirectory}/test.ts`);
       // ESLint runs and exits successfully
       expect(result.status).toBe(0);
     });
@@ -1038,7 +1038,7 @@ describe('E2E: Python Lint Hook', () => {
 
   describe('Test 2.3: Skips Ruff gracefully if not installed', () => {
     it('should not error when Ruff is missing from PATH', () => {
-      writeTestFile(projectDirectory, 'test.py', 'print("hello")\n');
+      writeTestFile(shared.projectDirectory, 'test.py', 'print("hello")\n');
 
       // Find actual bun path (process.execPath gives node when running via vitest)
       const bunPath = execSync('which bun', { encoding: 'utf8' }).trim();
@@ -1049,11 +1049,11 @@ describe('E2E: Python Lint Hook', () => {
         'bash',
         [
           '-c',
-          `PATH=/bin:/usr/bin:${bunDirectory} bun .safeword/hooks/lib/lint.ts "${projectDirectory}/test.py"`,
+          `PATH=/bin:/usr/bin:${bunDirectory} bun .safeword/hooks/lib/lint.ts "${shared.projectDirectory}/test.py"`,
         ],
         {
-          cwd: projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
           encoding: 'utf8',
         },
       );
@@ -1067,14 +1067,14 @@ describe('E2E: Python Lint Hook', () => {
     it.skipIf(!IS_RUFF_AVAILABLE)('should format Python files when run through lint hook', () => {
       // Create badly formatted Python file
       const badCode = 'x=1;y=2';
-      writeTestFile(projectDirectory, 'format-test.py', badCode);
+      writeTestFile(shared.projectDirectory, 'format-test.py', badCode);
 
       // Run lint hook on the file
-      const result = runPostToolLint(projectDirectory, `${projectDirectory}/format-test.py`);
+      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/format-test.py`);
       expect(result.status).toBe(0);
 
       // File should now be formatted
-      const formatted = readTestFile(projectDirectory, 'format-test.py');
+      const formatted = readTestFile(shared.projectDirectory, 'format-test.py');
       expect(formatted).toContain('x = 1');
       expect(formatted).toContain('y = 2');
     });
@@ -1082,14 +1082,14 @@ describe('E2E: Python Lint Hook', () => {
     it.skipIf(!IS_RUFF_AVAILABLE)('should fix auto-fixable lint issues', () => {
       // Create file with unused import (auto-fixable with --fix)
       const codeWithUnusedImport = 'import os\nx = 1\n';
-      writeTestFile(projectDirectory, 'fix-test.py', codeWithUnusedImport);
+      writeTestFile(shared.projectDirectory, 'fix-test.py', codeWithUnusedImport);
 
       // Run lint hook on the file
-      const result = runPostToolLint(projectDirectory, `${projectDirectory}/fix-test.py`);
+      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/fix-test.py`);
       expect(result.status).toBe(0);
 
       // Unused import should be removed
-      const fixed = readTestFile(projectDirectory, 'fix-test.py');
+      const fixed = readTestFile(shared.projectDirectory, 'fix-test.py');
       expect(fixed).not.toContain('import os');
       expect(fixed).toContain('x = 1');
     });
@@ -1099,9 +1099,9 @@ describe('E2E: Python Lint Hook', () => {
       () => {
         // F841 (unused variable after return) is not auto-fixable without --unsafe-fixes
         const codeWithUnfixable = 'def foo():\n    return\n    x = 1\n';
-        writeTestFile(projectDirectory, 'unfixable-test.py', codeWithUnfixable);
+        writeTestFile(shared.projectDirectory, 'unfixable-test.py', codeWithUnfixable);
 
-        const result = runPostToolLint(projectDirectory, `${projectDirectory}/unfixable-test.py`);
+        const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/unfixable-test.py`);
         expect(result.status).toBe(0);
 
         // Hook should output additionalContext JSON for remaining errors
@@ -1117,9 +1117,9 @@ describe('E2E: Python Lint Hook', () => {
     it.skipIf(!IS_RUFF_AVAILABLE)('should output no JSON when all errors are auto-fixed', () => {
       // Unused import is fully auto-fixable — no remaining errors
       const autoFixable = 'import os\nx = 1\n';
-      writeTestFile(projectDirectory, 'clean-after-fix.py', autoFixable);
+      writeTestFile(shared.projectDirectory, 'clean-after-fix.py', autoFixable);
 
-      const result = runPostToolLint(projectDirectory, `${projectDirectory}/clean-after-fix.py`);
+      const result = runPostToolLint(shared.projectDirectory, `${shared.projectDirectory}/clean-after-fix.py`);
       expect(result.status).toBe(0);
 
       // No additionalContext should be output (file is clean after fix)
@@ -1138,8 +1138,8 @@ describe('session-safeword-context.ts', () => {
       'bun',
       ['.safeword/hooks/session-safeword-context.ts', '--agent=claude'],
       {
-        cwd: projectDirectory,
-        input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: projectDirectory }),
+        cwd: shared.projectDirectory,
+        input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: shared.projectDirectory }),
         encoding: 'utf8',
       },
     );
@@ -1156,8 +1156,8 @@ describe('session-safeword-context.ts', () => {
       'bun',
       ['.safeword/hooks/session-safeword-context.ts', '--agent=cursor'],
       {
-        cwd: projectDirectory,
-        input: JSON.stringify({ workspace_root: projectDirectory }),
+        cwd: shared.projectDirectory,
+        input: JSON.stringify({ workspace_root: shared.projectDirectory }),
         encoding: 'utf8',
       },
     );
@@ -1169,18 +1169,18 @@ describe('session-safeword-context.ts', () => {
   });
 
   it('uses hook stdin cwd when the process starts from a subdirectory', () => {
-    const nestedDirectory = nodePath.join(projectDirectory, 'src/nested');
+    const nestedDirectory = nodePath.join(shared.projectDirectory, 'src/nested');
     mkdirSync(nestedDirectory, { recursive: true });
 
     const result = spawnSync(
       'bun',
       [
-        nodePath.join(projectDirectory, '.safeword/hooks/session-safeword-context.ts'),
+        nodePath.join(shared.projectDirectory, '.safeword/hooks/session-safeword-context.ts'),
         '--agent=codex',
       ],
       {
         cwd: nestedDirectory,
-        input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: projectDirectory }),
+        input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: shared.projectDirectory }),
         encoding: 'utf8',
       },
     );
@@ -1197,13 +1197,13 @@ describe('session-safeword-context.ts', () => {
       const result = spawnSync(
         'bun',
         [
-          nodePath.join(projectDirectory, '.safeword/hooks/session-safeword-context.ts'),
+          nodePath.join(shared.projectDirectory, '.safeword/hooks/session-safeword-context.ts'),
           '--agent=codex',
         ],
         {
           cwd: staleDirectory,
           env: { ...process.env, CLAUDE_PROJECT_DIR: staleDirectory },
-          input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: projectDirectory }),
+          input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: shared.projectDirectory }),
           encoding: 'utf8',
         },
       );

--- a/packages/cli/tests/integration/impl-plan-gate.test.ts
+++ b/packages/cli/tests/integration/impl-plan-gate.test.ts
@@ -21,17 +21,17 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let projectDirectory: string;
+const shared: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
+  shared.projectDirectory = createTemporaryDirectory();
+  createTypeScriptPackageJson(shared.projectDirectory);
+  initGitRepo(shared.projectDirectory);
+  await setupOrThrow(shared.projectDirectory);
 });
 
 afterAll(() => {
-  if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  if (shared.projectDirectory) removeTemporaryDirectory(shared.projectDirectory);
 });
 
 const VALID_PLAN = `# Impl Plan: test
@@ -71,34 +71,34 @@ interface TicketFixture {
 
 function writeTicket(fixture: TicketFixture): void {
   const folder = `.project/tickets/${fixture.id}`;
-  mkdirSync(nodePath.join(projectDirectory, folder), { recursive: true });
+  mkdirSync(nodePath.join(shared.projectDirectory, folder), { recursive: true });
   writeTestFile(
-    projectDirectory,
+    shared.projectDirectory,
     `${folder}/ticket.md`,
     `---\nid: ${fixture.id}\ntype: ${fixture.type}\nphase: ${fixture.phase}\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
   );
   if (fixture.type === 'feature') {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       `${folder}/test-definitions.md`,
       '# Test Definitions\n\n## Rule: Test rule\n\n- [ ] Scenario one\n',
     );
   }
   if (fixture.spec) {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       `${folder}/spec.md`,
       '# Spec\n\n## Jobs To Be Done\n\nskip: fixture\n',
     );
   }
   if (fixture.implPlan !== undefined) {
-    writeTestFile(projectDirectory, `${folder}/impl-plan.md`, fixture.implPlan);
+    writeTestFile(shared.projectDirectory, `${folder}/impl-plan.md`, fixture.implPlan);
   }
 }
 
 function runStopHook(ticketId: string): string {
   const sessionId = `session-${ticketId}`;
-  const transcriptPath = nodePath.join(projectDirectory, `transcript-${ticketId}.jsonl`);
+  const transcriptPath = nodePath.join(shared.projectDirectory, `transcript-${ticketId}.jsonl`);
   writeFileSync(
     transcriptPath,
     `${JSON.stringify({
@@ -113,13 +113,13 @@ function runStopHook(ticketId: string): string {
     })}\n`,
   );
   writeFileSync(
-    nodePath.join(projectDirectory, '.project', `quality-state-${sessionId}.json`),
+    nodePath.join(shared.projectDirectory, '.project', `quality-state-${sessionId}.json`),
     JSON.stringify({ activeTicket: ticketId }),
   );
   const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
     input: JSON.stringify({ transcript_path: transcriptPath, session_id: sessionId }),
-    cwd: projectDirectory,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+    cwd: shared.projectDirectory,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
     encoding: 'utf8',
   });
   try {

--- a/packages/cli/tests/integration/loc-gate-merge.test.ts
+++ b/packages/cli/tests/integration/loc-gate-merge.test.ts
@@ -25,36 +25,36 @@ import {
 const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 const POST_TOOL_QUALITY = nodePath.join(SAFEWORD_ROOT, '.safeword/hooks/post-tool-quality.ts');
 
-let projectDirectory: string;
+const fixture: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
-  initGitRepo(projectDirectory);
-  writeTestFile(projectDirectory, 'seed.txt', 'seed\n');
+  fixture.projectDirectory = createTemporaryDirectory();
+  initGitRepo(fixture.projectDirectory);
+  writeTestFile(fixture.projectDirectory, 'seed.txt', 'seed\n');
   execSync('git add seed.txt && git commit -m initial', {
-    cwd: projectDirectory,
+    cwd: fixture.projectDirectory,
     stdio: 'pipe',
   });
 });
 
 afterEach(() => {
-  removeTemporaryDirectory(projectDirectory);
+  removeTemporaryDirectory(fixture.projectDirectory);
 });
 
 /** Stage >400 lines of uncommitted non-meta change. */
 function stageLargeChange(): void {
   const lines = Array.from({ length: 420 }, (_, i) => `const x${i} = ${i};`).join('\n');
-  writeTestFile(projectDirectory, 'large-file.ts', lines);
-  execSync('git add large-file.ts', { cwd: projectDirectory, stdio: 'pipe' });
+  writeTestFile(fixture.projectDirectory, 'large-file.ts', lines);
+  execSync('git add large-file.ts', { cwd: fixture.projectDirectory, stdio: 'pipe' });
 }
 
 function seedState(): void {
   const head = execSync('git rev-parse --short HEAD', {
-    cwd: projectDirectory,
+    cwd: fixture.projectDirectory,
     encoding: 'utf8',
   }).trim();
   writeFileSync(
-    nodePath.join(projectDirectory, '.safeword-project', 'quality-state-test.json'),
+    nodePath.join(fixture.projectDirectory, '.safeword-project', 'quality-state-test.json'),
     JSON.stringify({ locSinceCommit: 0, lastCommitHash: head, activeTicket: null, gate: null }),
   );
 }
@@ -65,15 +65,15 @@ function runPostTool(): { gate: string | null } {
       session_id: 'test',
       hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
-      tool_input: { file_path: nodePath.join(projectDirectory, 'large-file.ts') },
+      tool_input: { file_path: nodePath.join(fixture.projectDirectory, 'large-file.ts') },
     }),
-    cwd: projectDirectory,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+    cwd: fixture.projectDirectory,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: fixture.projectDirectory },
     encoding: 'utf8',
   });
   const state = JSON.parse(
     readFileSync(
-      nodePath.join(projectDirectory, '.safeword-project', 'quality-state-test.json'),
+      nodePath.join(fixture.projectDirectory, '.safeword-project', 'quality-state-test.json'),
       'utf8',
     ),
   );
@@ -83,7 +83,7 @@ function runPostTool(): { gate: string | null } {
 describe('LOC gate × git operation (MT27QG)', () => {
   it('loc_gate_still_arms_with_no_operation', () => {
     // create the state dir, then seed
-    writeTestFile(projectDirectory, '.safeword-project/.keep', '');
+    writeTestFile(fixture.projectDirectory, '.safeword-project/.keep', '');
     seedState();
     stageLargeChange();
 
@@ -91,15 +91,15 @@ describe('LOC gate × git operation (MT27QG)', () => {
   });
 
   it('loc_gate_does_not_arm_mid_merge', () => {
-    writeTestFile(projectDirectory, '.safeword-project/.keep', '');
+    writeTestFile(fixture.projectDirectory, '.safeword-project/.keep', '');
     seedState();
     stageLargeChange();
     // Simulate a merge in progress.
     const head = execSync('git rev-parse HEAD', {
-      cwd: projectDirectory,
+      cwd: fixture.projectDirectory,
       encoding: 'utf8',
     }).trim();
-    writeFileSync(nodePath.join(projectDirectory, '.git', 'MERGE_HEAD'), `${head}\n`);
+    writeFileSync(nodePath.join(fixture.projectDirectory, '.git', 'MERGE_HEAD'), `${head}\n`);
 
     expect(runPostTool().gate).not.toBe('loc');
   });

--- a/packages/cli/tests/integration/mixed-project-golang.test.ts
+++ b/packages/cli/tests/integration/mixed-project-golang.test.ts
@@ -30,7 +30,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
+const IS_GOLANGCI_LINT_AVAILABLE = isGolangciLintInstalled();
 
 describe('E2E: Mixed Project (TypeScript + Go)', () => {
   let projectDirectory: string;
@@ -126,7 +126,7 @@ func main() {
     }).toThrow();
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint runs on Go files', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint runs on Go files', () => {
     // main.go should be valid
     const result = spawnSync('golangci-lint', ['run', 'main.go'], {
       cwd: projectDirectory,
@@ -135,7 +135,7 @@ func main() {
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!GOLANGCI_LINT_AVAILABLE)('golangci-lint detects Go violations', () => {
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint detects Go violations', () => {
     // Unused import will be caught by 'unused' linter in standard set
     writeTestFile(
       projectDirectory,
@@ -170,7 +170,7 @@ func bad() {
       expect(formatted.trim()).toBe('const x = 1;');
     });
 
-    it.skipIf(!GOLANGCI_LINT_AVAILABLE)('routes .go files to golangci-lint', () => {
+    it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('routes .go files to golangci-lint', () => {
       const filePath = nodePath.join(projectDirectory, 'lint-go.go');
       writeTestFile(
         projectDirectory,

--- a/packages/cli/tests/integration/mixed-project.test.ts
+++ b/packages/cli/tests/integration/mixed-project.test.ts
@@ -29,7 +29,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const RUFF_AVAILABLE = isRuffInstalled();
+const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 describe('E2E: Mixed Project (TypeScript + Python)', () => {
   let projectDirectory: string;
@@ -113,7 +113,7 @@ version = "0.1.0"
     }).toThrow();
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('Ruff runs on Python files', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('Ruff runs on Python files', () => {
     writeTestFile(projectDirectory, 'src/valid.py', 'x = 1\n');
 
     const result = spawnSync('ruff', ['check', 'src/valid.py'], {
@@ -123,7 +123,7 @@ version = "0.1.0"
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('Ruff detects Python violations', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('Ruff detects Python violations', () => {
     writeTestFile(projectDirectory, 'src/bad.py', 'import os\nx = 1\n');
 
     const result = spawnSync('ruff', ['check', 'src/bad.py'], {
@@ -147,7 +147,7 @@ version = "0.1.0"
       expect(formatted.trim()).toBe('const x = 1;');
     });
 
-    it.skipIf(!RUFF_AVAILABLE)('routes .py files to Ruff', () => {
+    it.skipIf(!IS_RUFF_AVAILABLE)('routes .py files to Ruff', () => {
       const filePath = nodePath.join(projectDirectory, 'src/lint-py.py');
       writeTestFile(projectDirectory, 'src/lint-py.py', 'x=1;y=2');
 

--- a/packages/cli/tests/integration/override-survival.test.ts
+++ b/packages/cli/tests/integration/override-survival.test.ts
@@ -37,7 +37,7 @@ function applyOverride(existingConfig: string, overrideBlock: string): string {
   const match = /\n\](\)?);\s*$/.exec(existingConfig);
   if (!match) throw new Error('applyOverride: could not locate closing bracket');
   const close = match[1] ?? '';
-  return existingConfig.replace(/\n\]\)?;\s*$/, `\n${overrideBlock}]${close};\n`);
+  return existingConfig.replace(/\n\]\)?;\s*$/, () => `\n${overrideBlock}]${close};\n`);
 }
 
 async function runUpgradeAndAssertFileUnchanged(

--- a/packages/cli/tests/integration/python-golden-path.test.ts
+++ b/packages/cli/tests/integration/python-golden-path.test.ts
@@ -32,7 +32,7 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const RUFF_AVAILABLE = isRuffInstalled();
+const IS_RUFF_AVAILABLE = isRuffInstalled();
 
 describe('E2E: Python Golden Path', () => {
   let projectDirectory: string;
@@ -67,7 +67,7 @@ describe('E2E: Python Golden Path', () => {
     expect(ruffToml).toContain('customer-owned');
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('ruff config is valid and runs', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('ruff config is valid and runs', () => {
     writeTestFile(projectDirectory, 'src/valid.py', 'x = 1\n');
 
     // Should not throw - ruff check runs successfully
@@ -80,7 +80,7 @@ describe('E2E: Python Golden Path', () => {
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('ruff detects violations', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('ruff detects violations', () => {
     // Unused import, which is flagged by Ruff
     writeTestFile(projectDirectory, 'src/bad.py', 'import os\nx = 1\n');
 
@@ -94,7 +94,7 @@ describe('E2E: Python Golden Path', () => {
     expect(result.stdout).toContain('F401'); // unused import
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('ruff formats files', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('ruff formats files', () => {
     // Badly formatted Python - extra spaces, missing newline
     writeTestFile(projectDirectory, 'src/ugly.py', 'x=1;y=2');
 
@@ -106,7 +106,7 @@ describe('E2E: Python Golden Path', () => {
     expect(formatted).toContain('y = 2');
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('post-tool-lint hook processes Python files', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('post-tool-lint hook processes Python files', () => {
     const filePath = nodePath.join(projectDirectory, 'src/hook-test.py');
     // Intentionally badly formatted
     writeTestFile(projectDirectory, 'src/hook-test.py', 'x=1;y=2');
@@ -168,7 +168,7 @@ describe('E2E: Python Setup Idempotency', () => {
     expect(ruffToml).toContain('customer-owned');
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('Ruff still works after running setup twice', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('Ruff still works after running setup twice', () => {
     writeTestFile(projectDirectory, 'src/idempotent.py', 'x = 1\n');
 
     const result = spawnSync('ruff', ['check', 'src/idempotent.py'], {
@@ -214,7 +214,7 @@ describe('E2E: Python Lint Hook Fallback', () => {
     }
   });
 
-  it.skipIf(!RUFF_AVAILABLE)('lint hook formats files without safeword Ruff config', () => {
+  it.skipIf(!IS_RUFF_AVAILABLE)('lint hook formats files without safeword Ruff config', () => {
     writeTestFile(projectDirectory, 'src/fallback.py', 'x=1;y=2');
     const filePath = nodePath.join(projectDirectory, 'src/fallback.py');
 

--- a/packages/cli/tests/integration/rust-golden-path.test.ts
+++ b/packages/cli/tests/integration/rust-golden-path.test.ts
@@ -34,8 +34,8 @@ import {
   writeTestFile,
 } from '../helpers';
 
-const CLIPPY_AVAILABLE = isClippyInstalled();
-const RUSTFMT_AVAILABLE = isRustfmtInstalled();
+const IS_CLIPPY_AVAILABLE = isClippyInstalled();
+const IS_RUSTFMT_AVAILABLE = isRustfmtInstalled();
 
 describe('E2E: Rust Golden Path', () => {
   let projectDirectory: string;
@@ -99,7 +99,7 @@ describe('E2E: Rust Golden Path', () => {
     expect(cargoToml).toContain('unsafe_code');
   });
 
-  it.skipIf(!CLIPPY_AVAILABLE)('clippy config is valid', () => {
+  it.skipIf(!IS_CLIPPY_AVAILABLE)('clippy config is valid', () => {
     // cargo clippy should run without config errors
     const result = spawnSync('cargo', ['clippy', '--', '--version'], {
       cwd: projectDirectory,
@@ -110,7 +110,7 @@ describe('E2E: Rust Golden Path', () => {
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!CLIPPY_AVAILABLE)('clippy runs on valid code', () => {
+  it.skipIf(!IS_CLIPPY_AVAILABLE)('clippy runs on valid code', () => {
     // main.rs from createRustProject should be valid
     const result = spawnSync('cargo', ['clippy'], {
       cwd: projectDirectory,
@@ -120,7 +120,7 @@ describe('E2E: Rust Golden Path', () => {
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!CLIPPY_AVAILABLE)('clippy detects unwrap_used violation', () => {
+  it.skipIf(!IS_CLIPPY_AVAILABLE)('clippy detects unwrap_used violation', () => {
     // Modify main.rs to include an unwrap call (files must be in module tree to be checked)
     writeTestFile(
       projectDirectory,
@@ -143,7 +143,7 @@ describe('E2E: Rust Golden Path', () => {
     expect(result.stdout + result.stderr).toMatch(/unwrap_used|unwrap/i);
   });
 
-  it.skipIf(!RUSTFMT_AVAILABLE)('rustfmt formats files', () => {
+  it.skipIf(!IS_RUSTFMT_AVAILABLE)('rustfmt formats files', () => {
     writeTestFile(projectDirectory, 'src/ugly.rs', `fn main(){println!("no spaces")}`);
 
     spawnSync('rustfmt', ['src/ugly.rs'], { cwd: projectDirectory });
@@ -152,7 +152,7 @@ describe('E2E: Rust Golden Path', () => {
     expect(formatted).toContain('fn main() {');
   });
 
-  it.skipIf(!RUSTFMT_AVAILABLE)('lint hook processes .rs files', () => {
+  it.skipIf(!IS_RUSTFMT_AVAILABLE)('lint hook processes .rs files', () => {
     const filePath = nodePath.join(projectDirectory, 'src/hook-test.rs');
     writeTestFile(projectDirectory, 'src/hook-test.rs', `fn hook_test(){println!("test")}`);
 
@@ -588,7 +588,7 @@ describe('E2E: Rust Lint Hook Fallback', () => {
     }
   });
 
-  it.skipIf(!RUSTFMT_AVAILABLE)('lint hook formats .rs files without safeword config', () => {
+  it.skipIf(!IS_RUSTFMT_AVAILABLE)('lint hook formats .rs files without safeword config', () => {
     const filePath = nodePath.join(projectDirectory, 'src/fallback-test.rs');
     writeTestFile(projectDirectory, 'src/fallback-test.rs', `fn fallback_test(){println!("test")}`);
 
@@ -698,7 +698,7 @@ describe('E2E: Add Rust to Existing TypeScript Project', () => {
       expect(fileExists(projectDirectory, '.safeword/eslint.config.mjs')).toBe(true);
     });
 
-    it.skipIf(!RUSTFMT_AVAILABLE)('rustfmt works on Rust files', () => {
+    it.skipIf(!IS_RUSTFMT_AVAILABLE)('rustfmt works on Rust files', () => {
       writeTestFile(projectDirectory, 'src/test.rs', `fn test(){println!("test")}`);
 
       const filePath = nodePath.join(projectDirectory, 'src/test.rs');
@@ -771,7 +771,7 @@ describe('E2E: Rust Lint Hook Package Targeting', () => {
     }
   });
 
-  it.skipIf(!CLIPPY_AVAILABLE)(
+  it.skipIf(!IS_CLIPPY_AVAILABLE)(
     'lint hook runs cargo clippy with -p <package> for workspace member (Scenario 10)',
     () => {
       // Create a file with a clippy-fixable issue: single_char_pattern
@@ -800,7 +800,7 @@ describe('E2E: Rust Lint Hook Package Targeting', () => {
     },
   );
 
-  it.skipIf(!CLIPPY_AVAILABLE)(
+  it.skipIf(!IS_CLIPPY_AVAILABLE)(
     'lint hook skips clippy for virtual workspace root files (no package)',
     () => {
       // Create a build.rs at workspace root (no [package] section in root Cargo.toml)

--- a/packages/cli/tests/integration/skill-gate-integration.test.ts
+++ b/packages/cli/tests/integration/skill-gate-integration.test.ts
@@ -20,19 +20,6 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let projectDirectory: string;
-
-beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
-});
-
-afterAll(() => {
-  if (projectDirectory) removeTemporaryDirectory(projectDirectory);
-});
-
 function writeFeatureTicketAtDone(directory: string, ticketId: string): void {
   const folder = `.project/tickets/${ticketId}`;
   execSync(`mkdir -p "${directory}/${folder}"`, { cwd: directory });
@@ -99,6 +86,19 @@ function runStopHookWithSession(
 }
 
 describe('skill-invocation gate: end-to-end (147)', () => {
+  let projectDirectory: string;
+
+  beforeAll(async () => {
+    projectDirectory = createTemporaryDirectory();
+    createTypeScriptPackageJson(projectDirectory);
+    initGitRepo(projectDirectory);
+    await setupOrThrow(projectDirectory);
+  });
+
+  afterAll(() => {
+    if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  });
+
   it('feature done blocks when /verify and /audit log entries are missing in this session', () => {
     writeFeatureTicketAtDone(projectDirectory, '901');
     writeSkillLog(projectDirectory, []);

--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -89,10 +89,12 @@ function parseFrontmatter(
   // Find closing ---
   let endIndex = -1;
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i]?.trim() === '---') {
-      endIndex = i;
-      break;
+    if (lines[i]?.trim() !== '---') {
+    	continue;
     }
+
+    endIndex = i;
+    break;
   }
 
   if (endIndex === -1) {
@@ -218,11 +220,13 @@ function findBrokenMarkdownLinks(body: string, baseDirectory: string): string[] 
   const brokenLinks: string[] = [];
 
   for (const link of links) {
-    if (link.path.endsWith('.md')) {
-      const fullPath = nodePath.join(baseDirectory, link.path);
-      if (!existsSync(fullPath)) {
-        brokenLinks.push(`[${link.text}](${link.path})`);
-      }
+    if (!link.path.endsWith('.md')) {
+    	continue;
+    }
+
+    const fullPath = nodePath.join(baseDirectory, link.path);
+    if (!existsSync(fullPath)) {
+      brokenLinks.push(`[${link.text}](${link.path})`);
     }
   }
 
@@ -353,13 +357,15 @@ describe('Skills Validation (Claude Code Format)', () => {
 
       // File reference validation
       it('should have valid markdown file references in body', () => {
-        if (parsed?.body) {
-          const brokenLinks = findBrokenMarkdownLinks(
-            parsed.body,
-            nodePath.join(SKILLS_DIR, skillDirectory),
-          );
-          expect(brokenLinks, `Broken markdown links: ${brokenLinks.join(', ')}`).toHaveLength(0);
+        if (!parsed?.body) {
+        	return;
         }
+
+        const brokenLinks = findBrokenMarkdownLinks(
+          parsed.body,
+          nodePath.join(SKILLS_DIR, skillDirectory),
+        );
+        expect(brokenLinks, `Broken markdown links: ${brokenLinks.join(', ')}`).toHaveLength(0);
       });
 
       // Skills use short, action-oriented names (bdd, debug, refactor, quality-review)
@@ -421,20 +427,24 @@ describe('Commands Validation (Claude Code Format)', () => {
 
       it('should have description field for /help display', () => {
         // Safeword commands should have descriptions
-        if (parsed) {
-          expect(
-            parsed.frontmatter.description,
-            'Commands should have description for /help',
-          ).toBeDefined();
-          expect(parsed.frontmatter.description).not.toBe('');
+        if (!parsed) {
+        	return;
         }
+
+        expect(
+          parsed.frontmatter.description,
+          'Commands should have description for /help',
+        ).toBeDefined();
+        expect(parsed.frontmatter.description).not.toBe('');
       });
 
       it('should have markdown body (not just frontmatter)', () => {
-        if (parsed) {
-          expect(parsed.body, 'Command needs content after frontmatter').not.toBe('');
-          expect(parsed.body?.length, 'Body should have content').toBeGreaterThan(MIN_BODY_LENGTH);
+        if (!parsed) {
+        	return;
         }
+
+        expect(parsed.body, 'Command needs content after frontmatter').not.toBe('');
+        expect(parsed.body?.length, 'Body should have content').toBeGreaterThan(MIN_BODY_LENGTH);
       });
 
       it('should not use $0 (invalid argument)', () => {
@@ -491,10 +501,10 @@ describe('Commands Validation (Claude Code Format)', () => {
       // Validate argument pattern usage
       it('should use valid argument patterns ($1, $2, $ARGUMENTS)', () => {
         // Check if command uses any argument patterns
-        const usesArguments =
+        const isUsesArguments =
           content.includes('$1') || content.includes('$2') || content.includes('$ARGUMENTS');
 
-        if (usesArguments) {
+        if (isUsesArguments) {
           const invalidPatterns = findInvalidArgumentPatterns(content);
           expect(
             invalidPatterns,
@@ -505,10 +515,12 @@ describe('Commands Validation (Claude Code Format)', () => {
 
       // File reference validation for commands
       it('should have valid markdown file references in body', () => {
-        if (parsed?.body) {
-          const brokenLinks = findBrokenMarkdownLinks(parsed.body, COMMANDS_DIR);
-          expect(brokenLinks, `Broken markdown links: ${brokenLinks.join(', ')}`).toHaveLength(0);
+        if (!parsed?.body) {
+        	return;
         }
+
+        const brokenLinks = findBrokenMarkdownLinks(parsed.body, COMMANDS_DIR);
+        expect(brokenLinks, `Broken markdown links: ${brokenLinks.join(', ')}`).toHaveLength(0);
       });
     });
   }

--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -90,7 +90,7 @@ function parseFrontmatter(
   let endIndex = -1;
   for (let i = 1; i < lines.length; i++) {
     if (lines[i]?.trim() !== '---') {
-    	continue;
+      continue;
     }
 
     endIndex = i;
@@ -221,7 +221,7 @@ function findBrokenMarkdownLinks(body: string, baseDirectory: string): string[] 
 
   for (const link of links) {
     if (!link.path.endsWith('.md')) {
-    	continue;
+      continue;
     }
 
     const fullPath = nodePath.join(baseDirectory, link.path);
@@ -358,7 +358,7 @@ describe('Skills Validation (Claude Code Format)', () => {
       // File reference validation
       it('should have valid markdown file references in body', () => {
         if (!parsed?.body) {
-        	return;
+          return;
         }
 
         const brokenLinks = findBrokenMarkdownLinks(
@@ -428,7 +428,7 @@ describe('Commands Validation (Claude Code Format)', () => {
       it('should have description field for /help display', () => {
         // Safeword commands should have descriptions
         if (!parsed) {
-        	return;
+          return;
         }
 
         expect(
@@ -440,7 +440,7 @@ describe('Commands Validation (Claude Code Format)', () => {
 
       it('should have markdown body (not just frontmatter)', () => {
         if (!parsed) {
-        	return;
+          return;
         }
 
         expect(parsed.body, 'Command needs content after frontmatter').not.toBe('');
@@ -516,7 +516,7 @@ describe('Commands Validation (Claude Code Format)', () => {
       // File reference validation for commands
       it('should have valid markdown file references in body', () => {
         if (!parsed?.body) {
-        	return;
+          return;
         }
 
         const brokenLinks = findBrokenMarkdownLinks(parsed.body, COMMANDS_DIR);
@@ -659,7 +659,7 @@ describe('Skills-Cursor Parity', () => {
 
     const missingRules: string[] = [];
     for (const skillDirectory of skillDirectories) {
-      if (!(skillDirectory in SKILL_TO_RULE_MAP)) {
+      if (!Object.hasOwn(SKILL_TO_RULE_MAP, skillDirectory)) {
         missingRules.push(`${skillDirectory} (no rule mapping defined)`);
         continue;
       }

--- a/packages/cli/tests/integration/status-close-gate.test.ts
+++ b/packages/cli/tests/integration/status-close-gate.test.ts
@@ -22,17 +22,17 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let projectDirectory: string;
+const fixture: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
+  fixture.projectDirectory = createTemporaryDirectory();
+  createTypeScriptPackageJson(fixture.projectDirectory);
+  initGitRepo(fixture.projectDirectory);
+  await setupOrThrow(fixture.projectDirectory);
 });
 
 afterAll(() => {
-  if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  if (fixture.projectDirectory) removeTemporaryDirectory(fixture.projectDirectory);
 });
 
 /** A feature closed by the sidestep: status:done but phase still intake, with
@@ -91,10 +91,10 @@ function runStopHook(targetDirectory: string, sessionId: string): { reason: stri
 
 describe('status-close done-gate (2JMQMX)', () => {
   it('blocks a feature closed by status:done with no verify.md', () => {
-    writeFeatureClosedByStatus(projectDirectory, '910');
-    writeSessionState(projectDirectory, 'session-910', '910');
+    writeFeatureClosedByStatus(fixture.projectDirectory, '910');
+    writeSessionState(fixture.projectDirectory, 'session-910', '910');
 
-    const result = runStopHook(projectDirectory, 'session-910');
+    const result = runStopHook(fixture.projectDirectory, 'session-910');
 
     // The surfaced phase:'done' reached the real done-gate, which blocked on the
     // missing evidence — the sidestep is closed.

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -129,21 +129,24 @@ function runStopHook(directory: string, transcriptPath: string, sessionId?: stri
   });
 }
 
-let projectDirectory: string;
+const state: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  state.projectDirectory = createTemporaryDirectory();
   // Hook only requires .safeword/ to exist (checked with existsSync)
-  mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+  mkdirSync(nodePath.join(state.projectDirectory, '.safeword'), { recursive: true });
 });
 
 afterEach(() => {
-  removeTemporaryDirectory(projectDirectory);
+  removeTemporaryDirectory(state.projectDirectory);
 });
 
 describe('Stop Hook: Done-phase verify.md artifact gate', () => {
   it('hard blocks done-phase without verify.md regardless of transcript content', () => {
-    const result = runStopHookDonePhase(projectDirectory, 'I updated the configuration file.');
+    const result = runStopHookDonePhase(
+      state.projectDirectory,
+      'I updated the configuration file.',
+    );
     expect(result.status).toBe(0);
     const parsed = JSON.parse(result.stdout.trim()) as { decision?: string; reason?: string };
     expect(parsed.decision).toBe('block');
@@ -170,14 +173,14 @@ describe('Stop Hook: Done-gate fires without recent edit tools (AP3FGJ)', () => 
   }
 
   it('evaluates the done-gate on a no-edit transcript (blocks on missing verify.md)', () => {
-    const transcriptPath = writeNoEditTranscript(projectDirectory);
-    createTicket(projectDirectory, '099', 'done-task', {
+    const transcriptPath = writeNoEditTranscript(state.projectDirectory);
+    createTicket(state.projectDirectory, '099', 'done-task', {
       phase: 'done',
       status: 'in_progress',
       type: 'task',
     });
 
-    const result = runStopHook(projectDirectory, transcriptPath);
+    const result = runStopHook(state.projectDirectory, transcriptPath);
 
     expect(result.status).toBe(0);
     const parsed = JSON.parse(result.stdout.trim()) as { decision?: string; reason?: string };
@@ -186,14 +189,14 @@ describe('Stop Hook: Done-gate fires without recent edit tools (AP3FGJ)', () => 
   });
 
   it('still exits silently on a no-edit transcript at a non-done phase (review path unchanged)', () => {
-    const transcriptPath = writeNoEditTranscript(projectDirectory);
-    createTicket(projectDirectory, '098', 'impl-task', {
+    const transcriptPath = writeNoEditTranscript(state.projectDirectory);
+    createTicket(state.projectDirectory, '098', 'impl-task', {
       phase: 'implement',
       status: 'in_progress',
       type: 'task',
     });
 
-    const result = runStopHook(projectDirectory, transcriptPath);
+    const result = runStopHook(state.projectDirectory, transcriptPath);
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('');
@@ -209,8 +212,8 @@ describe('Stop Hook: Frozen Transcript Format Compatibility', () => {
         // combinedText now reads from this field instead of the transcript.
         last_assistant_message: 'Here is what I did: updated the file.',
       }),
-      cwd: projectDirectory,
-      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+      cwd: state.projectDirectory,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: state.projectDirectory },
       encoding: 'utf8',
       timeout: TIMEOUT_QUICK,
     });
@@ -253,12 +256,12 @@ describe('Stop Hook: Frozen Transcript Format Compatibility', () => {
 
 describe('Stop Hook: Ticket Resolution Context', () => {
   it('shows quality review when active ticket at implement phase', () => {
-    createTicket(projectDirectory, '099', 'test', {
+    createTicket(state.projectDirectory, '099', 'test', {
       phase: 'implement',
       status: 'in_progress',
     });
-    const transcriptPath = createTranscript(projectDirectory);
-    const result = runStopHook(projectDirectory, transcriptPath);
+    const transcriptPath = createTranscript(state.projectDirectory);
+    const result = runStopHook(state.projectDirectory, transcriptPath);
 
     expect(result.status).toBe(0);
     // Should soft-block with quality review (edits were made)
@@ -269,8 +272,8 @@ describe('Stop Hook: Ticket Resolution Context', () => {
 
   it('shows generic quality review when no ticket exists', () => {
     // No ticket created — just .safeword/ dir (from beforeEach)
-    const transcriptPath = createTranscript(projectDirectory);
-    const result = runStopHook(projectDirectory, transcriptPath);
+    const transcriptPath = createTranscript(state.projectDirectory);
+    const result = runStopHook(state.projectDirectory, transcriptPath);
 
     expect(result.status).toBe(0);
     // Should still soft-block with generic quality review (edits were made, no ticket context)
@@ -280,12 +283,12 @@ describe('Stop Hook: Ticket Resolution Context', () => {
   });
 
   it('shows done-phase hard block when active ticket at done phase', () => {
-    createTicket(projectDirectory, '099', 'test', {
+    createTicket(state.projectDirectory, '099', 'test', {
       phase: 'done',
       status: 'in_progress',
     });
-    const transcriptPath = createTranscript(projectDirectory);
-    const result = runStopHook(projectDirectory, transcriptPath);
+    const transcriptPath = createTranscript(state.projectDirectory);
+    const result = runStopHook(state.projectDirectory, transcriptPath);
 
     expect(result.status).toBe(0);
     // Should hard-block requiring evidence (done phase)
@@ -296,15 +299,15 @@ describe('Stop Hook: Ticket Resolution Context', () => {
 
   it('uses session binding when session_id and state file exist', () => {
     // Create two tickets — session is bound to 099
-    createTicket(projectDirectory, '099', 'session-ticket', {
+    createTicket(state.projectDirectory, '099', 'session-ticket', {
       phase: 'implement',
       status: 'in_progress',
     });
-    createTicket(projectDirectory, '100', 'other-ticket', {
+    createTicket(state.projectDirectory, '100', 'other-ticket', {
       phase: 'done',
       status: 'in_progress',
     });
-    writeSessionState(projectDirectory, 'test-session', {
+    writeSessionState(state.projectDirectory, 'test-session', {
       locSinceCommit: 100,
       lastCommitHash: '',
       activeTicket: '099',
@@ -315,8 +318,8 @@ describe('Stop Hook: Ticket Resolution Context', () => {
       locAtLastReview: 0,
     });
 
-    const transcriptPath = createTranscript(projectDirectory);
-    const result = runStopHook(projectDirectory, transcriptPath, 'test-session');
+    const transcriptPath = createTranscript(state.projectDirectory);
+    const result = runStopHook(state.projectDirectory, transcriptPath, 'test-session');
 
     expect(result.status).toBe(0);
     const parsed = JSON.parse(result.stdout.trim());
@@ -328,11 +331,11 @@ describe('Stop Hook: Ticket Resolution Context', () => {
   });
 
   it('shows no ticket context when session ticket is done status', () => {
-    createTicket(projectDirectory, '099', 'done-ticket', {
+    createTicket(state.projectDirectory, '099', 'done-ticket', {
       phase: 'done',
       status: 'done',
     });
-    writeSessionState(projectDirectory, 'test-session', {
+    writeSessionState(state.projectDirectory, 'test-session', {
       locSinceCommit: 0,
       lastCommitHash: '',
       activeTicket: '099',
@@ -343,8 +346,8 @@ describe('Stop Hook: Ticket Resolution Context', () => {
       locAtLastReview: 0,
     });
 
-    const transcriptPath = createTranscript(projectDirectory);
-    const result = runStopHook(projectDirectory, transcriptPath, 'test-session');
+    const transcriptPath = createTranscript(state.projectDirectory);
+    const result = runStopHook(state.projectDirectory, transcriptPath, 'test-session');
 
     expect(result.status).toBe(0);
     const parsed = JSON.parse(result.stdout.trim());

--- a/packages/cli/tests/integration/tooling-validation.test.ts
+++ b/packages/cli/tests/integration/tooling-validation.test.ts
@@ -123,11 +123,10 @@ describe('E2E: mypy Type Error Detection', () => {
     writeTestFile(
       projectDirectory,
       'src/valid_types.py',
-      `def greet(name: str) -> str:
-    return f"Hello, {name}"
-
-result: str = greet("world")
-`,
+      'def greet(name: str) -> str:\n' +
+        '    return f"Hello, {name}"\n' +
+        '\n' +
+        'result: str = greet("world")\n',
     );
 
     const result = spawnSync('mypy', ['src/valid_types.py'], {

--- a/packages/cli/tests/integration/tooling-validation.test.ts
+++ b/packages/cli/tests/integration/tooling-validation.test.ts
@@ -94,7 +94,7 @@ requires-python = ">=3.10"
 // Suite 2: mypy Type Error Detection
 // =============================================================================
 
-const MYPY_AVAILABLE = isMypyInstalled();
+const IS_MYPY_AVAILABLE = isMypyInstalled();
 
 describe('E2E: mypy Type Error Detection', () => {
   let projectDirectory: string;
@@ -119,7 +119,7 @@ describe('E2E: mypy Type Error Detection', () => {
     expect(config).toContain('show_error_codes = True');
   });
 
-  it.skipIf(!MYPY_AVAILABLE)('mypy runs without error on valid code', () => {
+  it.skipIf(!IS_MYPY_AVAILABLE)('mypy runs without error on valid code', () => {
     writeTestFile(
       projectDirectory,
       'src/valid_types.py',
@@ -138,7 +138,7 @@ result: str = greet("world")
     expect(result.status).toBe(0);
   });
 
-  it.skipIf(!MYPY_AVAILABLE)('mypy catches type errors', () => {
+  it.skipIf(!IS_MYPY_AVAILABLE)('mypy catches type errors', () => {
     writeTestFile(
       projectDirectory,
       'src/bad_types.py',
@@ -162,7 +162,7 @@ result: int = add_numbers("hello", 42)
     expect(result.stdout).toMatch(/str|incompatible/i);
   });
 
-  it.skipIf(!MYPY_AVAILABLE)('mypy catches return type errors', () => {
+  it.skipIf(!IS_MYPY_AVAILABLE)('mypy catches return type errors', () => {
     writeTestFile(
       projectDirectory,
       'src/bad_return.py',

--- a/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
+++ b/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
@@ -24,17 +24,17 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let projectDirectory: string;
+const shared: { projectDirectory: string; ticketSeq: number } = { projectDirectory: '', ticketSeq: 0 };
 
 beforeAll(async () => {
-  projectDirectory = createTemporaryDirectory();
-  createTypeScriptPackageJson(projectDirectory);
-  initGitRepo(projectDirectory);
-  await setupOrThrow(projectDirectory);
+  shared.projectDirectory = createTemporaryDirectory();
+  createTypeScriptPackageJson(shared.projectDirectory);
+  initGitRepo(shared.projectDirectory);
+  await setupOrThrow(shared.projectDirectory);
 });
 
 afterAll(() => {
-  if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  if (shared.projectDirectory) removeTemporaryDirectory(shared.projectDirectory);
 });
 
 // A legacy scenario block (bare [x], no annotations) — ledger-exempt, but it
@@ -57,7 +57,6 @@ const annotatedLoop = (name: string, red: string, green: string) =>
 // Each fixture stays in_progress, so the hook's most-recent-in_progress
 // resolution must pick the ticket under test — give each a strictly increasing
 // last_modified so the newest write wins.
-let ticketSeq = 0;
 
 function writeTicket(
   ticketId: string,
@@ -65,12 +64,12 @@ function writeTicket(
   body: string,
   crossScenarioRow?: string,
 ): void {
-  ticketSeq += 1;
-  const lastModified = `2026-06-20T10:${String(ticketSeq).padStart(2, '0')}:00Z`;
+  shared.ticketSeq += 1;
+  const lastModified = `2026-06-20T10:${String(shared.ticketSeq).padStart(2, '0')}:00Z`;
   const folder = `.project/tickets/${ticketId}`;
-  execSync(`mkdir -p "${projectDirectory}/${folder}"`, { cwd: projectDirectory });
+  execSync(`mkdir -p "${shared.projectDirectory}/${folder}"`, { cwd: shared.projectDirectory });
   writeTestFile(
-    projectDirectory,
+    shared.projectDirectory,
     `${folder}/ticket.md`,
     `---\nid: ${ticketId}\ntype: ${type}\nphase: done\nstatus: in_progress\nlast_modified: ${lastModified}\n---\n# Test\n`,
   );
@@ -85,16 +84,16 @@ function writeTicket(
     '',
     ...(crossScenarioRow === undefined ? [] : [crossScenarioRow, '']),
   ].join('\n');
-  writeTestFile(projectDirectory, `${folder}/test-definitions.md`, testDefs);
+  writeTestFile(shared.projectDirectory, `${folder}/test-definitions.md`, testDefs);
   writeTestFile(
-    projectDirectory,
+    shared.projectDirectory,
     `${folder}/verify.md`,
     'Verified\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
   );
 }
 
 function writeSkillLog(entries: string[]): void {
-  const dir = nodePath.join(projectDirectory, '.project');
+  const dir = nodePath.join(shared.projectDirectory, '.project');
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     nodePath.join(dir, 'skill-invocations.log'),
@@ -103,15 +102,15 @@ function writeSkillLog(entries: string[]): void {
 }
 
 function twoReachableShas(): [string, string] {
-  execSync('git commit --allow-empty -q -m loop-c1', { cwd: projectDirectory });
-  const a = execSync('git rev-parse --short HEAD', { cwd: projectDirectory }).toString().trim();
-  execSync('git commit --allow-empty -q -m loop-c2', { cwd: projectDirectory });
-  const b = execSync('git rev-parse --short HEAD', { cwd: projectDirectory }).toString().trim();
+  execSync('git commit --allow-empty -q -m loop-c1', { cwd: shared.projectDirectory });
+  const a = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory }).toString().trim();
+  execSync('git commit --allow-empty -q -m loop-c2', { cwd: shared.projectDirectory });
+  const b = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory }).toString().trim();
   return [a, b];
 }
 
 function runDoneGate(sessionId: string): { exitCode: number; reason: string } {
-  const transcriptPath = nodePath.join(projectDirectory, 'transcript.jsonl');
+  const transcriptPath = nodePath.join(shared.projectDirectory, 'transcript.jsonl');
   writeFileSync(
     transcriptPath,
     `${JSON.stringify({
@@ -133,8 +132,8 @@ function runDoneGate(sessionId: string): { exitCode: number; reason: string } {
       // so the task fixtures reach the ledger/skill gates under test.
       last_assistant_message: '1/1 tests pass',
     }),
-    cwd: projectDirectory,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory },
+    cwd: shared.projectDirectory,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
     encoding: 'utf8',
   });
   const exitCode = result.status ?? 0;

--- a/packages/cli/tests/owned-paths.test.ts
+++ b/packages/cli/tests/owned-paths.test.ts
@@ -117,7 +117,9 @@ describe('generateOwnedPathsModule', () => {
     expect(match).not.toBeNull();
     if (match === null) return; // narrow for TS; toEqual above would have failed first
     const arrayBody = match[1] ?? '';
-    const emitted = [...arrayBody.matchAll(/'([^']+)'/g)]
+    const emitted = arrayBody
+      .matchAll(/'([^']+)'/g)
+      .toArray()
       .map(m => m[1] ?? '')
       .toSorted((a, b) => a.localeCompare(b));
     // The generator adds '.project/' alongside the schema's legacy namespace

--- a/packages/cli/tests/owned-paths.test.ts
+++ b/packages/cli/tests/owned-paths.test.ts
@@ -119,8 +119,8 @@ describe('generateOwnedPathsModule', () => {
     const arrayBody = match[1] ?? '';
     const emitted = arrayBody
       .matchAll(/'([^']+)'/g)
-      .toArray()
       .map(m => m[1] ?? '')
+      .toArray()
       .toSorted((a, b) => a.localeCompare(b));
     // The generator adds '.project/' alongside the schema's legacy namespace
     // prefix — installed projects run either root (AQJ95G).

--- a/packages/cli/tests/packs/js-app-tooling-gate.test.ts
+++ b/packages/cli/tests/packs/js-app-tooling-gate.test.ts
@@ -78,7 +78,9 @@ describe('JS-app-only tooling is gated on real JS source (BE7C7B)', () => {
 
   it('does not emit knip.json without JS source, but does with it', () => {
     const generator = SAFEWORD_SCHEMA.managedFiles?.['knip.json']?.generator;
-    expect(generator?.(ctxWith(projectType({ hasJsSource: false })))).toBeUndefined();
-    expect(generator?.(ctxWith(projectType({ hasJsSource: true })))).toBeDefined();
+    const withoutJs = ctxWith(projectType({ hasJsSource: false }));
+    const withJs = ctxWith(projectType({ hasJsSource: true }));
+    expect(generator?.(withoutJs)).toBeUndefined();
+    expect(generator?.(withJs)).toBeDefined();
   });
 });

--- a/packages/cli/tests/packs/packs.test.ts
+++ b/packages/cli/tests/packs/packs.test.ts
@@ -143,7 +143,7 @@ describe('Pack Installation', () => {
     initGitRepo(fixture.testDirectory);
     writeSafewordConfig(fixture.testDirectory, { installedPacks: [] });
 
-    installPack('python', testDirectory);
+    installPack('python', fixture.testDirectory);
 
     // Config updated
     const config = readSafewordConfig(fixture.testDirectory);
@@ -160,7 +160,7 @@ describe('Pack Installation', () => {
     writeSafewordConfig(fixture.testDirectory, { installedPacks: ['python'] });
     const initialPyproject = readTestFile(fixture.testDirectory, 'pyproject.toml');
 
-    installPack('python', testDirectory);
+    installPack('python', fixture.testDirectory);
 
     // Config unchanged
     const config = readSafewordConfig(fixture.testDirectory);
@@ -174,7 +174,7 @@ describe('Pack Installation', () => {
     createPythonProject(fixture.testDirectory);
     initGitRepo(fixture.testDirectory);
 
-    installPack('python', testDirectory);
+    installPack('python', fixture.testDirectory);
 
     // Read raw JSON — the `version` key must not exist on disk
     const raw = JSON.parse(readTestFile(fixture.testDirectory, '.safeword/config.json')) as Record<

--- a/packages/cli/tests/packs/packs.test.ts
+++ b/packages/cli/tests/packs/packs.test.ts
@@ -23,15 +23,15 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-let testDirectory: string;
+const fixture: { testDirectory: string } = { testDirectory: '' };
 
 beforeEach(() => {
-  testDirectory = createTemporaryDirectory();
+  fixture.testDirectory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (testDirectory) {
-    removeTemporaryDirectory(testDirectory);
+  if (fixture.testDirectory) {
+    removeTemporaryDirectory(fixture.testDirectory);
   }
 });
 
@@ -69,12 +69,12 @@ describe('Pack Registry', () => {
 
   it('Test 1.2: Detects languages from project markers', () => {
     // Create project with both Python and TypeScript markers
-    createPythonProject(testDirectory);
-    createPackageJson(testDirectory, {
+    createPythonProject(fixture.testDirectory);
+    createPackageJson(fixture.testDirectory, {
       devDependencies: { typescript: '^5.0.0' },
     });
 
-    const detected = detectLanguages(testDirectory);
+    const detected = detectLanguages(fixture.testDirectory);
 
     // Should detect both (order doesn't matter)
     expect(detected).toContain('python');
@@ -83,17 +83,17 @@ describe('Pack Registry', () => {
   });
 
   it('Test 1.8: Detects Python from requirements.txt only', () => {
-    writeTestFile(testDirectory, 'requirements.txt', 'flask>=3.0\n');
+    writeTestFile(fixture.testDirectory, 'requirements.txt', 'flask>=3.0\n');
 
-    const detected = detectLanguages(testDirectory);
+    const detected = detectLanguages(fixture.testDirectory);
 
     expect(detected).toContain('python');
   });
 
   it('Test 1.6: Detects Rust from Cargo.toml', () => {
-    createRustProject(testDirectory);
+    createRustProject(fixture.testDirectory);
 
-    const detected = detectLanguages(testDirectory);
+    const detected = detectLanguages(fixture.testDirectory);
 
     expect(detected).toContain('rust');
     expect(detected).toHaveLength(1);
@@ -101,12 +101,12 @@ describe('Pack Registry', () => {
 
   it('Test 1.7: Detects multiple languages including Rust', () => {
     // Create project with TypeScript AND Rust
-    createPackageJson(testDirectory, {
+    createPackageJson(fixture.testDirectory, {
       devDependencies: { typescript: '^5.0.0' },
     });
-    createRustProject(testDirectory);
+    createRustProject(fixture.testDirectory);
 
-    const detected = detectLanguages(testDirectory);
+    const detected = detectLanguages(fixture.testDirectory);
 
     expect(detected).toContain('typescript');
     expect(detected).toContain('rust');
@@ -121,15 +121,15 @@ describe('Pack Registry', () => {
 describe('Config Tracking', () => {
   it('Test 1.3: Reads installed packs from config', () => {
     // Empty config → empty array
-    writeSafewordConfig(testDirectory, { installedPacks: [] });
-    expect(getInstalledPacks(testDirectory)).toEqual([]);
-    expect(isPackInstalled(testDirectory, 'python')).toBe(false);
+    writeSafewordConfig(fixture.testDirectory, { installedPacks: [] });
+    expect(getInstalledPacks(fixture.testDirectory)).toEqual([]);
+    expect(isPackInstalled(fixture.testDirectory, 'python')).toBe(false);
 
     // With installed pack
-    writeSafewordConfig(testDirectory, { installedPacks: ['python'] });
-    expect(getInstalledPacks(testDirectory)).toEqual(['python']);
-    expect(isPackInstalled(testDirectory, 'python')).toBe(true);
-    expect(isPackInstalled(testDirectory, 'go')).toBe(false);
+    writeSafewordConfig(fixture.testDirectory, { installedPacks: ['python'] });
+    expect(getInstalledPacks(fixture.testDirectory)).toEqual(['python']);
+    expect(isPackInstalled(fixture.testDirectory, 'python')).toBe(true);
+    expect(isPackInstalled(fixture.testDirectory, 'go')).toBe(false);
   });
 });
 
@@ -139,14 +139,14 @@ describe('Config Tracking', () => {
 
 describe('Pack Installation', () => {
   it('Test 1.4: Installs pack and updates config', () => {
-    createPythonProject(testDirectory);
-    initGitRepo(testDirectory);
-    writeSafewordConfig(testDirectory, { installedPacks: [] });
+    createPythonProject(fixture.testDirectory);
+    initGitRepo(fixture.testDirectory);
+    writeSafewordConfig(fixture.testDirectory, { installedPacks: [] });
 
     installPack('python', testDirectory);
 
     // Config updated
-    const config = readSafewordConfig(testDirectory);
+    const config = readSafewordConfig(fixture.testDirectory);
     expect(config.installedPacks).toContain('python');
 
     // Pack setup ran - setupPythonTooling now returns empty (reconciliation handles files)
@@ -155,29 +155,29 @@ describe('Pack Installation', () => {
   });
 
   it('Test 1.5: Skips already-installed packs', () => {
-    createPythonProject(testDirectory);
-    initGitRepo(testDirectory);
-    writeSafewordConfig(testDirectory, { installedPacks: ['python'] });
-    const initialPyproject = readTestFile(testDirectory, 'pyproject.toml');
+    createPythonProject(fixture.testDirectory);
+    initGitRepo(fixture.testDirectory);
+    writeSafewordConfig(fixture.testDirectory, { installedPacks: ['python'] });
+    const initialPyproject = readTestFile(fixture.testDirectory, 'pyproject.toml');
 
     installPack('python', testDirectory);
 
     // Config unchanged
-    const config = readSafewordConfig(testDirectory);
+    const config = readSafewordConfig(fixture.testDirectory);
     expect(config.installedPacks).toEqual(['python']);
 
     // Setup not called (pyproject unchanged)
-    expect(readTestFile(testDirectory, 'pyproject.toml')).toBe(initialPyproject);
+    expect(readTestFile(fixture.testDirectory, 'pyproject.toml')).toBe(initialPyproject);
   });
 
   it('Test 1.6: Fresh install writes config without `version` field (ticket 154)', () => {
-    createPythonProject(testDirectory);
-    initGitRepo(testDirectory);
+    createPythonProject(fixture.testDirectory);
+    initGitRepo(fixture.testDirectory);
 
     installPack('python', testDirectory);
 
     // Read raw JSON — the `version` key must not exist on disk
-    const raw = JSON.parse(readTestFile(testDirectory, '.safeword/config.json')) as Record<
+    const raw = JSON.parse(readTestFile(fixture.testDirectory, '.safeword/config.json')) as Record<
       string,
       unknown
     >;

--- a/packages/cli/tests/packs/sql-dialect.test.ts
+++ b/packages/cli/tests/packs/sql-dialect.test.ts
@@ -9,15 +9,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { detectSqlDialect } from '../../src/packs/sql/dialect.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, writeTestFile } from '../helpers';
 
-let projectDirectory: string;
+const state: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  state.projectDirectory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
+  if (state.projectDirectory) {
+    removeTemporaryDirectory(state.projectDirectory);
   }
 });
 
@@ -27,73 +27,85 @@ describe('detectSqlDialect', () => {
   // =========================================================================
 
   it('detects postgres from profiles.yml type field', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: my_project\nprofile: my_project\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
+      'dbt_project.yml',
+      'name: my_project\nprofile: my_project\n',
+    );
+    writeTestFile(
+      state.projectDirectory,
       'profiles.yml',
       'my_project:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n      host: localhost\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects snowflake from profiles.yml type field', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: analytics\nprofile: analytics\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
+      'dbt_project.yml',
+      'name: analytics\nprofile: analytics\n',
+    );
+    writeTestFile(
+      state.projectDirectory,
       'profiles.yml',
       'analytics:\n  target: prod\n  outputs:\n    prod:\n      type: snowflake\n      account: xy12345\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('snowflake');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('snowflake');
   });
 
   it('matches profile name from dbt_project.yml (ignores other profiles)', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: my_project\nprofile: my_project\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
+      'dbt_project.yml',
+      'name: my_project\nprofile: my_project\n',
+    );
+    writeTestFile(
+      state.projectDirectory,
       'profiles.yml',
       'other_project:\n  target: dev\n  outputs:\n    dev:\n      type: bigquery\nmy_project:\n  target: dev\n  outputs:\n    dev:\n      type: redshift\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('redshift');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('redshift');
   });
 
   it('falls back to first output when target is missing', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'profiles.yml',
       'test:\n  outputs:\n    dev:\n      type: bigquery\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('bigquery');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('bigquery');
   });
 
   it('checks dbt/ subdir for profiles.yml', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: mono\nprofile: mono\n');
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: mono\nprofile: mono\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'dbt/profiles.yml',
       'mono:\n  target: dev\n  outputs:\n    dev:\n      type: clickhouse\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('clickhouse');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('clickhouse');
   });
 
   it('returns undefined for unknown adapter type in profiles.yml', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'profiles.yml',
       'test:\n  target: dev\n  outputs:\n    dev:\n      type: firebolt\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 
   it('returns undefined when profile name does not match any profile', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: test\nprofile: my_project\n');
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: test\nprofile: my_project\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'profiles.yml',
       'other_project:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 
   // =========================================================================
@@ -101,37 +113,41 @@ describe('detectSqlDialect', () => {
   // =========================================================================
 
   it('detects postgres from requirements.txt dbt-postgres', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-core==1.8.0\ndbt-postgres==1.8.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    writeTestFile(
+      state.projectDirectory,
+      'requirements.txt',
+      'dbt-core==1.8.0\ndbt-postgres==1.8.0\n',
+    );
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects snowflake from pyproject.toml dbt-snowflake', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'pyproject.toml',
       '[project]\ndependencies = ["dbt-snowflake>=1.7"]\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('snowflake');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('snowflake');
   });
 
   it('detects bigquery from dbt-bigquery', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-bigquery==1.8.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('bigquery');
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-bigquery==1.8.0\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('bigquery');
   });
 
   it('maps spark adapter to sparksql dialect', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-spark==1.8.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('sparksql');
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-spark==1.8.0\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('sparksql');
   });
 
   it('maps fabric adapter to tsql dialect', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-fabric==1.8.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('tsql');
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-fabric==1.8.0\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('tsql');
   });
 
   it('returns undefined for unknown dbt adapter', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-firebolt==1.0.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-firebolt==1.0.0\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 
   // =========================================================================
@@ -140,20 +156,20 @@ describe('detectSqlDialect', () => {
 
   it('detects postgres from sqlc.yaml engine', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'sqlc.yaml',
       'version: 2\nsql:\n  - engine: postgresql\n    queries: query.sql\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects mysql from sqlc.json engine', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'sqlc.json',
       '{"version": "2", "sql": [{"engine": "mysql"}]}\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('mysql');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('mysql');
   });
 
   // =========================================================================
@@ -162,29 +178,29 @@ describe('detectSqlDialect', () => {
 
   it('detects postgres from prisma schema provider', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'prisma/schema.prisma',
       'datasource db {\n  provider = "postgresql"\n  url = env("DATABASE_URL")\n}\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects mysql from prisma schema provider', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'prisma/schema.prisma',
       'datasource db {\n  provider = "mysql"\n  url = env("DATABASE_URL")\n}\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('mysql');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('mysql');
   });
 
   it('detects tsql from prisma sqlserver provider', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'prisma/schema.prisma',
       'datasource db {\n  provider = "sqlserver"\n  url = env("DATABASE_URL")\n}\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('tsql');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('tsql');
   });
 
   // =========================================================================
@@ -193,65 +209,65 @@ describe('detectSqlDialect', () => {
 
   it('detects postgres from drizzle.config.ts dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.ts',
       'import { defineConfig } from "drizzle-kit";\nexport default defineConfig({ dialect: "postgresql", schema: "./src/schema.ts" });\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects sqlite from drizzle.config.ts turso dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.ts',
       "export default defineConfig({ dialect: 'turso', schema: './src/schema.ts' });\n",
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('sqlite');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('sqlite');
   });
 
   it('detects tsql from drizzle.config.mjs mssql dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.mjs',
       'export default defineConfig({ dialect: "mssql" });\n',
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('tsql');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('tsql');
   });
 
   it('detects mysql from drizzle.config.js singlestore dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.js',
       "module.exports = { dialect: 'singlestore' };\n",
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('mysql');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('mysql');
   });
 
   it('detects postgres from drizzle.config.ts gel dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.ts',
       "export default defineConfig({ dialect: 'gel' });\n",
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects postgres from drizzle.config.ts cockroach dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.ts',
       "export default defineConfig({ dialect: 'cockroach' });\n",
     );
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('returns undefined for unknown Drizzle dialect', () => {
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'drizzle.config.ts',
       "export default defineConfig({ dialect: 'unknown_db' });\n",
     );
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 
   // =========================================================================
@@ -259,23 +275,23 @@ describe('detectSqlDialect', () => {
   // =========================================================================
 
   it('detects postgres from DATABASE_URL scheme', () => {
-    writeTestFile(projectDirectory, '.env', 'DATABASE_URL=postgresql://localhost/mydb\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('postgres');
+    writeTestFile(state.projectDirectory, '.env', 'DATABASE_URL=postgresql://localhost/mydb\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('postgres');
   });
 
   it('detects mysql from DATABASE_URL scheme', () => {
-    writeTestFile(projectDirectory, '.env', 'DATABASE_URL="mysql://localhost/mydb"\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('mysql');
+    writeTestFile(state.projectDirectory, '.env', 'DATABASE_URL="mysql://localhost/mydb"\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('mysql');
   });
 
   it('detects clickhouse from DATABASE_URL scheme', () => {
-    writeTestFile(projectDirectory, '.env', "DATABASE_URL='clickhouse://localhost/mydb'\n");
-    expect(detectSqlDialect(projectDirectory)).toBe('clickhouse');
+    writeTestFile(state.projectDirectory, '.env', "DATABASE_URL='clickhouse://localhost/mydb'\n");
+    expect(detectSqlDialect(state.projectDirectory)).toBe('clickhouse');
   });
 
   it('detects sqlite from DATABASE_URL without slashes', () => {
-    writeTestFile(projectDirectory, '.env', 'DATABASE_URL=sqlite:db/app.sqlite3\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('sqlite');
+    writeTestFile(state.projectDirectory, '.env', 'DATABASE_URL=sqlite:db/app.sqlite3\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('sqlite');
   });
 
   // =========================================================================
@@ -283,20 +299,20 @@ describe('detectSqlDialect', () => {
   // =========================================================================
 
   it('profiles.yml takes priority over Python deps', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
     writeTestFile(
-      projectDirectory,
+      state.projectDirectory,
       'profiles.yml',
       'test:\n  target: dev\n  outputs:\n    dev:\n      type: snowflake\n',
     );
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-postgres==1.8.0\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('snowflake');
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-postgres==1.8.0\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('snowflake');
   });
 
   it('Python deps take priority over DATABASE_URL', () => {
-    writeTestFile(projectDirectory, 'requirements.txt', 'dbt-snowflake==1.8.0\n');
-    writeTestFile(projectDirectory, '.env', 'DATABASE_URL=postgresql://localhost/mydb\n');
-    expect(detectSqlDialect(projectDirectory)).toBe('snowflake');
+    writeTestFile(state.projectDirectory, 'requirements.txt', 'dbt-snowflake==1.8.0\n');
+    writeTestFile(state.projectDirectory, '.env', 'DATABASE_URL=postgresql://localhost/mydb\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBe('snowflake');
   });
 
   // =========================================================================
@@ -304,11 +320,11 @@ describe('detectSqlDialect', () => {
   // =========================================================================
 
   it('returns undefined when no signals found', () => {
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 
   it('returns undefined for project with only dbt_project.yml (no deps)', () => {
-    writeTestFile(projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
-    expect(detectSqlDialect(projectDirectory)).toBeUndefined();
+    writeTestFile(state.projectDirectory, 'dbt_project.yml', 'name: test\nprofile: test\n');
+    expect(detectSqlDialect(state.projectDirectory)).toBeUndefined();
   });
 });

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1662,7 +1662,7 @@ describe('Reconcile - Reconciliation Engine', () => {
 
       const projectType = { ...DEFAULT_PROJECT_TYPE };
 
-      const installedDevelopmentDeps = {
+      const installedDevelopmentDependencies = {
         eslint: '^8.0.0',
         prettier: '^3.0.0',
         knip: '^5.0.0',
@@ -1671,7 +1671,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       const result = computePackagesToInstall(
         SAFEWORD_SCHEMA,
         projectType,
-        installedDevelopmentDeps,
+        installedDevelopmentDependencies,
       );
 
       expect(result).not.toContain(ESLINT_PACKAGE);

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -358,7 +358,7 @@ describe('Schema - Single Source of Truth', () => {
       // Extract skill names from Claude schema paths (short names: debug, quality-review, refactor)
       const claudeSkills = Object.keys(SAFEWORD_SCHEMA.ownedFiles)
         .filter(path => path.startsWith('.claude/skills/') && path.endsWith('/SKILL.md'))
-        .map(path => path.split('/')[2])
+        .map(path => path.split('/', 3)[2])
         .filter(isDefined)
         // Exclude BDD (split into multiple Cursor rules) and action skills (Cursor commands, not rules)
         .filter(name => name !== 'bdd' && !ACTION_SKILLS.has(name))
@@ -422,8 +422,8 @@ describe('Schema - Single Source of Truth', () => {
       // Cursor commands must be a superset of Claude commands
       // (Cursor needs explicit commands for all capabilities since it has no skills)
       // Claude commands are standalone-only — skills auto-create /slash-commands
-      for (const cmd of claudeCommands) {
-        expect(cursorCommands, `Cursor missing Claude command: ${cmd}`).toContain(cmd);
+      for (const command of claudeCommands) {
+        expect(cursorCommands, `Cursor missing Claude command: ${command}`).toContain(command);
       }
     });
   });

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -538,7 +538,8 @@ describe('Schema - Single Source of Truth', () => {
       function collectFiles(directory: string, prefix: string): string[] {
         const results: string[] = [];
         if (!existsSync(directory)) return results;
-        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const entries = readdirSync(directory, { withFileTypes: true });
+        for (const entry of entries) {
           if (entry.name.startsWith('.')) continue;
           const relativePath = `${prefix}/${entry.name}`;
           if (entry.isDirectory()) {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -26,8 +26,8 @@ describe('cleanup-zombies.sh', () => {
   });
 
   function runScript(args: string[] = []): string {
-    const cmd = `bash "${SCRIPT_PATH}" --dry-run ${args.join(' ')}`;
-    return execSync(cmd, { cwd: temporaryDirectory, encoding: 'utf8' });
+    const command = `bash "${SCRIPT_PATH}" --dry-run ${args.join(' ')}`;
+    return execSync(command, { cwd: temporaryDirectory, encoding: 'utf8' });
   }
 
   function createFile(relativePath: string, content = ''): void {

--- a/packages/cli/tests/smoke/hook-coverage.test.ts
+++ b/packages/cli/tests/smoke/hook-coverage.test.ts
@@ -101,9 +101,9 @@ describe('smoke hook coverage (drift guard)', () => {
     const uncovered: string[] = [];
 
     for (const hook of hooks) {
-      const exempt = Object.prototype.hasOwnProperty.call(EXEMPT_HOOKS, hook);
-      const covered = smokeText.includes(hook);
-      if (!exempt && !covered) uncovered.push(hook);
+      const isExempt = Object.prototype.hasOwnProperty.call(EXEMPT_HOOKS, hook);
+      const isCovered = smokeText.includes(hook);
+      if (!isExempt && !isCovered) uncovered.push(hook);
     }
 
     const list = uncovered.map(h => `  - ${h}`).join('\n');

--- a/packages/cli/tests/smoke/steering.live.test.ts
+++ b/packages/cli/tests/smoke/steering.live.test.ts
@@ -48,7 +48,8 @@ const HOOK_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-qu
  * require >= 2.x (older claude lacks the flags this test uses). Undefined => skip.
  */
 function resolveClaude(): string | undefined {
-  for (const bin of [process.env.SMOKE_CLAUDE_BIN, 'claude'].filter(Boolean) as string[]) {
+  const candidateBins = [process.env.SMOKE_CLAUDE_BIN, 'claude'].filter(Boolean) as string[];
+  for (const bin of candidateBins) {
     const probe = spawnSync(bin, ['--version'], { encoding: 'utf8' });
     const major = /(\d+)\.\d+\.\d+/.exec(probe.stdout ?? '');
     if (probe.status === 0 && major && Number(major[1]) >= MIN_MAJOR) return bin;

--- a/packages/cli/tests/smoke/steering.live.test.ts
+++ b/packages/cli/tests/smoke/steering.live.test.ts
@@ -129,10 +129,10 @@ describe.skipIf(!CAN_RUN)('live smoke: safeword steers a real Claude agent', () 
     const output = JSON.parse(result.stdout) as {
       permission_denials?: { tool_name?: string }[];
     };
-    const deniedWrite = (output.permission_denials ?? []).some(d => d.tool_name === 'Write');
+    const isDeniedWrite = (output.permission_denials ?? []).some(d => d.tool_name === 'Write');
 
     expect(
-      deniedWrite,
+      isDeniedWrite,
       `Expected safeword's hook to deny the agent's Write. permission_denials=${JSON.stringify(
         output.permission_denials,
       )}`,

--- a/packages/cli/tests/test-plan/cli-sh.test.ts
+++ b/packages/cli/tests/test-plan/cli-sh.test.ts
@@ -10,7 +10,9 @@ import { runCli } from '../helpers.js';
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
-  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+  const directories = [...temporaryDirectories];
+  temporaryDirectories.length = 0;
+  for (const dir of directories) rmSync(dir, { force: true, recursive: true });
 });
 
 function makeRepo(files: Record<string, string>): string {

--- a/packages/cli/tests/test-plan/cli.test.ts
+++ b/packages/cli/tests/test-plan/cli.test.ts
@@ -9,7 +9,8 @@ import { runCli } from '../helpers.js';
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
-  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+  for (const dir of temporaryDirectories) rmSync(dir, { force: true, recursive: true });
+  temporaryDirectories.length = 0;
 });
 
 function makeGoRepo(): string {

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -9,7 +9,8 @@ import { type Language, type PlanEntry, resolveTestPlan } from '../../src/test-p
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
-  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+  for (const dir of temporaryDirectories) rmSync(dir, { force: true, recursive: true });
+  temporaryDirectories.length = 0;
 });
 
 /** Build a temp repo from a map of relative path → file contents. */
@@ -44,7 +45,10 @@ describe('resolveTestPlan — every detected language appears (no first-match)',
       'pyproject.toml': '[project]\nname = "x"\n',
     });
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
-    expect(languages(plan).toSorted()).toEqual(['javascript', 'python']);
+    expect(languages(plan).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'javascript',
+      'python',
+    ]);
     expect(plan).toHaveLength(2);
   });
 

--- a/packages/cli/tests/utils/architecture-records.test.ts
+++ b/packages/cli/tests/utils/architecture-records.test.ts
@@ -12,19 +12,19 @@ import { listArchitectureRecords } from '../../src/utils/architecture-records.js
 import { resolveConfiguredPath } from '../../src/utils/configured-paths.js';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
 
-let directory: string;
+const context: { directory: string } = { directory: '' };
 
 beforeEach(() => {
-  directory = createTemporaryDirectory();
+  context.directory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  removeTemporaryDirectory(directory);
+  removeTemporaryDirectory(context.directory);
 });
 
 describe('listArchitectureRecords (Rule 1)', () => {
   it('reports a single markdown file as the record', () => {
-    const filePath = nodePath.join(directory, 'architecture.md');
+    const filePath = nodePath.join(context.directory, 'architecture.md');
     writeFileSync(filePath, '# Architecture\n');
 
     const result = listArchitectureRecords(filePath);
@@ -34,25 +34,30 @@ describe('listArchitectureRecords (Rule 1)', () => {
   });
 
   it('lists top-level .md files in a directory — accept-any naming, no recursion, non-markdown excluded', () => {
-    writeFileSync(nodePath.join(directory, '0001-storage.md'), '# ADR-001\n');
-    writeFileSync(nodePath.join(directory, 'ADR-queue.md'), '# Queue\n');
-    writeFileSync(nodePath.join(directory, 'naming-freeform.md'), '# Freeform\n');
-    writeFileSync(nodePath.join(directory, 'notes.txt'), 'not an ADR\n');
-    mkdirSync(nodePath.join(directory, 'nested'));
-    writeFileSync(nodePath.join(directory, 'nested', '0002-deep.md'), '# Deep\n');
+    writeFileSync(nodePath.join(context.directory, '0001-storage.md'), '# ADR-001\n');
+    writeFileSync(nodePath.join(context.directory, 'ADR-queue.md'), '# Queue\n');
+    writeFileSync(nodePath.join(context.directory, 'naming-freeform.md'), '# Freeform\n');
+    writeFileSync(nodePath.join(context.directory, 'notes.txt'), 'not an ADR\n');
+    mkdirSync(nodePath.join(context.directory, 'nested'));
+    writeFileSync(nodePath.join(context.directory, 'nested', '0002-deep.md'), '# Deep\n');
 
-    const result = listArchitectureRecords(directory);
+    const result = listArchitectureRecords(context.directory);
 
     expect(result.kind).toBe('directory');
-    expect(result.records.toSorted()).toEqual(
+    const byCodeUnit = (a: string, b: string): number => {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    };
+    expect(result.records.toSorted(byCodeUnit)).toEqual(
       ['0001-storage.md', 'ADR-queue.md', 'naming-freeform.md']
-        .map(name => nodePath.join(directory, name))
-        .toSorted(),
+        .map(name => nodePath.join(context.directory, name))
+        .toSorted(byCodeUnit),
     );
   });
 
   it('reports a path routed through a file as absent instead of throwing (ENOTDIR, nodejs#56993)', () => {
-    const filePath = nodePath.join(directory, 'architecture.md');
+    const filePath = nodePath.join(context.directory, 'architecture.md');
     writeFileSync(filePath, '# Architecture\n');
 
     const result = listArchitectureRecords(nodePath.join(filePath, 'nested'));
@@ -62,45 +67,48 @@ describe('listArchitectureRecords (Rule 1)', () => {
   });
 
   it('reports an absent location with zero records', () => {
-    const result = listArchitectureRecords(nodePath.join(directory, 'does-not-exist'));
+    const result = listArchitectureRecords(nodePath.join(context.directory, 'does-not-exist'));
 
     expect(result.kind).toBe('absent');
     expect(result.records).toEqual([]);
   });
 
   it('reports a README-only directory with zero records', () => {
-    writeFileSync(nodePath.join(directory, 'README.md'), '# ADR conventions\n');
+    writeFileSync(nodePath.join(context.directory, 'README.md'), '# ADR conventions\n');
 
-    const result = listArchitectureRecords(directory);
+    const result = listArchitectureRecords(context.directory);
 
     expect(result.kind).toBe('directory');
     expect(result.records).toEqual([]);
   });
 
   it('consumes a configured paths.architecture override directory (seam with resolveConfiguredPath)', () => {
-    mkdirSync(nodePath.join(directory, '.safeword'), { recursive: true });
+    mkdirSync(nodePath.join(context.directory, '.safeword'), { recursive: true });
     writeFileSync(
-      nodePath.join(directory, '.safeword', 'config.json'),
+      nodePath.join(context.directory, '.safeword', 'config.json'),
       JSON.stringify({ version: 1, paths: { architecture: 'docs/docs/arch' } }),
     );
-    mkdirSync(nodePath.join(directory, 'docs', 'docs', 'arch'), { recursive: true });
-    writeFileSync(nodePath.join(directory, 'docs', 'docs', 'arch', '0001-foo.md'), '# ADR\n');
+    mkdirSync(nodePath.join(context.directory, 'docs', 'docs', 'arch'), { recursive: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'docs', 'docs', 'arch', '0001-foo.md'),
+      '# ADR\n',
+    );
 
-    const resolved = resolveConfiguredPath(directory, 'architecture');
+    const resolved = resolveConfiguredPath(context.directory, 'architecture');
     const result = listArchitectureRecords(resolved);
 
     expect(result.kind).toBe('directory');
     expect(result.records).toEqual([
-      nodePath.join(directory, 'docs', 'docs', 'arch', '0001-foo.md'),
+      nodePath.join(context.directory, 'docs', 'docs', 'arch', '0001-foo.md'),
     ]);
   });
 
   it('excludes README.md from directory records', () => {
-    writeFileSync(nodePath.join(directory, 'README.md'), '# ADR conventions\n');
-    writeFileSync(nodePath.join(directory, '0001-storage.md'), '# ADR-001\n');
+    writeFileSync(nodePath.join(context.directory, 'README.md'), '# ADR conventions\n');
+    writeFileSync(nodePath.join(context.directory, '0001-storage.md'), '# ADR-001\n');
 
-    const result = listArchitectureRecords(directory);
+    const result = listArchitectureRecords(context.directory);
 
-    expect(result.records).toEqual([nodePath.join(directory, '0001-storage.md')]);
+    expect(result.records).toEqual([nodePath.join(context.directory, '0001-storage.md')]);
   });
 });

--- a/packages/cli/tests/utils/depcruise-config.test.ts
+++ b/packages/cli/tests/utils/depcruise-config.test.ts
@@ -13,13 +13,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   detectWorkspaces,
-  generateDepCruiseConfigFile as generateDependencyCruiseConfigFile,
-  generateDepCruiseMainConfig as generateDependencyCruiseMainConfig,
+  generateDependencyCruiseConfigFile,
+  generateDependencyCruiseMainConfig,
 } from '../../src/utils/depcruise-config.js';
 import { removeTemporaryDirectory } from '../helpers.js';
 
 describe('DepCruise Config Generator', () => {
-  describe('generateDepCruiseConfigFile', () => {
+  describe('generateDependencyCruiseConfigFile', () => {
     it('generates circular dependency rule', () => {
       // Test 1.1: Config always includes no-circular rule regardless of architecture
       const config = generateDependencyCruiseConfigFile({
@@ -152,7 +152,7 @@ describe('DepCruise Config Generator', () => {
     });
   });
 
-  describe('generateDepCruiseMainConfig', () => {
+  describe('generateDependencyCruiseMainConfig', () => {
     it('generates main config that imports generated', () => {
       // Test 1.4: Main config imports and spreads generated rules
       const config = generateDependencyCruiseMainConfig();

--- a/packages/cli/tests/utils/depcruise-config.test.ts
+++ b/packages/cli/tests/utils/depcruise-config.test.ts
@@ -13,8 +13,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   detectWorkspaces,
-  generateDepCruiseConfigFile,
-  generateDepCruiseMainConfig,
+  generateDepCruiseConfigFile as generateDependencyCruiseConfigFile,
+  generateDepCruiseMainConfig as generateDependencyCruiseMainConfig,
 } from '../../src/utils/depcruise-config.js';
 import { removeTemporaryDirectory } from '../helpers.js';
 
@@ -22,7 +22,7 @@ describe('DepCruise Config Generator', () => {
   describe('generateDepCruiseConfigFile', () => {
     it('generates circular dependency rule', () => {
       // Test 1.1: Config always includes no-circular rule regardless of architecture
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -44,7 +44,7 @@ describe('DepCruise Config Generator', () => {
 
     it('generates monorepo layer rules from workspaces', () => {
       // Test 1.2: Detects workspaces and generates hierarchy rules
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: true,
         workspaces: ['packages/*', 'apps/*', 'libs/*'],
@@ -62,7 +62,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('generates orphan detection rule with comprehensive exclusions', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -81,7 +81,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('generates no-deprecated-deps rule', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -92,7 +92,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('generates no-dev-deps-in-src rule as warning', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -106,7 +106,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('includes doNotFollow for node_modules and .safeword', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -117,7 +117,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('includes exclude patterns for build artifacts', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -131,7 +131,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('enables TypeScript pre-compilation deps analysis', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -140,7 +140,7 @@ describe('DepCruise Config Generator', () => {
     });
 
     it('configures modern module resolution options', () => {
-      const config = generateDepCruiseConfigFile({
+      const config = generateDependencyCruiseConfigFile({
         elements: [],
         isMonorepo: false,
       });
@@ -155,7 +155,7 @@ describe('DepCruise Config Generator', () => {
   describe('generateDepCruiseMainConfig', () => {
     it('generates main config that imports generated', () => {
       // Test 1.4: Main config imports and spreads generated rules
-      const config = generateDepCruiseMainConfig();
+      const config = generateDependencyCruiseMainConfig();
 
       // Imports from .safeword
       expect(config).toContain('./.safeword/depcruise-config.cjs');

--- a/packages/cli/tests/utils/feature-source.test.ts
+++ b/packages/cli/tests/utils/feature-source.test.ts
@@ -21,9 +21,10 @@ function writeProjectFile(project: string, relativePath: string, content = ''): 
 }
 
 afterEach(() => {
-  for (const directory of temporaryDirectories.splice(0)) {
+  for (const directory of temporaryDirectories) {
     rmSync(directory, { force: true, recursive: true });
   }
+  temporaryDirectories.length = 0;
 });
 
 describe('findFeatureSourcePath', () => {

--- a/packages/cli/tests/utils/fs.test.ts
+++ b/packages/cli/tests/utils/fs.test.ts
@@ -15,34 +15,34 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readJson } from '../../src/utils/fs.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, writeTestFile } from '../helpers';
 
-let dir: string;
+const shared: { dir: string } = { dir: '' };
 
 beforeEach(() => {
-  dir = createTemporaryDirectory();
+  shared.dir = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (dir) removeTemporaryDirectory(dir);
+  if (shared.dir) removeTemporaryDirectory(shared.dir);
 });
 
 describe('readJson', () => {
   it('parses a valid JSON file', () => {
-    writeTestFile(dir, 'config.json', JSON.stringify({ a: 1 }));
-    expect(readJson(nodePath.join(dir, 'config.json'))).toEqual({ a: 1 });
+    writeTestFile(shared.dir, 'config.json', JSON.stringify({ a: 1 }));
+    expect(readJson(nodePath.join(shared.dir, 'config.json'))).toEqual({ a: 1 });
   });
 
   it('returns undefined for a missing file', () => {
-    expect(readJson(nodePath.join(dir, 'nope.json'))).toBeUndefined();
+    expect(readJson(nodePath.join(shared.dir, 'nope.json'))).toBeUndefined();
   });
 
   it('returns undefined (no throw) for a file with JSONC comments', () => {
-    writeTestFile(dir, 'config.jsonc', '{\n  // a comment\n  "a": 1\n}\n');
-    expect(readJson(nodePath.join(dir, 'config.jsonc'))).toBeUndefined();
+    writeTestFile(shared.dir, 'config.jsonc', '{\n  // a comment\n  "a": 1\n}\n');
+    expect(readJson(nodePath.join(shared.dir, 'config.jsonc'))).toBeUndefined();
   });
 
   it('returns undefined (no throw) when a directory sits at the path (EISDIR)', () => {
-    mkdirSync(nodePath.join(dir, 'config.json'));
-    expect(() => readJson(nodePath.join(dir, 'config.json'))).not.toThrow();
-    expect(readJson(nodePath.join(dir, 'config.json'))).toBeUndefined();
+    mkdirSync(nodePath.join(shared.dir, 'config.json'));
+    expect(() => readJson(nodePath.join(shared.dir, 'config.json'))).not.toThrow();
+    expect(readJson(nodePath.join(shared.dir, 'config.json'))).toBeUndefined();
   });
 });

--- a/packages/cli/tests/utils/has-js-source.test.ts
+++ b/packages/cli/tests/utils/has-js-source.test.ts
@@ -9,7 +9,9 @@ import { hasJsSource } from '../../src/utils/project-detector';
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
-  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+  const directories = [...temporaryDirectories];
+  temporaryDirectories.length = 0;
+  for (const dir of directories) rmSync(dir, { force: true, recursive: true });
 });
 
 function makeRepo(files: Record<string, string>): string {

--- a/packages/cli/tests/utils/index-files-in-tree.test.ts
+++ b/packages/cli/tests/utils/index-files-in-tree.test.ts
@@ -9,7 +9,8 @@ import { indexFilesInTree } from '../../src/utils/fs';
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
-  for (const dir of temporaryDirectories.splice(0)) rmSync(dir, { force: true, recursive: true });
+  for (const dir of temporaryDirectories) rmSync(dir, { force: true, recursive: true });
+  temporaryDirectories.length = 0;
 });
 
 function makeRepo(files: Record<string, string>): string {

--- a/packages/cli/tests/utils/python-setup.test.ts
+++ b/packages/cli/tests/utils/python-setup.test.ts
@@ -21,15 +21,15 @@ import {
   writeTestFile,
 } from '../helpers';
 
-let projectDirectory: string;
+const context: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  context.projectDirectory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
+  if (context.projectDirectory) {
+    removeTemporaryDirectory(context.projectDirectory);
   }
 });
 
@@ -39,21 +39,21 @@ afterEach(() => {
 
 describe('detectPythonPackageManager', () => {
   it('detects uv from uv.lock', () => {
-    createPythonProject(projectDirectory, { manager: 'uv' });
+    createPythonProject(context.projectDirectory, { manager: 'uv' });
 
-    expect(detectPythonPackageManager(projectDirectory)).toBe('uv');
+    expect(detectPythonPackageManager(context.projectDirectory)).toBe('uv');
   });
 
   it('detects poetry from poetry.lock', () => {
-    createPythonProject(projectDirectory, { manager: 'poetry' });
+    createPythonProject(context.projectDirectory, { manager: 'poetry' });
 
-    expect(detectPythonPackageManager(projectDirectory)).toBe('poetry');
+    expect(detectPythonPackageManager(context.projectDirectory)).toBe('poetry');
   });
 
   it('detects poetry from [tool.poetry] section', () => {
     // Create project without lockfile but with [tool.poetry]
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -63,19 +63,19 @@ name = "test"
 `,
     );
 
-    expect(detectPythonPackageManager(projectDirectory)).toBe('poetry');
+    expect(detectPythonPackageManager(context.projectDirectory)).toBe('poetry');
   });
 
   it('detects pipenv from Pipfile', () => {
-    createPythonProject(projectDirectory, { manager: 'pipenv' });
+    createPythonProject(context.projectDirectory, { manager: 'pipenv' });
 
-    expect(detectPythonPackageManager(projectDirectory)).toBe('pipenv');
+    expect(detectPythonPackageManager(context.projectDirectory)).toBe('pipenv');
   });
 
   it('defaults to pip when no manager detected', () => {
-    createPythonProject(projectDirectory, { manager: 'pip' });
+    createPythonProject(context.projectDirectory, { manager: 'pip' });
 
-    expect(detectPythonPackageManager(projectDirectory)).toBe('pip');
+    expect(detectPythonPackageManager(context.projectDirectory)).toBe('pip');
   });
 });
 
@@ -85,12 +85,12 @@ name = "test"
 
 describe('hasRuffDependency', () => {
   it('returns false when pyproject.toml missing', () => {
-    expect(hasRuffDependency(projectDirectory)).toBe(false);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(false);
   });
 
   it('returns false when ruff not in dependencies', () => {
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -98,12 +98,12 @@ dependencies = ["flask"]
 `,
     );
 
-    expect(hasRuffDependency(projectDirectory)).toBe(false);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(false);
   });
 
   it('detects ruff in PEP 621 dependencies array', () => {
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -111,12 +111,12 @@ dependencies = ["ruff>=0.8.0"]
 `,
     );
 
-    expect(hasRuffDependency(projectDirectory)).toBe(true);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(true);
   });
 
   it('detects ruff in optional-dependencies', () => {
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -126,12 +126,12 @@ dev = ["ruff", "mypy"]
 `,
     );
 
-    expect(hasRuffDependency(projectDirectory)).toBe(true);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(true);
   });
 
   it('detects ruff in Poetry dev dependencies', () => {
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -141,12 +141,12 @@ ruff = "^0.8.0"
 `,
     );
 
-    expect(hasRuffDependency(projectDirectory)).toBe(true);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(true);
   });
 
   it('does NOT match [tool.ruff] config section', () => {
     writeTestFile(
-      projectDirectory,
+      context.projectDirectory,
       'pyproject.toml',
       `[project]
 name = "test"
@@ -156,7 +156,7 @@ line-length = 88
 `,
     );
 
-    expect(hasRuffDependency(projectDirectory)).toBe(false);
+    expect(hasRuffDependency(context.projectDirectory)).toBe(false);
   });
 });
 
@@ -166,15 +166,15 @@ line-length = 88
 
 describe('installPythonDependencies', () => {
   it('returns true for empty tools array', () => {
-    createPythonProject(projectDirectory);
+    createPythonProject(context.projectDirectory);
 
-    expect(installPythonDependencies(projectDirectory, [])).toBe(true);
+    expect(installPythonDependencies(context.projectDirectory, [])).toBe(true);
   });
 
   it('returns false for pip projects (PEP 668 safety)', () => {
-    createPythonProject(projectDirectory, { manager: 'pip' });
+    createPythonProject(context.projectDirectory, { manager: 'pip' });
 
-    expect(installPythonDependencies(projectDirectory, ['ruff'])).toBe(false);
+    expect(installPythonDependencies(context.projectDirectory, ['ruff'])).toBe(false);
   });
 
   // Conditional tests - only run if package manager is available
@@ -182,15 +182,15 @@ describe('installPythonDependencies', () => {
   const IS_POETRY_AVAILABLE = isPoetryInstalled();
 
   it.skipIf(!IS_UV_AVAILABLE)('installs tools with uv', () => {
-    createPythonProject(projectDirectory, { manager: 'uv' });
+    createPythonProject(context.projectDirectory, { manager: 'uv' });
 
     // This actually runs uv add --dev ruff
-    const isResult = installPythonDependencies(projectDirectory, ['ruff']);
+    const isResult = installPythonDependencies(context.projectDirectory, ['ruff']);
 
     expect(isResult).toBe(true);
 
     // Verify ruff is now in pyproject.toml
-    const pyproject = readTestFile(projectDirectory, 'pyproject.toml');
+    const pyproject = readTestFile(context.projectDirectory, 'pyproject.toml');
     expect(pyproject).toContain('ruff');
   });
 
@@ -201,15 +201,15 @@ describe('installPythonDependencies', () => {
   // - Production code has 60s timeout to prevent hanging (see setup.ts)
   // Re-enable with: POETRY_AVAILABLE && process.env.TEST_POETRY === "1"
   it.skipIf(!IS_POETRY_AVAILABLE || !process.env.TEST_POETRY)('installs tools with poetry', () => {
-    createPythonProject(projectDirectory, { manager: 'poetry' });
+    createPythonProject(context.projectDirectory, { manager: 'poetry' });
 
     // This actually runs poetry add --group dev ruff
-    const isResult = installPythonDependencies(projectDirectory, ['ruff']);
+    const isResult = installPythonDependencies(context.projectDirectory, ['ruff']);
 
     expect(isResult).toBe(true);
 
     // Verify ruff is now in pyproject.toml
-    const pyproject = readTestFile(projectDirectory, 'pyproject.toml');
+    const pyproject = readTestFile(context.projectDirectory, 'pyproject.toml');
     expect(pyproject).toContain('ruff');
   });
 });

--- a/packages/cli/tests/utils/python-setup.test.ts
+++ b/packages/cli/tests/utils/python-setup.test.ts
@@ -178,16 +178,16 @@ describe('installPythonDependencies', () => {
   });
 
   // Conditional tests - only run if package manager is available
-  const UV_AVAILABLE = isUvInstalled();
-  const POETRY_AVAILABLE = isPoetryInstalled();
+  const IS_UV_AVAILABLE = isUvInstalled();
+  const IS_POETRY_AVAILABLE = isPoetryInstalled();
 
-  it.skipIf(!UV_AVAILABLE)('installs tools with uv', () => {
+  it.skipIf(!IS_UV_AVAILABLE)('installs tools with uv', () => {
     createPythonProject(projectDirectory, { manager: 'uv' });
 
     // This actually runs uv add --dev ruff
-    const result = installPythonDependencies(projectDirectory, ['ruff']);
+    const isResult = installPythonDependencies(projectDirectory, ['ruff']);
 
-    expect(result).toBe(true);
+    expect(isResult).toBe(true);
 
     // Verify ruff is now in pyproject.toml
     const pyproject = readTestFile(projectDirectory, 'pyproject.toml');
@@ -200,13 +200,13 @@ describe('installPythonDependencies', () => {
   // - The uv test above exercises the same installPythonDependencies code path
   // - Production code has 60s timeout to prevent hanging (see setup.ts)
   // Re-enable with: POETRY_AVAILABLE && process.env.TEST_POETRY === "1"
-  it.skipIf(!POETRY_AVAILABLE || !process.env.TEST_POETRY)('installs tools with poetry', () => {
+  it.skipIf(!IS_POETRY_AVAILABLE || !process.env.TEST_POETRY)('installs tools with poetry', () => {
     createPythonProject(projectDirectory, { manager: 'poetry' });
 
     // This actually runs poetry add --group dev ruff
-    const result = installPythonDependencies(projectDirectory, ['ruff']);
+    const isResult = installPythonDependencies(projectDirectory, ['ruff']);
 
-    expect(result).toBe(true);
+    expect(isResult).toBe(true);
 
     // Verify ruff is now in pyproject.toml
     const pyproject = readTestFile(projectDirectory, 'pyproject.toml');

--- a/packages/cli/tests/utils/shallow-detection.test.ts
+++ b/packages/cli/tests/utils/shallow-detection.test.ts
@@ -12,15 +12,15 @@ import { existsInTree, findInTree } from '../../src/utils/fs.js';
 import { detectLanguages } from '../../src/utils/project-detector.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, writeTestFile } from '../helpers';
 
-let projectDirectory: string;
+const shared: { projectDirectory: string } = { projectDirectory: '' };
 
 beforeEach(() => {
-  projectDirectory = createTemporaryDirectory();
+  shared.projectDirectory = createTemporaryDirectory();
 });
 
 afterEach(() => {
-  if (projectDirectory) {
-    removeTemporaryDirectory(projectDirectory);
+  if (shared.projectDirectory) {
+    removeTemporaryDirectory(shared.projectDirectory);
   }
 });
 
@@ -30,65 +30,65 @@ afterEach(() => {
 
 describe('existsInTree', () => {
   it('finds file at project root', () => {
-    writeTestFile(projectDirectory, 'pyproject.toml', '[project]\nname = "test"\n');
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(true);
+    writeTestFile(shared.projectDirectory, 'pyproject.toml', '[project]\nname = "test"\n');
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(true);
   });
 
   it('finds file in immediate subdirectory', () => {
-    writeTestFile(projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(true);
+    writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(true);
   });
 
   it('finds file at depth 2 (monorepo pattern)', () => {
-    writeTestFile(projectDirectory, 'apps/engine/go.mod', 'module example.com/apps/engine\n');
-    expect(existsInTree(projectDirectory, 'go.mod')).toBe(true);
+    writeTestFile(shared.projectDirectory, 'apps/engine/go.mod', 'module example.com/apps/engine\n');
+    expect(existsInTree(shared.projectDirectory, 'go.mod')).toBe(true);
   });
 
   it('finds file at depth 3', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'platform/services/auth/pyproject.toml',
       '[project]\nname = "auth"\n',
     );
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(true);
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(true);
   });
 
   it('returns false when file does not exist anywhere', () => {
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(false);
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(false);
   });
 
   it('excludes node_modules', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'node_modules/some-pkg/pyproject.toml',
       '[project]\nname = "vendored"\n',
     );
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(false);
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(false);
   });
 
   it('excludes hidden directories', () => {
-    writeTestFile(projectDirectory, '.venv/pyproject.toml', '[project]\nname = "venv"\n');
-    expect(existsInTree(projectDirectory, 'pyproject.toml')).toBe(false);
+    writeTestFile(shared.projectDirectory, '.venv/pyproject.toml', '[project]\nname = "venv"\n');
+    expect(existsInTree(shared.projectDirectory, 'pyproject.toml')).toBe(false);
   });
 
   it('excludes vendor directory', () => {
-    writeTestFile(projectDirectory, 'vendor/lib/go.mod', 'module vendored\n');
-    expect(existsInTree(projectDirectory, 'go.mod')).toBe(false);
+    writeTestFile(shared.projectDirectory, 'vendor/lib/go.mod', 'module vendored\n');
+    expect(existsInTree(shared.projectDirectory, 'go.mod')).toBe(false);
   });
 
   it('excludes dbt_packages directory', () => {
-    writeTestFile(projectDirectory, 'dbt_packages/some_pkg/dbt_project.yml', 'name: vendored\n');
-    expect(existsInTree(projectDirectory, 'dbt_project.yml')).toBe(false);
+    writeTestFile(shared.projectDirectory, 'dbt_packages/some_pkg/dbt_project.yml', 'name: vendored\n');
+    expect(existsInTree(shared.projectDirectory, 'dbt_project.yml')).toBe(false);
   });
 
   it('excludes node_modules nested deep', () => {
-    writeTestFile(projectDirectory, 'apps/node_modules/pkg/go.mod', 'module vendored\n');
-    expect(existsInTree(projectDirectory, 'go.mod')).toBe(false);
+    writeTestFile(shared.projectDirectory, 'apps/node_modules/pkg/go.mod', 'module vendored\n');
+    expect(existsInTree(shared.projectDirectory, 'go.mod')).toBe(false);
   });
 
   it('excludes vendor nested deep', () => {
-    writeTestFile(projectDirectory, 'apps/engine/vendor/dep/go.mod', 'module vendored\n');
-    expect(existsInTree(projectDirectory, 'go.mod')).toBe(false);
+    writeTestFile(shared.projectDirectory, 'apps/engine/vendor/dep/go.mod', 'module vendored\n');
+    expect(existsInTree(shared.projectDirectory, 'go.mod')).toBe(false);
   });
 });
 
@@ -98,42 +98,42 @@ describe('existsInTree', () => {
 
 describe('findInTree', () => {
   it('returns cwd when file is at root', () => {
-    writeTestFile(projectDirectory, 'pyproject.toml', '[project]\nname = "test"\n');
-    expect(findInTree(projectDirectory, 'pyproject.toml')).toBe(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'pyproject.toml', '[project]\nname = "test"\n');
+    expect(findInTree(shared.projectDirectory, 'pyproject.toml')).toBe(shared.projectDirectory);
   });
 
   it('returns subdirectory path when file is in subdir', () => {
-    writeTestFile(projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
-    const result = findInTree(projectDirectory, 'pyproject.toml');
+    writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
+    const result = findInTree(shared.projectDirectory, 'pyproject.toml');
     expect(result).toContain('/dbt');
   });
 
   it('returns deep subdirectory path', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'apps/coordinator/pyproject.toml',
       '[project]\nname = "coordinator"\n',
     );
-    const result = findInTree(projectDirectory, 'pyproject.toml');
+    const result = findInTree(shared.projectDirectory, 'pyproject.toml');
     expect(result).toContain('/apps/coordinator');
   });
 
   it('returns undefined when file not found', () => {
-    expect(findInTree(projectDirectory, 'pyproject.toml')).toBeUndefined();
+    expect(findInTree(shared.projectDirectory, 'pyproject.toml')).toBeUndefined();
   });
 
   it('prefers root over subdirectory', () => {
-    writeTestFile(projectDirectory, 'pyproject.toml', '[project]\nname = "root"\n');
-    writeTestFile(projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "sub"\n');
-    expect(findInTree(projectDirectory, 'pyproject.toml')).toBe(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'pyproject.toml', '[project]\nname = "root"\n');
+    writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "sub"\n');
+    expect(findInTree(shared.projectDirectory, 'pyproject.toml')).toBe(shared.projectDirectory);
   });
 
   it('respects maxDepth parameter', () => {
-    writeTestFile(projectDirectory, 'a/b/c/pyproject.toml', '[project]\nname = "deep"\n');
+    writeTestFile(shared.projectDirectory, 'a/b/c/pyproject.toml', '[project]\nname = "deep"\n');
     // depth 2 should not reach a/b/c (depth 3)
-    expect(findInTree(projectDirectory, 'pyproject.toml', 2)).toBeUndefined();
+    expect(findInTree(shared.projectDirectory, 'pyproject.toml', 2)).toBeUndefined();
     // depth 3 should reach it
-    expect(findInTree(projectDirectory, 'pyproject.toml', 3)).toContain('/a/b/c');
+    expect(findInTree(shared.projectDirectory, 'pyproject.toml', 3)).toContain('/a/b/c');
   });
 });
 
@@ -143,58 +143,58 @@ describe('findInTree', () => {
 
 describe('detectLanguages with subdirectories', () => {
   it('detects Python in subdirectory', () => {
-    writeTestFile(projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.python).toBe(true);
   });
 
   it('detects SQL in subdirectory', () => {
-    writeTestFile(projectDirectory, 'dbt/dbt_project.yml', 'name: test\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'dbt/dbt_project.yml', 'name: test\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.sql).toBe(true);
   });
 
   it('detects Go in subdirectory', () => {
-    writeTestFile(projectDirectory, 'backend/go.mod', 'module example.com/backend\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'backend/go.mod', 'module example.com/backend\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.golang).toBe(true);
   });
 
   it('detects Rust in subdirectory', () => {
-    writeTestFile(projectDirectory, 'native/Cargo.toml', '[package]\nname = "native"\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'native/Cargo.toml', '[package]\nname = "native"\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.rust).toBe(true);
   });
 
   it('does NOT detect JS/TS in subdirectory (root-only)', () => {
-    writeTestFile(projectDirectory, 'frontend/package.json', '{"name": "test"}\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'frontend/package.json', '{"name": "test"}\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.javascript).toBe(false);
   });
 
   it('detects multiple languages across root and subdirectories', () => {
-    writeTestFile(projectDirectory, 'package.json', '{"name": "root"}\n');
-    writeTestFile(projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "dbt"\n');
-    writeTestFile(projectDirectory, 'dbt/dbt_project.yml', 'name: dbt\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'package.json', '{"name": "root"}\n');
+    writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "dbt"\n');
+    writeTestFile(shared.projectDirectory, 'dbt/dbt_project.yml', 'name: dbt\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.javascript).toBe(true);
     expect(languages.python).toBe(true);
     expect(languages.sql).toBe(true);
   });
 
   it('detects Go at depth 2 (monorepo pattern)', () => {
-    writeTestFile(projectDirectory, 'apps/engine/go.mod', 'module example.com/engine\n');
-    const languages = detectLanguages(projectDirectory);
+    writeTestFile(shared.projectDirectory, 'apps/engine/go.mod', 'module example.com/engine\n');
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.golang).toBe(true);
   });
 
   it('detects Python at depth 2 (monorepo pattern)', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'apps/coordinator/pyproject.toml',
       '[project]\nname = "coordinator"\n',
     );
-    const languages = detectLanguages(projectDirectory);
+    const languages = detectLanguages(shared.projectDirectory);
     expect(languages.python).toBe(true);
   });
 });
@@ -217,51 +217,51 @@ describe('SQL pack detection', () => {
     ['liquibase.properties', 'changeLogFile=changelog.sql\n'],
     ['schemachange-config.yml', 'root-folder: migrations\n'],
   ])('Tier 1: detects SQL from %s', (filename, content) => {
-    writeTestFile(projectDirectory, filename, content);
-    expect(sqlPack.detect(projectDirectory)).toBe(true);
+    writeTestFile(shared.projectDirectory, filename, content);
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(true);
   });
 
   // Tier 2: directory conventions with .sql files
   it('Tier 2: detects SQL from prisma/migrations with .sql in subdirs', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'prisma/migrations/20210313_init/migration.sql',
       'CREATE TABLE users (id INT);',
     );
-    expect(sqlPack.detect(projectDirectory)).toBe(true);
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(true);
   });
 
   it('Tier 2: detects SQL from drizzle/ with .sql', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'drizzle/0001_create_users.sql',
       'CREATE TABLE users (id INT);',
     );
-    expect(sqlPack.detect(projectDirectory)).toBe(true);
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(true);
   });
 
   it('Tier 2: detects SQL from db/migrations/ with .sql', () => {
-    writeTestFile(projectDirectory, 'db/migrations/001_init.sql', 'CREATE TABLE users (id INT);');
-    expect(sqlPack.detect(projectDirectory)).toBe(true);
+    writeTestFile(shared.projectDirectory, 'db/migrations/001_init.sql', 'CREATE TABLE users (id INT);');
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(true);
   });
 
   // Tier 2 negative: directory exists but no .sql files
   it('Tier 2: does NOT detect from empty drizzle/ directory', () => {
-    writeTestFile(projectDirectory, 'drizzle/.gitkeep', '');
-    expect(sqlPack.detect(projectDirectory)).toBe(false);
+    writeTestFile(shared.projectDirectory, 'drizzle/.gitkeep', '');
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(false);
   });
 
   // Negative cases
   it('does NOT detect SQL in empty project', () => {
-    expect(sqlPack.detect(projectDirectory)).toBe(false);
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(false);
   });
 
   it('does NOT detect SQL from bare migrations/ directory', () => {
     writeTestFile(
-      projectDirectory,
+      shared.projectDirectory,
       'migrations/001_create_users.sql',
       'CREATE TABLE users (id INT);',
     );
-    expect(sqlPack.detect(projectDirectory)).toBe(false);
+    expect(sqlPack.detect(shared.projectDirectory)).toBe(false);
   });
 });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "ESNext.Iterator"],
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## What & why

Adopts **eslint-plugin-unicorn 68** (Dependabot #289), which requires `eslint >=10.4` and therefore drops ESLint 9. This makes the repo ESLint-10-primary and is a **breaking change for consumers of `safeword/eslint`** — the shipped `recommended` config now references unicorn 68 rules, so downstream projects must be on ESLint ≥ 10.4. Version bumped `0.52.2 → 0.53.0` (0.x breaking-change convention).

Supersedes #289 (the unicorn 64→68 bump).

## Key changes

**Dependencies / peer range**
- `eslint` (dev) → `^10.5.0` primary; `@eslint/js` → `^10`; `eslint-plugin-unicorn` `64 → 68`.
- `peerDependencies.eslint`: `^9.22.0 || ^10.0.0` → **`^10.4.0`**.
- Removed the now-moot dual-major (`eslint-v9`) backward-compat gate (script + CI step + alias).

**unicorn 68 rule migration**
- Renames: `prevent-abbreviations → name-replacements`, `no-array-for-each → no-for-each`, and exported `DepCruise* → DependencyCruise*` (`name-replacements`).
- Adopted unicorn 68's expanded recommended set and **fixed all ~220 resulting violations** in safeword's own code (`max-nested-calls`, `no-computed-property-existence-check`, `no-top-level-assignment-in-function`, `require-array-sort-compare`, `no-unnecessary-splice`, iterator-helpers, etc.) — behavior-preserving.
- `filename-case`: configured to ignore dunder dirs (`__tests__`) rather than rename ecosystem-convention directories.
- **`consistent-boolean-name`: disabled with documented justification.** Its schema offers no way to exclude function declarations or allowlist names, so adopting it would force *incorrect* renames of status-returning action functions and idiomatic predicates (`installPythonDependencies → isInstallPythonDependencies`, `exists → isExisting`) at error-level into customer agent code. Disabled alongside the existing `no-process-exit` / `prefer-module` exceptions; re-enable scoped to variables if unicorn ever ships a `checkFunctions:false` option.

**Other**
- Fixes a pre-existing dead rule reference in the Tailwind preset (`better-tailwindcss/no-unregistered-classes → no-unknown-classes`, renamed upstream in 4.6) and strengthens its test to catch dead rule names against the loaded plugin.
- `tsconfig`: adds `ESNext.Iterator` lib so the adopted iterator-helper form type-checks (Node ≥ 22.12 supports it at runtime).
- `eslint-peer-check`: now warns on ESLint 9 (below the new supported range); tests updated.

## Verification (all green under ESLint 10)
- `eslint src tests`: 0 · gherkin lint: 0 · `tsc --noEmit`: 0
- Full unit suite: **3178 passing** (5 skipped)
- Parity contracts ✓ · BDD lane 18/18 ✓ · dependency-cruiser ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSufeC2ZK326gXAtfgxLCx)_