### PR TITLE
fix(dep-readiness): document the no-op recovery escape so the gate can't loop

### DIFF
--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -428,10 +428,23 @@ export function formatDependencyRecovery(readiness: DependencyReadiness): string
       ? 'dependency inputs changed after the last install'
       : 'dependencies are not installed in this worktree';
 
-  return [
+  const lines = [
     `${problem}.`,
     `Run \`${installCommand}\` from the project root, then retry the command.`,
-  ].join('\n');
+  ];
+
+  // A version-bump pull changes the input fingerprint without changing resolved
+  // dependencies, so the install reports "no changes" and does not refresh the
+  // marker — which would otherwise leave this stale check looping. No package
+  // manager offers a cheap "lockfile already satisfied" probe (pnpm#4861), so
+  // document the one-step escape for that no-op case.
+  if (readiness.status === 'stale') {
+    lines.push(
+      'If it reports no changes, the lockfile is already satisfied — run `touch node_modules` to clear this check.',
+    );
+  }
+
+  return lines.join('\n');
 }
 
 function collectWorkspacePackageJsonPaths(

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -428,10 +428,23 @@ export function formatDependencyRecovery(readiness: DependencyReadiness): string
       ? 'dependency inputs changed after the last install'
       : 'dependencies are not installed in this worktree';
 
-  return [
+  const lines = [
     `${problem}.`,
     `Run \`${installCommand}\` from the project root, then retry the command.`,
-  ].join('\n');
+  ];
+
+  // A version-bump pull changes the input fingerprint without changing resolved
+  // dependencies, so the install reports "no changes" and does not refresh the
+  // marker — which would otherwise leave this stale check looping. No package
+  // manager offers a cheap "lockfile already satisfied" probe (pnpm#4861), so
+  // document the one-step escape for that no-op case.
+  if (readiness.status === 'stale') {
+    lines.push(
+      'If it reports no changes, the lockfile is already satisfied — run `touch node_modules` to clear this check.',
+    );
+  }
+
+  return lines.join('\n');
 }
 
 function collectWorkspacePackageJsonPaths(

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   dependencyInputFingerprint,
   detectDependencyPlan,
+  formatDependencyRecovery,
   getDependencyReadiness,
   isDependencyBackedCommand,
   readDependencyBootstrapConfig,
@@ -451,6 +452,39 @@ describe('dependency readiness hook support', () => {
     // marker still matches the current content, so it stays ready.
     utimesSync(artifact, past, past);
     expect(getDependencyReadiness(projectDirectory).status).toBe('ready');
+  });
+
+  it('stale recovery documents the no-op escape so the gate cannot loop', () => {
+    writeBunProject();
+    const artifact = path.join(projectDirectory, 'node_modules');
+    mkdirSync(artifact);
+    writeInstallMarker(projectDirectory, getDependencyReadiness(projectDirectory));
+
+    // Version-bump-style change: tracked content differs from the marker while
+    // the artifact mtime sits behind it — exactly the case a no-op `bun ci`
+    // cannot heal (it reports "no changes" and never re-stamps the marker).
+    writeTestFile(projectDirectory, 'bun.lock', '# changed lockfile');
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(artifact, past, past);
+
+    const stale = getDependencyReadiness(projectDirectory);
+    expect(stale.status).toBe('stale');
+
+    const recovery = formatDependencyRecovery(stale);
+    expect(recovery).toContain('bun ci');
+    expect(recovery).toContain('reports no changes');
+    expect(recovery).toContain('touch node_modules');
+  });
+
+  it('missing recovery installs for real, so it omits the touch escape', () => {
+    writeBunProject();
+
+    const missing = getDependencyReadiness(projectDirectory);
+    expect(missing.status).toBe('missing');
+
+    const recovery = formatDependencyRecovery(missing);
+    expect(recovery).toContain('bun ci');
+    expect(recovery).not.toContain('touch node_modules');
   });
 
   it('reads explicit auto-install opt-in from safeword config', () => {


### PR DESCRIPTION
## Problem (hit this session)

The dependency-readiness PreToolUse gate blocks dependency-backed commands when `getDependencyReadiness` returns `stale`. A **version-bump `git pull`** changes the input fingerprint (package.json version + regenerated lockfile) *without* changing resolved deps, so:
1. The content marker (`node_modules/.safeword-deps-fingerprint`) goes stale.
2. mtime says stale (git wrote the inputs at pull-time; `node_modules` kept its older install mtime).
3. Gate blocks: "Run `bun ci`".
4. `bun ci` reports **no changes** (lockfile already satisfied) → doesn't reinstall, doesn't bump `node_modules` mtime, doesn't refresh the marker.
5. Retry → **still blocked**. The only escape is the undocumented `touch node_modules`.

## Why not auto-heal?

I investigated all three candidate fixes. A true gate-time auto-heal would need a cheap "is `node_modules` in sync with the lockfile" probe — **no package manager offers one** ([pnpm#4861](https://github.com/pnpm/pnpm/issues/4861) is an open feature request; npm/bun have none). And the gate already self-stamps the marker on `ready` — the *only* broken path is the no-op version-bump: the **real-dep-pull case already self-heals** (a real install bumps the artifact mtime → `ready` → re-stamp). Downgrading the hard block (warn-only, or trust-any-present-node_modules) would be a gate *redesign* that weakens the protection — disproportionate to fixing one loop.

## Fix

Make the **`stale` recovery message** name the exact one-step escape for the no-op case, so the documented recovery always clears the gate:

```
dependency inputs changed after the last install.
Run `bun ci` from the project root, then retry the command.
If it reports no changes, the lockfile is already satisfied — run `touch node_modules` to clear this check.
```

The `missing` case is unchanged (a real install creates `node_modules` → no touch needed). Both byte-parity hook copies edited identically; `stop-quality.ts` (done-gate) shares the same message, so it benefits too.

## Verification

- 69/69 dep-readiness tests pass, incl. 2 new regressions (stale recovery names the escape; missing recovery omits it).
- `tsc --noEmit` clean; changed test lint-clean; both hook copies byte-identical (`diff -q`); `parity-check --mode=contracts-only` green.

Closes the dep-readiness gate self-heal chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)