### PR TITLE
Refactor Codex hook adapters and fix quality gates

### DIFF
--- a/.project/tickets/W0E292-codex-hook-adapter-helpers/ticket.md
+++ b/.project/tickets/W0E292-codex-hook-adapter-helpers/ticket.md
@@ -2,8 +2,8 @@
 id: W0E292
 slug: codex-hook-adapter-helpers
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 parent: S3T6JA
 epic: agent-surface-refactor
 scope:
@@ -18,7 +18,7 @@ done_when:
   - Pure tests cover apply_patch target extraction, direct-tool forwarding, and denial reason parsing.
   - Schema registration covers any new deployed helper file.
 created: 2026-06-14T01:39:34.081Z
-last_modified: 2026-06-24T02:14:08Z
+last_modified: 2026-06-24T04:38:32Z
 ---
 
 # Make Codex hook adapter behavior easier to test
@@ -47,6 +47,7 @@ last_modified: 2026-06-24T02:14:08Z
 
 ## Work Log
 
+- 2026-06-24T04:38:32Z Verified and closed: Ran clean-worktree generated verify plan (3382 tests passed, 3 skipped), `bun run lint`, `bun run test:bdd` (149 scenarios passed), focused Codex adapter tests (53 passed), and `git diff --check`. Build plan was empty. Recorded verification in `verify.md` and marked the task done.
 - 2026-06-24T02:14:08Z Implemented: Extracted Codex adapter translation and denial parsing into `hooks/codex/pre-tool-quality-helpers.ts`, registered the helper in schema, and dogfooded the installed `.safeword/hooks/codex/` copy. Added unit tests for apply_patch translation, direct-tool forwarding, unsupported-tool ignoring, and denial reason parsing. Added setup coverage that the helper is installed with Codex project assets. Verified `bun run --cwd packages/cli test tests/hooks/codex-pre-tool-quality-helpers.test.ts tests/integration/codex-pretooluse-spike.test.ts tests/schema.test.ts tests/commands/setup-reconcile.test.ts`, `bun run --cwd packages/cli typecheck`, targeted ESLint, and `git diff --check`.
 - 2026-06-14T02:05:00Z Reviewed: Added schema-registration and installed-template execution guardrails.
 - 2026-06-14T01:46:00Z Scoped: Figure-it-out selected pure helper extraction, not a generic adapter framework.

--- a/.project/tickets/W0E292-codex-hook-adapter-helpers/ticket.md
+++ b/.project/tickets/W0E292-codex-hook-adapter-helpers/ticket.md
@@ -2,7 +2,7 @@
 id: W0E292
 slug: codex-hook-adapter-helpers
 type: task
-phase: intake
+phase: implement
 status: in_progress
 parent: S3T6JA
 epic: agent-surface-refactor
@@ -18,7 +18,7 @@ done_when:
   - Pure tests cover apply_patch target extraction, direct-tool forwarding, and denial reason parsing.
   - Schema registration covers any new deployed helper file.
 created: 2026-06-14T01:39:34.081Z
-last_modified: 2026-06-14T02:05:00Z
+last_modified: 2026-06-24T02:14:08Z
 ---
 
 # Make Codex hook adapter behavior easier to test
@@ -47,6 +47,7 @@ last_modified: 2026-06-14T02:05:00Z
 
 ## Work Log
 
+- 2026-06-24T02:14:08Z Implemented: Extracted Codex adapter translation and denial parsing into `hooks/codex/pre-tool-quality-helpers.ts`, registered the helper in schema, and dogfooded the installed `.safeword/hooks/codex/` copy. Added unit tests for apply_patch translation, direct-tool forwarding, unsupported-tool ignoring, and denial reason parsing. Added setup coverage that the helper is installed with Codex project assets. Verified `bun run --cwd packages/cli test tests/hooks/codex-pre-tool-quality-helpers.test.ts tests/integration/codex-pretooluse-spike.test.ts tests/schema.test.ts tests/commands/setup-reconcile.test.ts`, `bun run --cwd packages/cli typecheck`, targeted ESLint, and `git diff --check`.
 - 2026-06-14T02:05:00Z Reviewed: Added schema-registration and installed-template execution guardrails.
 - 2026-06-14T01:46:00Z Scoped: Figure-it-out selected pure helper extraction, not a generic adapter framework.
 - 2026-06-14T01:39:34.081Z Started: Created ticket W0E292.

--- a/.project/tickets/W0E292-codex-hook-adapter-helpers/verify.md
+++ b/.project/tickets/W0E292-codex-hook-adapter-helpers/verify.md
@@ -1,0 +1,23 @@
+# Verify: W0E292 codex-hook-adapter-helpers
+
+## Verify Checklist
+
+**Test Suite:** ✓ 3382/3382 tests pass (clean worktree; 3 skipped)
+**Gherkin:** ✅ Acceptance lane passes (149 scenarios, 2492 steps)
+**Build:** ⏭️ Skipped — no build step
+**Lint:** ✅ Clean
+**Scenarios:** All 0 scenarios marked complete (task has no test-definitions.md)
+**Dep Drift:** ✅ Clean
+**Parent Epic:** S3T6JA (siblings: 1/7 done)
+**Reconcile:** ✅ No pattern deviation
+
+## Evidence
+
+- Verify invocation proof: unavailable in this Codex runtime because no Claude session id was present; allowed for this task ticket.
+- Clean worktree generated verify plan: `bash -c "$(bun packages/cli/src/cli.ts test-plan --kind verify --format sh)"` passed with 226/226 test files, 3382 tests passed, 3 skipped.
+- Clean worktree lint: `bun run lint` passed.
+- Clean worktree Gherkin lane: `bun run test:bdd` passed with 149 scenarios and 2492 steps.
+- Clean worktree build plan: `bun packages/cli/src/cli.ts test-plan --kind build --format sh` returned no build step.
+- Focused ticket suite: `bun run --cwd packages/cli test tests/hooks/codex-pre-tool-quality-helpers.test.ts tests/integration/codex-pretooluse-spike.test.ts tests/schema.test.ts tests/commands/setup-reconcile.test.ts` passed 53/53.
+- `git diff --check` passed.
+- A shared-worktree full-suite run first failed one suite because `packages/cli/dist/cli.js` was missing during fixture setup; rerunning that suite in isolation passed 6/6, and the clean-worktree full verify plan passed afterward.

--- a/.safeword/hooks/codex/pre-tool-quality-helpers.ts
+++ b/.safeword/hooks/codex/pre-tool-quality-helpers.ts
@@ -1,0 +1,112 @@
+export interface CodexHookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: {
+    command?: string;
+    file_path?: string;
+    notebook_path?: string;
+    old_string?: string;
+    new_string?: string;
+    content?: string;
+    edits?: Array<{ old_string?: string; new_string?: string }>;
+  };
+}
+
+export interface ClaudeHookInput {
+  session_id?: string;
+  hook_event_name: 'PreToolUse';
+  tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
+  tool_input: NonNullable<CodexHookInput['tool_input']>;
+}
+
+interface PatchTarget {
+  filePath: string;
+  toolName: 'Edit' | 'Write';
+  content?: string;
+}
+
+const DIRECT_TOOLS = new Set(['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+export function translateCodexInputToClaudeInputs(input: CodexHookInput): ClaudeHookInput[] {
+  const toolName = input.tool_name ?? '';
+
+  if (DIRECT_TOOLS.has(toolName)) {
+    return [
+      {
+        session_id: input.session_id,
+        hook_event_name: 'PreToolUse',
+        tool_name: toolName as ClaudeHookInput['tool_name'],
+        tool_input: input.tool_input ?? {},
+      },
+    ];
+  }
+
+  if (toolName !== 'apply_patch') return [];
+
+  return extractPatchTargets(input.tool_input?.command ?? '').map(patchTarget => ({
+    session_id: input.session_id,
+    hook_event_name: 'PreToolUse',
+    tool_name: patchTarget.toolName,
+    tool_input: {
+      file_path: patchTarget.filePath,
+      ...(patchTarget.content === undefined ? {} : { content: patchTarget.content }),
+    },
+  }));
+}
+
+export function denialReasonFromHookOutput(stdout: string): string | undefined {
+  if (stdout.trim() === '') return undefined;
+
+  try {
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: {
+        permissionDecision?: unknown;
+        permissionDecisionReason?: unknown;
+      };
+    };
+    if (parsed.hookSpecificOutput?.permissionDecision !== 'deny') return undefined;
+
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    return typeof reason === 'string' ? reason : 'Safeword denied this action.';
+  } catch {
+    return undefined;
+  }
+}
+
+function extractPatchTargets(command: string): PatchTarget[] {
+  const lines = command.split(/\r?\n/);
+  const targets: PatchTarget[] = [];
+
+  for (const [index, line] of lines.entries()) {
+    const match = /^\*\*\* (Add|Update|Delete) File: (.+)$/.exec(line.trim());
+    if (!match) continue;
+
+    const operation = match[1];
+    const filePath = match[2]?.trim();
+    if (!filePath) continue;
+
+    if (operation === 'Add') {
+      targets.push({
+        filePath,
+        toolName: 'Write',
+        content: extractAddedFileContent(lines.slice(index + 1)),
+      });
+      continue;
+    }
+
+    targets.push({ filePath, toolName: 'Edit' });
+  }
+
+  return targets;
+}
+
+function extractAddedFileContent(linesAfterHeader: string[]): string {
+  const contentLines: string[] = [];
+  for (const line of linesAfterHeader) {
+    if (line.startsWith('*** ')) break;
+    if (line.startsWith('+')) {
+      contentLines.push(line.slice(1));
+    }
+  }
+  return contentLines.join('\n');
+}

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -9,123 +9,18 @@ import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-interface CodexHookInput {
-  session_id?: string;
-  tool_name?: string;
-  tool_input?: {
-    command?: string;
-    file_path?: string;
-    notebook_path?: string;
-    old_string?: string;
-    new_string?: string;
-    content?: string;
-    edits?: Array<{ old_string?: string; new_string?: string }>;
-  };
-}
+import {
+  type ClaudeHookInput,
+  type CodexHookInput,
+  denialReasonFromHookOutput,
+  translateCodexInputToClaudeInputs,
+} from './pre-tool-quality-helpers.ts';
 
-interface ClaudeHookInput {
-  session_id?: string;
-  hook_event_name: 'PreToolUse';
-  tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
-  tool_input: NonNullable<CodexHookInput['tool_input']>;
-}
-
-interface PatchTarget {
-  filePath: string;
-  toolName: 'Edit' | 'Write';
-  content?: string;
-}
-
-const DIRECT_TOOLS = new Set(['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 const EXIT_CODE_DENY_MODE = 'exit-code';
 
 async function readInput(): Promise<CodexHookInput | undefined> {
   try {
     return JSON.parse(await Bun.stdin.text()) as CodexHookInput;
-  } catch {
-    return undefined;
-  }
-}
-
-function extractPatchTargets(command: string): PatchTarget[] {
-  const lines = command.split(/\r?\n/);
-  const targets: PatchTarget[] = [];
-
-  for (const [index, line] of lines.entries()) {
-    const match = /^\*\*\* (Add|Update|Delete) File: (.+)$/.exec(line.trim());
-    if (!match) continue;
-
-    const operation = match[1];
-    const filePath = match[2]?.trim();
-    if (!filePath) continue;
-
-    if (operation === 'Add') {
-      targets.push({
-        filePath,
-        toolName: 'Write',
-        content: extractAddedFileContent(lines.slice(index + 1)),
-      });
-      continue;
-    }
-
-    targets.push({ filePath, toolName: 'Edit' });
-  }
-
-  return targets;
-}
-
-function extractAddedFileContent(linesAfterHeader: string[]): string {
-  const contentLines: string[] = [];
-  for (const line of linesAfterHeader) {
-    if (line.startsWith('*** ')) break;
-    if (line.startsWith('+')) {
-      contentLines.push(line.slice(1));
-    }
-  }
-  return contentLines.join('\n');
-}
-
-function translateInput(input: CodexHookInput): ClaudeHookInput[] {
-  const toolName = input.tool_name ?? '';
-
-  if (DIRECT_TOOLS.has(toolName)) {
-    return [
-      {
-        session_id: input.session_id,
-        hook_event_name: 'PreToolUse',
-        tool_name: toolName as ClaudeHookInput['tool_name'],
-        tool_input: input.tool_input ?? {},
-      },
-    ];
-  }
-
-  if (toolName !== 'apply_patch') return [];
-
-  return extractPatchTargets(input.tool_input?.command ?? '').map(patchTarget => ({
-    session_id: input.session_id,
-    hook_event_name: 'PreToolUse',
-    tool_name: patchTarget.toolName,
-    tool_input: {
-      file_path: patchTarget.filePath,
-      ...(patchTarget.content === undefined ? {} : { content: patchTarget.content }),
-    },
-  }));
-}
-
-function denialReasonFrom(stdout: string): string | undefined {
-  if (stdout.trim() === '') return undefined;
-
-  try {
-    const parsed = JSON.parse(stdout) as {
-      hookSpecificOutput?: {
-        permissionDecision?: unknown;
-        permissionDecisionReason?: unknown;
-      };
-    };
-    if (parsed.hookSpecificOutput?.permissionDecision !== 'deny') return undefined;
-
-    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
-    return typeof reason === 'string' ? reason : 'Safeword denied this action.';
   } catch {
     return undefined;
   }
@@ -152,7 +47,7 @@ function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
 const input = await readInput();
 if (!input) process.exit(0);
 
-const translatedInputs = translateInput(input);
+const translatedInputs = translateCodexInputToClaudeInputs(input);
 if (translatedInputs.length === 0) process.exit(0);
 
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
@@ -161,7 +56,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath, translated));
 
 for (const result of results) {
-  const reason = denialReasonFrom(result.stdout ?? '');
+  const reason = denialReasonFromHookOutput(result.stdout ?? '');
   if (reason === undefined) continue;
 
   if (process.env.SAFEWORD_CODEX_DENY_MODE === EXIT_CODE_DENY_MODE) {

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -125,6 +125,9 @@ state.locSinceCommit = countLoc();
 // LOC gate (only hard gate remaining — blast radius control). Stands down while
 // a git merge/rebase/cherry-pick/revert is in progress: those incoming lines are
 // not agent edits and must not block conflict resolution (ticket MT27QG).
+if (state.gate === 'loc' && state.locSinceCommit < LOC_THRESHOLD) {
+  state.gate = null;
+}
 if (state.locSinceCommit >= LOC_THRESHOLD && !isGitOperationInProgress(projectDirectory)) {
   state.gate = 'loc';
 }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -551,7 +551,11 @@ if (!state.gate) {
 
 // LOC gate stands down during a git merge/rebase/cherry-pick/revert so it can't
 // block the edits that resolve the operation (ticket MT27QG).
-if (state.gate === 'loc' && !isGitOperationInProgress(projectDirectory)) {
+if (
+  state.gate === 'loc' &&
+  state.locSinceCommit >= LOC_THRESHOLD &&
+  !isGitOperationInProgress(projectDirectory)
+) {
   recordFailure(projectDirectory, input.session_id, 'loc-exceeded');
   deny(`${state.locSinceCommit} LOC since last commit (threshold: ${LOC_THRESHOLD}).
 

--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -8,8 +8,14 @@ import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
-// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
-const ENV_SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
+// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote
+// container sessions (web, GitHub Actions). Codex exposes CODEX_THREAD_ID
+// instead; the done gate treats session ids as opaque tokens, so the thread id
+// is a compatible proof binding.
+const ENV_SESSION_ID =
+  process.env.CLAUDE_SESSION_ID ||
+  process.env.CLAUDE_CODE_SESSION_ID ||
+  process.env.CODEX_THREAD_ID;
 
 export function recordSkillInvocation(
   projectDirectory: string,
@@ -20,7 +26,7 @@ export function recordSkillInvocation(
     throw new Error(`Invalid skill name "${skillName}"`);
   }
   if (sessionId === undefined || sessionId.trim().length === 0) {
-    // Non-Claude runtimes (Codex, etc.) don't expose a session id — skip silently.
+    // Runtimes without a compatible session id skip silently.
     return;
   }
 

--- a/.safeword/logs/explore-codex-open-tickets.md
+++ b/.safeword/logs/explore-codex-open-tickets.md
@@ -1,0 +1,7 @@
+# Work Log: explore Codex open tickets
+
+## 2026-06-24
+
+- 2026-06-24T02:00:24Z Started: User asked to catch up to main, inspect open Codex-related tickets, and tackle Codex bugs where practical.
+- 2026-06-24T02:00:24Z Found: Worktree is clean on `main`; `git pull --ff-only origin main` reported already up to date.
+- 2026-06-24T02:03:24Z Selected: `W0E292` as the actionable open Codex task. Created branch `codex/w0e292-hook-adapter-helpers`. Stale-index findings: `HMZSCD`, `K2ZP40`, and `Y5GS4X` are marked done in their ticket files despite appearing in the index as in progress.

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -621,6 +621,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/codex/pre-tool-quality.ts': {
       template: 'hooks/codex/pre-tool-quality.ts',
     },
+    '.safeword/hooks/codex/pre-tool-quality-helpers.ts': {
+      template: 'hooks/codex/pre-tool-quality-helpers.ts',
+    },
     '.safeword/hooks/write-review-stamp.ts': {
       template: 'hooks/write-review-stamp.ts',
     },

--- a/packages/cli/templates/hooks/codex/pre-tool-quality-helpers.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality-helpers.ts
@@ -1,0 +1,112 @@
+export interface CodexHookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: {
+    command?: string;
+    file_path?: string;
+    notebook_path?: string;
+    old_string?: string;
+    new_string?: string;
+    content?: string;
+    edits?: Array<{ old_string?: string; new_string?: string }>;
+  };
+}
+
+export interface ClaudeHookInput {
+  session_id?: string;
+  hook_event_name: 'PreToolUse';
+  tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
+  tool_input: NonNullable<CodexHookInput['tool_input']>;
+}
+
+interface PatchTarget {
+  filePath: string;
+  toolName: 'Edit' | 'Write';
+  content?: string;
+}
+
+const DIRECT_TOOLS = new Set(['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+export function translateCodexInputToClaudeInputs(input: CodexHookInput): ClaudeHookInput[] {
+  const toolName = input.tool_name ?? '';
+
+  if (DIRECT_TOOLS.has(toolName)) {
+    return [
+      {
+        session_id: input.session_id,
+        hook_event_name: 'PreToolUse',
+        tool_name: toolName as ClaudeHookInput['tool_name'],
+        tool_input: input.tool_input ?? {},
+      },
+    ];
+  }
+
+  if (toolName !== 'apply_patch') return [];
+
+  return extractPatchTargets(input.tool_input?.command ?? '').map(patchTarget => ({
+    session_id: input.session_id,
+    hook_event_name: 'PreToolUse',
+    tool_name: patchTarget.toolName,
+    tool_input: {
+      file_path: patchTarget.filePath,
+      ...(patchTarget.content === undefined ? {} : { content: patchTarget.content }),
+    },
+  }));
+}
+
+export function denialReasonFromHookOutput(stdout: string): string | undefined {
+  if (stdout.trim() === '') return undefined;
+
+  try {
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: {
+        permissionDecision?: unknown;
+        permissionDecisionReason?: unknown;
+      };
+    };
+    if (parsed.hookSpecificOutput?.permissionDecision !== 'deny') return undefined;
+
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    return typeof reason === 'string' ? reason : 'Safeword denied this action.';
+  } catch {
+    return undefined;
+  }
+}
+
+function extractPatchTargets(command: string): PatchTarget[] {
+  const lines = command.split(/\r?\n/);
+  const targets: PatchTarget[] = [];
+
+  for (const [index, line] of lines.entries()) {
+    const match = /^\*\*\* (Add|Update|Delete) File: (.+)$/.exec(line.trim());
+    if (!match) continue;
+
+    const operation = match[1];
+    const filePath = match[2]?.trim();
+    if (!filePath) continue;
+
+    if (operation === 'Add') {
+      targets.push({
+        filePath,
+        toolName: 'Write',
+        content: extractAddedFileContent(lines.slice(index + 1)),
+      });
+      continue;
+    }
+
+    targets.push({ filePath, toolName: 'Edit' });
+  }
+
+  return targets;
+}
+
+function extractAddedFileContent(linesAfterHeader: string[]): string {
+  const contentLines: string[] = [];
+  for (const line of linesAfterHeader) {
+    if (line.startsWith('*** ')) break;
+    if (line.startsWith('+')) {
+      contentLines.push(line.slice(1));
+    }
+  }
+  return contentLines.join('\n');
+}

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -9,123 +9,18 @@ import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-interface CodexHookInput {
-  session_id?: string;
-  tool_name?: string;
-  tool_input?: {
-    command?: string;
-    file_path?: string;
-    notebook_path?: string;
-    old_string?: string;
-    new_string?: string;
-    content?: string;
-    edits?: Array<{ old_string?: string; new_string?: string }>;
-  };
-}
+import {
+  type ClaudeHookInput,
+  type CodexHookInput,
+  denialReasonFromHookOutput,
+  translateCodexInputToClaudeInputs,
+} from './pre-tool-quality-helpers.ts';
 
-interface ClaudeHookInput {
-  session_id?: string;
-  hook_event_name: 'PreToolUse';
-  tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
-  tool_input: NonNullable<CodexHookInput['tool_input']>;
-}
-
-interface PatchTarget {
-  filePath: string;
-  toolName: 'Edit' | 'Write';
-  content?: string;
-}
-
-const DIRECT_TOOLS = new Set(['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 const EXIT_CODE_DENY_MODE = 'exit-code';
 
 async function readInput(): Promise<CodexHookInput | undefined> {
   try {
     return JSON.parse(await Bun.stdin.text()) as CodexHookInput;
-  } catch {
-    return undefined;
-  }
-}
-
-function extractPatchTargets(command: string): PatchTarget[] {
-  const lines = command.split(/\r?\n/);
-  const targets: PatchTarget[] = [];
-
-  for (const [index, line] of lines.entries()) {
-    const match = /^\*\*\* (Add|Update|Delete) File: (.+)$/.exec(line.trim());
-    if (!match) continue;
-
-    const operation = match[1];
-    const filePath = match[2]?.trim();
-    if (!filePath) continue;
-
-    if (operation === 'Add') {
-      targets.push({
-        filePath,
-        toolName: 'Write',
-        content: extractAddedFileContent(lines.slice(index + 1)),
-      });
-      continue;
-    }
-
-    targets.push({ filePath, toolName: 'Edit' });
-  }
-
-  return targets;
-}
-
-function extractAddedFileContent(linesAfterHeader: string[]): string {
-  const contentLines: string[] = [];
-  for (const line of linesAfterHeader) {
-    if (line.startsWith('*** ')) break;
-    if (line.startsWith('+')) {
-      contentLines.push(line.slice(1));
-    }
-  }
-  return contentLines.join('\n');
-}
-
-function translateInput(input: CodexHookInput): ClaudeHookInput[] {
-  const toolName = input.tool_name ?? '';
-
-  if (DIRECT_TOOLS.has(toolName)) {
-    return [
-      {
-        session_id: input.session_id,
-        hook_event_name: 'PreToolUse',
-        tool_name: toolName as ClaudeHookInput['tool_name'],
-        tool_input: input.tool_input ?? {},
-      },
-    ];
-  }
-
-  if (toolName !== 'apply_patch') return [];
-
-  return extractPatchTargets(input.tool_input?.command ?? '').map(patchTarget => ({
-    session_id: input.session_id,
-    hook_event_name: 'PreToolUse',
-    tool_name: patchTarget.toolName,
-    tool_input: {
-      file_path: patchTarget.filePath,
-      ...(patchTarget.content === undefined ? {} : { content: patchTarget.content }),
-    },
-  }));
-}
-
-function denialReasonFrom(stdout: string): string | undefined {
-  if (stdout.trim() === '') return undefined;
-
-  try {
-    const parsed = JSON.parse(stdout) as {
-      hookSpecificOutput?: {
-        permissionDecision?: unknown;
-        permissionDecisionReason?: unknown;
-      };
-    };
-    if (parsed.hookSpecificOutput?.permissionDecision !== 'deny') return undefined;
-
-    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
-    return typeof reason === 'string' ? reason : 'Safeword denied this action.';
   } catch {
     return undefined;
   }
@@ -152,7 +47,7 @@ function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
 const input = await readInput();
 if (!input) process.exit(0);
 
-const translatedInputs = translateInput(input);
+const translatedInputs = translateCodexInputToClaudeInputs(input);
 if (translatedInputs.length === 0) process.exit(0);
 
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
@@ -161,7 +56,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath, translated));
 
 for (const result of results) {
-  const reason = denialReasonFrom(result.stdout ?? '');
+  const reason = denialReasonFromHookOutput(result.stdout ?? '');
   if (reason === undefined) continue;
 
   if (process.env.SAFEWORD_CODEX_DENY_MODE === EXIT_CODE_DENY_MODE) {

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -125,6 +125,9 @@ state.locSinceCommit = countLoc();
 // LOC gate (only hard gate remaining — blast radius control). Stands down while
 // a git merge/rebase/cherry-pick/revert is in progress: those incoming lines are
 // not agent edits and must not block conflict resolution (ticket MT27QG).
+if (state.gate === 'loc' && state.locSinceCommit < LOC_THRESHOLD) {
+  state.gate = null;
+}
 if (state.locSinceCommit >= LOC_THRESHOLD && !isGitOperationInProgress(projectDirectory)) {
   state.gate = 'loc';
 }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -551,7 +551,11 @@ if (!state.gate) {
 
 // LOC gate stands down during a git merge/rebase/cherry-pick/revert so it can't
 // block the edits that resolve the operation (ticket MT27QG).
-if (state.gate === 'loc' && !isGitOperationInProgress(projectDirectory)) {
+if (
+  state.gate === 'loc' &&
+  state.locSinceCommit >= LOC_THRESHOLD &&
+  !isGitOperationInProgress(projectDirectory)
+) {
   recordFailure(projectDirectory, input.session_id, 'loc-exceeded');
   deny(`${state.locSinceCommit} LOC since last commit (threshold: ${LOC_THRESHOLD}).
 

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -8,8 +8,14 @@ import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
-// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote container sessions (web, GitHub Actions).
-const ENV_SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID;
+// CLAUDE_CODE_SESSION_ID is set (and CLAUDE_SESSION_ID is empty) in remote
+// container sessions (web, GitHub Actions). Codex exposes CODEX_THREAD_ID
+// instead; the done gate treats session ids as opaque tokens, so the thread id
+// is a compatible proof binding.
+const ENV_SESSION_ID =
+  process.env.CLAUDE_SESSION_ID ||
+  process.env.CLAUDE_CODE_SESSION_ID ||
+  process.env.CODEX_THREAD_ID;
 
 export function recordSkillInvocation(
   projectDirectory: string,
@@ -20,7 +26,7 @@ export function recordSkillInvocation(
     throw new Error(`Invalid skill name "${skillName}"`);
   }
   if (sessionId === undefined || sessionId.trim().length === 0) {
-    // Non-Claude runtimes (Codex, etc.) don't expose a session id — skip silently.
+    // Runtimes without a compatible session id skip silently.
     return;
   }
 

--- a/packages/cli/tests/commands/setup-reconcile.test.ts
+++ b/packages/cli/tests/commands/setup-reconcile.test.ts
@@ -205,6 +205,11 @@ describe('Setup Command - Reconcile Integration', () => {
       expect(
         existsSync(nodePath.join(temporaryDirectory, '.safeword/hooks/codex/pre-tool-quality.ts')),
       ).toBe(true);
+      expect(
+        existsSync(
+          nodePath.join(temporaryDirectory, '.safeword/hooks/codex/pre-tool-quality-helpers.ts'),
+        ),
+      ).toBe(true);
     });
 
     it('should wire Codex prompt timestamp and PreToolUse config to safeword hooks', async () => {

--- a/packages/cli/tests/hooks/codex-pre-tool-quality-helpers.test.ts
+++ b/packages/cli/tests/hooks/codex-pre-tool-quality-helpers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  denialReasonFromHookOutput,
+  translateCodexInputToClaudeInputs,
+} from '../../templates/hooks/codex/pre-tool-quality-helpers.js';
+
+describe('Codex pre-tool quality helpers (W0E292)', () => {
+  it('translates apply_patch targets into Claude-shaped edit inputs', () => {
+    const translated = translateCodexInputToClaudeInputs({
+      session_id: 'session-123',
+      tool_name: 'apply_patch',
+      tool_input: {
+        command: [
+          '*** Begin Patch',
+          '*** Add File: notes.md',
+          '+# Notes',
+          '+Body',
+          '*** Update File: existing.md',
+          '@@',
+          '-old',
+          '+new',
+          '*** End Patch',
+        ].join('\n'),
+      },
+    });
+
+    expect(translated).toEqual([
+      {
+        session_id: 'session-123',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: 'notes.md',
+          content: '# Notes\nBody',
+        },
+      },
+      {
+        session_id: 'session-123',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Edit',
+        tool_input: {
+          file_path: 'existing.md',
+        },
+      },
+    ]);
+  });
+
+  it('forwards direct Codex tools without changing the tool input', () => {
+    const translated = translateCodexInputToClaudeInputs({
+      session_id: 'session-abc',
+      tool_name: 'MultiEdit',
+      tool_input: {
+        file_path: 'src/example.ts',
+        edits: [{ old_string: 'old', new_string: 'new' }],
+      },
+    });
+
+    expect(translated).toEqual([
+      {
+        session_id: 'session-abc',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: 'src/example.ts',
+          edits: [{ old_string: 'old', new_string: 'new' }],
+        },
+      },
+    ]);
+  });
+
+  it('ignores unsupported Codex tool inputs', () => {
+    expect(
+      translateCodexInputToClaudeInputs({
+        tool_name: 'web_search',
+        tool_input: { command: 'query' },
+      }),
+    ).toEqual([]);
+  });
+
+  it('extracts deny reasons from Claude hook JSON output', () => {
+    const reason = denialReasonFromHookOutput(
+      JSON.stringify({
+        hookSpecificOutput: {
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'Write test definitions first.',
+        },
+      }),
+    );
+
+    expect(reason).toBe('Write test definitions first.');
+  });
+
+  it('uses a stable fallback when deny output omits a string reason', () => {
+    const reason = denialReasonFromHookOutput(
+      JSON.stringify({
+        hookSpecificOutput: {
+          permissionDecision: 'deny',
+          permissionDecisionReason: 42,
+        },
+      }),
+    );
+
+    expect(reason).toBe('Safeword denied this action.');
+  });
+
+  it('ignores non-deny and malformed hook output', () => {
+    expect(
+      denialReasonFromHookOutput(
+        JSON.stringify({
+          hookSpecificOutput: {
+            permissionDecision: 'allow',
+          },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(denialReasonFromHookOutput('not json')).toBeUndefined();
+    expect(denialReasonFromHookOutput('')).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/hooks/record-skill-invocation.test.ts
+++ b/packages/cli/tests/hooks/record-skill-invocation.test.ts
@@ -129,11 +129,34 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
     expect(logContent).toMatch(/ remote-session-uuid verify$/m);
   });
 
+  it('falls back to CODEX_THREAD_ID when Claude session ids are unavailable (Codex)', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.project'), { recursive: true });
+
+    const output = execFileSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLAUDE_SESSION_ID: '',
+        CLAUDE_CODE_SESSION_ID: '',
+        CODEX_THREAD_ID: 'codex-thread-uuid',
+      },
+    });
+
+    expect(output.trim()).toBe('[skill-invocation-log] quality-review ✓');
+    const logContent = readFileSync(
+      nodePath.join(projectDirectory, '.project', 'skill-invocations.log'),
+      'utf8',
+    );
+    expect(logContent).toMatch(/ codex-thread-uuid quality-review$/m);
+  });
+
   it('exits 0 and skips when no session id is available (non-Claude runtime graceful)', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
     const env = { ...process.env };
     delete env.CLAUDE_SESSION_ID;
     delete env.CLAUDE_CODE_SESSION_ID;
+    delete env.CODEX_THREAD_ID;
 
     const result = spawnSync('bun', [helperPath, projectDirectory, 'verify'], {
       encoding: 'utf8',

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -3,14 +3,14 @@
  *
  * `skill-gate-integration.test.ts` writes `skill-invocations.log` directly. This
  * test instead drives the *real* `record-skill-invocation.ts` fallback command
- * under a non-Claude runtime (no `CLAUDE_SESSION_ID` / `CLAUDE_CODE_SESSION_ID`
- * in the environment) — the path Codex/Cursor take when the inline `!` line is
- * rendered as Markdown rather than executed. It confirms:
+ * under a runtime that does not execute Claude's inline `!` line — the path
+ * Codex/Cursor take when that line is rendered as Markdown. It confirms:
  *
  *   1. The fallback records gate-readable, session-bound proof for every gated
- *      skill when a session id is supplied explicitly (the HMZSCD arg path),
+ *      skill when a session id is supplied explicitly (the HMZSCD arg path) or
+ *      exposed through a compatible runtime identity such as CODEX_THREAD_ID,
  *      and degrades gracefully (exit 0, nothing recorded) when none is — so a
- *      non-Claude runtime never silently mis-binds.
+ *      runtime never silently mis-binds.
  *   2. End-to-end, a feature done-gate PASSES when verify+audit proof was
  *      recorded via the fallback, and FAILS CLOSED with a clear,
  *      `CLAUDE_SESSION_ID`-free message when the runtime could not bind one.
@@ -39,14 +39,18 @@ import { runDoneGate, writeFeatureTicketAtDone } from './done-gate-harness.js';
 // agnostic, so the fallback mechanism is exercised across all three.
 const GATED_SKILLS = ['verify', 'audit', 'quality-review'] as const;
 
-// A non-Claude runtime exposes no Claude session id in the shell environment.
-// Scrub both vars so the only session id is whatever is passed explicitly —
-// otherwise a CLAUDE_SESSION_ID leaking in from the harness running this suite
-// would mask the very degradation we are asserting.
-function nonClaudeEnvironment(projectDirectory: string): NodeJS.ProcessEnv {
+// Scrub ambient session vars so each test controls the binding source. Without
+// this, a CLAUDE_SESSION_ID or CODEX_THREAD_ID leaking in from the harness would
+// mask the very path being asserted.
+function fallbackEnvironment(
+  projectDirectory: string,
+  sessionEnvironment: Partial<NodeJS.ProcessEnv> = {},
+): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory };
   delete environment.CLAUDE_SESSION_ID;
   delete environment.CLAUDE_CODE_SESSION_ID;
+  delete environment.CODEX_THREAD_ID;
+  Object.assign(environment, sessionEnvironment);
   return environment;
 }
 
@@ -56,11 +60,16 @@ function runFallback(
   projectDirectory: string,
   skill: string,
   sessionIdArgument: string,
+  sessionEnvironment: Partial<NodeJS.ProcessEnv> = {},
 ): { exitCode: number; output: string } {
   const result = spawnSync(
     'bun',
     ['.safeword/hooks/record-skill-invocation.ts', projectDirectory, skill, sessionIdArgument],
-    { cwd: projectDirectory, env: nonClaudeEnvironment(projectDirectory), encoding: 'utf8' },
+    {
+      cwd: projectDirectory,
+      env: fallbackEnvironment(projectDirectory, sessionEnvironment),
+      encoding: 'utf8',
+    },
   );
   return { exitCode: result.status ?? 0, output: `${result.stdout}${result.stderr}` };
 }
@@ -112,6 +121,20 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
       expect(logContents(projectDirectory)).toBe(before);
     });
   }
+
+  it('feature done PASSES when verify+audit are recorded from CODEX_THREAD_ID', () => {
+    writeFeatureTicketAtDone(projectDirectory, '950');
+    const sessionId = 'codex-thread-950';
+    const codexEnvironment = { CODEX_THREAD_ID: sessionId };
+
+    runFallback(projectDirectory, 'verify', '', codexEnvironment);
+    runFallback(projectDirectory, 'audit', '', codexEnvironment);
+
+    const result = runDoneGate(projectDirectory, sessionId);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Required skill invocation');
+  });
 
   it('feature done PASSES the skill gate when verify+audit are recorded via the fallback (non-Claude runtime)', () => {
     writeFeatureTicketAtDone(projectDirectory, '951');

--- a/packages/cli/tests/integration/quality-gates.test.ts
+++ b/packages/cli/tests/integration/quality-gates.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
@@ -248,7 +249,29 @@ describe('Quality Gates', () => {
       expect(state.locSinceCommit).toBeGreaterThanOrEqual(400);
     });
 
-    it('1.3: PreToolUse blocks with commit reminder at LOC gate', () => {
+    it('1.3: PostToolUse clears LOC gate when diff drops below threshold without commit', () => {
+      const largeFilePath = nodePath.join(projectDirectory, 'large-file.ts');
+      const lines = Array.from({ length: 420 }, (_, i) => `const x${i} = ${i};`).join('\n');
+      writeTestFile(projectDirectory, 'large-file.ts', lines);
+      execSync('git add large-file.ts', { cwd: projectDirectory, stdio: 'pipe' });
+
+      const armedResult = runPostToolQuality(projectDirectory, 'Edit', largeFilePath);
+
+      expect(armedResult.status).toBe(0);
+      expect(readState(projectDirectory).gate).toBe('loc');
+
+      execSync('git restore --staged large-file.ts', { cwd: projectDirectory, stdio: 'pipe' });
+      rmSync(largeFilePath);
+
+      const clearedResult = runPostToolQuality(projectDirectory, 'Bash', largeFilePath);
+
+      expect(clearedResult.status).toBe(0);
+      const state = readState(projectDirectory);
+      expect(state.locSinceCommit).toBe(0);
+      expect(state.gate).toBeNull();
+    });
+
+    it('1.4: PreToolUse blocks with commit reminder at LOC gate', () => {
       const head = getHead(projectDirectory);
       writeState(projectDirectory, {
         locSinceCommit: 450,
@@ -274,7 +297,24 @@ describe('Quality Gates', () => {
       expect(output.systemMessage).toContain('Run `/explain` for a plain-English version');
     });
 
-    it('1.4: LOC gate clears on commit', () => {
+    it('1.5: PreToolUse allows stale LOC gate when stored LOC is below threshold', () => {
+      const head = getHead(projectDirectory);
+      writeState(projectDirectory, {
+        locSinceCommit: 0,
+        lastCommitHash: head,
+        activeTicket: null,
+        lastKnownPhase: null,
+        gate: 'loc',
+      });
+
+      const result = runPreToolQuality(projectDirectory, 'Edit');
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe('');
+    });
+
+    it('1.6: LOC gate clears on commit', () => {
       // State has a stale hash — doesn't match current HEAD
       writeState(projectDirectory, {
         locSinceCommit: 500,

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -511,13 +511,14 @@ describe('Schema - Single Source of Truth', () => {
         }
       }
 
-      // Manually-invoked utilities live beside lifecycle hooks because they
-      // share hook libs and write gate-owned state, but Claude Code never
-      // fires them on an event, so they have no SETTINGS_HOOKS entry.
-      const MANUAL_HOOK_SCRIPTS = new Set([
+      // Non-lifecycle hook modules live beside lifecycle hooks because they
+      // share hook libs or are imported by hook entrypoints, but Claude Code
+      // never fires them directly, so they have no SETTINGS_HOOKS entry.
+      const NON_LIFECYCLE_HOOK_MODULES = new Set([
         'write-review-stamp.ts',
         'resolve-namespace-root.ts',
         'record-skill-invocation.ts',
+        'pre-tool-quality-helpers.ts',
       ]);
 
       // Hook files in ownedFiles (excluding lib/ modules and cursor/ adapters)
@@ -530,7 +531,7 @@ describe('Schema - Single Source of Truth', () => {
         )
         .map(path => path.split('/').pop())
         .filter(isDefined)
-        .filter(file => !MANUAL_HOOK_SCRIPTS.has(file));
+        .filter(file => !NON_LIFECYCLE_HOOK_MODULES.has(file));
 
       const unwired: string[] = [];
       for (const file of hookFiles) {

--- a/planning/test-definitions/issue-369-loc-gate-clears-below-threshold.md
+++ b/planning/test-definitions/issue-369-loc-gate-clears-below-threshold.md
@@ -1,0 +1,19 @@
+# Test Definitions: LOC Gate Clears Below Threshold (Issue #369)
+
+Feature source: `planning/user-stories/issue-369-loc-gate-clears-below-threshold.md`
+
+## Rule: LOC gate state follows the current measured diff
+
+### Scenario: PostToolUse clears stale LOC gate after cleanup without commit
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+## Rule: PreToolUse does not hard-block inconsistent below-threshold LOC state
+
+### Scenario: PreToolUse allows gate loc when stored LOC is below threshold
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR

--- a/planning/test-definitions/issue-372-codex-skill-invocation-proof.md
+++ b/planning/test-definitions/issue-372-codex-skill-invocation-proof.md
@@ -1,0 +1,25 @@
+# Test Definitions: Codex Skill Invocation Proof (Issue #372)
+
+Feature source: `planning/user-stories/issue-372-codex-skill-invocation-proof.md`
+
+## Rule: Codex thread identity is a compatible skill-invocation session
+
+### Scenario: Helper records proof from CODEX_THREAD_ID
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: Done gate accepts fallback proof recorded with CODEX_THREAD_ID
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+## Rule: Runtimes with no compatible session still fail closed
+
+### Scenario: Helper skips without writing proof when no session identity exists
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR

--- a/planning/user-stories/issue-369-loc-gate-clears-below-threshold.md
+++ b/planning/user-stories/issue-369-loc-gate-clears-below-threshold.md
@@ -1,0 +1,30 @@
+# User Stories: LOC Gate Clears Below Threshold (Issue #369)
+
+Related issue: https://github.com/ArcadeAI/safeword/issues/369
+
+## Story 1: Recover From Large Diff Cleanup Without Commit
+
+As a developer using Safeword's quality gates,
+I want the LOC gate to clear when my current worktree diff drops below the LOC threshold,
+so that cleanup actions like stashing or removing unrelated churn do not leave me blocked by stale state.
+
+Acceptance criteria:
+
+- Given a session has armed the LOC gate after a diff at or above `LOC_THRESHOLD`
+- When a later PostToolUse pass recalculates the current diff below `LOC_THRESHOLD` without a new commit
+- Then the saved quality state no longer has `gate: "loc"`
+- And the saved `locSinceCommit` reflects the recalculated below-threshold diff
+
+## Story 2: Ignore Internally Inconsistent LOC Gate State
+
+As a developer recovering from stale or upgraded quality-state files,
+I want PreToolUse to deny only when the stored LOC count still meets the LOC threshold,
+so that `gate: "loc"` with `locSinceCommit` below threshold cannot produce a nonsense hard block.
+
+Acceptance criteria:
+
+- Given quality state contains `gate: "loc"`
+- And `locSinceCommit` is below `LOC_THRESHOLD`
+- And `lastCommitHash` still matches the current `HEAD`
+- When PreToolUse runs for an edit
+- Then it allows the edit instead of denying with a commit reminder

--- a/planning/user-stories/issue-372-codex-skill-invocation-proof.md
+++ b/planning/user-stories/issue-372-codex-skill-invocation-proof.md
@@ -1,0 +1,42 @@
+# User Stories: Codex Skill Invocation Proof (Issue #372)
+
+Related issue: https://github.com/ArcadeAI/safeword/issues/372
+
+## Story 1: Record Skill Proof In Codex
+
+As a developer using Safeword in Codex,
+I want gated skills such as `/quality-review` to record proof using Codex's session identity,
+so that done-gate requirements can be satisfied when I actually invoke the required skill.
+
+Acceptance criteria:
+
+- Given `CLAUDE_SESSION_ID` and `CLAUDE_CODE_SESSION_ID` are absent
+- And `CODEX_THREAD_ID` is present
+- When `record-skill-invocation.ts` runs without an explicit session id argument
+- Then it writes a `skill-invocations.log` entry using `CODEX_THREAD_ID`
+- And it prints the normal success message
+
+## Story 2: Preserve Fail-Closed Behavior Without Any Compatible Session
+
+As a developer in a runtime that does not expose a compatible session identity,
+I want Safeword to keep failing closed for done-gate proof,
+so that it never silently records skill proof against an empty or ambient session.
+
+Acceptance criteria:
+
+- Given Claude session variables and `CODEX_THREAD_ID` are absent
+- When `record-skill-invocation.ts` runs without an explicit session id argument
+- Then it exits successfully with a clear no-session message
+- And it does not write `skill-invocations.log`
+
+## Root Cause
+
+`record-skill-invocation.ts` derives session proof only from `CLAUDE_SESSION_ID` or `CLAUDE_CODE_SESSION_ID`. In Codex, the current runtime exposes `CODEX_THREAD_ID` instead, so the helper receives an empty session argument, ignores the available Codex identity, and prints `no session id — skipped`.
+
+Confirmed by inspecting the live Codex environment variable names and the helper's `ENV_SESSION_ID` definition.
+
+Ruled out:
+
+- The fallback command itself is missing: the quality-review skill includes the fallback command.
+- The helper cannot support env-derived sessions: it already does for Claude Code remote containers via `CLAUDE_CODE_SESSION_ID`.
+- The done-gate parser requires a Claude-specific session format: `checkSkillInvocations()` compares opaque whitespace-delimited session tokens, so `CODEX_THREAD_ID` is structurally valid.


### PR DESCRIPTION
## Summary
- Extract Codex pre-tool translation and denial parsing into registered pure helper modules.
- Fixes #369 by clearing stale LOC quality-gate state once recalculated LOC drops below the threshold, and by preventing stale LOC blocks in the pre-tool hook.
- Fixes #372 by binding skill-invocation fallback proof to `CODEX_THREAD_ID` in Codex while preserving fail-closed behavior when no compatible session exists.

## Verification
- `bun run --cwd packages/cli test tests/hooks/record-skill-invocation.test.ts tests/integration/codex-cursor-skill-fallback.test.ts tests/integration/quality-gates.test.ts` — 3 files, 90 tests passed.
- `bun run --cwd packages/cli test:done` — 42 files, 539 tests passed.
- `bun run --cwd packages/cli typecheck` passed.
- `bunx prettier --check ...` passed for touched files/docs.
- `bunx eslint ...` passed for touched tests.
- Pre-push schema-drift gate passed: 2 files, 624 tests.

## Notes
- The branch was rebased onto latest `origin/main` before push.
- The #369 and #372 fixes are split into separate commits on top of the original Codex hook adapter helper commits.