### PR TITLE
docs: reviewer-class taxonomy + verify/audit class labels

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
+**Reviewer class:** audit is _class-2 — independent observation_ (PRINCIPLES.md §1). Every check below — config drift, circular deps, layer violations, dead code, duplication, doc drift, test-quality patterns — confirms an observable fact, so a cheap checker suffices and no cross-model reviewer applies. The _class-1_ counterpart — judging whether the architecture is actually _sound_ — is not audit's job; it lives in the Architecture Review Gate (`ARCHITECTURE.md` → "Architecture Review Gate") and `quality-review`, where the fresh-context, never-weaker, cross-model-when-on rule belongs.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /audit was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing audit results cannot produce this feature-gate proof.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
+**Reviewer class:** verify is _class-2 — independent observation_ (PRINCIPLES.md §1). It checks observable facts (tests pass, build succeeds, scenarios complete) against ground truth, so the test suite and parsers are the independent party. No fresh-context or cross-model reviewer applies — a cheap/weaker judge is fine; cross-modeling a test run buys nothing.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
+**Reviewer class:** audit is _class-2 — independent observation_ (PRINCIPLES.md §1). Every check below — config drift, circular deps, layer violations, dead code, duplication, doc drift, test-quality patterns — confirms an observable fact, so a cheap checker suffices and no cross-model reviewer applies. The _class-1_ counterpart — judging whether the architecture is actually _sound_ — is not audit's job; it lives in the Architecture Review Gate (`ARCHITECTURE.md` → "Architecture Review Gate") and `quality-review`, where the fresh-context, never-weaker, cross-model-when-on rule belongs.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /audit was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing audit results cannot produce this feature-gate proof.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
+**Reviewer class:** verify is _class-2 — independent observation_ (PRINCIPLES.md §1). It checks observable facts (tests pass, build succeeds, scenarios complete) against ground truth, so the test suite and parsers are the independent party. No fresh-context or cross-model reviewer applies — a cheap/weaker judge is fine; cross-modeling a test run buys nothing.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/principles-taxonomy-draft.md
+++ b/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/principles-taxonomy-draft.md
@@ -8,11 +8,11 @@
 
 **Match the reviewer to the threat.** "Independent observation" is not one mechanism. What it should be depends on what the check defends against:
 
-| The check is…                                                | Threat                | Reviewer                                                                              |
-| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------ |
-| Your own _judgment/work_ (spec, scenarios, code, design)     | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
-| An _observable fact_ (tests pass, types check, citation present) | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred |
-| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply |
+| The check is…                                                       | Threat                 | Reviewer                                                                                                                    |
+| ------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Your own _judgment/work_ (spec, scenarios, code, design)            | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
+| An _observable fact_ (tests pass, types check, citation present)    | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred                        |
+| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply                           |
 
 One question routes it: _is the reviewer checking work it (or a peer model) produced?_ Yes → review. Checking an observable → observation. Making new candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run is meaningless) or collapses the angle diversity that is the whole point of fan-out.
 
@@ -20,16 +20,16 @@ One question routes it: _is the reviewer checking work it (or a peer model) prod
 
 ## Surface → class mapping (the realignment work this taxonomy enables)
 
-| Surface | Class today | Class it should declare | Action |
-| --- | --- | --- | --- |
-| `quality-review` | review (fork + no-weaker) | review | reference implementation — no change |
-| `review-spec` (scenario-gate) | review (fork, cross-model via 7A0B2K) | review | reference implementation — no change |
-| arch-review-gate (impl-plan) | review (cross-model opt-in) | review | reference implementation — no change |
-| **`spec.md` self-review** | self-review (Tier 1) | **review** | **gap — add independent cross-model-when-on gate** |
-| **`tdd-review`** | advisory self-check | review (advisory) | label as class-1; lean keep-advisory (boundary cadence covers it) |
-| `verify` | mechanical | **observation** | tag class-2; cross-model is a category error |
-| **`audit`** | single-agent | **split** | dead-code/dep-drift → observation; architecture-judgment → review |
-| `figure-it-out` domain fan-out | producer (already correct) | producer | no change — already states no-weaker excluded |
-| `refactor` discovery sweep | producer (already correct) | producer | no change — already states coverage-diversity lever |
+| Surface                        | Class today                           | Class it should declare | Action                                                            |
+| ------------------------------ | ------------------------------------- | ----------------------- | ----------------------------------------------------------------- |
+| `quality-review`               | review (fork + no-weaker)             | review                  | reference implementation — no change                              |
+| `review-spec` (scenario-gate)  | review (fork, cross-model via 7A0B2K) | review                  | reference implementation — no change                              |
+| arch-review-gate (impl-plan)   | review (cross-model opt-in)           | review                  | reference implementation — no change                              |
+| **`spec.md` self-review**      | self-review (Tier 1)                  | **review**              | **gap — add independent cross-model-when-on gate**                |
+| **`tdd-review`**               | advisory self-check                   | review (advisory)       | label as class-1; lean keep-advisory (boundary cadence covers it) |
+| `verify`                       | mechanical                            | **observation**         | tag class-2; cross-model is a category error                      |
+| **`audit`**                    | single-agent                          | **split**               | dead-code/dep-drift → observation; architecture-judgment → review |
+| `figure-it-out` domain fan-out | producer (already correct)            | producer                | no change — already states no-weaker excluded                     |
+| `refactor` discovery sweep     | producer (already correct)            | producer                | no change — already states coverage-diversity lever               |
 
 The one genuine judgment call is **audit**: it does both observation (dead code, dep drift) and review (is the architecture sound?). Recommendation is to split rather than force it into one class.

--- a/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/principles-taxonomy-draft.md
+++ b/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/principles-taxonomy-draft.md
@@ -1,0 +1,35 @@
+# PRINCIPLES.md taxonomy draft — for review
+
+**Placement:** subsection of §1 ("Structure enforces; instructions suggest"), inserted after the testing paragraph, before the `---`. NOT a 6th principle — §5 caps the count, and this refines §1's "Independent observation" tier (item 2 of the enforcement hierarchy). Applied to the live file on this branch; this copy is the reviewable source of record.
+
+**Why here:** the existing hierarchy already lists "Independent observation — a separate process verifies (Haiku judge, test suite, artifact parsing)." That single line silently merges three different mechanisms with three different threat models. This subsection splits them.
+
+---
+
+**Match the reviewer to the threat.** "Independent observation" is not one mechanism. What it should be depends on what the check defends against:
+
+| The check is…                                                | Threat                | Reviewer                                                                              |
+| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------ |
+| Your own _judgment/work_ (spec, scenarios, code, design)     | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
+| An _observable fact_ (tests pass, types check, citation present) | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred |
+| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply |
+
+One question routes it: _is the reviewer checking work it (or a peer model) produced?_ Yes → review. Checking an observable → observation. Making new candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run is meaningless) or collapses the angle diversity that is the whole point of fan-out.
+
+---
+
+## Surface → class mapping (the realignment work this taxonomy enables)
+
+| Surface | Class today | Class it should declare | Action |
+| --- | --- | --- | --- |
+| `quality-review` | review (fork + no-weaker) | review | reference implementation — no change |
+| `review-spec` (scenario-gate) | review (fork, cross-model via 7A0B2K) | review | reference implementation — no change |
+| arch-review-gate (impl-plan) | review (cross-model opt-in) | review | reference implementation — no change |
+| **`spec.md` self-review** | self-review (Tier 1) | **review** | **gap — add independent cross-model-when-on gate** |
+| **`tdd-review`** | advisory self-check | review (advisory) | label as class-1; lean keep-advisory (boundary cadence covers it) |
+| `verify` | mechanical | **observation** | tag class-2; cross-model is a category error |
+| **`audit`** | single-agent | **split** | dead-code/dep-drift → observation; architecture-judgment → review |
+| `figure-it-out` domain fan-out | producer (already correct) | producer | no change — already states no-weaker excluded |
+| `refactor` discovery sweep | producer (already correct) | producer | no change — already states coverage-diversity lever |
+
+The one genuine judgment call is **audit**: it does both observation (dead code, dep drift) and review (is the architecture sound?). Recommendation is to split rather than force it into one class.

--- a/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
+++ b/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
@@ -1,42 +1,42 @@
 ---
 id: BHK9PW
 slug: adversarial-review-class-taxonomy
-type: feature
-phase: intake
+type: task
+phase: implement
 status: in_progress
 created: 2026-06-23T05:48:00.000Z
-last_modified: 2026-06-23T05:48:00.000Z
+last_modified: 2026-06-23T06:06:00.000Z
 ---
 
 # Unify adversarial review under a 3-class reviewer taxonomy
 
-**Goal:** Take a *consistent* approach to review across safeword — but consistency in the **taxonomy and the ledger**, not one uniform mechanism. Name the three reviewer classes in one place, make every class-1 (independent-review) gate share one shape, and explicitly tag the class-2/class-3 surfaces so nobody cargo-cults cross-model onto them.
+**Goal:** Take a _consistent_ approach to review across safeword — but consistency in the **taxonomy and the ledger**, not one uniform mechanism. Name the three reviewer classes in one place, make every class-1 (independent-review) gate share one shape, and explicitly tag the class-2/class-3 surfaces so nobody cargo-cults cross-model onto them.
 
 **Why:** A `/figure-it-out` pass (2026-06-23) mapped where adversarial review exists. The system already encodes three different "checks" — independent review of own work (`quality-review`, `review-spec`, arch-gate: fork + no-weaker + cross-model-ideal), independent observation of an observable (`PRINCIPLES.md:20` — Haiku judge / test suite / parser; weaker is fine), and producer fan-out (`refactor:39`, `figure-it-out:64` — varied/cheaper models on purpose; no-weaker rule explicitly does **not** apply). The drift is that this taxonomy lives in three scattered spots, and **class 1 is internally inconsistent**: `spec.md` is class-1 work stuck at Tier-1 self-review, and `tdd-review` is class-1 work that is advisory-only. The threat model differs by class (correlated blind spots vs self-report bias vs narrow framing), so one mechanism cannot serve all three — forcing fork+cross-model everywhere wastes tokens on class 2 and collapses the diversity that is the point of class 3.
 
 ## Scope
 
-- **Codify the taxonomy** in `PRINCIPLES.md` as a subsection under §1 ("Structure enforces") refining the "Independent observation" tier — NOT a 6th principle (§5 caps the count). Three classes + the one-question routing rule: *"is the reviewer checking work it (or a peer model) produced?"* yes → review (no-weaker / cross-model), observable → observation (cheap/weaker fine), new candidates → producer (varied/cheaper on purpose). **(drafted in this ticket — see `principles-taxonomy-draft.md`)**
-- **Close the missing class-1 gate:** add an independent (cross-model-when-on) review of `spec.md` — the intake analog of `/review-spec`. Reuse the review-ledger verbatim; stamp `<ticket>:phase:intake`. Default-off; cross-model-required when on; features only (never patch/task). Auto-on under YOLO via 2VCSZY's mechanism (the human-as-reviewer guard disappears there).
-- **Realign existing surfaces to declared classes:**
-  - `tdd-review` — class-1 work but advisory; decide keep-advisory vs. promote to a stamped gate (lean: keep advisory — boundary cadence already covers it; just *label* it class-1 so the inconsistency is intentional, not accidental).
-  - `verify` — tag class-2 (machine evidence; cross-model is a category error).
-  - `audit` — the one genuine fork in the road: split it. Dead-code / dep-drift half = class-2 (cheap observer); architecture-judgment half = class-1 (fresh different mind). Decide at scenario design.
-- Sync any template ↔ `.safeword/hooks` dogfood copies; register new hooks/libs in `schema.ts` + settings if the spec gate ships.
+Re-scoped feature → **task** (2026-06-23, `/figure-it-out`): the intake survey found the spec-review gate already exists (NMSD94's phase-exit gate fires on any phase advance) and the refinements are owned tickets, so the only unowned work is the doc + making it actionable.
+
+- **Codify the taxonomy** in `PRINCIPLES.md` as a subsection under §1 ("Structure enforces") refining the "Independent observation" tier — NOT a 6th principle (§5 caps the count). Three classes + the one-question routing rule: _"is the reviewer checking work it (or a peer model) produced?"_ yes → review (no-weaker / cross-model), observable → observation (cheap/weaker fine), new candidates → producer (varied/cheaper on purpose). **DONE** — applied to `PRINCIPLES.md`; reviewable copy at `principles-taxonomy-draft.md`.
+- **`verify` → tag class-2** (independent observation; cross-model is a category error). **DONE** — `skills/verify/SKILL.md` + dogfood copies.
+- **`audit` → split** into class-2 (config drift / circular deps / dead code / test-quality patterns — cheap observer) and class-1 (architecture-soundness judgment — fresh, never-weaker, cross-model when stakes warrant). **DONE** — `skills/audit/SKILL.md` + dogfood copies. Documentation/skill guidance only — `/audit` stays invocation-logged, no new stamp/gate.
 
 ## Out of scope
 
-- The reasoning-skill uplift already owned by epic **B6MZ4Z** (`debug`, `figure-it-out`, `refactor`, `elicit`, `quality-review` provenance) — those are class-1/class-3 mechanics tracked elsewhere; this ticket only *names the classes* and aligns the gate surfaces.
-- Cross-model for the scenario-gate review — owned by **7A0B2K**.
-- YOLO auto-enable mechanics themselves — owned by **2VCSZY**; this ticket only declares that the spec gate couples to that switch.
-- Changing the no-weaker rule's wording in `quality-review` / `review-spec` — already correct; they become reference implementations of class-1.
+- **A standalone spec-review gate** — already implemented by NMSD94's phase-exit gate (fires on intake exit when `reviewGate` is on). Building a parallel one would duplicate the stamp machinery and fork the policy 2VCSZY owns. Dropped.
+- The reasoning-skill uplift already owned by epic **B6MZ4Z** (`debug`, `figure-it-out`, `refactor`, `elicit`, `quality-review` provenance).
+- Cross-model on phase-exit reviews — owned by **7A0B2K**.
+- YOLO auto-enable mechanics — owned by **2VCSZY**.
+- `tdd-review` re-labeling — left as-is (advisory self-check); the boundary cadence already covers it and no surface lies about its class. Revisit only if it starts claiming independence.
+- Changing the no-weaker wording in `quality-review` / `review-spec` — already correct; they are the reference implementations of class-1.
 
 ## Done when
 
-- `PRINCIPLES.md` carries the 3-class taxonomy + one-question routing rule under §1, principle count still 5.
-- Every review/observation surface in the skills set maps to exactly one declared class (audit may map to two by explicit split).
-- A `spec.md` independent-review gate exists (default-off, cross-model-when-on, features-only) OR a logged decision records why it stays self-review-only.
-- Tests cover: spec-gate on/off, cross-model-required-when-on, skip-reason path, patch/task exemption.
+- `PRINCIPLES.md` carries the 3-class taxonomy + one-question routing rule under §1, principle count still 5. ✅
+- `verify` declares class-2 and `audit` declares its class-1/class-2 split, in template + both dogfood copies (byte-parity). ✅
+- A logged decision records that the spec-review gate is covered by NMSD94 rather than re-built. ✅ (this ticket's Out-of-scope + work log)
+- Existing suite still green (no behavior change — doc/skill edits only).
 
 ## Decision record
 
@@ -48,3 +48,6 @@ last_modified: 2026-06-23T05:48:00.000Z
 
 - 2026-06-23T05:48:00Z Created from `/figure-it-out` analysis of adversarial-review coverage. Classified feature (multi-artifact: doc + new gate + surface realignment, dependencies on B6MZ4Z/7A0B2K/2VCSZY).
 - 2026-06-23T05:48:00Z Drafted the PRINCIPLES.md taxonomy subsection (see `principles-taxonomy-draft.md`) for review before editing the live file.
+- 2026-06-23T06:06:00Z RE-SCOPE via `/figure-it-out` (option A): feature → task. Dropped the redundant spec-gate; kept taxonomy doc + verify class-2 label + audit split. Applied `verify`/`audit` SKILL edits to template + `.claude` + `.agents` (byte-parity verified). Spawning a fresh-context class-1 review of the change before commit (dogfooding the taxonomy).
+- 2026-06-23T06:13:00Z CLASS-1 REVIEW (fresh-context, same-model per no-weaker rule — Opus author has no stronger model) found 1 BLOCKING + 2 SHOULD-FIX. BLOCKING: the audit note claimed a class-1 architecture-soundness pass the audit body never performs (all its checks are mechanical/observable) — corrected to "audit = class-2; the class-1 arch-soundness counterpart lives in the Architecture Review Gate + quality-review." SHOULD-FIX: PRINCIPLES routing question mis-routed author-produced tests to class-1 → reworded to lead with observable-fact/judgment/new-candidates; "Independent observation" term collided with the §1 hierarchy tier name → reworded to "Tier-2 verification." Re-ran parity + verify/audit skill tests: 53/53 pass. So the "audit split" the user approved became "audit is class-2, class-1 arch judgment documented to live elsewhere" — accurate to what audit actually does.
+- 2026-06-23T05:58:00Z INTAKE SURVEY — scope-shrinking discovery. The phase-exit review gate (NMSD94, `pre-tool-quality.ts:382-401`) fires on **any** phase advance: `detectPhaseAdvance` (`review-ledger.ts:171`) has no phase filter. So when `reviewGate` is on, leaving **intake** already requires an independent fork-review stamp on `<ticket>:phase:intake`. The "missing class-1 spec-review gate" is therefore **already implemented** for the autonomous/reviewGate-on case — a standalone spec gate would be redundant bloat. Genuinely-unowned remainder: (a) cross-model enforcement on phase-exit reviews → already owned by **7A0B2K**; (b) auto-on under YOLO → already owned by **2VCSZY**; (c) the taxonomy doc → DONE; (d) verify class-2 labeling + audit class-1/class-2 split → docs/skill only, the real remaining in-scope work. Conclusion: re-scope from feature → task; drop the new-gate scope line; keep doc + labeling work. Decision surfaced to user.

--- a/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
+++ b/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
@@ -2,10 +2,10 @@
 id: BHK9PW
 slug: adversarial-review-class-taxonomy
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-06-23T05:48:00.000Z
-last_modified: 2026-06-23T06:06:00.000Z
+last_modified: 2026-06-23T06:17:00.000Z
 ---
 
 # Unify adversarial review under a 3-class reviewer taxonomy
@@ -49,5 +49,6 @@ Re-scoped feature → **task** (2026-06-23, `/figure-it-out`): the intake survey
 - 2026-06-23T05:48:00Z Created from `/figure-it-out` analysis of adversarial-review coverage. Classified feature (multi-artifact: doc + new gate + surface realignment, dependencies on B6MZ4Z/7A0B2K/2VCSZY).
 - 2026-06-23T05:48:00Z Drafted the PRINCIPLES.md taxonomy subsection (see `principles-taxonomy-draft.md`) for review before editing the live file.
 - 2026-06-23T06:06:00Z RE-SCOPE via `/figure-it-out` (option A): feature → task. Dropped the redundant spec-gate; kept taxonomy doc + verify class-2 label + audit split. Applied `verify`/`audit` SKILL edits to template + `.claude` + `.agents` (byte-parity verified). Spawning a fresh-context class-1 review of the change before commit (dogfooding the taxonomy).
+- 2026-06-23T06:17:00Z CLOSED done (user confirmed). Audit call settled: audit stays class-2; the class-1 architecture-soundness judgment lives in the Architecture Review Gate + quality-review (option 2 — a new class-1 pass inside audit — rejected as duplicating the arch-gate). Shipped in commits f42a2f2 (taxonomy + ticket) and 376c3a7 (verify/audit labels + review fixes). 53/53 targeted tests pass; template↔dogfood byte-parity verified.
 - 2026-06-23T06:13:00Z CLASS-1 REVIEW (fresh-context, same-model per no-weaker rule — Opus author has no stronger model) found 1 BLOCKING + 2 SHOULD-FIX. BLOCKING: the audit note claimed a class-1 architecture-soundness pass the audit body never performs (all its checks are mechanical/observable) — corrected to "audit = class-2; the class-1 arch-soundness counterpart lives in the Architecture Review Gate + quality-review." SHOULD-FIX: PRINCIPLES routing question mis-routed author-produced tests to class-1 → reworded to lead with observable-fact/judgment/new-candidates; "Independent observation" term collided with the §1 hierarchy tier name → reworded to "Tier-2 verification." Re-ran parity + verify/audit skill tests: 53/53 pass. So the "audit split" the user approved became "audit is class-2, class-1 arch judgment documented to live elsewhere" — accurate to what audit actually does.
 - 2026-06-23T05:58:00Z INTAKE SURVEY — scope-shrinking discovery. The phase-exit review gate (NMSD94, `pre-tool-quality.ts:382-401`) fires on **any** phase advance: `detectPhaseAdvance` (`review-ledger.ts:171`) has no phase filter. So when `reviewGate` is on, leaving **intake** already requires an independent fork-review stamp on `<ticket>:phase:intake`. The "missing class-1 spec-review gate" is therefore **already implemented** for the autonomous/reviewGate-on case — a standalone spec gate would be redundant bloat. Genuinely-unowned remainder: (a) cross-model enforcement on phase-exit reviews → already owned by **7A0B2K**; (b) auto-on under YOLO → already owned by **2VCSZY**; (c) the taxonomy doc → DONE; (d) verify class-2 labeling + audit class-1/class-2 split → docs/skill only, the real remaining in-scope work. Conclusion: re-scope from feature → task; drop the new-gate scope line; keep doc + labeling work. Decision surfaced to user.

--- a/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
+++ b/.project/tickets/BHK9PW-adversarial-review-class-taxonomy/ticket.md
@@ -1,0 +1,50 @@
+---
+id: BHK9PW
+slug: adversarial-review-class-taxonomy
+type: feature
+phase: intake
+status: in_progress
+created: 2026-06-23T05:48:00.000Z
+last_modified: 2026-06-23T05:48:00.000Z
+---
+
+# Unify adversarial review under a 3-class reviewer taxonomy
+
+**Goal:** Take a *consistent* approach to review across safeword — but consistency in the **taxonomy and the ledger**, not one uniform mechanism. Name the three reviewer classes in one place, make every class-1 (independent-review) gate share one shape, and explicitly tag the class-2/class-3 surfaces so nobody cargo-cults cross-model onto them.
+
+**Why:** A `/figure-it-out` pass (2026-06-23) mapped where adversarial review exists. The system already encodes three different "checks" — independent review of own work (`quality-review`, `review-spec`, arch-gate: fork + no-weaker + cross-model-ideal), independent observation of an observable (`PRINCIPLES.md:20` — Haiku judge / test suite / parser; weaker is fine), and producer fan-out (`refactor:39`, `figure-it-out:64` — varied/cheaper models on purpose; no-weaker rule explicitly does **not** apply). The drift is that this taxonomy lives in three scattered spots, and **class 1 is internally inconsistent**: `spec.md` is class-1 work stuck at Tier-1 self-review, and `tdd-review` is class-1 work that is advisory-only. The threat model differs by class (correlated blind spots vs self-report bias vs narrow framing), so one mechanism cannot serve all three — forcing fork+cross-model everywhere wastes tokens on class 2 and collapses the diversity that is the point of class 3.
+
+## Scope
+
+- **Codify the taxonomy** in `PRINCIPLES.md` as a subsection under §1 ("Structure enforces") refining the "Independent observation" tier — NOT a 6th principle (§5 caps the count). Three classes + the one-question routing rule: *"is the reviewer checking work it (or a peer model) produced?"* yes → review (no-weaker / cross-model), observable → observation (cheap/weaker fine), new candidates → producer (varied/cheaper on purpose). **(drafted in this ticket — see `principles-taxonomy-draft.md`)**
+- **Close the missing class-1 gate:** add an independent (cross-model-when-on) review of `spec.md` — the intake analog of `/review-spec`. Reuse the review-ledger verbatim; stamp `<ticket>:phase:intake`. Default-off; cross-model-required when on; features only (never patch/task). Auto-on under YOLO via 2VCSZY's mechanism (the human-as-reviewer guard disappears there).
+- **Realign existing surfaces to declared classes:**
+  - `tdd-review` — class-1 work but advisory; decide keep-advisory vs. promote to a stamped gate (lean: keep advisory — boundary cadence already covers it; just *label* it class-1 so the inconsistency is intentional, not accidental).
+  - `verify` — tag class-2 (machine evidence; cross-model is a category error).
+  - `audit` — the one genuine fork in the road: split it. Dead-code / dep-drift half = class-2 (cheap observer); architecture-judgment half = class-1 (fresh different mind). Decide at scenario design.
+- Sync any template ↔ `.safeword/hooks` dogfood copies; register new hooks/libs in `schema.ts` + settings if the spec gate ships.
+
+## Out of scope
+
+- The reasoning-skill uplift already owned by epic **B6MZ4Z** (`debug`, `figure-it-out`, `refactor`, `elicit`, `quality-review` provenance) — those are class-1/class-3 mechanics tracked elsewhere; this ticket only *names the classes* and aligns the gate surfaces.
+- Cross-model for the scenario-gate review — owned by **7A0B2K**.
+- YOLO auto-enable mechanics themselves — owned by **2VCSZY**; this ticket only declares that the spec gate couples to that switch.
+- Changing the no-weaker rule's wording in `quality-review` / `review-spec` — already correct; they become reference implementations of class-1.
+
+## Done when
+
+- `PRINCIPLES.md` carries the 3-class taxonomy + one-question routing rule under §1, principle count still 5.
+- Every review/observation surface in the skills set maps to exactly one declared class (audit may map to two by explicit split).
+- A `spec.md` independent-review gate exists (default-off, cross-model-when-on, features-only) OR a logged decision records why it stays self-review-only.
+- Tests cover: spec-gate on/off, cross-model-required-when-on, skip-reason path, patch/task exemption.
+
+## Decision record
+
+- Source analysis: `/figure-it-out` session 2026-06-23 (this branch). Inventory of 8 existing review mechanisms + phase-by-phase gap map produced by two Explore agents.
+- Key citations: `ARCHITECTURE.md:555` (self-adversarial review weaker than independent — the correlated-blind-spot ADR), `PRINCIPLES.md:20` (Haiku judge as legitimate cheap observer), `refactor:39` + `figure-it-out:64` (no-weaker rule deliberately excluded from producer fan-out), arch-gate ADR `ARCHITECTURE.md:574-586` (voting panels rejected — "popularity trap" of correlated models).
+- Rejected: uniform fork+cross-model for all reviews (wastes tokens on class 2; collapses angle diversity in class 3). Rejected: a 6th PRINCIPLES principle (violates §5's "few principles" — taxonomy is a refinement of §1's observation tier).
+
+## Work Log
+
+- 2026-06-23T05:48:00Z Created from `/figure-it-out` analysis of adversarial-review coverage. Classified feature (multi-artifact: doc + new gate + surface realignment, dependencies on B6MZ4Z/7A0B2K/2VCSZY).
+- 2026-06-23T05:48:00Z Drafted the PRINCIPLES.md taxonomy subsection (see `principles-taxonomy-draft.md`) for review before editing the live file.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -33,7 +33,7 @@ This extends to testing: specify WHAT the system does (behavior), not HOW it doe
 | An _observable fact_ (tests pass, types check, citation present)    | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred                        |
 | _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply                           |
 
-One question routes it: _is the check an observable fact, a judgment about work a model produced, or the generation of new candidates?_ Observable fact → observation. Judgment on produced work → review. New candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run buys nothing) or collapses the angle diversity that is the whole point of fan-out.
+One question routes it: _is the check a judgment about work a model produced, an observable fact, or the generation of new candidates?_ Judgment on produced work → review. Observable fact → observation. New candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run buys nothing) or collapses the angle diversity that is the whole point of fan-out.
 
 ---
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -25,15 +25,15 @@ Design enforcement at the highest tier that's practical. When you reach for a se
 
 This extends to testing: specify WHAT the system does (behavior), not HOW it does it (implementation). Behavior-biased tests are natural gates against regressions — they fail when the system breaks, not when internals change.
 
-**Match the reviewer to the threat.** "Independent observation" is not one mechanism. What it should be depends on what the check defends against:
+**Match the reviewer to the threat.** Tier-2 verification above is not one mechanism — what a check should be depends on what it defends against:
 
-| The check is…                                                | Threat                | Reviewer                                                                              |
-| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------ |
-| Your own _judgment/work_ (spec, scenarios, code, design)     | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
-| An _observable fact_ (tests pass, types check, citation present) | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred |
-| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply |
+| The check is…                                                       | Threat                 | Reviewer                                                                                                                    |
+| ------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Your own _judgment/work_ (spec, scenarios, code, design)            | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
+| An _observable fact_ (tests pass, types check, citation present)    | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred                        |
+| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply                           |
 
-One question routes it: _is the reviewer checking work it (or a peer model) produced?_ Yes → review. Checking an observable → observation. Making new candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run is meaningless) or collapses the angle diversity that is the whole point of fan-out.
+One question routes it: _is the check an observable fact, a judgment about work a model produced, or the generation of new candidates?_ Observable fact → observation. Judgment on produced work → review. New candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run buys nothing) or collapses the angle diversity that is the whole point of fan-out.
 
 ---
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -25,6 +25,16 @@ Design enforcement at the highest tier that's practical. When you reach for a se
 
 This extends to testing: specify WHAT the system does (behavior), not HOW it does it (implementation). Behavior-biased tests are natural gates against regressions — they fail when the system breaks, not when internals change.
 
+**Match the reviewer to the threat.** "Independent observation" is not one mechanism. What it should be depends on what the check defends against:
+
+| The check is…                                                | Threat                | Reviewer                                                                              |
+| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------ |
+| Your own _judgment/work_ (spec, scenarios, code, design)     | correlated blind spots | independent **review** — fresh-context sub-agent, **never weaker** than the author, a _different model_ when stakes warrant |
+| An _observable fact_ (tests pass, types check, citation present) | self-report bias       | cheap **observation** — test suite, parser, or a small judge; a weaker model is fine, even preferred |
+| _New candidates_ (design options, refactor smells, research angles) | narrow framing         | **producer** fan-out — varied or cheaper models on purpose; the no-weaker rule does **not** apply |
+
+One question routes it: _is the reviewer checking work it (or a peer model) produced?_ Yes → review. Checking an observable → observation. Making new candidates → producer. Only the review class earns the no-weaker / cross-model rule; applying it to the other two wastes tokens (cross-modeling a test run is meaningless) or collapses the angle diversity that is the whole point of fan-out.
+
 ---
 
 ## 2. Fire at boundaries, not every turn

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
+**Reviewer class:** audit is _class-2 — independent observation_ (PRINCIPLES.md §1). Every check below — config drift, circular deps, layer violations, dead code, duplication, doc drift, test-quality patterns — confirms an observable fact, so a cheap checker suffices and no cross-model reviewer applies. The _class-1_ counterpart — judging whether the architecture is actually _sound_ — is not audit's job; it lives in the Architecture Review Gate (`ARCHITECTURE.md` → "Architecture Review Gate") and `quality-review`, where the fresh-context, never-weaker, cross-model-when-on rule belongs.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /audit was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing audit results cannot produce this feature-gate proof.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
+**Reviewer class:** verify is _class-2 — independent observation_ (PRINCIPLES.md §1). It checks observable facts (tests pass, build succeeds, scenarios complete) against ground truth, so the test suite and parsers are the independent party. No fresh-context or cross-model reviewer applies — a cheap/weaker judge is fine; cross-modeling a test run buys nothing.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a session-scoped entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and substitutes `${CLAUDE_SESSION_ID}` for session binding. Codex and Cursor docs do not document Claude-style `!` expansion or `${CLAUDE_SESSION_ID}` substitution, so the fallback below is explicit. Hand-writing verify.md cannot produce this feature-gate proof.


### PR DESCRIPTION
## What

Codifies a **3-class reviewer taxonomy** so safeword takes a *consistent* approach to review — consistent in the taxonomy, not one uniform mechanism — and applies it to the `verify` and `audit` skill surfaces.

- **`PRINCIPLES.md` §1** — new "Match the reviewer to the threat" subsection (a refinement of the "Independent observation" tier, **not** a 6th principle, so the count stays 5):
  - **class-1 — independent review** (judgment on produced work): fresh-context sub-agent, never weaker than the author, different model when stakes warrant. Threat: correlated blind spots.
  - **class-2 — independent observation** (observable facts: tests pass, types check): cheap/weaker checker fine; cross-model is a category error.
  - **class-3 — producer fan-out** (new candidates): varied/cheaper models on purpose; the no-weaker rule does **not** apply.
  - One routing question: *is the check a judgment about produced work, an observable fact, or the generation of new candidates?*
- **`verify` skill** → labeled **class-2** (the test suite is the independent party).
- **`audit` skill** → labeled **class-2** (all its checks are observable); the **class-1** architecture-soundness counterpart is documented to live in the Architecture Review Gate + `quality-review`, not audit.

## Why

Review patterns were scattered and class-1 was internally inconsistent. The threat model differs by class, so forcing fork+cross-model everywhere wastes tokens (class-2) and collapses the angle diversity that is the point of fan-out (class-3). Grounded in the repo's own ADRs (`ARCHITECTURE.md:555`, `:574-586`) and existing reference skills (`quality-review`, `refactor`, `figure-it-out`).

## Scope note

Started as a feature to add a spec-review gate; the intake survey found that gate **already exists** via NMSD94's phase-exit gate, and the refinements are owned elsewhere (cross-model → 7A0B2K, YOLO auto-on → 2VCSZY). Re-scoped to a docs/skill **task** (ticket BHK9PW) — no new hook code.

## Verification

- Dogfooded the taxonomy: a class-1 fresh-context review caught a blocking mislabel (audit over-claiming a class-1 pass it doesn't perform) — fixed before merge. A second `/quality-review` pass returned **APPROVE** with one wording nit, applied.
- 53/53 targeted tests pass (`parity`, `verify-skill`, `audit-documentation-sources`); template ↔ `.claude`/`.agents` byte-parity verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYmttepx21bjayxkpAcGUY)_