### PR TITLE
De-jargon the LOW NTB surfaces (JZQ85C)

### DIFF
--- a/.project/tickets/JZQ85C-ntb-low-jargon-surfaces/ticket.md
+++ b/.project/tickets/JZQ85C-ntb-low-jargon-surfaces/ticket.md
@@ -3,10 +3,10 @@ id: JZQ85C
 slug: ntb-low-jargon-surfaces
 parent: K6CAJN-ntb-experience-epic
 type: task
-phase: intake
-status: backlog
+phase: done
+status: done
 created: 2026-06-24T02:21:00Z
-last_modified: 2026-06-24T02:21:00Z
+last_modified: 2026-06-24T02:46:00Z
 ---
 
 # De-jargon the three LOW NTB surfaces

--- a/.project/tickets/JZQ85C-ntb-low-jargon-surfaces/verify.md
+++ b/.project/tickets/JZQ85C-ntb-low-jargon-surfaces/verify.md
@@ -1,0 +1,48 @@
+# Verify — ntb-low-jargon-surfaces (JZQ85C)
+
+## Verify Checklist
+
+**Test Suite:** ✓ done-gate lane green + 70 targeted tests (hooks integration + config-guard patterns)
+**Gherkin:** ✅ Acceptance lane passes (149 scenarios / 2,492 steps)
+**Build:** ✅ tsup build clean; `tsc --noEmit` clean
+**Lint:** ✅ Clean (prettier --check passes on all six changed files)
+**Scenarios:** ⏭️ Skipped — task, no test-definitions.md
+**Dep Drift:** ✅ Clean — no dependency changes
+**Parent Epic:** K6CAJN
+**Reconcile:** Applied the QQJK5S "gloss at the decision point" contract; no new pattern
+
+## What was verified — and the scope call
+
+Applying the shipped plainness contract (gloss where it's load-bearing in an
+_ask_; leave informational narration a developer skims), the three LOW surfaces
+split into two reworded, one light-touch, one verify-only:
+
+- **`pre-tool-config-guard.ts`** (a permission **ask** → reworded) — was
+  _"{category} change requires approval … Per SAFEWORD policy: Fix code, don't
+  weaken configs."_; now _"The agent wants to change a settings file that
+  controls your safety checks ({category}). Approving this could weaken those
+  checks … the agent should explain why."_ Highest-value: it's a real decision
+  the human is asked to make.
+- **`post-tool-bypass-warn.ts`** (user-visible warning → reworded) — dropped
+  "Bypass pattern detected" / "Per SAFEWORD policy" / "Scope suppressions: line
+  > block > file > project"; now leads plain: _"The agent tried to silence a
+  > safety check instead of fixing the underlying code."_ The exact symbols
+  > (`@ts-ignore`, etc.) are still listed for the developer.
+- **`session-lint-check.ts`** (developer config-health narration → light touch)
+  — replaced the `SAFEWORD Lint Check:` header with a plain lead (_"Heads-up:
+  your code-style tools aren't fully set up, so safeword's automatic checks may
+  not run:"_). The per-tool lines ("ESLint config not found", install commands)
+  stay technical — they name the exact fix a developer needs, and the contract
+  says don't gloss skimmable narration. Tests asserting those lines still pass.
+- **`session-compact-context.ts`** (verify-only, **not changed**) — its
+  `Phase | Gate` labels are injected as **agent context** to re-orient the agent
+  after a compaction, not shown to the human as a primary message. The labels
+  are correct for that audience. Confirmed it stays agent-context; rewording
+  would strip vocabulary the agent uses. Left as-is by design.
+
+Templates synced byte-identical to dogfood copies (all three). No tests asserted
+the reworded strings (config-guard test checks patterns, not the reason text;
+bypass-warn text is untested); the lint-check warning lines the tests _do_ check
+were intentionally preserved.
+
+Ready to mark done.

--- a/.safeword/hooks/post-tool-bypass-warn.ts
+++ b/.safeword/hooks/post-tool-bypass-warn.ts
@@ -89,14 +89,12 @@ for (const { pattern, category, example } of BYPASS_PATTERNS) {
 // If bypass patterns found, output warning
 if (foundPatterns.length > 0) {
   const filePath = input.tool_input?.file_path ?? input.tool_input?.notebook_path ?? 'unknown';
-  console.log(`⚠️ Bypass pattern detected in ${filePath}
+  console.log(`⚠️ The agent tried to silence a safety check instead of fixing the underlying code, in ${filePath}
 
 Found:
 ${foundPatterns.join('\n')}
 
-Per SAFEWORD policy: Fix code, don't weaken enforcement.
-Scope suppressions to the problem: line > block > file > project.
-If this is justified, document the evidence in a comment.`);
+Fix the code rather than turning the check off. If a suppression is genuinely justified, make it as narrow as possible (a single line, not a whole file) and leave a comment explaining why.`);
 }
 
 process.exit(0);

--- a/.safeword/hooks/pre-tool-config-guard.ts
+++ b/.safeword/hooks/pre-tool-config-guard.ts
@@ -76,7 +76,7 @@ for (const { pattern, category } of PROTECTED_PATTERNS) {
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'ask',
-        permissionDecisionReason: `⚠️ ${category} change requires approval.\n\nFile: ${filePath}\n\nPer SAFEWORD policy: Fix code, don't weaken configs.\nIf this is a justified change, explain the evidence.`,
+        permissionDecisionReason: `⚠️ The agent wants to change a settings file that controls your safety checks (${category}). Approving this could weaken those checks.\n\nFile: ${filePath}\n\nPrefer fixing the code over loosening the settings. If this change is genuinely needed, the agent should explain why.`,
       },
     };
     console.log(JSON.stringify(output));

--- a/.safeword/hooks/session-lint-check.ts
+++ b/.safeword/hooks/session-lint-check.ts
@@ -60,7 +60,9 @@ if (await pkgJsonFile.exists()) {
 
 // Output warnings if any
 if (warnings.length > 0) {
-  console.log('SAFEWORD Lint Check:');
+  console.log(
+    "Heads-up: your code-style tools aren't fully set up, so safeword's automatic checks may not run:",
+  );
   for (const warning of warnings) {
     console.log(`  ⚠️  ${warning}`);
   }

--- a/packages/cli/templates/hooks/post-tool-bypass-warn.ts
+++ b/packages/cli/templates/hooks/post-tool-bypass-warn.ts
@@ -89,14 +89,12 @@ for (const { pattern, category, example } of BYPASS_PATTERNS) {
 // If bypass patterns found, output warning
 if (foundPatterns.length > 0) {
   const filePath = input.tool_input?.file_path ?? input.tool_input?.notebook_path ?? 'unknown';
-  console.log(`⚠️ Bypass pattern detected in ${filePath}
+  console.log(`⚠️ The agent tried to silence a safety check instead of fixing the underlying code, in ${filePath}
 
 Found:
 ${foundPatterns.join('\n')}
 
-Per SAFEWORD policy: Fix code, don't weaken enforcement.
-Scope suppressions to the problem: line > block > file > project.
-If this is justified, document the evidence in a comment.`);
+Fix the code rather than turning the check off. If a suppression is genuinely justified, make it as narrow as possible (a single line, not a whole file) and leave a comment explaining why.`);
 }
 
 process.exit(0);

--- a/packages/cli/templates/hooks/pre-tool-config-guard.ts
+++ b/packages/cli/templates/hooks/pre-tool-config-guard.ts
@@ -76,7 +76,7 @@ for (const { pattern, category } of PROTECTED_PATTERNS) {
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'ask',
-        permissionDecisionReason: `⚠️ ${category} change requires approval.\n\nFile: ${filePath}\n\nPer SAFEWORD policy: Fix code, don't weaken configs.\nIf this is a justified change, explain the evidence.`,
+        permissionDecisionReason: `⚠️ The agent wants to change a settings file that controls your safety checks (${category}). Approving this could weaken those checks.\n\nFile: ${filePath}\n\nPrefer fixing the code over loosening the settings. If this change is genuinely needed, the agent should explain why.`,
       },
     };
     console.log(JSON.stringify(output));

--- a/packages/cli/templates/hooks/session-lint-check.ts
+++ b/packages/cli/templates/hooks/session-lint-check.ts
@@ -60,7 +60,9 @@ if (await pkgJsonFile.exists()) {
 
 // Output warnings if any
 if (warnings.length > 0) {
-  console.log('SAFEWORD Lint Check:');
+  console.log(
+    "Heads-up: your code-style tools aren't fully set up, so safeword's automatic checks may not run:",
+  );
   for (const warning of warnings) {
     console.log(`  ⚠️  ${warning}`);
   }


### PR DESCRIPTION
## What & why

Follow-up to the NTB epic (#355): closes the three **LOW**-severity findings from `PRODUCT-AUDIT-ntb.md` — the last low-traffic spots where safeword shows a non-technical user (directs an AI agent, can't read code) raw jargon.

Applies the same governing rule the epic shipped (`SAFEWORD.md` "gloss a term only where it's load-bearing in an *ask*; leave informational narration a developer skims technical"), which is why this is sharper than "reword all four surfaces."

## What changed

- **`pre-tool-config-guard.ts`** (a permission **ask** → reworded) — was _"{category} change requires approval … Per SAFEWORD policy: Fix code, don't weaken configs"_; now _"The agent wants to change a settings file that controls your safety checks ({category}). Approving this could weaken those checks … the agent should explain why."_ The highest-value one: it's a real decision the human is asked to approve.
- **`post-tool-bypass-warn.ts`** (user-visible warning → reworded) — dropped "Bypass pattern detected" / "Per SAFEWORD policy" / "Scope suppressions: line > block > file > project"; leads plain: _"The agent tried to silence a safety check instead of fixing the underlying code."_ The detected symbols (`@ts-ignore`, etc.) are still listed for the developer.
- **`session-lint-check.ts`** (developer config-health narration → light touch) — plain header lead; the per-tool warnings ("ESLint config not found", install commands) stay technical (they name the exact fix a developer needs, and tests rely on them).
- **`session-compact-context.ts`** — **intentionally not changed.** Its `Phase | Gate` labels are injected as *agent context* to re-orient the agent after a long chat is compacted, not shown to the human as a message. Rewording would strip vocabulary the agent uses.

## Verification

`verify.md` in the ticket. Behavior unchanged (string-only — control flow, exit codes, JSON shapes, `permissionDecision` all preserved). `tsc` clean, done-gate lane green, BDD **149 scenarios / 2,492 steps**, prettier clean, templates byte-identical to dogfood copies. Passed an independent fresh-context review (APPROVE, no critical issues).

No application dependencies added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFr41XAU9zAZ6vYM2HZE7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFr41XAU9zAZ6vYM2HZE7A)_