### PR TITLE
chore(hooks): drop SAFEWORD: prefix from hook output

### DIFF
--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -300,7 +300,7 @@ export function formatDependencyRecovery(readiness: DependencyReadiness): string
       : 'dependencies are not installed in this worktree';
 
   return [
-    `SAFEWORD: ${problem}.`,
+    `${problem}.`,
     `Run \`${installCommand}\` from the project root, then retry the command.`,
   ].join('\n');
 }

--- a/.safeword/hooks/lib/lint.ts
+++ b/.safeword/hooks/lib/lint.ts
@@ -193,11 +193,11 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
   if (upgradeAttempted) return false;
   upgradeAttempted = true;
 
-  console.error(`SAFEWORD: ${packName} pack missing, running upgrade...`);
+  console.error(`${packName} pack missing, running upgrade...`);
 
   const result = await $`bunx safeword@latest upgrade`.nothrow().quiet();
   if (result.exitCode !== 0) {
-    console.error('SAFEWORD: Upgrade failed. Run manually: bunx safeword upgrade');
+    console.error('Upgrade failed. Run manually: bunx safeword upgrade');
     return false;
   }
 
@@ -205,7 +205,7 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
   // a location safeword can't auto-detect.
   if (!hasConfig(configPath)) {
     console.error(
-      `SAFEWORD: ${packName} config not created after upgrade. ` +
+      `${packName} config not created after upgrade. ` +
         `Linting with ${packName} defaults (no strict safeword rules).`,
     );
   }
@@ -218,11 +218,9 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
       .nothrow()
       .quiet();
   if (commitResult.exitCode !== 0) {
-    console.error(
-      'SAFEWORD: Could not auto-commit .safeword/ changes (not a git repo or no changes)',
-    );
+    console.error('Could not auto-commit .safeword/ changes (not a git repo or no changes)');
   } else {
-    console.error('SAFEWORD: Upgrade complete and committed');
+    console.error('Upgrade complete and committed');
   }
 
   return hasConfig(configPath);

--- a/.safeword/hooks/post-tool-bypass-warn.ts
+++ b/.safeword/hooks/post-tool-bypass-warn.ts
@@ -89,7 +89,7 @@ for (const { pattern, category, example } of BYPASS_PATTERNS) {
 // If bypass patterns found, output warning
 if (foundPatterns.length > 0) {
   const filePath = input.tool_input?.file_path ?? input.tool_input?.notebook_path ?? 'unknown';
-  console.log(`⚠️ SAFEWORD: Bypass pattern detected in ${filePath}
+  console.log(`⚠️ Bypass pattern detected in ${filePath}
 
 Found:
 ${foundPatterns.join('\n')}

--- a/.safeword/hooks/post-tool-lint.ts
+++ b/.safeword/hooks/post-tool-lint.ts
@@ -38,7 +38,7 @@ const parts: string[] = [];
 
 // Surface warnings as plain text (missing tool binaries)
 if (result.warnings.length > 0) {
-  parts.push(result.warnings.map(w => `${w}`).join('\n'));
+  parts.push(result.warnings.join('\n'));
 }
 
 // Surface remaining lint errors via additionalContext so Claude can fix them

--- a/.safeword/hooks/post-tool-lint.ts
+++ b/.safeword/hooks/post-tool-lint.ts
@@ -38,7 +38,7 @@ const parts: string[] = [];
 
 // Surface warnings as plain text (missing tool binaries)
 if (result.warnings.length > 0) {
-  parts.push(result.warnings.map(w => `SAFEWORD: ${w}`).join('\n'));
+  parts.push(result.warnings.map(w => `${w}`).join('\n'));
 }
 
 // Surface remaining lint errors via additionalContext so Claude can fix them

--- a/.safeword/hooks/session-auto-upgrade.ts
+++ b/.safeword/hooks/session-auto-upgrade.ts
@@ -181,7 +181,7 @@ if (decision === 'notify') {
   // Major bump — may carry breaking changes, so we notify rather than apply.
   // exit 2 delivers this message to Claude (asyncRewake rewake contract).
   console.error(
-    `SAFEWORD: v${latest} available (${bump}) — run \`bunx safeword@${latest} upgrade\` to update`,
+    `v${latest} available (${bump}) — run \`bunx safeword@${latest} upgrade\` to update`,
   );
   process.exit(2);
 }
@@ -288,7 +288,7 @@ try {
 
   if (failure.reachedCap) {
     console.error(
-      `SAFEWORD: auto-upgrade to v${latest} failed ${MAX_UPGRADE_ATTEMPTS}× — run \`bunx safeword@${latest} upgrade\` manually, or disable with \`autoUpgrade: false\` in .safeword/config.json`,
+      `auto-upgrade to v${latest} failed ${MAX_UPGRADE_ATTEMPTS}× — run \`bunx safeword@${latest} upgrade\` manually, or disable with \`autoUpgrade: false\` in .safeword/config.json`,
     );
     process.exit(2);
   }
@@ -307,5 +307,5 @@ try {
 }
 
 // exit 2 surfaces the outcome to Claude (asyncRewake rewake contract).
-console.error(`SAFEWORD: Auto-upgraded v${currentVersion} → v${latest}`);
+console.error(`Auto-upgraded v${currentVersion} → v${latest}`);
 process.exit(2);

--- a/.safeword/hooks/session-bun-check.sh
+++ b/.safeword/hooks/session-bun-check.sh
@@ -11,7 +11,7 @@ if [ ! -d "$PROJECT_DIR/.safeword" ]; then
 fi
 
 if ! command -v bun &> /dev/null; then
-  echo "SAFEWORD: bun is required for quality hooks but was not found in PATH." >&2
+  echo "bun is required for quality hooks but was not found in PATH." >&2
   echo "All quality gates, auto-linting, and review hooks are inactive without it." >&2
   echo "" >&2
   echo "Install: curl -fsSL https://bun.sh/install | bash" >&2

--- a/.safeword/hooks/session-dependency-readiness.ts
+++ b/.safeword/hooks/session-dependency-readiness.ts
@@ -54,11 +54,11 @@ if (config.autoInstall && readiness.plan !== undefined) {
   if (result.status === 0 && readiness.status === 'ready') {
     writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
     writeInstallMarker(projectDirectory, readiness);
-    emitContext(`SAFEWORD: dependencies bootstrapped with \`${display}\`.`);
+    emitContext(`dependencies bootstrapped with \`${display}\`.`);
   }
 
   const message = [
-    `SAFEWORD: dependency bootstrap failed while running \`${display}\`.`,
+    `dependency bootstrap failed while running \`${display}\`.`,
     'Run the install command manually, inspect the package manager output, then retry.',
     trimOutput(result.stderr) || trimOutput(result.stdout),
   ]

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -300,7 +300,7 @@ export function formatDependencyRecovery(readiness: DependencyReadiness): string
       : 'dependencies are not installed in this worktree';
 
   return [
-    `SAFEWORD: ${problem}.`,
+    `${problem}.`,
     `Run \`${installCommand}\` from the project root, then retry the command.`,
   ].join('\n');
 }

--- a/packages/cli/templates/hooks/lib/lint.ts
+++ b/packages/cli/templates/hooks/lib/lint.ts
@@ -193,11 +193,11 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
   if (upgradeAttempted) return false;
   upgradeAttempted = true;
 
-  console.error(`SAFEWORD: ${packName} pack missing, running upgrade...`);
+  console.error(`${packName} pack missing, running upgrade...`);
 
   const result = await $`bunx safeword@latest upgrade`.nothrow().quiet();
   if (result.exitCode !== 0) {
-    console.error('SAFEWORD: Upgrade failed. Run manually: bunx safeword upgrade');
+    console.error('Upgrade failed. Run manually: bunx safeword upgrade');
     return false;
   }
 
@@ -205,7 +205,7 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
   // a location safeword can't auto-detect.
   if (!hasConfig(configPath)) {
     console.error(
-      `SAFEWORD: ${packName} config not created after upgrade. ` +
+      `${packName} config not created after upgrade. ` +
         `Linting with ${packName} defaults (no strict safeword rules).`,
     );
   }
@@ -218,11 +218,9 @@ async function ensurePackInstalled(packName: string, configPath: string): Promis
       .nothrow()
       .quiet();
   if (commitResult.exitCode !== 0) {
-    console.error(
-      'SAFEWORD: Could not auto-commit .safeword/ changes (not a git repo or no changes)',
-    );
+    console.error('Could not auto-commit .safeword/ changes (not a git repo or no changes)');
   } else {
-    console.error('SAFEWORD: Upgrade complete and committed');
+    console.error('Upgrade complete and committed');
   }
 
   return hasConfig(configPath);

--- a/packages/cli/templates/hooks/post-tool-bypass-warn.ts
+++ b/packages/cli/templates/hooks/post-tool-bypass-warn.ts
@@ -89,7 +89,7 @@ for (const { pattern, category, example } of BYPASS_PATTERNS) {
 // If bypass patterns found, output warning
 if (foundPatterns.length > 0) {
   const filePath = input.tool_input?.file_path ?? input.tool_input?.notebook_path ?? 'unknown';
-  console.log(`⚠️ SAFEWORD: Bypass pattern detected in ${filePath}
+  console.log(`⚠️ Bypass pattern detected in ${filePath}
 
 Found:
 ${foundPatterns.join('\n')}

--- a/packages/cli/templates/hooks/post-tool-lint.ts
+++ b/packages/cli/templates/hooks/post-tool-lint.ts
@@ -38,7 +38,7 @@ const parts: string[] = [];
 
 // Surface warnings as plain text (missing tool binaries)
 if (result.warnings.length > 0) {
-  parts.push(result.warnings.map(w => `${w}`).join('\n'));
+  parts.push(result.warnings.join('\n'));
 }
 
 // Surface remaining lint errors via additionalContext so Claude can fix them

--- a/packages/cli/templates/hooks/post-tool-lint.ts
+++ b/packages/cli/templates/hooks/post-tool-lint.ts
@@ -38,7 +38,7 @@ const parts: string[] = [];
 
 // Surface warnings as plain text (missing tool binaries)
 if (result.warnings.length > 0) {
-  parts.push(result.warnings.map(w => `SAFEWORD: ${w}`).join('\n'));
+  parts.push(result.warnings.map(w => `${w}`).join('\n'));
 }
 
 // Surface remaining lint errors via additionalContext so Claude can fix them

--- a/packages/cli/templates/hooks/session-auto-upgrade.ts
+++ b/packages/cli/templates/hooks/session-auto-upgrade.ts
@@ -181,7 +181,7 @@ if (decision === 'notify') {
   // Major bump — may carry breaking changes, so we notify rather than apply.
   // exit 2 delivers this message to Claude (asyncRewake rewake contract).
   console.error(
-    `SAFEWORD: v${latest} available (${bump}) — run \`bunx safeword@${latest} upgrade\` to update`,
+    `v${latest} available (${bump}) — run \`bunx safeword@${latest} upgrade\` to update`,
   );
   process.exit(2);
 }
@@ -288,7 +288,7 @@ try {
 
   if (failure.reachedCap) {
     console.error(
-      `SAFEWORD: auto-upgrade to v${latest} failed ${MAX_UPGRADE_ATTEMPTS}× — run \`bunx safeword@${latest} upgrade\` manually, or disable with \`autoUpgrade: false\` in .safeword/config.json`,
+      `auto-upgrade to v${latest} failed ${MAX_UPGRADE_ATTEMPTS}× — run \`bunx safeword@${latest} upgrade\` manually, or disable with \`autoUpgrade: false\` in .safeword/config.json`,
     );
     process.exit(2);
   }
@@ -307,5 +307,5 @@ try {
 }
 
 // exit 2 surfaces the outcome to Claude (asyncRewake rewake contract).
-console.error(`SAFEWORD: Auto-upgraded v${currentVersion} → v${latest}`);
+console.error(`Auto-upgraded v${currentVersion} → v${latest}`);
 process.exit(2);

--- a/packages/cli/templates/hooks/session-bun-check.sh
+++ b/packages/cli/templates/hooks/session-bun-check.sh
@@ -11,7 +11,7 @@ if [ ! -d "$PROJECT_DIR/.safeword" ]; then
 fi
 
 if ! command -v bun &> /dev/null; then
-  echo "SAFEWORD: bun is required for quality hooks but was not found in PATH." >&2
+  echo "bun is required for quality hooks but was not found in PATH." >&2
   echo "All quality gates, auto-linting, and review hooks are inactive without it." >&2
   echo "" >&2
   echo "Install: curl -fsSL https://bun.sh/install | bash" >&2

--- a/packages/cli/templates/hooks/session-dependency-readiness.ts
+++ b/packages/cli/templates/hooks/session-dependency-readiness.ts
@@ -54,11 +54,11 @@ if (config.autoInstall && readiness.plan !== undefined) {
   if (result.status === 0 && readiness.status === 'ready') {
     writeDependencyReadinessState(projectDirectory, toDependencyReadinessState(readiness));
     writeInstallMarker(projectDirectory, readiness);
-    emitContext(`SAFEWORD: dependencies bootstrapped with \`${display}\`.`);
+    emitContext(`dependencies bootstrapped with \`${display}\`.`);
   }
 
   const message = [
-    `SAFEWORD: dependency bootstrap failed while running \`${display}\`.`,
+    `dependency bootstrap failed while running \`${display}\`.`,
     'Run the install command manually, inspect the package manager output, then retry.',
     trimOutput(result.stderr) || trimOutput(result.stdout),
   ]


### PR DESCRIPTION
## Why

Standing user preference (`feedback_no_branding_hooks`): **no `SAFEWORD:` prefix in hook output** — branding noise, not functional. Surfaced by quality-review on dependency-readiness's recovery message (`formatDependencyRecovery`), then swept across all hook output strings.

## What

Stripped `SAFEWORD: ` from output messages in **7 hooks** (×2 dogfood `.safeword/hooks/**` + template `packages/cli/templates/hooks/**`, byte-identical pairs):
`session-bun-check.sh`, `post-tool-bypass-warn.ts`, `post-tool-lint.ts`, `session-auto-upgrade.ts`, `session-dependency-readiness.ts`, `lib/lint.ts`, `lib/dependency-readiness.ts`.

## Safety

- **No parser or test depends on the prefix** — verified: no code matches `SAFEWORD:` and no test asserts on it.
- Message **bodies unchanged**, so the two tests asserting on affected messages (`bun is required`, `dependency bootstrap failed`) still pass.
- typecheck + parity contracts clean; all 7 dogfood↔template pairs byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)