### PR TITLE
Probe test-plan capability in verify resolver

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -65,15 +65,37 @@ not a `test-plan` suite).
 
 ```bash
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
-# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
-if [ -x node_modules/.bin/safeword ]; then
+# only if it actually supports test-plan.
+supports_test_plan() {
+  case "$CANDIDATE" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword test-plan --help > /dev/null 2>&1 ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts test-plan --help > /dev/null 2>&1 ;;
+    "bunx safeword") bunx safeword test-plan --help > /dev/null 2>&1 ;;
+  esac
+}
+
+run_safeword() {
+  case "$SW" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword "$@" ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts "$@" ;;
+    "bunx safeword") bunx safeword "$@" ;;
+  esac
+}
+
+CANDIDATE="node_modules/.bin/safeword"
+if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
-elif [ -f packages/cli/src/cli.ts ]; then
+elif CANDIDATE="bun packages/cli/src/cli.ts" && [ -f packages/cli/src/cli.ts ] && supports_test_plan; then
   SW="bun packages/cli/src/cli.ts"
-else SW="bunx safeword"; fi
+elif CANDIDATE="bunx safeword" && supports_test_plan; then
+  SW="bunx safeword"
+else
+  echo "No test-plan-capable safeword CLI found. Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword." >&2
+  exit 1
+fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$($SW test-plan --kind verify --format sh)"
+bash -c "$(run_safeword test-plan --kind verify --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -83,7 +105,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$($SW test-plan --kind build --format sh)"
+bash -c "$(run_safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -65,15 +65,37 @@ not a `test-plan` suite).
 
 ```bash
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
-# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
-if [ -x node_modules/.bin/safeword ]; then
+# only if it actually supports test-plan.
+supports_test_plan() {
+  case "$CANDIDATE" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword test-plan --help > /dev/null 2>&1 ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts test-plan --help > /dev/null 2>&1 ;;
+    "bunx safeword") bunx safeword test-plan --help > /dev/null 2>&1 ;;
+  esac
+}
+
+run_safeword() {
+  case "$SW" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword "$@" ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts "$@" ;;
+    "bunx safeword") bunx safeword "$@" ;;
+  esac
+}
+
+CANDIDATE="node_modules/.bin/safeword"
+if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
-elif [ -f packages/cli/src/cli.ts ]; then
+elif CANDIDATE="bun packages/cli/src/cli.ts" && [ -f packages/cli/src/cli.ts ] && supports_test_plan; then
   SW="bun packages/cli/src/cli.ts"
-else SW="bunx safeword"; fi
+elif CANDIDATE="bunx safeword" && supports_test_plan; then
+  SW="bunx safeword"
+else
+  echo "No test-plan-capable safeword CLI found. Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword." >&2
+  exit 1
+fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$($SW test-plan --kind verify --format sh)"
+bash -c "$(run_safeword test-plan --kind verify --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -83,7 +105,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$($SW test-plan --kind build --format sh)"
+bash -c "$(run_safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -59,15 +59,37 @@ not a `test-plan` suite).
 
 ```bash
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
-# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
-if [ -x node_modules/.bin/safeword ]; then
+# only if it actually supports test-plan.
+supports_test_plan() {
+  case "$CANDIDATE" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword test-plan --help > /dev/null 2>&1 ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts test-plan --help > /dev/null 2>&1 ;;
+    "bunx safeword") bunx safeword test-plan --help > /dev/null 2>&1 ;;
+  esac
+}
+
+run_safeword() {
+  case "$SW" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword "$@" ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts "$@" ;;
+    "bunx safeword") bunx safeword "$@" ;;
+  esac
+}
+
+CANDIDATE="node_modules/.bin/safeword"
+if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
-elif [ -f packages/cli/src/cli.ts ]; then
+elif CANDIDATE="bun packages/cli/src/cli.ts" && [ -f packages/cli/src/cli.ts ] && supports_test_plan; then
   SW="bun packages/cli/src/cli.ts"
-else SW="bunx safeword"; fi
+elif CANDIDATE="bunx safeword" && supports_test_plan; then
+  SW="bunx safeword"
+else
+  echo "No test-plan-capable safeword CLI found. Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword." >&2
+  exit 1
+fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$($SW test-plan --kind verify --format sh)"
+bash -c "$(run_safeword test-plan --kind verify --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -77,7 +99,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$($SW test-plan --kind build --format sh)"
+bash -c "$(run_safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/.project/tickets/C25VKV-align-verification-commands-with-monorepo-scripts/ticket.md
+++ b/.project/tickets/C25VKV-align-verification-commands-with-monorepo-scripts/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: intake
 status: in_progress
 created: 2026-06-15T13:52:10.892Z
-last_modified: 2026-06-15T13:52:44Z
+last_modified: 2026-06-24T05:18:26Z
 ---
 
 # Align verification commands with monorepo scripts
@@ -29,3 +29,4 @@ last_modified: 2026-06-15T13:52:44Z
 
 - 2026-06-15T13:52:10.892Z Started: Created ticket C25VKV
 - 2026-06-15T13:52:44Z Intake: Audit found root `bun run build` fails with `Script not found "build"`, root `bunx tsc --noEmit` reports 38 ES2023 lib diagnostics, while canonical `bun run lint` and package `typecheck` pass.
+- 2026-06-24T05:18:26Z Issue #375: Added capability probing so verify instructions skip stale Safeword binaries that lack `test-plan`, with focused tests covering templates and dogfood surfaces.

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -59,15 +59,37 @@ not a `test-plan` suite).
 
 ```bash
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
-# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
-if [ -x node_modules/.bin/safeword ]; then
+# only if it actually supports test-plan.
+supports_test_plan() {
+  case "$CANDIDATE" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword test-plan --help > /dev/null 2>&1 ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts test-plan --help > /dev/null 2>&1 ;;
+    "bunx safeword") bunx safeword test-plan --help > /dev/null 2>&1 ;;
+  esac
+}
+
+run_safeword() {
+  case "$SW" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword "$@" ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts "$@" ;;
+    "bunx safeword") bunx safeword "$@" ;;
+  esac
+}
+
+CANDIDATE="node_modules/.bin/safeword"
+if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
-elif [ -f packages/cli/src/cli.ts ]; then
+elif CANDIDATE="bun packages/cli/src/cli.ts" && [ -f packages/cli/src/cli.ts ] && supports_test_plan; then
   SW="bun packages/cli/src/cli.ts"
-else SW="bunx safeword"; fi
+elif CANDIDATE="bunx safeword" && supports_test_plan; then
+  SW="bunx safeword"
+else
+  echo "No test-plan-capable safeword CLI found. Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword." >&2
+  exit 1
+fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$($SW test-plan --kind verify --format sh)"
+bash -c "$(run_safeword test-plan --kind verify --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -77,7 +99,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$($SW test-plan --kind build --format sh)"
+bash -c "$(run_safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -65,15 +65,37 @@ not a `test-plan` suite).
 
 ```bash
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
-# (a bare `bunx safeword` can resolve the published CLI, which may predate test-plan).
-if [ -x node_modules/.bin/safeword ]; then
+# only if it actually supports test-plan.
+supports_test_plan() {
+  case "$CANDIDATE" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword test-plan --help > /dev/null 2>&1 ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts test-plan --help > /dev/null 2>&1 ;;
+    "bunx safeword") bunx safeword test-plan --help > /dev/null 2>&1 ;;
+  esac
+}
+
+run_safeword() {
+  case "$SW" in
+    node_modules/.bin/safeword) node_modules/.bin/safeword "$@" ;;
+    "bun packages/cli/src/cli.ts") bun packages/cli/src/cli.ts "$@" ;;
+    "bunx safeword") bunx safeword "$@" ;;
+  esac
+}
+
+CANDIDATE="node_modules/.bin/safeword"
+if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
-elif [ -f packages/cli/src/cli.ts ]; then
+elif CANDIDATE="bun packages/cli/src/cli.ts" && [ -f packages/cli/src/cli.ts ] && supports_test_plan; then
   SW="bun packages/cli/src/cli.ts"
-else SW="bunx safeword"; fi
+elif CANDIDATE="bunx safeword" && supports_test_plan; then
+  SW="bunx safeword"
+else
+  echo "No test-plan-capable safeword CLI found. Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword." >&2
+  exit 1
+fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$($SW test-plan --kind verify --format sh)"
+bash -c "$(run_safeword test-plan --kind verify --format sh)"
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -83,7 +105,7 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$($SW test-plan --kind build --format sh)"
+bash -c "$(run_safeword test-plan --kind build --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors.

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -14,11 +14,31 @@ const commandContent = readFileSync(
   nodePath.join(templatesDirectory, 'commands/verify.md'),
   'utf8',
 );
+const dogfoodAgentsSkillContent = readFileSync(
+  nodePath.join(repoRoot, '.agents/skills/verify/SKILL.md'),
+  'utf8',
+);
+const dogfoodClaudeSkillContent = readFileSync(
+  nodePath.join(repoRoot, '.claude/skills/verify/SKILL.md'),
+  'utf8',
+);
+const dogfoodCursorCommandContent = readFileSync(
+  nodePath.join(repoRoot, '.cursor/commands/verify.md'),
+  'utf8',
+);
 
 // Both surfaces share the same instructions; tests run against both.
 const surfaces: [string, string][] = [
   ['skill', skillContent],
   ['command', commandContent],
+];
+
+const allVerifySurfaces: [string, string][] = [
+  ['template skill', skillContent],
+  ['template command', commandContent],
+  ['dogfood agents skill', dogfoodAgentsSkillContent],
+  ['dogfood claude skill', dogfoodClaudeSkillContent],
+  ['dogfood cursor command', dogfoodCursorCommandContent],
 ];
 
 describe('verify report structure (146)', () => {
@@ -128,5 +148,48 @@ describe('verify report structure (146)', () => {
     it.each(surfaces)('%s carries no inline per-language test/build branch', (_name, content) => {
       expect(content).not.toMatch(/uv run pytest|go test|cargo test|go build|cargo build/);
     });
+  });
+
+  describe('Rule: verify resolver selects only a test-plan-capable Safeword CLI (375)', () => {
+    it.each(allVerifySurfaces)('%s probes node_modules before selecting it', (_name, content) => {
+      expect(content).toContain('supports_test_plan()');
+      expect(content).toContain('CANDIDATE="node_modules/.bin/safeword"');
+      expect(content).toContain('[ -x node_modules/.bin/safeword ] && supports_test_plan');
+      expect(content).not.toMatch(
+        /if \[ -x node_modules\/\.bin\/safeword \]; then\s+SW="node_modules\/\.bin\/safeword"/,
+      );
+    });
+
+    it.each(allVerifySurfaces)('%s falls back to the source CLI before bunx', (_name, content) => {
+      const sourceProbe = 'CANDIDATE="bun packages/cli/src/cli.ts"';
+      const bunxProbe = 'CANDIDATE="bunx safeword"';
+
+      expect(content).toContain(sourceProbe);
+      expect(content.indexOf(sourceProbe)).toBeGreaterThan(-1);
+      expect(content.indexOf(bunxProbe)).toBeGreaterThan(content.indexOf(sourceProbe));
+      expect(content).toContain('SW="bun packages/cli/src/cli.ts"');
+    });
+
+    it.each(allVerifySurfaces)(
+      '%s fails clearly when no candidate supports test-plan',
+      (_name, content) => {
+        expect(content).toContain('No test-plan-capable safeword CLI found');
+        expect(content).toContain(
+          'Tried node_modules/.bin/safeword, packages/cli/src/cli.ts, and bunx safeword.',
+        );
+        expect(content).toMatch(/exit 1/);
+      },
+    );
+
+    it.each(allVerifySurfaces)(
+      '%s executes test-plan through dispatch instead of shell word splitting',
+      (_name, content) => {
+        expect(content).toContain('run_safeword()');
+        expect(content).toContain('bash -c "$(run_safeword test-plan --kind verify --format sh)"');
+        expect(content).toContain('bash -c "$(run_safeword test-plan --kind build --format sh)"');
+        expect(content).not.toContain('$($SW test-plan');
+        expect(content).not.toContain('$1');
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Require each verify resolver candidate to pass `test-plan --help` before selection
- Add a clear fail-closed error when no test-plan-capable Safeword CLI is available
- Cover packaged and dogfood verify surfaces with regression tests and planning docs

Closes #375

## Verification
- `bun run --cwd packages/cli test tests/verify-skill.test.ts` (RED before fix, GREEN after fix)
- `bun run --cwd packages/cli test tests/verify-skill.test.ts tests/skill-invocation-log.test.ts`
- `bun run lint`
- `git diff --check`