### PR TITLE
feat(bdd,verify): rave-moment intake + two-lens experience review

### DIFF
--- a/.agents/skills/bdd/DISCOVERY.md
+++ b/.agents/skills/bdd/DISCOVERY.md
@@ -91,6 +91,22 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 **Pause and confirm** the AC list grouped by JTBD with the user before advancing — this is the AC **Sub-phase gate** (see above). Iterate until they sign off, then build engineering scope (Understanding) on top.
 
+## Author the Rave Moment
+
+Optional, and only for the **highest persona-facing surface** in the tree — the epic if there is one, else this feature. Child features under an epic that already named one inherit it; internal/plumbing work skips it. Advisory: it never blocks intake exit.
+
+The jobs above say what a persona can _do_. The rave moment says what would make them _tell a peer about it_ — a different and higher bar. It needs three things at once:
+
+- **The moment** — one specific beat they'd screenshot or recount, not a diffuse "it's nice." People remember the peak and the ending, not the average — name the peak.
+- **The expectation it beats** — the dread, status-quo pain, or competitor clunk it's measured against. A moment that beats nothing is table-stakes, not a rave.
+- **The one-sentence test** — can the persona repeat it to a peer with the same problem, in a way that makes _them_ look in-the-know? If it can't be said in a sentence, it won't travel.
+
+**Ground it in evidence — don't write it from your priors.** A moment invented from memory is how you get a plausible-but-fake rave, so it isn't optional: **run `/figure-it-out` every time**, handing it the three criteria above as the brief, to research the real dread, the competitor's actual clunk, and what genuinely travels here. (Where that skill isn't available, do that research inline — the grounding is the requirement; the skill is only the tool.) If the real gap is persona intent or raw ideation, it routes you to `/elicit` or `/brainstorm`.
+
+Aim for **awe** ("whoa, it just did that"), not mild satisfaction — low-arousal "fine" doesn't get shared. Write it to `spec.md`'s `## Rave Moment` (e.g., oauth-flow: _"I expected a coordinated flag-day; the old key just kept working while I rolled the fleet"_). If nothing clears the expectation bar, write `skip: table-stakes` — "no rave here" is an honest, common answer, not a gap to fill. Manufacturing one to fill the field is the failure mode; the beaten-expectation requirement is the guard.
+
+`/verify`'s experience lens walks this moment as the persona later and asks whether it landed.
+
 ## Understanding (Propose-and-Converge)
 
 Follow the understanding pattern from SAFEWORD.md — including contribution techniques. Converge until the user accepts a proposal with structured scope (Scope, Out of Scope, Done When) written to the ticket spec.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -146,9 +146,19 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
+**Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
+
+**Experience** is soft — it never blocks the done gate (it has no done-gate evidence pattern; a ⚠️ here never hard-blocks `done`). Run it for persona-facing work; use `N/A` for internal/plumbing. It is the one _class-1 qualitative judgment_ in an otherwise _class-2_ skill (PRINCIPLES.md §1): no parser stands in as the independent party here, so this lens alone carries the self-preference risk the rest of verify doesn't — which is why the walk-artifact below is mandatory. Two lenses:
+
+- **Friction (every persona-facing feature):** did this add a step, a wait, a re-entry, or a dead-end the persona didn't have before? Walk the changed flow as the persona and inspect its _ending_ specifically — last impressions dominate the memory and are the most under-designed. Effort erodes advocacy faster than peaks build it, so a new friction point is the higher-priority finding. **Record the walk as evidence, not a verdict:** `Walked <persona> through <flow>; worst step = <the one most likely to make them bounce>; new steps vs before = <n>`. Name the _worst_ step, not a tidy summary — you are grading your own work, and a bare `✅` or a flattering "feels clean" is exactly the self-rating this artifact exists to defeat.
+- **Peak (only when the ticket or its parent declared a `## Rave Moment` in `spec.md`):** walk that moment as the persona — does it still land, and did this work advance or endanger it? A peak that quietly degraded is a finding even when every test is green.
+
+A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it now, or to **Decisions needed** if it's a scope/value call for the user. It is never a reason to hold `done` on its own.
+
+**Escalation.** Verify's class-2 checks need no fresh-context reviewer — a test run is its own independent party. This lens is the class-1 exception, so it does: the inline self-check is the cheap first guard, and if shipped work keeps clearing it while real friction reaches users, that is the signal to move _the Experience lens alone_ to an independent reviewer (a fresh-context fork, or a persona-walk of the running product), not to keep trusting the inline pass.
 
 **Done-gate evidence patterns** (the stop hook validates these literal phrases — do not move or rename):
 

--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -91,6 +91,22 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 **Pause and confirm** the AC list grouped by JTBD with the user before advancing — this is the AC **Sub-phase gate** (see above). Iterate until they sign off, then build engineering scope (Understanding) on top.
 
+## Author the Rave Moment
+
+Optional, and only for the **highest persona-facing surface** in the tree — the epic if there is one, else this feature. Child features under an epic that already named one inherit it; internal/plumbing work skips it. Advisory: it never blocks intake exit.
+
+The jobs above say what a persona can _do_. The rave moment says what would make them _tell a peer about it_ — a different and higher bar. It needs three things at once:
+
+- **The moment** — one specific beat they'd screenshot or recount, not a diffuse "it's nice." People remember the peak and the ending, not the average — name the peak.
+- **The expectation it beats** — the dread, status-quo pain, or competitor clunk it's measured against. A moment that beats nothing is table-stakes, not a rave.
+- **The one-sentence test** — can the persona repeat it to a peer with the same problem, in a way that makes _them_ look in-the-know? If it can't be said in a sentence, it won't travel.
+
+**Ground it in evidence — don't write it from your priors.** A moment invented from memory is how you get a plausible-but-fake rave, so it isn't optional: **run `/figure-it-out` every time**, handing it the three criteria above as the brief, to research the real dread, the competitor's actual clunk, and what genuinely travels here. (Where that skill isn't available, do that research inline — the grounding is the requirement; the skill is only the tool.) If the real gap is persona intent or raw ideation, it routes you to `/elicit` or `/brainstorm`.
+
+Aim for **awe** ("whoa, it just did that"), not mild satisfaction — low-arousal "fine" doesn't get shared. Write it to `spec.md`'s `## Rave Moment` (e.g., oauth-flow: _"I expected a coordinated flag-day; the old key just kept working while I rolled the fleet"_). If nothing clears the expectation bar, write `skip: table-stakes` — "no rave here" is an honest, common answer, not a gap to fill. Manufacturing one to fill the field is the failure mode; the beaten-expectation requirement is the guard.
+
+`/verify`'s experience lens walks this moment as the persona later and asks whether it landed.
+
 ## Understanding (Propose-and-Converge)
 
 Follow the understanding pattern from SAFEWORD.md — including contribution techniques. Converge until the user accepts a proposal with structured scope (Scope, Out of Scope, Done When) written to the ticket spec.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -146,9 +146,19 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
+**Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
+
+**Experience** is soft — it never blocks the done gate (it has no done-gate evidence pattern; a ⚠️ here never hard-blocks `done`). Run it for persona-facing work; use `N/A` for internal/plumbing. It is the one _class-1 qualitative judgment_ in an otherwise _class-2_ skill (PRINCIPLES.md §1): no parser stands in as the independent party here, so this lens alone carries the self-preference risk the rest of verify doesn't — which is why the walk-artifact below is mandatory. Two lenses:
+
+- **Friction (every persona-facing feature):** did this add a step, a wait, a re-entry, or a dead-end the persona didn't have before? Walk the changed flow as the persona and inspect its _ending_ specifically — last impressions dominate the memory and are the most under-designed. Effort erodes advocacy faster than peaks build it, so a new friction point is the higher-priority finding. **Record the walk as evidence, not a verdict:** `Walked <persona> through <flow>; worst step = <the one most likely to make them bounce>; new steps vs before = <n>`. Name the _worst_ step, not a tidy summary — you are grading your own work, and a bare `✅` or a flattering "feels clean" is exactly the self-rating this artifact exists to defeat.
+- **Peak (only when the ticket or its parent declared a `## Rave Moment` in `spec.md`):** walk that moment as the persona — does it still land, and did this work advance or endanger it? A peak that quietly degraded is a finding even when every test is green.
+
+A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it now, or to **Decisions needed** if it's a scope/value call for the user. It is never a reason to hold `done` on its own.
+
+**Escalation.** Verify's class-2 checks need no fresh-context reviewer — a test run is its own independent party. This lens is the class-1 exception, so it does: the inline self-check is the cheap first guard, and if shipped work keeps clearing it while real friction reaches users, that is the signal to move _the Experience lens alone_ to an independent reviewer (a fresh-context fork, or a persona-walk of the running product), not to keep trusting the inline pass.
 
 **Done-gate evidence patterns** (the stop hook validates these literal phrases — do not move or rename):
 

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -140,9 +140,19 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
+**Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
+
+**Experience** is soft — it never blocks the done gate (it has no done-gate evidence pattern; a ⚠️ here never hard-blocks `done`). Run it for persona-facing work; use `N/A` for internal/plumbing. It is the one _class-1 qualitative judgment_ in an otherwise _class-2_ skill (PRINCIPLES.md §1): no parser stands in as the independent party here, so this lens alone carries the self-preference risk the rest of verify doesn't — which is why the walk-artifact below is mandatory. Two lenses:
+
+- **Friction (every persona-facing feature):** did this add a step, a wait, a re-entry, or a dead-end the persona didn't have before? Walk the changed flow as the persona and inspect its _ending_ specifically — last impressions dominate the memory and are the most under-designed. Effort erodes advocacy faster than peaks build it, so a new friction point is the higher-priority finding. **Record the walk as evidence, not a verdict:** `Walked <persona> through <flow>; worst step = <the one most likely to make them bounce>; new steps vs before = <n>`. Name the _worst_ step, not a tidy summary — you are grading your own work, and a bare `✅` or a flattering "feels clean" is exactly the self-rating this artifact exists to defeat.
+- **Peak (only when the ticket or its parent declared a `## Rave Moment` in `spec.md`):** walk that moment as the persona — does it still land, and did this work advance or endanger it? A peak that quietly degraded is a finding even when every test is green.
+
+A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it now, or to **Decisions needed** if it's a scope/value call for the user. It is never a reason to hold `done` on its own.
+
+**Escalation.** Verify's class-2 checks need no fresh-context reviewer — a test run is its own independent party. This lens is the class-1 exception, so it does: the inline self-check is the cheap first guard, and if shipped work keeps clearing it while real friction reaches users, that is the signal to move _the Experience lens alone_ to an independent reviewer (a fresh-context fork, or a persona-walk of the running product), not to keep trusting the inline pass.
 
 **Done-gate evidence patterns** (the stop hook validates these literal phrases — do not move or rename):
 

--- a/.safeword/templates/spec-template.md
+++ b/.safeword/templates/spec-template.md
@@ -71,6 +71,23 @@ to enumerate, write `skip: <reason>` under it instead of ACs.
 #### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
 -->
 
+## Rave Moment
+
+<!-- Optional, and only for the highest persona-facing surface in the tree (the
+epic if there is one, else this feature). Child features under an epic that
+already named one inherit it — skip here; internal/plumbing work skips entirely.
+Advisory; never blocks intake exit. The one moment a persona would tell a peer
+about: name the moment, the expectation it beats, and the one sentence they'd
+repeat. Aim for awe, not "fine." If nothing clears the expectation bar, write
+`skip: table-stakes`.
+
+### <slug> — <the moment in a few words>
+
+- **Moment:** <the specific beat they'd screenshot or recount>
+- **Beats:** <the dread / status-quo pain / competitor clunk it's measured against>
+- **They'd say:** "<the one repeatable, status-conferring sentence>"
+-->
+
 ## Outcomes
 
 <!-- Observable results that tell us the JTBDs are satisfied — the product

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -140,9 +140,19 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
+**Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
+
+**Experience** is soft — it never blocks the done gate (it has no done-gate evidence pattern; a ⚠️ here never hard-blocks `done`). Run it for persona-facing work; use `N/A` for internal/plumbing. It is the one _class-1 qualitative judgment_ in an otherwise _class-2_ skill (PRINCIPLES.md §1): no parser stands in as the independent party here, so this lens alone carries the self-preference risk the rest of verify doesn't — which is why the walk-artifact below is mandatory. Two lenses:
+
+- **Friction (every persona-facing feature):** did this add a step, a wait, a re-entry, or a dead-end the persona didn't have before? Walk the changed flow as the persona and inspect its _ending_ specifically — last impressions dominate the memory and are the most under-designed. Effort erodes advocacy faster than peaks build it, so a new friction point is the higher-priority finding. **Record the walk as evidence, not a verdict:** `Walked <persona> through <flow>; worst step = <the one most likely to make them bounce>; new steps vs before = <n>`. Name the _worst_ step, not a tidy summary — you are grading your own work, and a bare `✅` or a flattering "feels clean" is exactly the self-rating this artifact exists to defeat.
+- **Peak (only when the ticket or its parent declared a `## Rave Moment` in `spec.md`):** walk that moment as the persona — does it still land, and did this work advance or endanger it? A peak that quietly degraded is a finding even when every test is green.
+
+A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it now, or to **Decisions needed** if it's a scope/value call for the user. It is never a reason to hold `done` on its own.
+
+**Escalation.** Verify's class-2 checks need no fresh-context reviewer — a test run is its own independent party. This lens is the class-1 exception, so it does: the inline self-check is the cheap first guard, and if shipped work keeps clearing it while real friction reaches users, that is the signal to move _the Experience lens alone_ to an independent reviewer (a fresh-context fork, or a persona-walk of the running product), not to keep trusting the inline pass.
 
 **Done-gate evidence patterns** (the stop hook validates these literal phrases — do not move or rename):
 

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -91,6 +91,22 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 **Pause and confirm** the AC list grouped by JTBD with the user before advancing — this is the AC **Sub-phase gate** (see above). Iterate until they sign off, then build engineering scope (Understanding) on top.
 
+## Author the Rave Moment
+
+Optional, and only for the **highest persona-facing surface** in the tree — the epic if there is one, else this feature. Child features under an epic that already named one inherit it; internal/plumbing work skips it. Advisory: it never blocks intake exit.
+
+The jobs above say what a persona can _do_. The rave moment says what would make them _tell a peer about it_ — a different and higher bar. It needs three things at once:
+
+- **The moment** — one specific beat they'd screenshot or recount, not a diffuse "it's nice." People remember the peak and the ending, not the average — name the peak.
+- **The expectation it beats** — the dread, status-quo pain, or competitor clunk it's measured against. A moment that beats nothing is table-stakes, not a rave.
+- **The one-sentence test** — can the persona repeat it to a peer with the same problem, in a way that makes _them_ look in-the-know? If it can't be said in a sentence, it won't travel.
+
+**Ground it in evidence — don't write it from your priors.** A moment invented from memory is how you get a plausible-but-fake rave, so it isn't optional: **run `/figure-it-out` every time**, handing it the three criteria above as the brief, to research the real dread, the competitor's actual clunk, and what genuinely travels here. (Where that skill isn't available, do that research inline — the grounding is the requirement; the skill is only the tool.) If the real gap is persona intent or raw ideation, it routes you to `/elicit` or `/brainstorm`.
+
+Aim for **awe** ("whoa, it just did that"), not mild satisfaction — low-arousal "fine" doesn't get shared. Write it to `spec.md`'s `## Rave Moment` (e.g., oauth-flow: _"I expected a coordinated flag-day; the old key just kept working while I rolled the fleet"_). If nothing clears the expectation bar, write `skip: table-stakes` — "no rave here" is an honest, common answer, not a gap to fill. Manufacturing one to fill the field is the failure mode; the beaten-expectation requirement is the guard.
+
+`/verify`'s experience lens walks this moment as the persona later and asks whether it landed.
+
 ## Understanding (Propose-and-Converge)
 
 Follow the understanding pattern from SAFEWORD.md — including contribution techniques. Converge until the user accepts a proposal with structured scope (Scope, Out of Scope, Done When) written to the ticket spec.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -146,9 +146,19 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
+**Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
+
+**Experience** is soft — it never blocks the done gate (it has no done-gate evidence pattern; a ⚠️ here never hard-blocks `done`). Run it for persona-facing work; use `N/A` for internal/plumbing. It is the one _class-1 qualitative judgment_ in an otherwise _class-2_ skill (PRINCIPLES.md §1): no parser stands in as the independent party here, so this lens alone carries the self-preference risk the rest of verify doesn't — which is why the walk-artifact below is mandatory. Two lenses:
+
+- **Friction (every persona-facing feature):** did this add a step, a wait, a re-entry, or a dead-end the persona didn't have before? Walk the changed flow as the persona and inspect its _ending_ specifically — last impressions dominate the memory and are the most under-designed. Effort erodes advocacy faster than peaks build it, so a new friction point is the higher-priority finding. **Record the walk as evidence, not a verdict:** `Walked <persona> through <flow>; worst step = <the one most likely to make them bounce>; new steps vs before = <n>`. Name the _worst_ step, not a tidy summary — you are grading your own work, and a bare `✅` or a flattering "feels clean" is exactly the self-rating this artifact exists to defeat.
+- **Peak (only when the ticket or its parent declared a `## Rave Moment` in `spec.md`):** walk that moment as the persona — does it still land, and did this work advance or endanger it? A peak that quietly degraded is a finding even when every test is green.
+
+A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it now, or to **Decisions needed** if it's a scope/value call for the user. It is never a reason to hold `done` on its own.
+
+**Escalation.** Verify's class-2 checks need no fresh-context reviewer — a test run is its own independent party. This lens is the class-1 exception, so it does: the inline self-check is the cheap first guard, and if shipped work keeps clearing it while real friction reaches users, that is the signal to move _the Experience lens alone_ to an independent reviewer (a fresh-context fork, or a persona-walk of the running product), not to keep trusting the inline pass.
 
 **Done-gate evidence patterns** (the stop hook validates these literal phrases — do not move or rename):
 

--- a/packages/cli/templates/spec-template.md
+++ b/packages/cli/templates/spec-template.md
@@ -71,6 +71,23 @@ to enumerate, write `skip: <reason>` under it instead of ACs.
 #### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
 -->
 
+## Rave Moment
+
+<!-- Optional, and only for the highest persona-facing surface in the tree (the
+epic if there is one, else this feature). Child features under an epic that
+already named one inherit it — skip here; internal/plumbing work skips entirely.
+Advisory; never blocks intake exit. The one moment a persona would tell a peer
+about: name the moment, the expectation it beats, and the one sentence they'd
+repeat. Aim for awe, not "fine." If nothing clears the expectation bar, write
+`skip: table-stakes`.
+
+### <slug> — <the moment in a few words>
+
+- **Moment:** <the specific beat they'd screenshot or recount>
+- **Beats:** <the dread / status-quo pain / competitor clunk it's measured against>
+- **They'd say:** "<the one repeatable, status-conferring sentence>"
+-->
+
 ## Outcomes
 
 <!-- Observable results that tell us the JTBDs are satisfied — the product

--- a/packages/cli/tests/utils/ticket-writer.test.ts
+++ b/packages/cli/tests/utils/ticket-writer.test.ts
@@ -131,7 +131,7 @@ describe('ticket-writer — type-aware ticket.md body (Rule 2)', () => {
 describe('spec-template.md is well-formed (Rule 3)', () => {
   const template = readFileSync(nodePath.join(getTemplatesDirectory(), 'spec-template.md'), 'utf8');
 
-  it('has the eight section headers in canonical order', () => {
+  it('has the nine section headers in canonical order', () => {
     expect(specHeaders(template)).toEqual([
       'Intent',
       'Intake Brief',
@@ -139,6 +139,7 @@ describe('spec-template.md is well-formed (Rule 3)', () => {
       'Personas',
       'Vocabulary',
       'Jobs To Be Done',
+      'Rave Moment',
       'Outcomes',
       'Open Questions',
     ]);


### PR DESCRIPTION
## What & why

Products should delight users, but the Safeword workflow had almost no place where "would a user love this?" enters as a prompt or check. The spine is binary/observable (tests pass, scenarios non-vacuous, build/lint green); delight is qualitative, so it fell straight through. This adds an **advisory** product-delight pass — fired at boundaries, never per-turn, and **never blocking `done`** (PRINCIPLES §2).

The sharper design prompt than "delight" is **"would they rave to a peer?"** — it stakes social capital, is differential (the gap between dread and reality), locatable to one moment, and articulable in one sentence.

## What it adds

10 files = **4 canonical templates + 6 byte-identical dogfood copies** (`.claude/skills`, `.agents/skills`, `.cursor/commands`, `.safeword/templates`). Purely additive (+132 lines), no schema change.

**Generate — once, at the top (`bdd/DISCOVERY.md`):** a new "Author the Rave Moment" step for the **highest persona-facing surface** (epic else feature; children inherit; internal/plumbing skips). Captures the one beat a persona would tell a peer about, the expectation it beats, and the one-sentence test. Authoring **runs `/figure-it-out` every time** to ground the moment in current evidence (the real dread, the competitor's clunk, what travels), degrading to inline research where the skill isn't available (Codex/Cursor). Recorded in `spec.md`'s new `## Rave Moment` section. `skip: table-stakes` is a first-class answer.

**Review — per ticket (`verify` SKILL.md + command, byte-identical):** a soft `**Experience:**` checklist line with two lenses:

- **Friction** (every persona-facing feature) — did this add a step / wait / re-entry / dead-end? Walk the changed flow as the persona, inspect the _ending_. Requires an **adversarial walk-artifact** — `Walked <persona> through <flow>; worst step = <where they bounce>; new steps vs before = <n>` — to defeat a content-free ✅.
- **Peak** (only when a `## Rave Moment` was declared) — walk that moment; does it still land?

Findings route to verify's existing **Actions / Decisions** sections; an Experience ⚠️ **never** holds `done` on its own.

## Key design calls (all via `/figure-it-out`, evidence-backed)

- **Two lenses, not one** — raving (driven by peaks/surprise) and retention (driven by absence of friction) have different, sometimes opposed drivers. Friction is the higher-priority finding: effort erodes advocacy faster than peaks build it ([CES > NPS, HBR 2010](https://hbr.org/2010/07/stop-trying-to-delight-your-customers)).
- **Adversarial evidence-artifact over a content-free ✅** — inline self-correction is unreliable without an external signal ([Huang et al.](https://arxiv.org/abs/2310.01798)); a forced verification artifact cuts vacuous output ([Chain-of-Verification](https://arxiv.org/pdf/2309.11495)); same-model self-judging is directionally biased ([self-preference, NeurIPS 2024](https://arxiv.org/html/2410.21819v2)).
- **Class-1 carve-out** — the Experience lens is the lone _qualitative_ judgment in an otherwise _class-2 observable_ verify (reconciles with the #351 reviewer-class taxonomy): no parser is the independent party, so it alone carries self-preference risk — hence the mandatory artifact now and a documented escalation to an independent reviewer later.
- **`/figure-it-out` grounds the GENERATE step, never the REVIEW lens** — a producer can't grade its own work. The mandate degrades gracefully because skill-to-skill calls are Claude-mediated and soft: the _grounding_ is the requirement, the skill is only the tool ([Anthropic skill-authoring best-practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), [Opus-4.8 prompting](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-4-8)).

## Verification

- `parity --mode=all`: **160 pairs + 3 contracts in sync**; cursor rules thin.
- Targeted suites green (verify-skill, schema, parity, intake-brief, discovery integration); **release dogfood-parity gate green**.
- prettier + markdownlint clean; verify SKILL ↔ command block byte-identical.

> Note: CI runs the full suite. The next real validation per Anthropic's skill docs is _observed use_ — dogfood the rave-moment step on one live epic and watch whether `/figure-it-out` actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
