### PR TITLE
Fix done-gate dependency misreporting (#325) + reconcile tdd-review docs (#326)

### DIFF
--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -79,7 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR
 
-**Evidence before claims:** Show test output, don't just claim "tests pass". Run FULL suite at GREEN to catch regressions.
+**Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
 ### Red Flags — STOP:
 

--- a/.agents/skills/tdd-review/SKILL.md
+++ b/.agents/skills/tdd-review/SKILL.md
@@ -8,17 +8,21 @@ allowed-tools: '*'
 
 Step-aware quality review at TDD phase boundaries. Fires when a sub-checkbox is marked in test-definitions.md during implement phase.
 
+These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
+
 ## Detect Step
 
-Read the gate message to determine which TDD step is next:
+Key the review off the **last checked** box in the current scenario — that's the step you just completed:
 
-| Gate triggered | Step just completed           | Review focus              |
-| -------------- | ----------------------------- | ------------------------- |
-| `tdd:green`    | RED (test written)            | Review test quality       |
-| `tdd:refactor` | GREEN (implementation passes) | Review implementation     |
-| `tdd:red`      | REFACTOR (cleanup done)       | Review completed scenario |
+| Last checked (step just done) | Review focus              |
+| ----------------------------- | ------------------------- |
+| RED (test written)            | Review test quality       |
+| GREEN (implementation passes) | Review implementation     |
+| REFACTOR (cleanup done)       | Review completed scenario |
 
-## GREEN Gate (RED just completed — review test)
+Depth scales with the step: lightweight after RED, moderate after GREEN, full after REFACTOR.
+
+## After RED — review the test
 
 Focused review (~1 minute). Check the test that was just written:
 
@@ -27,34 +31,35 @@ Focused review (~1 minute). Check the test that was just written:
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
 - **Fails for the right reason?** Missing behavior, not syntax errors.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
-- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values — as candidates for additional scenarios.
+- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 
-## REFACTOR Gate (GREEN just completed — review implementation)
+## After GREEN — review the implementation
 
 Moderate review (~1-2 minutes). Check the implementation:
 
 - **Minimal?** Only code the test requires. No anticipatory design.
 - **Correct?** Does it actually satisfy the test's intent, not just make it pass by coincidence?
-- **No regressions?** Full test suite still passes.
+- **No regressions?** Run the **targeted** suite for the module under test. The full-suite regression check belongs once per scenario, at scenario close (after REFACTOR) — not at every GREEN.
 - **Run /refactor** for structural cleanup.
 
 If issues found: fix before refactoring. If clean: run /refactor, commit, proceed.
 
-## RED Gate (REFACTOR just completed — review completed scenario)
+## After REFACTOR — review the completed scenario
 
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
-- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then?
-- **Run /quality-review** for ecosystem verification (versions, deprecated APIs, security).
+- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Full suite green?** Run the full suite once here to catch cross-module regressions.
+- **New external dependency or API in this scenario?** Only then run **/quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?
 
 If issues found: address before starting next scenario. If clean: commit and proceed to next `[ ] RED`.
 
-### Concrete example (GREEN gate)
+### Concrete example (after RED — reviewing the test)
 
-**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files). The `tdd:green` gate fires.
+**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
 **Agent review:**
 
@@ -73,18 +78,19 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
 
-- GREEN gate clean → `**Next:** implement minimum code in {file} to make this test pass.`
-- GREEN gate issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
-- REFACTOR gate clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
-- RED gate clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
+- After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
+- After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
+- After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
+- After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
 
 A review without a Next: line is incomplete.
 
 ## Reminders
 
-1. **Depth matches step** — lightweight for GREEN, moderate for REFACTOR, full for RED
-2. **Single source of truth** — this skill owns all TDD review content
-3. **Commit clears the gate** — review, then commit to proceed
-4. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
+1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
+2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
+3. **Single source of truth** — this skill owns all TDD review content
+4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review, then commit to proceed
+5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -79,7 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR
 
-**Evidence before claims:** Show test output, don't just claim "tests pass". Run FULL suite at GREEN to catch regressions.
+**Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
 ### Red Flags — STOP:
 

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -8,17 +8,21 @@ allowed-tools: '*'
 
 Step-aware quality review at TDD phase boundaries. Fires when a sub-checkbox is marked in test-definitions.md during implement phase.
 
+These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
+
 ## Detect Step
 
-Read the gate message to determine which TDD step is next:
+Key the review off the **last checked** box in the current scenario — that's the step you just completed:
 
-| Gate triggered | Step just completed           | Review focus              |
-| -------------- | ----------------------------- | ------------------------- |
-| `tdd:green`    | RED (test written)            | Review test quality       |
-| `tdd:refactor` | GREEN (implementation passes) | Review implementation     |
-| `tdd:red`      | REFACTOR (cleanup done)       | Review completed scenario |
+| Last checked (step just done) | Review focus              |
+| ----------------------------- | ------------------------- |
+| RED (test written)            | Review test quality       |
+| GREEN (implementation passes) | Review implementation     |
+| REFACTOR (cleanup done)       | Review completed scenario |
 
-## GREEN Gate (RED just completed — review test)
+Depth scales with the step: lightweight after RED, moderate after GREEN, full after REFACTOR.
+
+## After RED — review the test
 
 Focused review (~1 minute). Check the test that was just written:
 
@@ -27,34 +31,35 @@ Focused review (~1 minute). Check the test that was just written:
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
 - **Fails for the right reason?** Missing behavior, not syntax errors.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
-- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values — as candidates for additional scenarios.
+- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 
-## REFACTOR Gate (GREEN just completed — review implementation)
+## After GREEN — review the implementation
 
 Moderate review (~1-2 minutes). Check the implementation:
 
 - **Minimal?** Only code the test requires. No anticipatory design.
 - **Correct?** Does it actually satisfy the test's intent, not just make it pass by coincidence?
-- **No regressions?** Full test suite still passes.
+- **No regressions?** Run the **targeted** suite for the module under test. The full-suite regression check belongs once per scenario, at scenario close (after REFACTOR) — not at every GREEN.
 - **Run /refactor** for structural cleanup.
 
 If issues found: fix before refactoring. If clean: run /refactor, commit, proceed.
 
-## RED Gate (REFACTOR just completed — review completed scenario)
+## After REFACTOR — review the completed scenario
 
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
-- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then?
-- **Run /quality-review** for ecosystem verification (versions, deprecated APIs, security).
+- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Full suite green?** Run the full suite once here to catch cross-module regressions.
+- **New external dependency or API in this scenario?** Only then run **/quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?
 
 If issues found: address before starting next scenario. If clean: commit and proceed to next `[ ] RED`.
 
-### Concrete example (GREEN gate)
+### Concrete example (after RED — reviewing the test)
 
-**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files). The `tdd:green` gate fires.
+**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
 **Agent review:**
 
@@ -73,18 +78,19 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
 
-- GREEN gate clean → `**Next:** implement minimum code in {file} to make this test pass.`
-- GREEN gate issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
-- REFACTOR gate clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
-- RED gate clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
+- After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
+- After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
+- After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
+- After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
 
 A review without a Next: line is incomplete.
 
 ## Reminders
 
-1. **Depth matches step** — lightweight for GREEN, moderate for REFACTOR, full for RED
-2. **Single source of truth** — this skill owns all TDD review content
-3. **Commit clears the gate** — review, then commit to proceed
-4. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
+1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
+2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
+3. **Single source of truth** — this skill owns all TDD review content
+4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review, then commit to proceed
+5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.safeword/hooks/lib/test-runner.ts
+++ b/.safeword/hooks/lib/test-runner.ts
@@ -41,6 +41,13 @@ export interface TestResult {
   output: string;
   /** true if no test command was found — caller should skip, not block. */
   skipped: boolean;
+  /**
+   * true when a command failed because its binary was not found (exit 127 /
+   * "command not found") — an environment problem (uninstalled toolchain), not a
+   * red test. Lets the caller surface an install recovery instead of "tests
+   * failed". (Issue #325.)
+   */
+  toolchainMissing?: boolean;
 }
 
 /** Timeout for test suite execution (60 seconds). */
@@ -155,7 +162,11 @@ function truncateOutput(output: string): string {
   return '...(truncated)\n' + tail.slice(-MAX_OUTPUT_CHARS);
 }
 
-function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; output: string } {
+function runSingleTestCommand(testCommand: TestCommand): {
+  passed: boolean;
+  output: string;
+  toolchainMissing?: boolean;
+} {
   try {
     const output = execSync(testCommand.command, {
       cwd: testCommand.cwd,
@@ -166,6 +177,7 @@ function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; outp
     return { passed: true, output: formatCommandOutput(testCommand, output) };
   } catch (error) {
     const err = error as NodeJS.ErrnoException & {
+      status?: number;
       stdout?: string;
       stderr?: string;
       killed?: boolean;
@@ -181,12 +193,16 @@ function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; outp
     }
 
     const combined = (err.stdout ?? '') + (err.stderr ?? '');
+    // Exit 127 (or a shell "command not found") means the runner binary is
+    // absent — an uninstalled toolchain, not a failing test.
+    const toolchainMissing = err.status === 127 || /command not found|: not found/i.test(combined);
     return {
       passed: false,
       output: formatCommandOutput(
         testCommand,
         combined || `${testCommand.script} exited with non-zero status`,
       ),
+      toolchainMissing,
     };
   }
 }
@@ -209,7 +225,12 @@ export function runTests(cwd: string = projectDir): TestResult {
     const result = runSingleTestCommand(testCommand);
     outputs.push(result.output);
     if (!result.passed)
-      return { passed: false, output: truncateOutput(outputs.join('\n\n')), skipped: false };
+      return {
+        passed: false,
+        output: truncateOutput(outputs.join('\n\n')),
+        skipped: false,
+        toolchainMissing: result.toolchainMissing,
+      };
   }
 
   return { passed: true, output: truncateOutput(outputs.join('\n\n')), skipped: false };

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -12,10 +12,7 @@ import {
   getTicketInfo,
   resolveStopPhase,
 } from './lib/active-ticket.ts';
-import {
-  formatDependencyRecovery,
-  getDependencyReadiness,
-} from './lib/dependency-readiness.ts';
+import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependency-readiness.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -12,6 +12,10 @@ import {
   getTicketInfo,
   resolveStopPhase,
 } from './lib/active-ticket.ts';
+import {
+  formatDependencyRecovery,
+  getDependencyReadiness,
+} from './lib/dependency-readiness.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
@@ -472,10 +476,31 @@ if (currentPhase === 'done') {
   // Features need test + Gherkin acceptance + scenario + audit evidence; tasks need test only.
   const isFeature = ticketInfo.type === 'feature';
 
+  // Dependencies must be installed before the test gate can run. Otherwise a
+  // missing toolchain surfaces as a false "tests failed" (the runner's command
+  // exits 127). Fail closed with the install recovery instead — a verification
+  // gate that cannot run its check must not pass. The recovery (`bun ci`) is
+  // idempotent and re-stamps the freshness marker, so even a false `stale`
+  // self-heals on the next install. (Issue #325.)
+  const readiness = getDependencyReadiness(projectDir);
+  if (readiness.status === 'missing' || readiness.status === 'stale') {
+    recordFailure(projectDir, input.session_id, 'done-gate-deps-missing');
+    hardBlockDone(formatDependencyRecovery(readiness));
+  }
+
   // Run tests directly — authoritative external gate, cannot be gamed by prose.
   // skipped=true means no test command found (package.json missing or no scripts.test).
   const testResult = runTests(projectDir);
   if (!testResult.skipped && !testResult.passed) {
+    // toolchainMissing covers the readiness check's blind spot: an `unsupported`
+    // project (no recognized lockfile) whose test binary is still absent. Surface
+    // the missing-toolchain cause, not a misleading red-test verdict.
+    if (testResult.toolchainMissing) {
+      recordFailure(projectDir, input.session_id, 'done-gate-toolchain-missing');
+      hardBlockDone(
+        `Test toolchain not found — dependencies are likely not installed. Install them, then retry.\n\n${testResult.output}`,
+      );
+    }
     recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
     hardBlockDone(`Tests failed. Fix failures before marking done.\n\n${testResult.output}`);
   }

--- a/packages/cli/templates/hooks/lib/test-runner.ts
+++ b/packages/cli/templates/hooks/lib/test-runner.ts
@@ -41,6 +41,13 @@ export interface TestResult {
   output: string;
   /** true if no test command was found — caller should skip, not block. */
   skipped: boolean;
+  /**
+   * true when a command failed because its binary was not found (exit 127 /
+   * "command not found") — an environment problem (uninstalled toolchain), not a
+   * red test. Lets the caller surface an install recovery instead of "tests
+   * failed". (Issue #325.)
+   */
+  toolchainMissing?: boolean;
 }
 
 /** Timeout for test suite execution (60 seconds). */
@@ -155,7 +162,11 @@ function truncateOutput(output: string): string {
   return '...(truncated)\n' + tail.slice(-MAX_OUTPUT_CHARS);
 }
 
-function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; output: string } {
+function runSingleTestCommand(testCommand: TestCommand): {
+  passed: boolean;
+  output: string;
+  toolchainMissing?: boolean;
+} {
   try {
     const output = execSync(testCommand.command, {
       cwd: testCommand.cwd,
@@ -166,6 +177,7 @@ function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; outp
     return { passed: true, output: formatCommandOutput(testCommand, output) };
   } catch (error) {
     const err = error as NodeJS.ErrnoException & {
+      status?: number;
       stdout?: string;
       stderr?: string;
       killed?: boolean;
@@ -181,12 +193,16 @@ function runSingleTestCommand(testCommand: TestCommand): { passed: boolean; outp
     }
 
     const combined = (err.stdout ?? '') + (err.stderr ?? '');
+    // Exit 127 (or a shell "command not found") means the runner binary is
+    // absent — an uninstalled toolchain, not a failing test.
+    const toolchainMissing = err.status === 127 || /command not found|: not found/i.test(combined);
     return {
       passed: false,
       output: formatCommandOutput(
         testCommand,
         combined || `${testCommand.script} exited with non-zero status`,
       ),
+      toolchainMissing,
     };
   }
 }
@@ -209,7 +225,12 @@ export function runTests(cwd: string = projectDir): TestResult {
     const result = runSingleTestCommand(testCommand);
     outputs.push(result.output);
     if (!result.passed)
-      return { passed: false, output: truncateOutput(outputs.join('\n\n')), skipped: false };
+      return {
+        passed: false,
+        output: truncateOutput(outputs.join('\n\n')),
+        skipped: false,
+        toolchainMissing: result.toolchainMissing,
+      };
   }
 
   return { passed: true, output: truncateOutput(outputs.join('\n\n')), skipped: false };

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -12,6 +12,7 @@ import {
   getTicketInfo,
   resolveStopPhase,
 } from './lib/active-ticket.ts';
+import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependency-readiness.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
@@ -472,10 +473,31 @@ if (currentPhase === 'done') {
   // Features need test + Gherkin acceptance + scenario + audit evidence; tasks need test only.
   const isFeature = ticketInfo.type === 'feature';
 
+  // Dependencies must be installed before the test gate can run. Otherwise a
+  // missing toolchain surfaces as a false "tests failed" (the runner's command
+  // exits 127). Fail closed with the install recovery instead — a verification
+  // gate that cannot run its check must not pass. The recovery (`bun ci`) is
+  // idempotent and re-stamps the freshness marker, so even a false `stale`
+  // self-heals on the next install. (Issue #325.)
+  const readiness = getDependencyReadiness(projectDir);
+  if (readiness.status === 'missing' || readiness.status === 'stale') {
+    recordFailure(projectDir, input.session_id, 'done-gate-deps-missing');
+    hardBlockDone(formatDependencyRecovery(readiness));
+  }
+
   // Run tests directly — authoritative external gate, cannot be gamed by prose.
   // skipped=true means no test command found (package.json missing or no scripts.test).
   const testResult = runTests(projectDir);
   if (!testResult.skipped && !testResult.passed) {
+    // toolchainMissing covers the readiness check's blind spot: an `unsupported`
+    // project (no recognized lockfile) whose test binary is still absent. Surface
+    // the missing-toolchain cause, not a misleading red-test verdict.
+    if (testResult.toolchainMissing) {
+      recordFailure(projectDir, input.session_id, 'done-gate-toolchain-missing');
+      hardBlockDone(
+        `Test toolchain not found — dependencies are likely not installed. Install them, then retry.\n\n${testResult.output}`,
+      );
+    }
     recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
     hardBlockDone(`Tests failed. Fix failures before marking done.\n\n${testResult.output}`);
   }

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -79,7 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR
 
-**Evidence before claims:** Show test output, don't just claim "tests pass". Run FULL suite at GREEN to catch regressions.
+**Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
 ### Red Flags — STOP:
 

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -8,17 +8,21 @@ allowed-tools: '*'
 
 Step-aware quality review at TDD phase boundaries. Fires when a sub-checkbox is marked in test-definitions.md during implement phase.
 
+These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
+
 ## Detect Step
 
-Read the gate message to determine which TDD step is next:
+Key the review off the **last checked** box in the current scenario — that's the step you just completed:
 
-| Gate triggered | Step just completed           | Review focus              |
-| -------------- | ----------------------------- | ------------------------- |
-| `tdd:green`    | RED (test written)            | Review test quality       |
-| `tdd:refactor` | GREEN (implementation passes) | Review implementation     |
-| `tdd:red`      | REFACTOR (cleanup done)       | Review completed scenario |
+| Last checked (step just done) | Review focus              |
+| ----------------------------- | ------------------------- |
+| RED (test written)            | Review test quality       |
+| GREEN (implementation passes) | Review implementation     |
+| REFACTOR (cleanup done)       | Review completed scenario |
 
-## GREEN Gate (RED just completed — review test)
+Depth scales with the step: lightweight after RED, moderate after GREEN, full after REFACTOR.
+
+## After RED — review the test
 
 Focused review (~1 minute). Check the test that was just written:
 
@@ -27,34 +31,35 @@ Focused review (~1 minute). Check the test that was just written:
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
 - **Fails for the right reason?** Missing behavior, not syntax errors.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
-- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values — as candidates for additional scenarios.
+- **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 
-## REFACTOR Gate (GREEN just completed — review implementation)
+## After GREEN — review the implementation
 
 Moderate review (~1-2 minutes). Check the implementation:
 
 - **Minimal?** Only code the test requires. No anticipatory design.
 - **Correct?** Does it actually satisfy the test's intent, not just make it pass by coincidence?
-- **No regressions?** Full test suite still passes.
+- **No regressions?** Run the **targeted** suite for the module under test. The full-suite regression check belongs once per scenario, at scenario close (after REFACTOR) — not at every GREEN.
 - **Run /refactor** for structural cleanup.
 
 If issues found: fix before refactoring. If clean: run /refactor, commit, proceed.
 
-## RED Gate (REFACTOR just completed — review completed scenario)
+## After REFACTOR — review the completed scenario
 
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
-- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then?
-- **Run /quality-review** for ecosystem verification (versions, deprecated APIs, security).
+- **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Full suite green?** Run the full suite once here to catch cross-module regressions.
+- **New external dependency or API in this scenario?** Only then run **/quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?
 
 If issues found: address before starting next scenario. If clean: commit and proceed to next `[ ] RED`.
 
-### Concrete example (GREEN gate)
+### Concrete example (after RED — reviewing the test)
 
-**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files). The `tdd:green` gate fires.
+**Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
 **Agent review:**
 
@@ -73,18 +78,19 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
 
-- GREEN gate clean → `**Next:** implement minimum code in {file} to make this test pass.`
-- GREEN gate issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
-- REFACTOR gate clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
-- RED gate clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
+- After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
+- After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
+- After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
+- After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
 
 A review without a Next: line is incomplete.
 
 ## Reminders
 
-1. **Depth matches step** — lightweight for GREEN, moderate for REFACTOR, full for RED
-2. **Single source of truth** — this skill owns all TDD review content
-3. **Commit clears the gate** — review, then commit to proceed
-4. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
+1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
+2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
+3. **Single source of truth** — this skill owns all TDD review content
+4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review, then commit to proceed
+5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/packages/cli/tests/hooks/test-runner.test.ts
+++ b/packages/cli/tests/hooks/test-runner.test.ts
@@ -71,6 +71,31 @@ describe('runTests (resolves its suite via safeword test-plan)', () => {
     expect(result.output).toContain('test:bdd');
   });
 
+  it('flags toolchainMissing when the runner binary is not found (exit 127)', () => {
+    // A test command whose binary is absent: the shell emits "command not found"
+    // and exits 127 — an uninstalled toolchain, not a red test. (Issue #325.)
+    const project = makeProject({
+      'test:done': 'echo "vitest: command not found" 1>&2; exit 127',
+    });
+
+    const result = runTests(project);
+
+    expect(result.skipped).toBe(false);
+    expect(result.passed).toBe(false);
+    expect(result.toolchainMissing).toBe(true);
+  });
+
+  it('does not flag toolchainMissing for an ordinary test failure', () => {
+    const project = makeProject({
+      'test:done': 'echo "1 test failed" 1>&2; exit 1',
+    });
+
+    const result = runTests(project);
+
+    expect(result.passed).toBe(false);
+    expect(result.toolchainMissing).toBeFalsy();
+  });
+
   it('skips when the project has no runnable test scripts', () => {
     const project = makeProject({});
 

--- a/packages/cli/tests/integration/stop-done-dependencies-gate.test.ts
+++ b/packages/cli/tests/integration/stop-done-dependencies-gate.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration test for the done-gate dependency-readiness check wired into the
+ * real stop-quality hook (issue #325). When a fresh worktree lacks installed
+ * dependencies, the done-gate's own test run fails with `command not found`
+ * (exit 127) and was mislabeled as "Tests failed". The gate now fails closed
+ * with the install recovery instead, and does not fire when dependencies are
+ * present.
+ *
+ * Spawns `.safeword/hooks/stop-quality.ts` against a Bun fixture project at the
+ * done phase, toggling whether `node_modules` is present.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  dependencyInputFingerprint,
+  detectDependencyPlan,
+} from '../../../../.safeword/hooks/lib/dependency-readiness';
+import {
+  createTemporaryDirectory,
+  initGitRepo,
+  removeTemporaryDirectory,
+  writeTestFile,
+} from '../helpers';
+
+const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+const STOP_QUALITY = nodePath.join(SAFEWORD_ROOT, '.safeword/hooks/stop-quality.ts');
+
+interface HookRun {
+  status: number | null;
+  stdout: string;
+}
+
+/** A Bun task project at the done phase. `installed` controls node_modules. */
+function buildProject(installed: boolean): string {
+  const cwd = createTemporaryDirectory();
+  initGitRepo(cwd);
+
+  writeTestFile(
+    cwd,
+    'package.json',
+    JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { 'test:done': 'echo ok' } }),
+  );
+  writeTestFile(cwd, 'bun.lock', '{}\n');
+  writeTestFile(cwd, '.gitignore', 'node_modules\nquality-state-*.json\n');
+  writeTestFile(cwd, '.safeword/.gitkeep', ''); // hook's "is this a safeword project?" guard
+  // A task (not feature) so the feature-artifact / scenario gates don't fire
+  // first; the readiness check is the first gate in the done branch.
+  writeTestFile(
+    cwd,
+    '.safeword-project/tickets/099-test/ticket.md',
+    ['---', 'id: 099', 'status: in_progress', 'type: task', 'phase: done', '---'].join('\n'),
+  );
+  writeTestFile(
+    cwd,
+    '.safeword-project/quality-state-test-session.json',
+    JSON.stringify({ activeTicket: '099', locSinceCommit: 0, locAtLastReview: 0 }),
+  );
+  writeTestFile(cwd, 'transcript.jsonl', transcriptLine());
+
+  execSync('git add . && git commit -qm base', { cwd, stdio: 'pipe' });
+
+  if (installed) {
+    // Mark node_modules present AND fresh: stamp the fingerprint marker so
+    // readiness resolves to `ready` deterministically (not mtime-dependent).
+    const plan = detectDependencyPlan(cwd);
+    if (!plan) throw new Error('expected a Bun dependency plan for the fixture');
+    const fingerprint = dependencyInputFingerprint(cwd, plan);
+    writeTestFile(cwd, 'node_modules/.safeword-deps-fingerprint', fingerprint);
+  }
+
+  return cwd;
+}
+
+function transcriptLine(): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Edit', id: 'toolu_1' },
+        { type: 'text', text: 'Made changes.' },
+      ],
+    },
+  });
+}
+
+function runStop(cwd: string): HookRun {
+  const result = spawnSync('bun', [STOP_QUALITY], {
+    input: JSON.stringify({
+      session_id: 'test-session',
+      transcript_path: nodePath.join(cwd, 'transcript.jsonl'),
+      last_assistant_message: 'Made changes.',
+      stop_hook_active: false,
+    }),
+    cwd,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  return { status: result.status, stdout: result.stdout ?? '' };
+}
+
+describe('stop-quality done-gate dependency readiness (#325)', () => {
+  let cwd = '';
+  afterEach(() => {
+    if (cwd) removeTemporaryDirectory(cwd);
+    cwd = '';
+  });
+  beforeEach(() => {
+    cwd = '';
+  });
+
+  it('blocks with the install recovery — not "Tests failed" — when node_modules is missing', () => {
+    cwd = buildProject(false);
+
+    const run = runStop(cwd);
+
+    expect(run.status).toBe(0);
+    const parsed = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).toContain('dependencies are not installed');
+    expect(parsed.reason).toContain('bun ci');
+    // The whole point: a missing toolchain must not masquerade as a red test.
+    expect(parsed.reason).not.toContain('Tests failed');
+  });
+
+  it('does not fire the readiness block when dependencies are present', () => {
+    cwd = buildProject(true);
+
+    const run = runStop(cwd);
+
+    // It will still block further down the done-gate (no verify.md), but the
+    // reason must not be the dependency-recovery message — readiness is satisfied.
+    expect(run.stdout).not.toContain('dependencies are not installed');
+  });
+});

--- a/packages/cli/tests/integration/stop-done-dependencies-gate.test.ts
+++ b/packages/cli/tests/integration/stop-done-dependencies-gate.test.ts
@@ -132,8 +132,13 @@ describe('stop-quality done-gate dependency readiness (#325)', () => {
 
     const run = runStop(cwd);
 
-    // It will still block further down the done-gate (no verify.md), but the
-    // reason must not be the dependency-recovery message — readiness is satisfied.
-    expect(run.stdout).not.toContain('dependencies are not installed');
+    // Positively assert it advanced PAST the readiness gate to a later one: a
+    // task at done with no verify.md blocks on that instead. (A negative-only
+    // "no recovery message" check could pass even if the gate were skipped.)
+    expect(run.status).toBe(0);
+    const parsed = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).not.toContain('dependencies are not installed');
+    expect(parsed.reason).toContain('verify.md');
   });
 });


### PR DESCRIPTION
Two related fixes that came out of a review of how the TDD workflow runs quality checks.

## #325 — done-gate mislabels missing/stale deps as "Tests failed"

The done-gate Stop hook ran the test suite via its own `runTests()` path, which sits outside the PreToolUse dependency guard and had no readiness pre-check. In a fresh worktree without `node_modules`, the runner exited 127 (`vitest: command not found`) and was reported as **"Tests failed. Fix failures before marking done."** — a misleading verdict that burned a Stop loop.

**Fix (fail closed when the gate can't run its check):**
- `stop-quality.ts` done-gate: `getDependencyReadiness()` pre-check before `runTests`; on `missing`/`stale`, `hardBlockDone(formatDependencyRecovery(...))` → tells you to run `bun ci`. Idempotent recovery that re-stamps the freshness marker, so a false `stale` self-heals.
- `lib/test-runner.ts`: classify exit-127 / "command not found" as `toolchainMissing`, so the gate can surface a missing-toolchain message for `unsupported` projects (no recognized lockfile) the readiness check skips.
- Mirrored into `packages/cli/templates/hooks/` (byte-identical parity).
- New `runTests` unit test (127 classification) + integration test driving the real stop hook at the done phase with/without `node_modules`.

## #326 — reconcile `tdd-review/SKILL.md` with the actual gate mechanism

The skill described gate triggers the hooks never use (`tdd:green`/`tdd:red`/`tdd:refactor` — phantom; they appear in no hook/src code) and prescribed an unenforced per-scenario `/quality-review`, so agents following it literally incurred per-scenario ecosystem web-review at real cost.

**Docs-only reconciliation (no hook behavior change):**
- Replace the phantom gate-name table; key reviews on the last-checked box. Rename sections to **After RED / After GREEN / After REFACTOR** (kills the inverted naming).
- Per-scenario review is **local**; ecosystem `/quality-review` fires only when a scenario first introduces a **new external dependency/API**, plus the enforced whole-ticket pass at implement-exit (unchanged).
- Suite scope: targeted at GREEN, full suite once at scenario close (also in `bdd/TDD.md`).
- Coverage-gap discoveries route to a follow-up / re-gate, not a silent append to a signed-off `test-definitions.md`.
- Mirrored across `.claude`, `.agents`, and `packages/cli/templates` (3-copy parity).

## Review / verification

Both changes were quality-reviewed by independent fresh-context reviewers (web-verified `bun ci` semantics and Node `execSync` exit-127 behavior). That review caught a parity drift in #325 — the readiness import rendered multi-line in the dogfood hook vs. single-line in the template, failing the **release-only** parity gate (`test:release`, split out of the default suite). Fixed and re-verified: dogfood/template byte-identical and prettier-stable, release parity gate green. The "deps present" integration assertion was also strengthened to positively assert it advances past the readiness gate.

Closes #325
Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbTWkWNhzDvLas6MNAkp4k)_