### PR TITLE
chore: close shipped tickets HMZSCD + K2ZP40

### DIFF
--- a/.project/tickets/HMZSCD-let-codex-verify-task-tickets-without-claude-session-proof/ticket.md
+++ b/.project/tickets/HMZSCD-let-codex-verify-task-tickets-without-claude-session-proof/ticket.md
@@ -2,8 +2,8 @@
 id: HMZSCD
 slug: let-codex-verify-task-tickets-without-claude-session-proof
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 scope:
   - Align `/verify` and `/audit` invocation-log instructions with the actual done-gate policy: feature tickets still require current-session skill proof; task/patch tickets may continue with `verify.md` when session proof is unavailable.
   - Let the invocation helper accept an explicit session id argument so Claude skill surfaces can pass `${CLAUDE_SESSION_ID}` directly instead of relying only on an exported environment variable.
@@ -22,7 +22,7 @@ done_when:
   - README and done-gate failure text match the feature-only invocation-proof enforcement.
   - Focused invocation-log and verify/audit surface tests pass.
 created: 2026-06-15T22:50:05.640Z
-last_modified: 2026-06-16T01:29:30Z
+last_modified: 2026-06-21T21:52:00Z
 ---
 
 # Let Codex verify task tickets without Claude session proof
@@ -74,6 +74,7 @@ last_modified: 2026-06-16T01:29:30Z
 
 ## Work Log
 
+- 2026-06-21T21:52:00Z Closed: deliverables verified on origin/main (explicit session-id arg in record-skill-invocation.ts, verify/audit task-fallback wording, generic done-gate message, README fix); done_when re-confirmed — focused suites pass (skill-invocation-log, record-skill-invocation, review-stamp). Work shipped 2026-06-16 but the ticket was left in_progress; closing administratively (one of the #294 stale set).
 - 2026-06-16T01:29:30Z Follow-up: Updated README permission guidance from stale inline `node -e`/`mkdir -p`/`echo` fragments to the current Bun helper pattern (`Bash(bun */.safeword/hooks/record-skill-invocation.ts*)`) and added README contract coverage. Revalidated focused invocation-log tests, related hook/gate tests, `test:done`, and `git diff --check`. Figure-it-out review chose not to rewrite generated skill commands or auto-install Claude permissions because Claude evaluates compound Bash commands per subcommand and repo-installed permission grants should remain an explicit user/team choice.
 - 2026-06-15T23:56:22Z Verified: Focused suite passed (`tests/hooks/record-skill-invocation.test.ts`, `tests/skill-invocation-log.test.ts`, `tests/integration/skill-gate-integration.test.ts`); broader hook/schema suite passed (`test:done`, 457 tests).
 - 2026-06-15T23:55:00Z Implemented: `record-skill-invocation.ts` now accepts an explicit session id argument with `CLAUDE_SESSION_ID` fallback; verify/audit templates and dogfood copies pass `${CLAUDE_SESSION_ID}` explicitly and document feature fail-closed vs task/patch/no-ticket fallback behavior; done-gate and README wording now describe missing session-scoped proof generically.

--- a/.project/tickets/K2ZP40-let-codex-earn-self-review-stamps-without-render-time-shell/ticket.md
+++ b/.project/tickets/K2ZP40-let-codex-earn-self-review-stamps-without-render-time-shell/ticket.md
@@ -2,8 +2,8 @@
 id: K2ZP40
 slug: let-codex-earn-self-review-stamps-without-render-time-shell
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 scope:
   - Add explicit manual fallback guidance to `/self-review` surfaces when Claude-style render-time `!` execution does not run.
   - Clarify that `write-review-stamp.ts` can earn the content-bound review stamp without `CLAUDE_SESSION_ID`.
@@ -18,7 +18,7 @@ done_when:
   - Surface-contract tests cover the manual fallback wording.
   - Existing review-stamp helper and gate tests continue to pass.
 created: 2026-06-15T22:53:45.782Z
-last_modified: 2026-06-15T23:56:22Z
+last_modified: 2026-06-21T21:52:00Z
 ---
 
 # Let Codex earn self-review stamps without render-time shell
@@ -43,6 +43,7 @@ This was found during the `HMZSCD` codebase sweep. It is related to the same por
 
 ## Work Log
 
+- 2026-06-21T21:52:00Z Closed: self-review manual write-review-stamp.ts fallback verified on origin/main, byte-aligned dogfood+template; review-stamp helper/gate tests pass. Shipped 2026-06-16 but the ticket was left in_progress; closing administratively (one of the #294 stale set).
 - 2026-06-15T23:56:22Z Verified: Focused surface suite passed and `tests/integration/review-stamp.test.ts` passed, confirming stamp helper semantics still work unchanged.
 - 2026-06-15T23:55:00Z Implemented: `/self-review` templates and dogfood copies now include an explicit `write-review-stamp.ts spec` fallback for clients that do not execute Claude-style render-time `!` lines, and clarify the stamp is content-bound rather than `CLAUDE_SESSION_ID` proof.
 - 2026-06-15T23:50:00Z RED: Added failing surface-contract coverage across template and dogfood self-review command/skill copies.


### PR DESCRIPTION
## What

Closes two task tickets — **HMZSCD** (Codex verify without Claude session proof) and **K2ZP40** (self-review stamp without render-time shell) — implemented, verified, and merged on 2026-06-15/16 but left `status: in_progress`.

## Why

They're 2 of the 97 stale `in_progress` tickets in #294. Re-validation confirms their deliverables are live on `origin/main` (`git diff origin/main` for their surfaces is empty):
- **HMZSCD**: explicit session-id arg in `record-skill-invocation.ts`, verify/audit task-fallback wording, generic done-gate message, README fix.
- **K2ZP40**: manual `write-review-stamp.ts spec` fallback, byte-aligned dogfood+template.

`done_when` re-confirmed — skill-invocation-log, record-skill-invocation, and review-stamp suites pass (61 tests).

## Scope note

`INDEX.md` is intentionally **not** regenerated here: `sync-tickets` showed ~131 lines of pre-existing drift unrelated to these two (262→296 active), which belongs with the #294 wholesale cleanup, not a 2-ticket close. The `ticket.md` frontmatter is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)