### PR TITLE
feat: enforce cross-model on the phase-exit review gate (7A0B2K)

### DIFF
--- a/.project/tickets/7A0B2K-scenario-review-cross-model/ticket.md
+++ b/.project/tickets/7A0B2K-scenario-review-cross-model/ticket.md
@@ -2,20 +2,35 @@
 id: 7A0B2K
 slug: scenario-review-cross-model
 type: task
-phase: intake
-status: backlog
+phase: implement
+status: in_progress
 created: 2026-06-12T02:37:21.358Z
-last_modified: 2026-06-12T02:37:21.358Z
-blocked_by:
-  - 'MR5M3A (builds the cross-model primitive in review-ledger.ts that this consumes)'
+last_modified: 2026-06-24T00:46:00.000Z
 ---
 
-# Wire scenario-gate fork review to the cross-model knob
+# Wire the phase-exit fork review to the cross-model knob
 
-**Goal:** Let the existing Tier 2 scenario-gate fork review require a different-model reviewer, reusing the `modelsMatch` primitive MR5M3A adds to `review-ledger.ts`.
+**Goal:** Let the Tier 2 phase-exit fork review (NMSD94) require a different-model reviewer when `crossModelReview` is on, reusing MR5M3A's `modelsMatch` / `isCrossModelReviewRequired` / `AUTHOR_MODEL_ENV` primitives in `review-ledger.ts`.
 
-**Why:** safeword's scenario-gate review is currently same-model, so it shares the author's blind spots (the correlated-error problem MR5M3A documents). MR5M3A fixes this for the design review; this extends the same protection to the scenario review — the review that catches bad scenarios should itself be independent of the author's model when configured. Surfaced 2026-06-12 while dogfooding MR5M3A: the fork review that caught 7 real findings was itself same-model.
+**Why:** the phase-exit review is currently same-model, so it shares the author's blind spots (the correlated-error problem MR5M3A documents). MR5M3A fixed this for the design review; this extends the same protection to phase reviews — the review that catches bad scenarios should itself be independent of the author's model when configured. Surfaced 2026-06-12 while dogfooding MR5M3A: the fork review that caught 7 real findings was itself same-model. Realigned by ticket BHK9PW's reviewer-class taxonomy: phase-exit review is class-1, so cross-model is exactly the protection it should carry.
+
+## Scope decision
+
+The NMSD94 phase-exit gate (`pre-tool-quality.ts`) is **already generalized** — it fires on any phase advance (`detectPhaseAdvance` has no phase filter), not just scenario-gate. So rather than special-casing scenario-gate, the cross-model ceiling-raiser was added to the **general** phase-exit gate: it now covers scenario-gate _and_ every other gated phase exit uniformly. This is the consistent class-1 application the taxonomy argues for, and it is less code than a special case. Ticket title/slug kept for traceability; goal reworded.
+
+## What shipped
+
+- `pre-tool-quality.ts`: after the stamp-presence check passes, a cross-model ceiling-raiser (mirroring the arch-gate in `stop-quality.ts`): under `crossModelReview`, real-review stamps at the phase scope must include one whose `model:` tag differs from `SAFEWORD_AUTHOR_MODEL`; else deny. Logged skips bypass (same auditable escape valve). Fails closed when either model tag is absent.
+- `isCrossModelOn()` config reader added beside `isReviewGateOn()`.
+- Synced template → `.safeword/hooks/` dogfood copy.
+- Tests: 6 new cases in `tests/integration/phase-review-gate.test.ts` (equal-model blocks, different-model allows, no-model fails closed, cross-model-OFF allows, skip bypasses, different-model re-review after same-model passes).
+
+## Done when
+
+- Phase-exit gate blocks a same-model (or untagged) review under `crossModelReview`, allows a different-model one, stays inert when the flag is off, and the skip valve still works. ✅
+- Full suite green; typecheck clean. ⏳ (full run in progress)
 
 ## Work Log
 
 - 2026-06-12T02:37:21.358Z Started: Created ticket 7A0B2K
+- 2026-06-24T00:46:00Z Implemented via TDD (RED: 2 failing cross-model cases → GREEN: ceiling-raiser in phase-exit gate). Reused MR5M3A primitives verbatim. Scoped to the general phase-exit gate (covers scenario-gate + all phases) per the taxonomy. 13/13 phase-gate tests pass; 75/75 across phase-gate + arch-gate + review-gate + review-ledger + models-match; typecheck clean. Synced dogfood copy. Full suite running before commit.

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -14,10 +14,13 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  AUTHOR_MODEL_ENV,
   detectPhaseAdvance,
   gatePhaseAdvance,
   hashArtifact,
+  isCrossModelReviewRequired,
   isReviewGateEnabled,
+  modelsMatch,
   parseReviewStamps,
   type ReviewStamp,
   reviewGateForNextAsset,
@@ -131,6 +134,15 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 function isReviewGateOn(): boolean {
   const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
   return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
+// Whether phase-exit reviews must run on a different model than the author
+// (ticket 7A0B2K, reusing MR5M3A's `crossModelReview` knob). Off by default.
+function isCrossModelOn(): boolean {
+  const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  return isCrossModelReviewRequired(
+    existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined,
+  );
 }
 
 // The review stamps both gates read from the shared skill-invocation-log
@@ -395,6 +407,25 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
           `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
           `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
         );
+      }
+      // Ceiling-raiser (7A0B2K): under cross-model, a real-review stamp must record a
+      // model different from the author. Evaluate over ALL real-review stamps at this
+      // scope (the log is append-only, so a corrected re-review can follow a same-model
+      // attempt) — pass if any is cross-model. A logged skip records no real-review
+      // stamp, so it deliberately bypasses this, matching the arch-gate's escape valve.
+      else if (isCrossModelOn()) {
+        const realReviews = stamps.filter(
+          s => s.scope === phaseScope && s.skipReason === undefined,
+        );
+        const hasCrossModelReview = realReviews.some(
+          s => !modelsMatch(s.model, process.env[AUTHOR_MODEL_ENV]),
+        );
+        if (realReviews.length > 0 && !hasCrossModelReview) {
+          deny(
+            `Phase "${exitedPhase}" review (cross-model): the phase review must be performed by a different model than the author.`,
+            `Re-run with an explicit different-model subagent (not a context:fork, which inherits the author model), then record it via \`bun .safeword/hooks/write-review-stamp.ts --model <id> --phase ${exitedPhase}\`.`,
+          );
+        }
       }
     }
   }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -14,10 +14,13 @@ import { parseFrontmatter } from './lib/hierarchy.ts';
 import { evaluateAcGate, evaluateJtbdGate } from './lib/jtbd.ts';
 import { classifyAnnotation, isValidSkipReason } from './lib/parse-annotation.ts';
 import {
+  AUTHOR_MODEL_ENV,
   detectPhaseAdvance,
   gatePhaseAdvance,
   hashArtifact,
+  isCrossModelReviewRequired,
   isReviewGateEnabled,
+  modelsMatch,
   parseReviewStamps,
   type ReviewStamp,
   reviewGateForNextAsset,
@@ -131,6 +134,15 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 function isReviewGateOn(): boolean {
   const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
   return isReviewGateEnabled(existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined);
+}
+
+// Whether phase-exit reviews must run on a different model than the author
+// (ticket 7A0B2K, reusing MR5M3A's `crossModelReview` knob). Off by default.
+function isCrossModelOn(): boolean {
+  const configFile = nodePath.join(projectDirectory, '.safeword', 'config.json');
+  return isCrossModelReviewRequired(
+    existsSync(configFile) ? readFileSync(configFile, 'utf8') : undefined,
+  );
 }
 
 // The review stamps both gates read from the shared skill-invocation-log
@@ -395,6 +407,25 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
           `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
           `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
         );
+      }
+      // Ceiling-raiser (7A0B2K): under cross-model, a real-review stamp must record a
+      // model different from the author. Evaluate over ALL real-review stamps at this
+      // scope (the log is append-only, so a corrected re-review can follow a same-model
+      // attempt) — pass if any is cross-model. A logged skip records no real-review
+      // stamp, so it deliberately bypasses this, matching the arch-gate's escape valve.
+      else if (isCrossModelOn()) {
+        const realReviews = stamps.filter(
+          s => s.scope === phaseScope && s.skipReason === undefined,
+        );
+        const hasCrossModelReview = realReviews.some(
+          s => !modelsMatch(s.model, process.env[AUTHOR_MODEL_ENV]),
+        );
+        if (realReviews.length > 0 && !hasCrossModelReview) {
+          deny(
+            `Phase "${exitedPhase}" review (cross-model): the phase review must be performed by a different model than the author.`,
+            `Re-run with an explicit different-model subagent (not a context:fork, which inherits the author model), then record it via \`bun .safeword/hooks/write-review-stamp.ts --model <id> --phase ${exitedPhase}\`.`,
+          );
+        }
       }
     }
   }

--- a/packages/cli/tests/integration/phase-review-gate.test.ts
+++ b/packages/cli/tests/integration/phase-review-gate.test.ts
@@ -41,14 +41,27 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
   let ticketDirectory: string;
   let ticketFile: string;
 
-  function runGateWrite(newPhase: string): HookResult {
+  function runGateWrite(
+    newPhase: string,
+    extraEnvironment: Record<string, string> = {},
+  ): HookResult {
+    // Control the ambient author model: tests that exercise cross-model pass it
+    // explicitly; everything else runs with it unset so same-model defaults are
+    // deterministic regardless of the dev's SessionStart env.
+    const childEnvironment: NodeJS.ProcessEnv = {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: projectRoot,
+      ...extraEnvironment,
+    };
+    if (!('SAFEWORD_AUTHOR_MODEL' in extraEnvironment))
+      delete childEnvironment.SAFEWORD_AUTHOR_MODEL;
     const result = spawnSync('bun', [GATE_PATH], {
       input: JSON.stringify({
         tool_name: 'Write',
         tool_input: { file_path: ticketFile, content: ticketBody(newPhase) },
       }),
       encoding: 'utf8',
-      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+      env: childEnvironment,
     });
     return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
   }
@@ -76,11 +89,18 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
     });
   }
 
-  function writeConfig(reviewGate: boolean): void {
+  function stampPhaseModel(phase: string, model: string): void {
+    spawnSync('bun', [STAMP_PATH, '--model', model, '--phase', phase], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot, CLAUDE_SESSION_ID: 'sess-1' },
+    });
+  }
+
+  function writeConfig(reviewGate: boolean, crossModelReview = false): void {
     mkdirSync(nodePath.join(projectRoot, '.safeword'), { recursive: true });
     writeFileSync(
       nodePath.join(projectRoot, '.safeword', 'config.json'),
-      JSON.stringify({ reviewGate }),
+      JSON.stringify({ reviewGate, crossModelReview }),
     );
   }
 
@@ -131,5 +151,50 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
   it('is inert when reviewGate is off (default)', () => {
     writeConfig(false);
     expectHookAllow(runGateWrite('implement'));
+  });
+
+  describe('cross-model (7A0B2K) — phase-exit review must be a different model', () => {
+    it('blocks when the phase stamp model equals the author model', () => {
+      writeConfig(true, true);
+      stampPhaseModel('define-behavior', 'claude-opus-4-8');
+      expectHookDeny(
+        runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }),
+        'cross-model',
+      );
+    });
+
+    it('allows when the phase stamp model differs from the author model', () => {
+      writeConfig(true, true);
+      stampPhaseModel('define-behavior', 'claude-sonnet-4-6');
+      expectHookAllow(runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }));
+    });
+
+    it('blocks when the phase stamp records no model (fails closed)', () => {
+      writeConfig(true, true);
+      stampPhase('define-behavior');
+      expectHookDeny(
+        runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }),
+        'cross-model',
+      );
+    });
+
+    it('allows when crossModelReview is OFF even if stamp model equals author', () => {
+      writeConfig(true, false);
+      stampPhaseModel('define-behavior', 'claude-opus-4-8');
+      expectHookAllow(runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }));
+    });
+
+    it('a logged skip bypasses the cross-model requirement', () => {
+      writeConfig(true, true);
+      stampPhase('define-behavior', 'docs-only', 'phase');
+      expectHookAllow(runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }));
+    });
+
+    it('passes when a different-model re-review follows a same-model stamp', () => {
+      writeConfig(true, true);
+      stampPhaseModel('define-behavior', 'claude-opus-4-8');
+      stampPhaseModel('define-behavior', 'claude-sonnet-4-6');
+      expectHookAllow(runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }));
+    });
   });
 });


### PR DESCRIPTION
## What

Extends the NMSD94 Tier-2 **phase-exit review gate** to enforce cross-model review when `crossModelReview` is enabled. Previously the gate checked only that an independent phase-exit review **stamp** existed; it didn't care which model produced it. Now, under `crossModelReview`, a real-review stamp's `model:` tag must differ from `SAFEWORD_AUTHOR_MODEL` — otherwise the advance is blocked.

Implementation mirrors the architecture-review-gate ceiling-raiser in `stop-quality.ts` and reuses MR5M3A's primitives verbatim (`modelsMatch`, `isCrossModelReviewRequired`, `AUTHOR_MODEL_ENV`). Logged skips bypass it (the same auditable escape valve every gate carries); an absent model tag on either side fails closed.

## Why

The phase-exit review is **class-1** (judgment on produced work) in the reviewer-class taxonomy shipped in #351 — its threat is *correlated blind spots*. A same-model reviewer shares the author's blind spots, so cross-model is exactly the protection it should carry. MR5M3A closed this for the design review; this closes it for phase reviews. (Surfaced while dogfooding MR5M3A: the fork review that caught 7 real findings was itself same-model.)

## Scope decision

The phase-exit gate is **already phase-general** (`detectPhaseAdvance` has no filter), so rather than special-casing scenario-gate, the cross-model check was added to the general gate — it now covers scenario-gate **and every other gated phase exit** uniformly. That's the consistent class-1 application the taxonomy argues for, and it's less code than a special case. Ticket 7A0B2K's title/slug are kept for traceability.

## Tests

6 new cases in `tests/integration/phase-review-gate.test.ts`: equal-model blocks, different-model allows, no-model fails closed, cross-model-OFF allows, logged-skip bypasses, different-model re-review after a same-model stamp passes. TDD (RED → GREEN). Template ↔ `.safeword/hooks` dogfood copy kept in sync.

Local: 13/13 phase-gate, 75/75 across phase-gate + arch-gate + review-gate + review-ledger + models-match; typecheck clean. Full suite verified by CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYmttepx21bjayxkpAcGUY)_