### PR TITLE
docs: align ESLint version references with v0.54.0 peer range

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -353,9 +353,9 @@ CLI command
 
 ### Peer
 
-| Package  | Version  | Purpose                        |
-| -------- | -------- | ------------------------------ |
-| `eslint` | `^9.0.0` | Required by consuming projects |
+| Package  | Version   | Purpose                        |
+| -------- | --------- | ------------------------------ |
+| `eslint` | `^10.4.0` | Required by consuming projects |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ This section is for contributors to safeword itself.
 | CLI       | TypeScript, Commander.js    |
 | Build     | tsup (ESM-only output)      |
 | Tests     | Vitest                      |
-| Linting   | ESLint 9 + Prettier         |
+| Linting   | ESLint 10 + Prettier        |
 
 ### Optional System Binaries
 

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -19,7 +19,7 @@ export default defineConfig([
 ]);
 ```
 
-Safeword's generated config uses [`defineConfig`](https://eslint.org/docs/latest/use/configure/configuration-files#the-defineconfig-helper) (ESLint ≥9.22) — the canonical flat-config helper. It enables file-scoped `extends:` and validates the config shape at lint time.
+Safeword's generated config uses [`defineConfig`](https://eslint.org/docs/latest/use/configure/configuration-files#the-defineconfig-helper) (ESLint ≥10.4) — the canonical flat-config helper. It enables file-scoped `extends:` and validates the config shape at lint time.
 
 **Available configs:**
 


### PR DESCRIPTION
Corrects the user-facing docs that still referenced **ESLint 9** after [#300](https://github.com/ArcadeAI/safeword/pull/300) narrowed `peerDependencies.eslint` to `^10.4.0` in v0.54.0.

- `ARCHITECTURE.md` — Peer table `eslint ^9.0.0` → `^10.4.0`
- `README.md` — "ESLint 9 + Prettier" → "ESLint 10 + Prettier"
- `packages/website/.../configuration.mdx` — "ESLint ≥9.22" → "ESLint ≥10.4"

Docs-only, no version bump (repo docs, not shipped in the npm package).

Part of #304. Deferred to follow-ups (deliberately split, see issue threads):
- Root `package.json` eslint devDep `9.39.4 → 10.5.0` + `tsx`/`turbo` removal — needs a `bun install` + `eslint .` + suite cycle (root `.bin/eslint` currently resolves to v9, so the bump changes which major lints the whole repo).
- [#310](https://github.com/ArcadeAI/safeword/issues/310) prettier/CI — `.prettierignore` is safeword-owned and lacks `dist/`+`.claude/` exclusions, so wiring `prettier --check` into CI needs template-level work, not a quick edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)