### PR TITLE
feat(dep-readiness): support pnpm first-class (#323)

### DIFF
--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun';
+export type DependencyManager = 'bun' | 'pnpm';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -113,28 +113,50 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
   );
   if (packageJson === undefined) return undefined;
 
-  const bunLockfile = BUN_LOCKFILES.find(lockfile =>
+  const packageManager =
+    typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
+  const manager = detectDependencyManager(projectDirectory, packageManager);
+
+  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
+  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
+  return undefined;
+}
+
+/**
+ * Resolve the readiness-supported package manager (bun or pnpm), or undefined
+ * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
+ * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
+ * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
+ * manager (unsupported by this gate) abstains rather than misfiring bun, so a
+ * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ */
+function detectDependencyManager(
+  projectDirectory: string,
+  packageManager: string | undefined,
+): DependencyManager | undefined {
+  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const packageManager = packageJson.packageManager;
+  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
+  const prefersPnpm =
+    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
+    (packageManager?.startsWith('pnpm@') ?? false);
+  const declaresOtherManager =
+    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
 
-  // Abstain for projects that are explicitly not bun, even when a bun lockfile
-  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
-  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
-  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
-  // at a pnpm workspace (#321).
-  const declaresNonBunManager =
-    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
-  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
-    return undefined;
-  }
+  if (declaresOtherManager && !prefersPnpm) return undefined;
+  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
+  if (bunLockfilePresent && !prefersPnpm) return 'bun';
+  return undefined;
+}
 
-  const usesBun =
-    (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
-    bunLockfile !== undefined;
-
-  if (!usesBun || bunLockfile === undefined) return undefined;
-
+function buildBunPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  const bunLockfile =
+    BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
+    'bun.lock';
   const inputPaths = uniqueSorted([
     'package.json',
     bunLockfile,
@@ -143,10 +165,32 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   return {
     manager: 'bun',
+    installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths,
+  };
+}
+
+/**
+ * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
+ * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
+ * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ */
+function buildPnpmPlan(projectDirectory: string): DependencyPlan {
+  const inputPaths = uniqueSorted([
+    'package.json',
+    'pnpm-lock.yaml',
+    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
+      ? ['pnpm-workspace.yaml']
+      : []),
+  ]);
+
+  return {
+    manager: 'pnpm',
     installCommand: {
-      binary: 'bun',
-      args: ['ci'],
-      display: 'bun ci',
+      binary: 'pnpm',
+      args: ['install', '--frozen-lockfile'],
+      display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
     inputPaths,

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun';
+export type DependencyManager = 'bun' | 'pnpm';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -113,28 +113,50 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
   );
   if (packageJson === undefined) return undefined;
 
-  const bunLockfile = BUN_LOCKFILES.find(lockfile =>
+  const packageManager =
+    typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
+  const manager = detectDependencyManager(projectDirectory, packageManager);
+
+  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
+  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
+  return undefined;
+}
+
+/**
+ * Resolve the readiness-supported package manager (bun or pnpm), or undefined
+ * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
+ * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
+ * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
+ * manager (unsupported by this gate) abstains rather than misfiring bun, so a
+ * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ */
+function detectDependencyManager(
+  projectDirectory: string,
+  packageManager: string | undefined,
+): DependencyManager | undefined {
+  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const packageManager = packageJson.packageManager;
+  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
+  const prefersPnpm =
+    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
+    (packageManager?.startsWith('pnpm@') ?? false);
+  const declaresOtherManager =
+    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
 
-  // Abstain for projects that are explicitly not bun, even when a bun lockfile
-  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
-  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
-  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
-  // at a pnpm workspace (#321).
-  const declaresNonBunManager =
-    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
-  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
-    return undefined;
-  }
+  if (declaresOtherManager && !prefersPnpm) return undefined;
+  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
+  if (bunLockfilePresent && !prefersPnpm) return 'bun';
+  return undefined;
+}
 
-  const usesBun =
-    (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
-    bunLockfile !== undefined;
-
-  if (!usesBun || bunLockfile === undefined) return undefined;
-
+function buildBunPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  const bunLockfile =
+    BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
+    'bun.lock';
   const inputPaths = uniqueSorted([
     'package.json',
     bunLockfile,
@@ -143,10 +165,32 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   return {
     manager: 'bun',
+    installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths,
+  };
+}
+
+/**
+ * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
+ * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
+ * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ */
+function buildPnpmPlan(projectDirectory: string): DependencyPlan {
+  const inputPaths = uniqueSorted([
+    'package.json',
+    'pnpm-lock.yaml',
+    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
+      ? ['pnpm-workspace.yaml']
+      : []),
+  ]);
+
+  return {
+    manager: 'pnpm',
     installCommand: {
-      binary: 'bun',
-      args: ['ci'],
-      display: 'bun ci',
+      binary: 'pnpm',
+      args: ['install', '--frozen-lockfile'],
+      display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
     inputPaths,

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -142,6 +142,65 @@ describe('dependency readiness hook support', () => {
     expect(getDependencyReadiness(projectDirectory).status).toBe('unsupported');
   });
 
+  it('detects a pnpm workspace and plans a frozen pnpm install (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-project', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    const plan = detectDependencyPlan(projectDirectory);
+
+    expect(plan).toMatchObject({
+      manager: 'pnpm',
+      installCommand: {
+        binary: 'pnpm',
+        args: ['install', '--frozen-lockfile'],
+        display: 'pnpm install --frozen-lockfile',
+      },
+      installArtifact: 'node_modules',
+    });
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+    ]);
+  });
+
+  it('prefers pnpm over a coexisting bun lockfile when the project signals pnpm (#323)', () => {
+    writeJson('package.json', { name: 'mixed', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+    writeTestFile(projectDirectory, 'bun.lock', '# stray bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('pnpm');
+  });
+
+  it('treats pnpm-lock.yaml alone (no bun lockfile) as pnpm (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-single' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('pnpm');
+  });
+
+  it('keeps bun precedence when bun.lock coexists with pnpm-lock.yaml and no pnpm signal (#323)', () => {
+    writeJson('package.json', { name: 'ambiguous' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+    writeTestFile(projectDirectory, 'bun.lock', '# bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('bun');
+  });
+
+  it('reports missing then ready for a pnpm project (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-project', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    const missing = getDependencyReadiness(projectDirectory);
+    expect(missing.status).toBe('missing');
+    expect(missing.installCommand).toBe('pnpm install --frozen-lockfile');
+
+    mkdirSync(path.join(projectDirectory, 'node_modules'), { recursive: true });
+    expect(getDependencyReadiness(projectDirectory).status).toBe('ready');
+  });
+
   it('tracks package manifests matched by recursive workspace globs', () => {
     writeJson('package.json', {
       name: 'recursive-workspace-project',


### PR DESCRIPTION
> **Stacked on #322** (base = `fix/dep-readiness-abstain-non-bun`). Merge #322 first; this PR's diff is the pnpm-support delta on top of it.

## Feature (#323)

Extends the dependency-readiness gate beyond bun to **pnpm**, so pnpm consumers get the same readiness protection bun consumers have. Supersedes #321's pnpm *abstention* with pnpm *enforcement*.

## How

`detectDependencyPlan` resolves the manager via a single precedence resolver mirroring `install.ts:detectPackageManager`:
- a pnpm workspace (`pnpm-workspace.yaml`) or `pnpm@` declaration → **pnpm** (beats a coexisting bun lockfile)
- otherwise a bun lockfile → **bun**
- `pnpm-lock.yaml` with no bun lockfile → **pnpm**
- a declared `npm@`/`yarn@` → **unsupported** (abstain; not yet supported)

pnpm projects get `pnpm install --frozen-lockfile` (the frozen analog of `bun ci`), fingerprinting `package.json` + `pnpm-lock.yaml` + `pnpm-workspace.yaml`.

## Follow-ups (noted, out of scope)

- **Per-workspace-manifest tracking for pnpm** — the bun path expands `package.json` `workspaces` globs into the fingerprint; pnpm would need `pnpm-workspace.yaml` `packages:` parsing. Current pnpm fingerprint relies on the lockfile + workspace config (catches install-time changes, but not a workspace manifest edited before reinstall).
- npm / yarn first-class support.

## Verification

- 5 new tests (pnpm detect+command, precedence-over-bun, pnpm-lock-alone, bun-beats-pnpm-lock, missing→ready), RED→GREEN.
- Full `dependency-readiness.test.ts`: **60 pass** — all existing bun + #321 abstain tests unaffected.
- Dogfood + template byte-identical; parity in sync; typecheck + eslint clean.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)