### PR TITLE
refactor(bdd): dedup temp-project + feature-file scaffolding in cucumber steps

### DIFF
--- a/packages/cli/features/steps/codify.steps.ts
+++ b/packages/cli/features/steps/codify.steps.ts
@@ -39,8 +39,13 @@ const DEMO_DEFINITIONS = [
   '',
 ].join('\n');
 
+/** A fresh, isolated temp project directory for one scenario. */
+function freshTemporaryDirectory(): string {
+  return mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
+}
+
 Given('a ticket {string} with one scenario', function (this: SafewordWorld, id: string) {
-  this.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
+  this.temporaryDirectory = freshTemporaryDirectory();
   const ticketDirectory = nodePath.join(
     this.temporaryDirectory,
     '.safeword-project',
@@ -52,7 +57,7 @@ Given('a ticket {string} with one scenario', function (this: SafewordWorld, id: 
 });
 
 Given('a ticket {string} with two acceptance criteria', function (this: SafewordWorld, id: string) {
-  this.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
+  this.temporaryDirectory = freshTemporaryDirectory();
   const ticketDirectory = nodePath.join(
     this.temporaryDirectory,
     '.project',
@@ -121,7 +126,7 @@ Given(
 Given(
   'a ticket {string} with a feature source containing two scenarios',
   function (this: SafewordWorld, id: string) {
-    this.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
+    this.temporaryDirectory = freshTemporaryDirectory();
     const ticketDirectory = nodePath.join(
       this.temporaryDirectory,
       '.safeword-project',
@@ -159,7 +164,7 @@ Given(
 Given(
   'a ticket {string} with a Scenario Outline feature source',
   function (this: SafewordWorld, id: string) {
-    this.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
+    this.temporaryDirectory = freshTemporaryDirectory();
     const ticketDirectory = nodePath.join(
       this.temporaryDirectory,
       '.safeword-project',

--- a/packages/cli/features/steps/codify.steps.ts
+++ b/packages/cli/features/steps/codify.steps.ts
@@ -44,6 +44,13 @@ function freshTemporaryDirectory(): string {
   return mkdtempSync(nodePath.join(tmpdir(), 'safeword-bdd-'));
 }
 
+/** Write `features/demo.feature` with the given Gherkin content. */
+function writeFeatureFile(world: SafewordWorld, content: string): void {
+  const featuresDirectory = nodePath.join(world.temporaryDirectory, 'features');
+  mkdirSync(featuresDirectory, { recursive: true });
+  writeFileSync(nodePath.join(featuresDirectory, 'demo.feature'), content);
+}
+
 Given('a ticket {string} with one scenario', function (this: SafewordWorld, id: string) {
   this.temporaryDirectory = freshTemporaryDirectory();
   const ticketDirectory = nodePath.join(
@@ -103,10 +110,8 @@ Given('a ticket {string} with two acceptance criteria', function (this: Safeword
 Given(
   'a feature source for {string} that covers {string}',
   function (this: SafewordWorld, _id: string, acReference: string) {
-    const featuresDirectory = nodePath.join(this.temporaryDirectory, 'features');
-    mkdirSync(featuresDirectory, { recursive: true });
-    writeFileSync(
-      nodePath.join(featuresDirectory, 'demo.feature'),
+    writeFeatureFile(
+      this,
       [
         'Feature: Demo',
         '',
@@ -133,12 +138,10 @@ Given(
       'tickets',
       `${id}-demo`,
     );
-    const featuresDirectory = nodePath.join(this.temporaryDirectory, 'features');
     mkdirSync(ticketDirectory, { recursive: true });
-    mkdirSync(featuresDirectory, { recursive: true });
     writeFileSync(nodePath.join(ticketDirectory, 'ticket.md'), '# demo');
-    writeFileSync(
-      nodePath.join(featuresDirectory, 'demo.feature'),
+    writeFeatureFile(
+      this,
       [
         'Feature: Demo feature source',
         '',
@@ -171,12 +174,10 @@ Given(
       'tickets',
       `${id}-demo`,
     );
-    const featuresDirectory = nodePath.join(this.temporaryDirectory, 'features');
     mkdirSync(ticketDirectory, { recursive: true });
-    mkdirSync(featuresDirectory, { recursive: true });
     writeFileSync(nodePath.join(ticketDirectory, 'ticket.md'), '# demo');
-    writeFileSync(
-      nodePath.join(featuresDirectory, 'demo.feature'),
+    writeFeatureFile(
+      this,
       [
         'Feature: Demo feature source',
         '',
@@ -198,10 +199,8 @@ Given(
 );
 
 Given('an invalid feature source for {string}', function (this: SafewordWorld, _id: string) {
-  const featuresDirectory = nodePath.join(this.temporaryDirectory, 'features');
-  mkdirSync(featuresDirectory, { recursive: true });
-  writeFileSync(
-    nodePath.join(featuresDirectory, 'demo.feature'),
+  writeFeatureFile(
+    this,
     ['Feature: Broken', '  Rule: r', '    Scenario: bad', '      Given ok', '      nope', ''].join(
       '\n',
     ),


### PR DESCRIPTION
## What

Two behavior-preserving Extract-Function refactorings in `packages/cli/features/steps/codify.steps.ts`, each its own atomic commit:

1. **`freshTemporaryDirectory()`** — the `mkdtempSync(join(tmpdir(), 'safeword-bdd-'))` boilerplate was repeated across 4 `Given` steps.
2. **`writeFeatureFile(world, content)`** — the "make `features/` + write `demo.feature`" boilerplate was repeated across 4 `Given` steps.

## Why this scope (DAMP/DRY)

Test code balances DRY (dedup the *how-to's*) against DAMP (keep the *what-to's* — the scenario-meaningful data — explicit at the call site). So this extracts **only the mechanical scaffolding**; every scenario's `demo.feature` Gherkin content stays inline at its call site. The temp-dir prefix and feature-file path now have a single source of truth.

Net line count is ~flat (+24/−20) — the helpers cost lines, offset by call-site savings. The win is **centralized knowledge + more readable call sites** (`writeFeatureFile(this, content)` vs 3 lines of `mkdir`/`writeFileSync`), not fewer lines.

## Verification

- One refactoring → test → commit (per the refactor discipline), cucumber lane **green after each**.
- `tsc --noEmit` clean; `eslint` clean (root config).
- No behavior change — the `Given` steps produce identical fixtures; all cucumber scenarios pass.

Stacked cleanly on `main` (post-#337); touches only the `Given` steps, not the `When` step #337 hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)