### PR TITLE
fix(dep-readiness): abstain for non-bun workspaces with a coexisting bun lockfile (#321)

### DIFF
--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -117,6 +117,18 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
   const packageManager = packageJson.packageManager;
+
+  // Abstain for projects that are explicitly not bun, even when a bun lockfile
+  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
+  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
+  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
+  // at a pnpm workspace (#321).
+  const declaresNonBunManager =
+    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
+  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
+    return undefined;
+  }
+
   const usesBun =
     (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
     bunLockfile !== undefined;

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -117,6 +117,18 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
   const packageManager = packageJson.packageManager;
+
+  // Abstain for projects that are explicitly not bun, even when a bun lockfile
+  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
+  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
+  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
+  // at a pnpm workspace (#321).
+  const declaresNonBunManager =
+    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
+  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
+    return undefined;
+  }
+
   const usesBun =
     (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
     bunLockfile !== undefined;

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -117,6 +117,31 @@ describe('dependency readiness hook support', () => {
     ]);
   });
 
+  it('abstains (unsupported) for a pnpm workspace with a coexisting bun lockfile (#321)', () => {
+    writeJson('package.json', {
+      name: 'pnpm-workspace-project',
+      packageManager: 'pnpm@9.0.0',
+      workspaces: ['packages/*'],
+    });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    // A stray/legacy bun lockfile must not flip this pnpm workspace to `bun ci`.
+    writeTestFile(projectDirectory, 'bun.lock', '# stray bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)).toBeUndefined();
+    expect(getDependencyReadiness(projectDirectory).status).toBe('unsupported');
+  });
+
+  it('abstains when packageManager declares a non-bun manager despite a coexisting bun lockfile (#321)', () => {
+    writeJson('package.json', {
+      name: 'declared-pnpm-project',
+      packageManager: 'pnpm@9.0.0',
+    });
+    writeTestFile(projectDirectory, 'bun.lock', '# stray bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)).toBeUndefined();
+    expect(getDependencyReadiness(projectDirectory).status).toBe('unsupported');
+  });
+
   it('tracks package manifests matched by recursive workspace globs', () => {
     writeJson('package.json', {
       name: 'recursive-workspace-project',


### PR DESCRIPTION
## Problem (#321)

`detectDependencyPlan` (the dependency-readiness gate) is bun-only by design, but it selects a `bun ci` plan **whenever a bun lockfile exists**, with no pnpm guard. A pnpm workspace with a stray/legacy `bun.lock` was told to run `bun ci` — which would corrupt its pnpm install. This diverged from `install.ts:detectPackageManager`, which gives `pnpm-workspace.yaml` priority over a bun lockfile.

A *pure* pnpm workspace (no bun.lock) already returned `'unsupported'`, so the misfire needed a coexisting bun lockfile (e.g. Bun-as-runtime + pnpm-as-PM, or a migration).

## Fix

Abstain (`'unsupported'`) when a definitive non-bun signal is present:
- a `packageManager` declaring pnpm/npm/yarn (authoritative corepack signal), or
- `pnpm-workspace.yaml` (mirrors install.ts's precedence).

Keeps the gate bun-only and stops the harmful misfire. Existing bun projects are unaffected (this repo is itself bun → guard is a no-op).

## Scope

This is the **abstain** fix. First-class pnpm *enforcement* (the gate running `pnpm install` readiness) is a separate feature, tracked separately (the "B" follow-up).

## Verification

- 2 new tests (pnpm-workspace + bun.lock → unsupported; declared-pnpm + bun.lock → unsupported), RED→GREEN.
- Full `dependency-readiness.test.ts`: **55 pass** (no regression to bun detection).
- Dogfood `.safeword/hooks/lib/` + `templates/hooks/lib/` synced byte-identical; parity contracts in sync; typecheck clean.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)