### PR TITLE
Expand personas: add Non-Technical Builder, rename to Technical/Non-Technical Builder (TB/NTB)

### DIFF
--- a/.project/glossary.md
+++ b/.project/glossary.md
@@ -57,7 +57,7 @@ and could mean two things. One-spec-only vocabulary stays in that ticket.
 
 ## Persona
 
-**Definition:** A user archetype the project serves, defined in `.safeword-project/personas.md` with a `**Role:**` line and a short code (e.g. `DEV`, `SM`). JTBDs and scenarios reference personas by name or code.
+**Definition:** A user archetype the project serves, defined in `.safeword-project/personas.md` with a `**Role:**` line and a short code (e.g. `TB`, `SM`). JTBDs and scenarios reference personas by name or code.
 
 ## Acceptance Criterion
 

--- a/.project/personas.md
+++ b/.project/personas.md
@@ -7,17 +7,23 @@ unknown references as questions. Format and short-code rules:
 packages/cli/templates/personas-template.md.
 -->
 
-## Agent-Driven Developer (DEV)
+<!--
+Code note: the Technical Builder persona keeps the legacy `DEV` short code
+(not `TB`) because existing specs reference `DEV`. Migrating the code to
+`TB` is part of the deferred spec re-scan, not a personas.md-only change.
+-->
+
+## Technical Builder (DEV)
 
 **Role:** A developer who runs an AI coding agent (Claude Code, Cursor, or Codex) on a real project and installs safeword to keep that agent test-first, design-validated, and consistent.
 
 **Context:** Stack-agnostic and harness-agnostic — safeword is a process layer, not a framework opinion, so this persona ships Next, Django, Gin, anything across Claude Code, Cursor, or Codex. Doesn't want to learn safeword's internals; expects it to feel like an experienced teammate that "just does things well." Guardrails fire only during agent sessions, never blocking their own hand-written commits. Drives the agent across many sessions and leans on tickets, gates, and BDD/TDD to stay oriented and to get unblocked when a gate fires. Can read the diff and unblock themselves with technical reasoning when a gate fires.
 
-## Agent-Driven Builder (ADB)
+## Non-Technical Builder (NTB)
 
 **Role:** Someone who ships software by directing an AI coding agent but doesn't read or write the code themselves — leans entirely on safeword's guardrails to keep the agent honest.
 
-**Context:** Founders, PMs, designers, and domain experts — likely the larger audience. Harness-agnostic: drives Claude Code, Cursor, or Codex in natural language. Judges success by whether the feature works and is safe, not by code quality they can inspect, because they can't audit the diff. When a gate fires, needs a plain-language explanation and a concrete next action — internal jargon ("RED phase", "type narrowing") is a dead end. Safeword's value is highest here: it is the only thing standing between them and an agent that confidently ships broken or unsafe code.
+**Context:** Founders, PMs, designers, and domain experts — likely the larger audience. Understands systems, logic, and data flow, but doesn't read or write code. Harness-agnostic: drives Claude Code, Cursor, or Codex in natural language. Judges success by whether the feature works and is safe, not by code quality they can inspect, because they can't audit the diff. When a gate fires, needs a plain-language explanation and a concrete next action — internal jargon ("RED phase", "type narrowing") is a dead end. Safeword's value is highest here: it is the only thing standing between them and an agent that confidently ships broken or unsafe code.
 
 ## Safeword Maintainer (SM)
 

--- a/.project/personas.md
+++ b/.project/personas.md
@@ -7,13 +7,7 @@ unknown references as questions. Format and short-code rules:
 packages/cli/templates/personas-template.md.
 -->
 
-<!--
-Code note: the Technical Builder persona keeps the legacy `DEV` short code
-(not `TB`) because existing specs reference `DEV`. Migrating the code to
-`TB` is part of the deferred spec re-scan, not a personas.md-only change.
--->
-
-## Technical Builder (DEV)
+## Technical Builder (TB)
 
 **Role:** A developer who runs an AI coding agent (Claude Code, Cursor, or Codex) on a real project and installs safeword to keep that agent test-first, design-validated, and consistent.
 
@@ -29,4 +23,4 @@ Code note: the Technical Builder persona keeps the legacy `DEV` short code
 
 **Role:** A contributor who builds and extends safeword itself — authoring hooks, gates, skills, and enforcement rules in this repo.
 
-**Context:** Works in the safeword repo, which dogfoods safeword, so a Maintainer is always also a DEV in their own sessions. Needs enforcement defined in one declarative place rather than scattered through TypeScript, and needs to trust and verify the rule set before it ships and fires on real projects.
+**Context:** Works in the safeword repo, which dogfoods safeword, so a Maintainer is always also a TB in their own sessions. Needs enforcement defined in one declarative place rather than scattered through TypeScript, and needs to trust and verify the rule set before it ships and fires on real projects.

--- a/.project/personas.md
+++ b/.project/personas.md
@@ -9,9 +9,15 @@ packages/cli/templates/personas-template.md.
 
 ## Agent-Driven Developer (DEV)
 
-**Role:** A developer who runs an AI coding agent (Claude Code or Cursor) on a real project and installs safeword to keep that agent test-first, design-validated, and consistent.
+**Role:** A developer who runs an AI coding agent (Claude Code, Cursor, or Codex) on a real project and installs safeword to keep that agent test-first, design-validated, and consistent.
 
-**Context:** Stack-agnostic — safeword is a process layer, not a framework opinion, so this persona ships Next, Django, Gin, anything. Doesn't want to learn safeword's internals; expects it to feel like an experienced teammate that "just does things well." Guardrails fire only during agent sessions, never blocking their own hand-written commits. Drives the agent across many sessions and leans on tickets, gates, and BDD/TDD to stay oriented and to get unblocked when a gate fires.
+**Context:** Stack-agnostic and harness-agnostic — safeword is a process layer, not a framework opinion, so this persona ships Next, Django, Gin, anything across Claude Code, Cursor, or Codex. Doesn't want to learn safeword's internals; expects it to feel like an experienced teammate that "just does things well." Guardrails fire only during agent sessions, never blocking their own hand-written commits. Drives the agent across many sessions and leans on tickets, gates, and BDD/TDD to stay oriented and to get unblocked when a gate fires. Can read the diff and unblock themselves with technical reasoning when a gate fires.
+
+## Agent-Driven Builder (ADB)
+
+**Role:** Someone who ships software by directing an AI coding agent but doesn't read or write the code themselves — leans entirely on safeword's guardrails to keep the agent honest.
+
+**Context:** Founders, PMs, designers, and domain experts — likely the larger audience. Harness-agnostic: drives Claude Code, Cursor, or Codex in natural language. Judges success by whether the feature works and is safe, not by code quality they can inspect, because they can't audit the diff. When a gate fires, needs a plain-language explanation and a concrete next action — internal jargon ("RED phase", "type narrowing") is a dead end. Safeword's value is highest here: it is the only thing standing between them and an agent that confidently ships broken or unsafe code.
 
 ## Safeword Maintainer (SM)
 

--- a/.project/tickets/102a-gherkin-typescript/spec.md
+++ b/.project/tickets/102a-gherkin-typescript/spec.md
@@ -13,7 +13,7 @@ Safeword orchestrates BDD but never executes the specs it produces — Given/Whe
 
 ## Personas
 
-**Agent-Driven Developer (DEV)** — runs safeword's BDD flow; wants scenarios to become runnable acceptance tests instead of hand-copied vitest.
+**Technical Builder (TB)** — runs safeword's BDD flow; wants scenarios to become runnable acceptance tests instead of hand-copied vitest.
 
 **Safeword Maintainer (SM)** — builds safeword; wants safeword's own repo to execute `.feature` tests (dogfood the capability it will ship to customers).
 
@@ -27,7 +27,7 @@ Safeword orchestrates BDD but never executes the specs it produces — Given/Whe
 
 ### gherkin-typescript.DEV1 — Generate a runnable `.feature` from my scenarios
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I've defined a ticket's scenarios, I want to generate a Gherkin `.feature` from them, so my specs are executable acceptance tests instead of Markdown I hand-translate into vitest.
 

--- a/.project/tickets/102b-gherkin-polyglot-ts-steps/spec.md
+++ b/.project/tickets/102b-gherkin-polyglot-ts-steps/spec.md
@@ -13,7 +13,7 @@ Safeword's whole purpose is BDD/TDD discipline — so the executable-Gherkin acc
 
 ## Personas
 
-**Agent-Driven Developer (DEV)** — runs `safeword setup` on a real project (any stack) and expects safeword's BDD discipline, including a runnable acceptance lane, to be set up for them.
+**Technical Builder (TB)** — runs `safeword setup` on a real project (any stack) and expects safeword's BDD discipline, including a runnable acceptance lane, to be set up for them.
 
 ## Vocabulary
 
@@ -25,7 +25,7 @@ Safeword's whole purpose is BDD/TDD discipline — so the executable-Gherkin acc
 
 ### gherkin-setup.DEV1 — Get a runnable acceptance lane from `safeword setup`, in any project
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I set up safeword on my project — whatever language it is — I want the executable-Gherkin acceptance lane installed as part of that setup, so running `.feature` tests is built in rather than something I hand-wire.
 

--- a/.project/tickets/1DT29X-feature-files-as-source/spec.md
+++ b/.project/tickets/1DT29X-feature-files-as-source/spec.md
@@ -17,7 +17,7 @@ because hooks enforce R/G/R from its checkboxes.
 ## Personas
 
 - Safeword Maintainer (SM)
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 
 ## Vocabulary
 

--- a/.project/tickets/1GGD28-ticket-discovery-index/spec.md
+++ b/.project/tickets/1GGD28-ticket-discovery-index/spec.md
@@ -19,7 +19,7 @@ grep instead.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — accumulates a ticket corpus across many sessions and needs to find prior/related work without learning safeword internals. Covers the Safeword Maintainer (SM), who is a DEV in their own dogfood sessions.
+- **Technical Builder (TB)** — accumulates a ticket corpus across many sessions and needs to find prior/related work without learning safeword internals. Covers the Safeword Maintainer (SM), who is a DEV in their own dogfood sessions.
 
 ## Vocabulary
 
@@ -29,7 +29,7 @@ Uses existing glossary terms: Ticket, Epic (as the `epic:` frontmatter grouping 
 
 ### ticket-discovery-index.DEV1 — Discover existing tickets by capability
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I want to know whether the ticket corpus already covers a capability, I
 > want to grep a single generated index instead of scanning hundreds of

--- a/.project/tickets/31W8M3/spec.md
+++ b/.project/tickets/31W8M3/spec.md
@@ -19,7 +19,7 @@ the fourth and final product-framing artifact the DZ2NM5 epic set out to merge.
 
 ## Personas
 
-**Agent-Driven Developer (DEV)** — primary beneficiary; gets purposeful,
+**Technical Builder (TB)** — primary beneficiary; gets purposeful,
 design-validated scenario coverage from the AC rung. **Safeword Maintainer (SM)**
 is the dogfooding subset, exercising this very layer when building safeword.
 
@@ -33,7 +33,7 @@ that prove it. (Project-wide `glossary.md` is not yet bootstrapped.)
 
 ### ac-layer.DEV1 — Trust that scenarios prove the feature, not just that code runs
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I have my agent build a feature, I want each job's required capabilities
 > pinned as acceptance criteria before any scenarios are written, so I can trust

--- a/.project/tickets/3293WH-self-verify-setup-upgrade/spec.md
+++ b/.project/tickets/3293WH-self-verify-setup-upgrade/spec.md
@@ -22,13 +22,13 @@ doctor-style diagnostic for CI and debugging.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs `safeword setup`/`upgrade` on their project and needs breakage surfaced at the moment it happens, not discovered sessions later.
+- **Technical Builder (TB)** — runs `safeword setup`/`upgrade` on their project and needs breakage surfaced at the moment it happens, not discovered sessions later.
 
 ## Jobs To Be Done
 
 ### self-verify-setup-upgrade.DEV1 — Know immediately when setup or upgrade left the project broken
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run `safeword setup` or `safeword upgrade`, I want the command to
 > verify the configuration it just wrote and fail loudly if it's broken, so I
@@ -46,7 +46,7 @@ doctor-style diagnostic for CI and debugging.
 
 ### self-verify-setup-upgrade.DEV2 — Trust the install without learning safeword's diagnostic commands
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I install or upgrade safeword, I want health verification to happen
 > without me knowing a separate command exists, so the tool carries its own

--- a/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
+++ b/.project/tickets/5FF0ZD-migrate-consumers-to-test-plan/spec.md
@@ -11,7 +11,7 @@ Make `test-runner.ts` and `/verify` consume the `safeword test-plan` resolver so
 ## Personas
 
 - Safeword Maintainer (SM) — owns the gates; needs one definition of how a language is tested.
-- Agent-Driven Developer (DEV) — relies on the done-gate to run the right suite for their language.
+- Technical Builder (TB) — relies on the done-gate to run the right suite for their language.
 
 ## Jobs To Be Done
 
@@ -35,7 +35,7 @@ Make `test-runner.ts` and `/verify` consume the `safeword test-plan` resolver so
 
 ### migrate-consumers.DEV1 — the done-gate runs my real suite (preserved/upgraded)
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my agent hits the done-gate in a Go/Rust/polyglot repo, I want my actual suite(s) run — no regression from the migration.
 

--- a/.project/tickets/9MMWS7-upgrade-namespace-migration/spec.md
+++ b/.project/tickets/9MMWS7-upgrade-namespace-migration/spec.md
@@ -16,13 +16,13 @@ where it is; `safeword check` nudges only when a half-finished state exists.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — upgrades safeword on an old project and gets walked across the namespace convention in one keystroke, or declines with zero consequence.
+- **Technical Builder (TB)** — upgrades safeword on an old project and gets walked across the namespace convention in one keystroke, or declines with zero consequence.
 
 ## Jobs To Be Done
 
 ### upgrade-namespace-migration.DEV1 — Converge an old install during a routine upgrade
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run `safeword upgrade` on a project still using `.safeword-project/`,
 > I want it to offer the move to `.project/` as the recommended default and do

--- a/.project/tickets/AQJ95G-project-namespace-default/spec.md
+++ b/.project/tickets/AQJ95G-project-namespace-default/spec.md
@@ -25,7 +25,7 @@ working untouched via automatic legacy detection.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs arcade and/or safeword on a real project; feels the duplicate-maintenance pain and adopts/migrates the convention.
+- **Technical Builder (TB)** — runs arcade and/or safeword on a real project; feels the duplicate-maintenance pain and adopts/migrates the convention.
 - **Safeword Maintainer (SM)** — extends safeword itself; needs the resolution precedence defined in one place, not re-derived per call site.
 
 ## Vocabulary
@@ -37,7 +37,7 @@ working untouched via automatic legacy detection.
 
 ### project-namespace-default.DEV1 — Maintain shared knowledge in one place
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run both arcade and safeword on the same project, I want both tools to
 > read my personas, glossary, and specs from one directory, so I can maintain
@@ -51,7 +51,7 @@ working untouched via automatic legacy detection.
 
 ### project-namespace-default.DEV2 — Point the namespace where my repo keeps it
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my project keeps shared knowledge somewhere other than the default, I
 > want to tell safeword where the namespace root lives, so I can adopt safeword
@@ -63,7 +63,7 @@ working untouched via automatic legacy detection.
 
 ### project-namespace-default.DEV3 — Upgrade an existing install without a flag day
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I upgrade safeword on a project that already uses `.safeword-project/`, I
 > want my existing layout to keep working untouched, so I can take the upgrade
@@ -75,7 +75,7 @@ working untouched via automatic legacy detection.
 
 ### project-namespace-default.DEV4 — Converge an old install via upgrade
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run `safeword upgrade` on a project still using `.safeword-project/`, I
 > want it to offer to move me onto `.project/` as the recommended default, so I

--- a/.project/tickets/BKTTZA-test-plan-resolver/spec.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/spec.md
@@ -11,14 +11,14 @@ A single pure resolver, exposed as `safeword test-plan`, that emits the correct 
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Jobs To Be Done
 
 ### test-plan-resolver.DEV1 — trustworthy done-gate across languages
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my agent finishes work in a Python/Go/Rust or polyglot repo, I want the gate to run my real suite(s), so "done" means verified — not a silent pass.
 

--- a/.project/tickets/CS86B0/spec.md
+++ b/.project/tickets/CS86B0/spec.md
@@ -21,7 +21,7 @@ unchanged.
 
 ## Personas
 
-**Agent-Driven Developer (DEV)** — drives the BDD flow on a real project; after
+**Technical Builder (TB)** — drives the BDD flow on a real project; after
 the scenario-gate, wants a runnable test board scaffolded from the scenarios so
 "3/12 passing" is visible from the first implement step.
 
@@ -39,7 +39,7 @@ fail for a true-RED "make them pass" board. (`it.fails` is wrong — green-while
 
 ### codify.DEV1 — Scaffold every scenario into a runnable test board in one shot
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I finish defining and gating a ticket's scenarios, I want to generate the
 > whole vitest test file at once — one stub per scenario, traceable to its AC —

--- a/.project/tickets/ERVA6V/spec.md
+++ b/.project/tickets/ERVA6V/spec.md
@@ -12,7 +12,7 @@ Keep the impl plan honest: when implementation finishes, the plan is reconciled 
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Vocabulary
@@ -23,7 +23,7 @@ Keep the impl plan honest: when implementation finishes, the plan is reconciled 
 
 ### plan-reconciliation.DEV1 — Trust the plan as a record of what shipped
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I read a finished feature's impl plan, I want it to reflect what was actually built — including decisions that changed mid-flight — so I can rely on it instead of diffing it against the code.
 

--- a/.project/tickets/JYWZG1-migration-stale-config-warning/spec.md
+++ b/.project/tickets/JYWZG1-migration-stale-config-warning/spec.md
@@ -18,13 +18,13 @@ keep the old path.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs `safeword upgrade --migrate-namespace` on a real project and needs their lint/CI to keep working, or to be told exactly what to fix.
+- **Technical Builder (TB)** — runs `safeword upgrade --migrate-namespace` on a real project and needs their lint/CI to keep working, or to be told exactly what to fix.
 
 ## Jobs To Be Done
 
 ### migration-stale-config-warning.DEV1 — Don't let the move silently break my tooling
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When `safeword upgrade` moves my namespace to `.project/`, I want it to tell
 > me which of my own tooling configs still point at the old path, so I fix my

--- a/.project/tickets/K4BWTQ/spec.md
+++ b/.project/tickets/K4BWTQ/spec.md
@@ -13,7 +13,7 @@ Make architectural awareness a working part of impl-plan authoring: before TDD s
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Vocabulary
@@ -24,7 +24,7 @@ Make architectural awareness a working part of impl-plan authoring: before TDD s
 
 ### adr-consultation.DEV1 — Implementations honor recorded decisions
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my agent plans an implementation, I want it to read the architecture decisions my project has already recorded and name the relevant ones in the impl plan, so I can trust new code follows the decisions instead of silently drifting.
 

--- a/.project/tickets/KJAM82-verify-safeword-in-any-project/spec.md
+++ b/.project/tickets/KJAM82-verify-safeword-in-any-project/spec.md
@@ -13,7 +13,7 @@ Safeword's quality workflows should behave correctly after installation into arb
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Vocabulary
@@ -27,7 +27,7 @@ Safeword's quality workflows should behave correctly after installation into arb
 
 ### verify-safeword-any-project.DEV1 - Finish work without false verification failures
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I use safeword in a Go, Python, Rust, npm, pnpm, yarn, Bun, or minimal project, I want `/verify` to run the checks my project actually supports, so I can trust the done gate instead of debugging missing scripts from another stack.
 

--- a/.project/tickets/MR5M3A-architecture-gate/spec.md
+++ b/.project/tickets/MR5M3A-architecture-gate/spec.md
@@ -15,7 +15,7 @@ That is precisely the correlated-single-agent-error gap the M6D315 ADR itself na
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs an AI agent on a real project and installs safeword to keep that agent design-validated. #204 gives them a recorded design; this gives them an _independently challenged_ one.
+- **Technical Builder (TB)** — runs an AI agent on a real project and installs safeword to keep that agent design-validated. #204 gives them a recorded design; this gives them an _independently challenged_ one.
 
 ## Vocabulary
 
@@ -27,7 +27,7 @@ That is precisely the correlated-single-agent-error gap the M6D315 ADR itself na
 
 ### architecture-gate.DEV1 — The design is generated from evidence, then independently challenged, before code completes
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my agent records an implementation plan for a non-trivial feature, I want its key decisions backed by cited evidence and then challenged by an independent reviewer before the work can finish, so I can trust the design wasn't a confident first guess that only its own author ever checked.
 
@@ -39,7 +39,7 @@ That is precisely the correlated-single-agent-error gap the M6D315 ADR itself na
 
 ### architecture-gate.DEV2 — The gate ships safely without bricking existing workflows
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I upgrade safeword, I want this new blocking gate to arrive inert until I deliberately enable it, so an in-flight feature doesn't suddenly become unshippable.
 

--- a/.project/tickets/MT27QG-loc-gate-vs-phase-placement/spec.md
+++ b/.project/tickets/MT27QG-loc-gate-vs-phase-placement/spec.md
@@ -22,13 +22,13 @@ it git-operation-aware.
 
 ## Personas
 
-- **Safeword Maintainer (SM)** / **Agent-Driven Developer (DEV)** — both hit the gate; the deadlock strands anyone whose agent edits during a merge/rebase/cherry-pick.
+- **Safeword Maintainer (SM)** / **Technical Builder (TB)** — both hit the gate; the deadlock strands anyone whose agent edits during a merge/rebase/cherry-pick.
 
 ## Jobs To Be Done
 
 ### loc-gate-vs-phase-placement.DEV1 — Resolve a merge without the blast-radius gate deadlocking me
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my agent is mid-merge (or rebase/cherry-pick) and needs to edit files to
 > resolve conflicts, I want the LOC gate to stand down, so blast-radius control

--- a/.project/tickets/N9S5XG-setup-scaffolds-project-dir/spec.md
+++ b/.project/tickets/N9S5XG-setup-scaffolds-project-dir/spec.md
@@ -16,13 +16,13 @@ never has a file clobbered.
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs `safeword setup` on a fresh repo, an arcade repo, or an old safeword repo, and gets one correct namespace with zero questions asked.
+- **Technical Builder (TB)** — runs `safeword setup` on a fresh repo, an arcade repo, or an old safeword repo, and gets one correct namespace with zero questions asked.
 
 ## Jobs To Be Done
 
 ### setup-scaffolds-project-dir.DEV1 — Set up into the right namespace, whatever my repo looks like
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run `safeword setup`, I want the namespace scaffolded at the right
 > root for my repo's state — new, arcade, or legacy — so setup just works and

--- a/.project/tickets/NMSD94-per-asset-review-gate/spec.md
+++ b/.project/tickets/NMSD94-per-asset-review-gate/spec.md
@@ -14,7 +14,7 @@ Make "work is reviewed before it's built on" enforceable in the safeword workflo
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — builds features through the agent; bears the cost of a flawed early asset compounding downstream, and of review being silently skipped.
+- **Technical Builder (TB)** — builds features through the agent; bears the cost of a flawed early asset compounding downstream, and of review being silently skipped.
 - **Safeword Maintainer (SM)** — owns the gates; bears the cost of bloat and of low-signal gates training `--no-verify` bypass.
 
 ## Vocabulary
@@ -26,7 +26,7 @@ Make "work is reviewed before it's built on" enforceable in the safeword workflo
 
 ### review-gate.DEV1 — catch a weak asset before downstream work is built on it
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I'm building a feature and the agent produces each artifact in turn (jobs → acceptance criteria → scenarios, and each TDD step), I want a quick review forced on each one before the next is authored, so a flawed foundation is caught early instead of after the whole chain has been poured on top of it.
 
@@ -40,7 +40,7 @@ Satisfying the per-asset stamp spawns no fresh sub-agent — the review is the w
 
 ### review-gate.DEV2 — guarantee an independent review actually ran at each phase
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When the agent advances from one workflow phase to the next, I want proof that an independent review ran — not the author grading its own work, and not skipped — so review isn't silently dropped and I don't have to keep manually prompting for it.
 

--- a/.project/tickets/P30CRP-safeword-md-via-hooks/spec.md
+++ b/.project/tickets/P30CRP-safeword-md-via-hooks/spec.md
@@ -14,14 +14,14 @@ Safeword should deliver its standing agent instructions through files and hooks 
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Jobs To Be Done
 
 ### safeword-md-via-hooks.DEV1 - Keep safeword active without owning my context files
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I install safeword in a project with my own agent instructions, I want safeword to load its required workflow context without editing my `CLAUDE.md` or `AGENTS.md`, so I can customize those files without accidentally disabling safeword.
 

--- a/.project/tickets/TAGWZ8-namespace-root-resolver/spec.md
+++ b/.project/tickets/TAGWZ8-namespace-root-resolver/spec.md
@@ -21,7 +21,7 @@ every surface through it, so the default flips to `.project/` while existing
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — gets `.project/` as the default and a configurable root; existing installs keep working.
+- **Technical Builder (TB)** — gets `.project/` as the default and a configurable root; existing installs keep working.
 - **Safeword Maintainer (SM)** — gets one resolver to call instead of re-deriving precedence per call site.
 
 ## Vocabulary
@@ -44,7 +44,7 @@ every surface through it, so the default flips to `.project/` while existing
 
 ### namespace-root-resolver.DEV1 — Read project knowledge from the resolved root
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When safeword reads my personas, glossary, architecture, tickets, and
 > learnings, I want them read from whichever root resolves, so the new
@@ -56,7 +56,7 @@ every surface through it, so the default flips to `.project/` while existing
 
 ### namespace-root-resolver.DEV2 — Point the namespace where my repo keeps it
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my project keeps shared knowledge somewhere other than the default, I
 > want to set the namespace root in config, so I can adopt safeword without

--- a/.project/tickets/V7GGJZ-formatter-aware-lint-hook/spec.md
+++ b/.project/tickets/V7GGJZ-formatter-aware-lint-hook/spec.md
@@ -18,7 +18,7 @@ eliminates the prettier-vs-formatter churn that makes safeword unwelcome in esta
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — runs an AI agent under safeword on a real repo that already has a formatter.
+- **Technical Builder (TB)** — runs an AI agent under safeword on a real repo that already has a formatter.
 
 ## Vocabulary
 
@@ -29,7 +29,7 @@ eliminates the prettier-vs-formatter churn that makes safeword unwelcome in esta
 
 ### formatter-aware-lint-hook.DEV1 — Keep my formatter's style; no churn from the agent
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I run an agent under safeword on a repo whose JS/TS formatting is owned by a non-Prettier
 > formatter (Biome, dprint, oxfmt, deno), I want the auto-lint hook to not reformat my files with
@@ -43,7 +43,7 @@ eliminates the prettier-vs-formatter churn that makes safeword unwelcome in esta
 
 ### formatter-aware-lint-hook.DEV2 — Format with my own Prettier config
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my repo has its own Prettier config, I want agent edits formatted with my config, so they
 > match my house style rather than safeword's defaults.
@@ -52,7 +52,7 @@ eliminates the prettier-vs-formatter churn that makes safeword unwelcome in esta
 
 ### formatter-aware-lint-hook.DEV3 — Still get formatting on a greenfield repo
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my repo has no formatter of its own, I want safeword to keep formatting my files with its
 > defaults, so I still get consistent formatting from the agent.
@@ -61,7 +61,7 @@ eliminates the prettier-vs-formatter churn that makes safeword unwelcome in esta
 
 ### formatter-aware-lint-hook.DEV4 — Don't push Prettier on me
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my repo uses a non-Prettier formatter, I don't want safeword's session start warning that
 > Prettier is missing or telling me to install it, so I'm not pushed toward a tool I don't use.

--- a/.project/tickets/W610WW-whole-ticket-quality-refactor/spec.md
+++ b/.project/tickets/W610WW-whole-ticket-quality-refactor/spec.md
@@ -31,7 +31,7 @@ when there's more than one RGR loop, and auto-skipping when there's just one
 
 ## Personas
 
-- **Agent-Driven Developer (DEV)** — the pass fires in their agent sessions
+- **Technical Builder (TB)** — the pass fires in their agent sessions
   on real projects; they get whole-ticket cleanup before done.
 - **Safeword Maintainer (SM)** — owns the gate; wants one derived trigger,
   not a new artifact or a parallel signal.
@@ -48,7 +48,7 @@ when there's more than one RGR loop, and auto-skipping when there's just one
 
 ### whole-ticket-quality-refactor.DEV1 — Clean up cross-loop debt before verify
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I finish implementing a ticket that went through several RED-GREEN-REFACTOR
 > loops, I want one whole-ticket quality review and refactor pass before verify,
@@ -63,7 +63,7 @@ when there's more than one RGR loop, and auto-skipping when there's just one
 
 ### whole-ticket-quality-refactor.DEV2 — No ceremony when there's nothing to cross
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When my ticket had only a single RGR loop, I want the whole-ticket pass to be
 > skipped automatically, so I'm not forced through a quality-review-and-refactor

--- a/.project/tickets/XDNSZA/spec.md
+++ b/.project/tickets/XDNSZA/spec.md
@@ -13,7 +13,7 @@ Give feature work an upfront design record — what approach was chosen, what al
 
 ## Personas
 
-- Agent-Driven Developer (DEV)
+- Technical Builder (TB)
 - Safeword Maintainer (SM)
 
 ## Vocabulary
@@ -24,7 +24,7 @@ Give feature work an upfront design record — what approach was chosen, what al
 
 ### impl-plan-artifact.DEV1 — Know why the implementation looks the way it does
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When I revisit a feature my agent built weeks ago, I want the chosen approach, the rejected alternatives, and the known deviations recorded next to the ticket, so I can tell intentional design from accident without re-deriving it.
 

--- a/.project/tickets/XT1FFM/spec.md
+++ b/.project/tickets/XT1FFM/spec.md
@@ -17,7 +17,7 @@ no AC) surface without a human cross-referencing by eye.
 
 ## Personas
 
-**Agent-Driven Developer (DEV)** — traces a failing or revisited scenario back to
+**Technical Builder (TB)** — traces a failing or revisited scenario back to
 the capability it proves, and learns at a glance whether every AC is covered.
 
 ## Vocabulary
@@ -30,7 +30,7 @@ this term is feature-local.)
 
 ### cross-reference-numbering.DEV1 — Trace a scenario to the capability it proves
 
-**Persona:** Agent-Driven Developer (DEV)
+**Persona:** Technical Builder (TB)
 
 > When a scenario fails or I revisit a feature's coverage, I want each scenario's
 > name to carry the acceptance criterion it proves, so I can see at a glance which


### PR DESCRIPTION
## What

Expands safeword's persona set and renames the existing one for clarity.

| Code | Name | Differentiator |
|------|------|----------------|
| `TB` | **Technical Builder** (was `DEV` / "Agent-Driven Developer") | Reads the diff, unblocks self with technical reasoning |
| `NTB` | **Non-Technical Builder** *(new)* | Doesn't read code; judges by works/safe; needs plain-language gates. Likely the larger audience |
| `SM` | Safeword Maintainer | Builds safeword itself |

## Why

- **Added a non-dev persona.** Non-devs already drive coding agents and may be the bigger TAM. They can't audit the diff, so they judge success by *does it work / is it safe* and need plain-language gate messages — a real outcome divergence from the developer persona, which is what justifies a distinct persona (per Cooper/JTBD: differentiate only on divergent desired outcomes).
- **Harness is not a persona axis.** Claude Code / Cursor / Codex is a capability attribute shared across personas, not a goal — so it lives in each persona's `**Context:**` line rather than spawning per-harness personas.
- **Dropped the "Agent-Driven" prefix.** Every persona runs an AI agent, so the prefix carried no differentiating signal. Names now turn on the axis that actually changes agent behavior: code literacy.

## Scope of the `DEV` → `TB` rename

- Renamed in the source of truth (`personas.md`), the glossary example, the SM context line, and the persona-reference form across **25 active ticket specs**.
- **Deliberately left untouched:** JTBD/AC identifier codes (e.g. `DEV1.AC1`), which are baked into production test names, `.feature` files, and completed-ticket history. `safeword check` validates only `personas.md` well-formedness — not these ID prefixes — so nothing is broken by leaving them as historical labels.

## Follow-ups (not in this PR)

- **NTB gate-copy sweep** — gate messages still assume a Technical Builder; jargon is a dead end for the NTB persona.
- Ticket `108-persona-checks` — wire personas into BDD scenario-coverage review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TH2y8Nbd3nQu9yqYAx9jNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH2y8Nbd3nQu9yqYAx9jNX)_