### PR TITLE
Serialize package test runner for focused commands

### DIFF
--- a/.project/tickets/CQJBSN-test-suite-parallelism/ticket.md
+++ b/.project/tickets/CQJBSN-test-suite-parallelism/ticket.md
@@ -2,10 +2,10 @@
 id: CQJBSN
 slug: test-suite-parallelism
 type: task
-phase: intake
-status: backlog
+phase: implement
+status: in_progress
 created: 2026-06-01T01:03:41.848Z
-last_modified: 2026-06-01T01:03:41.848Z
+last_modified: 2026-06-24T05:58:34Z
 ---
 
 # Speed up the vitest suite — lift blanket maxWorkers:1, isolate the offenders
@@ -51,3 +51,5 @@ last_modified: 2026-06-01T01:03:41.848Z
 - 2026-06-01T14:12:00.000Z Interim: bumped `maxWorkers: 1 → 3` (kept `pool: 'forks'`). Full suite green, 146 files / 2358 pass, **~343s vs ~750s sequential (~2.2× faster)**. NOT the full fix — the proper isolation audit + `'50%'` / threads-tiering / CI-vs-local questions remain open.
 - 2026-06-01T15:05:00.000Z Reverted to `maxWorkers: 1` after the 3-worker bump flaked the pre-push gate 2/2 push runs. **(This reasoning was wrong — corrected below.)**
 - 2026-06-01T15:28:00.000Z **Investigated rigorously (user-requested). Two corrections:** (1) The "flake" is NOT a maxWorkers:3 determinism bug — **35/35 isolated runs passed** (npx + bunx, maxWorkers 3 and 5). It only failed during `git push` when the machine was CPU-saturated (load avg ~10 from back-to-back suites). So it's a **rare, load-dependent timing race** in the spawn-heavy integration tier, needing external CPU saturation to trigger — not reproducible at normal load. My earlier "~2/3 flake rate" was an artifact of 2 push-time samples. (2) **The CI block was a TIMEOUT, not a flake** — the `test` job (`timeout-minutes: 20`) was _cancelled_ at 20m13s at maxWorkers:1; sequential is too slow for the 2358-test suite + setup on the 4-vCPU `ubuntu-latest` runner. So maxWorkers:1 is a _guaranteed_ CI failure; the revert was backwards. **Resolution (`/figure-it-out` → option A):** re-set `maxWorkers: 3` (fits the 4-vCPU runner ~2.2×; CI is a dedicated runner with no competing load → the saturation-triggered race won't manifest) + raised CI `timeout-minutes` 20→30 for headroom. The proper two-tier fix (parallel pure-units + sequential spawn-tier) stays this ticket's real scope — it would also remove the residual saturation-race risk.
+- 2026-06-24T05:51:10Z Issue #379: Started focused slice for concurrent `bun run --cwd packages/cli test ...` invocations racing in package `pretest`/`tsup` clean. Scope is the package test command only: serialize build+Vitest for separate focused command processes so parallel agent verification waits instead of false-reding.
+- 2026-06-24T05:58:34Z Issue #379: Implemented package test runner lock around build+Vitest and removed the `pretest` lifecycle hook from `packages/cli` test. Verified with `tests/test-runner-lock.test.ts`, the originally observed two focused commands running concurrently (both 0), `bun run lint`, and `git diff --check`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,8 +32,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "pretest": "tsup",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest-with-build-lock.mjs",
     "pretest:bdd": "tsup",
     "test:bdd": "cucumber-js",
     "test:done": "vitest run tests/hooks/ tests/schema.test.ts",

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -1,0 +1,139 @@
+import { spawnSync } from 'node:child_process';
+import console from 'node:console';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+const scriptDirectory = import.meta.dirname;
+const cliRoot = nodePath.resolve(scriptDirectory, '..');
+const vitestArguments = process.argv.slice(2);
+const lockParent = nodePath.join(tmpdir(), 'safeword-test-locks');
+const lockName = createHash('sha256').update(cliRoot).digest('hex').slice(0, 16);
+const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
+  ? nodePath.resolve(process.env.SAFEWORD_TEST_LOCK_DIR)
+  : nodePath.join(lockParent, `${lockName}.lock`);
+const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+function removeStaleLock() {
+  let owner;
+  try {
+    owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
+  } catch {
+    const lockAgeMilliseconds = Date.now() - statSync(lockDirectory).mtimeMs;
+    if (lockAgeMilliseconds > 30_000) {
+      rmSync(lockDirectory, { force: true, recursive: true });
+      return true;
+    }
+    return false;
+  }
+
+  if (typeof owner.pid === 'number' && !isProcessAlive(owner.pid)) {
+    rmSync(lockDirectory, { force: true, recursive: true });
+    return true;
+  }
+
+  const createdAt = Date.parse(owner.createdAt);
+  if (Number.isFinite(createdAt) && Date.now() - createdAt > 6 * 60 * 60 * 1000) {
+    rmSync(lockDirectory, { force: true, recursive: true });
+    return true;
+  }
+
+  return false;
+}
+
+function acquireLock() {
+  mkdirSync(nodePath.dirname(lockDirectory), { recursive: true });
+
+  let waitedMilliseconds = 0;
+  for (;;) {
+    let mkdirError;
+    try {
+      mkdirSync(lockDirectory);
+      writeFileSync(
+        ownerPath,
+        `${JSON.stringify(
+          {
+            createdAt: new Date().toISOString(),
+            pid: process.pid,
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+      return;
+    } catch (error) {
+      mkdirError = error;
+    }
+
+    if (mkdirError?.code !== 'EEXIST') {
+      throw mkdirError;
+    }
+
+    if (removeStaleLock()) {
+      continue;
+    }
+
+    if (waitedMilliseconds >= 1000) {
+      console.error('Waiting for another safeword package test run to finish...');
+      waitedMilliseconds = -Infinity;
+    }
+    sleep(250);
+    waitedMilliseconds += 250;
+  }
+}
+
+function releaseLock() {
+  rmSync(lockDirectory, { force: true, recursive: true });
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: cliRoot,
+    env: process.env,
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.signal) {
+    console.error(`${command} terminated with signal ${result.signal}`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+let acquiredLock = false;
+let status;
+try {
+  acquireLock();
+  acquiredLock = true;
+  status = run('bun', ['run', 'build']);
+  if (status === 0) {
+    status = run('vitest', ['run', ...vitestArguments]);
+  }
+} finally {
+  if (acquiredLock) {
+    releaseLock();
+  }
+}
+
+process.exitCode = status ?? 1;

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -1,0 +1,117 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const cliRoot = nodePath.resolve(import.meta.dirname, '..');
+const runnerPath = nodePath.join(cliRoot, 'scripts/run-vitest-with-build-lock.mjs');
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  const directories = [...temporaryDirectories];
+  temporaryDirectories.length = 0;
+  await Promise.all(directories.map(directory => rm(directory, { force: true, recursive: true })));
+});
+
+function makeTemporaryDirectory(): string {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-test-runner-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function runNodeScript(scriptPath: string, args: string[], env: NodeJS.ProcessEnv) {
+  return await new Promise<{ stderr: string; stdout: string; status: number | null }>(resolve => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: cliRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', chunk => {
+      stderr += String(chunk);
+    });
+    child.on('close', status => {
+      resolve({ stderr, stdout, status });
+    });
+  });
+}
+
+describe('package test runner lock (379)', () => {
+  it('serializes build and vitest for concurrent focused test commands', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
+    await mkdir(binaryDirectory, { recursive: true });
+    const logPath = nodePath.join(temporaryDirectory, 'events.log');
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+
+    writeFileSync(
+      nodePath.join(binaryDirectory, 'bun'),
+      `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+const log = ${JSON.stringify(logPath)};
+const parent = process.ppid;
+appendFileSync(log, \`build:start:\${parent}\\n\`);
+await new Promise(resolve => setTimeout(resolve, 120));
+appendFileSync(log, \`build:end:\${parent}\\n\`);
+`,
+      { mode: 0o755 },
+    );
+
+    writeFileSync(
+      nodePath.join(binaryDirectory, 'vitest'),
+      `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+const log = ${JSON.stringify(logPath)};
+const parent = process.ppid;
+appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')}\\n\`);
+await new Promise(resolve => setTimeout(resolve, 120));
+appendFileSync(log, \`vitest:end:\${parent}\\n\`);
+`,
+      { mode: 0o755 },
+    );
+
+    const env = {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    };
+
+    const [first, second] = await Promise.all([
+      runNodeScript(runnerPath, ['tests/first.test.ts'], env),
+      runNodeScript(runnerPath, ['tests/second.test.ts'], env),
+    ]);
+
+    expect(first).toMatchObject({ status: 0, stderr: '' });
+    expect(second).toMatchObject({ status: 0, stderr: '' });
+
+    const events = readFileSync(logPath, 'utf8').trim().split('\n');
+    const parentIds = [...new Set(events.map(event => event.split(':', 3)[2]))];
+    expect(parentIds).toHaveLength(2);
+
+    for (const parentId of parentIds) {
+      const parentEvents = events.filter(event => event.includes(`:${parentId}`));
+      expect(parentEvents[0]).toBe(`build:start:${parentId}`);
+      expect(parentEvents[1]).toBe(`build:end:${parentId}`);
+      expect([
+        `vitest:start:${parentId}:run,tests/first.test.ts`,
+        `vitest:start:${parentId}:run,tests/second.test.ts`,
+      ]).toContain(parentEvents[2]);
+      expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
+    }
+
+    const firstParentEnd = events.findLastIndex(event => event.includes(`:${parentIds[0]}`));
+    const secondParentStart = events.findIndex(event => event.includes(`:${parentIds[1]}`));
+    expect(secondParentStart).toBeGreaterThan(firstParentEnd);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the package `pretest` lifecycle build with a locked test runner that wraps build + Vitest
- Serialize concurrent `bun run --cwd packages/cli test ...` invocations for the same checkout so they cannot race while cleaning `dist`
- Add a deterministic regression test with fake `bun` and `vitest` executables

Closes #379

## Verification
- `bun run --cwd packages/cli test tests/test-runner-lock.test.ts` (RED before script, GREEN after)
- Concurrent observed commands: `tests/hooks/record-skill-invocation.test.ts` and `tests/integration/codex-cursor-skill-fallback.test.ts` both exited 0
- `bun run lint`
- `git diff --check`