### PR TITLE
fix(bdd): surface subprocess diagnostics in cucumber check step

### DIFF
--- a/packages/cli/features/steps/codify.steps.ts
+++ b/packages/cli/features/steps/codify.steps.ts
@@ -212,15 +212,34 @@ When('I run {string}', async function (this: SafewordWorld, argumentLine: string
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
       [CLI_PATH, ...argumentLine.split(' ')],
-      { cwd: this.temporaryDirectory },
+      { cwd: this.temporaryDirectory, timeout: 30_000, maxBuffer: 16 * 1024 * 1024 },
     );
     this.result = { stdout, stderr, exitCode: 0 };
   } catch (error: unknown) {
-    const failure = error as { stdout?: string; stderr?: string; code?: number };
+    const failure = error as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      signal?: string;
+      killed?: boolean;
+      message?: string;
+    };
+    const stdout = failure.stdout ?? '';
+    const stderr = failure.stderr ?? '';
+    // A non-zero exit that still produced output is the normal "check found
+    // problems" path. Empty output means the subprocess never reported — it
+    // crashed, was killed (OOM/timeout → signal), or failed to spawn (missing
+    // dist → ENOENT). Preserve that diagnostic instead of a blank, so a rare CI
+    // flake is debuggable rather than a confusing "output does not contain X"
+    // with nothing to go on.
+    const noOutputDiagnostic =
+      stdout === '' && stderr === ''
+        ? `[no subprocess output] code=${String(failure.code)} signal=${String(failure.signal)} killed=${String(failure.killed)} cli=${CLI_PATH}: ${failure.message ?? ''}`
+        : '';
     this.result = {
-      stdout: failure.stdout ?? '',
-      stderr: failure.stderr ?? '',
-      exitCode: failure.code ?? 1,
+      stdout,
+      stderr: `${stderr}${noOutputDiagnostic}`,
+      exitCode: typeof failure.code === 'number' ? failure.code : 1,
     };
   }
 });


### PR DESCRIPTION
## Problem

The BDD scenario *"Check reports invalid feature syntax without parser stack"* (`packages/cli/features/feature-files-as-source.feature:33`) flaked one CI run but is **not locally reproducible** (6/6 + 5/5 stable post-rebuild). The only symptom was the assertion `the output contains "features/demo.feature"` failing with **empty stdout *and* stderr** — i.e. the `check` subprocess produced zero output, and the failure message was a confusing "output does not contain X" with nothing to debug.

## Root cause (investigated, not guessed)

`/figure-it-out` ruled out the usual suspects:
- **Not** a scenario-parallel race — cucumber runs serially (no `parallel` in `cucumber.mjs`).
- **Not** a sub-subprocess race — `check.ts` spawns nothing.
- **Not** a `cwd` race — the scenario's prior `Given` mkdtemps a valid dir.

The real defect: the `When('I run')` step swallowed any non-zero exit into `{ stdout: '', stderr: '', exitCode }`, **discarding `code`/`signal`/`killed`/`message`**. So an empty-output death (crash, OOM-kill under CI load → `signal`, or spawn failure → `code=ENOENT`) was indistinguishable from "command ran but printed nothing." Empirically confirmed Node's error-field shapes for each case.

## Fix — diagnose-first, not blind-retry

- Preserve the subprocess diagnostic (`code`/`signal`/`killed`/`message`) when **both** streams are empty, so the next occurrence shows e.g. `signal=SIGKILL` (OOM) or `code=ENOENT` (missing dist) instead of a blank.
- Add an explicit `timeout` (30s) + `maxBuffer` (16MB) so a hung or oversized subprocess fails clearly rather than silently.

The cause is still **unconfirmed** (rare, not reproducible), so this makes the next failure *visible* rather than masking it with a retry. If a future occurrence shows `signal=SIGKILL`, the follow-up is reducing concurrent subprocess load (or a narrow retry).

## Verification

- `tsc --noEmit` clean; `eslint` clean under the root config (the `**/features/**/*.ts` override is in the root config, not packages/cli's).
- Happy path: cucumber lane **3/3 green** post-change.
- Proved the diagnostic surfaces: a SIGKILL'd subprocess through the new catch yields `[no subprocess output] code=null signal=SIGKILL killed=false cli=…` instead of `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)