### PR TITLE
fix(audit): resolve local safeword CLI for sync-config drift check (#264)

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -41,7 +41,14 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 
 # 0. Compare generated vs on-disk depcruise config. Non-zero exit = drift.
 #    /audit must never mutate the working tree; surface stale config as W007.
-bunx safeword@latest sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
+#    Resolve the locally installed safeword CLI first so the check reflects the
+#    repo's pinned version, not whatever the npm registry currently calls @latest.
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+$SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -41,7 +41,14 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 
 # 0. Compare generated vs on-disk depcruise config. Non-zero exit = drift.
 #    /audit must never mutate the working tree; surface stale config as W007.
-bunx safeword@latest sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
+#    Resolve the locally installed safeword CLI first so the check reflects the
+#    repo's pinned version, not whatever the npm registry currently calls @latest.
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+$SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)

--- a/.cursor/commands/audit.md
+++ b/.cursor/commands/audit.md
@@ -37,7 +37,14 @@ cd "$CLAUDE_PROJECT_DIR" || exit 1
 
 # 0. Compare generated vs on-disk depcruise config. Non-zero exit = drift.
 #    /audit must never mutate the working tree; surface stale config as W007.
-bunx safeword@latest sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
+#    Resolve the locally installed safeword CLI first so the check reflects the
+#    repo's pinned version, not whatever the npm registry currently calls @latest.
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+$SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)

--- a/packages/cli/templates/commands/audit.md
+++ b/packages/cli/templates/commands/audit.md
@@ -37,7 +37,14 @@ cd "$CLAUDE_PROJECT_DIR" || exit 1
 
 # 0. Compare generated vs on-disk depcruise config. Non-zero exit = drift.
 #    /audit must never mutate the working tree; surface stale config as W007.
-bunx safeword@latest sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
+#    Resolve the locally installed safeword CLI first so the check reflects the
+#    repo's pinned version, not whatever the npm registry currently calls @latest.
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+$SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -41,7 +41,14 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 
 # 0. Compare generated vs on-disk depcruise config. Non-zero exit = drift.
 #    /audit must never mutate the working tree; surface stale config as W007.
-bunx safeword@latest sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
+#    Resolve the locally installed safeword CLI first so the check reflects the
+#    repo's pinned version, not whatever the npm registry currently calls @latest.
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+$SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)

--- a/packages/cli/tests/skill-invocation-log.test.ts
+++ b/packages/cli/tests/skill-invocation-log.test.ts
@@ -224,6 +224,45 @@ describe('skill-invocation log: /quality-review carries its invocation line (W61
   );
 });
 
+// /audit's depcruise drift check (#264) must resolve the locally installed
+// safeword CLI, not pin to the npm registry's `@latest` — otherwise audit
+// behavior depends on whatever the registry currently publishes instead of the
+// repo's installed/pinned version. Mirrors the local-first resolver /verify
+// already uses for `safeword test-plan`.
+const auditDriftForms: [string, string][] = [
+  ['audit template skill', auditSkill],
+  ['audit template command', auditCommand],
+  [
+    'audit dogfood claude skill',
+    readFileSync(nodePath.join(repoRoot, '.claude/skills/audit/SKILL.md'), 'utf8'),
+  ],
+  [
+    'audit dogfood agents skill',
+    readFileSync(nodePath.join(repoRoot, '.agents/skills/audit/SKILL.md'), 'utf8'),
+  ],
+  [
+    'audit dogfood cursor command',
+    readFileSync(nodePath.join(repoRoot, '.cursor/commands/audit.md'), 'utf8'),
+  ],
+];
+
+describe('audit drift check resolves the local safeword CLI, not @latest (#264)', () => {
+  it.each(auditDriftForms)(
+    '%s does not pin the depcruise drift check to safeword@latest',
+    (_name, content) => {
+      expect(content).not.toContain('bunx safeword@latest sync-config');
+    },
+  );
+
+  it.each(auditDriftForms)(
+    '%s prefers the locally installed safeword binary before bunx',
+    (_name, content) => {
+      expect(content).toContain('node_modules/.bin/safeword');
+      expect(content).toContain('$SW sync-config --check');
+    },
+  );
+});
+
 describe('self-review stamp fallback surfaces (K2ZP40)', () => {
   it.each(selfReviewForms)(
     '%s documents a manual write-review-stamp fallback for non-Claude render contexts',

--- a/packages/cli/tests/skill-invocation-log.test.ts
+++ b/packages/cli/tests/skill-invocation-log.test.ts
@@ -258,6 +258,9 @@ describe('audit drift check resolves the local safeword CLI, not @latest (#264)'
     '%s prefers the locally installed safeword binary before bunx',
     (_name, content) => {
       expect(content).toContain('node_modules/.bin/safeword');
+      // The in-repo source checkout is the middle fallback — assert it too so a
+      // regression that drops the dogfood branch can't pass silently.
+      expect(content).toContain('bun packages/cli/src/cli.ts');
       expect(content).toContain('$SW sync-config --check');
     },
   );


### PR DESCRIPTION
## What

`/audit`'s depcruise drift check (step 0) shelled out to `bunx safeword@latest sync-config --check`, so audit behavior depended on whatever the npm registry currently calls `@latest` rather than the consuming repo's installed/pinned safeword version — and produced surprising registry-resolution output (`Resolving dependencies / Saved lockfile`) during a read-only audit run.

This adopts the same local-first resolver `/verify` already uses for `safeword test-plan`:

```bash
if [ -x node_modules/.bin/safeword ]; then
  SW="node_modules/.bin/safeword"
elif [ -f packages/cli/src/cli.ts ]; then
  SW="bun packages/cli/src/cli.ts"
else SW="bunx safeword"; fi
$SW sync-config --check 2>&1 || echo "[W007] ..."
```

## Scope

Applied across both template forms and the three dogfood mirrors (byte-mirrors of the templates):

- `packages/cli/templates/skills/audit/SKILL.md`
- `packages/cli/templates/commands/audit.md`
- `.claude/skills/audit/SKILL.md`
- `.agents/skills/audit/SKILL.md`
- `.cursor/commands/audit.md`

Left untouched: the `setup`/`upgrade`/`check`/`diff` `@latest` usages in README/docs/plugin — those are intentional consumer bootstrap commands where the published CLI is what you want.

## Tests

Added a `#264` block to `tests/skill-invocation-log.test.ts` asserting all five audit surfaces (a) avoid `safeword@latest` for the drift check and (b) prefer the local binary. **45/45 pass.** eslint + markdownlint clean; template↔mirror contract check passes.

Verified live: resolver picks the local CLI (`bun packages/cli/src/cli.ts` in the dogfood repo), `sync-config --check` runs → `✓ Config in sync`, exit 0, no registry resolution.

Closes #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cktDNJuULcB8NJYGfBH5e)_