### PR TITLE
fix: dependency-readiness uses content fingerprint, not mtime (#282)

### DIFF
--- a/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
+++ b/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
@@ -2,7 +2,7 @@
 id: 4JMBXT
 slug: dep-readiness-mtime-stale
 type: patch
-phase: intake
+phase: done
 status: in_progress
 created: 2026-06-21T15:19:39.648Z
 last_modified: 2026-06-21T15:19:39.648Z
@@ -20,3 +20,8 @@ last_modified: 2026-06-21T15:19:39.648Z
 - 2026-06-21 Context: fix committed as 5f1a166 on branch claude/github-issue-282-pyebfb before ticket existed (jumped straight to impl because issue carried a complete figure-it-out decision).
 - 2026-06-21 Design (per #282 comment): content-fingerprint marker `node_modules/.safeword-deps-fingerprint`, stamped on `ready` by hooks; getDependencyReadiness short-circuits ready on marker==fingerprint, mtime demoted to bootstrap fallback. Applied to template + .safeword mirror (parity clean). Tests: rebase-suppressed + real-change-detected. 51/51 hook tests pass.
 - 2026-06-21 Now running full QC: verify → quality-review → audit → refactor.
+- 2026-06-21 VERIFY: full suite 3183 passed / 5 skipped (211 files); tsup build success; gherkin 69/69; eslint+gherkin-lint+typecheck clean; dep drift clean (no new deps).
+- 2026-06-21 QUALITY-REVIEW: independent fresh-context reviewer → APPROVE, 0 critical. Confirmed marker can't mask a real content change (mismatch falls through to mtime); trim/newline round-trips; no scan/gitignore pollution. Acted on its one real gap → added hook-level marker-stamp integration test + unsupported no-op guard test (commit fb311f2). 53/53 hook tests.
+- 2026-06-21 AUDIT: scoped to diff — no new cross-module imports/cycles (depcruise covers packages/\*/src only, not templates/hooks); jscpd 0 clones; no dead code (writeInstallMarker used by 2 hooks + tests). Repo-wide knip/outdated left as pre-existing, out of patch scope. Audit passed.
+- 2026-06-21 REFACTOR: one ledger entry — duplicate `ready` return literal in getDependencyReadiness. Collapsed to "stale only when !markerFresh && mtime-stale; else ready" (commit 00a66ca). Behavior-identical (truth table preserved), also skips statSync when marker matches. 53/53 green.
+- 2026-06-21 Phase=done. Awaiting user confirmation before status=done.

--- a/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
+++ b/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
@@ -1,0 +1,22 @@
+---
+id: 4JMBXT
+slug: dep-readiness-mtime-stale
+type: patch
+phase: intake
+status: in_progress
+created: 2026-06-21T15:19:39.648Z
+last_modified: 2026-06-21T15:19:39.648Z
+---
+
+# dependency-readiness false-positive stale after rebase (mtime vs content)
+
+**Goal:** Make the dependency-readiness stale decision content-based (fingerprint marker) so rebase/checkout/clone no longer falsely block dependency-backed commands.
+
+**Why:** GH #282 — pure-mtime staleness reports "stale forever" after any content-preserving op + no-op `bun ci`, hard-blocking the test/lint toolchain with only `touch node_modules` as escape.
+
+## Work Log
+
+- 2026-06-21T15:19:39.648Z Started: Created ticket 4JMBXT (retroactive; fix already implemented + pushed)
+- 2026-06-21 Context: fix committed as 5f1a166 on branch claude/github-issue-282-pyebfb before ticket existed (jumped straight to impl because issue carried a complete figure-it-out decision).
+- 2026-06-21 Design (per #282 comment): content-fingerprint marker `node_modules/.safeword-deps-fingerprint`, stamped on `ready` by hooks; getDependencyReadiness short-circuits ready on marker==fingerprint, mtime demoted to bootstrap fallback. Applied to template + .safeword mirror (parity clean). Tests: rebase-suppressed + real-change-detected. 51/51 hook tests pass.
+- 2026-06-21 Now running full QC: verify → quality-review → audit → refactor.

--- a/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
+++ b/.project/tickets/4JMBXT-dep-readiness-mtime-stale/ticket.md
@@ -5,7 +5,7 @@ type: patch
 phase: done
 status: in_progress
 created: 2026-06-21T15:19:39.648Z
-last_modified: 2026-06-21T15:19:39.648Z
+last_modified: 2026-06-21T15:45:13.912Z
 ---
 
 # dependency-readiness false-positive stale after rebase (mtime vs content)

--- a/.project/tickets/4JMBXT-dep-readiness-mtime-stale/verify.md
+++ b/.project/tickets/4JMBXT-dep-readiness-mtime-stale/verify.md
@@ -1,0 +1,32 @@
+# Verify Checklist
+
+**Ticket:** 4JMBXT — dependency-readiness false-positive stale after rebase (mtime vs content)
+**Type:** patch
+**Date:** 2026-06-21
+
+**Test Suite:** ✓ 3183/3183 tests pass (5 skipped, 211 files); dependency-readiness hook suite 53/53
+**Gherkin:** ✅ Acceptance lane passes (69 scenarios, 741 steps)
+**Build:** ✅ Success (tsup ESM + DTS)
+**Lint:** ✅ Clean (eslint + gherkin-lint + tsc --noEmit)
+**Scenarios:** ⏭️ Skipped — patch ticket, no test-definitions.md (behavior covered by unit/integration tests)
+**Dep Drift:** ✅ Clean — no new dependencies added (only `node:fs`/`node:crypto`/`node:path` built-ins)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — content-marker mirrors npm's hidden-lockfile staleness pattern; existing exported-helper + template/`.safeword` mirror conventions followed
+**Audit passed** — scoped to diff: no new cross-module imports or cycles (depcruise covers `packages/*/src` only), jscpd 0 clones, no dead code (`writeInstallMarker` consumed by both hooks + tests). Repo-wide knip/outdated are pre-existing and out of patch scope.
+
+## Quality Review
+
+Independent fresh-context review → **APPROVE**, 0 critical issues. Confirmed the marker can never mask a genuine content change (a fingerprint mismatch falls through to the existing mtime check), the trim/newline round-trips cleanly, and there is no workspace-scan or gitignore pollution. Acted on its one real finding: added a hook-level marker-stamp integration test and an `unsupported` no-op guard test.
+
+## Refactor
+
+One ledger entry resolved: collapsed the duplicate `ready` return literal in `getDependencyReadiness` into a single `markerFresh` guard ("stale only when `!markerFresh && isInstallArtifactStale`; else ready"). Behavior-identical (truth table preserved) and skips `statSync` when the marker matches. 53/53 green after.
+
+## Commits
+
+- `5f1a166` fix: content-based stale check (marker + mtime fallback)
+- `fb311f2` test: hook-level marker stamping + unsupported no-op
+- `00a66ca` refactor: collapse duplicate ready-return
+- ticket + QC-log commits
+
+Ready to mark done (pending user confirmation).

--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -54,6 +54,7 @@ export interface DependencyReadinessState {
 }
 
 const INSTALL_ARTIFACT = 'node_modules';
+const INSTALL_MARKER_FILENAME = '.safeword-deps-fingerprint';
 const DEPENDENCY_STATE_FILENAME = 'dependency-readiness.json';
 const BUN_LOCKFILES = ['bun.lock', 'bun.lockb'];
 const WORKSPACE_SCAN_EXCLUDED_DIRECTORIES = new Set([
@@ -180,6 +181,21 @@ export function getDependencyReadiness(projectDirectory: string): DependencyRead
     };
   }
 
+  // Content-fingerprint marker is the authoritative freshness signal: it
+  // survives content-preserving operations (rebase, checkout, clone, cp) that
+  // bump input mtimes without changing input content. mtime is only a
+  // bootstrap fallback for the first check after an install, before any hook
+  // has stamped the marker.
+  if (readInstallMarker(projectDirectory, plan) === fingerprint) {
+    return {
+      status: 'ready',
+      reason: 'install_artifact_current',
+      installCommand,
+      fingerprint,
+      plan,
+    };
+  }
+
   if (isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
     return {
       status: 'stale',
@@ -246,6 +262,31 @@ export function readDependencyReadinessState(
   projectDirectory: string,
 ): DependencyReadinessState | undefined {
   return readJsonFile<DependencyReadinessState>(getDependencyReadinessStatePath(projectDirectory));
+}
+
+export function writeInstallMarker(projectDirectory: string, readiness: DependencyReadiness): void {
+  if (readiness.status !== 'ready') return;
+  const { plan, fingerprint } = readiness;
+  if (plan === undefined || fingerprint === undefined) return;
+
+  try {
+    writeFileSync(installMarkerPath(projectDirectory, plan), fingerprint);
+  } catch {
+    // The marker shares node_modules' lifecycle and is best-effort. A failure
+    // to stamp it simply falls back to the mtime check on the next read.
+  }
+}
+
+function readInstallMarker(projectDirectory: string, plan: DependencyPlan): string | undefined {
+  try {
+    return readFileSync(installMarkerPath(projectDirectory, plan), 'utf8').trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function installMarkerPath(projectDirectory: string, plan: DependencyPlan): string {
+  return nodePath.join(projectDirectory, plan.installArtifact, INSTALL_MARKER_FILENAME);
 }
 
 export function toDependencyReadinessState(

--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -181,22 +181,14 @@ export function getDependencyReadiness(projectDirectory: string): DependencyRead
     };
   }
 
-  // Content-fingerprint marker is the authoritative freshness signal: it
+  // The content-fingerprint marker is the authoritative freshness signal: it
   // survives content-preserving operations (rebase, checkout, clone, cp) that
-  // bump input mtimes without changing input content. mtime is only a
-  // bootstrap fallback for the first check after an install, before any hook
-  // has stamped the marker.
-  if (readInstallMarker(projectDirectory, plan) === fingerprint) {
-    return {
-      status: 'ready',
-      reason: 'install_artifact_current',
-      installCommand,
-      fingerprint,
-      plan,
-    };
-  }
+  // bump input mtimes without changing input content. mtime is only a bootstrap
+  // fallback for the first check after an install, before any hook has stamped
+  // the marker — so it is consulted only when the marker is absent or stale.
+  const markerFresh = readInstallMarker(projectDirectory, plan) === fingerprint;
 
-  if (isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
+  if (!markerFresh && isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
     return {
       status: 'stale',
       reason: 'install_artifact_stale',

--- a/.safeword/hooks/pre-tool-dependency-readiness.ts
+++ b/.safeword/hooks/pre-tool-dependency-readiness.ts
@@ -10,6 +10,7 @@ import {
   isDependencyBackedCommand,
   toDependencyReadinessState,
   writeDependencyReadinessState,
+  writeInstallMarker,
 } from './lib/dependency-readiness.ts';
 
 interface HookInput {
@@ -53,6 +54,7 @@ if (command === undefined || !isDependencyBackedCommand(command)) {
 const readiness = getDependencyReadiness(projectDirectory);
 if (readiness.status === 'ready' || readiness.status === 'unsupported') {
   writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+  writeInstallMarker(projectDirectory, readiness);
   process.exit(0);
 }
 

--- a/.safeword/hooks/session-dependency-readiness.ts
+++ b/.safeword/hooks/session-dependency-readiness.ts
@@ -11,6 +11,7 @@ import {
   readDependencyBootstrapConfig,
   toDependencyReadinessState,
   writeDependencyReadinessState,
+  writeInstallMarker,
 } from './lib/dependency-readiness.ts';
 
 interface SessionStartOutput {
@@ -34,6 +35,7 @@ if (readiness.status === 'unsupported') {
 
 if (readiness.status === 'ready') {
   writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+  writeInstallMarker(projectDirectory, readiness);
   process.exit(0);
 }
 
@@ -51,6 +53,7 @@ if (config.autoInstall && readiness.plan !== undefined) {
 
   if (result.status === 0 && readiness.status === 'ready') {
     writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+    writeInstallMarker(projectDirectory, readiness);
     emitContext(`SAFEWORD: dependencies bootstrapped with \`${display}\`.`);
   }
 

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -54,6 +54,7 @@ export interface DependencyReadinessState {
 }
 
 const INSTALL_ARTIFACT = 'node_modules';
+const INSTALL_MARKER_FILENAME = '.safeword-deps-fingerprint';
 const DEPENDENCY_STATE_FILENAME = 'dependency-readiness.json';
 const BUN_LOCKFILES = ['bun.lock', 'bun.lockb'];
 const WORKSPACE_SCAN_EXCLUDED_DIRECTORIES = new Set([
@@ -180,6 +181,21 @@ export function getDependencyReadiness(projectDirectory: string): DependencyRead
     };
   }
 
+  // Content-fingerprint marker is the authoritative freshness signal: it
+  // survives content-preserving operations (rebase, checkout, clone, cp) that
+  // bump input mtimes without changing input content. mtime is only a
+  // bootstrap fallback for the first check after an install, before any hook
+  // has stamped the marker.
+  if (readInstallMarker(projectDirectory, plan) === fingerprint) {
+    return {
+      status: 'ready',
+      reason: 'install_artifact_current',
+      installCommand,
+      fingerprint,
+      plan,
+    };
+  }
+
   if (isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
     return {
       status: 'stale',
@@ -246,6 +262,31 @@ export function readDependencyReadinessState(
   projectDirectory: string,
 ): DependencyReadinessState | undefined {
   return readJsonFile<DependencyReadinessState>(getDependencyReadinessStatePath(projectDirectory));
+}
+
+export function writeInstallMarker(projectDirectory: string, readiness: DependencyReadiness): void {
+  if (readiness.status !== 'ready') return;
+  const { plan, fingerprint } = readiness;
+  if (plan === undefined || fingerprint === undefined) return;
+
+  try {
+    writeFileSync(installMarkerPath(projectDirectory, plan), fingerprint);
+  } catch {
+    // The marker shares node_modules' lifecycle and is best-effort. A failure
+    // to stamp it simply falls back to the mtime check on the next read.
+  }
+}
+
+function readInstallMarker(projectDirectory: string, plan: DependencyPlan): string | undefined {
+  try {
+    return readFileSync(installMarkerPath(projectDirectory, plan), 'utf8').trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function installMarkerPath(projectDirectory: string, plan: DependencyPlan): string {
+  return nodePath.join(projectDirectory, plan.installArtifact, INSTALL_MARKER_FILENAME);
 }
 
 export function toDependencyReadinessState(

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -181,22 +181,14 @@ export function getDependencyReadiness(projectDirectory: string): DependencyRead
     };
   }
 
-  // Content-fingerprint marker is the authoritative freshness signal: it
+  // The content-fingerprint marker is the authoritative freshness signal: it
   // survives content-preserving operations (rebase, checkout, clone, cp) that
-  // bump input mtimes without changing input content. mtime is only a
-  // bootstrap fallback for the first check after an install, before any hook
-  // has stamped the marker.
-  if (readInstallMarker(projectDirectory, plan) === fingerprint) {
-    return {
-      status: 'ready',
-      reason: 'install_artifact_current',
-      installCommand,
-      fingerprint,
-      plan,
-    };
-  }
+  // bump input mtimes without changing input content. mtime is only a bootstrap
+  // fallback for the first check after an install, before any hook has stamped
+  // the marker — so it is consulted only when the marker is absent or stale.
+  const markerFresh = readInstallMarker(projectDirectory, plan) === fingerprint;
 
-  if (isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
+  if (!markerFresh && isInstallArtifactStale(projectDirectory, plan, artifactPath)) {
     return {
       status: 'stale',
       reason: 'install_artifact_stale',

--- a/packages/cli/templates/hooks/pre-tool-dependency-readiness.ts
+++ b/packages/cli/templates/hooks/pre-tool-dependency-readiness.ts
@@ -10,6 +10,7 @@ import {
   isDependencyBackedCommand,
   toDependencyReadinessState,
   writeDependencyReadinessState,
+  writeInstallMarker,
 } from './lib/dependency-readiness.ts';
 
 interface HookInput {
@@ -53,6 +54,7 @@ if (command === undefined || !isDependencyBackedCommand(command)) {
 const readiness = getDependencyReadiness(projectDirectory);
 if (readiness.status === 'ready' || readiness.status === 'unsupported') {
   writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+  writeInstallMarker(projectDirectory, readiness);
   process.exit(0);
 }
 

--- a/packages/cli/templates/hooks/session-dependency-readiness.ts
+++ b/packages/cli/templates/hooks/session-dependency-readiness.ts
@@ -11,6 +11,7 @@ import {
   readDependencyBootstrapConfig,
   toDependencyReadinessState,
   writeDependencyReadinessState,
+  writeInstallMarker,
 } from './lib/dependency-readiness.ts';
 
 interface SessionStartOutput {
@@ -34,6 +35,7 @@ if (readiness.status === 'unsupported') {
 
 if (readiness.status === 'ready') {
   writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+  writeInstallMarker(projectDirectory, readiness);
   process.exit(0);
 }
 
@@ -51,6 +53,7 @@ if (config.autoInstall && readiness.plan !== undefined) {
 
   if (result.status === 0 && readiness.status === 'ready') {
     writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
+    writeInstallMarker(projectDirectory, readiness);
     emitContext(`SAFEWORD: dependencies bootstrapped with \`${display}\`.`);
   }
 

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -10,6 +10,7 @@ import {
   getDependencyReadiness,
   isDependencyBackedCommand,
   readDependencyBootstrapConfig,
+  writeInstallMarker,
 } from '../../templates/hooks/lib/dependency-readiness.js';
 import {
   createTemporaryDirectory,
@@ -233,6 +234,65 @@ describe('dependency readiness hook support', () => {
       status: 'ready',
       installCommand: 'bun ci',
     });
+  });
+
+  it('stays ready after a content-preserving op bumps input mtimes past the artifact', () => {
+    writeBunProject();
+    const artifact = path.join(projectDirectory, 'node_modules');
+    mkdirSync(artifact);
+
+    // A hook stamps the marker once dependencies resolve ready.
+    const ready = getDependencyReadiness(projectDirectory);
+    expect(ready.status).toBe('ready');
+    writeInstallMarker(projectDirectory, ready);
+
+    // Simulate a rebase/checkout: input mtimes jump forward while content is
+    // unchanged, and a no-op `bun ci` never touches the artifact.
+    const future = new Date(Date.now() + 60_000);
+    for (const input of ['package.json', 'bun.lock', 'packages/cli/package.json']) {
+      utimesSync(path.join(projectDirectory, input), future, future);
+    }
+
+    expect(getDependencyReadiness(projectDirectory)).toMatchObject({
+      status: 'ready',
+      reason: 'install_artifact_current',
+    });
+
+    // Without the marker the mtime fallback would (incorrectly) flag stale —
+    // proving the marker is what keeps the worktree usable after a rebase.
+    rmSync(path.join(artifact, '.safeword-deps-fingerprint'));
+    expect(getDependencyReadiness(projectDirectory).status).toBe('stale');
+  });
+
+  it('reports stale when tracked input content changes, then ready once re-stamped', () => {
+    writeBunProject();
+    const artifact = path.join(projectDirectory, 'node_modules');
+    mkdirSync(artifact);
+    writeInstallMarker(projectDirectory, getDependencyReadiness(projectDirectory));
+
+    // A genuine dependency-spec change: content differs from the marker, and the
+    // artifact has not been reinstalled yet (mtime behind the changed input).
+    writeTestFile(projectDirectory, 'bun.lock', '# changed lockfile');
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(artifact, past, past);
+
+    expect(getDependencyReadiness(projectDirectory)).toMatchObject({
+      status: 'stale',
+      reason: 'install_artifact_stale',
+    });
+
+    // Reinstall bumps the artifact mtime (bun repoints symlinks); the mtime
+    // fallback then resolves ready and the hook re-stamps the new fingerprint.
+    const future = new Date(Date.now() + 60_000);
+    utimesSync(artifact, future, future);
+    const reinstalled = getDependencyReadiness(projectDirectory);
+    expect(reinstalled.status).toBe('ready');
+    writeInstallMarker(projectDirectory, reinstalled);
+
+    // A later rebase pushes the artifact mtime behind again, but the refreshed
+    // marker still matches the current content, so it stays ready.
+    utimesSync(artifact, past, past);
+    expect(getDependencyReadiness(projectDirectory).status).toBe('ready');
   });
 
   it('reads explicit auto-install opt-in from safeword config', () => {

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -474,4 +474,34 @@ describe('dependency readiness hook support', () => {
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('');
   });
+
+  it('session hook stamps the install marker when dependencies are ready', () => {
+    writeBunProject();
+    markSafewordProject();
+    mkdirSync(path.join(projectDirectory, 'node_modules'));
+
+    const result = runHook(SESSION_HOOK);
+
+    expect(result.status).toBe(0);
+    const plan = detectDependencyPlan(projectDirectory);
+    if (plan === undefined) throw new Error('expected Bun dependency plan');
+    expect(readTestFile(projectDirectory, 'node_modules/.safeword-deps-fingerprint')).toBe(
+      dependencyInputFingerprint(projectDirectory, plan),
+    );
+  });
+
+  it('does not stamp a marker for unsupported projects', () => {
+    // No package.json/lockfile → unsupported readiness carries no plan or
+    // fingerprint. writeInstallMarker must no-op rather than crash, since the
+    // pre-tool hook calls it on the unsupported branch.
+    const readiness = getDependencyReadiness(projectDirectory);
+    expect(readiness.status).toBe('unsupported');
+
+    expect(() => {
+      writeInstallMarker(projectDirectory, readiness);
+    }).not.toThrow();
+    expect(
+      existsSync(path.join(projectDirectory, 'node_modules', '.safeword-deps-fingerprint')),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #282.

## Problem

`isInstallArtifactStale` decided staleness purely by **mtime** — comparing `node_modules`' mtime against the input files' mtimes (`package.json`, `bun.lock`, workspace `package.json`s). Any content-preserving operation (rebase, `git checkout`, fresh clone, `cp`) rewrites the input mtimes to *now* without changing content. A no-op `bun ci` then leaves `node_modules` untouched, so the guard reported **"stale forever"** and blocked every dependency-backed command — the only escape was `touch node_modules`. Meanwhile `dependencyInputFingerprint` already computed a content sha256 that the decision ignored.

## Fix

A **content-fingerprint marker** inside the artifact (`node_modules/.safeword-deps-fingerprint`):

- `getDependencyReadiness` short-circuits to `ready` when the marker matches the current input fingerprint, **before** the mtime check. mtime is demoted to a bootstrap-only fallback for the first check after an install.
- `writeInstallMarker` stamps the fingerprint whenever readiness resolves `ready` (guarded so it never writes on `stale`/`missing`/`unsupported`, which would mask a real change). Wired into the `ready` paths of both hooks plus the session auto-install success path.
- The marker shares `node_modules`' lifecycle — gone on reinstall, untouched by git on rebase — so it survives exactly the operations that defeat mtime, while a genuine dependency-spec change still flips the fingerprint and reports `stale`. This mirrors npm's own hidden-lockfile staleness pattern.

Applied to both the template (`packages/cli/templates/hooks/`) and the dogfood mirror (`.safeword/hooks/`), kept byte-identical.

## Why it's safe (the dangerous direction)

A marker match means the input content is byte-identical to a state previously declared `ready`. Any real content change alters the fingerprint, the marker mismatches, and control falls through to the existing mtime check — so the marker can **never** mask a genuinely stale install; it only adds a provably-correct ready path.

## Tests

- **rebase-suppressed**: bump all input mtimes past the artifact → still `ready`; remove the marker → `stale` (proves the marker is load-bearing).
- **real-change-detected**: change `bun.lock` content + push artifact mtime back → `stale`; bump artifact mtime (reinstall) → `ready` via mtime fallback + re-stamp → survives a later mtime regression.
- **hook integration**: session hook driven to `ready` lands the marker file with the correct fingerprint.
- **unsupported no-op**: `writeInstallMarker` on an `unsupported` readiness is a silent no-op.

Full suite: 3183 passed / 5 skipped (211 files); build success; gherkin 69/69; lint/typecheck clean.

## Deferred (separate, non-blocking — both noted in #282)

- Recovery text hard-codes `bun ci`; a dependency *add* wants `bun install`.
- Optional hardening: a `PostToolUse` hook that stamps the marker on successful `bun ci`/`bun install`, removing the mtime fallback entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfGYyxJFX3L13ejEy97k96)_