### PR TITLE
docs(website): correct the auto-lint hook's illustrated output

### DIFF
--- a/packages/website/src/content/docs/getting-started/quick-start.mdx
+++ b/packages/website/src/content/docs/getting-started/quick-start.mdx
@@ -53,7 +53,7 @@ Open your project and ask your agent to build something real:
     Watch what happens:
 
     1. Your agent writes the endpoint
-    2. Lint runs automatically — you'll see `SAFEWORD: Linting...` in the output
+    2. Lint runs automatically on the new code, auto-fixing what it can
     3. If there are issues, your agent fixes them before you even see the code
     4. When you stop the session, a quality review runs automatically
 

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -117,7 +117,7 @@ After your agent writes or modifies a file, the right linter runs:
 
 If a linter isn't installed, it's silently skipped.
 
-**What you see:** `SAFEWORD: Linting...` appears in output. If there are issues, your agent sees them and fixes immediately.
+**What you see:** Usually nothing — the linter auto-fixes quietly. If problems remain, your agent sees them and fixes them immediately.
 
 ---
 


### PR DESCRIPTION
## Problem

Two doc pages illustrated the auto-lint hook as printing `SAFEWORD: Linting...`:
- `getting-started/quick-start.mdx:56`
- `reference/hooks-and-skills.mdx:120`

That's **doubly wrong**:
1. The `SAFEWORD:` prefix was stripped from all hook output in #332 — the docs now promise a prefix the hooks no longer emit.
2. The hook **never emitted a "Linting..." banner** at all. `post-tool-lint.ts` auto-fixes quietly and is silent on success; it only surfaces *remaining* lint errors (to the agent via `additionalContext`) or warnings (missing tool binary, or `"Linting with <pack> defaults"`).

So this was an accuracy fix, not a prefix-strip — the illustrated output described behavior that doesn't exist.

## Change

Describe what users actually see:
- quick-start: *"Lint runs automatically on the new code, auto-fixing what it can"*
- hooks reference: *"Usually nothing — the linter auto-fixes quietly. If problems remain, your agent sees them and fixes them immediately."*

## Verification

- Exhaustive grep: these were the **only 2** `SAFEWORD:`-prefixed illustrations in `packages/website/src`; both removed.
- No tests assert these doc files (checked `packages/cli/tests` + `packages/website`).
- `prettier --check` clean on both; website `dist` is gitignored (no rebuild needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)