### PR TITLE
chore(release): v0.56.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.56.0** — minor (additive features + fixes; auto-upgradeable). 27 commits since v0.55.0.

## Features
- **Tracker integration:** connect/onboarding flow — opt-in, verify-before-sync (#382); sync-tracker v1 + `blocked_on` gate (#349)
- **Language packs:** Go + Rust architecture introspection (#381); pnpm monorepo discovery + un-introspected-package marker (#354)
- **Quality gates:** PR-scope enforcement in the verify done-gate (#403); cross-model enforcement on the phase-exit review gate (#357, #359, #362)
- **Architecture docs:** enforcement + monorepo + prose persistence (#350)
- **Intake:** cold-start executability check (#348), rung-0 framing (#336), riskiest-assumption impl-plan ordering (#339), rave-moment intake + two-lens experience review (#356)
- **Worktrees:** auto-install deps at SessionStart (#371)
- **ticket-sync:** external issue/PR links (#396)
- **NTB persona:** legibility for non-technical builders + de-jargon (#355, #358)

## Fixes
- Probe test-plan-capable verify CLI (#377)
- Serialize package test runner / build-lock (#383)
- dep-readiness no-op recovery escape (#346)
- Refactor Codex hook adapters + fix quality gates (#373)
- Revalidate verify/audit on main (#387)

## Chore / docs
- reviewer-class taxonomy (#351), website auto-lint output fix (#338), cucumber steps dedup (#342), remove stray `planning/` dir (#378)

Both version files bumped to 0.56.0; lockfile regenerated (no resolution change).