### PR TITLE
test(integration): E2E Codex/Cursor skill fallback at the done-gate (#295)

### DIFF
--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration: Codex/Cursor skill-invocation fallback → done-gate (E2E) (#295)
+ *
+ * `skill-gate-integration.test.ts` writes `skill-invocations.log` directly. This
+ * test instead drives the *real* `record-skill-invocation.ts` fallback command
+ * under a non-Claude runtime (no `CLAUDE_SESSION_ID` / `CLAUDE_CODE_SESSION_ID`
+ * in the environment) — the path Codex/Cursor take when the inline `!` line is
+ * rendered as Markdown rather than executed. It confirms:
+ *
+ *   1. The fallback records gate-readable, session-bound proof for every gated
+ *      skill when a session id is supplied explicitly (the HMZSCD arg path),
+ *      and degrades gracefully (exit 0, nothing recorded) when none is — so a
+ *      non-Claude runtime never silently mis-binds.
+ *   2. End-to-end, a feature done-gate PASSES when verify+audit proof was
+ *      recorded via the fallback, and FAILS CLOSED with a clear,
+ *      `CLAUDE_SESSION_ID`-free message when the runtime could not bind one.
+ *
+ * Closes the cross-agent coverage gap: the recording mechanism is otherwise
+ * only unit-tested, with nothing exercising it against the actual done-gate
+ * under a non-Claude environment.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createTemporaryDirectory,
+  createTypeScriptPackageJson,
+  initGitRepo,
+  removeTemporaryDirectory,
+  setupOrThrow,
+  writeTestFile,
+} from '../helpers.js';
+
+// The done-gate's gated skills. record-skill-invocation.ts is skill-name
+// agnostic, so the fallback mechanism is exercised across all three.
+const GATED_SKILLS = ['verify', 'audit', 'quality-review'] as const;
+
+// A non-Claude runtime exposes no Claude session id in the shell environment.
+// Scrub both vars so the only session id is whatever is passed explicitly —
+// otherwise a CLAUDE_SESSION_ID leaking in from the harness running this suite
+// would mask the very degradation we are asserting.
+function nonClaudeEnvironment(projectDirectory: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory };
+  delete environment.CLAUDE_SESSION_ID;
+  delete environment.CLAUDE_CODE_SESSION_ID;
+  return environment;
+}
+
+// Drive the documented fallback exactly as a Codex/Cursor skill body would:
+// `bun record-skill-invocation.ts <projectDir> <skill> <sessionId>`.
+function runFallback(
+  projectDirectory: string,
+  skill: string,
+  sessionIdArgument: string,
+): { exitCode: number; output: string } {
+  const result = spawnSync(
+    'bun',
+    ['.safeword/hooks/record-skill-invocation.ts', projectDirectory, skill, sessionIdArgument],
+    { cwd: projectDirectory, env: nonClaudeEnvironment(projectDirectory), encoding: 'utf8' },
+  );
+  return { exitCode: result.status ?? 0, output: `${result.stdout}${result.stderr}` };
+}
+
+function logContents(projectDirectory: string): string {
+  const logPath = nodePath.join(projectDirectory, '.project', 'skill-invocations.log');
+  return existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
+}
+
+function writeFeatureTicketAtDone(directory: string, ticketId: string): void {
+  const folder = `.project/tickets/${ticketId}`;
+  mkdirSync(nodePath.join(directory, folder), { recursive: true });
+  // verify.md + test-definitions.md present so only the skill-invocation gate
+  // is in play (other done-gate checks are already satisfied).
+  writeTestFile(
+    directory,
+    `${folder}/ticket.md`,
+    `---\nid: ${ticketId}\ntype: feature\nphase: done\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
+  );
+  writeTestFile(
+    directory,
+    `${folder}/test-definitions.md`,
+    '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
+  );
+  writeTestFile(
+    directory,
+    `${folder}/verify.md`,
+    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
+  );
+}
+
+function runDoneGate(
+  projectDirectory: string,
+  sessionId: string,
+): { exitCode: number; reason: string } {
+  const transcriptPath = nodePath.join(projectDirectory, 'transcript.jsonl');
+  writeFileSync(
+    transcriptPath,
+    `${JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'done' },
+          { type: 'tool_use', name: 'Edit' },
+        ],
+      },
+    })}\n`,
+  );
+  const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
+    input: JSON.stringify({ transcript_path: transcriptPath, session_id: sessionId }),
+    cwd: projectDirectory,
+    env: nonClaudeEnvironment(projectDirectory),
+    encoding: 'utf8',
+  });
+  try {
+    return { exitCode: result.status ?? 0, reason: JSON.parse(result.stdout.trim()).reason ?? '' };
+  } catch {
+    return { exitCode: result.status ?? 0, reason: '' };
+  }
+}
+
+describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () => {
+  let projectDirectory: string;
+
+  beforeAll(async () => {
+    projectDirectory = createTemporaryDirectory();
+    createTypeScriptPackageJson(projectDirectory);
+    initGitRepo(projectDirectory);
+    await setupOrThrow(projectDirectory);
+  });
+
+  afterAll(() => {
+    if (projectDirectory) removeTemporaryDirectory(projectDirectory);
+  });
+
+  for (const skill of GATED_SKILLS) {
+    it(`records ${skill} under a non-Claude runtime when a session id is supplied explicitly`, () => {
+      const sessionId = `codex-${skill}-rec`;
+      const { exitCode, output } = runFallback(projectDirectory, skill, sessionId);
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain(`${skill} ✓`);
+      // The recorded line is session-bound and in the gate-readable format.
+      const recorded = logContents(projectDirectory)
+        .split('\n')
+        .some(line => line.includes(sessionId) && line.trim().endsWith(` ${skill}`));
+      expect(recorded).toBe(true);
+    });
+
+    it(`degrades gracefully for ${skill} with no session binding (true Codex/Cursor case)`, () => {
+      const before = logContents(projectDirectory);
+      const { exitCode, output } = runFallback(projectDirectory, skill, '');
+
+      expect(exitCode).toBe(0);
+      expect(output.toLowerCase()).toContain('no session id');
+      // Nothing recorded — no silent mis-binding to an empty/ambient session.
+      expect(logContents(projectDirectory)).toBe(before);
+    });
+  }
+
+  it('feature done PASSES the skill gate when verify+audit are recorded via the fallback (non-Claude runtime)', () => {
+    writeFeatureTicketAtDone(projectDirectory, '951');
+    const sessionId = 'codex-session-951';
+    runFallback(projectDirectory, 'verify', sessionId);
+    runFallback(projectDirectory, 'audit', sessionId);
+
+    const result = runDoneGate(projectDirectory, sessionId);
+
+    // Fallback-recorded proof satisfies the gate — no missing-invocation block.
+    expect(result.reason).not.toMatch(/Required skill invocation/);
+  });
+
+  it('feature done FAILS CLOSED with a clear, CLAUDE_SESSION_ID-free message when the fallback cannot bind a session', () => {
+    writeFeatureTicketAtDone(projectDirectory, '952');
+    // True no-binding: fallback runs but records nothing.
+    runFallback(projectDirectory, 'verify', '');
+    runFallback(projectDirectory, 'audit', '');
+
+    const result = runDoneGate(projectDirectory, 'codex-session-952');
+
+    expect(result.reason).toContain('/verify');
+    expect(result.reason).toContain('/audit');
+    expect(result.reason.toLowerCase()).toContain('missing');
+    expect(result.reason).toContain('session-scoped proof');
+    // HMZSCD: the message is runtime-agnostic, not CLAUDE_SESSION_ID-specific.
+    expect(result.reason).not.toContain('CLAUDE_SESSION_ID');
+  });
+});

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -92,9 +92,13 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
       expect(exitCode).toBe(0);
       expect(output).toContain(`${skill} ✓`);
       // The recorded line is session-bound and in the gate-readable format.
+      // Mirror the gate's parser (checkSkillInvocations): a gate-readable line
+      // is `<timestamp> <session-id> <skill>`. Assert that exact 3-token shape,
+      // not a substring, so producer/consumer format drift is caught.
       const recorded = logContents(projectDirectory)
         .split('\n')
-        .some(line => line.includes(sessionId) && line.trim().endsWith(` ${skill}`));
+        .map(line => line.trim().split(/\s+/))
+        .some(tokens => tokens.length >= 3 && tokens[1] === sessionId && tokens[2] === skill);
       expect(recorded).toBe(true);
     });
 
@@ -115,10 +119,15 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     runFallback(projectDirectory, 'verify', sessionId);
     runFallback(projectDirectory, 'audit', sessionId);
 
-    const result = runDoneGate(projectDirectory, sessionId, nonClaudeEnvironment(projectDirectory));
+    // The gate binds the session from stdin, not env, so the default env is fine
+    // here — the non-Claude simulation lives in runFallback's recording.
+    const result = runDoneGate(projectDirectory, sessionId);
 
     // Fallback-recorded proof satisfies the gate — no missing-invocation block.
-    expect(result.reason).not.toMatch(/Required skill invocation/);
+    // Assert exit code + raw stdout (not `reason`): a hook crash yields an empty
+    // reason that would satisfy a negative match vacuously.
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Required skill invocation');
   });
 
   it('feature done FAILS CLOSED with a clear, CLAUDE_SESSION_ID-free message when the fallback cannot bind a session', () => {
@@ -127,11 +136,7 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     runFallback(projectDirectory, 'verify', '');
     runFallback(projectDirectory, 'audit', '');
 
-    const result = runDoneGate(
-      projectDirectory,
-      'codex-session-952',
-      nonClaudeEnvironment(projectDirectory),
-    );
+    const result = runDoneGate(projectDirectory, 'codex-session-952');
 
     expect(result.reason).toContain('/verify');
     expect(result.reason).toContain('/audit');

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -32,8 +32,8 @@ import {
   initGitRepo,
   removeTemporaryDirectory,
   setupOrThrow,
-  writeTestFile,
 } from '../helpers.js';
+import { runDoneGate, writeFeatureTicketAtDone } from './done-gate-harness.js';
 
 // The done-gate's gated skills. record-skill-invocation.ts is skill-name
 // agnostic, so the fallback mechanism is exercised across all three.
@@ -68,59 +68,6 @@ function runFallback(
 function logContents(projectDirectory: string): string {
   const logPath = nodePath.join(projectDirectory, '.project', 'skill-invocations.log');
   return existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
-}
-
-function writeFeatureTicketAtDone(directory: string, ticketId: string): void {
-  const folder = `.project/tickets/${ticketId}`;
-  mkdirSync(nodePath.join(directory, folder), { recursive: true });
-  // verify.md + test-definitions.md present so only the skill-invocation gate
-  // is in play (other done-gate checks are already satisfied).
-  writeTestFile(
-    directory,
-    `${folder}/ticket.md`,
-    `---\nid: ${ticketId}\ntype: feature\nphase: done\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
-  );
-  writeTestFile(
-    directory,
-    `${folder}/test-definitions.md`,
-    '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
-  );
-  writeTestFile(
-    directory,
-    `${folder}/verify.md`,
-    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
-  );
-}
-
-function runDoneGate(
-  projectDirectory: string,
-  sessionId: string,
-): { exitCode: number; reason: string } {
-  const transcriptPath = nodePath.join(projectDirectory, 'transcript.jsonl');
-  writeFileSync(
-    transcriptPath,
-    `${JSON.stringify({
-      type: 'assistant',
-      message: {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: 'done' },
-          { type: 'tool_use', name: 'Edit' },
-        ],
-      },
-    })}\n`,
-  );
-  const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
-    input: JSON.stringify({ transcript_path: transcriptPath, session_id: sessionId }),
-    cwd: projectDirectory,
-    env: nonClaudeEnvironment(projectDirectory),
-    encoding: 'utf8',
-  });
-  try {
-    return { exitCode: result.status ?? 0, reason: JSON.parse(result.stdout.trim()).reason ?? '' };
-  } catch {
-    return { exitCode: result.status ?? 0, reason: '' };
-  }
 }
 
 describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () => {
@@ -168,7 +115,7 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     runFallback(projectDirectory, 'verify', sessionId);
     runFallback(projectDirectory, 'audit', sessionId);
 
-    const result = runDoneGate(projectDirectory, sessionId);
+    const result = runDoneGate(projectDirectory, sessionId, nonClaudeEnvironment(projectDirectory));
 
     // Fallback-recorded proof satisfies the gate — no missing-invocation block.
     expect(result.reason).not.toMatch(/Required skill invocation/);
@@ -180,7 +127,11 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     runFallback(projectDirectory, 'verify', '');
     runFallback(projectDirectory, 'audit', '');
 
-    const result = runDoneGate(projectDirectory, 'codex-session-952');
+    const result = runDoneGate(
+      projectDirectory,
+      'codex-session-952',
+      nonClaudeEnvironment(projectDirectory),
+    );
 
     expect(result.reason).toContain('/verify');
     expect(result.reason).toContain('/audit');

--- a/packages/cli/tests/integration/done-gate-harness.ts
+++ b/packages/cli/tests/integration/done-gate-harness.ts
@@ -47,7 +47,7 @@ export function runDoneGate(
   projectDirectory: string,
   sessionId: string,
   environment?: NodeJS.ProcessEnv,
-): { exitCode: number; reason: string } {
+): { exitCode: number; reason: string; stdout: string } {
   const resolvedEnvironment = environment ?? {
     ...process.env,
     CLAUDE_PROJECT_DIR: projectDirectory,
@@ -72,9 +72,14 @@ export function runDoneGate(
     env: resolvedEnvironment,
     encoding: 'utf8',
   });
+  const stdout = result.stdout ?? '';
+  const exitCode = result.status ?? 0;
   try {
-    return { exitCode: result.status ?? 0, reason: JSON.parse(result.stdout.trim()).reason ?? '' };
+    return { exitCode, reason: JSON.parse(stdout.trim()).reason ?? '', stdout };
   } catch {
-    return { exitCode: result.status ?? 0, reason: '' };
+    // Non-JSON stdout (e.g. a hook crash) yields no parsed reason. Callers
+    // asserting the gate PASSED must check exitCode and/or raw stdout — a
+    // negative `not.toContain` against an empty reason would pass vacuously.
+    return { exitCode, reason: '', stdout };
   }
 }

--- a/packages/cli/tests/integration/done-gate-harness.ts
+++ b/packages/cli/tests/integration/done-gate-harness.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared harness for the done-gate (stop-quality.ts) integration tests.
+ *
+ * Builds a feature ticket parked at done-phase and drives the real Stop hook,
+ * returning its block decision. Used by skill-gate-integration.test.ts and the
+ * Codex/Cursor fallback E2E test so the ticket scaffold and hook-invocation
+ * plumbing live in one place.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { writeTestFile } from '../helpers.js';
+
+/**
+ * A feature ticket at done-phase with verify.md + test-definitions.md present,
+ * so only the skill-invocation gate is in play (other done-gate checks pass).
+ */
+export function writeFeatureTicketAtDone(directory: string, ticketId: string): void {
+  const folder = `.project/tickets/${ticketId}`;
+  mkdirSync(nodePath.join(directory, folder), { recursive: true });
+  writeTestFile(
+    directory,
+    `${folder}/ticket.md`,
+    `---\nid: ${ticketId}\ntype: feature\nphase: done\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
+  );
+  writeTestFile(
+    directory,
+    `${folder}/test-definitions.md`,
+    '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
+  );
+  writeTestFile(
+    directory,
+    `${folder}/verify.md`,
+    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
+  );
+}
+
+/**
+ * Run the real stop-quality.ts done-gate against a project for a session, and
+ * return its exit code + block reason. `environment` defaults to the ambient
+ * env with CLAUDE_PROJECT_DIR set; pass a scrubbed env to simulate a non-Claude
+ * runtime.
+ */
+export function runDoneGate(
+  projectDirectory: string,
+  sessionId: string,
+  environment?: NodeJS.ProcessEnv,
+): { exitCode: number; reason: string } {
+  const resolvedEnvironment = environment ?? {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: projectDirectory,
+  };
+  const transcriptPath = nodePath.join(projectDirectory, 'transcript.jsonl');
+  writeFileSync(
+    transcriptPath,
+    `${JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'done' },
+          { type: 'tool_use', name: 'Edit' },
+        ],
+      },
+    })}\n`,
+  );
+  const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
+    input: JSON.stringify({ transcript_path: transcriptPath, session_id: sessionId }),
+    cwd: projectDirectory,
+    env: resolvedEnvironment,
+    encoding: 'utf8',
+  });
+  try {
+    return { exitCode: result.status ?? 0, reason: JSON.parse(result.stdout.trim()).reason ?? '' };
+  } catch {
+    return { exitCode: result.status ?? 0, reason: '' };
+  }
+}

--- a/packages/cli/tests/integration/skill-gate-integration.test.ts
+++ b/packages/cli/tests/integration/skill-gate-integration.test.ts
@@ -77,8 +77,10 @@ describe('skill-invocation gate: end-to-end (147)', () => {
     const result = runDoneGate(projectDirectory, 'session-903');
 
     // The skill gate passed; whether downstream gates also pass depends on
-    // other ticket state. Asserting only on the skill-gate message absence.
-    expect(result.reason).not.toMatch(/Required skill invocation/);
+    // other ticket state. Assert exit code + raw stdout (not `reason`): a hook
+    // crash yields an empty reason that would match negatively for free.
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Required skill invocation');
   });
 
   it('feature done with only OTHER session entries still blocks', () => {

--- a/packages/cli/tests/integration/skill-gate-integration.test.ts
+++ b/packages/cli/tests/integration/skill-gate-integration.test.ts
@@ -5,7 +5,6 @@
  * when /verify and /audit log entries are missing in the current session.
  */
 
-import { execSync, spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -17,28 +16,8 @@ import {
   initGitRepo,
   removeTemporaryDirectory,
   setupOrThrow,
-  writeTestFile,
 } from '../helpers.js';
-
-function writeFeatureTicketAtDone(directory: string, ticketId: string): void {
-  const folder = `.project/tickets/${ticketId}`;
-  execSync(`mkdir -p "${directory}/${folder}"`, { cwd: directory });
-  writeTestFile(
-    directory,
-    `${folder}/ticket.md`,
-    `---\nid: ${ticketId}\ntype: feature\nphase: done\nstatus: in_progress\nlast_modified: 2026-01-06T10:00:00Z\n---\n# Test\n`,
-  );
-  writeTestFile(
-    directory,
-    `${folder}/test-definitions.md`,
-    '# Test Definitions\n\n## Rule: Test rule\n\n- [x] Scenario one\n',
-  );
-  writeTestFile(
-    directory,
-    `${folder}/verify.md`,
-    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
-  );
-}
+import { runDoneGate, writeFeatureTicketAtDone } from './done-gate-harness.js';
 
 function writeSkillLog(directory: string, entries: string[]): void {
   const safewordDirectory = nodePath.join(directory, '.project');
@@ -47,42 +26,6 @@ function writeSkillLog(directory: string, entries: string[]): void {
     nodePath.join(safewordDirectory, 'skill-invocations.log'),
     entries.length > 0 ? `${entries.join('\n')}\n` : '',
   );
-}
-
-function runStopHookWithSession(
-  targetDirectory: string,
-  sessionId: string,
-): { exitCode: number; reason: string } {
-  const transcriptPath = nodePath.join(targetDirectory, 'transcript.jsonl');
-  writeFileSync(
-    transcriptPath,
-    `${JSON.stringify({
-      type: 'assistant',
-      message: {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: 'done' },
-          { type: 'tool_use', name: 'Edit' },
-        ],
-      },
-    })}\n`,
-  );
-  const result = spawnSync('bun', ['.safeword/hooks/stop-quality.ts'], {
-    input: JSON.stringify({
-      transcript_path: transcriptPath,
-      session_id: sessionId,
-    }),
-    cwd: targetDirectory,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: targetDirectory },
-    encoding: 'utf8',
-  });
-  const exitCode = result.status ?? 0;
-  try {
-    const parsed = JSON.parse(result.stdout.trim());
-    return { exitCode, reason: parsed.reason ?? '' };
-  } catch {
-    return { exitCode, reason: '' };
-  }
 }
 
 describe('skill-invocation gate: end-to-end (147)', () => {
@@ -103,7 +46,7 @@ describe('skill-invocation gate: end-to-end (147)', () => {
     writeFeatureTicketAtDone(projectDirectory, '901');
     writeSkillLog(projectDirectory, []);
 
-    const result = runStopHookWithSession(projectDirectory, 'session-901');
+    const result = runDoneGate(projectDirectory, 'session-901');
 
     expect(result.exitCode).toBe(0);
     expect(result.reason).toContain('/verify');
@@ -117,7 +60,7 @@ describe('skill-invocation gate: end-to-end (147)', () => {
     writeFeatureTicketAtDone(projectDirectory, '902');
     writeSkillLog(projectDirectory, ['2026-05-15T00:00:00Z session-902 verify']);
 
-    const result = runStopHookWithSession(projectDirectory, 'session-902');
+    const result = runDoneGate(projectDirectory, 'session-902');
 
     expect(result.exitCode).toBe(0);
     expect(result.reason).toContain('/audit');
@@ -131,7 +74,7 @@ describe('skill-invocation gate: end-to-end (147)', () => {
       '2026-05-15T00:00:01Z session-903 audit',
     ]);
 
-    const result = runStopHookWithSession(projectDirectory, 'session-903');
+    const result = runDoneGate(projectDirectory, 'session-903');
 
     // The skill gate passed; whether downstream gates also pass depends on
     // other ticket state. Asserting only on the skill-gate message absence.
@@ -145,7 +88,7 @@ describe('skill-invocation gate: end-to-end (147)', () => {
       '2026-05-15T00:00:01Z some-other-session audit',
     ]);
 
-    const result = runStopHookWithSession(projectDirectory, 'session-904');
+    const result = runDoneGate(projectDirectory, 'session-904');
 
     expect(result.exitCode).toBe(0);
     expect(result.reason).toContain('/verify');


### PR DESCRIPTION
## Problem

#295: the skill-invocation-log fallback (the `record-skill-invocation.ts` path Codex/Cursor take when the inline `!` line is rendered as Markdown, not executed) is only unit-tested. Nothing drives it **end-to-end against the done-gate under a non-Claude runtime** — so a regression in namespace/session resolution under that env could silently mis-gate a Codex/Cursor user at done-phase, with no test catching it.

## What this adds

`tests/integration/codex-cursor-skill-fallback.test.ts` drives the real fallback command with `CLAUDE_SESSION_ID` / `CLAUDE_CODE_SESSION_ID` scrubbed from the env (a faithful non-Claude runtime), then runs the real `stop-quality.ts` done-gate:

- **Parameterized over verify / audit / quality-review** (the fallback is skill-name-agnostic): records gate-readable, session-bound proof when a session id is passed explicitly; degrades gracefully (exit 0, nothing recorded) when none is — no silent mis-binding.
- **Feature done PASSES** the skill gate when verify+audit proof was recorded via the fallback.
- **Feature done FAILS CLOSED** with a clear, `CLAUDE_SESSION_ID`-free message when the runtime cannot bind a session.

8 tests, all green; typecheck + eslint clean.

## Guard, not a fix

The behavior shipped via HMZSCD (explicit session-id arg + runtime-agnostic gate message). This is the missing characterization test that locks it: a regressed explicit-arg path, or the gate message regressing to `CLAUDE_SESSION_ID`-specific wording, now fails CI.

## Scope

`checkSkillInvocations` is skill-name-generic — it matches `required` skills against the session log identically regardless of skill. The feature gate (verify+audit) exercises that path; quality-review's gate path is the same code with its recording already covered by the parameterized fixture, so I did not separately construct the multi-loop `wholeTicketPass` condition (it adds setup complexity without new code coverage).

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)