### PR TITLE
Monorepo coverage honesty: pnpm discovery + un-introspected-package marker

### DIFF
--- a/.project/architecture.generated.md
+++ b/.project/architecture.generated.md
@@ -1,6 +1,6 @@
 ---
 generator: safeword-architecture
-fingerprint: e5e3f59c49fd25673e3b6e0b1f1cbab1849e16493a29eac2fff1d5818769ef04
+fingerprint: 8787b9bdac85eb47beb60a6268f5989dd286a6239cdd43e75be0c4f48ee8e2e5
 ---
 
 # Architecture
@@ -9,13 +9,13 @@ fingerprint: e5e3f59c49fd25673e3b6e0b1f1cbab1849e16493a29eac2fff1d5818769ef04
 
 ### @safeword/website
 
-<!-- reconciled: e5e3f59c49fd25673e3b6e0b1f1cbab1849e16493a29eac2fff1d5818769ef04 -->
+<!-- reconciled: 8787b9bdac85eb47beb60a6268f5989dd286a6239cdd43e75be0c4f48ee8e2e5 -->
 
 No description yet — awaiting prose.
 
 ### safeword
 
-<!-- reconciled: e5e3f59c49fd25673e3b6e0b1f1cbab1849e16493a29eac2fff1d5818769ef04 -->
+<!-- reconciled: 8787b9bdac85eb47beb60a6268f5989dd286a6239cdd43e75be0c4f48ee8e2e5 -->
 
 No description yet — awaiting prose.
 

--- a/.project/tickets/WBM8JE-per-language-architecture-extractors/spec.md
+++ b/.project/tickets/WBM8JE-per-language-architecture-extractors/spec.md
@@ -1,0 +1,86 @@
+# Spec: per-language-architecture-extractors
+
+<!--
+Product-framing spec for a feature ticket. The engineering contract
+(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
+file holds the *why and who*. The bdd intake flow authors it before
+engineering scope. Fill each section, then delete the
+guidance comments.
+-->
+
+## Intent
+
+<!-- One or two sentences: what this feature is for and why it matters.
+This is the single source of truth for motivation — ticket.md drops its
+**Why:** line and points here. -->
+
+## Intake Brief
+
+<!-- The decide-to-build framing for substantial features (advisory — write
+`skip: <reason>` on any line that doesn't apply). Intent above is the positive
+"why"; this is who asked, the cost of NOT doing it, and how reversible it is.
+If cost-of-inaction is low and reversibility is high, ask whether this is a
+feature at all, or a leaner task. -->
+
+- **Requested by:** <who asked for this — distinct from the persona it serves>
+- **Cost of inaction:** <what changes, breaks, or is lost if we don't build it>
+- **Reversibility:** <how hard to undo once shipped — one-way or two-way door; cross-cutting changes (data model, public API, migration) count as one-way>
+
+## References
+
+<!-- Related tickets, prior art, designs, external docs. Optional. -->
+
+## Personas
+
+<!-- The personas this feature serves, referenced by name or code from
+the configured personas file (e.g., Platform Operator (PO)). Add new
+personas to that file — don't invent them here. -->
+
+## Vocabulary
+
+<!-- Domain terms specific to this feature, consistent with
+the configured glossary file. Optional. -->
+
+## Jobs To Be Done
+
+<!--
+One persona per JTBD, in the form "When I …, I want …, so I can …". If two
+personas share a motivation, write two JTBDs. The heading id is
+<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
+feature needs. If there is genuinely no persona-facing job (internal
+plumbing), write `skip: <reason>` here instead.
+
+Uncomment and customize:
+
+### oauth-flow.PO1 — Rotate credentials without a flag day
+
+**Persona:** Platform Operator (PO)
+
+> When I rotate a server's API key, I want the previous key to keep working
+> for a short grace period, so I can roll the change across my fleet without
+> coordinated downtime.
+
+Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
+in descriptive product language (a guarantee the user can observe), NOT
+implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
+scenario will prove a specific AC. If a JTBD has no user-observable capability
+to enumerate, write `skip: <reason>` under it instead of ACs.
+
+#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+
+#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
+-->
+
+## Outcomes
+
+<!-- Observable results that tell us the JTBDs are satisfied — the product
+counterpart to ticket.md's done_when. -->
+
+## Open Questions
+
+<!-- Unresolved questions surfaced during intake — the spec's running list of
+what we don't know yet (the equivalent of Example Mapping's red "question"
+cards). Add one per line as they come up; before advancing to define-behavior,
+resolve each (answer it, then delete the line) or record `defer: <reason>` for
+a deliberate punt. A long unresolved list means intake isn't done — keep
+converging. Delete this comment when you add real questions. -->

--- a/.project/tickets/WBM8JE-per-language-architecture-extractors/ticket.md
+++ b/.project/tickets/WBM8JE-per-language-architecture-extractors/ticket.md
@@ -1,0 +1,53 @@
+---
+id: WBM8JE
+slug: per-language-architecture-extractors
+type: feature
+phase: intake
+status: backlog
+created: 2026-06-23T15:07:27.802Z
+last_modified: 2026-06-23T15:08:00.000Z
+---
+
+# Per-language architecture extractors (Go / Rust / Python) — the epic's "language packs"
+
+**Goal:** Extend the generated architecture doc beyond the TypeScript/`src/`
+assumption so non-JS packages in a monorepo (and non-JS single repos) get real
+structural extraction and drift detection — not just a placeholder listing.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Status: BACKLOG — the deferred "language packs" (epic QD5DTT out-of-scope)
+
+Surfaced by the 2026-06-23 `/quality-review` of monorepo coverage. The shipped
+extractor is TypeScript-shaped on three axes; each needs a per-language strategy:
+
+- **Workspace discovery** — beyond `package.json workspaces` + `pnpm-workspace.yaml`
+  (the latter handled in ZRW21K): `go.work`, `Cargo.toml [workspace] members`,
+  Python (uv/poetry workspaces or multi-`pyproject.toml`).
+- **Module extraction** — beyond `<pkg>/src/*`: Go (`cmd/`, `internal/`, `pkg/`),
+  flat-layout Python packages, etc. (Rust already uses `src/`.)
+- **Shape-fingerprint inputs** — beyond `package.json` deps + dependency-cruiser
+  config: `go.mod`, `Cargo.toml`, `pyproject.toml`/`requirements.txt` dependency
+  sets, so structural drift in those packages is actually caught.
+
+## Why it's deferred
+
+Genuinely additive and large (three languages × three axes), and the safe
+degradation today (a non-introspectable package is marked, not silently wrong —
+delivered by ZRW21K) removes the urgency. The epic deliberately scoped this out
+("ship the TS extractor first"). Best done one language pack at a time, each its
+own slice, reusing the heal-target + fingerprint machinery.
+
+## Depends on / relates to
+
+- **ZRW21K** (monorepo-coverage-honesty) — adds pnpm discovery + the
+  "un-introspected package" marker. ZRW21K makes the omission honest; WBM8JE
+  removes the omission.
+- Mirrors safeword's existing per-language pack structure (`packs/golang`,
+  `packs/python`, `packs/rust`, `packs/sql`) — the extractor should plug into the
+  same pack seam.
+
+## Work Log
+
+- 2026-06-23T15:08:00Z Created from the monorepo-coverage /quality-review; deferred
+  to backlog behind ZRW21K (honest-omission first, fill-the-omission later).

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/dimensions.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/dimensions.md
@@ -1,0 +1,24 @@
+# Dimensions: Monorepo coverage honesty (ZRW21K)
+
+| Dimension                 | Partitions                                                                 | Source  |
+| ------------------------- | -------------------------------------------------------------------------- | ------- |
+| Workspace config          | pnpm-workspace.yaml · package.json `workspaces` · none (single repo)       | TB1     |
+| Package introspectability | has `src/` (introspected, gets leaf) · no `src/` (un-introspected, marked) | TB2     |
+| Regression surface        | single-repo output · npm-workspaces output (must be unchanged)             | TB1.AC2 |
+
+## Partition → scenario mapping
+
+- pnpm config × has-src → TB1.AC1 (root index + leaf).
+- none × has-src → TB1.AC2 (single doc, no leaves; regression).
+- npm config × has-src → TB1.AC2 (still discovered; regression).
+- pnpm/npm × no-src → TB2.AC1 (listed + "not introspected" marker, no leaf).
+- pnpm/npm × has-src → TB2.AC2 (listed, no marker).
+
+## Boundary notes
+
+- pnpm precedence: `package.json workspaces` wins when present; pnpm-workspace.yaml
+  is the fallback (so a repo with both is unchanged from today).
+- "no recognized source layout" = empty skeleton from `extractSkeleton` — covers
+  both a JS package without `src/` and a non-JS package, honestly, without
+  claiming language support (that's WBM8JE).
+- Out of scope here: flow-style pnpm YAML, `!`-exclusions, dirs without package.json.

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/impl-plan.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/impl-plan.md
@@ -1,0 +1,67 @@
+# Impl Plan: Monorepo coverage honesty (ZRW21K)
+
+**Status:** planned
+
+## Approach
+
+Two small, independent changes on the existing monorepo machinery; reuse
+everything downstream of discovery and rendering.
+
+Build order (each builds on the previous green):
+
+1. **`detectPnpmWorkspaces(cwd): string[] | undefined`** — a minimal,
+   dependency-free reader of `pnpm-workspace.yaml`: find the `packages:` block,
+   collect the indented `- "<glob>"` entries (strip quotes; ignore `!`-exclusions
+   and anything it can't parse → return `undefined`). _Unit_
+   (`architecture-monorepo.test.ts`). Covers the parse + the graceful-fallback edge.
+2. **Wire pnpm into discovery** — `discoverLeafDirectories` uses
+   `detectWorkspaces(cwd) ?? detectPnpmWorkspaces(cwd)`. The `??` gives the
+   required precedence for free (package.json `workspaces` wins; pnpm is the
+   fallback), and leaves `detectWorkspaces` — shared with `sync-config` —
+   untouched, so no sync-config behavior changes. _Integration_ (CLI over a pnpm
+   fixture). Covers TB1.AC1, the precedence, and the npm/single-repo regression.
+3. **Un-introspected marker** — `PackageNode` gains `introspected: boolean`
+   (`extractSkeleton(dir).nodes.length > 0`), set in `extractMonorepoModel`;
+   `renderPackageSection` emits `> ⚠ not introspected — no recognized source
+layout` for an un-introspected package instead of the `PURPOSE_PLACEHOLDER`
+   purpose line. _Unit_ (model + render) + _integration_. Covers TB2.AC1/AC2.
+4. **Black-box BDD steps** + dogfood: `steps/monorepo-coverage-honesty.steps.ts`
+   builds pnpm / npm / mixed fixtures and drives the real CLI; confirm this repo
+   (npm workspaces, both packages have `src/`) is unaffected and `--check` stays
+   green.
+
+Test-layer rationale: the YAML parse is pure → unit; discovery + render are a
+process-boundary contract (which docs appear, what the root index says) → CLI
+integration; the `.feature` lane is the end-to-end acceptance proof.
+
+## Decisions
+
+| Decision              | Choice                                                                             | Alternatives considered              | Rejected because                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| pnpm parse            | Minimal hand-parse of the `packages:` block list                                   | Add a YAML dependency                | Overkill for one simple file; breaks the zero-dependency posture                                                               |
+| Where pnpm plugs in   | `discoverLeafDirectories` via `detectWorkspaces(cwd) ?? detectPnpmWorkspaces(cwd)` | Extend the shared `detectWorkspaces` | That function feeds `sync-config` too; scoping pnpm to the architecture feature avoids an unintended depcruise behavior change |
+| Precedence            | `??` short-circuit — package.json wins                                             | Merge both lists                     | pnpm ignores package.json `workspaces`; a repo with both is a real config, package.json is authoritative                       |
+| Un-introspected mark  | A distinct `> ⚠ not introspected` blockquote, never the prose placeholder          | Reuse `PURPOSE_PLACEHOLDER`          | That is the exact "silently shallow" bug the ticket fixes                                                                      |
+| Flow-style / `!` YAML | Out of scope → parser returns `undefined` (graceful single-repo fallback)          | Full YAML support                    | Block-list covers the common case; degradation is safe, not wrong (proven by a scenario)                                       |
+
+## Arch alignment
+
+Honors `ARCHITECTURE.md`:
+
+- **Deterministic, LLM-free engine** — both changes are pure parse/derive; no new
+  source of truth, no LLM, no fingerprint-input change.
+- **Never silently wrong** (the state-doc contract) — the un-introspected marker
+  is the direct expression of "incomplete, but visibly so."
+
+## Known deviations
+
+- pnpm discovery lives beside `detectWorkspaces` rather than inside it — a
+  deliberate scope guard so `sync-config` is untouched. If a later ticket wants
+  pnpm-aware depcruise config, unify them then (and reconcile the precedence).
+
+## Assessment triggers
+
+- **WBM8JE** (per-language extractors) lands — it will want pnpm + go.work +
+  Cargo discovery in one place; revisit whether `detectPnpmWorkspaces` should
+  merge into a single multi-manifest discovery function.
+- pnpm adds/repractices its workspace file format — revisit the hand-parser.

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/spec.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/spec.md
@@ -1,0 +1,93 @@
+# Spec: Monorepo coverage honesty (pnpm discovery + un-introspected marker)
+
+**Scope of this spec:** two coverage gaps in the merged monorepo support — pnpm
+discovery and the un-introspected-package marker. No per-language extractors
+(Go/Rust/Python → WBM8JE); no fingerprint-input changes.
+
+## Intent
+
+The merged architecture-doc feature discovers monorepo packages only from a root
+`package.json` `workspaces` field. **pnpm** — one of the three major JS package
+managers — does not use that field; it requires `pnpm-workspace.yaml`. So a pnpm
+monorepo gets a silent `noop` (no docs at all), indistinguishable from "the
+feature is broken." Separately, when the root index lists a package that has no
+recognized source layout, it renders the same placeholder prose a real-but-
+undescribed module would — so a reader can mistake "safeword can't see this
+package" for "this package has no described architecture." Both undercut the
+core promise: the doc may be incomplete, but it must never be _silently_ wrong.
+
+## References
+
+- 2026-06-23 `/quality-review` of monorepo coverage (the gap analysis + probe)
+- XG9SFP (Slice 3) — `detectWorkspaces`, `discoverLeafDirectories`,
+  `extractMonorepoModel`, `renderRootIndex` (the machinery this extends)
+- WBM8JE — the deferred per-language extractors; ZRW21K makes the omission
+  honest, WBM8JE removes it
+- Verified: pnpm requires `pnpm-workspace.yaml` and ignores `package.json`
+  `workspaces` (pnpm.io/workspaces)
+
+## Personas
+
+- **Technical Builder (TB)** — runs an AI agent on a real monorepo; harmed when
+  their pnpm monorepo is silently skipped, or when the root index reads as a
+  complete map while quietly omitting packages safeword can't introspect.
+
+## Vocabulary
+
+- **Workspace discovery** — finding a monorepo's member packages. Today: root
+  `package.json` `workspaces`. This ticket adds `pnpm-workspace.yaml`.
+- **Un-introspected package** — a discovered package whose skeleton is empty (no
+  recognized `src/` modules), so it gets no leaf doc. The root index must mark it.
+
+## Jobs To Be Done
+
+### monorepo-coverage-honesty.TB1 — Get architecture docs in a pnpm monorepo
+
+**Persona:** Technical Builder (TB)
+
+> When I run safeword in my pnpm monorepo, I want the same architecture docs an
+> npm/yarn monorepo gets — a root index plus a doc per package — so my project
+> isn't silently skipped just because pnpm stores its workspace list in a
+> different file.
+
+#### monorepo-coverage-honesty.TB1.AC1 — A pnpm monorepo is discovered and documented
+
+A monorepo configured with `pnpm-workspace.yaml` (and no `package.json`
+`workspaces` field) produces the derived root index plus a colocated leaf doc per
+package with a `src/` tree — identical to an npm/yarn/bun monorepo.
+
+#### monorepo-coverage-honesty.TB1.AC2 — Existing discovery is unchanged
+
+A single repo (no workspace config) and an npm/yarn/bun-`workspaces` monorepo
+behave exactly as before — no regression from the pnpm fallback.
+
+### monorepo-coverage-honesty.TB2 — Trust the root index to be honest about what it omits
+
+**Persona:** Technical Builder (TB)
+
+> When the root index lists a package safeword couldn't introspect, I want it
+> clearly marked as not-described, so I never mistake an empty placeholder
+> listing for a complete one.
+
+#### monorepo-coverage-honesty.TB2.AC1 — An un-introspected package is visibly marked
+
+A discovered package with no recognized source layout (empty skeleton, no leaf
+doc) is listed in the root index with an explicit "not introspected" marker —
+never the same placeholder prose used for a described module.
+
+#### monorepo-coverage-honesty.TB2.AC2 — An introspected package is not marked
+
+A package that does have a `src/` tree (and gets a leaf doc) is listed normally,
+with no "not introspected" marker.
+
+## Outcomes
+
+- A pnpm monorepo yields the same root index + leaf docs as an npm monorepo.
+- The root index marks every package safeword can't introspect, so it can never
+  read as a complete map while silently omitting a package.
+- Single-repo and npm/yarn/bun-workspace behavior is byte-unchanged.
+
+## Open Questions
+
+- none — pnpm requires `pnpm-workspace.yaml` (verified); block-list parse covers
+  the common case, with flow-style YAML an explicit out-of-scope limitation.

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/test-definitions.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/test-definitions.md
@@ -8,44 +8,44 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A pnpm monorepo produces a root index and per-package leaf docs
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ### Scenario: A single repo with no workspace config stays a single-repo doc
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ### Scenario: An npm-workspaces monorepo is still discovered
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ### Scenario: package.json workspaces win when both config files are present
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ### Scenario: A pnpm-workspace.yaml the parser cannot read degrades gracefully
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ## Rule: The root index is honest about packages it cannot introspect
 
 ### Scenario: A package with no recognized source layout is marked, not placeholdered
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4
 
 ### Scenario: In a mixed monorepo, only the un-introspected package carries the marker
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 15702b4
+- [x] GREEN 15702b4
+- [x] REFACTOR 15702b4

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/test-definitions.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/test-definitions.md
@@ -1,0 +1,51 @@
+# Test Definitions: Monorepo coverage honesty (ZRW21K)
+
+Feature source: `features/monorepo-coverage-honesty.feature`
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: A pnpm monorepo is discovered, without changing existing discovery
+
+### Scenario: A pnpm monorepo produces a root index and per-package leaf docs
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A single repo with no workspace config stays a single-repo doc
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An npm-workspaces monorepo is still discovered
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: package.json workspaces win when both config files are present
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A pnpm-workspace.yaml the parser cannot read degrades gracefully
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: The root index is honest about packages it cannot introspect
+
+### Scenario: A package with no recognized source layout is marked, not placeholdered
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: In a mixed monorepo, only the un-introspected package carries the marker
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/ticket.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/ticket.md
@@ -2,10 +2,10 @@
 id: ZRW21K
 slug: monorepo-coverage-honesty
 type: feature
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-06-23T15:07:27.754Z
-last_modified: 2026-06-23T15:12:00.000Z
+last_modified: 2026-06-23T16:19:00.000Z
 scope:
   - pnpm-workspace.yaml discovery — detectWorkspaces also reads a pnpm-workspace.yaml `packages:` list when package.json has no `workspaces` field (so pnpm monorepos get the root index + leaf docs)
   - Un-introspected-package marker — a discovered package whose skeleton is empty (no recognized `src/` modules → noop leaf, no leaf doc) is marked in the root index ("not introspected — no recognized source layout") instead of rendering a bare placeholder that reads as authoritative-complete
@@ -76,3 +76,11 @@ WBM8JE).
   regression. Re-review PASS-WITH-NITS (nits = a tag-misread + degradation
   strength, non-blocking). Stamp recorded; impl-plan written (detectPnpmWorkspaces
   - `??` precedence + introspected flag). Advancing to implement.
+- 2026-06-23T16:19:00Z Complete: implement + verify + done. All 7 scenarios R/G/R
+  (15702b4). detectPnpmWorkspaces + collectPnpmGlobs (dependency-free block-list
+  parse), `??` precedence, introspected flag → root-index marker + fingerprint.
+  /verify: full suite green (3350 pass, fresh build), 7 BDD scenarios, build +
+  lint clean. /audit passed (0 cycles/violations, 0 clones, no dead code).
+  Investigated a lone full-suite failure → stale `dist/` (cold-start-check guide
+  from #348 not in the old build); clean rebuild → green, unrelated to ZRW21K.
+  Dogfood root index re-rendered + --check green. verify.md written. Closing.

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/ticket.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/ticket.md
@@ -1,0 +1,78 @@
+---
+id: ZRW21K
+slug: monorepo-coverage-honesty
+type: feature
+phase: implement
+status: in_progress
+created: 2026-06-23T15:07:27.754Z
+last_modified: 2026-06-23T15:12:00.000Z
+scope:
+  - pnpm-workspace.yaml discovery — detectWorkspaces also reads a pnpm-workspace.yaml `packages:` list when package.json has no `workspaces` field (so pnpm monorepos get the root index + leaf docs)
+  - Un-introspected-package marker — a discovered package whose skeleton is empty (no recognized `src/` modules → noop leaf, no leaf doc) is marked in the root index ("not introspected — no recognized source layout") instead of rendering a bare placeholder that reads as authoritative-complete
+  - Tests (unit + black-box BDD over real pnpm + mixed-layout fixtures) and dogfood verification
+out_of_scope:
+  - Per-language extractors / discovery for Go, Rust, Python (go.work, Cargo [workspace], pyproject) → deferred ticket WBM8JE
+  - Listing workspace dirs that have no package.json (a per-language discovery concern → WBM8JE)
+  - pnpm-workspace.yaml flow-style (`packages: ["a","b"]`) if it complicates the parser — block-list form covers the overwhelming common case; note any limitation
+  - Changing the shape-fingerprint inputs (still package.json-based; non-JS dep drift is WBM8JE)
+done_when:
+  - A pnpm monorepo (pnpm-workspace.yaml, no package.json workspaces) produces a root index + a colocated leaf doc per package with a src/ tree — same as an npm/yarn/bun monorepo today
+  - A monorepo package with no recognized source layout (empty skeleton) is listed in the root index with an explicit "not introspected" marker, never as a silently-complete placeholder
+  - Single-repo and npm/yarn/bun-workspace behavior is unchanged (no regression); `architecture --check` still passes on this repo
+  - All scenarios in features/monorepo-coverage-honesty.feature pass via the BDD lane; full suite green
+---
+
+# Monorepo coverage honesty — pnpm discovery + un-introspected-package marker
+
+**Goal:** Close the two coverage gaps the 2026-06-23 `/quality-review` found in
+the merged monorepo support: pnpm monorepos get **no docs at all**, and a
+non-introspectable package is listed in the root index as a bare placeholder that
+can read as "described" when safeword is actually blind to it.
+
+**Why:** safeword's promise is "never silently wrong." Today a **pnpm** monorepo
+(one of the three major JS package managers — pnpm requires `pnpm-workspace.yaml`
+and does **not** read `package.json`'s `workspaces` field) gets a silent `noop`,
+indistinguishable from "feature broken." And a JS-rooted polyglot monorepo's root
+index lists a package with no recognized source layout using the same placeholder
+prose as a real-but-undescribed module — silently shallow.
+
+## Resolved design (from the /quality-review /figure-it-out)
+
+1. **pnpm discovery** — extend `detectWorkspaces` (the single workspace-truth
+   source, already used by sync-config) to fall back to `pnpm-workspace.yaml` when
+   `package.json.workspaces` is absent. Minimal hand-parse of the `packages:`
+   block list (no new YAML dependency — keeps the zero-dep posture); fall back to
+   no-workspaces on anything it can't parse. Reuses ALL existing leaf/fingerprint
+   machinery unchanged.
+2. **Un-introspected marker** — in the monorepo model, a package whose
+   `extractSkeleton` yields zero modules is flagged; `renderRootIndex` emits an
+   explicit "⚠ not introspected — no recognized source layout" line for it instead
+   of the placeholder purpose. Honest: it's listed (the package set is real) but
+   visibly not described, upholding "incomplete, never silently wrong."
+
+**Rejected:** a new YAML dependency (overkill for one simple file); dropping the
+`package.json` requirement to list non-JS dirs (that's per-language discovery →
+WBM8JE).
+
+## Open questions
+
+- none — design resolved in the review; flow-style pnpm YAML is an explicit
+  out-of-scope limitation to note if it complicates the parser.
+
+## Work Log
+
+- 2026-06-23T15:07:27Z Created from the monorepo-coverage /quality-review.
+- 2026-06-23T15:12:00Z Intake: scope = pnpm-workspace.yaml discovery + the
+  un-introspected-package marker (per-language extractors split to WBM8JE).
+  Design resolved in the review's /figure-it-out. Next: BDD define-behavior.
+- 2026-06-23T15:15:00Z Complete: define-behavior — spec.md (TB1 + TB2, 4 ACs),
+  dimensions, 5 scenarios across 2 rules. Advancing to scenario-gate for
+  independent /review-spec.
+- 2026-06-23T15:25:00Z Complete: scenario-gate — independent /review-spec BLOCKED
+  the first cut (the not-introspected marker wasn't proven distinct from the
+  PURPOSE_PLACEHOLDER — the ticket's whole point). Reworked to 7 scenarios:
+  marker asserted + placeholder excluded, mixed-layout contrast, precedence
+  (both config files), graceful flow-style fallback, content-level single-repo
+  regression. Re-review PASS-WITH-NITS (nits = a tag-misread + degradation
+  strength, non-blocking). Stamp recorded; impl-plan written (detectPnpmWorkspaces
+  - `??` precedence + introspected flag). Advancing to implement.

--- a/.project/tickets/ZRW21K-monorepo-coverage-honesty/verify.md
+++ b/.project/tickets/ZRW21K-monorepo-coverage-honesty/verify.md
@@ -1,0 +1,35 @@
+# Verify: Monorepo coverage honesty (ZRW21K)
+
+## Verify Checklist
+
+**Test Suite:** ✓ green with a fresh build (see note) — 5 new unit tests + the full architecture set pass
+**Gherkin:** ✅ 7 new monorepo-coverage scenarios pass; full acceptance lane green
+**Build:** ✅ Success
+**Lint:** ✅ Clean (eslint + gherkin + tsc --noEmit; `detectPnpmWorkspaces` refactored under the complexity bar, regex hardened against backtracking)
+**Scenarios:** All 7 scenarios R/G/R (15702b4)
+**Dep Drift:** ✅ Clean (no new deps — dependency-free pnpm parse)
+**Parent Epic:** QD5DTT (architecture state docs); surfaced by the monorepo /quality-review
+**Reconcile:** ✅ No pattern deviation — pnpm plugs into `discoverLeafDirectories` via `??` (the shared `detectWorkspaces` is untouched, a deliberate scope guard documented in impl-plan.md "Known deviations"); the `introspected` flag mirrors the existing model/fingerprint shape.
+
+## Evidence
+
+- **Independent scenario-gate review** (fresh context, `/review-spec`): BLOCK on the first cut — the "not introspected" marker wasn't proven distinct from the existing `PURPOSE_PLACEHOLDER`, which is the ticket's whole point. Reworked to 7 scenarios (marker asserted + placeholder excluded, mixed-layout contrast, precedence with both config files, graceful flow-style fallback, content-level single-repo regression); re-review PASS.
+- **pnpm discovery** — `discoverLeafDirectories` falls back to a dependency-free `pnpm-workspace.yaml` block-list parse; `package.json workspaces` stays authoritative via `??`. Verified by unit + a real pnpm fixture: a pnpm monorepo now yields the root index + leaf docs (probed live).
+- **Un-introspected marker** — a package with an empty skeleton renders `⚠ not introspected — no recognized source layout`, never the prose placeholder, proven distinct in a mixed monorepo. The flag feeds `monorepoFingerprint`, so the marker can't go stale when a package gains/loses a `src/` tree (unit test pins the fingerprint move).
+- **Audit:** 0 errors / 0 warnings — depcruise 0 violations (158 modules), config in sync, 0 jscpd clones, no dead code.
+- **Dogfood:** this repo's root index re-rendered (the fingerprint now carries introspection status); `safeword architecture --check` exits 0.
+
+## Note on the suite
+
+A first local full-suite run flagged one failure (`setup-templates` broken-link
+check for `.safeword/guides/cold-start-check.md`). Root cause: a **stale `dist/`**
+predating the `cold-start-check` guide that landed on `main` via #348 — the test
+runs the built CLI, and the stale build installed an old template set. A clean
+rebuild makes the test pass (6/6); CI always builds first, so this never affected
+CI. Not a code issue and unrelated to ZRW21K (no involved file was touched).
+Final full suite re-run on a fresh build confirms green.
+
+## Audit
+
+Audit passed — 0 errors, 0 warnings. No circular dependencies or layer violations,
+no dead code, no duplication, config in sync, test quality verified.

--- a/features/monorepo-coverage-honesty.feature
+++ b/features/monorepo-coverage-honesty.feature
@@ -11,35 +11,35 @@ Feature: Honest monorepo coverage — pnpm discovery + un-introspected marker
     @monorepo-coverage-honesty.TB1.AC1
     Scenario: A pnpm monorepo produces a root index and per-package leaf docs
       Given a pnpm monorepo whose pnpm-workspace.yaml lists a package "web" with a src tree
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then a root index lists the package "web"
       And the package "web" has its own colocated leaf doc
 
     @monorepo-coverage-honesty.TB1.AC2
     Scenario: A single repo with no workspace config stays a single-repo doc
       Given a single-repo project with a src tree and no workspace config
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then the generated doc is a single-repo module doc, not a package root index
       And no colocated leaf docs are generated
 
     @monorepo-coverage-honesty.TB1.AC2
     Scenario: An npm-workspaces monorepo is still discovered
       Given an npm monorepo whose package.json workspaces list a package "web" with a src tree
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then a root index lists the package "web"
       And the package "web" has its own colocated leaf doc
 
     @monorepo-coverage-honesty.TB1.AC2
     Scenario: package.json workspaces win when both config files are present
       Given a monorepo whose package.json workspaces list "web" and whose pnpm-workspace.yaml lists "svc"
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then the root index lists the package "web"
       And the root index does not list the package "svc"
 
     @monorepo-coverage-honesty.TB1.AC1
     Scenario: A pnpm-workspace.yaml the parser cannot read degrades gracefully
       Given a pnpm monorepo whose pnpm-workspace.yaml uses unparseable flow-style packages
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then the command succeeds
       And no colocated leaf docs are generated
 
@@ -48,7 +48,7 @@ Feature: Honest monorepo coverage — pnpm discovery + un-introspected marker
     @monorepo-coverage-honesty.TB2.AC1
     Scenario: A package with no recognized source layout is marked, not placeholdered
       Given a pnpm monorepo with a package "svc" that has no src tree
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then the package "svc" is marked "not introspected" in the root index
       And the package "svc" line does not show the "awaiting prose" placeholder
       And the package "svc" has no colocated leaf doc
@@ -56,7 +56,7 @@ Feature: Honest monorepo coverage — pnpm discovery + un-introspected marker
     @monorepo-coverage-honesty.TB2.AC2
     Scenario: In a mixed monorepo, only the un-introspected package carries the marker
       Given a pnpm monorepo with a package "web" that has a src tree and a package "svc" that has no src tree
-      When the architecture doc is generated
+      When safeword generates the architecture doc
       Then the package "svc" is marked "not introspected" in the root index
       And the package "web" is not marked "not introspected" in the root index
       And the package "web" has its own colocated leaf doc

--- a/features/monorepo-coverage-honesty.feature
+++ b/features/monorepo-coverage-honesty.feature
@@ -1,0 +1,62 @@
+@monorepo-coverage-honesty
+Feature: Honest monorepo coverage — pnpm discovery + un-introspected marker
+
+  The generated architecture doc must cover pnpm monorepos (which store their
+  workspace list in pnpm-workspace.yaml, not package.json), and the derived root
+  index must never list a package safeword couldn't introspect as if it were a
+  described-but-empty module. Incomplete is fine; silently wrong is not.
+
+  Rule: A pnpm monorepo is discovered, without changing existing discovery
+
+    @monorepo-coverage-honesty.TB1.AC1
+    Scenario: A pnpm monorepo produces a root index and per-package leaf docs
+      Given a pnpm monorepo whose pnpm-workspace.yaml lists a package "web" with a src tree
+      When the architecture doc is generated
+      Then a root index lists the package "web"
+      And the package "web" has its own colocated leaf doc
+
+    @monorepo-coverage-honesty.TB1.AC2
+    Scenario: A single repo with no workspace config stays a single-repo doc
+      Given a single-repo project with a src tree and no workspace config
+      When the architecture doc is generated
+      Then the generated doc is a single-repo module doc, not a package root index
+      And no colocated leaf docs are generated
+
+    @monorepo-coverage-honesty.TB1.AC2
+    Scenario: An npm-workspaces monorepo is still discovered
+      Given an npm monorepo whose package.json workspaces list a package "web" with a src tree
+      When the architecture doc is generated
+      Then a root index lists the package "web"
+      And the package "web" has its own colocated leaf doc
+
+    @monorepo-coverage-honesty.TB1.AC2
+    Scenario: package.json workspaces win when both config files are present
+      Given a monorepo whose package.json workspaces list "web" and whose pnpm-workspace.yaml lists "svc"
+      When the architecture doc is generated
+      Then the root index lists the package "web"
+      And the root index does not list the package "svc"
+
+    @monorepo-coverage-honesty.TB1.AC1
+    Scenario: A pnpm-workspace.yaml the parser cannot read degrades gracefully
+      Given a pnpm monorepo whose pnpm-workspace.yaml uses unparseable flow-style packages
+      When the architecture doc is generated
+      Then the command succeeds
+      And no colocated leaf docs are generated
+
+  Rule: The root index is honest about packages it cannot introspect
+
+    @monorepo-coverage-honesty.TB2.AC1
+    Scenario: A package with no recognized source layout is marked, not placeholdered
+      Given a pnpm monorepo with a package "svc" that has no src tree
+      When the architecture doc is generated
+      Then the package "svc" is marked "not introspected" in the root index
+      And the package "svc" line does not show the "awaiting prose" placeholder
+      And the package "svc" has no colocated leaf doc
+
+    @monorepo-coverage-honesty.TB2.AC2
+    Scenario: In a mixed monorepo, only the un-introspected package carries the marker
+      Given a pnpm monorepo with a package "web" that has a src tree and a package "svc" that has no src tree
+      When the architecture doc is generated
+      Then the package "svc" is marked "not introspected" in the root index
+      And the package "web" is not marked "not introspected" in the root index
+      And the package "web" has its own colocated leaf doc

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -371,5 +371,11 @@ function renderRootIndex(model: MonorepoModel, fingerprint: string): string {
 }
 
 function renderPackageSection(node: PackageNode, stamp: string): string {
-  return `### ${node.name}\n\n${RECONCILED_PREFIX} ${stamp} -->\n\n${node.purpose}\n`;
+  // An un-introspected package (no recognized source layout, so no leaf doc) is
+  // marked explicitly — never shown with the bare prose placeholder, which would
+  // read as "described but empty" rather than "safeword can't see this" (ZRW21K).
+  const body = node.introspected
+    ? node.purpose
+    : '> ⚠ not introspected — no recognized source layout';
+  return `### ${node.name}\n\n${RECONCILED_PREFIX} ${stamp} -->\n\n${body}\n`;
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -14,6 +14,7 @@ import { createHash } from 'node:crypto';
 import { globSync } from 'node:fs';
 import nodePath from 'node:path';
 
+import { extractSkeleton } from './architecture-skeleton.js';
 import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
 
@@ -45,6 +46,13 @@ export interface PackageNode {
   dir: string;
   /** One-line purpose (the purpose floor); a placeholder until prose is written. */
   purpose: string;
+  /**
+   * Whether the package has a recognized source layout (a non-empty `src/`
+   * skeleton, so it gets a leaf doc). A package that is `false` here is listed in
+   * the root index but explicitly marked "not introspected" rather than shown
+   * with a bare placeholder — incomplete, never silently complete (ZRW21K).
+   */
+  introspected: boolean;
 }
 
 interface PackageEdge {
@@ -63,7 +71,9 @@ export interface MonorepoModel {
  * `package.json`. Returns `[]` for a non-workspace project.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  const patterns = detectWorkspaces(projectDirectory);
+  // package.json `workspaces` wins; pnpm-workspace.yaml is the fallback (pnpm
+  // ignores the package.json field, so a repo with both is npm-authoritative).
+  const patterns = detectWorkspaces(projectDirectory) ?? detectPnpmWorkspaces(projectDirectory);
   if (patterns === undefined) return [];
 
   const matches = new Set<string>();
@@ -90,6 +100,7 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
       name: packageName(dir),
       dir,
       purpose: PURPOSE_PLACEHOLDER,
+      introspected: extractSkeleton(dir).nodes.length > 0,
     }))
     .toSorted((a, b) => byString(a.name, b.name));
 
@@ -114,7 +125,10 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
 export function monorepoFingerprint(projectDirectory: string): string {
   const model = extractMonorepoModel(projectDirectory);
   const inputs = {
-    packages: model.packages.map(node => node.name),
+    // Introspection status is part of the root shape: a package gaining or losing
+    // a `src/` tree flips its root-index line (marker ↔ described), so the root
+    // index must re-render — otherwise the "not introspected" marker goes stale.
+    packages: model.packages.map(node => `${node.name}:${node.introspected}`),
     edges: model.edges.map(edge => `${edge.from}->${edge.to}`),
     boundaryConfig: readBoundaryConfig(projectDirectory),
   };
@@ -153,4 +167,45 @@ function readBoundaryConfig(projectDirectory: string): string {
     if (content !== undefined) return content;
   }
   return '';
+}
+
+/**
+ * Read workspace globs from `pnpm-workspace.yaml` (ticket ZRW21K) — pnpm stores
+ * its workspace list here, not in `package.json`'s `workspaces` field, so a pnpm
+ * monorepo would otherwise be invisible. A dependency-free parse of the
+ * block-list form:
+ *
+ *   packages:
+ *     - "packages/*"
+ *     - "apps/*"
+ *
+ * Returns the include globs (quotes stripped, `!`-exclusions skipped), or
+ * `undefined` when the file is absent or not in the block-list form (flow-style
+ * `packages: [..]` and other shapes are out of scope and degrade to no-workspaces
+ * — incomplete, never silently wrong).
+ */
+function detectPnpmWorkspaces(projectDirectory: string): string[] | undefined {
+  const content = readFileSafe(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'));
+  if (content === undefined) return undefined;
+
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex(line => /^packages:\s*$/.test(line));
+  if (start === -1) return undefined;
+
+  const globs = collectPnpmGlobs(lines.slice(start + 1));
+  return globs.length > 0 ? globs : undefined;
+}
+
+/** Collect the include globs from a pnpm `packages:` block, stopping at the dedent. */
+function collectPnpmGlobs(blockLines: string[]): string[] {
+  const globs: string[] = [];
+  for (const line of blockLines) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue; // blank/comment inside the block
+    const item = /^\s+-\s+(\S.*)$/.exec(line);
+    if (item?.[1] === undefined) break; // dedent / non-list line — block ended
+    const glob = item[1].trim().replaceAll(/^["']|["']$/g, '');
+    if (glob.length > 0 && !glob.startsWith('!')) globs.push(glob);
+  }
+  return globs;
 }

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -75,6 +75,72 @@ describe('discoverLeafDirectories', () => {
   });
 });
 
+describe('discoverLeafDirectories — pnpm + precedence (ZRW21K)', () => {
+  function writePnpmWorkspace(root: string, globs: string[]): void {
+    const body = ['packages:', ...globs.map(glob => `  - "${glob}"`)].join('\n');
+    writeFileSync(nodePath.join(root, 'pnpm-workspace.yaml'), `${body}\n`);
+  }
+
+  it('discovers packages from pnpm-workspace.yaml when package.json has no workspaces', () => {
+    writeManifest(context.directory, { name: 'root' }); // no `workspaces` field
+    writePnpmWorkspace(context.directory, ['packages/*']);
+    makePackage(context.directory, 'web');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
+  });
+
+  it('lets package.json workspaces win when both config files are present', () => {
+    // beforeEach already set workspaces: ['packages/*'].
+    writePnpmWorkspace(context.directory, ['apps/*']);
+    makePackage(context.directory, 'web'); // under packages/ (npm side)
+    writeManifest(nodePath.join(context.directory, 'apps', 'svc'), { name: 'svc' }); // pnpm side
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
+  });
+
+  it('falls back to no workspaces when pnpm-workspace.yaml is unparseable (flow style)', () => {
+    writeManifest(context.directory, { name: 'root' }); // no `workspaces`
+    writeFileSync(
+      nodePath.join(context.directory, 'pnpm-workspace.yaml'),
+      'packages: ["packages/*"]\n', // flow style — out of scope, must degrade
+    );
+    makePackage(context.directory, 'web');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+});
+
+describe('extractMonorepoModel — introspected flag (ZRW21K)', () => {
+  it('marks a package with a src tree introspected and one without not introspected', () => {
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    makePackage(context.directory, 'svc'); // no modules → no src tree
+
+    const model = extractMonorepoModel(context.directory);
+    const byName = new Map(model.packages.map(node => [node.name, node]));
+
+    expect(byName.get('web')?.introspected).toBe(true);
+    expect(byName.get('svc')?.introspected).toBe(false);
+  });
+});
+
+describe('monorepoFingerprint — introspection status is part of the root shape (ZRW21K)', () => {
+  it('moves when a package gains a src tree (so the root index re-renders)', () => {
+    makePackage(context.directory, 'svc'); // no src tree
+    const before = monorepoFingerprint(context.directory);
+
+    mkdirSync(nodePath.join(context.directory, 'packages', 'svc', 'src', 'api'), {
+      recursive: true,
+    });
+    const after = monorepoFingerprint(context.directory);
+
+    expect(after).not.toBe(before);
+  });
+});
+
 describe('extractMonorepoModel', () => {
   it('lists every package with a placeholder purpose', () => {
     makePackage(context.directory, 'core');

--- a/steps/monorepo-coverage-honesty.steps.ts
+++ b/steps/monorepo-coverage-honesty.steps.ts
@@ -1,0 +1,225 @@
+/**
+ * Acceptance-lane step definitions for monorepo coverage honesty (ticket
+ * ZRW21K). Black-box: builds pnpm / npm / mixed-layout fixtures and drives the
+ * real `safeword architecture` CLI, asserting which docs appear and what the
+ * derived root index says — the actual coverage contract — without importing
+ * package internals.
+ */
+
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodeOs from 'node:os';
+import nodePath from 'node:path';
+
+import { After, Given, Then, When } from '@cucumber/cucumber';
+
+import type { SafewordWorld } from './world.js';
+
+const PROJECT_ROOT = nodePath.resolve(import.meta.dirname, '..');
+const CLI_PATH = nodePath.join(PROJECT_ROOT, 'packages/cli/src/cli.ts');
+
+interface CoverageWorld extends SafewordWorld {
+  dir?: string;
+  status?: number;
+}
+
+function dir(world: CoverageWorld): string {
+  world.dir ??= mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'arch-coverage-bdd-'));
+  return world.dir;
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(nodePath.dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value));
+}
+
+/** A workspace package under packages/<name>, optionally with a src/ module. */
+function makePackage(world: CoverageWorld, name: string, options: { src?: boolean } = {}): void {
+  const packageDir = nodePath.join(dir(world), 'packages', name);
+  writeJson(nodePath.join(packageDir, 'package.json'), { name });
+  if (options.src) mkdirSync(nodePath.join(packageDir, 'src', 'ui'), { recursive: true });
+}
+
+function writePnpmWorkspace(world: CoverageWorld, globs: string[]): void {
+  const body = ['packages:', ...globs.map(glob => `  - "${glob}"`)].join('\n');
+  writeFileSync(nodePath.join(dir(world), 'pnpm-workspace.yaml'), `${body}\n`);
+}
+
+function rootDoc(world: CoverageWorld): string {
+  const path = nodePath.join(dir(world), '.project', 'architecture.generated.md');
+  return existsSync(path) ? readFileSync(path, 'utf8') : '';
+}
+
+function leafDocExists(world: CoverageWorld, name: string): boolean {
+  return existsSync(nodePath.join(dir(world), 'packages', name, 'architecture.generated.md'));
+}
+
+/** A `### name` package section of the root index (to its next heading or EOF). */
+function packageSection(world: CoverageWorld, name: string): string {
+  const chunk = rootDoc(world)
+    .split('\n### ')
+    .find(part => part.startsWith(`${name}\n`));
+  return chunk === undefined ? '' : `### ${chunk.split('\n## ')[0]}`;
+}
+
+After(function (this: CoverageWorld) {
+  if (this.dir !== undefined) rmSync(this.dir, { recursive: true, force: true });
+});
+
+// --- Givens ---
+
+Given(
+  /^a pnpm monorepo whose pnpm-workspace\.yaml lists a package "([^"]+)" with a src tree$/,
+  function (this: CoverageWorld, name: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writePnpmWorkspace(this, ['packages/*']);
+    makePackage(this, name, { src: true });
+  },
+);
+
+Given(
+  'a single-repo project with a src tree and no workspace config',
+  function (this: CoverageWorld) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'solo' });
+    mkdirSync(nodePath.join(dir(this), 'src', 'core'), { recursive: true });
+  },
+);
+
+Given(
+  /^an npm monorepo whose package\.json workspaces list a package "([^"]+)" with a src tree$/,
+  function (this: CoverageWorld, name: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    makePackage(this, name, { src: true });
+  },
+);
+
+Given(
+  /^a monorepo whose package\.json workspaces list "([^"]+)" and whose pnpm-workspace\.yaml lists "([^"]+)"$/,
+  function (this: CoverageWorld, npmName: string, pnpmName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    writePnpmWorkspace(this, ['apps/*']);
+    makePackage(this, npmName, { src: true });
+    writeJson(nodePath.join(dir(this), 'apps', pnpmName, 'package.json'), { name: pnpmName });
+    mkdirSync(nodePath.join(dir(this), 'apps', pnpmName, 'src', 'ui'), { recursive: true });
+  },
+);
+
+Given(
+  'a pnpm monorepo whose pnpm-workspace.yaml uses unparseable flow-style packages',
+  function (this: CoverageWorld) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writeFileSync(nodePath.join(dir(this), 'pnpm-workspace.yaml'), 'packages: ["packages/*"]\n');
+    makePackage(this, 'web', { src: true });
+  },
+);
+
+Given(
+  /^a pnpm monorepo with a package "([^"]+)" that has no src tree$/,
+  function (this: CoverageWorld, name: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writePnpmWorkspace(this, ['packages/*']);
+    makePackage(this, name, { src: false });
+  },
+);
+
+Given(
+  /^a pnpm monorepo with a package "([^"]+)" that has a src tree and a package "([^"]+)" that has no src tree$/,
+  function (this: CoverageWorld, withSrc: string, withoutSrc: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writePnpmWorkspace(this, ['packages/*']);
+    makePackage(this, withSrc, { src: true });
+    makePackage(this, withoutSrc, { src: false });
+  },
+);
+
+// --- When ---
+
+When('safeword generates the architecture doc', function (this: CoverageWorld) {
+  const result = spawnSync('bun', [CLI_PATH, 'architecture'], {
+    cwd: dir(this),
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  this.status = result.status ?? 1;
+});
+
+// --- Thens ---
+
+Then('the command succeeds', function (this: CoverageWorld) {
+  assert.equal(this.status, 0, 'architecture command failed');
+});
+
+Then(/^a root index lists the package "([^"]+)"$/, function (this: CoverageWorld, name: string) {
+  assert.match(rootDoc(this), /^## Packages/m, 'doc is not a root index');
+  assert.ok(packageSection(this, name).length > 0, `root index does not list ${name}`);
+});
+
+Then(/^the root index lists the package "([^"]+)"$/, function (this: CoverageWorld, name: string) {
+  assert.ok(packageSection(this, name).length > 0, `root index does not list ${name}`);
+});
+
+Then(
+  /^the root index does not list the package "([^"]+)"$/,
+  function (this: CoverageWorld, name: string) {
+    assert.equal(packageSection(this, name).length, 0, `root index unexpectedly lists ${name}`);
+  },
+);
+
+Then(
+  /^the package "([^"]+)" has its own colocated leaf doc$/,
+  function (this: CoverageWorld, name: string) {
+    assert.ok(leafDocExists(this, name), `leaf doc missing for ${name}`);
+  },
+);
+
+Then(
+  /^the package "([^"]+)" has no colocated leaf doc$/,
+  function (this: CoverageWorld, name: string) {
+    assert.ok(!leafDocExists(this, name), `unexpected leaf doc for ${name}`);
+  },
+);
+
+Then(
+  'the generated doc is a single-repo module doc, not a package root index',
+  function (this: CoverageWorld) {
+    const content = rootDoc(this);
+    assert.match(content, /^## Modules/m, 'expected a single-repo "## Modules" doc');
+    assert.doesNotMatch(content, /^## Packages/m, 'unexpectedly rendered a package root index');
+  },
+);
+
+Then('no colocated leaf docs are generated', function (this: CoverageWorld) {
+  // No architecture.generated.md under any candidate package directory.
+  assert.ok(
+    !['web', 'svc', 'core', 'api'].some(name => leafDocExists(this, name)),
+    'unexpected colocated leaf doc',
+  );
+});
+
+Then(
+  /^the package "([^"]+)" is marked "([^"]+)" in the root index$/,
+  function (this: CoverageWorld, name: string, marker: string) {
+    assert.match(packageSection(this, name), new RegExp(marker.replaceAll(' ', '\\s+')));
+  },
+);
+
+Then(
+  /^the package "([^"]+)" is not marked "([^"]+)" in the root index$/,
+  function (this: CoverageWorld, name: string, marker: string) {
+    assert.doesNotMatch(packageSection(this, name), new RegExp(marker.replaceAll(' ', '\\s+')));
+  },
+);
+
+Then(
+  /^the package "([^"]+)" line does not show the "([^"]+)" placeholder$/,
+  function (this: CoverageWorld, name: string, _placeholderHint: string) {
+    assert.doesNotMatch(packageSection(this, name), /awaiting prose/);
+  },
+);


### PR DESCRIPTION
Closes the two monorepo coverage gaps a `/quality-review` of the merged architecture-doc feature (#350) surfaced. Full BDD: intake → scenarios → independent scenario-gate review → TDD → verify → audit.

## What & why

The merged feature discovered monorepo packages only from a root `package.json` `workspaces` field, and listed un-introspectable packages with a bare prose placeholder. Two honesty gaps:

**1. pnpm monorepos got no docs at all.** pnpm — one of the three major JS package managers — stores its workspace list in `pnpm-workspace.yaml` and does **not** read `package.json`'s `workspaces` field, so a pnpm monorepo produced a silent `noop`, indistinguishable from "the feature is broken."
→ `discoverLeafDirectories` now falls back to a **dependency-free `pnpm-workspace.yaml` block-list parse** when `package.json` has no `workspaces`. `package.json` stays authoritative via `??`; the shared `detectWorkspaces` (used by `sync-config`) is deliberately untouched. A pnpm monorepo now gets the same root index + per-package leaf docs as npm/yarn/bun.

**2. The root index could read as silently complete.** A discovered package with no recognized source layout (empty `src/` skeleton, no leaf doc) rendered the same placeholder prose a real-but-undescribed module would.
→ `PackageNode` carries an `introspected` flag; the root index marks such a package `⚠ not introspected — no recognized source layout` instead of the placeholder. The flag feeds `monorepoFingerprint`, so the marker can't go stale when a package gains/loses a `src/` tree. Incomplete, never silently complete.

The deferred **per-language extractors** (Go/Rust/Python discovery + extraction + fingerprint) are tracked in backlog ticket **WBM8JE** — this PR makes the omission honest; WBM8JE removes it.

## Quality

- **Full suite green on a fresh build:** 3350 passing / 5 skipped (225 files). Build + lint + typecheck + gherkin clean; dependency-cruiser 0 violations; 0 jscpd clones.
- **Independent scenario-gate review** BLOCKED the first cut — the "not introspected" marker wasn't proven distinct from the existing placeholder (the ticket's whole point). Reworked to 7 scenarios (marker asserted + placeholder excluded, mixed-layout contrast, precedence with both config files, graceful flow-style fallback, content-level single-repo regression); re-review PASS.
- **Zero new dependencies** — the pnpm parse is a small hand-written block-list reader; flow-style YAML and `!`-exclusions are an explicit, tested-graceful out-of-scope (degrade to single-repo, never crash).
- **Dogfood:** this repo's root index re-rendered (the fingerprint now carries introspection status); `safeword architecture --check` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S)_