### PR TITLE
Language packs: Go + Rust architecture introspection (WBM8JE slices 1–2)

### DIFF
--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/dimensions.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/dimensions.md
@@ -1,0 +1,39 @@
+# Dimensions: Rust language pack (YKFA5X)
+
+| Dimension          | Partitions                                                                                       | Source      |
+| ------------------ | ------------------------------------------------------------------------------------------------ | ----------- |
+| Project shape      | single-crate (no workspace) · Cargo workspace · JS-rooted monorepo containing a Rust crate       | TB1, TB2    |
+| Source layout      | Rust modules (src/ files + dirs) · `src/` (JS/TS) · only crate root (lib.rs/main.rs, no modules) | TB1.AC1     |
+| Module kind (Rust) | `src/<name>.rs` file · `src/<name>/` dir · `src/lib.rs` / `src/main.rs` root (excluded)          | TB1.AC1     |
+| Discovery source   | Cargo `[workspace] members` · package.json workspaces (JS) · go.work · none                      | TB1.AC2     |
+| Fingerprint input  | Cargo `[dependencies]`/`[dev-dependencies]`/`[build-dependencies]` keys · package.json deps      | TB2.AC1     |
+| Regression surface | JS single-repo output · JS leaf output in a polyglot monorepo (must be unchanged)                | TB2.AC2/AC3 |
+
+## Partition → scenario mapping
+
+- single-crate × Rust modules (file + dir) → TB1.AC1 (module doc lists both, roots excluded).
+- Cargo workspace × Rust modules → TB1.AC2 (root index + Rust leaf doc).
+- single-crate × only crate root → TB1.AC1 honesty edge ("not introspected", no modules).
+- JS-rooted monorepo × (src + Rust crate) → TB2.AC2 (both introspected).
+- single-repo × src → TB2.AC3 (JS module doc unchanged — regression guard).
+- Cargo `[dependencies]` add/remove → TB2.AC1, BLACK-BOX: the dependency set feeds the
+  shape-fingerprint, written into the doc frontmatter and surfaced by `architecture
+--check`, so adding a dep makes the doc go stale (`--check` reports it). A unit test
+  pins the fingerprint composition beneath it. (Same observable-drift split ZD70P1 used.)
+
+## Boundary notes
+
+- **Extraction (Rust):** modules = top-level `src/` subdirectories AND `src/*.rs` files,
+  minus `lib.rs`/`main.rs` (crate roots). A crate with only a root file → empty skeleton
+  → honest "not introspected". `mod.rs` and nested `src/foo/bar.rs` are not top-level, so
+  not listed (module nesting is out of scope).
+- **Extraction precedence:** dispatch on manifest — a `Cargo.toml` directory uses the
+  Rust branch; TS `src/`-dir and Go (`go.mod`) branches are unchanged. A pure TS/Go repo
+  has no Cargo.toml, so its output is byte-identical.
+- **Discovery precedence:** `package.json workspaces` ?? `pnpm-workspace.yaml` ??
+  `go.work` ?? Cargo `[workspace]`. A JS-rooted monorepo containing a Rust crate still
+  discovers the crate (keep-predicate is "has package.json OR go.mod OR Cargo.toml").
+- **Crate identity:** name = Cargo.toml `[package] name`, fallback directory basename.
+- **Out of scope here:** Cargo `exclude`, inter-crate edges, module nesting/`mod.rs`,
+  `[workspace.dependencies]` inheritance / inline-table / feature / target deps, both a
+  Cargo workspace and package.json workspaces at the repo root (JS wins), Python pack.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/impl-plan.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/impl-plan.md
@@ -1,0 +1,73 @@
+# Impl Plan: Rust language pack (YKFA5X)
+
+**Status:** planned
+
+## Approach
+
+Outside-in TDD over the same three production seams ZD70P1 proved, plus a new
+TOML-subset parser. The new risk vs Go is TOML (multi-line arrays, dependency
+tables) — so the parser gets the hardest unit tests and degrades gracefully on
+anything outside the documented subset. Build order — keystone (extraction) first so
+single-crate Rust turns green, then discovery wires the workspace, then fingerprint
+closes drift:
+
+1. **TOML-subset parser** — `cargo-manifest.ts` (new): `readCargoWorkspaceMembers`
+   (the `[workspace] members = [..]` array, multi-line + single-line), `readCargoPackageName`
+   (`[package] name`), `readCargoDependencyNames` (keys under `[dependencies]` /
+   `[dev-dependencies]` / `[build-dependencies]`, table-scoped). Dependency-free;
+   returns empty/undefined on anything it can't parse. _Unit_ (`cargo-manifest.test.ts`).
+   This co-locates all Cargo parsing in one module from the start (ZD70P1 deferred a
+   `go-manifest.ts` for rule-of-three; with Rust this is the second consumer-language,
+   but a SINGLE-language module is still right — a shared multi-manifest module waits
+   for the Python slice to justify it).
+2. **Extraction (keystone)** — `architecture-skeleton.ts`: dispatch on `Cargo.toml` →
+   list `src/` subdirs AND `src/*.rs` files, minus `lib.rs`/`main.rs`. TS `src/`-dir and
+   Go branches unchanged. _Unit_ (`architecture-skeleton.test.ts`). Turns scenario 1 green.
+3. **Discovery** — `architecture-monorepo.ts`: `detectCargoWorkspace` (via the parser)
+   appended to the `??` chain; `hasRecognizedManifest` gains `Cargo.toml`; `packageName`
+   falls back to `readCargoPackageName`. _Unit_ (`architecture-monorepo.test.ts`).
+   Turns scenarios 2, 3, 5 green.
+4. **Fingerprint** — `architecture-fingerprint.ts`: union `readCargoDependencyNames`
+   into the dependency set. _Unit_ (`architecture-fingerprint.test.ts`). Turns scenario 4 green.
+5. **Black-box BDD** — `steps/architecture-rust-language-pack.steps.ts` over real
+   fixtures; reuses the shared When/Then vocabulary + `architecture-fixtures.ts`. NEW
+   step: `the doc does not list the module "X"` (negative of the Go positive). The
+   Cargo-drift AC is proven via `architecture --check` reporting stale.
+
+Test-layer rationale: TOML parse / extract / fingerprint are pure → unit; which docs
+appear and what `--check` reports are a process-boundary contract → the `.feature` lane.
+
+## Decisions
+
+| Decision            | Choice                                                              | Alternatives considered            | Rejected because                                                                  |
+| ------------------- | ------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------- |
+| Rust extraction     | src/ subdirs AND src/\*.rs files, minus lib.rs/main.rs roots        | Dir-only (reuse as-is)             | Rust modules are commonly FILES — dir-only leaves real crates "not introspected"  |
+| Cargo.toml parsing  | Hand-rolled TOML subset (members array, package name, dep tables)   | A TOML library / `cargo metadata`  | Zero-dep posture; `cargo metadata` needs a toolchain. Degrade gracefully.         |
+| Parser home         | One `cargo-manifest.ts` module for all Cargo parsing                | Inline per consumer (like Go)      | Three Cargo readers in one slice — co-locate now; multi-lang merge waits (Python) |
+| Extraction dispatch | Manifest-keyed: Cargo.toml → Rust branch, else src-dir, else go.mod | Augment src-dir path conditionally | Manifest dispatch keeps each language's branch isolated, zero TS/Go regression    |
+| Drift coverage      | Black-box scenario via `architecture --check` + a unit pin          | Unit only                          | The fingerprint is observable (frontmatter + `--check`), per ZD70P1 review        |
+
+## Arch alignment
+
+- **Deterministic, LLM-free engine** — TOML parse / extraction / fingerprint are pure
+  derive/parse; no new source of truth, no LLM, no toolchain shell-out.
+- **Never silently wrong** — a root-only crate stays the honest "not introspected"
+  marker; Cargo `exclude` over-inclusion is visible, documented out-of-scope.
+- **Polyglot promise** — Rust plugs into the same heal-target + fingerprint machinery
+  as JS and Go; the third pack (Python) reuses the seam, and at that point the
+  multi-manifest discovery/parse consolidation (ZD70P1's deferred trigger) is revisited.
+
+## Known deviations
+
+- Cargo parsing lives in a new `cargo-manifest.ts` rather than inline (Go kept its
+  readers inline). Justified: three Cargo readers ship together, so co-location is
+  warranted now; the cross-language merge of detect\* discovery still waits for Python.
+
+## Assessment triggers
+
+- **Python slice** lands → revisit merging `detectGoWork` / `detectPnpmWorkspaces` /
+  `detectCargoWorkspace` into one multi-manifest discovery, and the per-language
+  manifest modules into a shared dependency/identity reader.
+- Inter-crate edges needed → requires a path/workspace-dep → crate-dir map (own slice).
+- A crate uses `[workspace.dependencies]` inheritance or inline-table deps → revisit
+  the dep-table parser (currently flat-key only).

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/impl-plan.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/impl-plan.md
@@ -1,6 +1,15 @@
 # Impl Plan: Rust language pack (YKFA5X)
 
-**Status:** planned
+**Status:** implemented
+
+_Reconciled against what shipped: all five Decisions held as written (no mid-build
+reversals) — directory-convention Rust extraction, hand-rolled TOML subset, a single
+`cargo-manifest.ts` parser module, manifest-keyed dispatch, and black-box drift via
+`--check`. Arch alignment holds (pure derive/parse, honest "not introspected" for a
+root-only crate, JS/Go byte-identical). Two additions beyond the original plan are
+recorded under Known deviations: the `runArchitecture` fixture lift and the
+verify-phase rework of `readCargoWorkspaceMembers` (a /quality-review fix, not a
+design change)._
 
 ## Approach
 
@@ -62,6 +71,14 @@ appear and what `--check` reports are a process-boundary contract → the `.feat
 - Cargo parsing lives in a new `cargo-manifest.ts` rather than inline (Go kept its
   readers inline). Justified: three Cargo readers ship together, so co-location is
   warranted now; the cross-language merge of detect\* discovery still waits for Python.
+- `runArchitecture` (the CLI-spawn step helper) was lifted from the Go step file into
+  `steps/support/architecture-fixtures.ts` and is now imported by both the Go and Rust
+  step files — a behavior-identical de-dup so the Rust lane didn't re-clone the logic.
+- `readCargoWorkspaceMembers` was reworked during verify from a whole-file regex to a
+  table-scoped, comment-stripped line scan (`workspaceMembersArrayBody`) after the
+  /quality-review found the regex read the wrong `members` array (unscoped) and dropped
+  members on a `]`-in-comment. A correctness fix within the same subset, not a scope or
+  design change; two regression tests pin it.
 
 ## Assessment triggers
 

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/spec.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/spec.md
@@ -1,0 +1,92 @@
+# Spec: Rust language pack — Cargo workspace discovery, src extraction, Cargo.toml fingerprint
+
+## Intent
+
+Teach the generated architecture state-doc to introspect Rust projects — a
+single-crate library/binary and a Cargo workspace — so a crate gets real structural
+extraction (its top-level `src/` modules, both files and directories) and Cargo
+dependency-drift detection, rather than the honest-but-empty "not introspected"
+marker. Second of the WBM8JE language packs; reuses the per-language seam ZD70P1
+proved for Go and extends it to a TOML manifest.
+
+## Intake Brief
+
+- **Requested by:** WBM8JE epic continuation (the user, after ZD70P1 shipped) — the
+  second of the three deferred language packs.
+- **Cost of inaction:** A Rust project (single-crate or Cargo workspace) gets no
+  architecture doc, or — in a mixed JS+Rust monorepo — its Rust crates stay marked
+  "not introspected." The polyglot promise reads as "JS + Go only."
+- **Reversibility:** Two-way door. Pure addition behind the existing manifest-keyed
+  seam; JS/TS/Go behavior is regression-guarded and unchanged. No data-model or
+  public-API change — the doc format and fingerprint inputs only gain Rust entries.
+
+## References
+
+- Parent epic **WBM8JE**; sibling **ZD70P1** (Go pack — the seam this reuses).
+- Verified this session: doc.rust-lang.org/cargo/reference/workspaces.html
+  (`[workspace] members` = path-glob array + `exclude`) and the Rust module layout
+  (`src/<name>.rs` file OR `src/<name>/` dir; `lib.rs`/`main.rs` are roots).
+- Seams: `architecture-skeleton.ts` (extraction), `architecture-monorepo.ts`
+  (discovery), `architecture-fingerprint.ts` (drift).
+
+## Personas
+
+- **Technical Builder (TB)** — here, in its Rust/polyglot flavor: a developer running
+  an AI coding agent on a repo (or monorepo) that mixes Rust with TypeScript/Go, or is
+  pure Rust. TB is stack-agnostic by definition; they want the architecture doc to
+  describe the Rust code, not skip it.
+
+## Vocabulary
+
+- **Cargo workspace** — a `Cargo.toml` with a `[workspace]` table whose `members`
+  array lists member-crate directories (path globs); the Rust analogue of
+  `package.json` workspaces / `go.work`.
+- **Crate** — a Rust compilation unit with its own `Cargo.toml`; the leaf package.
+- **Rust module** — a top-level item under `src/`: a `src/<name>.rs` file or a
+  `src/<name>/` directory. `src/lib.rs` and `src/main.rs` are crate roots, not modules.
+- **Introspected** — a crate with a recognized source layout (so it gets a real leaf
+  doc), vs. "not introspected" (listed but explicitly undescribed).
+
+## Jobs To Be Done
+
+### architecture-rust-language-pack.TB1 — See my Rust crate's structure in the doc
+
+**Persona:** Technical Builder (TB)
+
+> When I generate the architecture doc for a Rust project, I want its top-level `src/`
+> modules (files and directories) listed with the same structure a TypeScript or Go
+> repo gets, so I can review and annotate the real shape instead of an empty placeholder.
+
+#### architecture-rust-language-pack.TB1.AC1 — A single-crate Rust project produces a doc listing its top-level src/ modules (files and dirs), excluding the crate roots
+
+#### architecture-rust-language-pack.TB1.AC2 — A Cargo workspace produces a root index plus a leaf doc per crate with a recognized layout
+
+### architecture-rust-language-pack.TB2 — Catch Cargo dependency drift, and never lose my other-language docs
+
+**Persona:** Technical Builder (TB)
+
+> When a crate's Cargo dependencies change, I want the architecture doc to register the
+> drift; and when my repo mixes Rust and JS, I want both introspected and my existing
+> JS docs untouched, so the doc stays trustworthy across languages.
+
+#### architecture-rust-language-pack.TB2.AC1 — Adding/removing a dependency in a crate's Cargo.toml moves that crate's shape-fingerprint
+
+#### architecture-rust-language-pack.TB2.AC2 — A mixed JS+Rust monorepo introspects both, with the JS output byte-identical to today
+
+#### architecture-rust-language-pack.TB2.AC3 — A pure JS/TS (or Go) repo's discovery, extraction, and fingerprint are unchanged (no regression)
+
+## Outcomes
+
+- A Rust project — single-crate or Cargo workspace — gets a real, structurally
+  accurate architecture doc with zero hand-run commands, identical in shape to what
+  npm/pnpm/go.work projects already get.
+- Cargo dependency drift is a first-class drift signal (fingerprint moves).
+- The polyglot promise holds across three languages: mixing Rust and JS introspects
+  both; the JS half is provably unchanged.
+
+## Open Questions
+
+- none — resolved during intake against the read seams and Rust primary docs. The
+  files-vs-dirs extraction fork is decided (files-and-dirs, per Rust convention); TOML
+  edge cases (`exclude`, workspace-dep inheritance, inline-table deps, module nesting)
+  are explicit out-of-scope limitations in ticket.md, not open questions.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
@@ -1,0 +1,64 @@
+# Test Definitions: Rust language pack (YKFA5X)
+
+Feature source: `features/architecture-rust-language-pack.feature`
+
+test-definitions.md is the R/G/R ledger. The black-box `.feature` lane proves the
+observable doc-coverage behaviors — including Cargo dependency drift, which is
+observable (the shape-fingerprint is written into the doc frontmatter and surfaced by
+`architecture --check`). Fine-grained TOML-subset parser and extractor internals are
+pinned by unit tests as a secondary layer, listed under "Unit-pinned" below.
+
+## Rule: Rust projects get real structural extraction and drift detection
+
+### Scenario: A single-crate Rust project lists its src modules, files and dirs, not the root
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A Cargo workspace produces a root index and per-crate leaf docs
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A crate with only a root file is marked, not introspected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Adding a Cargo dependency makes the architecture doc go stale
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Polyglot repos introspect every language without regressing JS
+
+### Scenario: A mixed JS and Rust monorepo introspects both packages
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A pure JS single-repo is unchanged by the Rust extractor
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Unit-pinned (secondary — fine-grained internals beneath the black-box scenarios)
+
+- **TB2.AC1 fine-grain — Cargo dependency fingerprint:** adding/removing a key in a
+  crate's `[dependencies]` / `[dev-dependencies]` / `[build-dependencies]` changes
+  `shapeFingerprint` for that directory while a JS package's fingerprint is untouched;
+  a version bump does NOT move it (versions excluded). `architecture-fingerprint.test.ts`.
+- **detectCargoWorkspace parse:** `[workspace] members = [..]` multi-line and
+  single-line array forms, comments, quotes; a Cargo.toml with no `[workspace]` table →
+  `undefined`; a member glob expands like the JS/Go globs. `architecture-monorepo.test.ts`.
+- **extractSkeleton Rust layout:** `Cargo.toml` + `src/<name>.rs` files AND `src/<name>/`
+  dirs → those modules, `lib.rs`/`main.rs` excluded; a crate with only a root file →
+  empty skeleton; `src/`-dir (TS) and `go.mod` (Go) branches unchanged.
+  `architecture-skeleton.test.ts`.
+- **Crate identity:** name from `[package] name`, fallback basename. `architecture-monorepo.test.ts`.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
@@ -12,41 +12,41 @@ pinned by unit tests as a secondary layer, listed under "Unit-pinned" below.
 
 ### Scenario: A single-crate Rust project lists its src modules, files and dirs, not the root
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ### Scenario: A Cargo workspace produces a root index and per-crate leaf docs
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ### Scenario: A crate with only a root file is marked, not introspected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ### Scenario: Adding a Cargo dependency makes the architecture doc go stale
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ## Rule: Polyglot repos introspect every language without regressing JS
 
 ### Scenario: A mixed JS and Rust monorepo introspects both packages
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ### Scenario: A pure JS single-repo is unchanged by the Rust extractor
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0afd962
+- [x] GREEN 0afd962
+- [x] REFACTOR 0afd962
 
 ## New step definitions (on the critical path — must be authored at RED)
 

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/test-definitions.md
@@ -48,6 +48,24 @@ pinned by unit tests as a secondary layer, listed under "Unit-pinned" below.
 - [ ] GREEN
 - [ ] REFACTOR
 
+## New step definitions (on the critical path — must be authored at RED)
+
+- **`the doc does not list the module "X"`** — NEW negative Then (the existing Go
+  step only has the positive `the doc lists the module "X"`). Asserts
+  `assert.doesNotMatch(rootDoc(world), /^### X$/m)`. Scenario 1's root-exclusion
+  assertion (`lib.rs` not listed) depends on it; without it that step no-ops as
+  undefined/pending. Rust-specific Givens (single-crate, Cargo workspace, file/dir
+  modules, root-only crate, mixed JS+Rust) are also new and live in the new
+  `steps/architecture-rust-language-pack.steps.ts`.
+
+## Scenario notes (coverage honesty)
+
+- **Scenario 1's load-bearing RED is the `config` (file) assertion.** A Rust crate
+  with a module DIR already gets a `## Modules` doc today, so `lists "handlers"`,
+  `single-repo module doc`, and `does not list "lib"` all pass pre-implementation;
+  only `lists the module "config"` (a `src/config.rs` FILE) is RED today. Do NOT
+  weaken the fixture to a dir-only module — that would make the scenario vacuous.
+
 ## Unit-pinned (secondary — fine-grained internals beneath the black-box scenarios)
 
 - **TB2.AC1 fine-grain — Cargo dependency fingerprint:** adding/removing a key in a

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
@@ -1,0 +1,84 @@
+---
+id: YKFA5X
+slug: architecture-rust-language-pack
+type: feature
+phase: scenario-gate
+status: in_progress
+created: 2026-06-24T04:07:49.850Z
+last_modified: 2026-06-24T04:12:00.000Z
+scope:
+  - Rust module extraction — extractSkeleton, when a directory has a `Cargo.toml`, lists the top-level `src/` modules = subdirectories AND `src/*.rs` files (excluding the crate roots `lib.rs` / `main.rs`), so a real Rust crate (whose modules are commonly files, not dirs) is introspected instead of marked "not introspected"
+  - Cargo workspace discovery — detectCargoWorkspace parses `[workspace] members = [globs]` (a dependency-free TOML-subset parse of the multi-line and single-line array forms), appended to the `??` discovery chain after the JS and Go sources
+  - Generalized leaf predicate — discoverLeafDirectories keeps a discovered directory that has a recognized manifest (`package.json` OR `go.mod` OR `Cargo.toml`)
+  - Cargo fingerprint input — the shape-fingerprint's dependency set includes the `[dependencies]` / `[dev-dependencies]` / `[build-dependencies]` table keys (names, not versions), so Rust dependency drift moves the crate's fingerprint
+  - Rust crate identity — a crate's name comes from its Cargo.toml `[package] name` (fallback: directory basename), mirroring JS `name` / Go `module`
+  - Tests (unit + black-box BDD over real Rust fixtures: single-crate Rust, Cargo workspace, mixed JS+Rust monorepo) and a no-regression guarantee for JS/TS/Go repos
+out_of_scope:
+  - Cargo `[workspace] exclude` — a member glob plus an excluded crate may over-list the excluded crate; a noted limitation (over-inclusion is visible, not silently dropped)
+  - Inter-crate dependency EDGES in the root index (mapping a `path`/workspace dependency back to a crate directory) — Rust leaves render with no edges in this slice; defer to a follow-up
+  - Module CONTENTS / nesting — only the TOP-level `src/` modules are listed; `src/foo/bar.rs`, a module's internals, and `mod.rs` resolution are out
+  - `[workspace.dependencies]` inheritance, target-specific deps, optional/feature deps, build-target tables — out (the three flat dependency tables cover the common case)
+  - Mixed ROOT polyglot where both a Cargo `[workspace]` and `package.json` workspaces sit at the repo root — JS wins the `??` chain; a noted limitation
+  - Python language pack — separate WBM8JE slice
+  - Changing the JS/TS/Go discovery, extraction, or fingerprint behavior in any observable way (pure addition; regression-guarded)
+done_when:
+  - A single-crate Rust project (Cargo.toml + src/ with module files and/or dirs) produces an architecture doc listing those modules — today it produces nothing
+  - A Cargo workspace produces a root index + a colocated leaf doc per crate that has src/ modules — the same shape an npm/pnpm/go.work monorepo gets
+  - A dependency added to or removed from a crate's Cargo.toml `[dependencies]` moves that crate's shape-fingerprint (drift is caught)
+  - A mixed JS+Rust monorepo introspects both the JS and the Rust packages; the JS packages are byte-identical to today
+  - JS/TS and Go behavior is unchanged (no regression); `safeword architecture --check` still passes on this repo
+  - All scenarios in features/architecture-rust-language-pack.feature pass via the BDD lane; full suite green
+---
+
+# Rust language pack — Cargo workspace discovery, src extraction, Cargo.toml fingerprint
+
+**Goal:** Teach the generated architecture doc to introspect **Rust** projects —
+single-crate and Cargo workspace — so a crate gets real structural extraction (its
+top-level `src/` modules, files _and_ dirs) and Cargo dependency-drift detection,
+instead of the "not introspected" marker. Second WBM8JE language pack; reuses the
+seam ZD70P1 proved for Go.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Parent epic
+
+Second slice of **WBM8JE** (per-language extractors), after **ZD70P1** (Go). The
+three-axis seam — discovery source + manifest-keyed `extractSkeleton` branch +
+manifest dependency set — is now proven twice; Python is the third slice.
+
+## Resolved design (grounded in the seams + Rust conventions)
+
+Verified against doc.rust-lang.org/cargo (this session): `[workspace] members =
+["crates/*", …]` is an array of path globs; a Rust module is `src/<name>.rs` OR
+`src/<name>/` (dir), with `src/lib.rs` / `src/main.rs` the crate roots. So, unlike
+Go (dirs only) and TS (dirs by convention), **Rust needs files-and-dirs extraction**
+— dir-only would leave most real crates "not introspected".
+
+1. **Extraction** — `extractSkeleton`: dispatch on `Cargo.toml` → list `src/`
+   subdirectories AND `src/*.rs` files, minus the `lib.rs`/`main.rs` roots. (TS
+   `src/`-dir and Go branches unchanged; a pure TS/Go repo never has a Cargo.toml.)
+2. **Discovery** — `detectCargoWorkspace` (TOML-subset `members` array parse) appended
+   to the `??` chain; keep-predicate gains `Cargo.toml`.
+3. **Fingerprint** — union the `[dependencies]`/`[dev-dependencies]`/`[build-dependencies]`
+   table keys into the dependency set.
+
+**Rejected:** a TOML library dependency (the zero-dep posture holds — parse only the
+documented subset and degrade gracefully, like the go.mod/pnpm hand-parses); a Rust
+AST/`cargo metadata` shell-out (heavy, needs a toolchain); inter-crate edges and
+module nesting (their own concerns).
+
+## Open questions
+
+- none — the files-vs-dirs extraction fork is resolved (files-and-dirs, per Rust
+  convention); TOML edge cases (`exclude`, workspace-dep inheritance, multi-line
+  inline tables) are explicit out-of-scope limitations, not open questions.
+
+## Work Log
+
+- 2026-06-24T04:07:49.850Z Started: Created ticket YKFA5X.
+- 2026-06-24T04:12:00Z Intake: sliced WBM8JE → Rust pack second (TOML manifest seam;
+  src/ extraction partly reused). Verified Cargo workspace + Rust module layout
+  against primary docs. Key resolved fork: Rust extraction lists src/ files AND dirs
+  (Rust modules are commonly files), a manifest-keyed branch mirroring Go. TOML
+  hand-parsed (zero-dep posture; only a transitive `toml` exists, unsafe to rely on,
+  and the CLI must run under Node). Next: define-behavior.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
@@ -2,7 +2,7 @@
 id: YKFA5X
 slug: architecture-rust-language-pack
 type: feature
-phase: scenario-gate
+phase: implement
 status: in_progress
 created: 2026-06-24T04:07:49.850Z
 last_modified: 2026-06-24T04:12:00.000Z
@@ -82,3 +82,10 @@ module nesting (their own concerns).
   (Rust modules are commonly files), a manifest-keyed branch mirroring Go. TOML
   hand-parsed (zero-dep posture; only a transitive `toml` exists, unsafe to rely on,
   and the CLI must run under Node). Next: define-behavior.
+- 2026-06-24T04:15:00Z Complete: scenario-gate. Independent /review-spec PASS-WITH-NITS
+  (verified every scenario is RED today for a NEW-behavior reason; vacuity, AODI,
+  marker-distinctness, drift-observability all checked). Addressed the required fix
+  (recorded the new `does not list the module` step in the ledger) + both nits
+  (file-module Givens on S2/S4/S5, load-bearing-RED note). Stamp recorded; impl-plan
+  written (TOML-subset parser first, then extraction keystone, discovery, fingerprint).
+  Advancing to implement.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
@@ -2,7 +2,7 @@
 id: YKFA5X
 slug: architecture-rust-language-pack
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 created: 2026-06-24T04:07:49.850Z
 last_modified: 2026-06-24T04:12:00.000Z

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
@@ -2,8 +2,8 @@
 id: YKFA5X
 slug: architecture-rust-language-pack
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-06-24T04:07:49.850Z
 last_modified: 2026-06-24T04:12:00.000Z
 scope:
@@ -90,3 +90,10 @@ module nesting (their own concerns).
   (file-module Givens on S2/S4/S5, load-bearing-RED note). Stamp recorded; impl-plan
   written (TOML-subset parser first, then extraction keystone, discovery, fingerprint).
   Advancing to implement.
+- 2026-06-24T05:29:00Z Closed. Done-gate: /verify green (3421 pass / 5 skip, 6 Rust
+  - 20 architecture BDD scenarios), /audit 0 errors (1 accepted import-boilerplate
+    clone), /quality-review TWO passes APPROVE (pass 1 found + fixed 2 silent-wrong Cargo
+    members-parser bugs; pass 2 broad — empirically verified extraction/discovery/
+    fingerprint/regression, no changes). /refactor scout: code clean; the cross-language
+    4-site parallelism (Generalize-the-Mechanism) deferred to the Python slice as its
+    opening refactor. impl-plan reconciled to implemented. phase=done.

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/ticket.md
@@ -19,6 +19,7 @@ out_of_scope:
   - Module CONTENTS / nesting — only the TOP-level `src/` modules are listed; `src/foo/bar.rs`, a module's internals, and `mod.rs` resolution are out
   - `[workspace.dependencies]` inheritance, target-specific deps, optional/feature deps, build-target tables — out (the three flat dependency tables cover the common case)
   - Mixed ROOT polyglot where both a Cargo `[workspace]` and `package.json` workspaces sit at the repo root — JS wins the `??` chain; a noted limitation
+  - Cross-manifest dependency-name masking — a single directory carrying BOTH a `package.json` and a `Cargo.toml` that share a literal dependency name unions to one fingerprint entry, so dropping it from one manifest while it survives in the other does not move the fingerprint (a contrived polyglot-leaf edge surfaced by the done-gate /quality-review; documented, not code-changed in this slice)
   - Python language pack — separate WBM8JE slice
   - Changing the JS/TS/Go discovery, extraction, or fingerprint behavior in any observable way (pure addition; regression-guarded)
 done_when:

--- a/.project/tickets/YKFA5X-architecture-rust-language-pack/verify.md
+++ b/.project/tickets/YKFA5X-architecture-rust-language-pack/verify.md
@@ -1,0 +1,33 @@
+# Verify: Rust language pack (YKFA5X)
+
+## Verify Checklist
+
+**Test Suite:** ✅ Full suite green — 3419 passed / 5 skipped (226 files, VITEST_EXIT=0). 26 new unit tests (cargo-manifest 13, skeleton 5, monorepo 5, fingerprint 3).
+**Gherkin:** ✅ 6 new Rust scenarios pass; 20 architecture scenarios green together (6 Rust + 7 Go + 7 monorepo), 0 failures.
+**Build:** ✅ Success (CLI runs from source in the BDD lane; dogfood `--check` exits 0).
+**Lint:** ✅ Clean (eslint per-file; the two block-parsers and scanners under the complexity bar, iterator helpers + linear regexes).
+**Scenarios:** All 6 scenarios R/G/R (0afd962).
+**Dep Drift:** ✅ Clean — zero new dependencies (Cargo.toml parsed by a hand-rolled subset reader).
+**Parent Epic:** WBM8JE (per-language extractors); second slice after ZD70P1 (Go).
+**Reconcile:** ✅ No pattern deviation — Cargo plugs into `discoverLeafDirectories` via the `??` chain, `extractSkeleton` via a manifest-keyed branch (like Go), and the fingerprint dependency set (like go.mod). The `cargo-manifest.ts` module co-locates all three Cargo readers (impl-plan "Known deviations" — three readers shipping together justify a module now; the cross-language merge waits for Python).
+
+## Evidence
+
+- **Independent scenario-gate review** (fresh context, `/review-spec`): PASS-WITH-NITS. Verified every scenario is RED today for a NEW-behavior reason (file extraction / Cargo discovery / keep-predicate / Cargo fingerprint), AODI, marker-distinctness, and drift-observability. Addressed the required fix (recorded the new `does not list the module` step in the ledger) + both nits (file-module Givens, load-bearing-RED note).
+- **Three-axis extraction + parser** — verified by unit + black-box fixtures:
+  - **Parser:** `cargo-manifest.ts` reads the `[workspace] members` array (multi-line + inline), the `[package] name` (table-scoped, not fooled by `[[bin]]`), and dependency keys across the three flat tables + `[dependencies.<name>]` sub-tables. 13 unit tests; degrades to empty/undefined outside the documented subset.
+  - **Extraction:** `extractSkeleton` dispatches on `Cargo.toml` to list `src/` files AND dirs, minus `lib.rs`/`main.rs` (proven against the dir-only baseline); `src/`-dir (TS) and `go.mod` (Go) branches unchanged.
+  - **Discovery/identity:** `detectCargoWorkspace` is the fourth `??` source; the keep-predicate accepts a Cargo-only directory; crate name from `[package] name`.
+  - **Fingerprint:** Cargo dependency keys join the shape set (versions excluded) — proven black-box via `architecture --check` going stale on a dep add.
+- **Audit:** 0 errors / 1 accepted warning — config in sync, depcruise 0 violations (159 modules, no cycles), no new dead code, zero new deps. The one jscpd clone is the 13-line import block shared by the Go and Rust step files (import boilerplate that appeared _because_ the real `runArchitecture` logic was deduped into `architecture-fixtures`) — benign, not logic duplication, and the repo broadly tolerates clones (not a CI gate).
+- **Dogfood:** this TS repo's `architecture --check` exits 0 with zero doc changes — the Rust pack is a pure addition (no Cargo.toml here), no JS/TS/Go regression.
+
+## Scope honesty
+
+Per ticket.md out_of_scope, these are explicit, visible limitations: Cargo `[workspace] exclude` (over-inclusion, not silent drop), inter-crate edges (no edges rendered for Rust leaves), module nesting / `mod.rs`, `[workspace.dependencies]` inheritance and inline-table/feature/target deps, and both-config-at-root polyglot (JS wins the `??` chain). A root-only crate stays the honest "not introspected" marker.
+
+## Audit
+
+Audit passed — 0 errors, 1 accepted warning (import-boilerplate clone). No circular
+dependencies or layer violations, no new dead code, no logic duplication, config in
+sync, zero new dependencies, test quality verified.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/dimensions.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/dimensions.md
@@ -1,0 +1,39 @@
+# Dimensions: Go language pack (ZD70P1)
+
+| Dimension          | Partitions                                                                                  | Source      |
+| ------------------ | ------------------------------------------------------------------------------------------- | ----------- |
+| Project shape      | single-repo (no workspaces) · go.work monorepo · JS-rooted monorepo containing a Go package | TB1, TB2    |
+| Source layout      | Go layout (cmd/internal/pkg) · `src/` (JS/TS) · flat Go (only top-level .go, no recognized) | TB1.AC1     |
+| Discovery source   | go.work `use` · package.json workspaces (JS) · none                                         | TB1.AC2     |
+| go.work parse      | readable block/single-line `use` · one unreadable entry skipped, readable survive           | TB1.AC2     |
+| Fingerprint input  | go.mod `require` set · package.json deps                                                    | TB2.AC1     |
+| Regression surface | JS single-repo output · JS leaf output in a polyglot monorepo (must be unchanged)           | TB2.AC2/AC3 |
+
+## Partition → scenario mapping
+
+- single-repo × Go layout → TB1.AC1 (single module doc lists cmd/internal/pkg).
+- go.work monorepo × Go layout → TB1.AC2 (root index + Go leaf doc).
+- go.work monorepo × flat Go → TB1.AC1 honesty edge ("not introspected", no leaf).
+- go.work × one unreadable entry → TB1.AC2 robustness (a readable sibling package
+  is still introspected — proves the parser ran and skipped the bad entry, not the
+  whole file; a pure-degrade "no leaves" assertion would pass vacuously today).
+- JS-rooted monorepo × (src + Go layout) → TB2.AC2 (both introspected).
+- single-repo × src → TB2.AC3 (JS module doc unchanged — regression guard).
+- go.mod require add/remove → TB2.AC1, BLACK-BOX: the shape-fingerprint is written
+  into the doc frontmatter and surfaced by `architecture --check`, so adding a
+  require makes the doc go stale (`--check` reports it). A unit test pins the
+  fingerprint composition beneath it. (Corrected from an earlier wrong "not
+  observable in the rendered doc" claim — the scenario-gate review caught it.)
+
+## Boundary notes
+
+- **Extraction precedence:** `src/` wins when present (TS stays byte-identical);
+  Go layout is read only when there is a `go.mod` and no `src/` tree.
+- **Discovery precedence:** `package.json workspaces` ?? `pnpm-workspace.yaml` ??
+  `go.work`. A JS-rooted monorepo containing a Go package still discovers the Go
+  package because the keep-predicate is "has package.json OR go.mod".
+- **Go identity:** leaf name = `go.mod` `module` directive, fallback directory
+  basename (mirrors JS using package.json `name`).
+- **Out of scope here:** inter-package Go edges (module-path→dir), both go.work and
+  package.json workspaces at the repo root (JS wins — noted), go.mod `replace` /
+  build tags / sub-modules, Rust and Python (separate WBM8JE slices).

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/impl-plan.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/impl-plan.md
@@ -1,78 +1,80 @@
 # Impl Plan: Go language pack (ZD70P1)
 
-Outside-in TDD. Three production seams + a black-box step file. Order is chosen so
-the keystone (extraction) lands first and immediately turns single-repo Go scenarios
-green, then discovery wires the monorepo, then fingerprint closes drift.
+**Status:** implemented
 
-## Production changes (by axis)
+_Reconciled against what shipped: all six Decisions held as written (no
+mid-build reversals); Arch alignment holds (pure derive/parse, honest "not
+introspected" for flat Go, JS byte-identical); the one addition beyond the
+original plan — the `manifest-block.ts` / `manifest-dependencies.ts` extraction —
+is recorded under Known deviations (an `/audit`-driven, behavior-preserving
+dedup)._
 
-### Axis 2 — Extraction (keystone): `architecture-skeleton.ts`
+## Approach
 
-- `extractSkeleton(dir)`: keep the `src/` branch FIRST and unchanged (TS byte-identical).
-  When `src/` is absent/empty AND `dir/go.mod` exists, enumerate the recognized Go
-  layout dirs that are present — `cmd`, `internal`, `pkg` — as nodes, each
-  `path: "<name>"`, sorted, placeholder purpose. Flat Go (none present) → `{nodes: []}`
-  (stays "not introspected").
-- Node `path` for Go is the bare dir name (no `src/` prefix); the renderer just
-  prints it in a code span, so this is fine and platform-stable.
+Outside-in TDD over three production seams + a black-box step file. The extractor
+is convention-driven (it enumerates directories), not language-parsing, so each
+axis is a small extension point. Build order — keystone first so single-repo Go
+turns green immediately, then discovery wires the monorepo, then fingerprint closes
+drift:
 
-### Axis 1 — Discovery: `architecture-monorepo.ts`
+1. **Extraction (keystone)** — `architecture-skeleton.ts`: `src/` stays
+   authoritative (TS byte-identical); when it yields nothing and a `go.mod` is
+   present, enumerate the recognized Go layout dirs (`cmd`/`internal`/`pkg`) as
+   modules. Flat Go → empty skeleton. _Unit_ (`architecture-skeleton.test.ts`).
+   Fixes single-repo Go AND monorepo Go leaves at once, and feeds the fingerprint's
+   `moduleNames` for free.
+2. **Discovery** — `architecture-monorepo.ts`: `detectGoWork` (dependency-free
+   `use` parse) appended to the `??` source chain; keep-predicate generalized to
+   "has package.json OR go.mod"; Go package name from the `go.mod` `module`
+   directive. _Unit_ (`architecture-monorepo.test.ts`).
+3. **Fingerprint** — `architecture-fingerprint.ts`: union the `go.mod` `require`
+   module paths (keys, not versions) into the dependency set. _Unit_
+   (`architecture-fingerprint.test.ts`).
+4. **Black-box BDD + dogfood** — `steps/architecture-go-language-pack.steps.ts`
+   over real fixtures; the dependency-drift AC is proven via `architecture --check`
+   reporting stale. Shared fixture helpers extracted to
+   `steps/support/architecture-fixtures.ts` (imported by the ZRW21K lane too).
 
-- `detectGoWork(projectDirectory)`: dependency-free parse of `go.work`, mirroring
-  `detectPnpmWorkspaces`. Collect `use` targets from both the block form
-  `use (\n  ./a\n  ./b\n)` and single-line `use ./a`. Skip blanks, comments (`//`),
-  and any entry that isn't a clean relative path (the "unreadable entry" is skipped,
-  not fatal). Return the relative dirs, or `undefined` when no `use` target parses.
-- `discoverLeafDirectories`: extend the source chain to
-  `detectWorkspaces(...) ?? detectPnpmWorkspaces(...) ?? detectGoWork(...)`.
-- Generalize the keep-predicate: keep a globbed dir if it has `package.json` OR
-  `go.mod` (extract a `hasRecognizedManifest(dir)` helper). go.work `use` targets are
-  exact dirs (not globs), but route them through the same glob/keep path for one
-  code path — `globSync` on a literal relative path returns it.
-- `packageName(dir)`: if no package.json name, and `go.mod` exists, read its `module`
-  directive (first `module <path>` line); fallback basename. Keep JS path first.
+Test-layer rationale: parse/extract/fingerprint are pure → unit; which docs appear
+and what `--check` reports are a process-boundary contract → the `.feature` lane.
 
-### Axis 3 — Fingerprint: `architecture-fingerprint.ts`
+## Decisions
 
-- `readDependencyNames(dir)`: union the existing package.json dep names with
-  `readGoModRequires(dir)` — the module paths from `go.mod`'s `require` block (both
-  the `require (\n  path v1\n)` block and single-line `require path v1`), keys only,
-  versions excluded. So a require add/remove moves `shapeFingerprint`. JS-only dirs
-  are unaffected (no go.mod → empty Go set).
+| Decision         | Choice                                                                | Alternatives considered                | Rejected because                                                                        |
+| ---------------- | --------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
+| Go extraction    | Directory-convention enumeration of `cmd`/`internal`/`pkg`            | Parse Go source / use the Go toolchain | Conventions are deterministic and dependency-free; matches the pnpm/go.work hand-parses |
+| src vs Go layout | `src/` wins; Go layout read only when no `src/` and a `go.mod` exists | Merge both                             | Keeps every TS/JS doc byte-identical — zero regression surface                          |
+| Discovery wiring | `detectGoWork` appended to `??` chain after JS/pnpm                   | Fold into shared `detectWorkspaces`    | That feeds `sync-config`; scoping go.work to the architecture feature avoids drift      |
+| Leaf predicate   | keep a dir with package.json **OR** go.mod                            | package.json only                      | Go leaves have no package.json — they'd be silently dropped                             |
+| Drift coverage   | Black-box scenario via `architecture --check` + a unit pin            | Unit test only                         | Scenario-gate review: the fingerprint IS observable (frontmatter + `--check`)           |
+| Go identity      | `go.mod` `module` directive, fallback basename                        | Always basename                        | The module path is the canonical identity, mirroring package.json `name`                |
 
-## Test changes
+## Arch alignment
 
-### Unit (RED→GREEN per axis, fast)
+Honors `ARCHITECTURE.md` and the state-doc contract:
 
-- `architecture-skeleton.test.ts`: Go layout extraction; src/ precedence; flat Go → empty.
-- `architecture-monorepo.test.ts`: detectGoWork block + single-line + skip-bad-entry
-  - no-use → undefined; discovery via go.work; mixed keep-predicate.
-- `architecture-fingerprint.test.ts`: go.mod require add/removes the fingerprint;
-  JS fingerprint untouched.
-
-### Black-box BDD: `steps/architecture-go-language-pack.steps.ts`
-
-- **Helper sharing (avoid jscpd clones with ZRW21K's steps):** the dir/rootDoc/
-  leafDocExists/packageSection/writeJson helpers are near-identical to
-  `steps/monorepo-coverage-honesty.steps.ts`. Extract them to
-  `steps/support/architecture-fixtures.ts` and import from BOTH step files (refactor
-  ZRW21K's file to import too — behavior-preserving, keeps the audit's 0-clone bar).
-- Reuse the shared `When 'safeword generates the architecture doc'` and the generic
-  Thens (`a root index lists the package`, `has its own colocated leaf doc`,
-  `is marked "..." in the root index`, `line does not show the "..." placeholder`,
-  `single-repo module doc`, `the command succeeds`) — do NOT redefine (cucumber
-  global registry → duplicate-step error).
-- New Go Givens (write go.mod/go.work/cmd/internal/pkg fixtures); new Thens
-  `the doc lists the module "<name>"`, `safeword reports the architecture doc is stale`;
-  new Whens `a require is added to its go.mod`, `safeword checks the architecture doc`
-  (runs `architecture --check`, captures exit).
-- **Scenario-4 fixture (review note):** a valid `use ./svc` PLUS one junk line the
-  parser skips — proves partial-skip, not total-degrade.
+- **Deterministic, LLM-free engine** — extraction/discovery/fingerprint are pure
+  derive/parse; no new source of truth, no LLM.
+- **Never silently wrong** — a flat Go package stays the honest ZRW21K "not
+  introspected" marker; the omission is visible, not faked.
+- **Polyglot promise** — Go plugs into the same heal-target + fingerprint machinery
+  as JS, the seam WBM8JE's Rust/Python slices reuse.
 
 ## Known deviations
 
-- `detectWorkspaces` (the sync-config truth source) stays untouched; go.work plugs in
-  via the `??` chain in `discoverLeafDirectories` only — same scope guard ZRW21K used
-  for pnpm.
-- Out of scope (ticket.md): inter-package Go edges, both-config-at-root polyglot,
-  go.mod replace / build tags / sub-modules, Rust/Python.
+- go.work discovery lives beside `detectWorkspaces` (via the `??` chain), not
+  inside it — a deliberate scope guard so `sync-config` is untouched, mirroring how
+  ZRW21K scoped pnpm.
+- During verify, `/audit` jscpd flagged the new block parsers + the duplicated
+  `DEPENDENCY_SECTIONS` loop; extracted `manifest-block.ts` and
+  `manifest-dependencies.ts` (behavior-preserving) to hold the 0-clone bar.
+
+## Assessment triggers
+
+- **WBM8JE Rust/Python slices** land — they will want Cargo `[workspace]` /
+  `go.work` / pnpm discovery in one place; revisit whether `detectGoWork` /
+  `detectPnpmWorkspaces` should merge into a single multi-manifest discovery.
+- Inter-package Go edges become needed — that requires a `go.mod` module-path →
+  workspace-directory map; its own slice (out of scope here).
+- Go changes its layout conventions or `go.work`/`go.mod` grammar — revisit the
+  hand-parsers and the `cmd`/`internal`/`pkg` recognized set.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/impl-plan.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/impl-plan.md
@@ -1,0 +1,78 @@
+# Impl Plan: Go language pack (ZD70P1)
+
+Outside-in TDD. Three production seams + a black-box step file. Order is chosen so
+the keystone (extraction) lands first and immediately turns single-repo Go scenarios
+green, then discovery wires the monorepo, then fingerprint closes drift.
+
+## Production changes (by axis)
+
+### Axis 2 — Extraction (keystone): `architecture-skeleton.ts`
+
+- `extractSkeleton(dir)`: keep the `src/` branch FIRST and unchanged (TS byte-identical).
+  When `src/` is absent/empty AND `dir/go.mod` exists, enumerate the recognized Go
+  layout dirs that are present — `cmd`, `internal`, `pkg` — as nodes, each
+  `path: "<name>"`, sorted, placeholder purpose. Flat Go (none present) → `{nodes: []}`
+  (stays "not introspected").
+- Node `path` for Go is the bare dir name (no `src/` prefix); the renderer just
+  prints it in a code span, so this is fine and platform-stable.
+
+### Axis 1 — Discovery: `architecture-monorepo.ts`
+
+- `detectGoWork(projectDirectory)`: dependency-free parse of `go.work`, mirroring
+  `detectPnpmWorkspaces`. Collect `use` targets from both the block form
+  `use (\n  ./a\n  ./b\n)` and single-line `use ./a`. Skip blanks, comments (`//`),
+  and any entry that isn't a clean relative path (the "unreadable entry" is skipped,
+  not fatal). Return the relative dirs, or `undefined` when no `use` target parses.
+- `discoverLeafDirectories`: extend the source chain to
+  `detectWorkspaces(...) ?? detectPnpmWorkspaces(...) ?? detectGoWork(...)`.
+- Generalize the keep-predicate: keep a globbed dir if it has `package.json` OR
+  `go.mod` (extract a `hasRecognizedManifest(dir)` helper). go.work `use` targets are
+  exact dirs (not globs), but route them through the same glob/keep path for one
+  code path — `globSync` on a literal relative path returns it.
+- `packageName(dir)`: if no package.json name, and `go.mod` exists, read its `module`
+  directive (first `module <path>` line); fallback basename. Keep JS path first.
+
+### Axis 3 — Fingerprint: `architecture-fingerprint.ts`
+
+- `readDependencyNames(dir)`: union the existing package.json dep names with
+  `readGoModRequires(dir)` — the module paths from `go.mod`'s `require` block (both
+  the `require (\n  path v1\n)` block and single-line `require path v1`), keys only,
+  versions excluded. So a require add/remove moves `shapeFingerprint`. JS-only dirs
+  are unaffected (no go.mod → empty Go set).
+
+## Test changes
+
+### Unit (RED→GREEN per axis, fast)
+
+- `architecture-skeleton.test.ts`: Go layout extraction; src/ precedence; flat Go → empty.
+- `architecture-monorepo.test.ts`: detectGoWork block + single-line + skip-bad-entry
+  - no-use → undefined; discovery via go.work; mixed keep-predicate.
+- `architecture-fingerprint.test.ts`: go.mod require add/removes the fingerprint;
+  JS fingerprint untouched.
+
+### Black-box BDD: `steps/architecture-go-language-pack.steps.ts`
+
+- **Helper sharing (avoid jscpd clones with ZRW21K's steps):** the dir/rootDoc/
+  leafDocExists/packageSection/writeJson helpers are near-identical to
+  `steps/monorepo-coverage-honesty.steps.ts`. Extract them to
+  `steps/support/architecture-fixtures.ts` and import from BOTH step files (refactor
+  ZRW21K's file to import too — behavior-preserving, keeps the audit's 0-clone bar).
+- Reuse the shared `When 'safeword generates the architecture doc'` and the generic
+  Thens (`a root index lists the package`, `has its own colocated leaf doc`,
+  `is marked "..." in the root index`, `line does not show the "..." placeholder`,
+  `single-repo module doc`, `the command succeeds`) — do NOT redefine (cucumber
+  global registry → duplicate-step error).
+- New Go Givens (write go.mod/go.work/cmd/internal/pkg fixtures); new Thens
+  `the doc lists the module "<name>"`, `safeword reports the architecture doc is stale`;
+  new Whens `a require is added to its go.mod`, `safeword checks the architecture doc`
+  (runs `architecture --check`, captures exit).
+- **Scenario-4 fixture (review note):** a valid `use ./svc` PLUS one junk line the
+  parser skips — proves partial-skip, not total-degrade.
+
+## Known deviations
+
+- `detectWorkspaces` (the sync-config truth source) stays untouched; go.work plugs in
+  via the `??` chain in `discoverLeafDirectories` only — same scope guard ZRW21K used
+  for pnpm.
+- Out of scope (ticket.md): inter-package Go edges, both-config-at-root polyglot,
+  go.mod replace / build tags / sub-modules, Rust/Python.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/spec.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/spec.md
@@ -1,0 +1,93 @@
+# Spec: Go language pack — architecture discovery, extraction, fingerprint
+
+## Intent
+
+Teach the generated architecture state-doc to introspect Go projects — both a
+single-repo Go service and a `go.work` monorepo — so a Go package gets real
+structural extraction (its `cmd`/`internal`/`pkg` modules) and Go dependency-drift
+detection, rather than the honest-but-empty "not introspected" marker ZRW21K shows
+today. First of the WBM8JE "language packs"; proves the per-language seam Rust and
+Python reuse.
+
+## Intake Brief
+
+- **Requested by:** Surfaced by the 2026-06-23 `/quality-review` of monorepo
+  coverage (the gap WBM8JE was filed to close); built now as the first slice.
+- **Cost of inaction:** A Go project (single-repo or monorepo) gets no architecture
+  doc, or — in a mixed JS+Go monorepo — its Go packages stay marked "not
+  introspected" indefinitely. The feature reads as "JS-only," undercutting the
+  polyglot promise the guide makes.
+- **Reversibility:** Two-way door. Pure addition behind the existing seam; JS/TS
+  behavior is regression-guarded and unchanged. No data-model or public-API change
+  — the doc format and fingerprint inputs only gain Go-shaped entries.
+
+## References
+
+- Parent epic **WBM8JE** (per-language extractors); itself out-of-scope of epic
+  **QD5DTT** (architecture state docs).
+- **ZRW21K** — the "not introspected" marker this slice replaces with real
+  extraction for Go; its `pnpm-workspace.yaml` block-parse is the template for
+  `detectGoWork`.
+- Seams: `architecture-skeleton.ts` (extraction), `architecture-monorepo.ts`
+  (discovery), `architecture-fingerprint.ts` (drift).
+
+## Personas
+
+- **Technical Builder (TB)** — here, in its polyglot flavor: a developer running an
+  AI coding agent on a repo (or monorepo) that mixes Go with TypeScript, or is pure
+  Go. TB is stack-agnostic by definition (personas.md: "ships Next, Django, Gin,
+  anything"); they want the architecture doc to describe the Go code, not skip it.
+
+## Vocabulary
+
+- **Go layout** — the convention where a module's code lives under top-level
+  `cmd/` (entrypoints), `internal/` (private packages), and `pkg/` (public
+  packages). The recognized structural unit for extraction.
+- **go.work** — Go's workspace file; its `use` directives list member module
+  directories (the Go analogue of `package.json` workspaces).
+- **Introspected** — a discovered package with a recognized source layout (so it
+  gets a real leaf doc), vs. "not introspected" (listed but explicitly undescribed).
+
+## Jobs To Be Done
+
+### architecture-go-language-pack.TB1 — See my Go service's structure in the doc
+
+**Persona:** Technical Builder (TB)
+
+> When I generate the architecture doc for a Go project, I want its `cmd`/`internal`/`pkg`
+> modules listed with the same structure a TypeScript repo gets, so I can review and
+> annotate the real shape instead of an empty placeholder.
+
+#### architecture-go-language-pack.TB1.AC1 — A single-repo Go project produces a doc listing its cmd/internal/pkg modules
+
+#### architecture-go-language-pack.TB1.AC2 — A go.work monorepo produces a root index plus a leaf doc per Go package with a recognized layout
+
+### architecture-go-language-pack.TB2 — Catch Go dependency drift, and never lose my JS docs
+
+**Persona:** Technical Builder (TB)
+
+> When a Go package's dependencies change, I want the architecture doc to register
+> the drift; and when my repo mixes Go and JS, I want both introspected and my
+> existing JS docs untouched, so the doc stays trustworthy across languages.
+
+#### architecture-go-language-pack.TB2.AC1 — Adding/removing a require in a package's go.mod moves that package's shape-fingerprint
+
+#### architecture-go-language-pack.TB2.AC2 — A mixed JS+Go monorepo introspects both, with the JS output byte-identical to today
+
+#### architecture-go-language-pack.TB2.AC3 — A pure JS/TS repo's discovery, extraction, and fingerprint are unchanged (no regression)
+
+## Outcomes
+
+- A Go project — single-repo or `go.work` monorepo — gets a real, structurally
+  accurate architecture doc with zero hand-run commands, identical in shape to what
+  npm/pnpm projects already get.
+- Go dependency drift is a first-class drift signal (fingerprint moves).
+- The polyglot promise holds: mixing Go and JS introspects both; the JS half is
+  provably unchanged.
+
+## Open Questions
+
+- none — resolved during intake against the read seams. Edge cases (inter-package
+  Go edges, flat single-package Go, both-config-at-root polyglot, go.mod replace /
+  build tags / sub-modules) are explicit out-of-scope limitations in ticket.md, not
+  open questions.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/test-definitions.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/test-definitions.md
@@ -1,0 +1,69 @@
+# Test Definitions: Go language pack (ZD70P1)
+
+Feature source: `features/architecture-go-language-pack.feature`
+
+test-definitions.md is the R/G/R ledger. The black-box `.feature` lane proves the
+observable doc-coverage behaviors — including Go dependency drift, which IS
+observable (the shape-fingerprint is written into the doc frontmatter and surfaced
+by `architecture --check`'s exit code; the scenario-gate review corrected an earlier
+wrong "not observable" claim). Fine-grained parser/extractor internals are pinned by
+unit tests as a secondary layer, listed under "Unit-pinned" below.
+
+## Rule: Go projects get real structural extraction and drift detection
+
+### Scenario: A single-repo Go project produces a module doc from its Go layout
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A go.work monorepo produces a root index and per-package leaf docs
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A flat Go package with no recognized layout is marked, not introspected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A go.work with an unreadable entry still introspects its readable packages
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Adding a Go dependency makes the architecture doc go stale
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Polyglot repos introspect both languages without regressing JS
+
+### Scenario: A mixed JS and Go monorepo introspects both packages
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A pure JS single-repo is unchanged by the Go extractor
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Unit-pinned (secondary — fine-grained internals beneath the black-box scenarios)
+
+- **TB2.AC1 fine-grain — fingerprint composition:** adding/removing a `require`
+  module path in a `go.mod` changes `shapeFingerprint` for that directory while a
+  JS package's fingerprint is untouched. (Black-box coverage: the "goes stale"
+  scenario above.) `architecture-fingerprint.test.ts`.
+- **detectGoWork parse:** block `use (...)`, single-line `use ./x`, comments, an
+  unreadable directive skipped while readable entries survive, and a fully
+  unreadable file → `undefined` (no workspaces). `architecture-monorepo.test.ts`.
+- **extractSkeleton Go layout:** `go.mod` + `cmd`/`internal`/`pkg` → those modules;
+  `src/` still wins when present (TS byte-identical); flat Go (no recognized dirs)
+  → empty skeleton. `architecture-skeleton.test.ts`.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/test-definitions.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/test-definitions.md
@@ -13,47 +13,47 @@ unit tests as a secondary layer, listed under "Unit-pinned" below.
 
 ### Scenario: A single-repo Go project produces a module doc from its Go layout
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ### Scenario: A go.work monorepo produces a root index and per-package leaf docs
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ### Scenario: A flat Go package with no recognized layout is marked, not introspected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ### Scenario: A go.work with an unreadable entry still introspects its readable packages
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ### Scenario: Adding a Go dependency makes the architecture doc go stale
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ## Rule: Polyglot repos introspect both languages without regressing JS
 
 ### Scenario: A mixed JS and Go monorepo introspects both packages
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ### Scenario: A pure JS single-repo is unchanged by the Go extractor
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 8677fe9
+- [x] GREEN 8677fe9
+- [x] REFACTOR 8677fe9
 
 ## Unit-pinned (secondary — fine-grained internals beneath the black-box scenarios)
 

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
@@ -2,7 +2,7 @@
 id: ZD70P1
 slug: architecture-go-language-pack
 type: feature
-phase: scenario-gate
+phase: verify
 status: in_progress
 created: 2026-06-24T02:21:10.704Z
 last_modified: 2026-06-24T02:25:00.000Z

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
@@ -1,0 +1,83 @@
+---
+id: ZD70P1
+slug: architecture-go-language-pack
+type: feature
+phase: scenario-gate
+status: in_progress
+created: 2026-06-24T02:21:10.704Z
+last_modified: 2026-06-24T02:25:00.000Z
+scope:
+  - Go module extraction — extractSkeleton recognizes a Go layout (top-level `cmd/`, `internal/`, `pkg/` directories as modules) when a directory has a `go.mod` and no `src/` tree; fixes BOTH single-repo Go (one architecture doc) and monorepo Go leaves (introspected + leaf doc) with one change
+  - go.work discovery — detectGoWork reads the `use (...)` block (and single-line `use ./x`) as a workspace source, after the JS sources (package.json workspaces ?? pnpm-workspace.yaml ?? go.work); dependency-free parse mirroring detectPnpmWorkspaces
+  - Generalized leaf predicate — discoverLeafDirectories keeps a discovered directory that has a recognized manifest (`package.json` OR `go.mod`), so Go leaves are not filtered out
+  - Go fingerprint input — the shape-fingerprint's dependency set includes the `go.mod` `require` module paths (keys, not versions), so Go dependency drift moves the leaf/single-repo fingerprint
+  - Go package identity — a Go leaf's name comes from the `go.mod` `module` directive (fallback: directory basename), mirroring how a JS leaf uses its package.json `name`
+  - Tests (unit + black-box BDD over real Go fixtures: single-repo Go, go.work monorepo, mixed JS+Go monorepo) and a no-regression guarantee for JS/TS repos
+out_of_scope:
+  - Inter-package Go dependency EDGES in the root index (mapping a `go.mod` require module path back to a workspace directory) — defer to a follow-up slice; Go leaves render with no edges in this slice
+  - Flat single-package Go (only `*.go` files at the package root, no cmd/internal/pkg) — stays "not introspected" (honest marker, ZRW21K), a noted limitation
+  - Mixed ROOT polyglot where both `go.work` and `package.json` workspaces sit at the repo root — JS wins the `??` chain; Go-rooted and JS-rooted repos are each handled, the both-at-root case is a noted limitation
+  - `go.mod` `replace` directives, build tags, and nested/sub-modules — out
+  - Rust and Python language packs — separate WBM8JE slices
+  - Changing the JS/TS discovery, extraction, or fingerprint behavior in any observable way (pure addition; regression-guarded)
+done_when:
+  - A single-repo Go project (go.mod + cmd/internal/pkg, no src/) produces an architecture doc listing those modules — today it produces nothing
+  - A go.work monorepo produces a root index + a colocated leaf doc per Go package that has a cmd/internal/pkg layout — same shape an npm/pnpm monorepo gets
+  - A Go dependency added to or removed from a package's `go.mod` require block moves that package's shape-fingerprint (drift is caught)
+  - A mixed JS+Go monorepo introspects both the JS and the Go packages; the JS packages are byte-identical to today
+  - JS/TS single-repo and monorepo behavior is unchanged (no regression); `safeword architecture --check` still passes on this repo
+  - All scenarios in features/architecture-go-language-pack.feature pass via the BDD lane; full suite green
+---
+
+# Go language pack — architecture discovery, extraction, fingerprint
+
+**Goal:** Teach the generated architecture doc to introspect **Go** projects —
+single-repo and go.work monorepo — so a Go package gets real structural extraction
+(its `cmd`/`internal`/`pkg` modules) and Go dependency-drift detection, instead of
+the "not introspected" marker ZRW21K honestly shows today.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Parent epic
+
+First slice of **WBM8JE** (per-language architecture extractors / "language packs",
+itself out-of-scope of epic **QD5DTT**). WBM8JE was deliberately deferred behind
+ZRW21K (make the omission honest first, fill it later). This slice fills it for Go;
+Rust and Python follow as their own slices. The seam proven here — discovery source
+
+- layout-aware `extractSkeleton` + manifest dependency set — is the template the
+  other two packs reuse.
+
+## Resolved design (grounded in the actual seams)
+
+The extractor is convention-driven, not language-parsing: `extractSkeleton` already
+just enumerates the subdirectories of `src/`. Three extension points, one per axis:
+
+1. **Extraction (keystone)** — `extractSkeleton`: keep `src/` first (TS byte-identical),
+   else, when a `go.mod` is present, enumerate top-level `cmd/`/`internal/`/`pkg/`
+   as modules. This single change fixes single-repo Go AND monorepo Go leaves, and
+   feeds the fingerprint's `moduleNames` for free.
+2. **Discovery** — `discoverLeafDirectories`: append `detectGoWork` to the `??`
+   source chain and generalize the keep-predicate from "has package.json" to "has
+   package.json OR go.mod".
+3. **Fingerprint** — `collectShapeInputs`: union the `go.mod` `require` module paths
+   into `dependencyNames`, so Go dep drift is a real drift signal.
+
+**Rejected:** a Go-toolchain/AST dependency (overkill — directory conventions are
+deterministic and dependency-free, consistent with the pnpm/go.work hand-parses);
+inter-package Go edges (a module-path→directory mapping problem, its own slice).
+
+## Open questions
+
+- none — design resolved against the read seams; the edge cases above are explicit
+  out-of-scope limitations to note in the doc/markers, not open questions.
+
+## Work Log
+
+- 2026-06-24T02:21:10.704Z Started: Created ticket ZD70P1.
+- 2026-06-24T02:25:00Z Intake: sliced WBM8JE → Go pack first (cleanest three-axis
+  seam: go.work discovery mirrors pnpm parse, cmd/internal/pkg is convention-deterministic,
+  go.mod require is a simple fingerprint source). Read all three seams
+  (architecture-skeleton/-monorepo/-fingerprint) to ground scope. Keystone =
+  layout-aware extractSkeleton (fixes single-repo + monorepo Go at once). Next:
+  define-behavior.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
@@ -81,3 +81,9 @@ inter-package Go edges (a module-path→directory mapping problem, its own slice
   (architecture-skeleton/-monorepo/-fingerprint) to ground scope. Keystone =
   layout-aware extractSkeleton (fixes single-repo + monorepo Go at once). Next:
   define-behavior.
+- 2026-06-24T03:16:00Z Verify + audit complete. Full suite green against merged
+  main (3387 pass / 5 skip); 7 BDD scenarios + 43 unit tests green; build + lint
+  clean; depcruise 0 violations; jscpd 0 clones (verify-phase dedup → manifest-block
+  - manifest-dependencies); knip no new dead code; zero new deps; dogfood --check
+    current (no JS/TS regression). Rebased cleanly onto origin/main (#355). impl-plan
+    reconciled to implemented. verify.md written. Awaiting confirmation to close.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
@@ -2,8 +2,8 @@
 id: ZD70P1
 slug: architecture-go-language-pack
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-06-24T02:21:10.704Z
 last_modified: 2026-06-24T02:25:00.000Z
 scope:
@@ -94,3 +94,8 @@ inter-package Go edges (a module-path→directory mapping problem, its own slice
   drift undetected); normalizeUseTarget dropped `use ./svc // comment` (idiomatic).
   Fixed both (TDD: 3 new regression tests RED→GREEN); independent re-review APPROVE.
   Full suite green (3390 pass / 5 skip), lint + 14 BDD scenarios clean.
+- 2026-06-24T04:05:00Z Closed. /refactor scout: code already at the right structure
+  (0 actioned, 3 candidates deferred with reasons — black-box/test-layer separations
+  - a rule-of-three go-manifest.ts extraction the impl-plan defers to the Rust/Python
+    slices). Gates: /verify green, /audit 0/0, /quality-review APPROVE (caught + fixed
+    2 critical parser bugs). phase=done. Pushing branch.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/ticket.md
@@ -87,3 +87,10 @@ inter-package Go edges (a module-path→directory mapping problem, its own slice
   - manifest-dependencies); knip no new dead code; zero new deps; dogfood --check
     current (no JS/TS regression). Rebased cleanly onto origin/main (#355). impl-plan
     reconciled to implemented. verify.md written. Awaiting confirmation to close.
+- 2026-06-24T03:49:00Z /quality-review (done-gate, 7-loop ticket): primary-source
+  research (go.dev/ref/mod) + independent reviewer found 2 critical parser bugs the
+  green suite missed (single-block fixtures only): readDelimitedBlock read only the
+  FIRST require/use block (go mod tidy splits indirect deps into a 2nd block →
+  drift undetected); normalizeUseTarget dropped `use ./svc // comment` (idiomatic).
+  Fixed both (TDD: 3 new regression tests RED→GREEN); independent re-review APPROVE.
+  Full suite green (3390 pass / 5 skip), lint + 14 BDD scenarios clean.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/verify.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/verify.md
@@ -1,0 +1,33 @@
+# Verify: Go language pack (ZD70P1)
+
+## Verify Checklist
+
+**Test Suite:** ✅ Full suite green against merged `main` — 3387 passed / 5 skipped (225 files, VITEST_EXIT=0). 43 new unit tests (skeleton 11, fingerprint 10, monorepo 22).
+**Gherkin:** ✅ 7 new Go scenarios pass; full acceptance lane green (156 scenarios, 0 failures).
+**Build:** ✅ Success
+**Lint:** ✅ Clean (eslint + gherkin; the two block-parsers refactored under the complexity bar, regexes literal/linear)
+**Scenarios:** All 7 scenarios R/G/R (8677fe9)
+**Dep Drift:** ✅ Clean — zero new dependencies (Go parsing is dependency-free hand-parsing)
+**Parent Epic:** WBM8JE (per-language extractors); itself out-of-scope of QD5DTT
+**Reconcile:** ✅ No pattern deviation — go.work plugs into `discoverLeafDirectories` via the `??` chain (shared `detectWorkspaces` untouched, the same scope guard ZRW21K used for pnpm); Go extraction reuses `extractSkeleton`'s directory-enumeration shape; Go fingerprint joins the existing dependency-name set. impl-plan reconciled to **implemented** (all six Decisions held).
+
+## Evidence
+
+- **Independent scenario-gate review** (fresh context, `/review-spec`): BLOCK on the first cut — three real findings: (1) the dependency-drift AC (TB2.AC1) was wrongly buried in a unit test on a false "not observable in the doc" premise — the fingerprint IS written to the doc frontmatter (architecture-document.ts:331/:370) and surfaced by `architecture --check`; (2) the unreadable-go.work scenario was vacuously green (passed against current no-go.work code); (3) the flat-Go marker scenario lacked the placeholder-distinctness assertion that blocked ZRW21K. All three reworked (black-box "goes stale" scenario added, scenario reworked to prove partial-skip survival, distinctness assertion restored); re-review **PASS**.
+- **Three-axis extraction** — verified by unit + black-box fixtures:
+  - **Extraction:** `extractSkeleton` reads a Go layout (`cmd`/`internal`/`pkg`) when a `go.mod` is present and no `src/` tree exists; `src/` stays authoritative (TS byte-identical). Fixes single-repo Go AND monorepo Go leaves with one change; flat Go → empty skeleton (honest "not introspected").
+  - **Discovery:** `detectGoWork` (dependency-free `use` block + single-line parse, one bad entry skipped not fatal) is the third source after package.json workspaces / pnpm; keep-predicate generalized to package.json OR go.mod; Go identity from the `go.mod` `module` directive.
+  - **Fingerprint:** `go.mod` `require` module paths (keys, not versions) join the dependency set, so Go dep drift moves `shapeFingerprint` — proven black-box via `architecture --check` going stale.
+- **Audit:** 0 errors / 0 warnings — config in sync, depcruise 0 violations (158 modules, no cycles), jscpd 0 clones, no new dead code (knip), zero new deps, test quality clean.
+- **Refactor (verify phase):** `/audit` jscpd flagged the new block parsers + the duplicated `DEPENDENCY_SECTIONS` loop; extracted `manifest-block.ts` (`readDelimitedBlock`) and `manifest-dependencies.ts` (`dependencySectionNames`), imported by fingerprint + monorepo (and the ZRW21K step lane reuses the shared fixture helpers). Behavior-preserving — 43 unit + 14 architecture BDD scenarios green after.
+- **Dogfood:** this TS repo's `architecture --check` exits 0 with zero doc changes — the Go pack is a pure addition, no JS/TS regression.
+
+## Scope honesty
+
+Per ticket.md out_of_scope, the following are explicit limitations of this slice (each an honest omission, not silent): inter-package Go dependency edges in the root index, both-config-at-root polyglot (JS wins the `??` chain), `go.mod` `replace` / build tags / sub-modules, and Rust/Python (separate WBM8JE slices). A flat single-package Go module (no cmd/internal/pkg) stays the honest "not introspected" marker.
+
+## Audit
+
+Audit passed — 0 errors, 0 warnings. No circular dependencies or layer violations,
+no dead code, no duplication, config in sync, zero new dependencies, test quality
+verified.

--- a/.project/tickets/ZD70P1-architecture-go-language-pack/verify.md
+++ b/.project/tickets/ZD70P1-architecture-go-language-pack/verify.md
@@ -26,6 +26,31 @@
 
 Per ticket.md out_of_scope, the following are explicit limitations of this slice (each an honest omission, not silent): inter-package Go dependency edges in the root index, both-config-at-root polyglot (JS wins the `??` chain), `go.mod` `replace` / build tags / sub-modules, and Rust/Python (separate WBM8JE slices). A flat single-package Go module (no cmd/internal/pkg) stays the honest "not introspected" marker.
 
+## Quality-review cycle (done-gate, ≥2-loop ticket)
+
+`/quality-review` with primary-source research (go.dev/ref/mod, fetched this session)
+
+- an independent fresh-context reviewer found **two critical parser bugs** the
+  unit/BDD suites missed because every fixture used a single block:
+
+* **C1 (HIGH) — multi-block `require` dropped.** `readDelimitedBlock` read only the
+  FIRST `keyword ( … )` block. `go mod tidy` (Go 1.17+) writes indirect deps into a
+  SECOND `require ( … )` block, so all indirect-dep drift went undetected — defeating
+  the headline "Go dep drift is caught" AC. Same root cause for two `use ( … )`
+  blocks in go.work (C2).
+* **Trailing-comment `use` dropped.** `normalizeUseTarget` rejected any entry with
+  whitespace, so the idiomatic `use ./svc // comment` (go.dev's own example) was
+  silently dropped → Go monorepo invisible.
+
+**Fix (one surgical change each, TDD):** `readDelimitedBlock` rewritten to collect
+every matching block and terminate on any `)`-prefixed line (covers `) // comment`);
+`normalizeUseTarget` strips a trailing `//` comment before the junk check. Three
+regression tests added (two-block go.mod fingerprint move; two-`use`-block discovery;
+trailing-comment `use`), each confirmed RED before the fix and GREEN after. Lint +
+typecheck clean; 14 architecture BDD scenarios green; independent re-review verdict
+**APPROVE** (no new defect; multi-block state machine verified against opener-inside-block,
+nested-paren, `)`-leading-entry, and require-vs-replace-bleed vectors).
+
 ## Audit
 
 Audit passed — 0 errors, 0 warnings. No circular dependencies or layer violations,

--- a/features/architecture-go-language-pack.feature
+++ b/features/architecture-go-language-pack.feature
@@ -1,0 +1,66 @@
+@architecture-go-language-pack
+Feature: Go language pack — architecture discovery, extraction, fingerprint
+
+  The generated architecture doc must introspect Go projects the same way it does
+  TypeScript ones: a single-repo Go service and a go.work monorepo each get a real
+  structural doc built from the Go layout (cmd/internal/pkg), Go dependency changes
+  register as drift, and a polyglot repo introspects Go and JS together without
+  disturbing the existing JS output. Incomplete is fine (a flat Go package stays
+  honestly "not introspected"); silently wrong or JS-regressing is not.
+
+  Rule: Go projects get real structural extraction and drift detection
+
+    @architecture-go-language-pack.TB1.AC1
+    Scenario: A single-repo Go project produces a module doc from its Go layout
+      Given a single-repo Go project with cmd, internal, and pkg directories
+      When safeword generates the architecture doc
+      Then the generated doc is a single-repo module doc, not a package root index
+      And the doc lists the module "cmd"
+      And the doc lists the module "internal"
+      And the doc lists the module "pkg"
+
+    @architecture-go-language-pack.TB1.AC2
+    Scenario: A go.work monorepo produces a root index and per-package leaf docs
+      Given a go.work monorepo listing a Go package "svc" with a cmd/internal/pkg layout
+      When safeword generates the architecture doc
+      Then a root index lists the package "svc"
+      And the package "svc" has its own colocated leaf doc
+
+    @architecture-go-language-pack.TB1.AC1
+    Scenario: A flat Go package with no recognized layout is marked, not introspected
+      Given a go.work monorepo with a Go package "flat" that has only top-level Go files
+      When safeword generates the architecture doc
+      Then the package "flat" is marked "not introspected" in the root index
+      And the package "flat" line does not show the "awaiting prose" placeholder
+      And the package "flat" has no colocated leaf doc
+
+    @architecture-go-language-pack.TB1.AC2
+    Scenario: A go.work with an unreadable entry still introspects its readable packages
+      Given a go.work monorepo listing a Go package "svc" with a cmd/internal/pkg layout alongside an unreadable use entry
+      When safeword generates the architecture doc
+      Then the command succeeds
+      And a root index lists the package "svc"
+      And the package "svc" has its own colocated leaf doc
+
+    @architecture-go-language-pack.TB2.AC1
+    Scenario: Adding a Go dependency makes the architecture doc go stale
+      Given a single-repo Go project with cmd, internal, and pkg directories whose architecture doc has been generated
+      When a require is added to its go.mod
+      And safeword checks the architecture doc
+      Then safeword reports the architecture doc is stale
+
+  Rule: Polyglot repos introspect both languages without regressing JS
+
+    @architecture-go-language-pack.TB2.AC2
+    Scenario: A mixed JS and Go monorepo introspects both packages
+      Given a monorepo whose workspaces include a JS package "web" with a src tree and a Go package "svc" with a cmd/internal/pkg layout
+      When safeword generates the architecture doc
+      Then the package "web" has its own colocated leaf doc
+      And the package "svc" has its own colocated leaf doc
+
+    @architecture-go-language-pack.TB2.AC3
+    Scenario: A pure JS single-repo is unchanged by the Go extractor
+      Given a single-repo project with a src tree and no workspace config
+      When safeword generates the architecture doc
+      Then the generated doc is a single-repo module doc, not a package root index
+      And the doc lists the module "core"

--- a/features/architecture-rust-language-pack.feature
+++ b/features/architecture-rust-language-pack.feature
@@ -1,0 +1,59 @@
+@architecture-rust-language-pack
+Feature: Rust language pack — Cargo workspace discovery, src extraction, Cargo.toml fingerprint
+
+  The generated architecture doc must introspect Rust projects the same way it does
+  TypeScript and Go ones: a single-crate project and a Cargo workspace each get a real
+  structural doc built from the crate's top-level src/ modules (files AND directories,
+  excluding the lib.rs/main.rs roots), Cargo dependency changes register as drift, and
+  a polyglot repo introspects Rust and JS together without disturbing the JS output.
+  Incomplete is fine (a root-only crate stays honestly "not introspected"); silently
+  wrong or JS-regressing is not.
+
+  Rule: Rust projects get real structural extraction and drift detection
+
+    @architecture-rust-language-pack.TB1.AC1
+    Scenario: A single-crate Rust project lists its src modules, files and dirs, not the root
+      Given a single-crate Rust project with a module file "config", a module dir "handlers", and a lib.rs root
+      When safeword generates the architecture doc
+      Then the generated doc is a single-repo module doc, not a package root index
+      And the doc lists the module "config"
+      And the doc lists the module "handlers"
+      And the doc does not list the module "lib"
+
+    @architecture-rust-language-pack.TB1.AC2
+    Scenario: A Cargo workspace produces a root index and per-crate leaf docs
+      Given a Cargo workspace listing a crate "svc" with src modules
+      When safeword generates the architecture doc
+      Then a root index lists the package "svc"
+      And the package "svc" has its own colocated leaf doc
+
+    @architecture-rust-language-pack.TB1.AC1
+    Scenario: A crate with only a root file is marked, not introspected
+      Given a Cargo workspace with a crate "bare" that has only a lib.rs root
+      When safeword generates the architecture doc
+      Then the package "bare" is marked "not introspected" in the root index
+      And the package "bare" line does not show the "awaiting prose" placeholder
+      And the package "bare" has no colocated leaf doc
+
+    @architecture-rust-language-pack.TB2.AC1
+    Scenario: Adding a Cargo dependency makes the architecture doc go stale
+      Given a single-crate Rust project with src modules whose architecture doc has been generated
+      When a dependency is added to its Cargo.toml
+      And safeword checks the architecture doc
+      Then safeword reports the architecture doc is stale
+
+  Rule: Polyglot repos introspect every language without regressing JS
+
+    @architecture-rust-language-pack.TB2.AC2
+    Scenario: A mixed JS and Rust monorepo introspects both packages
+      Given a monorepo whose workspaces include a JS package "web" with a src tree and a Rust crate "svc" with src modules
+      When safeword generates the architecture doc
+      Then the package "web" has its own colocated leaf doc
+      And the package "svc" has its own colocated leaf doc
+
+    @architecture-rust-language-pack.TB2.AC3
+    Scenario: A pure JS single-repo is unchanged by the Rust extractor
+      Given a single-repo project with a src tree and no workspace config
+      When safeword generates the architecture doc
+      Then the generated doc is a single-repo module doc, not a package root index
+      And the doc lists the module "core"

--- a/features/architecture-rust-language-pack.feature
+++ b/features/architecture-rust-language-pack.feature
@@ -22,7 +22,7 @@ Feature: Rust language pack — Cargo workspace discovery, src extraction, Cargo
 
     @architecture-rust-language-pack.TB1.AC2
     Scenario: A Cargo workspace produces a root index and per-crate leaf docs
-      Given a Cargo workspace listing a crate "svc" with src modules
+      Given a Cargo workspace listing a crate "svc" with a src module file
       When safeword generates the architecture doc
       Then a root index lists the package "svc"
       And the package "svc" has its own colocated leaf doc
@@ -37,7 +37,7 @@ Feature: Rust language pack — Cargo workspace discovery, src extraction, Cargo
 
     @architecture-rust-language-pack.TB2.AC1
     Scenario: Adding a Cargo dependency makes the architecture doc go stale
-      Given a single-crate Rust project with src modules whose architecture doc has been generated
+      Given a single-crate Rust project with a src module file whose architecture doc has been generated
       When a dependency is added to its Cargo.toml
       And safeword checks the architecture doc
       Then safeword reports the architecture doc is stale
@@ -46,7 +46,7 @@ Feature: Rust language pack — Cargo workspace discovery, src extraction, Cargo
 
     @architecture-rust-language-pack.TB2.AC2
     Scenario: A mixed JS and Rust monorepo introspects both packages
-      Given a monorepo whose workspaces include a JS package "web" with a src tree and a Rust crate "svc" with src modules
+      Given a monorepo whose workspaces include a JS package "web" with a src tree and a Rust crate "svc" with a src module file
       When safeword generates the architecture doc
       Then the package "web" has its own colocated leaf doc
       And the package "svc" has its own colocated leaf doc

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -14,6 +14,7 @@ import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
+import { readCargoDependencyNames } from './cargo-manifest.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 
@@ -75,12 +76,26 @@ function readDependencyNames(projectDirectory: string): string[] {
   // shape, so Go dependency drift moves the fingerprint the same way a package.json
   // dependency change does. A JS-only project has no go.mod, so this is a no-op there.
   for (const goModule of readGoModuleRequires(projectDirectory)) names.add(goModule);
+  // Cargo dependencies (ticket YKFA5X): a crate's Cargo.toml dependency keys are part
+  // of the shape too. A non-Rust project has no Cargo.toml, so this is a no-op there.
+  for (const crate of readCargoDependencies(projectDirectory)) names.add(crate);
   return [...names].toSorted(byString);
 }
 
 function readPackageJsonDependencyNames(projectDirectory: string): string[] {
   const manifest = readJson(nodePath.join(projectDirectory, 'package.json'));
   return manifest === undefined ? [] : dependencySectionNames(manifest);
+}
+
+/** Dependency names from a directory's `Cargo.toml`, or `[]` when there is none. */
+function readCargoDependencies(projectDirectory: string): string[] {
+  try {
+    return readCargoDependencyNames(
+      readFileSync(nodePath.join(projectDirectory, 'Cargo.toml'), 'utf8'),
+    );
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -14,6 +14,8 @@ import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
+import { readDelimitedBlock } from './manifest-block.js';
+import { dependencySectionNames } from './manifest-dependencies.js';
 
 /** Candidate dependency-cruiser config filenames, in resolution order. */
 const DEPENDENCY_CRUISER_CONFIG_NAMES = [
@@ -34,14 +36,6 @@ const SHAPE_SCAN_EXCLUDED_DIRECTORIES = new Set([
   'dist',
   'node_modules',
 ]);
-
-/** Dependency manifest sections whose *keys* contribute to the shape. */
-const DEPENDENCY_SECTIONS = [
-  'dependencies',
-  'devDependencies',
-  'peerDependencies',
-  'optionalDependencies',
-] as const;
 
 /** Stable string ordering for the fingerprint's sorted inputs. */
 const byString = (a: string, b: string): number => a.localeCompare(b);
@@ -86,17 +80,7 @@ function readDependencyNames(projectDirectory: string): string[] {
 
 function readPackageJsonDependencyNames(projectDirectory: string): string[] {
   const manifest = readJson(nodePath.join(projectDirectory, 'package.json'));
-  if (manifest === undefined) return [];
-
-  const names = new Set<string>();
-  for (const section of DEPENDENCY_SECTIONS) {
-    const entry = manifest[section];
-    if (entry !== null && typeof entry === 'object') {
-      for (const name of Object.keys(entry)) names.add(name);
-    }
-  }
-
-  return [...names];
+  return manifest === undefined ? [] : dependencySectionNames(manifest);
 }
 
 /**
@@ -122,15 +106,8 @@ function readGoModuleRequires(projectDirectory: string): string[] {
 
 /** Module paths from the `require (\n … \n)` block, stopping at the closing paren. */
 function collectGoRequireBlock(lines: string[], modules: Set<string>): void {
-  const start = lines.findIndex(line => /^require\s*\(\s*$/.test(line.trim()));
-  if (start === -1) return;
-
-  const blockLines = lines.slice(start + 1);
-  for (const line of blockLines) {
-    const trimmed = line.trim();
-    if (trimmed === ')') break;
-    if (trimmed === '' || trimmed.startsWith('//')) continue;
-    const [modulePath] = trimmed.split(/\s+/);
+  for (const entry of readDelimitedBlock(lines, /^require\s*\(\s*$/)) {
+    const [modulePath] = entry.split(/\s+/);
     if (modulePath !== undefined && modulePath.length > 0) modules.add(modulePath);
   }
 }

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -76,6 +76,15 @@ export function shapeFingerprint(projectDirectory: string): string {
 }
 
 function readDependencyNames(projectDirectory: string): string[] {
+  const names = new Set<string>(readPackageJsonDependencyNames(projectDirectory));
+  // Go module requires (ticket ZD70P1): a `go.mod`'s require set is part of the
+  // shape, so Go dependency drift moves the fingerprint the same way a package.json
+  // dependency change does. A JS-only project has no go.mod, so this is a no-op there.
+  for (const goModule of readGoModuleRequires(projectDirectory)) names.add(goModule);
+  return [...names].toSorted(byString);
+}
+
+function readPackageJsonDependencyNames(projectDirectory: string): string[] {
   const manifest = readJson(nodePath.join(projectDirectory, 'package.json'));
   if (manifest === undefined) return [];
 
@@ -87,7 +96,51 @@ function readDependencyNames(projectDirectory: string): string[] {
     }
   }
 
-  return [...names].toSorted(byString);
+  return [...names];
+}
+
+/**
+ * Module paths from a `go.mod`'s require directives — keys only, versions
+ * excluded (a version bump is noise, like a package.json version bump). Reads both
+ * the `require (\n  path v1\n)` block and single-line `require path v1` forms; a
+ * dependency-free parse, consistent with the go.work / pnpm hand-parses.
+ */
+function readGoModuleRequires(projectDirectory: string): string[] {
+  let content: string;
+  try {
+    content = readFileSync(nodePath.join(projectDirectory, 'go.mod'), 'utf8');
+  } catch {
+    return [];
+  }
+
+  const lines = content.split(/\r?\n/);
+  const modules = new Set<string>();
+  collectGoRequireBlock(lines, modules);
+  collectGoRequireLines(lines, modules);
+  return [...modules].toSorted(byString);
+}
+
+/** Module paths from the `require (\n … \n)` block, stopping at the closing paren. */
+function collectGoRequireBlock(lines: string[], modules: Set<string>): void {
+  const start = lines.findIndex(line => /^require\s*\(\s*$/.test(line.trim()));
+  if (start === -1) return;
+
+  const blockLines = lines.slice(start + 1);
+  for (const line of blockLines) {
+    const trimmed = line.trim();
+    if (trimmed === ')') break;
+    if (trimmed === '' || trimmed.startsWith('//')) continue;
+    const [modulePath] = trimmed.split(/\s+/);
+    if (modulePath !== undefined && modulePath.length > 0) modules.add(modulePath);
+  }
+}
+
+/** Module paths from single-line `require <path> <version>` directives. */
+function collectGoRequireLines(lines: string[], modules: Set<string>): void {
+  for (const line of lines) {
+    const match = /^require\s+(\S+)\s+\S/.exec(line.trim());
+    if (match?.[1] !== undefined) modules.add(match[1]);
+  }
 }
 
 function readBoundaryConfig(projectDirectory: string): string {

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -15,6 +15,7 @@ import { globSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
+import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
 import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
@@ -72,7 +73,8 @@ export function discoverLeafDirectories(projectDirectory: string): string[] {
   const patterns =
     detectWorkspaces(projectDirectory) ??
     detectPnpmWorkspaces(projectDirectory) ??
-    detectGoWork(projectDirectory);
+    detectGoWork(projectDirectory) ??
+    detectCargoWorkspace(projectDirectory);
   if (patterns === undefined) return [];
 
   const matches = new Set<string>();
@@ -93,7 +95,8 @@ export function discoverLeafDirectories(projectDirectory: string): string[] {
 function hasRecognizedManifest(directory: string): boolean {
   return (
     readJson(nodePath.join(directory, 'package.json')) !== undefined ||
-    readFileSafe(nodePath.join(directory, 'go.mod')) !== undefined
+    readFileSafe(nodePath.join(directory, 'go.mod')) !== undefined ||
+    readFileSafe(nodePath.join(directory, 'Cargo.toml')) !== undefined
   );
 }
 
@@ -149,9 +152,14 @@ function readManifest(packageDirectory: string): Record<string, unknown> | undef
 function packageName(packageDirectory: string): string {
   const name = readManifest(packageDirectory)?.name;
   if (typeof name === 'string' && name.length > 0) return name;
-  // A Go package's identity is its go.mod `module` directive (ticket ZD70P1),
-  // the analogue of package.json `name`; fall back to the directory basename.
-  return readGoModuleName(packageDirectory) ?? nodePath.basename(packageDirectory);
+  // A Go package's identity is its go.mod `module` directive and a Rust crate's is
+  // its Cargo.toml `[package] name` (tickets ZD70P1, YKFA5X) — the analogues of
+  // package.json `name`; fall back to the directory basename.
+  return (
+    readGoModuleName(packageDirectory) ??
+    readCargoCrateName(packageDirectory) ??
+    nodePath.basename(packageDirectory)
+  );
 }
 
 /** The `module` path declared in a directory's `go.mod`, if any. */
@@ -159,6 +167,12 @@ function readGoModuleName(packageDirectory: string): string | undefined {
   const content = readFileSafe(nodePath.join(packageDirectory, 'go.mod'));
   if (content === undefined) return undefined;
   return /^module\s+(\S+)/m.exec(content)?.[1];
+}
+
+/** The `[package] name` declared in a directory's `Cargo.toml`, if any. */
+function readCargoCrateName(packageDirectory: string): string | undefined {
+  const content = readFileSafe(nodePath.join(packageDirectory, 'Cargo.toml'));
+  return content === undefined ? undefined : readCargoPackageName(content);
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -270,4 +284,15 @@ function normalizeUseTarget(raw: string): string | undefined {
   const unquoted = noComment.replaceAll(/^["']|["']$/g, '');
   if (unquoted === '' || /\s/.test(unquoted)) return undefined; // empty or multi-token junk
   return unquoted.replace(/^\.\//, '');
+}
+
+/**
+ * Read workspace member globs from a `Cargo.toml` `[workspace] members` array (ticket
+ * YKFA5X) — Cargo stores its workspace list here, not in package.json. Returns the
+ * path globs, or `undefined` when the file is absent or has no parseable members
+ * array (so a single crate, or an unparseable manifest, degrades to no-workspaces).
+ */
+function detectCargoWorkspace(projectDirectory: string): string[] | undefined {
+  const content = readFileSafe(nodePath.join(projectDirectory, 'Cargo.toml'));
+  return content === undefined ? undefined : readCargoWorkspaceMembers(content);
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -71,9 +71,14 @@ export interface MonorepoModel {
  * `package.json`. Returns `[]` for a non-workspace project.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  // package.json `workspaces` wins; pnpm-workspace.yaml is the fallback (pnpm
-  // ignores the package.json field, so a repo with both is npm-authoritative).
-  const patterns = detectWorkspaces(projectDirectory) ?? detectPnpmWorkspaces(projectDirectory);
+  // package.json `workspaces` wins; pnpm-workspace.yaml is the next fallback (pnpm
+  // ignores the package.json field, so a repo with both is npm-authoritative); a
+  // go.work `use` list is the last fallback (ticket ZD70P1), so a Go-rooted
+  // monorepo is discovered when no JS workspace config is present.
+  const patterns =
+    detectWorkspaces(projectDirectory) ??
+    detectPnpmWorkspaces(projectDirectory) ??
+    detectGoWork(projectDirectory);
   if (patterns === undefined) return [];
 
   const matches = new Set<string>();
@@ -81,16 +86,21 @@ export function discoverLeafDirectories(projectDirectory: string): string[] {
     const globMatches = globSync(pattern, { cwd: projectDirectory });
     for (const match of globMatches) {
       const absolute = nodePath.join(projectDirectory, match);
-      if (
-        isDirectory(absolute) &&
-        readJson(nodePath.join(absolute, 'package.json')) !== undefined
-      ) {
+      if (isDirectory(absolute) && hasRecognizedManifest(absolute)) {
         matches.add(absolute);
       }
     }
   }
 
   return [...matches].toSorted(byString);
+}
+
+/** A discovered directory is a leaf package if it carries a recognized manifest. */
+function hasRecognizedManifest(directory: string): boolean {
+  return (
+    readJson(nodePath.join(directory, 'package.json')) !== undefined ||
+    readFileSafe(nodePath.join(directory, 'go.mod')) !== undefined
+  );
 }
 
 /** The package/edge model the root index renders over. */
@@ -144,7 +154,17 @@ function readManifest(packageDirectory: string): Record<string, unknown> | undef
 
 function packageName(packageDirectory: string): string {
   const name = readManifest(packageDirectory)?.name;
-  return typeof name === 'string' && name.length > 0 ? name : nodePath.basename(packageDirectory);
+  if (typeof name === 'string' && name.length > 0) return name;
+  // A Go package's identity is its go.mod `module` directive (ticket ZD70P1),
+  // the analogue of package.json `name`; fall back to the directory basename.
+  return readGoModuleName(packageDirectory) ?? nodePath.basename(packageDirectory);
+}
+
+/** The `module` path declared in a directory's `go.mod`, if any. */
+function readGoModuleName(packageDirectory: string): string | undefined {
+  const content = readFileSafe(nodePath.join(packageDirectory, 'go.mod'));
+  if (content === undefined) return undefined;
+  return /^module\s+(\S+)/m.exec(content)?.[1];
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -208,4 +228,64 @@ function collectPnpmGlobs(blockLines: string[]): string[] {
     if (glob.length > 0 && !glob.startsWith('!')) globs.push(glob);
   }
   return globs;
+}
+
+/**
+ * Read workspace member directories from `go.work` (ticket ZD70P1) — Go stores its
+ * workspace list in `use` directives, not in package.json. A dependency-free parse
+ * of both forms:
+ *
+ *   use ./svc                 // single-line
+ *   use (                     // block
+ *       ./svc
+ *       ./gateway
+ *   )
+ *
+ * Returns the member directories (leading `./` stripped, quotes removed), or
+ * `undefined` when the file is absent or no `use` target parses. An entry that is
+ * not a clean relative path (e.g. junk, or a multi-token line) is skipped, not
+ * fatal — a single unreadable entry never blinds the rest (incomplete, never
+ * silently wrong).
+ */
+function detectGoWork(projectDirectory: string): string[] | undefined {
+  const content = readFileSafe(nodePath.join(projectDirectory, 'go.work'));
+  if (content === undefined) return undefined;
+
+  const lines = content.split(/\r?\n/);
+  const directories: string[] = [];
+  collectGoWorkBlock(lines, directories);
+  collectGoWorkSingleLines(lines, directories);
+  return directories.length > 0 ? directories : undefined;
+}
+
+/** Member directories from a `use (\n  ./x\n)` block, stopping at the closing paren. */
+function collectGoWorkBlock(lines: string[], directories: string[]): void {
+  const start = lines.findIndex(line => /^use\s*\(\s*$/.test(line.trim()));
+  if (start === -1) return;
+
+  const blockLines = lines.slice(start + 1);
+  for (const line of blockLines) {
+    const trimmed = line.trim();
+    if (trimmed === ')') break;
+    if (trimmed === '' || trimmed.startsWith('//')) continue;
+    const target = normalizeUseTarget(trimmed);
+    if (target !== undefined) directories.push(target);
+  }
+}
+
+/** Member directories from single-line `use ./x` directives (ignores the block opener). */
+function collectGoWorkSingleLines(lines: string[], directories: string[]): void {
+  for (const line of lines) {
+    const match = /^use\s+(\S.*)$/.exec(line.trim());
+    if (match?.[1] === undefined || match[1].startsWith('(')) continue;
+    const target = normalizeUseTarget(match[1]);
+    if (target !== undefined) directories.push(target);
+  }
+}
+
+/** A clean relative member dir (quotes + leading `./` stripped), or undefined if junk. */
+function normalizeUseTarget(raw: string): string | undefined {
+  const unquoted = raw.trim().replaceAll(/^["']|["']$/g, '');
+  if (unquoted === '' || /\s/.test(unquoted)) return undefined; // empty or multi-token junk
+  return unquoted.replace(/^\.\//, '');
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -261,9 +261,13 @@ function collectGoWorkSingleLines(lines: string[], directories: string[]): void 
   }
 }
 
-/** A clean relative member dir (quotes + leading `./` stripped), or undefined if junk. */
+/** A clean relative member dir (trailing comment, quotes + leading `./` stripped), or undefined if junk. */
 function normalizeUseTarget(raw: string): string | undefined {
-  const unquoted = raw.trim().replaceAll(/^["']|["']$/g, '');
+  // A `use ./svc // comment` entry is idiomatic Go (the docs' own example); strip
+  // the trailing comment before the junk check, or the whole entry is dropped.
+  const commentAt = raw.indexOf('//');
+  const noComment = (commentAt === -1 ? raw : raw.slice(0, commentAt)).trim();
+  const unquoted = noComment.replaceAll(/^["']|["']$/g, '');
   if (unquoted === '' || /\s/.test(unquoted)) return undefined; // empty or multi-token junk
   return unquoted.replace(/^\.\//, '');
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -17,6 +17,8 @@ import nodePath from 'node:path';
 import { extractSkeleton } from './architecture-skeleton.js';
 import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
+import { readDelimitedBlock } from './manifest-block.js';
+import { dependencySectionNames } from './manifest-dependencies.js';
 
 /** Placeholder purpose for a freshly modelled package awaiting prose. */
 const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
@@ -28,14 +30,6 @@ const DEPENDENCY_CRUISER_CONFIG_NAMES = [
   '.dependency-cruiser.mjs',
   '.dependency-cruiser.json',
 ];
-
-/** Manifest sections whose workspace-internal keys become inter-package edges. */
-const DEPENDENCY_SECTIONS = [
-  'dependencies',
-  'devDependencies',
-  'peerDependencies',
-  'optionalDependencies',
-] as const;
 
 const byString = (a: string, b: string): number => a.localeCompare(b);
 
@@ -169,16 +163,7 @@ function readGoModuleName(packageDirectory: string): string | undefined {
 
 function manifestDependencyNames(packageDirectory: string): string[] {
   const manifest = readManifest(packageDirectory);
-  if (manifest === undefined) return [];
-
-  const names = new Set<string>();
-  for (const section of DEPENDENCY_SECTIONS) {
-    const entry = manifest[section];
-    if (entry !== null && typeof entry === 'object') {
-      for (const name of Object.keys(entry)) names.add(name);
-    }
-  }
-  return [...names];
+  return manifest === undefined ? [] : dependencySectionNames(manifest);
 }
 
 function readBoundaryConfig(projectDirectory: string): string {
@@ -260,15 +245,8 @@ function detectGoWork(projectDirectory: string): string[] | undefined {
 
 /** Member directories from a `use (\n  ./x\n)` block, stopping at the closing paren. */
 function collectGoWorkBlock(lines: string[], directories: string[]): void {
-  const start = lines.findIndex(line => /^use\s*\(\s*$/.test(line.trim()));
-  if (start === -1) return;
-
-  const blockLines = lines.slice(start + 1);
-  for (const line of blockLines) {
-    const trimmed = line.trim();
-    if (trimmed === ')') break;
-    if (trimmed === '' || trimmed.startsWith('//')) continue;
-    const target = normalizeUseTarget(trimmed);
+  for (const entry of readDelimitedBlock(lines, /^use\s*\(\s*$/)) {
+    const target = normalizeUseTarget(entry);
     if (target !== undefined) directories.push(target);
   }
 }

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -24,6 +24,12 @@ const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
  */
 const GO_LAYOUT_DIRECTORIES = ['cmd', 'internal', 'pkg'] as const;
 
+/**
+ * Crate-root files of a Rust crate (ticket YKFA5X) — entry points, not modules, so
+ * they are excluded from the listed `src/` modules.
+ */
+const RUST_ROOT_FILES = new Set(['lib.rs', 'main.rs']);
+
 export interface SkeletonNode {
   /** Module name — the top-level `src/` subdirectory. */
   name: string;
@@ -39,6 +45,14 @@ export interface Skeleton {
 }
 
 export function extractSkeleton(projectDirectory: string): Skeleton {
+  // A Rust crate (a `Cargo.toml` is present) is described by its top-level `src/`
+  // modules — files AND directories, since a Rust module can be either — minus the
+  // `lib.rs`/`main.rs` crate roots (ticket YKFA5X). Dispatched before the plain
+  // src-dir path so a crate's file modules are not lost.
+  if (exists(nodePath.join(projectDirectory, 'Cargo.toml'))) {
+    return { nodes: rustModuleNodes(projectDirectory) };
+  }
+
   // The `src/` layout (TS/JS) is authoritative and unchanged: when it yields
   // modules, that is the skeleton.
   const sourceNodes = enumerateModuleDirectories(
@@ -85,6 +99,46 @@ function enumerateModuleDirectories(
 function goLayoutNodes(projectDirectory: string): SkeletonNode[] {
   return GO_LAYOUT_DIRECTORIES.filter(name => isDirectory(nodePath.join(projectDirectory, name)))
     .map(name => ({ name, path: name, purpose: PURPOSE_PLACEHOLDER }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A Rust crate's top-level `src/` modules: each subdirectory (`src/<name>/`) and each
+ * `src/<name>.rs` file, excluding the `lib.rs`/`main.rs` crate roots. A directory wins
+ * over a same-named file (an invalid layout, but keeps the node set unique). Sorted by
+ * name, like every other skeleton. A crate with only a root file → empty (honest "not
+ * introspected").
+ */
+function rustModuleNodes(projectDirectory: string): SkeletonNode[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(nodePath.join(projectDirectory, 'src'), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const byName = new Map<string, SkeletonNode>();
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      byName.set(entry.name, {
+        name: entry.name,
+        path: `src/${entry.name}`,
+        purpose: PURPOSE_PLACEHOLDER,
+      });
+    }
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() || !entry.name.endsWith('.rs') || RUST_ROOT_FILES.has(entry.name)) {
+      continue;
+    }
+    const name = entry.name.slice(0, -'.rs'.length);
+    if (!byName.has(name)) {
+      byName.set(name, { name, path: `src/${entry.name}`, purpose: PURPOSE_PLACEHOLDER });
+    }
+  }
+  return byName
+    .values()
+    .toArray()
     .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -11,8 +11,18 @@
 import { type Dirent, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
+import { exists, isDirectory } from './fs.js';
+
 /** Placeholder purpose for a freshly extracted node awaiting human prose. */
 const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
+
+/**
+ * Conventional top-level directories of a Go module (ticket ZD70P1). Used as the
+ * structural modules when a directory has a `go.mod` and no `src/` tree, so a Go
+ * project is described by its real layout instead of the empty skeleton that left
+ * it "not introspected".
+ */
+const GO_LAYOUT_DIRECTORIES = ['cmd', 'internal', 'pkg'] as const;
 
 export interface SkeletonNode {
   /** Module name — the top-level `src/` subdirectory. */
@@ -29,29 +39,53 @@ export interface Skeleton {
 }
 
 export function extractSkeleton(projectDirectory: string): Skeleton {
-  const sourceDirectory = nodePath.join(projectDirectory, 'src');
+  // The `src/` layout (TS/JS) is authoritative and unchanged: when it yields
+  // modules, that is the skeleton.
+  const sourceNodes = enumerateModuleDirectories(
+    nodePath.join(projectDirectory, 'src'),
+    name => `src/${name}`,
+  );
+  if (sourceNodes.length > 0) return { nodes: sourceNodes };
 
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(sourceDirectory, { withFileTypes: true });
-  } catch {
-    return { nodes: [] };
+  // No `src/` modules: a Go module (a `go.mod` is present) is described by its
+  // conventional top-level layout directories instead (ticket ZD70P1). A flat Go
+  // package with none of these stays an empty skeleton — honestly "not
+  // introspected" (ZRW21K), never falsely complete.
+  if (exists(nodePath.join(projectDirectory, 'go.mod'))) {
+    return { nodes: goLayoutNodes(projectDirectory) };
   }
 
-  const nodes = entries
-    .filter(entry => entry.isDirectory())
-    .map(entry => ({
-      name: entry.name,
-      // Forward slashes always — the rendered doc and fingerprint must be
-      // platform-stable (the fingerprint normalizes paths the same way).
-      path: `src/${entry.name}`,
-      purpose: PURPOSE_PLACEHOLDER,
-    }))
-    // Sort by name so the rendered document is deterministic across
-    // filesystems (readdirSync order is not guaranteed), like the fingerprint.
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+  return { nodes: sourceNodes };
+}
 
-  return { nodes };
+/**
+ * The immediate subdirectories of `directory` as skeleton nodes, sorted by name
+ * (readdirSync order is not guaranteed; the rendered doc and fingerprint must be
+ * deterministic). `pathFor` maps a module name to its forward-slashed code
+ * reference — platform-stable, the way the fingerprint normalizes paths.
+ */
+function enumerateModuleDirectories(
+  directory: string,
+  pathFor: (name: string) => string,
+): SkeletonNode[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => ({ name: entry.name, path: pathFor(entry.name), purpose: PURPOSE_PLACEHOLDER }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+/** The recognized Go layout directories that actually exist, as sorted nodes. */
+function goLayoutNodes(projectDirectory: string): SkeletonNode[] {
+  return GO_LAYOUT_DIRECTORIES.filter(name => isDirectory(nodePath.join(projectDirectory, name)))
+    .map(name => ({ name, path: name, purpose: PURPOSE_PLACEHOLDER }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/packages/cli/src/utils/cargo-manifest.ts
+++ b/packages/cli/src/utils/cargo-manifest.ts
@@ -1,0 +1,116 @@
+/**
+ * Dependency-free parser for the `Cargo.toml` subset the architecture pack needs
+ * (ticket YKFA5X): the `[workspace] members` array, the `[package] name`, and the
+ * dependency-table keys. This is NOT a general TOML parser — it reads only these
+ * shapes and returns empty/undefined for anything outside them, consistent with the
+ * go.mod / pnpm hand-parses (incomplete, never silently wrong). Out of scope and
+ * intentionally not handled: `[workspace.dependencies]` inheritance, target-specific
+ * deps, and multi-line inline-table dependency values.
+ */
+
+/** Tables whose keys (or `[table.<name>]` sub-tables) are crate dependency names. */
+const DEPENDENCY_TABLES = ['dependencies', 'dev-dependencies', 'build-dependencies'] as const;
+
+/**
+ * The `[workspace] members = [..]` path globs, or `undefined` when the file has no
+ * `[workspace]` table or no parseable members array. The array body is read up to the
+ * first `]`, so both inline (`members = ["a"]`) and multi-line forms work; quoted
+ * entries are collected, comments and trailing commas are ignored.
+ */
+export function readCargoWorkspaceMembers(content: string): string[] | undefined {
+  if (!/^\[workspace\]\s*$/m.test(content)) return undefined;
+
+  const array = /members\s*=\s*\[([^\]]*)\]/.exec(content);
+  if (array?.[1] === undefined) return undefined;
+
+  const globs = array[1]
+    .matchAll(/"([^"]*)"|'([^']*)'/g)
+    .map(match => match[1] ?? match[2] ?? '')
+    .filter(glob => glob.length > 0)
+    .toArray();
+  return globs.length > 0 ? globs : undefined;
+}
+
+/** The `[package] name`, or `undefined` when there is no `[package]` table with a name. */
+export function readCargoPackageName(content: string): string | undefined {
+  return scanTables(content).packageName;
+}
+
+/** The dependency names (keys) across the flat dependency tables and their sub-tables. */
+export function readCargoDependencyNames(content: string): string[] {
+  return [...scanTables(content).dependencyNames];
+}
+
+interface TableScan {
+  packageName: string | undefined;
+  dependencyNames: Set<string>;
+}
+
+/**
+ * One line-oriented pass tracking the current table: collects the `[package] name`
+ * and every dependency key (flat `name = …` lines under a dependency table, plus the
+ * `<name>` of a `[dependencies.<name>]` sub-table).
+ */
+function scanTables(content: string): TableScan {
+  const scan: TableScan = { packageName: undefined, dependencyNames: new Set<string>() };
+  let currentTable = '';
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = stripComment(rawLine).trim();
+    if (line === '') continue;
+
+    const header = /^\[\[?([^\]]+)\]\]?$/.exec(line);
+    if (header?.[1] !== undefined) {
+      currentTable = header[1].trim();
+      const subTableDependency = dependencySubTableName(currentTable);
+      if (subTableDependency !== undefined) scan.dependencyNames.add(subTableDependency);
+      continue;
+    }
+
+    collectKey(line, currentTable, scan);
+  }
+
+  return scan;
+}
+
+/** Record a `key = …` line as the package name or a dependency, per the current table. */
+function collectKey(line: string, currentTable: string, scan: TableScan): void {
+  const key = leadingKey(line);
+  if (key === undefined) return;
+  if (currentTable === 'package' && key === 'name') {
+    scan.packageName ??= stringValue(line);
+  } else if ((DEPENDENCY_TABLES as readonly string[]).includes(currentTable)) {
+    scan.dependencyNames.add(key);
+  }
+}
+
+/** The dependency name of a `[dependencies.<name>]`-style sub-table, if this is one. */
+function dependencySubTableName(table: string): string | undefined {
+  for (const dependencyTable of DEPENDENCY_TABLES) {
+    if (!table.startsWith(`${dependencyTable}.`)) continue;
+    const name = unquote(table.slice(dependencyTable.length + 1).trim());
+    return name.length > 0 ? name : undefined;
+  }
+  return undefined;
+}
+
+/** The key on the left of `=` (quotes stripped), or undefined if the line is not `key = …`. */
+function leadingKey(line: string): string | undefined {
+  const match = /^("[^"]+"|'[^']+'|[\w-]+)\s*=/.exec(line);
+  return match?.[1] === undefined ? undefined : unquote(match[1]);
+}
+
+/** The `"…"` string value to the right of `=`, or undefined. */
+function stringValue(line: string): string | undefined {
+  return /=\s*"([^"]*)"/.exec(line)?.[1];
+}
+
+/** Drop an inline `# comment` (line-level; the subset has no `#` inside its values). */
+function stripComment(line: string): string {
+  const hash = line.indexOf('#');
+  return hash === -1 ? line : line.slice(0, hash);
+}
+
+function unquote(value: string): string {
+  return value.replaceAll(/^["']|["']$/g, '');
+}

--- a/packages/cli/src/utils/cargo-manifest.ts
+++ b/packages/cli/src/utils/cargo-manifest.ts
@@ -33,7 +33,9 @@ export function readCargoWorkspaceMembers(content: string): string[] | undefined
  * The comment-stripped text inside the `[workspace]` table's `members = [ … ]` array,
  * or `undefined` when there is no such array. Table-scoped (a `members` key under any
  * other table is ignored) and comment-aware (a `]` inside a `#` comment does not close
- * the array early) — both via the same line scan, so neither silently mis-reads.
+ * the array early) — both via the same line scan, so neither silently mis-reads. The one
+ * remaining limit: a member glob whose string literally contains `]` (a char-class glob
+ * like `"crates/[ab]/*"`, which Cargo member paths never use) ends the array early.
  */
 function workspaceMembersArrayBody(lines: string[]): string | undefined {
   let inWorkspace = false;

--- a/packages/cli/src/utils/cargo-manifest.ts
+++ b/packages/cli/src/utils/cargo-manifest.ts
@@ -18,17 +18,49 @@ const DEPENDENCY_TABLES = ['dependencies', 'dev-dependencies', 'build-dependenci
  * entries are collected, comments and trailing commas are ignored.
  */
 export function readCargoWorkspaceMembers(content: string): string[] | undefined {
-  if (!/^\[workspace\]\s*$/m.test(content)) return undefined;
+  const body = workspaceMembersArrayBody(content.split(/\r?\n/));
+  if (body === undefined) return undefined;
 
-  const array = /members\s*=\s*\[([^\]]*)\]/.exec(content);
-  if (array?.[1] === undefined) return undefined;
-
-  const globs = array[1]
+  const globs = body
     .matchAll(/"([^"]*)"|'([^']*)'/g)
     .map(match => match[1] ?? match[2] ?? '')
     .filter(glob => glob.length > 0)
     .toArray();
   return globs.length > 0 ? globs : undefined;
+}
+
+/**
+ * The comment-stripped text inside the `[workspace]` table's `members = [ … ]` array,
+ * or `undefined` when there is no such array. Table-scoped (a `members` key under any
+ * other table is ignored) and comment-aware (a `]` inside a `#` comment does not close
+ * the array early) — both via the same line scan, so neither silently mis-reads.
+ */
+function workspaceMembersArrayBody(lines: string[]): string | undefined {
+  let inWorkspace = false;
+  let body: string | undefined;
+
+  for (const rawLine of lines) {
+    const line = stripComment(rawLine);
+    const trimmed = line.trim();
+
+    if (body === undefined) {
+      const header = /^\[\[?([^[\]]+)\]\]?\s*$/.exec(trimmed);
+      if (header?.[1] !== undefined) {
+        inWorkspace = header[1].trim() === 'workspace';
+        continue;
+      }
+      const opening = inWorkspace ? /members\s*=\s*\[(.*)$/.exec(trimmed) : undefined;
+      if (opening?.[1] === undefined) continue;
+      body = opening[1];
+    } else {
+      body += `\n${line}`;
+    }
+
+    const close = body.indexOf(']');
+    if (close !== -1) return body.slice(0, close);
+  }
+
+  return body;
 }
 
 /** The `[package] name`, or `undefined` when there is no `[package]` table with a name. */

--- a/packages/cli/src/utils/manifest-block.ts
+++ b/packages/cli/src/utils/manifest-block.ts
@@ -7,21 +7,27 @@
  */
 
 /**
- * The trimmed, non-blank, non-comment entry lines inside the first
- * `<keyword> ( … )` block matched by `opener`, or `[]` when no such block exists.
- * `opener` must match the block's opening line (e.g. `/^require\s*\(\s*$/`).
+ * The trimmed, non-blank, non-comment entry lines inside EVERY `<keyword> ( … )`
+ * block matched by `opener`, or `[]` when no such block exists. `opener` must
+ * match a block's opening line (e.g. `/^require\s*\(\s*$/`).
+ *
+ * All blocks are read, not just the first: `go mod tidy` (Go 1.17+) writes direct
+ * and indirect requires into separate `require ( … )` blocks, and a go.work may
+ * carry more than one `use ( … )` block — reading only the first silently drops
+ * the rest (ticket ZD70P1 quality-review). A closing line is any line that begins
+ * with `)` (so a `) // comment` still terminates the block).
  */
 export function readDelimitedBlock(lines: string[], opener: RegExp): string[] {
-  const start = lines.findIndex(line => opener.test(line.trim()));
-  if (start === -1) return [];
-
   const entries: string[] = [];
-  const blockLines = lines.slice(start + 1);
-  for (const line of blockLines) {
+  let inBlock = false;
+  for (const line of lines) {
     const trimmed = line.trim();
-    if (trimmed === ')') break;
-    if (trimmed === '' || trimmed.startsWith('//')) continue;
-    entries.push(trimmed);
+    if (!inBlock) {
+      if (opener.test(trimmed)) inBlock = true;
+      continue;
+    }
+    if (trimmed.startsWith(')')) inBlock = false;
+    else if (trimmed !== '' && !trimmed.startsWith('//')) entries.push(trimmed);
   }
   return entries;
 }

--- a/packages/cli/src/utils/manifest-block.ts
+++ b/packages/cli/src/utils/manifest-block.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared parser for a parenthesised manifest block — the `go.mod` `require (…)`
+ * and `go.work` `use (…)` forms both wrap their entries in a `keyword ( … )`
+ * block, one entry per line (ticket ZD70P1). This returns the meaningful entry
+ * lines (trimmed, with blanks and `//` comments dropped) so each caller only
+ * supplies its own per-entry interpretation.
+ */
+
+/**
+ * The trimmed, non-blank, non-comment entry lines inside the first
+ * `<keyword> ( … )` block matched by `opener`, or `[]` when no such block exists.
+ * `opener` must match the block's opening line (e.g. `/^require\s*\(\s*$/`).
+ */
+export function readDelimitedBlock(lines: string[], opener: RegExp): string[] {
+  const start = lines.findIndex(line => opener.test(line.trim()));
+  if (start === -1) return [];
+
+  const entries: string[] = [];
+  const blockLines = lines.slice(start + 1);
+  for (const line of blockLines) {
+    const trimmed = line.trim();
+    if (trimmed === ')') break;
+    if (trimmed === '' || trimmed.startsWith('//')) continue;
+    entries.push(trimmed);
+  }
+  return entries;
+}

--- a/packages/cli/src/utils/manifest-dependencies.ts
+++ b/packages/cli/src/utils/manifest-dependencies.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared reader for a package.json's dependency names — the architecture
+ * fingerprint (drift signal) and the monorepo model (inter-package edges) both
+ * collect the *keys* across every dependency section, so the section list and the
+ * collection loop live in one place (ticket ZD70P1, factored out during verify).
+ */
+
+/** package.json dependency manifest sections whose *keys* are dependency names. */
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+/** The dependency names (keys) across all dependency sections of a parsed manifest. */
+export function dependencySectionNames(manifest: Record<string, unknown>): string[] {
+  const names = new Set<string>();
+  for (const section of DEPENDENCY_SECTIONS) {
+    const entry = manifest[section];
+    if (entry !== null && typeof entry === 'object') {
+      for (const name of Object.keys(entry)) names.add(name);
+    }
+  }
+  return [...names];
+}

--- a/packages/cli/tests/utils/architecture-fingerprint.test.ts
+++ b/packages/cli/tests/utils/architecture-fingerprint.test.ts
@@ -190,3 +190,43 @@ describe('shapeFingerprint — Go module dependencies (ticket ZD70P1)', () => {
     expect(shapeFingerprint(context.directory)).not.toBe(before);
   });
 });
+
+describe('shapeFingerprint — Cargo dependencies (ticket YKFA5X)', () => {
+  function writeCargo(directory: string, dependencies: string[]): void {
+    const block = dependencies.length === 0 ? '' : `\n[dependencies]\n${dependencies.join('\n')}\n`;
+    writeFileSync(nodePath.join(directory, 'Cargo.toml'), `[package]\nname = "app"\n${block}`);
+  }
+
+  function scaffoldCrate(directory: string, dependencies: string[]): void {
+    mkdirSync(nodePath.join(directory, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(directory, 'src', 'config.rs'), '// rust\n');
+    writeCargo(directory, dependencies);
+  }
+
+  it('moves when a Cargo dependency is added', () => {
+    scaffoldCrate(context.directory, ['serde = "1.0"']);
+    const before = shapeFingerprint(context.directory);
+
+    writeCargo(context.directory, ['serde = "1.0"', 'tokio = "1"']);
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
+
+  it('moves when a Cargo dependency is removed', () => {
+    scaffoldCrate(context.directory, ['serde = "1.0"', 'tokio = "1"']);
+    const before = shapeFingerprint(context.directory);
+
+    writeCargo(context.directory, ['serde = "1.0"']);
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
+
+  it('does not move when only a Cargo dependency version is bumped (versions excluded)', () => {
+    scaffoldCrate(context.directory, ['serde = "1.0"']);
+    const before = shapeFingerprint(context.directory);
+
+    writeCargo(context.directory, ['serde = "2.0"']);
+
+    expect(shapeFingerprint(context.directory)).toBe(before);
+  });
+});

--- a/packages/cli/tests/utils/architecture-fingerprint.test.ts
+++ b/packages/cli/tests/utils/architecture-fingerprint.test.ts
@@ -113,3 +113,62 @@ describe('shapeFingerprint — captures shape, not noise', () => {
     }
   });
 });
+
+describe('shapeFingerprint — Go module dependencies (ticket ZD70P1)', () => {
+  function writeGoModule(directory: string, requires: string[]): void {
+    const indented = requires.map(requireLine => `\t${requireLine}`).join('\n');
+    const block = requires.length === 0 ? '' : `\nrequire (\n${indented}\n)\n`;
+    writeFileSync(
+      nodePath.join(directory, 'go.mod'),
+      `module example.com/app\n\ngo 1.22\n${block}`,
+    );
+  }
+
+  function scaffoldGo(directory: string, requires: string[]): void {
+    mkdirSync(nodePath.join(directory, 'cmd', 'server'), { recursive: true });
+    writeGoModule(directory, requires);
+  }
+
+  it('moves when a go.mod require is added', () => {
+    scaffoldGo(context.directory, ['github.com/a/one v1.0.0']);
+    const before = shapeFingerprint(context.directory);
+
+    writeGoModule(context.directory, ['github.com/a/one v1.0.0', 'github.com/b/two v1.0.0']);
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
+
+  it('moves when a go.mod require is removed', () => {
+    scaffoldGo(context.directory, ['github.com/a/one v1.0.0', 'github.com/b/two v1.0.0']);
+    const before = shapeFingerprint(context.directory);
+
+    writeGoModule(context.directory, ['github.com/a/one v1.0.0']);
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
+
+  it('does not move when only a require version is bumped (versions excluded)', () => {
+    scaffoldGo(context.directory, ['github.com/a/one v1.0.0']);
+    const before = shapeFingerprint(context.directory);
+
+    writeGoModule(context.directory, ['github.com/a/one v2.0.0']);
+
+    expect(shapeFingerprint(context.directory)).toBe(before);
+  });
+
+  it('reads a single-line require directive', () => {
+    scaffoldGo(context.directory, []);
+    writeFileSync(
+      nodePath.join(context.directory, 'go.mod'),
+      'module example.com/app\n\ngo 1.22\n',
+    );
+    const before = shapeFingerprint(context.directory);
+
+    writeFileSync(
+      nodePath.join(context.directory, 'go.mod'),
+      'module example.com/app\n\ngo 1.22\n\nrequire github.com/a/one v1.0.0\n',
+    );
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
+});

--- a/packages/cli/tests/utils/architecture-fingerprint.test.ts
+++ b/packages/cli/tests/utils/architecture-fingerprint.test.ts
@@ -171,4 +171,22 @@ describe('shapeFingerprint — Go module dependencies (ticket ZD70P1)', () => {
 
     expect(shapeFingerprint(context.directory)).not.toBe(before);
   });
+
+  it('reads every require block, not just the first (go mod tidy splits indirect deps)', () => {
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+    // The `go mod tidy` default on Go 1.17+: direct deps in one block, indirect
+    // deps in a SECOND block. A change confined to the indirect block must still
+    // move the fingerprint, or drift in indirect deps goes undetected.
+    const twoBlock = (indirect: string): string =>
+      `module example.com/app\n\ngo 1.22\n\nrequire (\n\tgithub.com/a/one v1.0.0\n)\n\nrequire (\n\t${indirect} // indirect\n)\n`;
+    writeFileSync(nodePath.join(context.directory, 'go.mod'), twoBlock('golang.org/x/text v0.3.0'));
+    const before = shapeFingerprint(context.directory);
+
+    writeFileSync(
+      nodePath.join(context.directory, 'go.mod'),
+      twoBlock('golang.org/x/tools v0.1.0'),
+    );
+
+    expect(shapeFingerprint(context.directory)).not.toBe(before);
+  });
 });

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -264,6 +264,28 @@ describe('discoverLeafDirectories — go.work discovery (ticket ZD70P1)', () => 
     ]);
   });
 
+  it('discovers packages across more than one use block', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse (\n\t./svc\n)\n\nuse (\n\t./gateway\n)\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+    makeGoPackage(context.directory, 'gateway', { layout: true });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'gateway'),
+      nodePath.join(context.directory, 'svc'),
+    ]);
+  });
+
+  it('discovers a use entry that carries a trailing comment', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse ./svc // the service module\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'svc'),
+    ]);
+  });
+
   it('returns no leaves when go.work has no use directive', () => {
     clearRootManifest(context.directory);
     writeGoWork(context.directory, 'go 1.22\n');

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -5,7 +5,7 @@
  * the package set belong to the ROOT fingerprint, never a leaf's.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -213,5 +213,98 @@ describe('monorepoFingerprint — root owns the package set, edges, and boundary
       mkdirSync(nodePath.join(root, 'packages', 'core', 'src', 'newmod'), { recursive: true }),
     );
     expect(after).toBe(before);
+  });
+});
+
+describe('discoverLeafDirectories — go.work discovery (ticket ZD70P1)', () => {
+  function clearRootManifest(root: string): void {
+    rmSync(nodePath.join(root, 'package.json'), { force: true });
+  }
+
+  function writeGoWork(root: string, body: string): void {
+    writeFileSync(nodePath.join(root, 'go.work'), body);
+  }
+
+  function makeGoPackage(root: string, name: string, options: { layout?: boolean } = {}): void {
+    const dir = nodePath.join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(nodePath.join(dir, 'go.mod'), `module example.com/${name}\n\ngo 1.22\n`);
+    if (options.layout) mkdirSync(nodePath.join(dir, 'cmd', 'server'), { recursive: true });
+  }
+
+  it('discovers Go packages from a go.work use block', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse (\n\t./svc\n\t./gateway\n)\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+    makeGoPackage(context.directory, 'gateway', { layout: true });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'gateway'),
+      nodePath.join(context.directory, 'svc'),
+    ]);
+  });
+
+  it('discovers a Go package from a single-line use directive', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse ./svc\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'svc'),
+    ]);
+  });
+
+  it('skips an unreadable use entry while keeping the readable ones', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse (\n\t./svc\n\t@@@ not a path @@@\n)\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'svc'),
+    ]);
+  });
+
+  it('returns no leaves when go.work has no use directive', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+
+  it('keeps a Go package directory that has a go.mod but no package.json', () => {
+    clearRootManifest(context.directory);
+    writeGoWork(context.directory, 'go 1.22\n\nuse ./svc\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+
+    const leaves = discoverLeafDirectories(context.directory);
+
+    expect(leaves).toContain(nodePath.join(context.directory, 'svc'));
+  });
+
+  it('lets package.json workspaces win over go.work when both are present', () => {
+    // Root manifest (from beforeEach) declares workspaces: ['packages/*'].
+    writeGoWork(context.directory, 'go 1.22\n\nuse ./svc\n');
+    makeGoPackage(context.directory, 'svc', { layout: true });
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+
+    const leaves = discoverLeafDirectories(context.directory);
+
+    expect(leaves).toEqual([nodePath.join(context.directory, 'packages', 'web')]);
+    expect(leaves).not.toContain(nodePath.join(context.directory, 'svc'));
+  });
+});
+
+describe('extractMonorepoModel — Go package identity (ticket ZD70P1)', () => {
+  it('names a Go package from its go.mod module directive', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./svc\n');
+    const dir = nodePath.join(context.directory, 'svc');
+    mkdirSync(nodePath.join(dir, 'cmd', 'server'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'go.mod'), 'module github.com/acme/svc\n\ngo 1.22\n');
+
+    const model = extractMonorepoModel(context.directory);
+
+    expect(model.packages.map(node => node.name)).toEqual(['github.com/acme/svc']);
+    expect(model.packages[0]?.introspected).toBe(true);
   });
 });

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -330,3 +330,83 @@ describe('extractMonorepoModel — Go package identity (ticket ZD70P1)', () => {
     expect(model.packages[0]?.introspected).toBe(true);
   });
 });
+
+describe('discoverLeafDirectories — Cargo workspace discovery (ticket YKFA5X)', () => {
+  function makeCargoCrate(root: string, name: string, options: { module?: string } = {}): void {
+    const dir = nodePath.join(root, 'crates', name);
+    mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+    if (options.module !== undefined) {
+      writeFileSync(nodePath.join(dir, 'src', `${options.module}.rs`), '// rust\n');
+    }
+  }
+
+  it('discovers crates from a Cargo workspace members array', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/*"]\n',
+    );
+    makeCargoCrate(context.directory, 'svc', { module: 'config' });
+    makeCargoCrate(context.directory, 'api', { module: 'routes' });
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'crates', 'api'),
+      nodePath.join(context.directory, 'crates', 'svc'),
+    ]);
+  });
+
+  it('keeps a crate directory that has a Cargo.toml but no package.json', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/*"]\n',
+    );
+    makeCargoCrate(context.directory, 'svc', { module: 'config' });
+
+    expect(discoverLeafDirectories(context.directory)).toContain(
+      nodePath.join(context.directory, 'crates', 'svc'),
+    );
+  });
+
+  it('lets package.json workspaces win over a Cargo workspace when both are present', () => {
+    // Root manifest (from beforeEach) declares workspaces: ['packages/*'].
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/*"]\n',
+    );
+    makeCargoCrate(context.directory, 'svc', { module: 'config' });
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+
+    const leaves = discoverLeafDirectories(context.directory);
+
+    expect(leaves).toEqual([nodePath.join(context.directory, 'packages', 'web')]);
+    expect(leaves).not.toContain(nodePath.join(context.directory, 'crates', 'svc'));
+  });
+
+  it('returns no leaves when Cargo.toml has no [workspace] table', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(nodePath.join(context.directory, 'Cargo.toml'), '[package]\nname = "solo"\n');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+});
+
+describe('extractMonorepoModel — Rust crate identity (ticket YKFA5X)', () => {
+  it('names a Rust crate from its Cargo.toml [package] name', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/svc"]\n',
+    );
+    const dir = nodePath.join(context.directory, 'crates', 'svc');
+    mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'Cargo.toml'), '[package]\nname = "acme-svc"\n');
+    writeFileSync(nodePath.join(dir, 'src', 'config.rs'), '// rust\n');
+
+    const model = extractMonorepoModel(context.directory);
+
+    expect(model.packages.map(node => node.name)).toEqual(['acme-svc']);
+    expect(model.packages[0]?.introspected).toBe(true);
+  });
+});

--- a/packages/cli/tests/utils/architecture-skeleton.test.ts
+++ b/packages/cli/tests/utils/architecture-skeleton.test.ts
@@ -148,3 +148,65 @@ describe('extractSkeleton — Go layout (ticket ZD70P1)', () => {
     expect(skeleton.nodes).toEqual([]);
   });
 });
+
+describe('extractSkeleton — Rust layout (ticket YKFA5X)', () => {
+  function writeCargo(directory: string, name = 'app'): void {
+    writeFileSync(nodePath.join(directory, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+  }
+
+  function writeRustFile(directory: string, file: string): void {
+    mkdirSync(nodePath.join(directory, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(directory, 'src', file), '// rust\n');
+  }
+
+  it('lists src module files and dirs, excluding the lib.rs/main.rs roots', () => {
+    writeCargo(context.directory);
+    writeRustFile(context.directory, 'lib.rs');
+    writeRustFile(context.directory, 'config.rs');
+    mkdirSync(nodePath.join(context.directory, 'src', 'handlers'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['config', 'handlers']);
+    const pathByName = Object.fromEntries(skeleton.nodes.map(node => [node.name, node.path]));
+    expect(pathByName.config).toBe('src/config.rs');
+    expect(pathByName.handlers).toBe('src/handlers');
+  });
+
+  it('excludes main.rs as a crate root', () => {
+    writeCargo(context.directory);
+    writeRustFile(context.directory, 'main.rs');
+    writeRustFile(context.directory, 'cli.rs');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['cli']);
+  });
+
+  it('produces an empty skeleton for a crate with only a root file', () => {
+    writeCargo(context.directory);
+    writeRustFile(context.directory, 'lib.rs');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes).toEqual([]);
+  });
+
+  it('lists FILE modules even when a dir module is also present (not dir-only)', () => {
+    writeCargo(context.directory);
+    writeRustFile(context.directory, 'error.rs');
+    mkdirSync(nodePath.join(context.directory, 'src', 'store'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['error', 'store']);
+  });
+
+  it('does not list src/*.rs files without a Cargo.toml (TS stays dir-only)', () => {
+    writeRustFile(context.directory, 'thing.rs');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes).toEqual([]);
+  });
+});

--- a/packages/cli/tests/utils/architecture-skeleton.test.ts
+++ b/packages/cli/tests/utils/architecture-skeleton.test.ts
@@ -89,3 +89,62 @@ describe('extractSkeleton — skeleton reflects the real project', () => {
     expect(skeleton.nodes.map(node => node.name)).toContain('auth');
   });
 });
+
+describe('extractSkeleton — Go layout (ticket ZD70P1)', () => {
+  function writeGoModule(directory: string, modulePath = 'example.com/app'): void {
+    writeFileSync(nodePath.join(directory, 'go.mod'), `module ${modulePath}\n\ngo 1.22\n`);
+  }
+
+  it('lists the recognized Go layout directories as modules when there is a go.mod', () => {
+    writeGoModule(context.directory);
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+    mkdirSync(nodePath.join(context.directory, 'internal', 'store'), { recursive: true });
+    mkdirSync(nodePath.join(context.directory, 'pkg', 'api'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['cmd', 'internal', 'pkg']);
+    const pathByName = Object.fromEntries(skeleton.nodes.map(node => [node.name, node.path]));
+    expect(pathByName.cmd).toBe('cmd');
+    expect(pathByName.internal).toBe('internal');
+    expect(pathByName.pkg).toBe('pkg');
+  });
+
+  it('lists only the recognized Go directories that are present', () => {
+    writeGoModule(context.directory);
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+    mkdirSync(nodePath.join(context.directory, 'docs'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['cmd']);
+  });
+
+  it('keeps the src layout authoritative — go.mod is ignored when src modules exist', () => {
+    writeGoModule(context.directory);
+    mkdirSync(nodePath.join(context.directory, 'src', 'core'), { recursive: true });
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['core']);
+    expect(skeleton.nodes[0]?.path).toBe(nodePath.join('src', 'core'));
+  });
+
+  it('produces an empty skeleton for a flat Go package with no recognized layout', () => {
+    writeGoModule(context.directory);
+    writeFileSync(nodePath.join(context.directory, 'main.go'), 'package main\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes).toEqual([]);
+  });
+
+  it('does not treat cmd/internal/pkg as modules without a go.mod', () => {
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes).toEqual([]);
+  });
+});

--- a/packages/cli/tests/utils/cargo-manifest.test.ts
+++ b/packages/cli/tests/utils/cargo-manifest.test.ts
@@ -33,6 +33,23 @@ describe('readCargoWorkspaceMembers', () => {
     const toml = '[workspace]\nmembers = [\n  "a", # the a crate\n  "b",\n]\n';
     expect(readCargoWorkspaceMembers(toml)).toEqual(['a', 'b']);
   });
+
+  it('reads members from the [workspace] table, not a metadata members key', () => {
+    const toml = [
+      '[package.metadata.bundle]',
+      'members = ["META/wrong"]',
+      '',
+      '[workspace]',
+      'members = ["crates/*"]',
+      '',
+    ].join('\n');
+    expect(readCargoWorkspaceMembers(toml)).toEqual(['crates/*']);
+  });
+
+  it('does not drop members after a comment containing a closing bracket', () => {
+    const toml = '[workspace]\nmembers = [\n  "a", # see crates[] note\n  "b",\n  "c",\n]\n';
+    expect(readCargoWorkspaceMembers(toml)).toEqual(['a', 'b', 'c']);
+  });
 });
 
 describe('readCargoPackageName', () => {

--- a/packages/cli/tests/utils/cargo-manifest.test.ts
+++ b/packages/cli/tests/utils/cargo-manifest.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readCargoDependencyNames,
+  readCargoPackageName,
+  readCargoWorkspaceMembers,
+} from '../../src/utils/cargo-manifest.js';
+
+describe('readCargoWorkspaceMembers', () => {
+  it('reads a multi-line members array', () => {
+    const toml = ['[workspace]', 'members = [', '    "crates/*",', '    "app",', ']', ''].join(
+      '\n',
+    );
+    expect(readCargoWorkspaceMembers(toml)).toEqual(['crates/*', 'app']);
+  });
+
+  it('reads a single-line members array', () => {
+    const toml = '[workspace]\nmembers = ["crates/*", "tools/cli"]\n';
+    expect(readCargoWorkspaceMembers(toml)).toEqual(['crates/*', 'tools/cli']);
+  });
+
+  it('returns undefined when there is no [workspace] table', () => {
+    const toml = '[package]\nname = "solo"\n\n[dependencies]\nserde = "1"\n';
+    expect(readCargoWorkspaceMembers(toml)).toBeUndefined();
+  });
+
+  it('returns undefined when [workspace] has no members', () => {
+    const toml = '[workspace]\nresolver = "2"\n';
+    expect(readCargoWorkspaceMembers(toml)).toBeUndefined();
+  });
+
+  it('tolerates comments and a trailing comma in the array', () => {
+    const toml = '[workspace]\nmembers = [\n  "a", # the a crate\n  "b",\n]\n';
+    expect(readCargoWorkspaceMembers(toml)).toEqual(['a', 'b']);
+  });
+});
+
+describe('readCargoPackageName', () => {
+  it('reads the [package] name', () => {
+    expect(readCargoPackageName('[package]\nname = "my-crate"\nversion = "0.1.0"\n')).toBe(
+      'my-crate',
+    );
+  });
+
+  it('returns undefined when there is no [package] table', () => {
+    expect(readCargoPackageName('[workspace]\nmembers = ["a"]\n')).toBeUndefined();
+  });
+
+  it('does not mistake a [[bin]] name for the package name', () => {
+    const toml = '[package]\nname = "real"\n\n[[bin]]\nname = "a-binary"\n';
+    expect(readCargoPackageName(toml)).toBe('real');
+  });
+});
+
+describe('readCargoDependencyNames', () => {
+  it('collects keys across dependencies, dev-dependencies, and build-dependencies', () => {
+    const toml = [
+      '[package]',
+      'name = "c"',
+      '[dependencies]',
+      'serde = "1.0"',
+      'tokio = { version = "1", features = ["full"] }',
+      '[dev-dependencies]',
+      'mockall = "0.11"',
+      '[build-dependencies]',
+      'cc = "1.0"',
+      '',
+    ].join('\n');
+    expect(readCargoDependencyNames(toml).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'cc',
+      'mockall',
+      'serde',
+      'tokio',
+    ]);
+  });
+
+  it('reads a [dependencies.<name>] sub-table as the dependency name', () => {
+    const toml = '[dependencies.serde]\nversion = "1"\nfeatures = ["derive"]\n';
+    expect(readCargoDependencyNames(toml)).toEqual(['serde']);
+  });
+
+  it('handles a quoted dependency key', () => {
+    const toml = '[dependencies]\n"some-dep" = "1.0"\n';
+    expect(readCargoDependencyNames(toml)).toEqual(['some-dep']);
+  });
+
+  it('excludes versions and is empty when there are no dependency tables', () => {
+    expect(readCargoDependencyNames('[package]\nname = "c"\n')).toEqual([]);
+  });
+
+  it('does not collect keys from a non-dependency table', () => {
+    const toml = '[package]\nname = "c"\nversion = "0.1.0"\nedition = "2021"\n';
+    expect(readCargoDependencyNames(toml)).toEqual([]);
+  });
+});

--- a/steps/architecture-go-language-pack.steps.ts
+++ b/steps/architecture-go-language-pack.steps.ts
@@ -7,7 +7,6 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -15,8 +14,8 @@ import { Given, Then, When } from '@cucumber/cucumber';
 
 import {
   type ArchitectureWorld,
-  CLI_PATH,
   rootDoc,
+  runArchitecture,
   worldDir as dir,
   writeJson,
 } from './support/architecture-fixtures.ts';
@@ -56,15 +55,6 @@ function makeGoPackage(world: ArchitectureWorld, name: string, options: { layout
 
 function writeGoWork(world: ArchitectureWorld, body: string): void {
   writeFileSync(nodePath.join(dir(world), 'go.work'), body);
-}
-
-function runArchitecture(world: ArchitectureWorld, args: string[] = []): void {
-  const result = spawnSync('bun', [CLI_PATH, 'architecture', ...args], {
-    cwd: dir(world),
-    encoding: 'utf8',
-    timeout: 30_000,
-  });
-  world.status = result.status ?? 1;
 }
 
 // --- Givens ---

--- a/steps/architecture-go-language-pack.steps.ts
+++ b/steps/architecture-go-language-pack.steps.ts
@@ -1,0 +1,153 @@
+/**
+ * Acceptance-lane step definitions for the Go language pack (ticket ZD70P1).
+ * Black-box: builds single-repo Go, go.work monorepo, and mixed JS+Go fixtures and
+ * drives the real `safeword architecture` CLI, asserting the docs it writes and
+ * that Go dependency drift is caught via `architecture --check`. Reuses the shared
+ * When/Then vocabulary and fixture helpers (steps/support/architecture-fixtures).
+ */
+
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { Given, Then, When } from '@cucumber/cucumber';
+
+import {
+  type ArchitectureWorld,
+  CLI_PATH,
+  rootDoc,
+  worldDir as dir,
+  writeJson,
+} from './support/architecture-fixtures.ts';
+
+const GO_LAYOUT_DIRECTORIES = ['cmd', 'internal', 'pkg'];
+
+function writeGoModule(directory: string, modulePath: string): void {
+  writeFileSync(nodePath.join(directory, 'go.mod'), `module ${modulePath}\n\ngo 1.22\n`);
+}
+
+function makeLayout(directory: string): void {
+  for (const layoutDirectory of GO_LAYOUT_DIRECTORIES) {
+    mkdirSync(nodePath.join(directory, layoutDirectory), { recursive: true });
+  }
+}
+
+/** A single-repo Go project at the world root: go.mod + cmd/internal/pkg. */
+function makeSingleRepoGo(world: ArchitectureWorld): void {
+  const root = dir(world);
+  writeGoModule(root, 'example.com/app');
+  makeLayout(root);
+}
+
+/** A Go workspace package under packages/<name>; `layout` controls introspectability. */
+function makeGoPackage(world: ArchitectureWorld, name: string, options: { layout: boolean }): void {
+  const packageDirectory = nodePath.join(dir(world), 'packages', name);
+  mkdirSync(packageDirectory, { recursive: true });
+  // The module directive IS the package's identity in the root index; use the bare
+  // name so scenarios can refer to it directly (the full-path case is unit-tested).
+  writeGoModule(packageDirectory, name);
+  if (options.layout) {
+    makeLayout(packageDirectory);
+  } else {
+    writeFileSync(nodePath.join(packageDirectory, 'main.go'), 'package main\n');
+  }
+}
+
+function writeGoWork(world: ArchitectureWorld, body: string): void {
+  writeFileSync(nodePath.join(dir(world), 'go.work'), body);
+}
+
+function runArchitecture(world: ArchitectureWorld, args: string[] = []): void {
+  const result = spawnSync('bun', [CLI_PATH, 'architecture', ...args], {
+    cwd: dir(world),
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  world.status = result.status ?? 1;
+}
+
+// --- Givens ---
+
+Given(
+  'a single-repo Go project with cmd, internal, and pkg directories',
+  function (this: ArchitectureWorld) {
+    makeSingleRepoGo(this);
+  },
+);
+
+Given(
+  'a single-repo Go project with cmd, internal, and pkg directories whose architecture doc has been generated',
+  function (this: ArchitectureWorld) {
+    makeSingleRepoGo(this);
+    runArchitecture(this);
+  },
+);
+
+Given(
+  /^a go\.work monorepo listing a Go package "([^"]+)" with a cmd\/internal\/pkg layout$/,
+  function (this: ArchitectureWorld, name: string) {
+    writeGoWork(this, `go 1.22\n\nuse ./packages/${name}\n`);
+    makeGoPackage(this, name, { layout: true });
+  },
+);
+
+Given(
+  /^a go\.work monorepo with a Go package "([^"]+)" that has only top-level Go files$/,
+  function (this: ArchitectureWorld, name: string) {
+    writeGoWork(this, `go 1.22\n\nuse ./packages/${name}\n`);
+    makeGoPackage(this, name, { layout: false });
+  },
+);
+
+Given(
+  /^a go\.work monorepo listing a Go package "([^"]+)" with a cmd\/internal\/pkg layout alongside an unreadable use entry$/,
+  function (this: ArchitectureWorld, name: string) {
+    // A valid `use` line plus one junk line a working parser skips — proves
+    // partial-skip, not total-degrade (scenario-gate review note).
+    writeGoWork(this, `go 1.22\n\nuse (\n\t./packages/${name}\n\t@@@ not a path @@@\n)\n`);
+    makeGoPackage(this, name, { layout: true });
+  },
+);
+
+Given(
+  /^a monorepo whose workspaces include a JS package "([^"]+)" with a src tree and a Go package "([^"]+)" with a cmd\/internal\/pkg layout$/,
+  function (this: ArchitectureWorld, jsName: string, goName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    const jsDirectory = nodePath.join(dir(this), 'packages', jsName);
+    writeJson(nodePath.join(jsDirectory, 'package.json'), { name: jsName });
+    mkdirSync(nodePath.join(jsDirectory, 'src', 'ui'), { recursive: true });
+    makeGoPackage(this, goName, { layout: true });
+  },
+);
+
+// --- Whens ---
+
+When('a require is added to its go.mod', function (this: ArchitectureWorld) {
+  const goModPath = nodePath.join(dir(this), 'go.mod');
+  writeFileSync(
+    goModPath,
+    'module example.com/app\n\ngo 1.22\n\nrequire github.com/new/dep v1.0.0\n',
+  );
+});
+
+When('safeword checks the architecture doc', function (this: ArchitectureWorld) {
+  runArchitecture(this, ['--check']);
+});
+
+// --- Thens ---
+
+Then(/^the doc lists the module "([^"]+)"$/, function (this: ArchitectureWorld, name: string) {
+  assert.match(rootDoc(this), new RegExp(`^### ${name}$`, 'm'), `doc does not list module ${name}`);
+});
+
+Then('safeword reports the architecture doc is stale', function (this: ArchitectureWorld) {
+  assert.notEqual(
+    this.status,
+    0,
+    'expected architecture --check to report the doc stale (nonzero)',
+  );
+});

--- a/steps/architecture-rust-language-pack.steps.ts
+++ b/steps/architecture-rust-language-pack.steps.ts
@@ -1,0 +1,126 @@
+/**
+ * Acceptance-lane step definitions for the Rust language pack (ticket YKFA5X).
+ * Black-box: builds single-crate Rust, Cargo workspace, and mixed JS+Rust fixtures and
+ * drives the real `safeword architecture` CLI, asserting the docs it writes and that
+ * Cargo dependency drift is caught via `architecture --check`. Reuses the shared
+ * When/Then vocabulary and fixture helpers (steps/support/architecture-fixtures).
+ */
+
+import { strict as assert } from 'node:assert';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { Given, Then, When } from '@cucumber/cucumber';
+
+import {
+  type ArchitectureWorld,
+  rootDoc,
+  runArchitecture,
+  worldDir as dir,
+  writeJson,
+} from './support/architecture-fixtures.ts';
+
+function writeCargo(directory: string, name: string, withDependencies = false): void {
+  const dependencies = withDependencies ? '\n[dependencies]\nserde = "1.0"\n' : '';
+  writeFileSync(
+    nodePath.join(directory, 'Cargo.toml'),
+    `[package]\nname = "${name}"\n${dependencies}`,
+  );
+}
+
+function writeModuleFile(directory: string, name: string): void {
+  mkdirSync(nodePath.join(directory, 'src'), { recursive: true });
+  writeFileSync(nodePath.join(directory, 'src', `${name}.rs`), '// rust\n');
+}
+
+/** A Rust crate under packages/<name>; `module` adds a `src/<module>.rs` file (introspectable). */
+function makeCrate(
+  world: ArchitectureWorld,
+  name: string,
+  options: { module?: string; rootOnly?: boolean } = {},
+): void {
+  const crateDirectory = nodePath.join(dir(world), 'packages', name);
+  mkdirSync(crateDirectory, { recursive: true });
+  writeCargo(crateDirectory, name);
+  if (options.rootOnly) writeModuleFile(crateDirectory, 'lib');
+  if (options.module !== undefined) writeModuleFile(crateDirectory, options.module);
+}
+
+// Crates live under packages/<name> (not crates/) so the shared colocated-leaf-doc
+// assertions, which look in packages/<name>, work — Cargo is indifferent to the dir name.
+function writeWorkspace(world: ArchitectureWorld): void {
+  writeFileSync(nodePath.join(dir(world), 'Cargo.toml'), '[workspace]\nmembers = ["packages/*"]\n');
+}
+
+// --- Givens ---
+
+Given(
+  'a single-crate Rust project with a module file "config", a module dir "handlers", and a lib.rs root',
+  function (this: ArchitectureWorld) {
+    writeCargo(dir(this), 'app');
+    writeModuleFile(dir(this), 'lib');
+    writeModuleFile(dir(this), 'config');
+    mkdirSync(nodePath.join(dir(this), 'src', 'handlers'), { recursive: true });
+  },
+);
+
+Given(
+  /^a Cargo workspace listing a crate "([^"]+)" with a src module file$/,
+  function (this: ArchitectureWorld, name: string) {
+    writeWorkspace(this);
+    makeCrate(this, name, { module: 'config' });
+  },
+);
+
+Given(
+  /^a Cargo workspace with a crate "([^"]+)" that has only a lib.rs root$/,
+  function (this: ArchitectureWorld, name: string) {
+    writeWorkspace(this);
+    makeCrate(this, name, { rootOnly: true });
+  },
+);
+
+Given(
+  'a single-crate Rust project with a src module file whose architecture doc has been generated',
+  function (this: ArchitectureWorld) {
+    writeCargo(dir(this), 'app');
+    writeModuleFile(dir(this), 'config');
+    runArchitecture(this);
+  },
+);
+
+Given(
+  /^a monorepo whose workspaces include a JS package "([^"]+)" with a src tree and a Rust crate "([^"]+)" with a src module file$/,
+  function (this: ArchitectureWorld, jsName: string, rustName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    const jsDirectory = nodePath.join(dir(this), 'packages', jsName);
+    writeJson(nodePath.join(jsDirectory, 'package.json'), { name: jsName });
+    mkdirSync(nodePath.join(jsDirectory, 'src', 'ui'), { recursive: true });
+    const rustDirectory = nodePath.join(dir(this), 'packages', rustName);
+    mkdirSync(rustDirectory, { recursive: true });
+    writeCargo(rustDirectory, rustName);
+    writeModuleFile(rustDirectory, 'config');
+  },
+);
+
+// --- Whens ---
+
+When('a dependency is added to its Cargo.toml', function (this: ArchitectureWorld) {
+  writeCargo(dir(this), 'app', true);
+});
+
+// --- Thens ---
+
+Then(
+  /^the doc does not list the module "([^"]+)"$/,
+  function (this: ArchitectureWorld, name: string) {
+    assert.doesNotMatch(
+      rootDoc(this),
+      new RegExp(`^### ${name}$`, 'm'),
+      `doc unexpectedly lists module ${name}`,
+    );
+  },
+);

--- a/steps/monorepo-coverage-honesty.steps.ts
+++ b/steps/monorepo-coverage-honesty.steps.ts
@@ -8,31 +8,22 @@
 
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import nodeOs from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { After, Given, Then, When } from '@cucumber/cucumber';
+import { Given, Then, When } from '@cucumber/cucumber';
 
-import type { SafewordWorld } from './world.js';
+import {
+  type ArchitectureWorld,
+  CLI_PATH,
+  leafDocExists,
+  packageSection,
+  rootDoc,
+  worldDir as dir,
+  writeJson,
+} from './support/architecture-fixtures.ts';
 
-const PROJECT_ROOT = nodePath.resolve(import.meta.dirname, '..');
-const CLI_PATH = nodePath.join(PROJECT_ROOT, 'packages/cli/src/cli.ts');
-
-interface CoverageWorld extends SafewordWorld {
-  dir?: string;
-  status?: number;
-}
-
-function dir(world: CoverageWorld): string {
-  world.dir ??= mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'arch-coverage-bdd-'));
-  return world.dir;
-}
-
-function writeJson(path: string, value: unknown): void {
-  mkdirSync(nodePath.dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(value));
-}
+type CoverageWorld = ArchitectureWorld;
 
 /** A workspace package under packages/<name>, optionally with a src/ module. */
 function makePackage(world: CoverageWorld, name: string, options: { src?: boolean } = {}): void {
@@ -45,27 +36,6 @@ function writePnpmWorkspace(world: CoverageWorld, globs: string[]): void {
   const body = ['packages:', ...globs.map(glob => `  - "${glob}"`)].join('\n');
   writeFileSync(nodePath.join(dir(world), 'pnpm-workspace.yaml'), `${body}\n`);
 }
-
-function rootDoc(world: CoverageWorld): string {
-  const path = nodePath.join(dir(world), '.project', 'architecture.generated.md');
-  return existsSync(path) ? readFileSync(path, 'utf8') : '';
-}
-
-function leafDocExists(world: CoverageWorld, name: string): boolean {
-  return existsSync(nodePath.join(dir(world), 'packages', name, 'architecture.generated.md'));
-}
-
-/** A `### name` package section of the root index (to its next heading or EOF). */
-function packageSection(world: CoverageWorld, name: string): string {
-  const chunk = rootDoc(world)
-    .split('\n### ')
-    .find(part => part.startsWith(`${name}\n`));
-  return chunk === undefined ? '' : `### ${chunk.split('\n## ')[0]}`;
-}
-
-After(function (this: CoverageWorld) {
-  if (this.dir !== undefined) rmSync(this.dir, { recursive: true, force: true });
-});
 
 // --- Givens ---
 

--- a/steps/support/architecture-fixtures.ts
+++ b/steps/support/architecture-fixtures.ts
@@ -6,6 +6,7 @@
  * duplicated fixture scaffolding) and one cleanup hook.
  */
 
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodeOs from 'node:os';
 import nodePath from 'node:path';
@@ -31,6 +32,16 @@ export function worldDir(world: ArchitectureWorld): string {
 export function writeJson(path: string, value: unknown): void {
   mkdirSync(nodePath.dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(value));
+}
+
+/** Drive the real `safeword architecture` CLI in the world's project dir; record exit. */
+export function runArchitecture(world: ArchitectureWorld, args: string[] = []): void {
+  const result = spawnSync('bun', [CLI_PATH, 'architecture', ...args], {
+    cwd: worldDir(world),
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  world.status = result.status ?? 1;
 }
 
 /** The derived root index / single-repo doc at `.project/architecture.generated.md`. */

--- a/steps/support/architecture-fixtures.ts
+++ b/steps/support/architecture-fixtures.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared fixture + assertion helpers for the architecture-doc acceptance lanes
+ * (tickets ZRW21K, ZD70P1). Black-box: build a temp-dir project, drive the real
+ * `safeword architecture` CLI, and inspect the docs it writes. Centralized so the
+ * monorepo-coverage and Go-language-pack step files share one implementation (no
+ * duplicated fixture scaffolding) and one cleanup hook.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodeOs from 'node:os';
+import nodePath from 'node:path';
+
+import { After } from '@cucumber/cucumber';
+
+import type { SafewordWorld } from '../world.js';
+
+export const PROJECT_ROOT = nodePath.resolve(import.meta.dirname, '..', '..');
+export const CLI_PATH = nodePath.join(PROJECT_ROOT, 'packages/cli/src/cli.ts');
+
+export interface ArchitectureWorld extends SafewordWorld {
+  dir?: string;
+  status?: number;
+}
+
+/** The scenario's temp project directory, created on first use. */
+export function worldDir(world: ArchitectureWorld): string {
+  world.dir ??= mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'arch-bdd-'));
+  return world.dir;
+}
+
+export function writeJson(path: string, value: unknown): void {
+  mkdirSync(nodePath.dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value));
+}
+
+/** The derived root index / single-repo doc at `.project/architecture.generated.md`. */
+export function rootDoc(world: ArchitectureWorld): string {
+  const path = nodePath.join(worldDir(world), '.project', 'architecture.generated.md');
+  return existsSync(path) ? readFileSync(path, 'utf8') : '';
+}
+
+/** Whether a `packages/<name>` leaf carries its own colocated architecture doc. */
+export function leafDocExists(world: ArchitectureWorld, name: string): boolean {
+  return existsSync(nodePath.join(worldDir(world), 'packages', name, 'architecture.generated.md'));
+}
+
+/** A `### name` package section of the root index (to its next heading or EOF). */
+export function packageSection(world: ArchitectureWorld, name: string): string {
+  const chunk = rootDoc(world)
+    .split('\n### ')
+    .find(part => part.startsWith(`${name}\n`));
+  return chunk === undefined ? '' : `### ${chunk.split('\n## ')[0]}`;
+}
+
+After(function (this: ArchitectureWorld) {
+  if (this.dir !== undefined) rmSync(this.dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Extends the generated architecture doc beyond TypeScript to **Go** (ZD70P1) and **Rust** (YKFA5X) — the first two slices of epic **WBM8JE** (per-language extractors). Each language plugs into the same three-axis seam: workspace discovery → manifest-keyed `extractSkeleton` branch → manifest dependency set in the shape-fingerprint. Full BDD per slice: intake → scenarios → independent scenario-gate review → TDD → verify → audit → quality-review.

## What & why

The engine previously assumed a TypeScript `src/`-directory layout, so Go and Rust projects got the honest-but-empty "not introspected" marker (ZRW21K). These two slices make the polyglot promise real for the two most common JS companions.

### Go — ZD70P1
- **Extraction:** a `go.mod` directory is described by its conventional `cmd`/`internal`/`pkg` layout dirs.
- **Discovery:** `go.work` `use` directives are a workspace source (dependency-free parse).
- **Fingerprint:** `go.mod` `require` module paths join the shape set, so Go dependency drift is caught.
- A `/quality-review` against the official Go grammar caught and fixed two real parser bugs: a multi-block `require` read (the `go mod tidy` default split indirect deps into a second block) and dropped trailing-comment `use` entries.

### Rust — YKFA5X
- **Extraction:** a `Cargo.toml` crate lists its top-level `src/` modules — **files (`src/<name>.rs`) AND directories**, excluding the `lib.rs`/`main.rs` roots (Rust modules are commonly files, so dir-only would leave real crates undescribed).
- **Discovery:** `[workspace] members` globs via a dependency-free, table-scoped, comment-stripped TOML-subset parser (`cargo-manifest.ts`).
- **Fingerprint:** the `[dependencies]`/`[dev-dependencies]`/`[build-dependencies]` keys join the shape set.
- Two `/quality-review` passes: the first found and fixed two silently-wrong cases in the Cargo `members` parse (unscoped read; `]`-in-comment truncation); the second broad pass empirically confirmed the extraction/discovery/fingerprint/regression surface.

## Quality

- **Full suite green:** 3421 passing / 5 skipped. Build + lint + typecheck + gherkin clean; dependency-cruiser 0 violations; no new dead code.
- **Zero new dependencies** — both `go.mod`/`go.work` and `Cargo.toml` are parsed by small hand-written subset readers (no TOML/Go toolchain), consistent with the engine's deterministic, LLM-free, dependency-free posture.
- **Regression-guarded:** JS/TS single-repo and monorepo output is byte-identical (each language is a manifest-keyed branch that no-ops when its manifest is absent); the dogfood `architecture --check` on this repo exits 0 unchanged.
- **Honest omissions** (documented out-of-scope, never silently wrong): inter-package/crate dependency edges, module nesting, Cargo `exclude`/workspace-dep inheritance, both-config-at-root polyglot, and cross-manifest dep-name masking. A flat Go package / root-only Rust crate stays the explicit "not introspected" marker.

The remaining WBM8JE slice — **Python** — is next, and will open with a "generalize the mechanism" refactor (a per-language pack registry) now that three languages justify the abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S)_