### PR TITLE
chore(release): v0.54.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.54.0** — rolls up 24 PRs since `v0.52.1` (the prior published release; `0.53.0` was bumped in #300 but never tagged/published).

## ⚠️ Breaking — read before auto-upgrading

- **ESLint 10 + eslint-plugin-unicorn 68; ESLint 9 dropped (#300).** `peerDependencies.eslint` narrows `^9.22.0 || ^10.0.0` → **`^10.4.0`**. Consumers of `safeword/eslint` must be on **ESLint ≥ 10.4** — the shipped `recommended` config now references unicorn-68 rules. Projects still on ESLint 9 will see a peer-mismatch warning at install/upgrade and may have lint failures until they move to ESLint 10.4+.

> Note: shipped as a 0.x minor per 0.x breaking-change convention (maintainer's call), not a major. It is called out here so consumers aren't blindsided on auto-upgrade.

## Features / additive

- feat(codex): MCP server parity for `.codex/config.toml` (#269)
- Formatter coexistence: inert install, no collisions, self-contained ignores — epic 2H2XKH (#265)
- feat(namespace): wire a custom `paths.projectRoot` into formatter ignores + auto-upgrade staging (#285)
- feat(prettier): exclude a custom `paths.projectRoot` via ctx-aware, re-rendered `.prettierignore` (#296)
- Auto-upgrade hardening — seamless, non-blocking, resilient — XQ9CXA (#279)
- Whole-ticket quality-review + refactor pass before verify — W610WW (#284)
- Expand personas: add Non-Technical Builder, rename to Technical/Non-Technical Builder (TB/NTB) (#301)
- Provider-neutral model-tier policy + V2 lean reviewer-model wording (#283)
- quality-review: reviewer sub-agent must be a different model, and no weaker (#277)
- quality-review: add no-bloat verdict row (#280)
- Reasoning-skills uplift: find→verify discipline across 5 skills — B6MZ4Z (#266)
- refactor skill: split discovery (fan-out) from execution (linear) (#270)

## Fixes

- fix(reconcile): preserve user-customized MCP servers on upgrade (#268)
- fix(quality-review): add missing `verify` phase to the Detect Phase table (#267)
- fix: exclude generated agent docs from consuming-repo markdownlint + merge-engine hardening (#275)
- fix(schema): ignore transient session state under a custom `paths.projectRoot` (#276)
- fix: tag re-entry brief from the session binding, not a global scan (#278)

## Chores / deps

- refactor: extract shared `readSessionState` for the quality hooks (#286)
- chore(deps): bump the bun-minor-patch group — 10 updates, incl. sonarjs 4.1.0 (#288)
- chore(deps-dev): @types/node 25 → 26 (#291)
- chore(deps): @cucumber/gherkin 40 → 41 (#290)
- chore(deps): actions/checkout bump (#287)
- chore(EXP1PE): mark ticket done (#297)

---

Version bumped in both manifests (`packages/cli/package.json` + `marketplace.json`). Tag `v0.54.0` will be pushed on the squash-merge commit to trigger the OIDC publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
