### PR TITLE
docs(versioning): regenerate bun.lock during the release bump (#312)

### DIFF
--- a/.claude/skills/versioning/SKILL.md
+++ b/.claude/skills/versioning/SKILL.md
@@ -82,11 +82,19 @@ The publish path is CI-driven via OIDC trusted publishing. Tag push → GitHub A
    - `packages/cli/package.json` → `version`
    - `marketplace.json` → `plugins[0].version`
 
+   Then **regenerate the lockfile** so `bun.lock`'s `packages/cli` workspace
+   version tracks `package.json` — otherwise it drifts and CI's lockfile-drift
+   gate fails the next PR that touches `package.json` (see #312):
+
+   ```bash
+   bun install # rewrites bun.lock's workspace version; no resolution change
+   ```
+
 3. **PR + admin-merge.** `main` is protected:
 
    ```bash
    git checkout -b release/vX.Y.Z
-   git add packages/cli/package.json marketplace.json
+   git add packages/cli/package.json marketplace.json bun.lock
    git commit -m "chore(release): vX.Y.Z"
    git push -u origin release/vX.Y.Z
    gh pr create --title "chore(release): vX.Y.Z" --body "..."


### PR DESCRIPTION
## What

The version-bump procedure in the `versioning` skill updated `packages/cli/package.json` and `marketplace.json` but never the lockfile, so `bun.lock`'s `packages/cli` workspace version drifted one release behind (`0.53.0` while `package.json` was `0.54.0`).

Because release PRs are admin-merged, CI's lockfile-drift gate (`bun install --lockfile-only` + `git diff`) is bypassed and the drift reaches `main` — then surfaces as a surprise failure on the next PR that touches `package.json` (exactly what hit #309 this session).

## Fix

Add a `bun install` step to the bump procedure (step 2) and stage `bun.lock` in the release commit (step 3). No dependency-resolution change — only the workspace version field is rewritten.

Doc-only change to a Claude-only skill (no template/dogfood mirrors, so no parity surface).

## Note

The current `main` drift was already corrected incidentally by #309; this prevents recurrence at the source. A complementary enforcement (pre-commit assertion that `bun.lock`'s workspace version matches `package.json`) was considered but skipped — `bun.lock` is JSONC and brittle to parse in a hook one-liner, and the existing CI gate already covers every non-admin-merged PR.

Closes #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cktDNJuULcB8NJYGfBH5e)_