### PR TITLE
Rename generated architecture doc + don't birth empty docs

### DIFF
--- a/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
+++ b/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
@@ -17,3 +17,7 @@ last_modified: 2026-06-21T20:03:00.000Z
 ## Work Log
 
 - 2026-06-21T20:03:00Z Implement: added `resolveGeneratedArchitecturePath` (fixed `<namespace-root>/architecture.generated.md`, not overridable); `selfHeal` now writes there instead of `resolveConfiguredPath(cwd, 'architecture')`. Updated doc/command tests + BDD steps. 26 unit/integration tests + 21 BDD scenarios green; lint/typecheck clean. No migration: the old default `.project/architecture.md` doubled as the ADR-record location, so it must not be auto-deleted; in practice no generated docs exist in the wild (Slice 1 shipped hours ago).
+
+- 2026-06-21T21:25:00Z Decisions (via /figure-it-out), implemented D1:
+  - **D1 (empty-doc):** Don't birth an empty doc — `selfHeal` returns a new `noop` action when no doc exists and the skeleton has no modules (a contentless "## Modules" would falsely imply "no modules", e.g. for a monorepo the single-repo extractor can't read). An existing doc still heals toward empty (orphan markers show real removals). Revised the two no-modules BDD scenarios to assert "no doc is written" instead of "an empty doc is produced". Verified the dogfood monorepo now noops (writes nothing).
+  - **D2 (commit vs gitignore):** Commit the generated doc, do NOT gitignore — it's a deterministic, meaningful-diff, agent/human-read artifact (lockfile pattern; precedent: committed `.safeword/depcruise-config.cjs`). No code change. D1 ensures committing never means committing noise.

--- a/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
+++ b/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
@@ -2,8 +2,8 @@
 id: CTAZT5
 slug: rename-generated-architecture-doc
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-06-21T19:59:00.000Z
 last_modified: 2026-06-21T20:03:00.000Z
 ---
@@ -21,3 +21,4 @@ last_modified: 2026-06-21T20:03:00.000Z
 - 2026-06-21T21:25:00Z Decisions (via /figure-it-out), implemented D1:
   - **D1 (empty-doc):** Don't birth an empty doc — `selfHeal` returns a new `noop` action when no doc exists and the skeleton has no modules (a contentless "## Modules" would falsely imply "no modules", e.g. for a monorepo the single-repo extractor can't read). An existing doc still heals toward empty (orphan markers show real removals). Revised the two no-modules BDD scenarios to assert "no doc is written" instead of "an empty doc is produced". Verified the dogfood monorepo now noops (writes nothing).
   - **D2 (commit vs gitignore):** Commit the generated doc, do NOT gitignore — it's a deterministic, meaningful-diff, agent/human-read artifact (lockfile pattern; precedent: committed `.safeword/depcruise-config.cjs`). No code change. D1 ensures committing never means committing noise.
+- 2026-06-22T04:31:00Z Done: two independent reviews (rename diff + full diff, both APPROVE); applied 5 doc-accuracy fixes + precedence test + skeleton dedupe; /figure-it-out resolved D1 (no empty docs → noop) and D2 (keep committed); /refactor extracted byString comparator + de-exported dead constant. Audit clean (knip/depcruise/jscpd); full suite 3239 pass. Marked done; opening PR.

--- a/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
+++ b/.project/tickets/CTAZT5-rename-generated-architecture-doc/ticket.md
@@ -1,0 +1,19 @@
+---
+id: CTAZT5
+slug: rename-generated-architecture-doc
+type: task
+phase: implement
+status: in_progress
+created: 2026-06-21T19:59:00.000Z
+last_modified: 2026-06-21T20:03:00.000Z
+---
+
+# Rename generated architecture doc to architecture.generated.md
+
+**Goal:** Give the auto-generated architecture state doc a self-describing, machine-owned name (`<namespace-root>/architecture.generated.md`) that can't be confused with a hand-written architecture/ADR doc.
+
+**Why:** Slice 1 wrote the generated doc to `paths.architecture` (default `.project/architecture.md`) — the same config key that points at the hand-curated decision/ADR location. One name, two meanings. The `.generated.` infix signals "do not hand-edit" and decouples the generated state doc from `paths.architecture` (which stays for human-authored decisions).
+
+## Work Log
+
+- 2026-06-21T20:03:00Z Implement: added `resolveGeneratedArchitecturePath` (fixed `<namespace-root>/architecture.generated.md`, not overridable); `selfHeal` now writes there instead of `resolveConfiguredPath(cwd, 'architecture')`. Updated doc/command tests + BDD steps. 26 unit/integration tests + 21 BDD scenarios green; lint/typecheck clean. No migration: the old default `.project/architecture.md` doubled as the ADR-record location, so it must not be auto-deleted; in practice no generated docs exist in the wild (Slice 1 shipped hours ago).

--- a/.safeword/hooks/session-architecture-heal.ts
+++ b/.safeword/hooks/session-architecture-heal.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // Safeword: Architecture state-document self-heal (SessionStart)
-// Refreshes the architecture state doc at the configured paths.architecture so
+// Refreshes the generated architecture state doc (.project/architecture.generated.md) so
 // structural facts stay fresh — including after out-of-band human edits. Skips
 // any document safeword does not own (no generator marker), so a hand-written
 // ARCHITECTURE.md is never overwritten. Best-effort: never blocks a session.

--- a/features/architecture-state-docs.feature
+++ b/features/architecture-state-docs.feature
@@ -28,16 +28,16 @@ Feature: Always-fresh point-in-time architecture doc (Slice 1, single-repo)
       Then scripts/build.ts does not appear as a skeleton node
 
     @architecture-state-docs.NTB1.AC1
-    Scenario: A project with no src directory still produces a doc
+    Scenario: A project with no modules produces no doc, without error
       Given a project that has no src directory
       When the architecture doc is generated
-      Then a minimal skeleton is produced without error
+      Then no architecture doc is written
 
     @architecture-state-docs.NTB1.AC1
-    Scenario: A src directory with zero modules produces an empty skeleton
+    Scenario: An empty src directory produces no doc, without error
       Given a project whose src/ exists but contains no modules
       When the architecture doc is generated
-      Then an empty skeleton is produced without error
+      Then no architecture doc is written
 
     @architecture-state-docs.NTB1.AC1
     Scenario: Extraction is content-agnostic — a malformed file never aborts it

--- a/features/architecture-state-docs.feature
+++ b/features/architecture-state-docs.feature
@@ -1,7 +1,7 @@
 @architecture-state-docs
 Feature: Always-fresh point-in-time architecture doc (Slice 1, single-repo)
 
-  The architecture state doc (.project/architecture.md) describes the system as
+  The architecture state doc (.project/architecture.generated.md) describes the system as
   it is now. Its structural facts are extracted deterministically and self-heal
   at session start; any prose that has fallen behind the structure is visibly
   flagged, so the doc may be incomplete but is never silently wrong.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -86,7 +86,9 @@ program
 
 program
   .command('architecture')
-  .description('Refresh the architecture state document at the configured paths.architecture')
+  .description(
+    'Refresh the generated architecture state document (.project/architecture.generated.md)',
+  )
   .action(async () => {
     const { architecture } = await import('./commands/architecture.js');
     await architecture();

--- a/packages/cli/src/commands/architecture.ts
+++ b/packages/cli/src/commands/architecture.ts
@@ -3,7 +3,7 @@
  * QD5DTT, Slice 1).
  *
  * Thin CLI entry over `selfHeal`: re-extracts the skeleton and reconciles prose
- * markers at the configured `paths.architecture`. The SessionStart hook shells
+ * markers at the generated `.project/architecture.generated.md`. The SessionStart hook shells
  * out to this command so the heal logic lives in one place (the CLI), not
  * duplicated into the hook lib.
  */

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -67,13 +67,13 @@ export function selfHeal(projectDirectory: string): SelfHealResult {
   const path = resolveGeneratedArchitecturePath(projectDirectory);
   const fingerprint = shapeFingerprint(projectDirectory);
   const existing = readExisting(path);
-  const hasModules = extractSkeleton(projectDirectory).nodes.length > 0;
-  const action = decideAction(existing, fingerprint, hasModules);
+  const nodes = extractSkeleton(projectDirectory).nodes;
+  const action = decideAction(existing, fingerprint, nodes.length > 0);
 
   if (action !== 'unchanged' && action !== 'skipped' && action !== 'noop') {
     mkdirSync(nodePath.dirname(path), { recursive: true });
     const priorStamps = existing === undefined ? new Map() : parseSectionStamps(existing);
-    writeFileSync(path, renderDocument(projectDirectory, fingerprint, priorStamps));
+    writeFileSync(path, renderDocument(nodes, fingerprint, priorStamps));
   }
 
   return { action, path };
@@ -126,12 +126,10 @@ function parseSectionStamps(content: string): Map<string, string> {
 }
 
 function renderDocument(
-  projectDirectory: string,
+  nodes: SkeletonNode[],
   fingerprint: string,
   priorStamps: Map<string, string>,
 ): string {
-  const nodes = extractSkeleton(projectDirectory).nodes;
-
   // reconcileSections is the single source of truth for per-section status;
   // this layer only renders markers from its verdicts.
   const verdicts = reconcileSections({

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -1,8 +1,9 @@
 /**
  * Architecture state-document self-heal (ticket QD5DTT, Slice 1).
  *
- * Reads the document at the configured `paths.architecture`, compares its
- * recorded shape-fingerprint against the live one, and deterministically
+ * Reads the generated architecture state document at the fixed
+ * `<namespace-root>/architecture.generated.md`, compares its recorded
+ * shape-fingerprint against the live one, and deterministically
  * (LLM-free) re-extracts the skeleton when they differ — creating the document
  * when absent and regenerating it when its fingerprint is missing or corrupt.
  * This is the SessionStart entry point that keeps structural facts fresh,

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -18,7 +18,7 @@ import { reconcileSections, type SectionStatus } from './architecture-reconcile.
 import { extractSkeleton, type SkeletonNode } from './architecture-skeleton.js';
 import { resolveGeneratedArchitecturePath } from './configured-paths.js';
 
-type SelfHealAction = 'created' | 'healed' | 'unchanged' | 'regenerated' | 'skipped';
+type SelfHealAction = 'created' | 'healed' | 'unchanged' | 'regenerated' | 'skipped' | 'noop';
 
 export interface SelfHealResult {
   action: SelfHealAction;
@@ -67,9 +67,10 @@ export function selfHeal(projectDirectory: string): SelfHealResult {
   const path = resolveGeneratedArchitecturePath(projectDirectory);
   const fingerprint = shapeFingerprint(projectDirectory);
   const existing = readExisting(path);
-  const action = decideAction(existing, fingerprint);
+  const hasModules = extractSkeleton(projectDirectory).nodes.length > 0;
+  const action = decideAction(existing, fingerprint, hasModules);
 
-  if (action !== 'unchanged' && action !== 'skipped') {
+  if (action !== 'unchanged' && action !== 'skipped' && action !== 'noop') {
     mkdirSync(nodePath.dirname(path), { recursive: true });
     const priorStamps = existing === undefined ? new Map() : parseSectionStamps(existing);
     writeFileSync(path, renderDocument(projectDirectory, fingerprint, priorStamps));
@@ -86,8 +87,15 @@ function readExisting(path: string): string | undefined {
   }
 }
 
-function decideAction(existing: string | undefined, fingerprint: string): SelfHealAction {
-  if (existing === undefined) return 'created';
+function decideAction(
+  existing: string | undefined,
+  fingerprint: string,
+  hasModules: boolean,
+): SelfHealAction {
+  // Don't birth an empty doc: a contentless "## Modules" implies "no modules",
+  // which is false for a monorepo the single-repo extractor can't read yet.
+  // An existing doc still heals toward empty (orphan markers show real removals).
+  if (existing === undefined) return hasModules ? 'created' : 'noop';
 
   // Never touch a document safeword does not own — a hand-written architecture
   // doc has no generator marker and must be left exactly as-is.

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -15,7 +15,7 @@ import nodePath from 'node:path';
 import { shapeFingerprint } from './architecture-fingerprint.js';
 import { reconcileSections, type SectionStatus } from './architecture-reconcile.js';
 import { extractSkeleton, type SkeletonNode } from './architecture-skeleton.js';
-import { resolveConfiguredPath } from './configured-paths.js';
+import { resolveGeneratedArchitecturePath } from './configured-paths.js';
 
 type SelfHealAction = 'created' | 'healed' | 'unchanged' | 'regenerated' | 'skipped';
 
@@ -63,7 +63,7 @@ export function readDocumentFingerprint(content: string): string | undefined {
 const RECONCILED_PREFIX = '<!-- reconciled:';
 
 export function selfHeal(projectDirectory: string): SelfHealResult {
-  const path = resolveConfiguredPath(projectDirectory, 'architecture');
+  const path = resolveGeneratedArchitecturePath(projectDirectory);
   const fingerprint = shapeFingerprint(projectDirectory);
   const existing = readExisting(path);
   const action = decideAction(existing, fingerprint);

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -43,6 +43,9 @@ const DEPENDENCY_SECTIONS = [
   'optionalDependencies',
 ] as const;
 
+/** Stable string ordering for the fingerprint's sorted inputs. */
+const byString = (a: string, b: string): number => a.localeCompare(b);
+
 interface ShapeInputs {
   /** Top-level module names. */
   moduleNames: string[];
@@ -57,7 +60,7 @@ interface ShapeInputs {
 function collectShapeInputs(projectDirectory: string): ShapeInputs {
   const moduleNames = extractSkeleton(projectDirectory)
     .nodes.map(node => node.name)
-    .toSorted((a, b) => a.localeCompare(b));
+    .toSorted(byString);
 
   return {
     moduleNames,
@@ -84,7 +87,7 @@ function readDependencyNames(projectDirectory: string): string[] {
     }
   }
 
-  return [...names].toSorted((a, b) => a.localeCompare(b));
+  return [...names].toSorted(byString);
 }
 
 function readBoundaryConfig(projectDirectory: string): string {
@@ -109,7 +112,7 @@ function collectSchemaFiles(projectDirectory: string): string[] {
     }
   }
 
-  return schemaFiles.toSorted((a, b) => a.localeCompare(b));
+  return schemaFiles.toSorted(byString);
 }
 
 function scanDirectoryForSchema(

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -188,6 +188,22 @@ export function resolveLearningsDirectory(cwd: string): string {
   return nodePath.join(resolveNamespaceRoot(cwd), 'learnings');
 }
 
+/** Fixed filename of the auto-generated architecture state document. */
+export const GENERATED_ARCHITECTURE_FILENAME = 'architecture.generated.md';
+
+/**
+ * Absolute path of the auto-generated architecture state document, under the
+ * resolved namespace root (e.g. `.project/architecture.generated.md`).
+ *
+ * Deliberately fixed, NOT overridable via `paths.architecture`: the generated
+ * point-in-time state doc is a separate artifact from the hand-curated
+ * decision/ADR record that `paths.architecture` points to. The `.generated.`
+ * infix marks it as machine-owned (do not hand-edit).
+ */
+export function resolveGeneratedArchitecturePath(cwd: string): string {
+  return nodePath.join(resolveNamespaceRoot(cwd), GENERATED_ARCHITECTURE_FILENAME);
+}
+
 /**
  * The default (non-overridden) absolute location of a configurable read
  * target: `<resolveNamespaceRoot(cwd)>/<key>.md`.

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -189,7 +189,7 @@ export function resolveLearningsDirectory(cwd: string): string {
 }
 
 /** Fixed filename of the auto-generated architecture state document. */
-export const GENERATED_ARCHITECTURE_FILENAME = 'architecture.generated.md';
+const GENERATED_ARCHITECTURE_FILENAME = 'architecture.generated.md';
 
 /**
  * Absolute path of the auto-generated architecture state document, under the

--- a/packages/cli/templates/hooks/session-architecture-heal.ts
+++ b/packages/cli/templates/hooks/session-architecture-heal.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // Safeword: Architecture state-document self-heal (SessionStart)
-// Refreshes the architecture state doc at the configured paths.architecture so
+// Refreshes the generated architecture state doc (.project/architecture.generated.md) so
 // structural facts stay fresh — including after out-of-band human edits. Skips
 // any document safeword does not own (no generator marker), so a hand-written
 // ARCHITECTURE.md is never overwritten. Best-effort: never blocks a session.

--- a/packages/cli/tests/commands/architecture.test.ts
+++ b/packages/cli/tests/commands/architecture.test.ts
@@ -10,7 +10,7 @@ import nodePath from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { architecture } from '../../src/commands/architecture.js';
-import { resolveConfiguredPath } from '../../src/utils/configured-paths.js';
+import { resolveGeneratedArchitecturePath } from '../../src/utils/configured-paths.js';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
 
 const context: { directory: string } = { directory: '' };
@@ -32,6 +32,6 @@ describe('architecture command', () => {
   it('refreshes the architecture document at the configured location', async () => {
     await architecture(context.directory);
 
-    expect(existsSync(resolveConfiguredPath(context.directory, 'architecture'))).toBe(true);
+    expect(existsSync(resolveGeneratedArchitecturePath(context.directory))).toBe(true);
   });
 });

--- a/packages/cli/tests/utils/architecture-document.test.ts
+++ b/packages/cli/tests/utils/architecture-document.test.ts
@@ -2,8 +2,7 @@
  * Integration tests for the architecture state-document self-heal (ticket
  * QD5DTT, Slice 1). Covers the "structural facts self-heal at session start"
  * rule from features/architecture-state-docs.feature. Temp-dir fixtures; the
- * document lands at the configured paths.architecture (default
- * <root>/architecture.md).
+ * document lands at the fixed generated path (<namespace-root>/architecture.generated.md).
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -13,13 +12,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { readDocumentFingerprint, selfHeal } from '../../src/utils/architecture-document.js';
 import { shapeFingerprint } from '../../src/utils/architecture-fingerprint.js';
-import { resolveConfiguredPath } from '../../src/utils/configured-paths.js';
+import { resolveGeneratedArchitecturePath } from '../../src/utils/configured-paths.js';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
 
 const context: { directory: string } = { directory: '' };
 
 function documentPath(directory: string): string {
-  return resolveConfiguredPath(directory, 'architecture');
+  return resolveGeneratedArchitecturePath(directory);
 }
 
 beforeEach(() => {

--- a/packages/cli/tests/utils/architecture-document.test.ts
+++ b/packages/cli/tests/utils/architecture-document.test.ts
@@ -90,6 +90,20 @@ describe('selfHeal — structural facts self-heal at session start', () => {
     expect(readFileSync(documentPath(context.directory), 'utf8')).toBe(foreign);
   });
 
+  it('skips (not noop) a foreign doc even when the skeleton is empty', () => {
+    // No modules here, but a foreign doc exists: ownership wins over the
+    // empty-skeleton noop — the doc must be left untouched, never noop'd away.
+    rmSync(nodePath.join(context.directory, 'src'), { recursive: true, force: true });
+    const foreign = '# Our Architecture\n\nHand-written, no marker.\n';
+    mkdirSync(nodePath.dirname(documentPath(context.directory)), { recursive: true });
+    writeFileSync(documentPath(context.directory), foreign);
+
+    const result = selfHeal(context.directory);
+
+    expect(result.action).toBe('skipped');
+    expect(readFileSync(documentPath(context.directory), 'utf8')).toBe(foreign);
+  });
+
   it('recognizes a safeword-owned doc with CRLF line endings (heals, never skips)', () => {
     selfHeal(context.directory);
     // Re-encode an owned doc with CRLF (git core.autocrlf) and a stale fingerprint.

--- a/packages/cli/tests/utils/architecture-document.test.ts
+++ b/packages/cli/tests/utils/architecture-document.test.ts
@@ -138,4 +138,23 @@ describe('selfHeal — structural facts self-heal at session start', () => {
     expect(content).toMatch(/orphaned/i);
     expect(content).toContain('billing');
   });
+
+  it('does not create a doc when there are no modules and none exists (noop)', () => {
+    rmSync(nodePath.join(context.directory, 'src'), { recursive: true, force: true });
+
+    const result = selfHeal(context.directory);
+
+    expect(result.action).toBe('noop');
+    expect(existsSync(documentPath(context.directory))).toBe(false);
+  });
+
+  it('heals an existing doc toward empty when all modules are removed (not noop)', () => {
+    selfHeal(context.directory);
+    rmSync(nodePath.join(context.directory, 'src', 'auth'), { recursive: true, force: true });
+
+    const result = selfHeal(context.directory);
+
+    expect(result.action).toBe('healed');
+    expect(existsSync(documentPath(context.directory))).toBe(true);
+  });
 });

--- a/steps/architecture-state-docs.steps.ts
+++ b/steps/architecture-state-docs.steps.ts
@@ -32,7 +32,7 @@ function dir(world: ArchitectureWorld): string {
 
 function documentPath(world: ArchitectureWorld): string {
   // No config in the temp project → default namespace root `.project`.
-  return nodePath.join(dir(world), '.project', 'architecture.md');
+  return nodePath.join(dir(world), '.project', 'architecture.generated.md');
 }
 
 function makeModule(world: ArchitectureWorld, name: string): void {

--- a/steps/architecture-state-docs.steps.ts
+++ b/steps/architecture-state-docs.steps.ts
@@ -133,14 +133,10 @@ Then(/^scripts\/build\.ts does not appear as a skeleton node$/, function (this: 
   assert.doesNotMatch(readDocument(this), /### (scripts|build\.ts)/);
 });
 
-Then('a minimal skeleton is produced without error', function (this: ArchitectureWorld) {
-  assert.match(this.stdout ?? '', /created|unchanged/i);
-  assert.ok(existsSync(documentPath(this)));
-});
-
-Then('an empty skeleton is produced without error', function (this: ArchitectureWorld) {
-  assert.ok(existsSync(documentPath(this)));
-  assert.doesNotMatch(readDocument(this), /^### /m);
+Then('no architecture doc is written', function (this: ArchitectureWorld) {
+  // The command succeeds (runArchitecture asserts exit 0); with nothing to
+  // describe, no doc is born — an empty "## Modules" would be silently wrong.
+  assert.ok(!existsSync(documentPath(this)));
 });
 
 Then('the module is still listed in the skeleton', function (this: ArchitectureWorld) {


### PR DESCRIPTION
Follow-up to #316 (architecture state docs, Slice 1). Two coupled improvements to how the auto-generated doc is named and when it's written.

## What

**1. Rename + decouple the generated doc.** The self-healing architecture doc moves from the overridable `paths.architecture` (default `.project/architecture.md`) to a fixed `<namespace-root>/architecture.generated.md` via a new `resolveGeneratedArchitecturePath`. The `.generated.` infix marks it machine-owned, and it no longer collides with `paths.architecture` — which goes back to meaning only the **hand-curated decision/ADR record** (read by `listArchitectureRecords`, untouched here).

**2. Don't birth empty docs (`noop`).** When the single-repo extractor finds zero top-level `src/` modules (e.g. a monorepo whose code lives in `packages/*/src`), `selfHeal` now writes nothing and returns a new `noop` action instead of creating a contentless `## Modules` doc that would falsely imply "no architecture." An **existing** owned doc still heals normally (even toward empty, with orphan markers — real removals stay visible). Verified live: in this monorepo the SessionStart hook now logs `noop` instead of producing an empty file.

The generated doc stays **committed, not gitignored** — it's a deterministic, meaningful-diff, read-as-context artifact (the lockfile pattern), and suppressing empty docs means committing never means committing noise.

## Why

`paths.architecture` was serving two masters (generated state doc *and* hand-curated ADR location), and the generated file read like a hand-written architecture doc. And an auto-generated doc that claims to describe the architecture but lists nothing is worse than none.

## How it was decided & checked

- Both decisions worked through `/figure-it-out` (lockfile-vs-build-artifact distinction; "never silently wrong" applied to doc creation).
- **Two independent fresh-context reviews** (rename diff, then full diff focused on the `noop` precedence) — both **APPROVE**, no must-fix. Applied their suggestions: 5 stale-reference fixes, a foreign-doc+empty-skeleton precedence test, and a skeleton-extract dedupe.
- `/refactor`: extracted a repeated comparator, de-exported a dead constant — audit-clean after (knip / depcruise / jscpd).
- **Verify:** full suite **3239 passed / 5 skipped**; 21 BDD scenarios; lint + typecheck green.

## Note for reviewers

Commits show as **Unverified** — the execution environment's commit-signing key is empty/inaccessible. Committer identity is correct (`noreply@anthropic.com`). Environment limitation, not a content issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S)_