### PR TITLE
ci: enforce prettier --check and clear formatting drift (#310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Format check
+        # prettier --check . — guards against formatting drift that eslint
+        # does not catch. Pre-commit (lint-staged) only formats staged files,
+        # so drift could land on main undetected before this step existed.
+        run: bun run format:check
+
       - name: Type check
         run: bun run --cwd packages/cli typecheck
 

--- a/.project/learnings/intake-readiness-architect-consultant-analogy.md
+++ b/.project/learnings/intake-readiness-architect-consultant-analogy.md
@@ -6,50 +6,50 @@ What a world-class engineer/architect and a top-tier consultant ask at intake wh
 
 ## Architect's signature move: make the fuzzy measurable + surface constraints
 
-Architects are pulled into elicitation early (>60% involvement) and their distinctive contribution is turning vague quality words into **measurable fit criteria / quality scenarios**. "No one can explain what they mean by performance, scalability, usability, maintainability" — the architect's job is to make the "-ilities" concrete and measurable. Rule of thumb: *if a tester cannot measure success, the requirement is incomplete.*
+Architects are pulled into elicitation early (>60% involvement) and their distinctive contribution is turning vague quality words into **measurable fit criteria / quality scenarios**. "No one can explain what they mean by performance, scalability, usability, maintainability" — the architect's job is to make the "-ilities" concrete and measurable. Rule of thumb: _if a tester cannot measure success, the requirement is incomplete._
 
 Two intake axes this adds:
 
-1. **Non-functional / constraint questions.** Scale, performance, security, compatibility, *what must not break*, *who maintains this*, *what can't change*. These drive architecture and are expensive to retrofit — i.e. exactly the irreversible / high-blast category the readiness gate already cares about.
+1. **Non-functional / constraint questions.** Scale, performance, security, compatibility, _what must not break_, _who maintains this_, _what can't change_. These drive architecture and are expensive to retrofit — i.e. exactly the irreversible / high-blast category the readiness gate already cares about.
 2. **Fit criteria over vibes.** "How will I know it's done" must be a measurable criterion, not a feeling. Sharpens `done_when`.
 
 Tools named: Architecture Characteristics Worksheet, quality scenarios, fit criteria. "Prototypes help elicit NFRs but never replace written fit criteria."
 
 ### Fresh-evidence sharpening: constraint decay (the load-bearing finding for a coding agent)
 
-A 2026 study ("Constraint Decay: The Fragility of LLM Agents in Backend Code Generation", arXiv 2605.06445) shows LLM coding-agent performance *declines as structural / non-functional constraints accumulate*, and that NFRs (architectural patterns, DBs, ORMs) are exactly what agents fail on. This cuts two ways and settles the design:
+A 2026 study ("Constraint Decay: The Fragility of LLM Agents in Backend Code Generation", arXiv 2605.06445) shows LLM coding-agent performance _declines as structural / non-functional constraints accumulate_, and that NFRs (architectural patterns, DBs, ORMs) are exactly what agents fail on. This cuts two ways and settles the design:
 
 - Constraints are **where coding agents fail** → surface the load-bearing ones at intake (don't defer to build).
-- But piling on constraints **degrades** the agent → surface only the *load-bearing* one ("what must not break / who depends / reversible?"), never an exhaustive NFR sweep. An NFR quality-attributes survey is self-defeating — it triggers the decay it's meant to prevent.
+- But piling on constraints **degrades** the agent → surface only the _load-bearing_ one ("what must not break / who depends / reversible?"), never an exhaustive NFR sweep. An NFR quality-attributes survey is self-defeating — it triggers the decay it's meant to prevent.
 
 The classic cost-of-late-defect curve (requirements defects ~20–400× cheaper to fix early; one defect propagates across design+code+tests) directionally supports early constraint capture — but note the honest caveat that this evidence is "sparse and very old," so it is corroborating, not load-bearing. The 2026 agentic-coding consensus is to balance upfront spec clarity with iterative refinement, not front-load everything.
 
 ## Consultant's signature move: the problem behind the problem + the stakeholder landscape
 
 - **"Search for the problem behind the problem" and remain curious.** Consultants assume the stated problem is a symptom — the sharpest form of the XY-problem guard.
-- **Stakeholder dynamics over advice.** "More engagements fail because of stakeholder dynamics than bad advice." Surface *who* the stakeholders are and their conflicting views before starting; talk to the people closest to the problem, not just the point of contact.
-- **The killer probe:** *"What would need to be true for this to be a definitive yes for you?"* — reveals hidden decision criteria and unnamed stakeholders in one question. High information gain; worth stealing for gate copy.
+- **Stakeholder dynamics over advice.** "More engagements fail because of stakeholder dynamics than bad advice." Surface _who_ the stakeholders are and their conflicting views before starting; talk to the people closest to the problem, not just the point of contact.
+- **The killer probe:** _"What would need to be true for this to be a definitive yes for you?"_ — reveals hidden decision criteria and unnamed stakeholders in one question. High information gain; worth stealing for gate copy.
 - **Scope explicitly** to prevent scope creep.
 
 ## The specific ask: technical vs non-technical requester
 
 The expert's real job is to **normalize the request shape** to the same intent + constraints + fit-criteria core, regardless of who sent it:
 
-- **Non-technical requester → under-specified.** Gives outcomes in domain language; omits the non-functionals they don't know to state (security, scale, failure modes). Expert *translates* to technical requirements, fills the unstated NFRs, restates in the requester's language, and confirms. "Avoid ambiguous terms; every requirement must support validation."
+- **Non-technical requester → under-specified.** Gives outcomes in domain language; omits the non-functionals they don't know to state (security, scale, failure modes). Expert _translates_ to technical requirements, fills the unstated NFRs, restates in the requester's language, and confirms. "Avoid ambiguous terms; every requirement must support validation."
 - **Technical requester → over-specified as a solution.** Often hands a solution (X) rather than the problem (Y). Expert reverse-engineers the intent and pressure-tests the proposed approach — the risk is anchoring on their stated solution.
 
-Both failure shapes — under-specified and solution-in-disguise — collapse to the same core. A coding agent receives both kinds constantly, so the intake must detect *which shape* it got and correct for it.
+Both failure shapes — under-specified and solution-in-disguise — collapse to the same core. A coding agent receives both kinds constantly, so the intake must detect _which shape_ it got and correct for it.
 
 ## The four-domain convergence
 
-| Domain | Adds to the readiness core |
-| --- | --- |
-| Mission command | Intent + end-state; prudent risk within intent |
-| PM (Cagan) | Objective, success-signal, problem-not-solution, who; riskiest assumption |
-| Architect | **Constraints / non-functionals; make done-state measurable** |
-| Consultant | **Problem-behind-the-problem; stakeholder landscape; "definitive yes" probe; request-shape normalization** |
+| Domain          | Adds to the readiness core                                                                                 |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| Mission command | Intent + end-state; prudent risk within intent                                                             |
+| PM (Cagan)      | Objective, success-signal, problem-not-solution, who; riskiest assumption                                  |
+| Architect       | **Constraints / non-functionals; make done-state measurable**                                              |
+| Consultant      | **Problem-behind-the-problem; stakeholder landscape; "definitive yes" probe; request-shape normalization** |
 
-Four independent fields converge on a small, bounded, problem/outcome-focused intake — and the two new axes (constraints + request-shape) are precisely what a *coding* agent needs that generic intent-clarification misses.
+Four independent fields converge on a small, bounded, problem/outcome-focused intake — and the two new axes (constraints + request-shape) are precisely what a _coding_ agent needs that generic intent-clarification misses.
 
 ## What this adds to TPP6Y2's self-test
 

--- a/.project/learnings/intake-readiness-leadership-analogy.md
+++ b/.project/learnings/intake-readiness-leadership-analogy.md
@@ -2,31 +2,31 @@
 
 Covers: intake readiness gate, commander's intent, situational leadership, when-to-ask vs. act, propose-and-converge validation, TPP6Y2.
 
-How people-management and leadership research maps onto how the safeword agent should gather context before executing. Researched during ticket TPP6Y2 (pm-grade-intake readiness gate) as an analogy for "get enough context, then run." Complements `propose-and-converge-research.md` (the interaction pattern) with the *operating model* behind it.
+How people-management and leadership research maps onto how the safeword agent should gather context before executing. Researched during ticket TPP6Y2 (pm-grade-intake readiness gate) as an analogy for "get enough context, then run." Complements `propose-and-converge-research.md` (the interaction pattern) with the _operating model_ behind it.
 
 ## The load-bearing model: Mission Command
 
-The strongest analogy for "extract enough to act independently, then run" is military **mission command**. A subordinate clarifies the **commander's intent** — the *why* and the *end-state* — to the point they can act on their own, then exercises **disciplined initiative** and **prudent risk** within that intent. The clarifying that matters is about intent and end-state, **not** exhaustive parameters.
+The strongest analogy for "extract enough to act independently, then run" is military **mission command**. A subordinate clarifies the **commander's intent** — the _why_ and the _end-state_ — to the point they can act on their own, then exercises **disciplined initiative** and **prudent risk** within that intent. The clarifying that matters is about intent and end-state, **not** exhaustive parameters.
 
-Design consequence: the readiness self-test should be weighted toward *intent-level* unknowns ("do I understand why, and what done looks like, well enough to take prudent risk at this blast radius?") over *detail-level* unknowns (a parameter checklist). An agent that nailed every parameter but missed the intent ships the wrong thing confidently; one that grasped the intent fills small unknowns correctly on its own.
+Design consequence: the readiness self-test should be weighted toward _intent-level_ unknowns ("do I understand why, and what done looks like, well enough to take prudent risk at this blast radius?") over _detail-level_ unknowns (a parameter checklist). An agent that nailed every parameter but missed the intent ships the wrong thing confidently; one that grasped the intent fills small unknowns correctly on its own.
 
 ## The dial: Situational Leadership
 
-Hersey-Blanchard: match direction-vs-autonomy to **follower readiness** (competence × commitment) — Directing/Telling when readiness is low, Delegating when high — and *assess readiness before choosing a style*. ~50 years of evidence: contingent-on-readiness beats any fixed style.
+Hersey-Blanchard: match direction-vs-autonomy to **follower readiness** (competence × commitment) — Directing/Telling when readiness is low, Delegating when high — and _assess readiness before choosing a style_. ~50 years of evidence: contingent-on-readiness beats any fixed style.
 
 Design consequence: validates "depth scales with ambiguity × blast radius" and confirms a **fixed** amount of upfront questioning (the rejected hard gate) is the wrong shape. Low readiness / high blast → clarify intent first. High readiness / low blast → run.
 
 ## The IC trait: selective early questions + self-awareness
 
-High-performer research: top performers don't ask everything — they "ask clarifying questions *before* problems escalate" and have the **self-awareness** to know what they don't know. The discriminating-question instinct is the IC mirror of the generative self-test's "name the single biggest unknown."
+High-performer research: top performers don't ask everything — they "ask clarifying questions _before_ problems escalate" and have the **self-awareness** to know what they don't know. The discriminating-question instinct is the IC mirror of the generative self-test's "name the single biggest unknown."
 
 ## Managing up validates contribute-before-asking
 
-Managing-up / leading-up literature: "never bring a problem without at least two viable solutions," and clarify the boss's intent *before* detailed planning. That is propose-and-converge almost verbatim — independent corroboration of the contribute-before-asking rule.
+Managing-up / leading-up literature: "never bring a problem without at least two viable solutions," and clarify the boss's intent _before_ detailed planning. That is propose-and-converge almost verbatim — independent corroboration of the contribute-before-asking rule.
 
 ## The trap: psychological safety misread as "ask lots"
 
-Project Aristotle found psychological safety is the top driver of team performance, and Edmondson prescribes "model curiosity and ask lots of questions." Read carelessly this licenses interrogation. Read correctly it is about making asking **cheap and non-punishing** — *safety to ask*, not *obligation to ask*. Agent translation: lower the cost of a question (contribute-before-asking already does this), don't raise the count. This is the single easiest finding to misapply.
+Project Aristotle found psychological safety is the top driver of team performance, and Edmondson prescribes "model curiosity and ask lots of questions." Read carelessly this licenses interrogation. Read correctly it is about making asking **cheap and non-punishing** — _safety to ask_, not _obligation to ask_. Agent translation: lower the cost of a question (contribute-before-asking already does this), don't raise the count. This is the single easiest finding to misapply.
 
 ## Net design principle
 

--- a/.project/learnings/intake-readiness-pm-analogy.md
+++ b/.project/learnings/intake-readiness-pm-analogy.md
@@ -6,19 +6,19 @@ What world-class product managers ask at intake, mapped to the safeword agent's 
 
 ## The headline: intake is BOUNDED, not exhaustive
 
-Marty Cagan's **Opportunity Assessment** is the canonical PM intake. The full SVPG version is **10 questions** (not four — an earlier draft of this note over-condensed it), but Cagan's explicit design goal is "quick, lightweight, yet effective," and he deliberately moved *away* from heavy PRDs toward lightweight artifacts. The load-bearing core distils to four:
+Marty Cagan's **Opportunity Assessment** is the canonical PM intake. The full SVPG version is **10 questions** (not four — an earlier draft of this note over-condensed it), but Cagan's explicit design goal is "quick, lightweight, yet effective," and he deliberately moved _away_ from heavy PRDs toward lightweight artifacts. The load-bearing core distils to four:
 
-1. **What business objective is this focused on?** — the *why* / outcome
+1. **What business objective is this focused on?** — the _why_ / outcome
 2. **How will you know if you've succeeded?** — the success signal / done-state
 3. **What problem are you solving for the customer?** — the problem, **not** the requested solution
 4. **Who are you solving it for?** — the persona
 
-Two facts matter more than the exact count. First, it is a *calibrated stopping rule* — the same "know when you know enough" theme as the clarifying-question research (`propose-and-converge-research.md`); world-class PMs hit a bounded core and stop. Second, Cagan says the assessment is worth running *even when the decision is already made* (e.g. mandated top-down) because it makes you better-informed — the value is in the thinking, not the gate.
+Two facts matter more than the exact count. First, it is a _calibrated stopping rule_ — the same "know when you know enough" theme as the clarifying-question research (`propose-and-converge-research.md`); world-class PMs hit a bounded core and stop. Second, Cagan says the assessment is worth running _even when the decision is already made_ (e.g. mandated top-down) because it makes you better-informed — the value is in the thinking, not the gate.
 
 ## Four supporting moves from the PM canon
 
 - **Job, not stated want (JTBD).** "What job is the customer hiring this for?" — surface underlying motivation, not the literal request. The XY-problem guard.
-- **Risk lens (Cagan's four big risks).** Pressure-test value, usability, feasibility, business viability. Teresa Torres' Opportunity Solution Tree terminates in *assumptions* — discovery is assumption-hunting.
+- **Risk lens (Cagan's four big risks).** Pressure-test value, usability, feasibility, business viability. Teresa Torres' Opportunity Solution Tree terminates in _assumptions_ — discovery is assumption-hunting.
 - **End-state first (Amazon Working Backwards / PR-FAQ).** Write the press release before building — articulate "done" before starting.
 - **Disambiguate terms before acting.** "When you say engagement, do you mean opens or click-through?" Clarify ambiguous words first.
 
@@ -28,7 +28,7 @@ Cagan's four questions ARE commander's intent in PM clothing: objective + succes
 
 ## Mapping to safeword (the gate adds little, recognizes a lot)
 
-Safeword *already* extracts Cagan's four: `spec.md` writes JTBD (problem + who) against a personas file, and `done_when` is the success signal. The readiness gate is not new fields — it is recognizing the existing intake IS the opportunity assessment, plus the one move both PMs and the military insist on that the current self-test underweights:
+Safeword _already_ extracts Cagan's four: `spec.md` writes JTBD (problem + who) against a personas file, and `done_when` is the success signal. The readiness gate is not new fields — it is recognizing the existing intake IS the opportunity assessment, plus the one move both PMs and the military insist on that the current self-test underweights:
 
 **"Name the biggest unknown" → "Name the riskiest assumption."** A risk, not just a gap. PMs chase the assumption most likely to be wrong and cheapest to check — not maximal coverage.
 

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/README.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/README.md
@@ -1,28 +1,28 @@
 # TPP6Y2 Research — Intake Readiness Gate
 
-Raw evidence and source material behind the readiness-gate design. The *synthesized* conclusions live in the ticket (`../ticket.md`) and in three project learnings (`.project/learnings/intake-readiness-*.md`); this folder holds the **raw findings** and **verbatim skill copies** they were drawn from, so the design is auditable without re-running the searches.
+Raw evidence and source material behind the readiness-gate design. The _synthesized_ conclusions live in the ticket (`../ticket.md`) and in three project learnings (`.project/learnings/intake-readiness-*.md`); this folder holds the **raw findings** and **verbatim skill copies** they were drawn from, so the design is auditable without re-running the searches.
 
 ## Layout
 
-| File | Contents |
-| --- | --- |
-| `findings-agent-clarification.md` | When agents should ask vs. act: CaRT, Value-of-Information, over/under-questioning, structured-vs-internal reasoning, **constraint decay**, cost-of-defect, 2026 coding-workflow consensus |
-| `findings-leadership.md` | Mission command, situational leadership, high-performer traits, Project Aristotle / psychological-safety trap |
-| `findings-product-management.md` | Cagan Opportunity Assessment (10 questions, lightweight), JTBD, Torres OST, Working Backwards, RICE |
-| `findings-architect-consultant.md` | Requirements elicitation, NFRs / fit criteria, problem-behind-the-problem, technical vs non-technical requester |
-| `findings-skills-review.md` | What was folded / rejected from each skill below |
-| `skills/` | Verbatim copies of every skill checked |
+| File                               | Contents                                                                                                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `findings-agent-clarification.md`  | When agents should ask vs. act: CaRT, Value-of-Information, over/under-questioning, structured-vs-internal reasoning, **constraint decay**, cost-of-defect, 2026 coding-workflow consensus |
+| `findings-leadership.md`           | Mission command, situational leadership, high-performer traits, Project Aristotle / psychological-safety trap                                                                              |
+| `findings-product-management.md`   | Cagan Opportunity Assessment (10 questions, lightweight), JTBD, Torres OST, Working Backwards, RICE                                                                                        |
+| `findings-architect-consultant.md` | Requirements elicitation, NFRs / fit criteria, problem-behind-the-problem, technical vs non-technical requester                                                                            |
+| `findings-skills-review.md`        | What was folded / rejected from each skill below                                                                                                                                           |
+| `skills/`                          | Verbatim copies of every skill checked                                                                                                                                                     |
 
 ## Skills captured (`skills/`)
 
-| File | Source | Verdict |
-| --- | --- | --- |
-| `safeword-elicit.SKILL.md` | safeword | Reuse its rules (Iron Law, info-gain ordering, anchoring guard, stopping rule); escalate to it |
-| `safeword-brainstorm.SKILL.md` | safeword | Folded two guards (divergence off-switch; don't announce framework) |
-| `safeword-figure-it-out.SKILL.md` | safeword | The decision method used for the passes |
-| `anthropic-doc-coauthoring.SKILL.md` | Anthropic example (`/mnt/skills/examples`) | Folded behavioral go/no-go (`:97`) + cold-start test (`:255-331`); rejected dump-first ordering |
-| `anthropic-product-brainstorming.SKILL.md` | Anthropic (pasted by user) | Resisted most (divergent machinery); folded "cheapest test" onto riskiest-assumption |
-| `anthropic-product-self-knowledge.SKILL.md` | Anthropic public (`/mnt/skills/public`) | Irrelevant (docs-routing); captured for completeness |
+| File                                        | Source                                     | Verdict                                                                                         |
+| ------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `safeword-elicit.SKILL.md`                  | safeword                                   | Reuse its rules (Iron Law, info-gain ordering, anchoring guard, stopping rule); escalate to it  |
+| `safeword-brainstorm.SKILL.md`              | safeword                                   | Folded two guards (divergence off-switch; don't announce framework)                             |
+| `safeword-figure-it-out.SKILL.md`           | safeword                                   | The decision method used for the passes                                                         |
+| `anthropic-doc-coauthoring.SKILL.md`        | Anthropic example (`/mnt/skills/examples`) | Folded behavioral go/no-go (`:97`) + cold-start test (`:255-331`); rejected dump-first ordering |
+| `anthropic-product-brainstorming.SKILL.md`  | Anthropic (pasted by user)                 | Resisted most (divergent machinery); folded "cheapest test" onto riskiest-assumption            |
+| `anthropic-product-self-knowledge.SKILL.md` | Anthropic public (`/mnt/skills/public`)    | Irrelevant (docs-routing); captured for completeness                                            |
 
 ## The converged design (for quick reference)
 

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-agent-clarification.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-agent-clarification.md
@@ -4,7 +4,7 @@ Raw web-search evidence from the TPP6Y2 figure-it-out passes. Synthesized into t
 
 ## When should an LLM agent ask vs. act (the core question)
 
-- **CaRT — "Teaching LLM Agents to Know When They Know Enough"** (arXiv 2510.08517). Frames two opposing failure modes: **over-asking** (wastes effort, frustrates users, erodes trust) and **under-asking** (acts on incomplete info, wrong output). The skill is the *threshold* — recognizing when additional questions yield diminishing returns — not the asking itself. Trains task-completion-feasibility confidence thresholds rather than fixed heuristics. https://arxiv.org/pdf/2510.08517
+- **CaRT — "Teaching LLM Agents to Know When They Know Enough"** (arXiv 2510.08517). Frames two opposing failure modes: **over-asking** (wastes effort, frustrates users, erodes trust) and **under-asking** (acts on incomplete info, wrong output). The skill is the _threshold_ — recognizing when additional questions yield diminishing returns — not the asking itself. Trains task-completion-feasibility confidence thresholds rather than fixed heuristics. https://arxiv.org/pdf/2510.08517
 - **"Learning to Ask: When LLM Agents Meet Unclear Instruction"** (EMNLP 2025 main 1104). Benchmarks clarifying agents; metrics include clarification rate, good-question rate, over-/under-questioning, dialogue efficiency, information recovery. https://aclanthology.org/2025.emnlp-main.1104.pdf
 - **Clarifying agent definition** (emergentmind): generate clarification questions until sufficient info OR further questions yield no added utility, then act. Up to +83% downstream accuracy (CoA / VQA) over strong baselines in some tasks.
 
@@ -15,7 +15,7 @@ Raw web-search evidence from the TPP6Y2 figure-it-out passes. Synthesized into t
 
 ## Structured scaffold vs. internal reasoning (is an explicit question set worth it?)
 
-- **"Exploring the Necessity of Reasoning in LLM-based Agent Scenarios"** (arXiv 2503.11074). Field is *unsettled* on whether explicit structured/tool-based reasoning complements or merely **duplicates** internal model reasoning; explicit reasoning adds computational overhead and can diminish efficiency in time-critical contexts. 2025 study: 17.14% of agent failures are step-repetitions, 13.98% reasoning/action mismatches. https://arxiv.org/pdf/2503.11074
+- **"Exploring the Necessity of Reasoning in LLM-based Agent Scenarios"** (arXiv 2503.11074). Field is _unsettled_ on whether explicit structured/tool-based reasoning complements or merely **duplicates** internal model reasoning; explicit reasoning adds computational overhead and can diminish efficiency in time-critical contexts. 2025 study: 17.14% of agent failures are step-repetitions, 13.98% reasoning/action mismatches. https://arxiv.org/pdf/2503.11074
 - Implication for TPP6Y2: keep the self-test lightweight (≤5 plain prompts), gate by blast radius; an exhaustive structured form risks pure overhead.
 
 ## Constraints are where coding agents fail (load-bearing)

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-leadership.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-leadership.md
@@ -5,21 +5,21 @@ Raw web-search evidence. Synthesized into `intake-readiness-leadership-analogy.m
 ## Mission command / commander's intent (the operating model)
 
 - **US Army, "Understanding mission command"** — philosophy: focus on commander's intent, empower subordinates to decide within it; flexibility to act fast while maintaining control. Six principles: cohesive teams via mutual trust, shared understanding, clear commander's intent, disciplined initiative, mission orders, **accept prudent risk**. https://www.army.mil/article/106872/understanding_mission_command
-- **FBI Law Enforcement Bulletin, "Commander's Intent: A Framework for Success"** — clarify the *why* and *end-state* to the point subordinates can act independently. https://leb.fbi.gov/articles/featured-articles/commanders-intent-a-framework-for-success
-- **Thayer Leadership, "Managing Your Boss with Mission Command"** — "the better you understand your boss's intent, the better you meet expectations"; meet to discuss your understanding + proposed way ahead *before* detailed planning; "never go to a boss with a problem without bringing at least two viable ways to solve it." https://thayerleadership.com/leadership-blog/managing-your-boss-with-mission-command/
+- **FBI Law Enforcement Bulletin, "Commander's Intent: A Framework for Success"** — clarify the _why_ and _end-state_ to the point subordinates can act independently. https://leb.fbi.gov/articles/featured-articles/commanders-intent-a-framework-for-success
+- **Thayer Leadership, "Managing Your Boss with Mission Command"** — "the better you understand your boss's intent, the better you meet expectations"; meet to discuss your understanding + proposed way ahead _before_ detailed planning; "never go to a boss with a problem without bringing at least two viable ways to solve it." https://thayerleadership.com/leadership-blog/managing-your-boss-with-mission-command/
 - Maps to: clarify intent/end-state, not exhaustive params; "two solutions not a problem" = contribute-before-asking.
 
 ## Situational leadership (the depth dial)
 
-- **Hersey-Blanchard Situational Leadership** — adapt style to **follower readiness** (competence × commitment). Four styles: Directing (S1), Coaching (S2), Supporting (S3), Delegating (S4) ↔ readiness D1–D4. Directing when low competence; Delegating (minimal supervision, autonomy) when high competence + commitment. *Assess readiness before choosing.* ~50 years of research: contingent-on-readiness beats fixed/mismatched styles. https://situational.com/situational-leadership/ ; https://www.indeed.com/career-advice/career-development/situational-leadership
-- Maps to: "depth scales with ambiguity × blast radius"; a *fixed* amount of upfront questioning (hard gate) is the wrong shape.
+- **Hersey-Blanchard Situational Leadership** — adapt style to **follower readiness** (competence × commitment). Four styles: Directing (S1), Coaching (S2), Supporting (S3), Delegating (S4) ↔ readiness D1–D4. Directing when low competence; Delegating (minimal supervision, autonomy) when high competence + commitment. _Assess readiness before choosing._ ~50 years of research: contingent-on-readiness beats fixed/mismatched styles. https://situational.com/situational-leadership/ ; https://www.indeed.com/career-advice/career-development/situational-leadership
+- Maps to: "depth scales with ambiguity × blast radius"; a _fixed_ amount of upfront questioning (hard gate) is the wrong shape.
 
 ## High performers (the IC traits)
 
 - Proactive: "do not wait for problems — anticipate and address before they escalate; proactively share progress, flag risks, **ask clarifying questions before problems escalate**." Self-awareness to know strengths/weaknesses and **seek support when necessary**. Learning orientation; strong communication. https://www.thrivesparrow.com/blog/characteristics-of-high-performing-employees ; https://www.indeed.com/career-advice/career-development/high-performers
-- Maps to: selective *early* questions + self-awareness = the generative "name the biggest unknown/riskiest assumption" prompt.
+- Maps to: selective _early_ questions + self-awareness = the generative "name the biggest unknown/riskiest assumption" prompt.
 
 ## Psychological safety (the trap)
 
 - **Google Project Aristotle** (re:Work) — top driver of team performance is **psychological safety**, not who is on the team. Edmondson: "frame work as a learning problem, acknowledge your own fallibility, **model curiosity and ask lots of questions**." https://rework.withgoogle.com/intl/en/guides/understand-team-effectiveness ; https://psychsafety.com/googles-project-aristotle/
-- **The trap:** "ask lots of questions" read carelessly = license to interrogate. Correct reading = make asking **cheap and non-punishing** (safety to ask), not obligation to ask. Agent translation: lower the *cost* of a question (contribute-before-asking), don't raise the *count*.
+- **The trap:** "ask lots of questions" read carelessly = license to interrogate. Correct reading = make asking **cheap and non-punishing** (safety to ask), not obligation to ask. Agent translation: lower the _cost_ of a question (contribute-before-asking), don't raise the _count_.

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-skills-review.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/findings-skills-review.md
@@ -5,6 +5,7 @@ Cross-check of the readiness-gate design against existing skills. Full copies in
 ## safeword/elicit (`skills/safeword-elicit.SKILL.md`)
 
 The gate REUSES elicit rather than duplicating it. Inherited rules:
+
 - **Iron Law** (`:11`): "NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF." → gate surfaces only user-only unknowns, after reading code/docs/git.
 - **Information-gain ordering** (`:28`): "ask the most discriminating question first… LLMs default to low-information questions — counter that deliberately."
 - **Anchoring guard** (`:50`): pre-supplied options lead; always offer "none of these."
@@ -15,12 +16,14 @@ The gate REUSES elicit rather than duplicating it. Inherited rules:
 ## safeword/brainstorm (`skills/safeword-brainstorm.SKILL.md`)
 
 Two guards folded:
+
 - **Divergence off-switch** (`:23`, "user controls convergence"): the gate is a convergence device; it stays silent while the user is exploring; activates at the brainstorm→build handoff.
 - **Don't announce the framework** (`:49`): render the five prompts as plain questions, never "running the readiness assessment." (Already house law — reused, not re-derived.)
 
 ## Anthropic/doc-coauthoring (`skills/anthropic-doc-coauthoring.SKILL.md`)
 
 The richest external find — two ideas folded (tiered):
+
 - **Behavioral go/no-go** (`:97`): "Sufficient context has been gathered when questions show understanding — when edge cases and trade-offs can be asked about without needing basics explained." → the gate is "go" when remaining questions are edge-cases, not basics. Observable; anti-rubber-stamp.
 - **Cold-start executability test** (`:22`, `:255-331` Reader Testing): hand captured context to a fresh Claude with no history, see if it can act. → high-blast escalation: "could a fresh agent run from the captured context?" Reuse the worktree sub-agent harness.
 - **Rejected:** doc-coauthoring's **dump-first ordering** (user dumps everything, then agent asks gaps) — inverts safeword's contribute-before-asking; a coding agent can read the code itself.
@@ -28,6 +31,7 @@ The richest external find — two ideas folded (tiered):
 ## Anthropic/product-brainstorming (`skills/anthropic-product-brainstorming.SKILL.md`)
 
 Mostly **out of scope** — divergent-ideation machinery (modes, HMW/SCAMPER/OST/OODA, Frame→Diverge→Provoke→Converge) that belongs to brainstorm, not the convergent gate. Folding it would be bloat + the skill's own "don't dump frameworks" anti-pattern.
+
 - **One fold:** Assumption-Testing mode pairs riskiest-assumption with "the cheapest way to test it before building." → upgraded the gate's assumption prompt from passive flagging to active de-risking (chains into the cold-start test).
 - **One reinforcement (no scope change):** OODA's "teams get stuck in Orient — endlessly analyzing" corroborates the anti-over-gating premortem.
 

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/skills/anthropic-doc-coauthoring.SKILL.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/skills/anthropic-doc-coauthoring.SKILL.md
@@ -10,6 +10,7 @@ This skill provides a structured workflow for guiding users through collaborativ
 ## When to Offer This Workflow
 
 **Trigger conditions:**
+
 - User mentions writing documentation: "write a doc", "draft a proposal", "create a spec", "write up"
 - User mentions specific doc types: "PRD", "design doc", "decision doc", "RFC"
 - User seems to be starting a substantial writing task
@@ -42,11 +43,13 @@ Start by asking the user for meta-context about the document:
 Inform them they can answer in shorthand or dump information however works best for them.
 
 **If user provides a template or mentions a doc type:**
+
 - Ask if they have a template document to share
 - If they provide a link to a shared document, use the appropriate integration to fetch it
 - If they provide a file, read it
 
 **If user mentions editing an existing shared document:**
+
 - Use the appropriate integration to read the current state
 - Check for images without alt-text
 - If images exist without alt-text, explain that when others use Claude to understand the doc, Claude won't be able to see them. Ask if they want alt-text generated. If so, request they paste each image into chat for descriptive alt-text generation.
@@ -54,6 +57,7 @@ Inform them they can answer in shorthand or dump information however works best 
 ### Info Dumping
 
 Once initial questions are answered, encourage the user to dump all the context they have. Request information such as:
+
 - Background on the project/problem
 - Related team discussions or shared documents
 - Why alternative solutions aren't being used
@@ -63,6 +67,7 @@ Once initial questions are answered, encourage the user to dump all the context 
 - Stakeholder concerns
 
 Advise them not to worry about organizing it - just get it all out. Offer multiple ways to provide context:
+
 - Info dump stream-of-consciousness
 - Point to team channels or threads to read
 - Link to shared documents
@@ -107,6 +112,7 @@ If user wants to add more, let them. When ready, proceed to Stage 2.
 
 **Instructions to user:**
 Explain that the document will be built section by section. For each section:
+
 1. Clarifying questions will be asked about what to include
 2. 5-20 options will be brainstormed
 3. User will indicate what to keep/remove/combine
@@ -162,6 +168,7 @@ Inform them they can answer in shorthand or just indicate what's important to co
 ### Step 2: Brainstorming
 
 For the [SECTION NAME] section, brainstorm [5-20] things that might be included, depending on the section's complexity. Look for:
+
 - Context shared that might have been forgotten
 - Angles or considerations not yet mentioned
 
@@ -172,6 +179,7 @@ Generate 5-20 numbered options based on section complexity. At the end, offer to
 Ask which points should be kept, removed, or combined. Request brief justifications to help learn priorities for the next sections.
 
 Provide examples:
+
 - "Keep 1,4,7,9"
 - "Remove 3 (duplicates 1)"
 - "Remove 6 (audience already knows this)"
@@ -205,6 +213,7 @@ Provide a note: Instead of editing the doc directly, ask them to indicate what t
 ### Step 6: Iterative Refinement
 
 As user provides feedback:
+
 - Use `str_replace` to make edits (never reprint the whole doc)
 - **If using artifacts:** Provide link to artifact after each edit
 - **If using files:** Just confirm edits are complete
@@ -223,6 +232,7 @@ When section is done, confirm [SECTION NAME] is complete. Ask if ready to move t
 ### Near Completion
 
 As approaching completion (80%+ of sections done), announce intention to re-read the entire document and check for:
+
 - Flow and consistency across sections
 - Redundancy or contradictions
 - Anything that feels like "slop" or generic filler
@@ -300,11 +310,13 @@ Generate 5-10 questions that readers would realistically ask.
 ### Step 2: Setup Testing
 
 Provide testing instructions:
+
 1. Open a fresh Claude conversation: https://claude.ai
 2. Paste or share the document content (if using a shared doc platform with connectors enabled, provide the link)
 3. Ask Reader Claude the generated questions
 
 For each question, instruct Reader Claude to provide:
+
 - The answer
 - Whether anything was ambiguous or unclear
 - What knowledge/context the doc assumes is already known
@@ -314,6 +326,7 @@ Check if Reader Claude gives correct answers or misinterprets anything.
 ### Step 3: Additional Checks
 
 Also ask Reader Claude:
+
 - "What in this doc might be ambiguous or unclear to readers?"
 - "What knowledge or context does this doc assume readers already have?"
 - "Are there any internal contradictions or inconsistencies?"
@@ -343,6 +356,7 @@ Ask if they want one more review, or if the work is done.
 
 **If user wants final review, provide it. Otherwise:**
 Announce document completion. Provide a few final tips:
+
 - Consider linking this conversation in an appendix so readers can see how the doc was developed
 - Use appendices to provide depth without bloating the main doc
 - Update the doc as feedback is received from real readers
@@ -350,26 +364,31 @@ Announce document completion. Provide a few final tips:
 ## Tips for Effective Guidance
 
 **Tone:**
+
 - Be direct and procedural
 - Explain rationale briefly when it affects user behavior
 - Don't try to "sell" the approach - just execute it
 
 **Handling Deviations:**
+
 - If user wants to skip a stage: Ask if they want to skip this and write freeform
 - If user seems frustrated: Acknowledge this is taking longer than expected. Suggest ways to move faster
 - Always give user agency to adjust the process
 
 **Context Management:**
+
 - Throughout, if context is missing on something mentioned, proactively ask
 - Don't let gaps accumulate - address them as they come up
 
 **Artifact Management:**
+
 - Use `create_file` for drafting full sections
 - Use `str_replace` for all edits
 - Provide artifact link after every change
 - Never use artifacts for brainstorming lists - that's just conversation
 
 **Quality over Speed:**
+
 - Don't rush through stages
 - Each iteration should make meaningful improvements
 - The goal is a document that actually works for readers

--- a/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/skills/anthropic-product-brainstorming.SKILL.md
+++ b/.project/tickets/TPP6Y2-pm-grade-intake-readiness-gate/research/skills/anthropic-product-brainstorming.SKILL.md
@@ -15,9 +15,11 @@ Your job is not to generate deliverables. Your job is to think alongside the PM.
 Different situations call for different modes of thinking. Identify which mode fits the conversation and adapt. You can shift between modes as the conversation evolves.
 
 ### Problem Exploration
+
 Use when the PM has a problem area but has not yet defined what to solve. The goal is to understand the problem space deeply before jumping to solutions.
 
 What to do:
+
 - Ask "who has this problem?" and "what are they doing about it today?" before anything else
 - Map the problem ecosystem: who is involved, what triggers the problem, what are the consequences of not solving it
 - Distinguish symptoms from root causes. PMs often describe symptoms. Keep asking "why" until you hit something structural.
@@ -25,15 +27,18 @@ What to do:
 - Ask how the problem varies across user segments — it rarely affects everyone the same way
 
 Useful questions:
+
 - "What happens if we do nothing? Who suffers and how?"
 - "Who has solved a version of this problem in a different context?"
 - "Is this a problem of awareness, ability, or motivation?"
 - "What would need to be true for this problem to not exist?"
 
 ### Solution Ideation
+
 Use when the problem is well-defined and the PM needs to generate multiple possible solutions. The goal is divergent thinking — quantity over quality.
 
 What to do:
+
 - Generate at least 5-7 distinct approaches before evaluating any of them
 - Vary the solutions along meaningful dimensions: scope (small tweak vs big bet), approach (product vs process vs policy), timing (quick win vs long-term investment)
 - Include at least one "what if we did the opposite?" option
@@ -41,6 +46,7 @@ What to do:
 - Resist the urge to converge too early. If the PM latches onto the first decent idea, push them to keep going.
 
 Ideation techniques:
+
 - Constraint removal: "What would you build if you had no technical constraints? No budget constraints? No political constraints?" Then work backward to what is feasible.
 - Analogies: "How does [another industry] solve this? What can we steal from that approach?"
 - Inversion: "How would we make this problem worse? Now reverse each of those."
@@ -48,9 +54,11 @@ Ideation techniques:
 - User hat-switching: "How would a power user solve this? A brand new user? An admin? Someone who hates our product?"
 
 ### Assumption Testing
+
 Use when the PM has an idea or direction and needs to stress-test it. The goal is to find the weak points before investing in execution.
 
 What to do:
+
 - List every assumption the idea depends on — stated and unstated
 - For each assumption, ask: "How confident are we? What evidence do we have? What would disprove this?"
 - Identify the riskiest assumption — the one that, if wrong, kills the idea entirely
@@ -58,6 +66,7 @@ What to do:
 - Play devil's advocate: argue the strongest possible case against the idea
 
 Assumption categories to probe:
+
 - User assumptions: "Users want this" — How do we know? From what evidence? How many users?
 - Problem assumptions: "This is a real problem" — How often does it occur? How much do users care?
 - Solution assumptions: "This solution will work" — Why this approach? What alternatives did we dismiss?
@@ -66,9 +75,11 @@ Assumption categories to probe:
 - Adoption assumptions: "Users will find and use this" — How? What behavior change does it require?
 
 ### Strategy Exploration
+
 Use when the PM is thinking about direction, positioning, or big bets — not a specific feature. The goal is to explore the strategic landscape.
 
 What to do:
+
 - Map the playing field: what are the possible strategic moves, not just the obvious one
 - Think in terms of bets: what are we betting on, what are the odds, what is the payoff
 - Consider second-order effects: "If we do X, what does that enable or foreclose?"
@@ -80,40 +91,51 @@ What to do:
 Use frameworks as thinking tools, not templates to fill in. Pull in a framework when it helps move the conversation forward. Do not force every conversation through every framework.
 
 ### How Might We (HMW)
+
 Reframe problems as opportunities. Turn a pain point into an actionable question.
 Structure: "How might we [desired outcome] for [user] without [constraint]?"
+
 - Too broad: "How might we improve onboarding?" — could mean anything
 - Too narrow: "How might we add a tooltip to step 3?" — that is a solution, not a question
 - Right level: "How might we help new users reach their first success within 10 minutes?"
 - Generate 5-10 HMW questions from a single problem statement.
 
 ### Jobs-to-be-Done (JTBD)
+
 Think from the user's job, not from features or demographics.
 Structure: "When [situation], I want to [motivation] so I can [expected outcome]."
+
 - The job is stable even when solutions change.
 - Functional jobs are easier to identify. Emotional and social jobs are often more powerful.
 - Ask "What did they fire to hire your product?" — reveals the real competitive set.
 
 ### Opportunity Solution Trees
+
 Map the path from outcome to experiment (Desired Outcome → Opportunities → Solutions → Experiments).
+
 - Opportunities come from research, not imagination.
 - Multiple solutions per opportunity; multiple experiments per solution (cheapest test first).
 - The tree is a living artifact.
 
 ### First Principles Decomposition
+
 1. State the problem/assumption. 2. Break into fundamental components/constraints. 3. Question each ("law of physics or convention?"). 4. Rebuild from fundamental truths.
-When: team stuck in incremental thinking; "that is just how it works"; category not reimagined in years.
+   When: team stuck in incremental thinking; "that is just how it works"; category not reimagined in years.
 
 ### SCAMPER
+
 Substitute, Combine, Adapt, Modify, Put-to-other-use, Eliminate, Reverse — seven lenses on an existing product/process.
 
 ### OODA Loop (Observe–Orient–Decide–Act)
+
 Decision-tempo framework. Power is cycling faster than competition.
+
 1. Observe (gather raw signals, cast wide). 2. Orient (sense-make; the critical step; challenge your own orientation). 3. Decide (a hypothesis to test, proportional to what you know). 4. Act (ship/experiment, then back to Observe).
-When: team over-deliberating; competitive dynamics; brainstorm circling without converging.
-The OODA advantage: most teams get **stuck in Orient** — endlessly analyzing, waiting for more data. Orient with what you have, decide, act, let the next observation correct course.
+   When: team over-deliberating; competitive dynamics; brainstorm circling without converging.
+   The OODA advantage: most teams get **stuck in Orient** — endlessly analyzing, waiting for more data. Orient with what you have, decide, act, let the next observation correct course.
 
 ### Reverse Brainstorming
+
 Brainstorm how to make the problem worse, then reverse each idea. People are better at spotting what is wrong than imagining what is right.
 
 ## Session Structure

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -138,7 +138,7 @@ function actionsToDiffs(actions: Action[], cwd: string): FileDiff[] {
 
   for (const action of actions) {
     if (action.type !== 'write') {
-    	continue;
+      continue;
     }
 
     if (seenPaths.has(action.path)) continue;

--- a/packages/cli/src/packs/sql/index.ts
+++ b/packages/cli/src/packs/sql/index.ts
@@ -38,7 +38,7 @@ function directoryHasSqlFiles(directory: string): boolean {
     // Check subdirectories for .sql files (prisma/migrations/20210313_init/migration.sql)
     for (const entry of entries) {
       if (!entry.isDirectory()) {
-      	continue;
+        continue;
       }
 
       const subEntries = readdirSync(nodePath.join(directory, entry.name));

--- a/packages/cli/src/presets/typescript/eslint-rules/no-accumulating-spread.ts
+++ b/packages/cli/src/presets/typescript/eslint-rules/no-accumulating-spread.ts
@@ -147,7 +147,7 @@ function checkArrowBody(
   if (body.type === 'BlockStatement') {
     for (const statement of body.body) {
       if (!(statement.type === 'ReturnStatement' && statement.argument)) {
-      	continue;
+        continue;
       }
 
       const found = containsAccumulatorSpread(statement.argument, accName);

--- a/packages/cli/src/presets/typescript/eslint-rules/no-incomplete-error-handling.ts
+++ b/packages/cli/src/presets/typescript/eslint-rules/no-incomplete-error-handling.ts
@@ -59,7 +59,9 @@ function isTerminatingBranch(statement: Statement): boolean {
  */
 function ifStatementTerminates(statement: Statement & { type: 'IfStatement' }): boolean {
   const isConsequentTerminates = isTerminatingBranch(statement.consequent);
-  const isAlternateTerminates = statement.alternate ? isTerminatingBranch(statement.alternate) : false;
+  const isAlternateTerminates = statement.alternate
+    ? isTerminatingBranch(statement.alternate)
+    : false;
   return isConsequentTerminates && isAlternateTerminates;
 }
 

--- a/packages/cli/src/utils/duplicate-ids.test.ts
+++ b/packages/cli/src/utils/duplicate-ids.test.ts
@@ -58,7 +58,10 @@ describe('findDuplicateTicketIds', () => {
     const duplicates = findDuplicateTicketIds(cwd);
     expect(duplicates).toHaveLength(1);
     expect(duplicates[0]?.id).toBe('7K9M3P');
-    expect(duplicates[0]?.folders.toSorted((a, b) => a.localeCompare(b))).toEqual(['7K9M3P', '7K9M3Q']);
+    expect(duplicates[0]?.folders.toSorted((a, b) => a.localeCompare(b))).toEqual([
+      '7K9M3P',
+      '7K9M3Q',
+    ]);
   });
 
   it('flags two LEGACY-format folders sharing the same id (reads frontmatter, not folder name)', () => {

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -28,7 +28,9 @@ function isHookEntry(h: unknown): h is HookEntry {
  */
 function isSafewordHook(h: unknown): boolean {
   if (!isHookEntry(h)) return false;
-  return h.hooks.some(command => typeof command.command === 'string' && command.command.includes('.safeword'));
+  return h.hooks.some(
+    command => typeof command.command === 'string' && command.command.includes('.safeword'),
+  );
 }
 
 /**

--- a/packages/cli/src/utils/namespace-migration.ts
+++ b/packages/cli/src/utils/namespace-migration.ts
@@ -79,7 +79,7 @@ function rewriteLegacyPathOverrides(cwd: string): string[] {
   const rewritten: string[] = [];
   for (const [key, value] of Object.entries(parsed.paths)) {
     if (!(typeof value === 'string' && value.startsWith(`${LEGACY_ROOT}/`))) {
-    	continue;
+      continue;
     }
 
     parsed.paths[key] = `${DEFAULT_ROOT}${value.slice(LEGACY_ROOT.length)}`;

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -107,7 +107,8 @@ export function removeTemporaryDirectory(dir: string): void {
  */
 export function createPackageJson(dir: string, overrides: Record<string, unknown> = {}): void {
   // Merge devDependencies to ensure local safeword is always included
-  const existingDevelopmentDependencies = (overrides.devDependencies as Record<string, string>) ?? {};
+  const existingDevelopmentDependencies =
+    (overrides.devDependencies as Record<string, string>) ?? {};
   const pkg = {
     name: 'test-project',
     version: '1.0.0',
@@ -130,7 +131,8 @@ export function createSafewordBasePackageJson(
   dir: string,
   overrides: Record<string, unknown> = {},
 ): void {
-  const existingDevelopmentDependencies = (overrides.devDependencies as Record<string, string>) ?? {};
+  const existingDevelopmentDependencies =
+    (overrides.devDependencies as Record<string, string>) ?? {};
   createPackageJson(dir, {
     ...overrides,
     devDependencies: {

--- a/packages/cli/tests/integration/architecture-review-gate.test.ts
+++ b/packages/cli/tests/integration/architecture-review-gate.test.ts
@@ -101,7 +101,8 @@ function writeTicket(id: string, type: 'feature' | 'task', implPlan?: string, sp
       '# Spec\n\n## Jobs To Be Done\n\nskip: fixture\n',
     );
   }
-  if (implPlan !== undefined) writeTestFile(shared.projectDirectory, `${folder}/impl-plan.md`, implPlan);
+  if (implPlan !== undefined)
+    writeTestFile(shared.projectDirectory, `${folder}/impl-plan.md`, implPlan);
 }
 
 /** Append a design-review stamp for the impl-plan to the invocation log. */
@@ -116,7 +117,10 @@ function writeStamp(
     hashArtifact(options.hashOf ?? planContent),
   );
   const line = `2026-06-12T00:00:00Z sess ${formatReviewStamp(scope, options.skip, options.model)}`;
-  appendFileSync(nodePath.join(shared.projectDirectory, '.project', 'skill-invocations.log'), `${line}\n`);
+  appendFileSync(
+    nodePath.join(shared.projectDirectory, '.project', 'skill-invocations.log'),
+    `${line}\n`,
+  );
 }
 
 function runStopHook(

--- a/packages/cli/tests/integration/golang-golden-path.test.ts
+++ b/packages/cli/tests/integration/golang-golden-path.test.ts
@@ -191,14 +191,17 @@ describe('E2E: Go Setup Idempotency', () => {
     expect(config).toContain('linters:');
   });
 
-  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)('golangci-lint still works after running setup twice', () => {
-    // main.go from createGoProject should still be valid
-    const result = spawnSync('golangci-lint', ['run', 'main.go'], {
-      cwd: projectDirectory,
-      encoding: 'utf8',
-    });
-    expect(result.status).toBe(0);
-  });
+  it.skipIf(!IS_GOLANGCI_LINT_AVAILABLE)(
+    'golangci-lint still works after running setup twice',
+    () => {
+      // main.go from createGoProject should still be valid
+      const result = spawnSync('golangci-lint', ['run', 'main.go'], {
+        cwd: projectDirectory,
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(0);
+    },
+  );
 
   it('config files remain valid', () => {
     expect(fileExists(projectDirectory, '.golangci.yml')).toBe(true);

--- a/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
+++ b/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
@@ -24,7 +24,10 @@ import {
   writeTestFile,
 } from '../helpers.js';
 
-const shared: { projectDirectory: string; ticketSeq: number } = { projectDirectory: '', ticketSeq: 0 };
+const shared: { projectDirectory: string; ticketSeq: number } = {
+  projectDirectory: '',
+  ticketSeq: 0,
+};
 
 beforeAll(async () => {
   shared.projectDirectory = createTemporaryDirectory();
@@ -103,9 +106,13 @@ function writeSkillLog(entries: string[]): void {
 
 function twoReachableShas(): [string, string] {
   execSync('git commit --allow-empty -q -m loop-c1', { cwd: shared.projectDirectory });
-  const a = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory }).toString().trim();
+  const a = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory })
+    .toString()
+    .trim();
   execSync('git commit --allow-empty -q -m loop-c2', { cwd: shared.projectDirectory });
-  const b = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory }).toString().trim();
+  const b = execSync('git rev-parse --short HEAD', { cwd: shared.projectDirectory })
+    .toString()
+    .trim();
   return [a, b];
 }
 

--- a/packages/cli/tests/utils/shallow-detection.test.ts
+++ b/packages/cli/tests/utils/shallow-detection.test.ts
@@ -40,7 +40,11 @@ describe('existsInTree', () => {
   });
 
   it('finds file at depth 2 (monorepo pattern)', () => {
-    writeTestFile(shared.projectDirectory, 'apps/engine/go.mod', 'module example.com/apps/engine\n');
+    writeTestFile(
+      shared.projectDirectory,
+      'apps/engine/go.mod',
+      'module example.com/apps/engine\n',
+    );
     expect(existsInTree(shared.projectDirectory, 'go.mod')).toBe(true);
   });
 
@@ -77,7 +81,11 @@ describe('existsInTree', () => {
   });
 
   it('excludes dbt_packages directory', () => {
-    writeTestFile(shared.projectDirectory, 'dbt_packages/some_pkg/dbt_project.yml', 'name: vendored\n');
+    writeTestFile(
+      shared.projectDirectory,
+      'dbt_packages/some_pkg/dbt_project.yml',
+      'name: vendored\n',
+    );
     expect(existsInTree(shared.projectDirectory, 'dbt_project.yml')).toBe(false);
   });
 
@@ -241,7 +249,11 @@ describe('SQL pack detection', () => {
   });
 
   it('Tier 2: detects SQL from db/migrations/ with .sql', () => {
-    writeTestFile(shared.projectDirectory, 'db/migrations/001_init.sql', 'CREATE TABLE users (id INT);');
+    writeTestFile(
+      shared.projectDirectory,
+      'db/migrations/001_init.sql',
+      'CREATE TABLE users (id INT);',
+    );
     expect(sqlPack.detect(shared.projectDirectory)).toBe(true);
   });
 


### PR DESCRIPTION
## Problem

CI's `lint` job runs `eslint . && lint:gherkin && typecheck` but **never `prettier --check`**. Formatting is only enforced by lint-staged (pre-commit, on staged files), so drift lands on `main` undetected — this PR found **21 tracked files** already drifted.

## Changes

1. **Clear the drift** — `prettier --write` on the 21 affected files:
   - 12 in `packages/cli/{src,tests}` — tab-indentation / over-width (the files #310 listed; drift had grown to 13 by the time I checked).
   - 9 markdown under `.project/` (learnings + TPP6Y2 research) — drift the issue's `packages/cli`-scoped measurement missed.
   - Formatting only: typecheck, parity contracts, and the reformatted unit tests stay green.
2. **Enforce it** — new `Format check` step (`bun run format:check`) in the CI lint job, so future drift fails CI.

## Scope notes

- **Not** folded into the `lint` npm script: `.claude/worktrees/` (local git worktrees) aren't in the managed `.prettierignore`, so a local `prettier --check .` reports worktree noise. Worktrees are gitignored → CI's fresh checkout never sees them, so the dedicated CI step is clean. Pruning + properly ignoring the stale worktrees is #306.
- `.prettierignore` is safeword-managed (`schema.ts`), so it's intentionally untouched here.

## Verification

- `prettier --check .` (worktrees excluded = CI view): **clean**.
- `bun run --cwd packages/cli typecheck`: clean.
- `parity-check --mode=contracts-only`: in sync.
- Reformatted unit tests (`duplicate-ids`, `shallow-detection`): 48 passing.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)