### PR TITLE
feat(dep-readiness): pnpm + npm/yarn first-class support (#323 + #327)

### DIFF
--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun';
+export type DependencyManager = 'bun' | 'pnpm';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -113,28 +113,50 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
   );
   if (packageJson === undefined) return undefined;
 
-  const bunLockfile = BUN_LOCKFILES.find(lockfile =>
+  const packageManager =
+    typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
+  const manager = detectDependencyManager(projectDirectory, packageManager);
+
+  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
+  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
+  return undefined;
+}
+
+/**
+ * Resolve the readiness-supported package manager (bun or pnpm), or undefined
+ * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
+ * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
+ * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
+ * manager (unsupported by this gate) abstains rather than misfiring bun, so a
+ * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ */
+function detectDependencyManager(
+  projectDirectory: string,
+  packageManager: string | undefined,
+): DependencyManager | undefined {
+  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const packageManager = packageJson.packageManager;
+  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
+  const prefersPnpm =
+    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
+    (packageManager?.startsWith('pnpm@') ?? false);
+  const declaresOtherManager =
+    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
 
-  // Abstain for projects that are explicitly not bun, even when a bun lockfile
-  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
-  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
-  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
-  // at a pnpm workspace (#321).
-  const declaresNonBunManager =
-    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
-  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
-    return undefined;
-  }
+  if (declaresOtherManager && !prefersPnpm) return undefined;
+  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
+  if (bunLockfilePresent && !prefersPnpm) return 'bun';
+  return undefined;
+}
 
-  const usesBun =
-    (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
-    bunLockfile !== undefined;
-
-  if (!usesBun || bunLockfile === undefined) return undefined;
-
+function buildBunPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  const bunLockfile =
+    BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
+    'bun.lock';
   const inputPaths = uniqueSorted([
     'package.json',
     bunLockfile,
@@ -143,10 +165,32 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   return {
     manager: 'bun',
+    installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths,
+  };
+}
+
+/**
+ * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
+ * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
+ * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ */
+function buildPnpmPlan(projectDirectory: string): DependencyPlan {
+  const inputPaths = uniqueSorted([
+    'package.json',
+    'pnpm-lock.yaml',
+    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
+      ? ['pnpm-workspace.yaml']
+      : []),
+  ]);
+
+  return {
+    manager: 'pnpm',
     installCommand: {
-      binary: 'bun',
-      args: ['ci'],
-      display: 'bun ci',
+      binary: 'pnpm',
+      args: ['install', '--frozen-lockfile'],
+      display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
     inputPaths,

--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun' | 'pnpm';
+export type DependencyManager = 'bun' | 'pnpm' | 'npm' | 'yarn';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -107,6 +107,17 @@ const DEPENDENCY_BINARIES = new Set([
   'vitest',
 ]);
 
+const MANAGER_LOCKFILES: Record<DependencyManager, readonly string[]> = {
+  bun: BUN_LOCKFILES,
+  pnpm: ['pnpm-lock.yaml'],
+  npm: ['package-lock.json'],
+  yarn: ['yarn.lock'],
+};
+
+// Lockfile-only precedence when nothing declares a manager — mirrors install.ts:
+// a bun lockfile beats pnpm-lock.yaml, then yarn.lock, then package-lock.json.
+const LOCKFILE_PRECEDENCE: readonly DependencyManager[] = ['bun', 'pnpm', 'yarn', 'npm'];
+
 export function detectDependencyPlan(projectDirectory: string): DependencyPlan | undefined {
   const packageJson = readJsonFile<Record<string, unknown>>(
     nodePath.join(projectDirectory, 'package.json'),
@@ -115,39 +126,56 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   const packageManager =
     typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
-  const manager = detectDependencyManager(projectDirectory, packageManager);
 
-  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
-  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
-  return undefined;
+  switch (detectDependencyManager(projectDirectory, packageManager)) {
+    case 'bun':
+      return buildBunPlan(projectDirectory, packageJson);
+    case 'pnpm':
+      return buildPnpmPlan(projectDirectory);
+    case 'npm':
+      return buildNpmPlan(projectDirectory, packageJson);
+    case 'yarn':
+      return buildYarnPlan(projectDirectory, packageJson, packageManager);
+    default:
+      return undefined;
+  }
 }
 
 /**
- * Resolve the readiness-supported package manager (bun or pnpm), or undefined
- * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
- * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
- * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
- * manager (unsupported by this gate) abstains rather than misfiring bun, so a
- * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ * Resolve the readiness-supported package manager (bun, pnpm, npm, or yarn), or
+ * undefined when unsupported. An explicit `packageManager` declaration is
+ * authoritative (honored when its lockfile exists); otherwise a pnpm workspace
+ * forces pnpm (beats a coexisting bun lockfile — mirrors install.ts); otherwise
+ * the manager is chosen by lockfile in install.ts precedence (bun > pnpm-lock >
+ * yarn > npm). Every manager requires its lockfile to produce a plan, so a
+ * declared-but-uninstalled manager (or a stray foreign lockfile in another
+ * manager's project) abstains rather than misfiring (#321/#323/#327).
  */
 function detectDependencyManager(
   projectDirectory: string,
   packageManager: string | undefined,
 ): DependencyManager | undefined {
-  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
+  const declared = parseDeclaredManager(packageManager);
+  if (declared !== undefined) {
+    return managerLockfilePresent(projectDirectory, declared) ? declared : undefined;
+  }
+
+  if (existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
+    return managerLockfilePresent(projectDirectory, 'pnpm') ? 'pnpm' : undefined;
+  }
+
+  return LOCKFILE_PRECEDENCE.find(manager => managerLockfilePresent(projectDirectory, manager));
+}
+
+function parseDeclaredManager(packageManager: string | undefined): DependencyManager | undefined {
+  const match = packageManager?.match(/^(bun|pnpm|npm|yarn)@/);
+  return match ? (match[1] as DependencyManager) : undefined;
+}
+
+function managerLockfilePresent(projectDirectory: string, manager: DependencyManager): boolean {
+  return MANAGER_LOCKFILES[manager].some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
-  const prefersPnpm =
-    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
-    (packageManager?.startsWith('pnpm@') ?? false);
-  const declaresOtherManager =
-    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
-
-  if (declaresOtherManager && !prefersPnpm) return undefined;
-  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
-  if (bunLockfilePresent && !prefersPnpm) return 'bun';
-  return undefined;
 }
 
 function buildBunPlan(
@@ -157,34 +185,25 @@ function buildBunPlan(
   const bunLockfile =
     BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
     'bun.lock';
-  const inputPaths = uniqueSorted([
-    'package.json',
-    bunLockfile,
-    ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
-  ]);
-
   return {
     manager: 'bun',
     installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
     installArtifact: INSTALL_ARTIFACT,
-    inputPaths,
+    inputPaths: uniqueSorted([
+      'package.json',
+      bunLockfile,
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
   };
 }
 
 /**
  * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
- * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
- * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ * `bun ci`), fingerprinting package.json, the pnpm lockfile, the workspace
+ * config, and the workspace package manifests it globs in.
  */
 function buildPnpmPlan(projectDirectory: string): DependencyPlan {
-  const inputPaths = uniqueSorted([
-    'package.json',
-    'pnpm-lock.yaml',
-    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
-      ? ['pnpm-workspace.yaml']
-      : []),
-  ]);
-
+  const workspaceConfigPresent = existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'));
   return {
     manager: 'pnpm',
     installCommand: {
@@ -193,8 +212,62 @@ function buildPnpmPlan(projectDirectory: string): DependencyPlan {
       display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
-    inputPaths,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'pnpm-lock.yaml',
+      ...(workspaceConfigPresent ? ['pnpm-workspace.yaml'] : []),
+      ...collectPnpmWorkspacePackageJsonPaths(projectDirectory),
+    ]),
   };
+}
+
+function buildNpmPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  return {
+    manager: 'npm',
+    installCommand: { binary: 'npm', args: ['ci'], display: 'npm ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'package-lock.json',
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
+  };
+}
+
+/**
+ * yarn readiness plan. Classic (v1) uses `--frozen-lockfile`; berry (v2+) uses
+ * `--immutable` (its rename of the same CI guard), detected via a `yarn@<major>`
+ * declaration or a `.yarnrc.yml`.
+ */
+function buildYarnPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+  packageManager: string | undefined,
+): DependencyPlan {
+  const args = isYarnBerry(projectDirectory, packageManager)
+    ? ['install', '--immutable']
+    : ['install', '--frozen-lockfile'];
+  return {
+    manager: 'yarn',
+    installCommand: { binary: 'yarn', args, display: `yarn ${args.join(' ')}` },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'yarn.lock',
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
+  };
+}
+
+function isYarnBerry(projectDirectory: string, packageManager: string | undefined): boolean {
+  if (packageManager?.startsWith('yarn@')) {
+    const major = Number.parseInt(packageManager.slice('yarn@'.length), 10);
+    return Number.isFinite(major) && major >= 2;
+  }
+  return existsSync(nodePath.join(projectDirectory, '.yarnrc.yml'));
 }
 
 export function dependencyInputFingerprint(projectDirectory: string, plan: DependencyPlan): string {
@@ -366,6 +439,52 @@ function collectWorkspacePackageJsonPaths(
   rootPackageJson: Record<string, unknown>,
 ): string[] {
   return expandWorkspacePatterns(projectDirectory, readWorkspacePatterns(rootPackageJson));
+}
+
+function collectPnpmWorkspacePackageJsonPaths(projectDirectory: string): string[] {
+  return expandWorkspacePatterns(projectDirectory, readPnpmWorkspacePackages(projectDirectory));
+}
+
+/**
+ * Extract the `packages:` block-list globs from pnpm-workspace.yaml without a
+ * YAML dependency (hooks are zero-third-party). Handles the standard block
+ * sequence, quotes, comments, and `!` negation (passed through to
+ * expandWorkspacePatterns). An inline flow sequence (`packages: [...]`) yields
+ * nothing — uncommon in pnpm-workspace.yaml.
+ */
+function readPnpmWorkspacePackages(projectDirectory: string): string[] {
+  let content: string;
+  try {
+    content = readFileSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'), 'utf8');
+  } catch {
+    return [];
+  }
+
+  const patterns: string[] = [];
+  let insidePackages = false;
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/(^|\s)#.*$/, '');
+    if (!insidePackages) {
+      if (/^packages:\s*$/.test(line)) insidePackages = true;
+      continue;
+    }
+    const item = line.match(/^\s*-\s*(.+?)\s*$/);
+    if (item?.[1] !== undefined) {
+      patterns.push(stripYamlQuotes(item[1]));
+      continue;
+    }
+    // A new top-level key (non-indented, non-comment, non-item) ends the block.
+    if (/^[^\s#-]/.test(line)) insidePackages = false;
+  }
+  return patterns;
+}
+
+function stripYamlQuotes(value: string): string {
+  const trimmed = value.trim();
+  const quoted =
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'));
+  return quoted ? trimmed.slice(1, -1) : trimmed;
 }
 
 function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string[] {

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun';
+export type DependencyManager = 'bun' | 'pnpm';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -113,28 +113,50 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
   );
   if (packageJson === undefined) return undefined;
 
-  const bunLockfile = BUN_LOCKFILES.find(lockfile =>
+  const packageManager =
+    typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
+  const manager = detectDependencyManager(projectDirectory, packageManager);
+
+  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
+  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
+  return undefined;
+}
+
+/**
+ * Resolve the readiness-supported package manager (bun or pnpm), or undefined
+ * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
+ * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
+ * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
+ * manager (unsupported by this gate) abstains rather than misfiring bun, so a
+ * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ */
+function detectDependencyManager(
+  projectDirectory: string,
+  packageManager: string | undefined,
+): DependencyManager | undefined {
+  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const packageManager = packageJson.packageManager;
+  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
+  const prefersPnpm =
+    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
+    (packageManager?.startsWith('pnpm@') ?? false);
+  const declaresOtherManager =
+    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
 
-  // Abstain for projects that are explicitly not bun, even when a bun lockfile
-  // coexists: a non-bun `packageManager` declaration (authoritative), or a pnpm
-  // workspace (mirrors install.ts, where pnpm-workspace.yaml beats a bun
-  // lockfile). Without this, a stray bun.lock makes the gate misfire `bun ci`
-  // at a pnpm workspace (#321).
-  const declaresNonBunManager =
-    typeof packageManager === 'string' && /^(?:pnpm|npm|yarn)@/.test(packageManager);
-  if (declaresNonBunManager || existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
-    return undefined;
-  }
+  if (declaresOtherManager && !prefersPnpm) return undefined;
+  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
+  if (bunLockfilePresent && !prefersPnpm) return 'bun';
+  return undefined;
+}
 
-  const usesBun =
-    (typeof packageManager === 'string' && packageManager.startsWith('bun@')) ||
-    bunLockfile !== undefined;
-
-  if (!usesBun || bunLockfile === undefined) return undefined;
-
+function buildBunPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  const bunLockfile =
+    BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
+    'bun.lock';
   const inputPaths = uniqueSorted([
     'package.json',
     bunLockfile,
@@ -143,10 +165,32 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   return {
     manager: 'bun',
+    installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths,
+  };
+}
+
+/**
+ * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
+ * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
+ * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ */
+function buildPnpmPlan(projectDirectory: string): DependencyPlan {
+  const inputPaths = uniqueSorted([
+    'package.json',
+    'pnpm-lock.yaml',
+    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
+      ? ['pnpm-workspace.yaml']
+      : []),
+  ]);
+
+  return {
+    manager: 'pnpm',
     installCommand: {
-      binary: 'bun',
-      args: ['ci'],
-      display: 'bun ci',
+      binary: 'pnpm',
+      args: ['install', '--frozen-lockfile'],
+      display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
     inputPaths,

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
 
-export type DependencyManager = 'bun' | 'pnpm';
+export type DependencyManager = 'bun' | 'pnpm' | 'npm' | 'yarn';
 export type DependencyReadinessStatus = 'ready' | 'missing' | 'stale' | 'unsupported';
 
 export interface InstallCommand {
@@ -107,6 +107,17 @@ const DEPENDENCY_BINARIES = new Set([
   'vitest',
 ]);
 
+const MANAGER_LOCKFILES: Record<DependencyManager, readonly string[]> = {
+  bun: BUN_LOCKFILES,
+  pnpm: ['pnpm-lock.yaml'],
+  npm: ['package-lock.json'],
+  yarn: ['yarn.lock'],
+};
+
+// Lockfile-only precedence when nothing declares a manager — mirrors install.ts:
+// a bun lockfile beats pnpm-lock.yaml, then yarn.lock, then package-lock.json.
+const LOCKFILE_PRECEDENCE: readonly DependencyManager[] = ['bun', 'pnpm', 'yarn', 'npm'];
+
 export function detectDependencyPlan(projectDirectory: string): DependencyPlan | undefined {
   const packageJson = readJsonFile<Record<string, unknown>>(
     nodePath.join(projectDirectory, 'package.json'),
@@ -115,39 +126,56 @@ export function detectDependencyPlan(projectDirectory: string): DependencyPlan |
 
   const packageManager =
     typeof packageJson.packageManager === 'string' ? packageJson.packageManager : undefined;
-  const manager = detectDependencyManager(projectDirectory, packageManager);
 
-  if (manager === 'bun') return buildBunPlan(projectDirectory, packageJson);
-  if (manager === 'pnpm') return buildPnpmPlan(projectDirectory);
-  return undefined;
+  switch (detectDependencyManager(projectDirectory, packageManager)) {
+    case 'bun':
+      return buildBunPlan(projectDirectory, packageJson);
+    case 'pnpm':
+      return buildPnpmPlan(projectDirectory);
+    case 'npm':
+      return buildNpmPlan(projectDirectory, packageJson);
+    case 'yarn':
+      return buildYarnPlan(projectDirectory, packageJson, packageManager);
+    default:
+      return undefined;
+  }
 }
 
 /**
- * Resolve the readiness-supported package manager (bun or pnpm), or undefined
- * when unsupported. Precedence mirrors install.ts: a pnpm workspace or a `pnpm@`
- * declaration beats a coexisting bun lockfile; otherwise a bun lockfile wins;
- * `pnpm-lock.yaml` is pnpm when no bun lockfile is present. A declared npm/yarn
- * manager (unsupported by this gate) abstains rather than misfiring bun, so a
- * stray bun.lock never recommends `bun ci` in a non-bun project (#321/#323).
+ * Resolve the readiness-supported package manager (bun, pnpm, npm, or yarn), or
+ * undefined when unsupported. An explicit `packageManager` declaration is
+ * authoritative (honored when its lockfile exists); otherwise a pnpm workspace
+ * forces pnpm (beats a coexisting bun lockfile — mirrors install.ts); otherwise
+ * the manager is chosen by lockfile in install.ts precedence (bun > pnpm-lock >
+ * yarn > npm). Every manager requires its lockfile to produce a plan, so a
+ * declared-but-uninstalled manager (or a stray foreign lockfile in another
+ * manager's project) abstains rather than misfiring (#321/#323/#327).
  */
 function detectDependencyManager(
   projectDirectory: string,
   packageManager: string | undefined,
 ): DependencyManager | undefined {
-  const bunLockfilePresent = BUN_LOCKFILES.some(lockfile =>
+  const declared = parseDeclaredManager(packageManager);
+  if (declared !== undefined) {
+    return managerLockfilePresent(projectDirectory, declared) ? declared : undefined;
+  }
+
+  if (existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) {
+    return managerLockfilePresent(projectDirectory, 'pnpm') ? 'pnpm' : undefined;
+  }
+
+  return LOCKFILE_PRECEDENCE.find(manager => managerLockfilePresent(projectDirectory, manager));
+}
+
+function parseDeclaredManager(packageManager: string | undefined): DependencyManager | undefined {
+  const match = packageManager?.match(/^(bun|pnpm|npm|yarn)@/);
+  return match ? (match[1] as DependencyManager) : undefined;
+}
+
+function managerLockfilePresent(projectDirectory: string, manager: DependencyManager): boolean {
+  return MANAGER_LOCKFILES[manager].some(lockfile =>
     existsSync(nodePath.join(projectDirectory, lockfile)),
   );
-  const pnpmLockfilePresent = existsSync(nodePath.join(projectDirectory, 'pnpm-lock.yaml'));
-  const prefersPnpm =
-    existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml')) ||
-    (packageManager?.startsWith('pnpm@') ?? false);
-  const declaresOtherManager =
-    packageManager !== undefined && /^(?:npm|yarn)@/.test(packageManager);
-
-  if (declaresOtherManager && !prefersPnpm) return undefined;
-  if (pnpmLockfilePresent && (prefersPnpm || !bunLockfilePresent)) return 'pnpm';
-  if (bunLockfilePresent && !prefersPnpm) return 'bun';
-  return undefined;
 }
 
 function buildBunPlan(
@@ -157,34 +185,25 @@ function buildBunPlan(
   const bunLockfile =
     BUN_LOCKFILES.find(lockfile => existsSync(nodePath.join(projectDirectory, lockfile))) ??
     'bun.lock';
-  const inputPaths = uniqueSorted([
-    'package.json',
-    bunLockfile,
-    ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
-  ]);
-
   return {
     manager: 'bun',
     installCommand: { binary: 'bun', args: ['ci'], display: 'bun ci' },
     installArtifact: INSTALL_ARTIFACT,
-    inputPaths,
+    inputPaths: uniqueSorted([
+      'package.json',
+      bunLockfile,
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
   };
 }
 
 /**
  * pnpm readiness plan: `pnpm install --frozen-lockfile` (the frozen analog of
- * `bun ci`). Fingerprints package.json, the pnpm lockfile, and the workspace
- * config; per-workspace-manifest tracking (as the bun path does) is a follow-up.
+ * `bun ci`), fingerprinting package.json, the pnpm lockfile, the workspace
+ * config, and the workspace package manifests it globs in.
  */
 function buildPnpmPlan(projectDirectory: string): DependencyPlan {
-  const inputPaths = uniqueSorted([
-    'package.json',
-    'pnpm-lock.yaml',
-    ...(existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))
-      ? ['pnpm-workspace.yaml']
-      : []),
-  ]);
-
+  const workspaceConfigPresent = existsSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'));
   return {
     manager: 'pnpm',
     installCommand: {
@@ -193,8 +212,62 @@ function buildPnpmPlan(projectDirectory: string): DependencyPlan {
       display: 'pnpm install --frozen-lockfile',
     },
     installArtifact: INSTALL_ARTIFACT,
-    inputPaths,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'pnpm-lock.yaml',
+      ...(workspaceConfigPresent ? ['pnpm-workspace.yaml'] : []),
+      ...collectPnpmWorkspacePackageJsonPaths(projectDirectory),
+    ]),
   };
+}
+
+function buildNpmPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+): DependencyPlan {
+  return {
+    manager: 'npm',
+    installCommand: { binary: 'npm', args: ['ci'], display: 'npm ci' },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'package-lock.json',
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
+  };
+}
+
+/**
+ * yarn readiness plan. Classic (v1) uses `--frozen-lockfile`; berry (v2+) uses
+ * `--immutable` (its rename of the same CI guard), detected via a `yarn@<major>`
+ * declaration or a `.yarnrc.yml`.
+ */
+function buildYarnPlan(
+  projectDirectory: string,
+  packageJson: Record<string, unknown>,
+  packageManager: string | undefined,
+): DependencyPlan {
+  const args = isYarnBerry(projectDirectory, packageManager)
+    ? ['install', '--immutable']
+    : ['install', '--frozen-lockfile'];
+  return {
+    manager: 'yarn',
+    installCommand: { binary: 'yarn', args, display: `yarn ${args.join(' ')}` },
+    installArtifact: INSTALL_ARTIFACT,
+    inputPaths: uniqueSorted([
+      'package.json',
+      'yarn.lock',
+      ...collectWorkspacePackageJsonPaths(projectDirectory, packageJson),
+    ]),
+  };
+}
+
+function isYarnBerry(projectDirectory: string, packageManager: string | undefined): boolean {
+  if (packageManager?.startsWith('yarn@')) {
+    const major = Number.parseInt(packageManager.slice('yarn@'.length), 10);
+    return Number.isFinite(major) && major >= 2;
+  }
+  return existsSync(nodePath.join(projectDirectory, '.yarnrc.yml'));
 }
 
 export function dependencyInputFingerprint(projectDirectory: string, plan: DependencyPlan): string {
@@ -366,6 +439,52 @@ function collectWorkspacePackageJsonPaths(
   rootPackageJson: Record<string, unknown>,
 ): string[] {
   return expandWorkspacePatterns(projectDirectory, readWorkspacePatterns(rootPackageJson));
+}
+
+function collectPnpmWorkspacePackageJsonPaths(projectDirectory: string): string[] {
+  return expandWorkspacePatterns(projectDirectory, readPnpmWorkspacePackages(projectDirectory));
+}
+
+/**
+ * Extract the `packages:` block-list globs from pnpm-workspace.yaml without a
+ * YAML dependency (hooks are zero-third-party). Handles the standard block
+ * sequence, quotes, comments, and `!` negation (passed through to
+ * expandWorkspacePatterns). An inline flow sequence (`packages: [...]`) yields
+ * nothing — uncommon in pnpm-workspace.yaml.
+ */
+function readPnpmWorkspacePackages(projectDirectory: string): string[] {
+  let content: string;
+  try {
+    content = readFileSync(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'), 'utf8');
+  } catch {
+    return [];
+  }
+
+  const patterns: string[] = [];
+  let insidePackages = false;
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/(^|\s)#.*$/, '');
+    if (!insidePackages) {
+      if (/^packages:\s*$/.test(line)) insidePackages = true;
+      continue;
+    }
+    const item = line.match(/^\s*-\s*(.+?)\s*$/);
+    if (item?.[1] !== undefined) {
+      patterns.push(stripYamlQuotes(item[1]));
+      continue;
+    }
+    // A new top-level key (non-indented, non-comment, non-item) ends the block.
+    if (/^[^\s#-]/.test(line)) insidePackages = false;
+  }
+  return patterns;
+}
+
+function stripYamlQuotes(value: string): string {
+  const trimmed = value.trim();
+  const quoted =
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'));
+  return quoted ? trimmed.slice(1, -1) : trimmed;
 }
 
 function readWorkspacePatterns(rootPackageJson: Record<string, unknown>): string[] {

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -201,6 +201,80 @@ describe('dependency readiness hook support', () => {
     expect(getDependencyReadiness(projectDirectory).status).toBe('ready');
   });
 
+  it('detects an npm project and plans npm ci (#327)', () => {
+    writeJson('package.json', { name: 'npm-project', packageManager: 'npm@10.0.0' });
+    writeTestFile(projectDirectory, 'package-lock.json', '{}');
+
+    const plan = detectDependencyPlan(projectDirectory);
+    expect(plan).toMatchObject({
+      manager: 'npm',
+      installCommand: { binary: 'npm', args: ['ci'], display: 'npm ci' },
+    });
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'package-lock.json',
+      'package.json',
+    ]);
+  });
+
+  it('treats package-lock.json alone as npm (#327)', () => {
+    writeJson('package.json', { name: 'npm-single' });
+    writeTestFile(projectDirectory, 'package-lock.json', '{}');
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('npm');
+  });
+
+  it('stays unsupported when npm is declared but no package-lock.json exists (#327)', () => {
+    writeJson('package.json', { name: 'npm-no-lock', packageManager: 'npm@10.0.0' });
+    writeTestFile(projectDirectory, 'bun.lock', '# stray bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)).toBeUndefined();
+  });
+
+  it('plans a frozen-lockfile install for yarn classic (#327)', () => {
+    writeJson('package.json', { name: 'yarn-classic', packageManager: 'yarn@1.22.22' });
+    writeTestFile(projectDirectory, 'yarn.lock', '# yarn lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.installCommand.display).toBe(
+      'yarn install --frozen-lockfile',
+    );
+  });
+
+  it('plans an immutable install for yarn berry (#327)', () => {
+    writeJson('package.json', { name: 'yarn-berry', packageManager: 'yarn@4.3.1' });
+    writeTestFile(projectDirectory, 'yarn.lock', '# yarn lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.installCommand.display).toBe(
+      'yarn install --immutable',
+    );
+  });
+
+  it('detects yarn berry from .yarnrc.yml when no packageManager is declared (#327)', () => {
+    writeJson('package.json', { name: 'yarn-berry-rc' });
+    writeTestFile(projectDirectory, 'yarn.lock', '# yarn lockfile');
+    writeTestFile(projectDirectory, '.yarnrc.yml', 'nodeLinker: node-modules\n');
+
+    const plan = detectDependencyPlan(projectDirectory);
+    expect(plan?.manager).toBe('yarn');
+    expect(plan?.installCommand.display).toBe('yarn install --immutable');
+  });
+
+  it('tracks pnpm workspace package manifests globbed from pnpm-workspace.yaml (#327)', () => {
+    writeJson('package.json', { name: 'pnpm-ws', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+    writeJson('packages/cli/package.json', { name: '@ws/cli' });
+    writeJson('packages/core/package.json', { name: '@ws/core' });
+
+    const plan = detectDependencyPlan(projectDirectory);
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'package.json',
+      'packages/cli/package.json',
+      'packages/core/package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+    ]);
+  });
+
   it('tracks package manifests matched by recursive workspace globs', () => {
     writeJson('package.json', {
       name: 'recursive-workspace-project',

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -142,6 +142,65 @@ describe('dependency readiness hook support', () => {
     expect(getDependencyReadiness(projectDirectory).status).toBe('unsupported');
   });
 
+  it('detects a pnpm workspace and plans a frozen pnpm install (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-project', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    const plan = detectDependencyPlan(projectDirectory);
+
+    expect(plan).toMatchObject({
+      manager: 'pnpm',
+      installCommand: {
+        binary: 'pnpm',
+        args: ['install', '--frozen-lockfile'],
+        display: 'pnpm install --frozen-lockfile',
+      },
+      installArtifact: 'node_modules',
+    });
+    expect(plan?.inputPaths.toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+    ]);
+  });
+
+  it('prefers pnpm over a coexisting bun lockfile when the project signals pnpm (#323)', () => {
+    writeJson('package.json', { name: 'mixed', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-workspace.yaml', "packages:\n  - 'packages/*'\n");
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+    writeTestFile(projectDirectory, 'bun.lock', '# stray bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('pnpm');
+  });
+
+  it('treats pnpm-lock.yaml alone (no bun lockfile) as pnpm (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-single' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('pnpm');
+  });
+
+  it('keeps bun precedence when bun.lock coexists with pnpm-lock.yaml and no pnpm signal (#323)', () => {
+    writeJson('package.json', { name: 'ambiguous' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+    writeTestFile(projectDirectory, 'bun.lock', '# bun lockfile');
+
+    expect(detectDependencyPlan(projectDirectory)?.manager).toBe('bun');
+  });
+
+  it('reports missing then ready for a pnpm project (#323)', () => {
+    writeJson('package.json', { name: 'pnpm-project', packageManager: 'pnpm@9.0.0' });
+    writeTestFile(projectDirectory, 'pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
+
+    const missing = getDependencyReadiness(projectDirectory);
+    expect(missing.status).toBe('missing');
+    expect(missing.installCommand).toBe('pnpm install --frozen-lockfile');
+
+    mkdirSync(path.join(projectDirectory, 'node_modules'), { recursive: true });
+    expect(getDependencyReadiness(projectDirectory).status).toBe('ready');
+  });
+
   it('tracks package manifests matched by recursive workspace globs', () => {
     writeJson('package.json', {
       name: 'recursive-workspace-project',


### PR DESCRIPTION
> **History:** originally stacked — #322 (abstain) ← #324 (pnpm, #323) ← this (npm/yarn, #327). #322 merged to `main`; deleting its branch auto-closed #324. I rebased this branch onto `main` and retargeted it here, so **this PR now carries BOTH the pnpm first-class support (#323, from the closed #324) and the npm/yarn + pnpm-workspace work (#327)** as a clean delta on top of the merged #322 abstain guard.

## What this adds (on top of #322's abstain guard, already on main)

Completes the multi-package-manager readiness gate.

**pnpm first-class (#323):** `pnpm install --frozen-lockfile`; precedence where `pnpm-workspace.yaml` / `pnpm@` beats a coexisting bun lockfile.

**npm / yarn + pnpm workspace fingerprinting (#327):**
- npm → `npm ci`; yarn classic → `yarn install --frozen-lockfile`, berry → `yarn install --immutable` (detected via `.yarnrc.yml` or `yarn@<major>`).
- pnpm now fingerprints workspace manifests via a `pnpm-workspace.yaml` `packages:` parser.
- `detectDependencyManager` is a single precedence resolver: explicit `packageManager` → `pnpm-workspace.yaml` → lockfile order `bun > pnpm-lock > yarn > npm`. Every manager requires its lockfile to produce a plan.

## Verification

- 67/67 dependency-readiness tests pass; typecheck + parity clean; dogfood↔template byte-identical.
- Rebased onto current `main`: confirmed multi-PM detection **and** #332's `SAFEWORD:` de-branding are both present, with the #322 abstain guard not duplicated.

Closes #323, #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)