### PR TITLE
Enforce PR scope in verify done gate

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -160,7 +160,21 @@ Do NOT flag:
 - Type-only packages (`@types/*`) and standard-library imports
 - Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
-### 6. Report Results
+### 6. Check PR Scope (skip if no ticket)
+
+Compare the final change set against the ticket's `scope`, `out_of_scope`, and `done_when`.
+
+Use the best available diff:
+
+- Active PR diff, when the user gave one.
+- Otherwise branch diff against the upstream/default branch, plus uncommitted changes.
+- If no base is knowable, inspect `git status --short` and the commits/files touched this session.
+
+Flag any changed file or behavior that only serves a different outcome than the ticket. Required supporting cleanup is fine. Nice-to-have refactors, opportunistic fixes, drive-by docs edits, and follow-up discoveries are separate tickets/PRs.
+
+If PR scope fails, do not collapse to "Ready to mark done." Put the concrete split/revert/follow-up action in **Agent's next actions**, or put the scope decision in **Decisions needed** when the user must decide whether to expand the ticket.
+
+### 7. Report Results
 
 Structure the report in three sections, in this order. **Empty sections are hidden entirely** — no "None" placeholders, no empty headers.
 
@@ -176,11 +190,14 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
+**PR Scope:** ✅ Diff matches ticket scope (or ❌ Piggybacked changes: <paths/behaviors>, or ⏭️ Skipped — no ticket/diff)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md/package.json)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
+
+**PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
 
@@ -198,6 +215,7 @@ A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it 
 - `✓ X/X tests pass` — proves test suite ran
 - `**Gherkin:**` — proves the acceptance lane ran or was explicitly skipped
 - `All N scenarios marked complete` — proves scenarios checked
+- `**PR Scope:**` — proves the final diff was checked against ticket scope
 - `Audit passed` — proves /audit ran (run /audit separately)
 
 Without the required patterns in Status, the done phase will hard block.
@@ -234,7 +252,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -160,7 +160,21 @@ Do NOT flag:
 - Type-only packages (`@types/*`) and standard-library imports
 - Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
-### 6. Report Results
+### 6. Check PR Scope (skip if no ticket)
+
+Compare the final change set against the ticket's `scope`, `out_of_scope`, and `done_when`.
+
+Use the best available diff:
+
+- Active PR diff, when the user gave one.
+- Otherwise branch diff against the upstream/default branch, plus uncommitted changes.
+- If no base is knowable, inspect `git status --short` and the commits/files touched this session.
+
+Flag any changed file or behavior that only serves a different outcome than the ticket. Required supporting cleanup is fine. Nice-to-have refactors, opportunistic fixes, drive-by docs edits, and follow-up discoveries are separate tickets/PRs.
+
+If PR scope fails, do not collapse to "Ready to mark done." Put the concrete split/revert/follow-up action in **Agent's next actions**, or put the scope decision in **Decisions needed** when the user must decide whether to expand the ticket.
+
+### 7. Report Results
 
 Structure the report in three sections, in this order. **Empty sections are hidden entirely** — no "None" placeholders, no empty headers.
 
@@ -176,11 +190,14 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
+**PR Scope:** ✅ Diff matches ticket scope (or ❌ Piggybacked changes: <paths/behaviors>, or ⏭️ Skipped — no ticket/diff)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md/package.json)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
+
+**PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
 
@@ -198,6 +215,7 @@ A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it 
 - `✓ X/X tests pass` — proves test suite ran
 - `**Gherkin:**` — proves the acceptance lane ran or was explicitly skipped
 - `All N scenarios marked complete` — proves scenarios checked
+- `**PR Scope:**` — proves the final diff was checked against ticket scope
 - `Audit passed` — proves /audit ran (run /audit separately)
 
 Without the required patterns in Status, the done phase will hard block.
@@ -234,7 +252,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -154,7 +154,21 @@ Do NOT flag:
 - Type-only packages (`@types/*`) and standard-library imports
 - Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
-### 6. Report Results
+### 6. Check PR Scope (skip if no ticket)
+
+Compare the final change set against the ticket's `scope`, `out_of_scope`, and `done_when`.
+
+Use the best available diff:
+
+- Active PR diff, when the user gave one.
+- Otherwise branch diff against the upstream/default branch, plus uncommitted changes.
+- If no base is knowable, inspect `git status --short` and the commits/files touched this session.
+
+Flag any changed file or behavior that only serves a different outcome than the ticket. Required supporting cleanup is fine. Nice-to-have refactors, opportunistic fixes, drive-by docs edits, and follow-up discoveries are separate tickets/PRs.
+
+If PR scope fails, do not collapse to "Ready to mark done." Put the concrete split/revert/follow-up action in **Agent's next actions**, or put the scope decision in **Decisions needed** when the user must decide whether to expand the ticket.
+
+### 7. Report Results
 
 Structure the report in three sections, in this order. **Empty sections are hidden entirely** — no "None" placeholders, no empty headers.
 
@@ -170,11 +184,14 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
+**PR Scope:** ✅ Diff matches ticket scope (or ❌ Piggybacked changes: <paths/behaviors>, or ⏭️ Skipped — no ticket/diff)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md/package.json)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
+
+**PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
 
@@ -192,6 +209,7 @@ A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it 
 - `✓ X/X tests pass` — proves test suite ran
 - `**Gherkin:**` — proves the acceptance lane ran or was explicitly skipped
 - `All N scenarios marked complete` — proves scenarios checked
+- `**PR Scope:**` — proves the final diff was checked against ticket scope
 - `Audit passed` — proves /audit ran (run /audit separately)
 
 Without the required patterns in Status, the done phase will hard block.
@@ -228,7 +246,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.safeword/hooks/lib/quality.ts
+++ b/.safeword/hooks/lib/quality.ts
@@ -63,7 +63,7 @@ const PHASE_EVIDENCE: Record<BddPhase, string> = {
     'Phase: implement. CONFIDENT cites the passing artifact (X/X tests pass; scenario checked off).',
   verify:
     'Phase: verify. CONFIDENT cites /verify result (X/X tests; N/N scenarios complete) and that no scenarios are stale.',
-  done: "Phase: done. CONFIDENT cites /audit passed, /verify passed, verify.md present, scope drift checked, scenario coverage validated (no behaviors emerged that aren't in test-definitions), and any clear-win cross-scenario refactoring done.",
+  done: "Phase: done. CONFIDENT cites /audit passed, /verify passed, verify.md present, PR scope checked against the ticket (no piggybacked work), scenario coverage validated (no behaviors emerged that aren't in test-definitions), and any clear-win cross-scenario refactoring done.",
 };
 
 /** TDD-step-specific evidence for implement phase (RED/GREEN/REFACTOR). */

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -68,6 +68,7 @@ const MAX_MESSAGES_FOR_TOOLS = 5;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
+const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
 const USAGE_LIMIT_PATTERN = /\b(usage limit reached|5-hour limit reached)\b/i;
 
 const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
@@ -78,6 +79,11 @@ interface TicketInfo {
   phase: BddPhase | undefined;
   type: string | undefined;
   folder: string | undefined;
+}
+
+interface VerifyArtifactStatus {
+  ok: boolean;
+  reason?: string;
 }
 
 /**
@@ -436,8 +442,31 @@ Run /audit, show output, then try again.`;
 Expected evidence formats:
 - "✓ X/X tests pass" or "X/X tests pass" (required for tasks with no test command)
 - "**Gherkin:** ✅ Acceptance lane passes" or "Skipped — no test:bdd script" (acceptance lane evidence)${auditLine}
+- "**PR Scope:** ✅ Diff matches ticket scope" or a skipped status with a reason
 
 Run /verify, show output, then try again.`;
+}
+
+function checkVerifyArtifact(content: string): VerifyArtifactStatus {
+  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
+  if (!prScopeMatch?.groups?.status) {
+    return {
+      ok: false,
+      reason:
+        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
+    };
+  }
+
+  const status = prScopeMatch.groups.status;
+  if (/❌|piggybacked changes/i.test(status)) {
+    return {
+      ok: false,
+      reason:
+        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
+    };
+  }
+
+  return { ok: true };
 }
 
 /**
@@ -526,17 +555,25 @@ if (currentPhase === 'done') {
   }
 
   // Verify.md artifact gate — replaces text-pattern matching for audit evidence.
-  // verify.md is written by /verify skill when all checks pass.
+  // verify.md is written by /verify skill when all checks pass, including the
+  // PR-scope evidence that keeps unrelated work out of the closing change.
   if (ticketInfo.folder) {
     const verifyPath = `${ticketsDir}/${ticketInfo.folder}/verify.md`;
     const verifyExists = existsSync(verifyPath);
-    const verifyValid = verifyExists && readFileSync(verifyPath, 'utf8').trim().length > 0;
+    const verifyContent = verifyExists ? readFileSync(verifyPath, 'utf8') : '';
+    const verifyValid = verifyContent.trim().length > 0;
 
     if (!verifyValid) {
       recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
       hardBlockDone(
         `No valid verify.md found in ticket folder. Run /verify to generate evidence before marking done.`,
       );
+    }
+
+    const verifyArtifactStatus = checkVerifyArtifact(verifyContent);
+    if (!verifyArtifactStatus.ok) {
+      recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
+      hardBlockDone(verifyArtifactStatus.reason ?? 'verify.md PR scope evidence is invalid.');
     }
   }
 

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -154,7 +154,21 @@ Do NOT flag:
 - Type-only packages (`@types/*`) and standard-library imports
 - Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
-### 6. Report Results
+### 6. Check PR Scope (skip if no ticket)
+
+Compare the final change set against the ticket's `scope`, `out_of_scope`, and `done_when`.
+
+Use the best available diff:
+
+- Active PR diff, when the user gave one.
+- Otherwise branch diff against the upstream/default branch, plus uncommitted changes.
+- If no base is knowable, inspect `git status --short` and the commits/files touched this session.
+
+Flag any changed file or behavior that only serves a different outcome than the ticket. Required supporting cleanup is fine. Nice-to-have refactors, opportunistic fixes, drive-by docs edits, and follow-up discoveries are separate tickets/PRs.
+
+If PR scope fails, do not collapse to "Ready to mark done." Put the concrete split/revert/follow-up action in **Agent's next actions**, or put the scope decision in **Decisions needed** when the user must decide whether to expand the ticket.
+
+### 7. Report Results
 
 Structure the report in three sections, in this order. **Empty sections are hidden entirely** — no "None" placeholders, no empty headers.
 
@@ -170,11 +184,14 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
+**PR Scope:** ✅ Diff matches ticket scope (or ❌ Piggybacked changes: <paths/behaviors>, or ⏭️ Skipped — no ticket/diff)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md/package.json)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
+
+**PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
 
@@ -192,6 +209,7 @@ A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it 
 - `✓ X/X tests pass` — proves test suite ran
 - `**Gherkin:**` — proves the acceptance lane ran or was explicitly skipped
 - `All N scenarios marked complete` — proves scenarios checked
+- `**PR Scope:**` — proves the final diff was checked against ticket scope
 - `Audit passed` — proves /audit ran (run /audit separately)
 
 Without the required patterns in Status, the done phase will hard block.
@@ -228,7 +246,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/packages/cli/templates/hooks/lib/quality.ts
+++ b/packages/cli/templates/hooks/lib/quality.ts
@@ -63,7 +63,7 @@ const PHASE_EVIDENCE: Record<BddPhase, string> = {
     'Phase: implement. CONFIDENT cites the passing artifact (X/X tests pass; scenario checked off).',
   verify:
     'Phase: verify. CONFIDENT cites /verify result (X/X tests; N/N scenarios complete) and that no scenarios are stale.',
-  done: "Phase: done. CONFIDENT cites /audit passed, /verify passed, verify.md present, scope drift checked, scenario coverage validated (no behaviors emerged that aren't in test-definitions), and any clear-win cross-scenario refactoring done.",
+  done: "Phase: done. CONFIDENT cites /audit passed, /verify passed, verify.md present, PR scope checked against the ticket (no piggybacked work), scenario coverage validated (no behaviors emerged that aren't in test-definitions), and any clear-win cross-scenario refactoring done.",
 };
 
 /** TDD-step-specific evidence for implement phase (RED/GREEN/REFACTOR). */

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -68,6 +68,7 @@ const MAX_MESSAGES_FOR_TOOLS = 5;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
+const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
 const USAGE_LIMIT_PATTERN = /\b(usage limit reached|5-hour limit reached)\b/i;
 
 const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
@@ -78,6 +79,11 @@ interface TicketInfo {
   phase: BddPhase | undefined;
   type: string | undefined;
   folder: string | undefined;
+}
+
+interface VerifyArtifactStatus {
+  ok: boolean;
+  reason?: string;
 }
 
 /**
@@ -436,8 +442,31 @@ Run /audit, show output, then try again.`;
 Expected evidence formats:
 - "✓ X/X tests pass" or "X/X tests pass" (required for tasks with no test command)
 - "**Gherkin:** ✅ Acceptance lane passes" or "Skipped — no test:bdd script" (acceptance lane evidence)${auditLine}
+- "**PR Scope:** ✅ Diff matches ticket scope" or a skipped status with a reason
 
 Run /verify, show output, then try again.`;
+}
+
+function checkVerifyArtifact(content: string): VerifyArtifactStatus {
+  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
+  if (!prScopeMatch?.groups?.status) {
+    return {
+      ok: false,
+      reason:
+        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
+    };
+  }
+
+  const status = prScopeMatch.groups.status;
+  if (/❌|piggybacked changes/i.test(status)) {
+    return {
+      ok: false,
+      reason:
+        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
+    };
+  }
+
+  return { ok: true };
 }
 
 /**
@@ -526,17 +555,25 @@ if (currentPhase === 'done') {
   }
 
   // Verify.md artifact gate — replaces text-pattern matching for audit evidence.
-  // verify.md is written by /verify skill when all checks pass.
+  // verify.md is written by /verify skill when all checks pass, including the
+  // PR-scope evidence that keeps unrelated work out of the closing change.
   if (ticketInfo.folder) {
     const verifyPath = `${ticketsDir}/${ticketInfo.folder}/verify.md`;
     const verifyExists = existsSync(verifyPath);
-    const verifyValid = verifyExists && readFileSync(verifyPath, 'utf8').trim().length > 0;
+    const verifyContent = verifyExists ? readFileSync(verifyPath, 'utf8') : '';
+    const verifyValid = verifyContent.trim().length > 0;
 
     if (!verifyValid) {
       recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
       hardBlockDone(
         `No valid verify.md found in ticket folder. Run /verify to generate evidence before marking done.`,
       );
+    }
+
+    const verifyArtifactStatus = checkVerifyArtifact(verifyContent);
+    if (!verifyArtifactStatus.ok) {
+      recordFailure(projectDir, input.session_id, 'done-gate-tests-failed');
+      hardBlockDone(verifyArtifactStatus.reason ?? 'verify.md PR scope evidence is invalid.');
     }
   }
 

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -160,7 +160,21 @@ Do NOT flag:
 - Type-only packages (`@types/*`) and standard-library imports
 - Tooling/dev dependencies (linters, formatters, test utils — across any language) — only flag deps that represent architectural choices
 
-### 6. Report Results
+### 6. Check PR Scope (skip if no ticket)
+
+Compare the final change set against the ticket's `scope`, `out_of_scope`, and `done_when`.
+
+Use the best available diff:
+
+- Active PR diff, when the user gave one.
+- Otherwise branch diff against the upstream/default branch, plus uncommitted changes.
+- If no base is knowable, inspect `git status --short` and the commits/files touched this session.
+
+Flag any changed file or behavior that only serves a different outcome than the ticket. Required supporting cleanup is fine. Nice-to-have refactors, opportunistic fixes, drive-by docs edits, and follow-up discoveries are separate tickets/PRs.
+
+If PR scope fails, do not collapse to "Ready to mark done." Put the concrete split/revert/follow-up action in **Agent's next actions**, or put the scope decision in **Decisions needed** when the user must decide whether to expand the ticket.
+
+### 7. Report Results
 
 Structure the report in three sections, in this order. **Empty sections are hidden entirely** — no "None" placeholders, no empty headers.
 
@@ -176,11 +190,14 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
+**PR Scope:** ✅ Diff matches ticket scope (or ❌ Piggybacked changes: <paths/behaviors>, or ⏭️ Skipped — no ticket/diff)
 **Dep Drift:** ✅ Clean (or ⚠️ N undocumented deps, or ⏭️ Skipped — no ARCHITECTURE.md/package.json)
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
 ```
+
+**PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
 
 **Reconcile** is soft — it never blocks the done gate. If the work introduced a pattern that diverges from existing siblings (see `.safeword/guides/architecture-guide.md` → Survey & Reconcile), confirm the ticket carries a reconcile record and every deviation has an uplevel follow-up ticket; flag any that don't. Use `N/A` when the work conformed or introduced no new pattern.
 
@@ -198,6 +215,7 @@ A ⚠️ Experience finding routes to **Agent's next actions** if you'll fix it 
 - `✓ X/X tests pass` — proves test suite ran
 - `**Gherkin:**` — proves the acceptance lane ran or was explicitly skipped
 - `All N scenarios marked complete` — proves scenarios checked
+- `**PR Scope:**` — proves the final diff was checked against ticket scope
 - `Audit passed` — proves /audit ran (run /audit separately)
 
 Without the required patterns in Status, the done phase will hard block.
@@ -234,7 +252,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/packages/cli/tests/integration/done-gate-harness.ts
+++ b/packages/cli/tests/integration/done-gate-harness.ts
@@ -33,7 +33,7 @@ export function writeFeatureTicketAtDone(directory: string, ticketId: string): v
   writeTestFile(
     directory,
     `${folder}/verify.md`,
-    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
+    'Verified: 2026-01-06\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n**PR Scope:** ✅ Diff matches ticket scope\n',
   );
 }
 

--- a/packages/cli/tests/integration/hierarchy-navigation.test.ts
+++ b/packages/cli/tests/integration/hierarchy-navigation.test.ts
@@ -141,7 +141,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/001a-feature/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     // Next sibling — not done
@@ -213,7 +213,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/013b-feat/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     const transcriptPath = createTranscript(projectDirectory, taskEvidence);
@@ -267,7 +267,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/013a-feat/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     // Uncle sibling — not done
@@ -317,7 +317,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/025-standalone/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     const transcriptPath = createTranscript(projectDirectory, featureEvidence);
@@ -342,7 +342,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/050-orphan/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     const transcriptPath = createTranscript(projectDirectory, taskEvidence);
@@ -374,7 +374,7 @@ describe('hierarchy navigation in stop hook', () => {
     writeTestFile(
       projectDirectory,
       '.safeword-project/tickets/016a-feat/verify.md',
-      'Verified: 2026-01-01T00:00:00Z\n',
+      'Verified: 2026-01-01T00:00:00Z\n\n**PR Scope:** ✅ Diff matches ticket scope\n',
     );
 
     const transcriptPath = createTranscript(projectDirectory, taskEvidence);

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -31,6 +31,8 @@ import {
 } from '../helpers';
 
 const IS_RUFF_AVAILABLE = isRuffInstalled();
+const VERIFIED_AT = '2026-04-15T18:00:00Z';
+const PR_SCOPE_OK_LINE = '**PR Scope:** ✅ Diff matches ticket scope';
 
 // Single setup for all hook tests - sharing avoids 3 separate bun installs
 // Tests must be idempotent or restore state after modification (see try/finally blocks)
@@ -67,6 +69,19 @@ function createTicketContent(options: {
   if (options.status) lines.push(`status: ${options.status}`);
   lines.push(`last_modified: ${options.lastModified}`, '---', '', `# Ticket ${options.id}`, '');
   return lines.join('\n');
+}
+
+/** Create valid verify.md content for done-gate tests */
+function createVerifyContent({
+  testSuite = '**Test Suite:** ✓ 42/42 tests pass',
+  extraLines = [],
+}: {
+  testSuite?: string;
+  extraLines?: string[];
+} = {}): string {
+  return [`Verified: ${VERIFIED_AT}`, '', testSuite, PR_SCOPE_OK_LINE, ...extraLines, ''].join(
+    '\n',
+  );
 }
 
 /** Clear tickets directory */
@@ -548,7 +563,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 10/10 tests pass\n',
+        createVerifyContent({ testSuite: '**Test Suite:** ✓ 10/10 tests pass' }),
       );
 
       const result = runStopHookForPhase(shared.projectDirectory);
@@ -783,7 +798,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\n',
+        createVerifyContent(),
       );
 
       const evidenceText = '## Done Checklist\n\n**Test Suite:** ✓ 42/42 tests pass';
@@ -791,6 +806,58 @@ describe('E2E: Phase-Aware Quality Review', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.reason).toBe('');
+    });
+
+    it('Scenario 15b: Task done blocks when verify.md lacks PR scope evidence', () => {
+      setupIssuesDirectory(shared.projectDirectory, [
+        {
+          id: '001',
+          type: 'task',
+          phase: 'done',
+          status: 'in_progress',
+          lastModified: '2026-01-06T10:00:00Z',
+        },
+      ]);
+      writeTestFile(
+        shared.projectDirectory,
+        '.project/tickets/001/verify.md',
+        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\n',
+      );
+
+      const evidenceText = '## Done Checklist\n\n**Test Suite:** ✓ 42/42 tests pass';
+      const result = runStopHookForPhase(shared.projectDirectory, evidenceText);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.reason).toContain('PR scope evidence');
+    });
+
+    it('Scenario 15c: Task done blocks when verify.md reports piggybacked changes', () => {
+      setupIssuesDirectory(shared.projectDirectory, [
+        {
+          id: '001',
+          type: 'task',
+          phase: 'done',
+          status: 'in_progress',
+          lastModified: '2026-01-06T10:00:00Z',
+        },
+      ]);
+      writeTestFile(
+        shared.projectDirectory,
+        '.project/tickets/001/verify.md',
+        [
+          'Verified: 2026-04-15T18:00:00Z',
+          '',
+          '**Test Suite:** ✓ 42/42 tests pass',
+          '**PR Scope:** ❌ Piggybacked changes: docs/drive-by.md',
+          '',
+        ].join('\n'),
+      );
+
+      const evidenceText = '## Done Checklist\n\n**Test Suite:** ✓ 42/42 tests pass';
+      const result = runStopHookForPhase(shared.projectDirectory, evidenceText);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.reason).toContain('PR scope failed');
     });
 
     it('Scenario 16: Feature done with verify.md and complete scenarios passes', () => {
@@ -811,7 +878,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
+        createVerifyContent({ extraLines: ['Audit passed'] }),
       );
 
       const result = runStopHookForPhase(shared.projectDirectory);
@@ -838,7 +905,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\n',
+        createVerifyContent(),
       );
 
       const result = runStopHookForPhase(shared.projectDirectory);
@@ -865,7 +932,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
+        createVerifyContent({ extraLines: ['Audit passed'] }),
       );
 
       const result = runStopHookForPhase(shared.projectDirectory);
@@ -902,7 +969,7 @@ describe('E2E: Phase-Aware Quality Review', () => {
       writeTestFile(
         shared.projectDirectory,
         '.project/tickets/001/verify.md',
-        'Verified: 2026-04-15T18:00:00Z\n\n**Test Suite:** ✓ 42/42 tests pass\nAudit passed\n',
+        createVerifyContent({ extraLines: ['Audit passed'] }),
       );
 
       const result = runStopHookForPhase(shared.projectDirectory);

--- a/packages/cli/tests/integration/phase-derivation.test.ts
+++ b/packages/cli/tests/integration/phase-derivation.test.ts
@@ -492,7 +492,7 @@ describe('Phase Derivation (#124)', () => {
       writeTestFile(
         projectDirectory,
         `${ticketFolder}/verify.md`,
-        'Verified: 2026-04-15T18:00:00Z\n\n## Verify Checklist\n\n**Test Suite:** ✓ 10/10 tests pass\n',
+        'Verified: 2026-04-15T18:00:00Z\n\n## Verify Checklist\n\n**Test Suite:** ✓ 10/10 tests pass\n**PR Scope:** ✅ Diff matches ticket scope\n',
       );
       // Skill-invocation gate (ticket 147): feature ticket entering done
       // requires current-session log entries for /verify and /audit.

--- a/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
+++ b/packages/cli/tests/integration/whole-ticket-quality-refactor.test.ts
@@ -91,7 +91,7 @@ function writeTicket(
   writeTestFile(
     shared.projectDirectory,
     `${folder}/verify.md`,
-    'Verified\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n',
+    'Verified\n\n## Verify Checklist\n\n**Test Suite:** ✓ 1/1 tests pass\n**PR Scope:** ✅ Diff matches ticket scope\n',
   );
 }
 

--- a/packages/cli/tests/quality.test.ts
+++ b/packages/cli/tests/quality.test.ts
@@ -242,12 +242,13 @@ describe('getQualityMessage — universal binary terminal (143 + F14BG2 + QSNKBB
       expect(message.toLowerCase()).toMatch(/tests.*pass/);
     });
 
-    it('done evidence cites /audit AND /verify AND verify.md AND scope drift AND scenario coverage AND refactoring', () => {
+    it('done evidence cites /audit AND /verify AND verify.md AND PR scope AND scenario coverage AND refactoring', () => {
       const message = getQualityMessage('done');
       expect(message).toContain('/audit');
       expect(message).toContain('/verify');
       expect(message).toContain('verify.md');
-      expect(message.toLowerCase()).toContain('scope drift');
+      expect(message.toLowerCase()).toContain('pr scope');
+      expect(message.toLowerCase()).toContain('no piggybacked work');
       expect(message.toLowerCase()).toContain('scenario coverage');
       expect(message.toLowerCase()).toContain('refactoring');
     });

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -56,6 +56,7 @@ describe('verify report structure (146)', () => {
       expect(content).toContain('✓ X/X tests pass');
       expect(content).toContain('**Gherkin:**');
       expect(content).toContain('All N scenarios marked complete');
+      expect(content).toContain('**PR Scope:**');
       expect(content).toContain('Audit passed');
       expect(content).not.toContain('Without all three patterns');
     });
@@ -137,6 +138,30 @@ describe('verify report structure (146)', () => {
     it.each(surfaces)('%s explicitly states empty sections are hidden', (_name, content) => {
       expect(content.toLowerCase()).toContain('empty sections are hidden');
     });
+  });
+
+  describe('Rule: PR scope prevents piggybacked changes', () => {
+    it.each(surfaces)('%s includes PR Scope in the Verify Checklist', (_name, content) => {
+      expect(content).toContain('**PR Scope:**');
+      expect(content).toContain('Diff matches ticket scope');
+      expect(content).toContain('Piggybacked changes');
+    });
+
+    it.each(surfaces)('%s blocks all-green collapse when PR scope fails', (_name, content) => {
+      expect(content).toMatch(/PR Scope[\s\S]*one purpose/);
+      expect(content).toMatch(/PR scope fails[\s\S]*do not collapse/);
+      expect(content).toContain('Ready to mark done');
+    });
+
+    it.each(surfaces)(
+      '%s routes unrelated work to split, revert, or scope decision',
+      (_name, content) => {
+        expect(content).toContain('Nice-to-have refactors');
+        expect(content).toContain('opportunistic fixes');
+        expect(content).toContain('separate tickets/PRs');
+        expect(content).toContain('split/revert/follow-up action');
+      },
+    );
   });
 
   describe('Rule: section 2 consumes safeword test-plan (5FF0ZD)', () => {


### PR DESCRIPTION
## Summary
- Add a PR Scope check to /verify so final diffs are compared against ticket scope, out_of_scope, and done_when
- Require verify.md to include PR scope evidence before done can pass
- Block done when verify.md reports piggybacked changes, and update fixtures/tests for the new evidence line

## Verification
- bun run --cwd packages/cli test -- tests/verify-skill.test.ts tests/quality.test.ts tests/integration/hooks.test.ts tests/integration/phase-derivation.test.ts tests/integration/whole-ticket-quality-refactor.test.ts tests/integration/skill-gate-integration.test.ts tests/integration/codex-cursor-skill-fallback.test.ts tests/integration/hierarchy-navigation.test.ts
- bun run --cwd packages/cli test -- tests/integration/hooks.test.ts
- bun run --cwd packages/cli typecheck
- bunx prettier --check packages/cli/tests/integration/hooks.test.ts
- git diff --check