### PR TITLE
chore(release): v0.55.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release. Rolls up 17 PRs since v0.54.0.

Passes the auto-upgrade test: new capability, **no breaking changes** — auto-upgradeable at SessionStart.

### Features / additive
- `feat(dep-readiness)`: pnpm + npm/yarn first-class support (#328)
- Always-fresh architecture state docs — Slice 1, single-repo (#316)
- Intake readiness gate: compressed Clarify-phase self-test (#311); scenarios wired to the hook (#317)

### Fixes
- done-gate dependency misreporting (#334)
- `dep-readiness`: abstain for non-bun workspaces with a coexisting bun lockfile (#322)
- `dep-readiness`: content fingerprint, not mtime (#315)
- `audit`: resolve local safeword CLI for sync-config drift check (#303)
- align turbo override to exact pin so `npx` works in-repo (#309)
- `bdd`: surface subprocess diagnostics in the cucumber `When` step (#337)

### Behavior / cosmetic (additive-safe)
- rename generated architecture doc + don't birth empty docs (#331)
- drop `SAFEWORD:` prefix from hook output (#332)

### Tests / CI / docs / chores
- E2E Codex/Cursor skill fallback at the done-gate (#320)
- enforce `prettier --check` in CI (#318)
- reconcile tdd-review docs (#326); align ESLint version references (#313); regenerate-bun.lock release note (#314)
- close shipped tickets (#319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)