### PR TITLE
feat(JNVP4W): auto-install deps in fresh worktrees at SessionStart

### DIFF
--- a/.project/tickets/JNVP4W-worktree-auto-deps/ticket.md
+++ b/.project/tickets/JNVP4W-worktree-auto-deps/ticket.md
@@ -2,10 +2,10 @@
 id: JNVP4W
 slug: worktree-auto-deps
 type: task
-phase: intake
-status: backlog
+phase: done
+status: done
 created: 2026-06-06T18:13:21.754Z
-last_modified: 2026-06-06T18:13:21.754Z
+last_modified: 2026-06-24T04:25:00.000Z
 ---
 
 # Auto-install deps in fresh worktrees via SessionStart hook
@@ -53,3 +53,4 @@ last_modified: 2026-06-06T18:13:21.754Z
 - 2026-06-06T18:14:00.000Z Drafted: Goal/Why/Scope/Done-when + /figure-it-out decision (SessionStart auto-install, --frozen-lockfile) and rejected alternatives. Sourced from the 0AWSY8 replan session where the block was hit.
 - 2026-06-06T22:55:00.000Z Corrected (quality-review + /figure-it-out): fixed the WorktreeCreate rationale — it DOES fire for isolation:"worktree"; real reasons to reject are VCS-adapter/replaces-git + drops .worktreeinclude (#27744 open). Recorded the blocking-not-async decision (SessionStart blocks init; order early so the chain + first commit see node_modules), degrade-exits-0, and the CLAUDE_PROJECT_DIR gate. Softened "offline" → "offline from a warm cache." Still build-deferred.
 - 2026-06-10T20:18:00.000Z Status → backlog (was in_progress since filing): build stays deferred; in_progress was polluting active-ticket detection for the whole Phase-1 session. Plan is converged — pick up from the figure-it-out decisions above.
+- 2026-06-24T04:25:00.000Z Built (status → done). Chose **B over the plan's A** (`/figure-it-out` 2026-06-24): rather than a new bun-only bash hook, extended the existing `session-dependency-readiness.ts` — already at chain position 1 (right after `session-bun-check.sh`, the slot the plan wanted), already multi-PM via the install plan (#328), already degrade-exit-0 — to bootstrap when `status === 'missing'` (node_modules absent) regardless of `autoInstall`, via a new exported `shouldBootstrapDependencies(status, autoInstall)` in the dep-readiness lib. Kept the plan's still-valid parts: narrow absent-only trigger (not `stale`), degrade-exit-0, pre-commit guard as defense-in-depth. Tests: 3 unit cases for the decision + the session-hook integration test now asserts install-attempt + degrade. Shipped via an isolated worktree (main checkout was on a parallel Codex branch).

--- a/.safeword/hooks/lib/dependency-readiness.ts
+++ b/.safeword/hooks/lib/dependency-readiness.ts
@@ -345,6 +345,24 @@ export function readDependencyBootstrapConfig(projectDirectory: string): Depende
   };
 }
 
+/**
+ * Whether SessionStart should auto-install dependencies for this readiness
+ * status. A `missing` install artifact (no `node_modules` — e.g. a fresh git
+ * worktree) is bootstrapped UNCONDITIONALLY: the worktree is unusable and a
+ * commit would bypass the husky guard chain (lint-staged can't resolve its
+ * tools), so install regardless of the `autoInstall` opt-in. The opt-in still
+ * governs the softer `stale` re-install (deps present but inputs changed).
+ * (JNVP4W)
+ */
+export function shouldBootstrapDependencies(
+  status: DependencyReadinessStatus,
+  autoInstall: boolean,
+): boolean {
+  if (status === 'missing') return true;
+  if (status === 'stale') return autoInstall;
+  return false;
+}
+
 export function isDependencyBackedCommand(command: string): boolean {
   const segments = splitShellSegments(command);
 

--- a/.safeword/hooks/session-dependency-readiness.ts
+++ b/.safeword/hooks/session-dependency-readiness.ts
@@ -9,6 +9,7 @@ import {
   formatDependencyRecovery,
   getDependencyReadiness,
   readDependencyBootstrapConfig,
+  shouldBootstrapDependencies,
   toDependencyReadinessState,
   writeDependencyReadinessState,
   writeInstallMarker,
@@ -41,7 +42,10 @@ if (readiness.status === 'ready') {
 
 const config = readDependencyBootstrapConfig(projectDirectory);
 
-if (config.autoInstall && readiness.plan !== undefined) {
+if (
+  shouldBootstrapDependencies(readiness.status, config.autoInstall) &&
+  readiness.plan !== undefined
+) {
   const { binary, args, display } = readiness.plan.installCommand;
   const result = spawnSync(binary, args, {
     cwd: projectDirectory,

--- a/packages/cli/templates/hooks/lib/dependency-readiness.ts
+++ b/packages/cli/templates/hooks/lib/dependency-readiness.ts
@@ -345,6 +345,24 @@ export function readDependencyBootstrapConfig(projectDirectory: string): Depende
   };
 }
 
+/**
+ * Whether SessionStart should auto-install dependencies for this readiness
+ * status. A `missing` install artifact (no `node_modules` — e.g. a fresh git
+ * worktree) is bootstrapped UNCONDITIONALLY: the worktree is unusable and a
+ * commit would bypass the husky guard chain (lint-staged can't resolve its
+ * tools), so install regardless of the `autoInstall` opt-in. The opt-in still
+ * governs the softer `stale` re-install (deps present but inputs changed).
+ * (JNVP4W)
+ */
+export function shouldBootstrapDependencies(
+  status: DependencyReadinessStatus,
+  autoInstall: boolean,
+): boolean {
+  if (status === 'missing') return true;
+  if (status === 'stale') return autoInstall;
+  return false;
+}
+
 export function isDependencyBackedCommand(command: string): boolean {
   const segments = splitShellSegments(command);
 

--- a/packages/cli/templates/hooks/session-dependency-readiness.ts
+++ b/packages/cli/templates/hooks/session-dependency-readiness.ts
@@ -9,6 +9,7 @@ import {
   formatDependencyRecovery,
   getDependencyReadiness,
   readDependencyBootstrapConfig,
+  shouldBootstrapDependencies,
   toDependencyReadinessState,
   writeDependencyReadinessState,
   writeInstallMarker,
@@ -41,7 +42,10 @@ if (readiness.status === 'ready') {
 
 const config = readDependencyBootstrapConfig(projectDirectory);
 
-if (config.autoInstall && readiness.plan !== undefined) {
+if (
+  shouldBootstrapDependencies(readiness.status, config.autoInstall) &&
+  readiness.plan !== undefined
+) {
   const { binary, args, display } = readiness.plan.installCommand;
   const result = spawnSync(binary, args, {
     cwd: projectDirectory,

--- a/packages/cli/tests/hooks/dependency-readiness.test.ts
+++ b/packages/cli/tests/hooks/dependency-readiness.test.ts
@@ -11,6 +11,7 @@ import {
   getDependencyReadiness,
   isDependencyBackedCommand,
   readDependencyBootstrapConfig,
+  shouldBootstrapDependencies,
   writeInstallMarker,
 } from '../../templates/hooks/lib/dependency-readiness.js';
 import {
@@ -487,6 +488,23 @@ describe('dependency readiness hook support', () => {
     expect(recovery).not.toContain('touch node_modules');
   });
 
+  it('bootstraps a missing install artifact even when auto-install is off (JNVP4W)', () => {
+    // The fix: a fresh worktree (no node_modules) installs unconditionally, so a
+    // commit never bypasses the husky guard chain — even with autoInstall off.
+    expect(shouldBootstrapDependencies('missing', false)).toBe(true);
+    expect(shouldBootstrapDependencies('missing', true)).toBe(true);
+  });
+
+  it('leaves the stale re-install behind the auto-install opt-in', () => {
+    expect(shouldBootstrapDependencies('stale', false)).toBe(false);
+    expect(shouldBootstrapDependencies('stale', true)).toBe(true);
+  });
+
+  it('never bootstraps a ready or unsupported worktree', () => {
+    expect(shouldBootstrapDependencies('ready', true)).toBe(false);
+    expect(shouldBootstrapDependencies('unsupported', true)).toBe(false);
+  });
+
   it('reads explicit auto-install opt-in from safeword config', () => {
     writeBunProject();
 
@@ -560,24 +578,23 @@ describe('dependency readiness hook support', () => {
     });
   });
 
-  it('session hook reports missing dependencies and writes readiness state', () => {
+  it('session hook auto-installs a missing worktree (JNVP4W), degrading if the install fails', () => {
     writeBunProject();
     markSafewordProject();
 
+    // node_modules absent → the hook bootstraps (`bun ci`) regardless of the
+    // autoInstall opt-in. The fixture's lockfile is a stub, so the install
+    // fails — exercising the degrade: exit 0, a 'failed' state, never a wedge.
     const result = runHook(SESSION_HOOK);
 
     expect(result.status).toBe(0);
     const output = JSON.parse(result.stdout);
-    expect(output.hookSpecificOutput).toMatchObject({
-      hookEventName: 'SessionStart',
-    });
+    expect(output.hookSpecificOutput.hookEventName).toBe('SessionStart');
     expect(output.hookSpecificOutput.additionalContext).toContain('bun ci');
 
     const state = JSON.parse(readTestFile(projectDirectory, '.project/dependency-readiness.json'));
-    expect(state).toMatchObject({
-      status: 'missing',
-      installCommand: 'bun ci',
-    });
+    expect(state.status).toBe('failed');
+    expect(state.installCommand).toBe('bun ci');
   });
 
   it('session hook bootstraps dependencies when auto-install is explicitly enabled', () => {


### PR DESCRIPTION
## Problem (the bug #368 flagged, which broke CI on #351)

A fresh `git worktree` has no `node_modules`. `git commit` is **not** a dependency-backed command, so the PreToolUse readiness gate never blocks it — and with `node_modules` absent, husky's lint-staged **silently no-ops** (can't resolve prettier/eslint). The *entire* deps-dependent pre-commit guard chain is bypassed in that window: on #351 an unformatted file landed and CI `format:check` failed.

## Fix (Option B — `/figure-it-out` 2026-06-24)

The existing SessionStart hook `session-dependency-readiness.ts` is already at **chain position 1** (right after `session-bun-check.sh` — exactly where JNVP4W's plan wanted to add a hook), already **multi-PM** (installs via `readiness.plan.installCommand` → bun/pnpm/npm/yarn, #328), and already **degrades exit-0**. So the fix is a narrow gate change: bootstrap when `status === 'missing'` (node_modules absent) **regardless of `autoInstall`**. The opt-in still governs the softer `'stale'` re-install.

Decision logic is extracted to an exported, unit-tested `shouldBootstrapDependencies(status, autoInstall)`.

**Chosen over JNVP4W's converged-but-stale plan** (a new bun-only bash hook): that plan predates multi-PM support and the existing hook — its "order early" rationale is moot (the existing hook is already position 1), and a bun-only hook wouldn't bootstrap pnpm/npm/yarn worktrees. Kept the plan's still-valid parts: narrow absent-only trigger (not `'stale'`), degrade-exit-0, and the pre-commit guard as defense-in-depth.

## Verification

- Byte-parity holds on both hook + lib copies; `parity-check --mode=contracts-only` green; `tsc --noEmit` clean.
- `dependency-readiness.test.ts`: **72 pass**, incl. 3 new decision unit-tests (`missing`→install even with autoInstall off; `stale` stays opt-in; `ready`/`unsupported` never) and the session-hook integration test updated to assert the **install-attempt + degrade-exit-0**.
- Built + committed via an isolated worktree (the main checkout was on a parallel Codex branch) — the pre-commit guard ran with deps present, i.e. the fix working on itself.

Closes JNVP4W. (The #368 bookkeeping PR that bumped JNVP4W's priority is now superseded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)