### PR TITLE
Project tracker graph and Codex live smoke

### DIFF
--- a/.project/tickets/CXP9LM-codex-live-parity-smoke/ticket.md
+++ b/.project/tickets/CXP9LM-codex-live-parity-smoke/ticket.md
@@ -56,4 +56,5 @@ The epic now has generation and hook-spike work, but those are still mostly repo
 
 ## Work Log
 
+- 2026-06-24T15:50:00Z Ran the live Codex parity smoke on Codex CLI 0.141.0 from a clean fixture. Added `tests/smoke/codex-parity.live.test.ts` as an opt-in repeatable smoke (`SAFEWORD_RUN_CODEX_LIVE_SMOKE=1`). Direct Codex hook payloads deny/allow correctly and now point Codex users at `$explain`; live `codex exec` currently performs the requested edit through a `file_change` execution path that is not intercepted by the configured `PreToolUse` matcher. Captured results and unsupported-path findings in `verify.md`; ticket remains in_progress until the unsupported live path is resolved or explicitly scoped out.
 - 2026-06-13 Created from Codex parity review gap: add a real black-box/trusted smoke after 5DEJ8V and N12G95.

--- a/.project/tickets/CXP9LM-codex-live-parity-smoke/verify.md
+++ b/.project/tickets/CXP9LM-codex-live-parity-smoke/verify.md
@@ -1,0 +1,35 @@
+# Verify: CXP9LM Codex live parity smoke
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5/5 targeted Codex adapter tests pass; ✓ 1/1 opt-in Codex live smoke test passes
+**Gherkin:** ⏭️ Skipped — `codex-live-parity-smoke.feature` is tagged `@live @manual`; the executable live coverage is `tests/smoke/codex-parity.live.test.ts`
+**Build:** ⏭️ Skipped — no production build required for this smoke/evidence update
+**Lint:** ⏭️ Skipped — targeted test/evidence update only
+**Scenarios:** ❌ 0/4 complete — live feature scenarios remain manual until unsupported Codex execution paths are resolved or deliberately scoped
+**Dep Drift:** ✅ Clean — no dependency changes
+**Parent Epic:** QM5G9M (siblings: live smoke still open)
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⚠️ Walked Codex user through clean setup + blocked edit help; worst step = the blocking hint previously said `/explain`, which is Claude/Cursor syntax, not Codex skill syntax. Fixed the Codex adapter to surface `$explain`.
+
+## Evidence
+
+- `bun install` completed and rebuilt `packages/cli/dist`.
+- `bun run --cwd packages/cli vitest run tests/integration/codex-pretooluse-spike.test.ts`
+  - Result: 5/5 passing.
+- `SAFEWORD_RUN_CODEX_LIVE_SMOKE=1 bun run --cwd packages/cli vitest run tests/smoke/codex-parity.live.test.ts --config vitest.live.config.ts`
+  - Result: 1/1 passing on local `codex-cli 0.141.0`.
+- Clean fixture setup from `node packages/cli/dist/cli.js setup --yes --no-modify` creates `.codex/config.toml`, `.agents/skills/explain/SKILL.md`, and `.safeword/hooks/codex/pre-tool-quality.ts`, and prints the `/hooks` trust next step.
+
+## Findings
+
+- Supported Codex hook payload path works: invoking `.safeword/hooks/codex/pre-tool-quality.ts` with an `apply_patch` payload denies an incomplete feature ticket and allows the same path after `scope`, `out_of_scope`, `done_when`, `dimensions.md`, `spec.md`, and `personas.md` are present.
+- Codex-specific help text now points at `$explain` instead of `/explain`, matching Codex skill invocation syntax while leaving the shared Claude/Cursor hint unchanged.
+- Current `codex exec` live editing on Codex CLI 0.141.0 used a `file_change` execution item for the requested file edit. That path was not intercepted by the configured `PreToolUse` matcher, so the edit succeeded even though the direct supported hook payload would deny it.
+- `codex debug prompt-input` in the clean fixture did not expose repo-scoped `.agents/skills/explain` in the visible skill roots during this run. That keeps the #360 manual `/explain` verification open.
+
+## Agent's next actions
+
+- Decide whether safeword can intercept Codex `file_change` via a current hook event/config path; if yes, add support and convert the live smoke from finding-tolerant to denial-required.
+- If Codex intentionally does not expose `file_change` to hooks, update the Codex parity support boundary and decide whether #394 can close with direct-adapter coverage plus the documented live limitation.
+- Run the remaining #360 manual UI check in an interactive Codex session: confirm the block text reaches the screen and `$explain` is invokable/read-only.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -39,6 +39,7 @@
 
 - **Auto-upgrade under Codex (7R1D3B)** (blocked, epic: auto-upgrade-cross-agent)
   Codex users get safeword's seamless patch/minor auto-upgrade (today Claude-Code-only) without manual `safeword upgrade` and within Codex's synchronous hook contract.
+  external issue: https://github.com/ArcadeAI/safeword/issues/393
   → `.project/tickets/7R1D3B-auto-upgrade-codex`
 - **Epic: Cross-agent auto-upgrade (Cursor + Codex) (BJX7WR)** (in_progress, epic: auto-upgrade-cross-agent)
   Extend safeword's seamless auto-upgrade — today Claude-Code-only — to the other two supported agents, Cursor and Codex, so customers on any agent stay current without manual `safeword upgrade`.
@@ -248,6 +249,7 @@
   Ship safeword as a Codex plugin distributed via Codex's marketplace, parallel to the Cursor packaging ticket (DXYKJX).
   → `.project/tickets/6WJ1RS-codex-plugin-marketplace-packaging`
 - **Prove Codex parity in a trusted customer repo (CXP9LM)** (in_progress, epic: codex-changelog-alignment)
+  external issue: https://github.com/ArcadeAI/safeword/issues/394
   → `.project/tickets/CXP9LM-codex-live-parity-smoke`
 - **Map safeword lifecycle events to Codex hook events (design) (HPP49X)** (done, epic: codex-changelog-alignment)
   Design doc mapping safeword's five gate moments onto Codex hook events.
@@ -263,6 +265,7 @@
   → `.project/tickets/QGHVXZ-codex-commands-skills-vs-prompts`
 - **Epic: OpenAI Codex changelog + docs alignment (QM5G9M)** (open, epic: codex-changelog-alignment)
   Bring safeword's gate model to OpenAI Codex (the `codex` CLI), now that research confirms Codex's enforcement surfaces are a clean fit.
+  external issue: https://github.com/ArcadeAI/safeword/issues/395
   → `.project/tickets/QM5G9M-codex-changelog-alignment-epic`
 - **Pin minimum codex CLI version that supports required hooks (WR4HRA)** (done, epic: codex-changelog-alignment)
   Record the minimum `codex` CLI version safeword requires, and warn below it during setup and upgrade.
@@ -905,9 +908,10 @@
 - **De-jargon the interactive CLI; auto-default the namespace-move prompt (KRUEWC)** (done, epic: —)
   Make the unmediated terminal surface (`setup`/`upgrade`/`check`) answerable by a non-coder, and never halt on a jargon-only decision.
   → `.project/tickets/KRUEWC-dejargon-interactive-cli`
-- **sync-tracker v2 — project the dependency graph (relations, sub-issues, types) (M1FGRJ)** (blocked, epic: —)
+- **sync-tracker v2 — project the dependency graph (relations, sub-issues, types) (M1FGRJ)** (in_progress, epic: —)
   Extend `safeword sync-tracker` from a flat board to a **dependency-aware** projection: map safeword's `epic`/`parent` to tracker **sub-issues/parents**, `blocked_on`/`depends_on` to tracker **issue relations**, and `type` to native **issue-types** — so the external roadmap shows ordering and hierarchy, not just grouping.
   blocked by: safeword sync-tracker — one-way projection to Linear + GitHub Issues (JS5K5G)
+  external issue: https://github.com/ArcadeAI/safeword/issues/347
   → `.project/tickets/M1FGRJ-tracker-relations-projection`
 - **Local ticket schema: epic + blocked_on, warn-only + one blocked_on hard gate (MBGQ89)** (done, epic: —)
   Promote `epic` and `blocked_on` from ad-hoc free-text frontmatter to canonical fields, validated **warn-only** by `safeword check` — with exactly **one** hard gate: `blocked_on` denies advancing a ticket's phase out of `intake` while a same-repo dependency isn't `done` (other terminal states need a reasoned override). (`depends_on` already landed via [AKZJXC](../AKZJXC-ticket-relations/ticket.md); `parent`/`paired_with` are deferred — no consumer yet.)
@@ -1024,7 +1028,7 @@
   Extend the repo-level extension contract (70G298) with a third precedence layer — personal extensions that an individual contributor can layer on top of both safeword core AND repo-level extensions. Personal extensions live in a gitignored location by default so personal customizations don't leak into the team's repo.
   blocked by: Make safeword extensible at the repo/organization level — customer-specific rules, hooks, skills, conventions (70G298)
   → `.project/tickets/XSDQZ0`
-- **Document Codex parity for developers (Y5GS4X)** (in_progress, epic: —)
+- **Document Codex parity for developers (Y5GS4X)** (done, epic: —)
   Make safeword's public developer docs reflect Codex as a first-class installed surface alongside Claude Code and Cursor.
   → `.project/tickets/Y5GS4X-document-codex-parity-for-developers`
 - **Rust language pack — Cargo workspace discovery, src extraction, Cargo.toml fingerprint (YKFA5X)** (done, epic: —)

--- a/.project/tickets/M1FGRJ-tracker-relations-projection/dimensions.md
+++ b/.project/tickets/M1FGRJ-tracker-relations-projection/dimensions.md
@@ -1,0 +1,11 @@
+# Dimensions: sync-tracker v2 graph projection
+
+| Dimension | Partitions | Notes |
+| --- | --- | --- |
+| Parent source | `parent:` resolves, `epic:` resolves, neither resolves | Native hierarchy is attempted only for known local tickets. |
+| Projection order | parent ID sorts before child, child ID sorts before parent | Parent-before-child ordering must be independent of ID sort. |
+| Relation source | `depends_on`, `blocked_on`, dangling relation | Known refs become native relations; dangling refs are skipped. |
+| Sync action | create, update, pending-entry reconcile | Graph projection must run in every idempotent path. |
+| Native type support | provider accepts type, provider rejects/omits type | The `type:<type>` label remains the fallback. |
+| Provider | GitHub, Linear | Tests mock provider ports; no live tracker dependency. |
+

--- a/.project/tickets/M1FGRJ-tracker-relations-projection/spec.md
+++ b/.project/tickets/M1FGRJ-tracker-relations-projection/spec.md
@@ -1,74 +1,78 @@
-# Spec: sync-tracker v2 — project the dependency graph (relations, sub-issues, types)
-
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
+# Spec: sync-tracker v2 — project the dependency graph
 
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Extend `safeword sync-tracker` from a flat issue mirror to a dependency-aware
+coordination mirror. Local ticket files remain canonical, while supported
+trackers receive native hierarchy, type, and dependency links when their APIs can
+represent them.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- GitHub issue: <https://github.com/ArcadeAI/safeword/issues/347>
+- Parent implementation: `../JS5K5G-sync-tracker/ticket.md`
+- Local relation source: `depends_on:` from `../AKZJXC-ticket-relations/ticket.md`
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-the configured personas file (e.g., Platform Operator (PO)). Add new
-personas to that file — don't invent them here. -->
+- Technical Builder (TB)
 
 ## Vocabulary
 
-<!-- Domain terms specific to this feature, consistent with
-the configured glossary file. Optional. -->
+- **Native hierarchy:** a tracker parent/sub-issue relationship, not a label.
+- **Native relation:** a tracker blocking/blocked-by edge, not prose in the body.
+- **Fallback label:** the existing v1 `epic:<slug>` or `type:<type>` label when
+  the tracker cannot set a native field.
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### tracker-relations.TB1 — Mirror ordering and dependencies without moving source of truth
 
-Uncomment and customize:
+**Persona:** Technical Builder (TB)
 
-### oauth-flow.PO1 — Rotate credentials without a flag day
+> When my local ticket corpus has parents, epics, types, and dependencies, I want
+> `safeword sync-tracker` to project those fields into my external tracker, so I
+> can coordinate roadmap order and blockers with teammates without editing the
+> tracker by hand.
 
-**Persona:** Platform Operator (PO)
+#### tracker-relations.TB1.AC1 — Parents exist before children are linked
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
+Tickets with a resolvable `parent:` or `epic:` link are projected after their
+parent so providers that link existing issues can succeed without a second pass.
 
-Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
-in descriptive product language (a guarantee the user can observe), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario will prove a specific AC. If a JTBD has no user-observable capability
-to enumerate, write `skip: <reason>` under it instead of ACs.
+#### tracker-relations.TB1.AC2 — Native hierarchy is attempted only for known parents
 
-#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
+If `parent:` or `epic:` resolves to a known ticket in the current corpus, the
+writer receives the parent tracker ref. If it does not resolve, the v1 labels
+remain and native hierarchy is skipped.
 
-#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
--->
+#### tracker-relations.TB1.AC3 — Dependencies become native issue relations
+
+Each `depends_on:` or `blocked_on:` edge whose target resolves to a synced ticket
+is projected as a native blocked-by/dependency relation. Dangling or cross-branch
+refs are skipped without creating a blind issue.
+
+#### tracker-relations.TB1.AC4 — Type promotion keeps the label fallback
+
+Writers receive the ticket's type as the native issue type candidate while the v1
+`type:<type>` label remains in the payload for providers or repositories without
+native issue-type support.
+
+#### tracker-relations.TB1.AC5 — Graph projection is idempotent
+
+The writer receives a graph request after create, update, or pending-entry
+reconcile. Re-running the command replays the same graph links against the same
+sidecar refs rather than creating duplicate issues.
 
 ## Outcomes
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+- `sync-tracker` produces parent-before-child create/update order.
+- `IssuePayload` carries native type and graph intent without removing v1 labels.
+- Writers expose graph projection through mocked unit-testable methods.
+- The live GitHub adapter uses current `gh issue edit` graph flags where
+  available and treats unsupported issue types as a label fallback.
 
 ## Open Questions
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+- defer: GitHub Projects v2 Status-field ownership needs a separate decision
+  because v1 deliberately ceded status except for close-on-terminal.

--- a/.project/tickets/M1FGRJ-tracker-relations-projection/test-definitions.md
+++ b/.project/tickets/M1FGRJ-tracker-relations-projection/test-definitions.md
@@ -1,0 +1,42 @@
+# Test Definitions: sync-tracker v2 graph projection
+
+## tracker-relations.TB1.AC1 — Parents exist before children are linked
+
+- [x] RED: added an orchestrator test where a child sorts before its parent by ID
+      but the writer creates the parent first; it failed with child-before-parent.
+- [x] GREEN: sorted the corpus by resolvable `parent:` / `epic:` before
+      projecting.
+- [x] REFACTOR: kept ordering pure and provider-neutral.
+
+## tracker-relations.TB1.AC2 — Native hierarchy is attempted only for known parents
+
+- [x] RED: added payload/corpus tests for native type and ticket graph metadata;
+      they failed before the new fields existed.
+- [x] GREEN: carried raw parent/dependency metadata through the corpus and
+      resolved it only against known corpus aliases during projection.
+- [x] REFACTOR: kept v1 `epic:` labels untouched as fallback.
+
+## tracker-relations.TB1.AC3 — Dependencies become native issue relations
+
+- [x] RED: added an orchestrator test that records a synced dependency target and
+      expects the writer to receive a blocked-by relation.
+- [x] GREEN: translated `depends_on:` / `blocked_on:` refs through the sidecar map
+      and skipped dangling refs.
+- [x] REFACTOR: shared graph-ref resolution across create/update/reconcile.
+
+## tracker-relations.TB1.AC4 — Type promotion keeps the label fallback
+
+- [x] RED: added payload/writer tests showing `issueType` is supplied while the
+      `type:<type>` label remains.
+- [x] GREEN: extended `IssuePayload` and writer graph requests with the native
+      type candidate.
+- [x] REFACTOR: kept unsupported native type fallback in the GitHub adapter, not
+      the orchestrator.
+
+## tracker-relations.TB1.AC5 — Graph projection is idempotent
+
+- [x] RED: added an orchestrator test that re-runs against recorded refs and still
+      calls the graph writer without creating a duplicate.
+- [x] GREEN: invoked graph projection after every successful create/update or
+      reconcile using recorded sidecar refs.
+- [x] REFACTOR: kept sidecar format stable.

--- a/.project/tickets/M1FGRJ-tracker-relations-projection/ticket.md
+++ b/.project/tickets/M1FGRJ-tracker-relations-projection/ticket.md
@@ -2,12 +2,30 @@
 id: M1FGRJ
 slug: tracker-relations-projection
 type: feature
-phase: intake
-status: blocked
+phase: verify
+status: in_progress
 depends_on: [JS5K5G]
 external: https://github.com/ArcadeAI/safeword/issues/347
 created: 2026-06-20T16:15:56.239Z
-last_modified: 2026-06-23T05:11:00Z
+last_modified: 2026-06-24T17:10:00Z
+scope:
+  - Extend `IssuePayload` with native graph intent — issue type, resolvable parent, and dependency relations — while preserving v1 `epic:`/`type:` labels as fallback.
+  - Project `parent:`/resolvable `epic:` to native parent/sub-issue relationships where a provider supports them.
+  - Project `depends_on:`/`blocked_on:` to native tracker issue relations where the related tickets already have sidecar refs.
+  - Sort the corpus parent-before-child before writing, because GitHub links existing issues for parent/sub-issue relationships.
+  - Keep projection idempotent by reusing `.safeword/tracker-map.json`; never create blind issues for dangling/cross-branch relation refs.
+  - Cover the provider behavior with unit tests against mocked clients and `gh` command arguments; no live tracker in tests.
+out_of_scope:
+  - Rebuilding the v1 `sync-tracker` command, auth, sidecar, body-egress, or flat issue creation/update mechanics.
+  - Two-way relation read-back or importing tracker changes into ticket files.
+  - Jira or any new provider.
+  - Taking ownership of GitHub Projects v2 Status values; v1 deliberately ceded status except close-on-terminal, so Status-field writes need a separate field-ownership decision.
+done_when:
+  - `parent:`/resolvable `epic:` fields project to native parent/sub-issue links for supported providers, and unresolved values fall back to v1 labels without failing the run.
+  - `depends_on:`/`blocked_on:` fields project to native blocking relations for supported providers when the target refs exist in the sidecar.
+  - Ticket projection runs parent-before-child and remains idempotent across create, update, and pending-entry reconcile paths.
+  - Native issue type is passed to providers that support it while the `type:<type>` label remains as fallback.
+  - Unit tests cover payload mapping, corpus ordering, writer graph requests, and GitHub `gh issue edit` argument generation; no live tracker required.
 ---
 
 # sync-tracker v2 — project the dependency graph (relations, sub-issues, types)
@@ -42,5 +60,7 @@ last_modified: 2026-06-23T05:11:00Z
 
 ## Work Log
 
+- 2026-06-24T17:10:00Z Implemented v2 graph projection. `IssuePayload` now carries `issueType`; corpus reads `parent:`/`slug` plus existing `depends_on:`/`blocked_on:`; sync order now visits known parents/dependencies before dependents; graph projection runs after create/update/reconcile using sidecar refs. GitHub adapter emits `gh issue edit --type/--parent/--add-blocked-by` and retries without `--type` when the repo lacks that issue type. Verification artifact added; ticket left in_progress pending maintainer/user confirmation before marking done.
+- 2026-06-24T16:30:00Z Picked up after origin/main sync. JS5K5G is complete, so the dependency block is satisfied. Added missing frontmatter scope/out_of_scope/done_when, dimensions, and a TB JTBD/spec before entering implementation.
 - 2026-06-23T05:11:00Z Backlogged. JS5K5G (v1) shipped → the `depends_on` block is satisfied (ready, not dependency-blocked). Deferred by prioritization, not readiness; surfaced as a coordination/backlog home at GitHub [#347](https://github.com/ArcadeAI/safeword/issues/347) for team prioritization (`external:` back-link added). Canonical spec stays here; promote to active work on pickup (re-run intake to refresh against the now-settled GitHub deps/sub-issue APIs).
 - 2026-06-20T16:16:00Z Created as the v2 split from JS5K5G — the dependency-graph projection deferred out of the v1 walking skeleton (cost/adoption/API-recency). `depends_on: [JS5K5G]`; status blocked until v1 ships.

--- a/.project/tickets/M1FGRJ-tracker-relations-projection/verify.md
+++ b/.project/tickets/M1FGRJ-tracker-relations-projection/verify.md
@@ -1,0 +1,40 @@
+# Verify: M1FGRJ sync-tracker v2 graph projection
+
+## Result
+
+Implemented and verified the unit-testable graph projection slice. Ticket remains
+`in_progress` until the maintainer confirms it should be marked done.
+
+## Evidence
+
+- `bun run --cwd packages/cli vitest run tests/tracker-sync` — 13 files / 85
+  tests passed.
+- `bun run --cwd packages/cli vitest run tests/tracker-sync tests/integration/codex-pretooluse-spike.test.ts`
+  — 14 files / 90 tests passed.
+- `bun run --cwd packages/cli typecheck` — passed.
+- `bunx eslint ...tracker-sync... ...codex...` — passed.
+- `bunx markdownlint-cli2 .project/tickets/M1FGRJ-tracker-relations-projection/*.md .project/tickets/CXP9LM-codex-live-parity-smoke/*.md`
+  — 0 errors.
+
+## Coverage
+
+- Parent/dependency ordering: child tickets no longer create before known parent
+  or dependency tickets.
+- Native hierarchy: resolved `parent:` / `epic:` refs become parent refs in the
+  graph writer request; unresolved refs fall back to labels.
+- Native relations: `depends_on:` and `blocked_on:` targets with sidecar refs
+  become blocked-by refs; dangling refs are skipped.
+- Native type: payloads include `issueType` while preserving `type:<type>` label
+  fallback.
+- Idempotence: create, update, and pending-entry reconcile paths all replay graph
+  projection against the same sidecar refs without duplicate creates.
+- GitHub adapter: mocked `gh issue edit` arguments cover `--type`, `--parent`,
+  and `--add-blocked-by`, including retry without `--type` when issue types are
+  unavailable.
+
+## Remaining Scope Notes
+
+- No live tracker run was performed; M1FGRJ explicitly calls for mocked clients
+  and no live tracker.
+- GitHub Projects v2 Status-field ownership remains deferred because v1 ceded
+  tracker status except close-on-terminal.

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -17,6 +17,8 @@ import {
 } from './pre-tool-quality-helpers.ts';
 
 const EXIT_CODE_DENY_MODE = 'exit-code';
+const CLAUDE_EXPLAIN_HINT = 'Run `/explain` for a plain-English version of this block.';
+const CODEX_EXPLAIN_HINT = 'Run `$explain` for a plain-English version of this block.';
 
 async function readInput(): Promise<CodexHookInput | undefined> {
   try {
@@ -29,6 +31,10 @@ async function readInput(): Promise<CodexHookInput | undefined> {
 function writeHookOutput(result: { stdout?: string | null; stderr?: string | null }): void {
   if (result.stdout !== '') process.stdout.write(result.stdout ?? '');
   if (result.stderr !== '') process.stderr.write(result.stderr ?? '');
+}
+
+function formatCodexReason(reason: string): string {
+  return reason.replaceAll(CLAUDE_EXPLAIN_HINT, CODEX_EXPLAIN_HINT);
 }
 
 function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
@@ -58,13 +64,15 @@ const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath,
 for (const result of results) {
   const reason = denialReasonFromHookOutput(result.stdout ?? '');
   if (reason === undefined) continue;
+  const codexReason = formatCodexReason(reason);
 
   if (process.env.SAFEWORD_CODEX_DENY_MODE === EXIT_CODE_DENY_MODE) {
-    console.error(reason);
+    console.error(codexReason);
     process.exit(2);
   }
 
-  writeHookOutput(result);
+  process.stdout.write(formatCodexReason(result.stdout ?? ''));
+  if (result.stderr !== '') process.stderr.write(formatCodexReason(result.stderr ?? ''));
   process.exit(result.status ?? 0);
 }
 

--- a/packages/cli/src/tracker-sync/clients.ts
+++ b/packages/cli/src/tracker-sync/clients.ts
@@ -17,6 +17,7 @@ import type { Provider } from './types.js';
 import {
   type CreateRequest,
   createWriter,
+  type GraphRequest,
   type TrackerClient,
   type TrackerWriter,
   type UpdateRequest,
@@ -40,9 +41,31 @@ function runGh(arguments_: string[]): string {
   }
 }
 
+function commandErrorMessage(error: unknown): string {
+  const stderr = (error as { stderr?: Buffer | string }).stderr?.toString() ?? '';
+  return `${stderr}${(error as Error).message ?? ''}`;
+}
+
+function isUnsupportedIssueTypeError(error: unknown): boolean {
+  const message = commandErrorMessage(error);
+  return /type/i.test(message) && /not found|does not exist|invalid|unsupported/i.test(message);
+}
+
 /** Adapter over `gh` for GitHub Issues. `repo` targets `owner/name`. */
 function githubClient(repo: string | undefined): TrackerClient {
   const repoArguments = repo === undefined ? [] : ['--repo', repo];
+  const graphEditArguments = (
+    request: GraphRequest,
+    options: { includeType: boolean },
+  ): string[] => [
+    'issue',
+    'edit',
+    request.id,
+    ...(options.includeType ? ['--type', request.issueType] : []),
+    ...(request.parentId === undefined ? [] : ['--parent', request.parentId]),
+    ...request.blockedByIds.flatMap(id => ['--add-blocked-by', id]),
+    ...repoArguments,
+  ];
   return {
     createIssue(request: CreateRequest) {
       const labels = request.labels.flatMap(label => ['--label', label]);
@@ -102,6 +125,15 @@ function githubClient(repo: string | undefined): TrackerClient {
       }
       return Promise.resolve();
     },
+    projectGraph(request: GraphRequest) {
+      try {
+        runGh(graphEditArguments(request, { includeType: true }));
+      } catch (error) {
+        if (!isUnsupportedIssueTypeError(error)) throw error;
+        runGh(graphEditArguments(request, { includeType: false }));
+      }
+      return Promise.resolve();
+    },
   };
 }
 
@@ -132,7 +164,7 @@ function throwingClient(message: string): TrackerClient {
   const fail = (): never => {
     throw new Error(message);
   };
-  return { createIssue: fail, updateIssue: fail };
+  return { createIssue: fail, updateIssue: fail, projectGraph: fail };
 }
 
 /** The Linear live client is pending the Arcade integration (2TK5AD). */

--- a/packages/cli/src/tracker-sync/corpus.ts
+++ b/packages/cli/src/tracker-sync/corpus.ts
@@ -13,9 +13,31 @@ import { readTickets, type TicketEntry, TICKETS_RELATIVE_PATH } from '../ticket-
 import { resolveTicketsDirectory } from '../utils/configured-paths.js';
 import type { TicketInput } from './types.js';
 
+type TicketProjectionEntry = Pick<
+  TicketEntry,
+  'id' | 'title' | 'status' | 'epic' | 'relativePath'
+> &
+  Partial<Pick<TicketEntry, 'dependsOn' | 'blockedOn'>>;
+
 /** Parse the `type:` frontmatter value from ticket.md content, defaulting to `task`. */
 function parseType(content: string): string {
   return /^type:\s*(\S+)/m.exec(content)?.[1] ?? 'task';
+}
+
+/** Parse a scalar frontmatter field from the hand-rolled ticket format. */
+function parseScalar(content: string, field: string): string | undefined {
+  const prefix = `${field}:`;
+  const line = content.split('\n').find(candidate => candidate.startsWith(prefix));
+  const value = line?.slice(prefix.length).trim();
+  if (value === undefined || value.length === 0) return undefined;
+  if (
+    value.length >= 2 &&
+    ((value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"')))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 /** Build the back-link URL for a ticket from the configured repo, else its path. */
@@ -25,17 +47,23 @@ export function backLinkUrl(relativePath: string, repo: string | undefined): str
 
 /** Map a ticket entry + its type to the neutral TicketInput. */
 export function toTicketInput(
-  entry: Pick<TicketEntry, 'id' | 'title' | 'status' | 'epic' | 'relativePath'>,
+  entry: TicketProjectionEntry,
   type: string,
   repo: string | undefined,
   bodyMarkdown: string | undefined,
+  graph: { parent?: string; slug?: string } = {},
 ): TicketInput {
   return {
     id: entry.id,
+    slug: graph.slug,
+    folder: nodePath.basename(entry.relativePath),
     title: entry.title,
     status: entry.status,
     type,
     epic: entry.epic,
+    parent: graph.parent,
+    dependsOn: entry.dependsOn ?? [],
+    blockedOn: entry.blockedOn ?? [],
     ticketUrl: backLinkUrl(entry.relativePath, repo),
     bodyMarkdown,
   };
@@ -49,6 +77,9 @@ export function readCorpus(cwd: string, repo: string | undefined): TicketInput[]
     // Read ticket.md once; derive both the type and the body from its content.
     const ticketPath = nodePath.join(cwd, entry.relativePath, 'ticket.md');
     const content = existsSync(ticketPath) ? readFileSync(ticketPath, 'utf8') : undefined;
-    return toTicketInput(entry, parseType(content ?? ''), repo, content);
+    return toTicketInput(entry, parseType(content ?? ''), repo, content, {
+      parent: parseScalar(content ?? '', 'parent'),
+      slug: parseScalar(content ?? '', 'slug'),
+    });
   });
 }

--- a/packages/cli/src/tracker-sync/index.ts
+++ b/packages/cli/src/tracker-sync/index.ts
@@ -11,8 +11,8 @@ import { withBackoff } from './backoff.js';
 import { buildPayload } from './payload.js';
 import { resolveCredential } from './secrets.js';
 import { loadTrackerMap, planTicketSync, TrackerMap } from './tracker-map.js';
-import type { BodyMode, Provider, TicketInput } from './types.js';
-import { dispatchCreate, type TrackerWriter } from './writers.js';
+import type { BodyMode, Provider, TicketInput, TrackerReference } from './types.js';
+import { dispatchCreate, type GraphProjection, type TrackerWriter } from './writers.js';
 
 export const SUPPORTED_PROVIDERS = new Set<Provider>(['linear', 'github']);
 const BACKOFF = { maxRetries: 3, baseMs: 50 };
@@ -49,6 +49,99 @@ export interface SyncTrackerResult {
 /** Narrow a configured provider to a supported one, else undefined. */
 function supportedProvider(provider: string): Provider | undefined {
   return SUPPORTED_PROVIDERS.has(provider as Provider) ? (provider as Provider) : undefined;
+}
+
+function isString(value: string | undefined): value is string {
+  return value !== undefined;
+}
+
+function ticketAliases(ticket: TicketInput): string[] {
+  return [ticket.id, ticket.slug, ticket.folder].filter(isString);
+}
+
+function aliasMap(tickets: TicketInput[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const ticket of tickets) {
+    for (const alias of ticketAliases(ticket)) aliases.set(alias, ticket.id);
+  }
+  return aliases;
+}
+
+function resolveTicketReference(
+  raw: string | undefined,
+  aliases: Map<string, string>,
+): string | undefined {
+  if (raw === undefined || raw.length === 0) return undefined;
+  return aliases.get(raw);
+}
+
+function prerequisiteIds(ticket: TicketInput, aliases: Map<string, string>): string[] {
+  const prerequisites = [
+    resolveTicketReference(ticket.parent, aliases),
+    resolveTicketReference(ticket.epic, aliases),
+    ...(ticket.dependsOn ?? []).map(id => resolveTicketReference(id, aliases)),
+    ...(ticket.blockedOn ?? []).map(id => resolveTicketReference(id, aliases)),
+  ];
+  return [...new Set(prerequisites.filter(isString).filter(id => id !== ticket.id))];
+}
+
+function orderTicketsForProjection(tickets: TicketInput[]): TicketInput[] {
+  const aliases = aliasMap(tickets);
+  const byId = new Map(tickets.map(ticket => [ticket.id, ticket]));
+  const ordered: TicketInput[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(ticket: TicketInput): void {
+    if (visited.has(ticket.id)) return;
+    if (visiting.has(ticket.id)) return;
+    visiting.add(ticket.id);
+    for (const prerequisite of prerequisiteIds(ticket, aliases)) {
+      const target = byId.get(prerequisite);
+      if (target !== undefined) visit(target);
+    }
+    visiting.delete(ticket.id);
+    visited.add(ticket.id);
+    ordered.push(ticket);
+  }
+
+  for (const ticket of tickets) visit(ticket);
+  return ordered;
+}
+
+function sameProviderReference(
+  map: TrackerMap,
+  ticketId: string | undefined,
+  provider: Provider,
+): TrackerReference | undefined {
+  if (ticketId === undefined) return undefined;
+  const ref = map.lookup(ticketId)?.ref;
+  return ref?.provider === provider ? ref : undefined;
+}
+
+function buildGraphProjection(args: {
+  ticket: TicketInput;
+  map: TrackerMap;
+  provider: Provider;
+  aliases: Map<string, string>;
+}): GraphProjection {
+  const parentId =
+    resolveTicketReference(args.ticket.parent, args.aliases) ??
+    resolveTicketReference(args.ticket.epic, args.aliases);
+  const relationIds = [...(args.ticket.dependsOn ?? []), ...(args.ticket.blockedOn ?? [])].map(id =>
+    resolveTicketReference(id, args.aliases),
+  );
+  return {
+    parent: sameProviderReference(args.map, parentId, args.provider),
+    blockedBy: new Map(
+      relationIds
+        .map(id => sameProviderReference(args.map, id, args.provider))
+        .filter((ref): ref is TrackerReference => ref !== undefined)
+        .map(ref => [ref.id, ref]),
+    )
+      .values()
+      .toArray(),
+  };
 }
 
 /** Pre-write advisories that don't block the run: CI auth (AC12) + egress (AC10). */
@@ -104,10 +197,12 @@ async function projectOne(args: {
   bodyMode: BodyMode;
   sleep: (ms: number) => Promise<void>;
   sidecarPath: string;
+  aliases: Map<string, string>;
 }): Promise<void> {
   const payload = buildPayload(args.ticket, { bodyMode: args.bodyMode });
   const action = planTicketSync(args.map, args.ticket.id);
   const backoff = { sleep: args.sleep, ...BACKOFF };
+  let currentReference: TrackerReference;
   if (action.kind === 'create') {
     const ref = await withBackoff(
       () => dispatchCreate(args.writers, args.provider, payload),
@@ -118,12 +213,25 @@ async function projectOne(args: {
     args.map.save(args.sidecarPath);
     args.map.record(args.ticket.id, ref);
     args.map.save(args.sidecarPath);
-    return;
+    currentReference = ref;
+  } else {
+    // update (AC6) and reconcile (AC8) both write outward only — no second create.
+    if (action.kind === 'reconcile') args.map.record(args.ticket.id, action.ref);
+    await withBackoff(() => args.writers[args.provider].update(action.ref, payload), backoff);
+    args.map.save(args.sidecarPath);
+    currentReference = action.ref;
   }
-  // update (AC6) and reconcile (AC8) both write outward only — no second create.
-  if (action.kind === 'reconcile') args.map.record(args.ticket.id, action.ref);
-  await withBackoff(() => args.writers[args.provider].update(action.ref, payload), backoff);
-  args.map.save(args.sidecarPath);
+
+  const graph = buildGraphProjection({
+    ticket: args.ticket,
+    map: args.map,
+    provider: args.provider,
+    aliases: args.aliases,
+  });
+  await withBackoff(
+    () => args.writers[args.provider].projectGraph(currentReference, payload, graph),
+    backoff,
+  );
 }
 
 export async function syncTracker(
@@ -152,7 +260,9 @@ export async function syncTracker(
 
   const sleep =
     dependencies.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
-  for (const ticket of dependencies.tickets) {
+  const tickets = orderTicketsForProjection(dependencies.tickets);
+  const aliases = aliasMap(tickets);
+  for (const ticket of tickets) {
     // Each ticket persists itself; a failure aborts the run but earlier
     // creates are already saved (resume re-projects only the unfinished ones).
     await projectOne({
@@ -163,6 +273,7 @@ export async function syncTracker(
       bodyMode,
       sleep,
       sidecarPath: dependencies.sidecarPath,
+      aliases,
     });
   }
   return { exitCode: 0 };

--- a/packages/cli/src/tracker-sync/payload.ts
+++ b/packages/cli/src/tracker-sync/payload.ts
@@ -38,6 +38,7 @@ export function buildPayload(ticket: TicketInput, options: { bodyMode: BodyMode 
   return {
     title: ticket.title,
     body: buildBody(ticket, options.bodyMode),
+    issueType: ticket.type,
     labels,
     state: TERMINAL_STATUSES.has(ticket.status) ? 'closed' : 'open',
   };

--- a/packages/cli/src/tracker-sync/types.ts
+++ b/packages/cli/src/tracker-sync/types.ts
@@ -13,6 +13,8 @@ export interface IssuePayload {
   title: string;
   /** v1: markdown. Jira (v3) widens this to ADF — the one non-neutral field. */
   body: string;
+  /** Native issue-type candidate for providers that support it; labels remain fallback. */
+  issueType: string;
   /** Includes `epic:<slug>` and `type:<type>` so the board groups/filters. */
   labels: string[];
   // No assignee — field ownership (AC7) cedes it to the tracker; a v2 concern.
@@ -26,10 +28,18 @@ export interface IssuePayload {
  */
 export interface TicketInput {
   id: string;
+  /** Optional slug/folder aliases let parent references resolve across ticket styles. */
+  slug?: string;
+  folder?: string;
   title: string;
   status: string;
   type: string;
   epic: string | undefined;
+  parent?: string;
+  /** Soft dependency edges: this ticket is blocked by these ticket ids. */
+  dependsOn?: string[];
+  /** Hard blocker edges: this ticket is blocked by these ticket ids. */
+  blockedOn?: string[];
   /** Canonical back-link target — the repo URL/path of this ticket. */
   ticketUrl: string;
   /** Full body markdown, included only when egress is `full`. */

--- a/packages/cli/src/tracker-sync/writers.ts
+++ b/packages/cli/src/tracker-sync/writers.ts
@@ -27,16 +27,30 @@ export interface UpdateRequest {
   state?: 'closed';
 }
 
+export interface GraphProjection {
+  parent?: TrackerReference;
+  blockedBy: TrackerReference[];
+}
+
+export interface GraphRequest {
+  id: string;
+  issueType: string;
+  parentId?: string;
+  blockedByIds: string[];
+}
+
 /** The provider-neutral port each provider adapter implements (Arcade / gh). */
 export interface TrackerClient {
   createIssue(request: CreateRequest): Promise<{ id: string; url?: string }>;
   updateIssue(request: UpdateRequest): Promise<void>;
+  projectGraph(request: GraphRequest): Promise<void>;
 }
 
 export interface TrackerWriter {
   readonly provider: Provider;
   create(payload: IssuePayload): Promise<TrackerReference>;
   update(ref: TrackerReference, payload: IssuePayload): Promise<void>;
+  projectGraph(ref: TrackerReference, payload: IssuePayload, graph: GraphProjection): Promise<void>;
 }
 
 /** Build a writer for `provider` over an injected client. */
@@ -56,6 +70,14 @@ export function createWriter(provider: Provider, client: TrackerClient): Tracker
       // The one universal status write: close when the ticket is terminal.
       if (payload.state === 'closed') request.state = 'closed';
       await client.updateIssue(request);
+    },
+    async projectGraph(ref, payload, graph) {
+      await client.projectGraph({
+        id: ref.id,
+        issueType: payload.issueType,
+        parentId: graph.parent?.id,
+        blockedByIds: graph.blockedBy.map(blocker => blocker.id),
+      });
     },
   };
 }

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -17,6 +17,8 @@ import {
 } from './pre-tool-quality-helpers.ts';
 
 const EXIT_CODE_DENY_MODE = 'exit-code';
+const CLAUDE_EXPLAIN_HINT = 'Run `/explain` for a plain-English version of this block.';
+const CODEX_EXPLAIN_HINT = 'Run `$explain` for a plain-English version of this block.';
 
 async function readInput(): Promise<CodexHookInput | undefined> {
   try {
@@ -29,6 +31,10 @@ async function readInput(): Promise<CodexHookInput | undefined> {
 function writeHookOutput(result: { stdout?: string | null; stderr?: string | null }): void {
   if (result.stdout !== '') process.stdout.write(result.stdout ?? '');
   if (result.stderr !== '') process.stderr.write(result.stderr ?? '');
+}
+
+function formatCodexReason(reason: string): string {
+  return reason.replaceAll(CLAUDE_EXPLAIN_HINT, CODEX_EXPLAIN_HINT);
 }
 
 function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
@@ -58,13 +64,15 @@ const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath,
 for (const result of results) {
   const reason = denialReasonFromHookOutput(result.stdout ?? '');
   if (reason === undefined) continue;
+  const codexReason = formatCodexReason(reason);
 
   if (process.env.SAFEWORD_CODEX_DENY_MODE === EXIT_CODE_DENY_MODE) {
-    console.error(reason);
+    console.error(codexReason);
     process.exit(2);
   }
 
-  writeHookOutput(result);
+  process.stdout.write(formatCodexReason(result.stdout ?? ''));
+  if (result.stderr !== '') process.stderr.write(formatCodexReason(result.stderr ?? ''));
   process.exit(result.status ?? 0);
 }
 

--- a/packages/cli/tests/integration/codex-pretooluse-spike.test.ts
+++ b/packages/cli/tests/integration/codex-pretooluse-spike.test.ts
@@ -121,6 +121,15 @@ describe('Codex PreToolUse deny spike (N12G95)', () => {
     expectHookDeny(runCodexHook(projectRoot), 'scope');
   });
 
+  it('points Codex users at the skill invocation syntax for explain help', () => {
+    writeIncompleteTicket(ticketDirectory);
+
+    const result = runCodexHook(projectRoot);
+
+    expect(result.stdout).toContain('Run `$explain`');
+    expect(result.stdout).not.toContain('Run `/explain`');
+  });
+
   it('denies multi-file Codex patches when any target violates safeword gates', () => {
     writeIncompleteTicket(ticketDirectory);
 
@@ -148,6 +157,8 @@ describe('Codex PreToolUse deny spike (N12G95)', () => {
     const result = runCodexHook(projectRoot, { fallbackMode: true });
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('scope');
+    expect(result.stderr).toContain('Run `$explain`');
+    expect(result.stderr).not.toContain('Run `/explain`');
     expect(result.stdout.trim()).toBe('');
   });
 });

--- a/packages/cli/tests/smoke/codex-parity.live.test.ts
+++ b/packages/cli/tests/smoke/codex-parity.live.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Live Codex parity smoke (ticket CXP9LM / GitHub #394).
+ *
+ * This is deliberately opt-in: it launches a real `codex exec` session and may
+ * spend tokens. Run with:
+ *
+ *   SAFEWORD_RUN_CODEX_LIVE_SMOKE=1 bun run --cwd packages/cli test:smoke:live
+ *
+ * The smoke distinguishes supported hook-adapter behavior from current Codex
+ * runtime gaps. Unsupported paths are reported as findings instead of silently
+ * skipped, because that is the point of CXP9LM's live customer-repo check.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_PATH = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
+const TICKET_ID = 'ABC123';
+const TEST_DEFINITIONS_PATH = `.project/tickets/${TICKET_ID}/test-definitions.md`;
+const TEST_DEFINITIONS_PATCH = `*** Begin Patch
+*** Add File: ${TEST_DEFINITIONS_PATH}
++# Test Definitions
+*** End Patch
+`;
+
+function resolveCodex(): string | undefined {
+  const candidates = [process.env.SMOKE_CODEX_BIN, 'codex'].filter(Boolean) as string[];
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+    if (probe.status === 0 && /\b0\.(?:13[3-9]|1[4-9]\d|\d{3,})\./.test(probe.stdout)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd: string; input?: string; timeout?: number },
+) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    input: options.input,
+    encoding: 'utf8',
+    env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: options.timeout ?? 60_000,
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function assertSuccess(
+  result: { status: number | null; stdout: string; stderr: string },
+  label: string,
+): void {
+  expect(
+    result.status,
+    `${label} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  ).toBe(0);
+}
+
+function createFixture(): string {
+  const projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'safeword-codex-live-'));
+  run('git', ['init', '-q'], { cwd: projectRoot });
+  writeFileSync(
+    nodePath.join(projectRoot, 'package.json'),
+    JSON.stringify({ name: 'codex-live-fixture', version: '1.0.0' }, undefined, 2),
+  );
+  return projectRoot;
+}
+
+function setupSafeword(projectRoot: string) {
+  const result = spawnSync(process.execPath, [CLI_PATH, 'setup', '--yes', '--no-modify'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: { ...process.env, SAFEWORD_SKIP_INSTALL: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 60_000,
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function writeIncompleteTicket(projectRoot: string): void {
+  const ticketDirectory = nodePath.join(projectRoot, '.project', 'tickets', TICKET_ID);
+  mkdirSync(ticketDirectory, { recursive: true });
+  writeFileSync(
+    nodePath.join(ticketDirectory, 'ticket.md'),
+    [
+      '---',
+      `id: ${TICKET_ID}`,
+      'type: feature',
+      'phase: define-behavior',
+      'status: in_progress',
+      '---',
+      '',
+      '# Live smoke fixture',
+      '',
+    ].join('\n'),
+  );
+}
+
+function writeCompleteTicket(projectRoot: string): void {
+  const ticketDirectory = nodePath.join(projectRoot, '.project', 'tickets', TICKET_ID);
+  mkdirSync(ticketDirectory, { recursive: true });
+  writeFileSync(
+    nodePath.join(ticketDirectory, 'ticket.md'),
+    [
+      '---',
+      `id: ${TICKET_ID}`,
+      'type: feature',
+      'phase: define-behavior',
+      'status: in_progress',
+      'scope:',
+      '  - prove the live Codex parity smoke',
+      'out_of_scope:',
+      '  - changing production hook policy',
+      'done_when:',
+      '  - Codex hook behavior is observed',
+      '---',
+      '',
+      '# Live smoke fixture',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(nodePath.join(ticketDirectory, 'dimensions.md'), 'skip: one obvious dimension');
+  writeFileSync(
+    nodePath.join(ticketDirectory, 'spec.md'),
+    [
+      '# Spec: Codex Live Smoke',
+      '',
+      '## Jobs To Be Done',
+      '',
+      '### codex-live-smoke.SM1 - Observe Codex hook behavior',
+      '',
+      '**Persona:** Safeword Maintainer (SM)',
+      '',
+      '> When I run a live Codex smoke, I want hook behavior recorded, so I can close parity honestly.',
+      '',
+      '#### codex-live-smoke.SM1.AC1 - Hook behavior is observable',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    nodePath.join(projectRoot, '.project', 'personas.md'),
+    '# Personas\n\n## Safeword Maintainer (SM)\n\n**Role:** Maintains safeword.\n',
+  );
+}
+
+function runInstalledCodexHook(projectRoot: string) {
+  return run('bun', [nodePath.join(projectRoot, '.safeword/hooks/codex/pre-tool-quality.ts')], {
+    cwd: projectRoot,
+    input: JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'apply_patch',
+      tool_input: { command: TEST_DEFINITIONS_PATCH },
+    }),
+  });
+}
+
+function inspectPromptInput(codex: string, projectRoot: string): string {
+  const result = run(codex, ['debug', 'prompt-input', 'List visible safeword context.'], {
+    cwd: projectRoot,
+    timeout: 60_000,
+  });
+  assertSuccess(result, 'codex debug prompt-input');
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+function runLiveEditAttempt(codex: string, projectRoot: string): string {
+  const prompt = [
+    `Use the apply_patch tool to create ${TEST_DEFINITIONS_PATH}.`,
+    'The file content must be exactly: # Test Definitions',
+    'Do not use a shell command.',
+  ].join(' ');
+
+  const result = run(
+    codex,
+    [
+      'exec',
+      '--json',
+      '--dangerously-bypass-hook-trust',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '-C',
+      projectRoot,
+      prompt,
+    ],
+    { cwd: projectRoot, timeout: 180_000 },
+  );
+  assertSuccess(result, 'codex exec live edit attempt');
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+const CODEX = resolveCodex();
+const CAN_RUN = process.env.SAFEWORD_RUN_CODEX_LIVE_SMOKE === '1' && CODEX !== undefined;
+
+describe.skipIf(!CAN_RUN)('live smoke: Codex customer-repo parity', () => {
+  let projectRoot: string;
+
+  beforeAll(() => {
+    projectRoot = createFixture();
+    const setup = setupSafeword(projectRoot);
+    assertSuccess(setup, 'safeword setup');
+    expect(`${setup.stdout}\n${setup.stderr}`).toContain('run `/hooks`');
+  });
+
+  afterAll(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('installs Codex assets and exposes current live execution gaps', () => {
+    if (!CODEX) throw new Error('unreachable: CAN_RUN guards codex presence');
+
+    expect(existsSync(nodePath.join(projectRoot, '.codex/config.toml'))).toBe(true);
+    expect(existsSync(nodePath.join(projectRoot, '.agents/skills/explain/SKILL.md'))).toBe(true);
+    expect(
+      existsSync(nodePath.join(projectRoot, '.safeword/hooks/codex/pre-tool-quality.ts')),
+    ).toBe(true);
+
+    const promptInput = inspectPromptInput(CODEX, projectRoot);
+    const seesProjectInstructions =
+      promptInput.includes('.safeword/SAFEWORD.md') || promptInput.includes('.safeword/AGENTS.md');
+    const seesRepoExplainSkill = promptInput.includes('.agents/skills/explain');
+    if (!seesProjectInstructions || !seesRepoExplainSkill) {
+      console.warn(
+        [
+          'Codex live smoke finding:',
+          `projectInstructionsVisible=${seesProjectInstructions}`,
+          `repoExplainSkillVisible=${seesRepoExplainSkill}`,
+        ].join(' '),
+      );
+    }
+
+    writeIncompleteTicket(projectRoot);
+    const directDeny = runInstalledCodexHook(projectRoot);
+    expect(directDeny.stdout).toContain('permissionDecision');
+    expect(directDeny.stdout).toContain('Run `$explain`');
+
+    writeCompleteTicket(projectRoot);
+    const directAllow = runInstalledCodexHook(projectRoot);
+    expect(directAllow.stdout.trim()).toBe('');
+    expect(directAllow.stderr.trim()).toBe('');
+
+    rmSync(nodePath.join(projectRoot, TEST_DEFINITIONS_PATH), { force: true });
+    writeIncompleteTicket(projectRoot);
+
+    const liveOutput = runLiveEditAttempt(CODEX, projectRoot);
+    const liveDenied = liveOutput.includes('Command blocked by PreToolUse hook');
+    const usedFileChangePath = liveOutput.includes('"type":"file_change"');
+
+    expect(
+      liveDenied || usedFileChangePath,
+      `Codex neither denied the edit nor exposed the known file_change path.\n${liveOutput}`,
+    ).toBe(true);
+
+    if (usedFileChangePath && !liveDenied) {
+      expect(readFileSync(nodePath.join(projectRoot, TEST_DEFINITIONS_PATH), 'utf8')).toContain(
+        '# Test Definitions',
+      );
+      console.warn(
+        'Codex live smoke finding: codex exec used file_change and bypassed PreToolUse for the requested edit.',
+      );
+    }
+  });
+});

--- a/packages/cli/tests/tracker-sync/clients-visibility.test.ts
+++ b/packages/cli/tests/tracker-sync/clients-visibility.test.ts
@@ -4,7 +4,7 @@ vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
 
 import { execFileSync } from 'node:child_process';
 
-import { resolveRepoVisibility } from '../../src/tracker-sync/clients.js';
+import { buildWriterRegistry, resolveRepoVisibility } from '../../src/tracker-sync/clients.js';
 
 /**
  * resolveRepoVisibility (JS5K5G AC10) — locks the public/private collapse and the
@@ -33,5 +33,74 @@ describe('resolveRepoVisibility', () => {
       throw new Error('gh: command not found');
     });
     expect(resolveRepoVisibility('acme/repo')).toBeUndefined();
+  });
+});
+
+describe('GitHub graph projection client', () => {
+  it('uses gh issue edit graph flags for type, parent, and blocked-by refs', async () => {
+    mockExec.mockReturnValue('');
+    const writer = buildWriterRegistry('github', { repo: 'acme/repo' }).github;
+
+    await writer.projectGraph(
+      { provider: 'github', id: '42' },
+      {
+        title: 'Wire it up',
+        body: 'banner',
+        issueType: 'feature',
+        labels: ['type:feature'],
+        state: 'open',
+      },
+      {
+        parent: { provider: 'github', id: '100' },
+        blockedBy: [{ provider: 'github', id: '7' }],
+      },
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      [
+        'issue',
+        'edit',
+        '42',
+        '--type',
+        'feature',
+        '--parent',
+        '100',
+        '--add-blocked-by',
+        '7',
+        '--repo',
+        'acme/repo',
+      ],
+      { encoding: 'utf8' },
+    );
+  });
+
+  it('retries graph projection without --type when the repo has no matching issue type', async () => {
+    const typeError = Object.assign(new Error('issue type not found'), {
+      stderr: Buffer.from('issue type not found'),
+    });
+    mockExec.mockImplementationOnce(() => {
+      throw typeError;
+    });
+    mockExec.mockReturnValue('');
+    const writer = buildWriterRegistry('github', { repo: 'acme/repo' }).github;
+
+    await writer.projectGraph(
+      { provider: 'github', id: '42' },
+      {
+        title: 'Wire it up',
+        body: 'banner',
+        issueType: 'feature',
+        labels: ['type:feature'],
+        state: 'open',
+      },
+      { parent: { provider: 'github', id: '100' }, blockedBy: [] },
+    );
+
+    expect(mockExec).toHaveBeenLastCalledWith(
+      'gh',
+      ['issue', 'edit', '42', '--parent', '100', '--repo', 'acme/repo'],
+      { encoding: 'utf8' },
+    );
   });
 });

--- a/packages/cli/tests/tracker-sync/corpus.test.ts
+++ b/packages/cli/tests/tracker-sync/corpus.test.ts
@@ -26,11 +26,14 @@ describe('sync-tracker corpus mapping', () => {
         title: 'Wire it up',
         status: 'in_progress',
         epic: 'bridge',
+        dependsOn: ['BASE01'],
+        blockedOn: ['GATE02'],
         relativePath: '.project/tickets/AB12CD-wire',
       },
       'feature',
       'acme/repo',
       'body text',
+      { parent: 'PARENT1', slug: 'wire-it-up' },
     );
     expect(input).toEqual({
       id: 'AB12CD',
@@ -38,6 +41,11 @@ describe('sync-tracker corpus mapping', () => {
       status: 'in_progress',
       type: 'feature',
       epic: 'bridge',
+      parent: 'PARENT1',
+      dependsOn: ['BASE01'],
+      blockedOn: ['GATE02'],
+      slug: 'wire-it-up',
+      folder: 'AB12CD-wire',
       ticketUrl: 'https://github.com/acme/repo/tree/HEAD/.project/tickets/AB12CD-wire',
       bodyMarkdown: 'body text',
     });
@@ -66,7 +74,17 @@ describe('sync-tracker corpus mapping', () => {
     it('maps an active ticket: parses type, includes full body, derives the back-link', () => {
       writeTicket(
         'AB12CD-wire',
-        ['id: AB12CD', 'type: feature', 'status: in_progress', 'epic: bridge', 'title: Wire it up'],
+        [
+          'id: AB12CD',
+          'slug: wire-it-up',
+          'parent: PARENT1',
+          'type: feature',
+          'status: in_progress',
+          'epic: bridge',
+          'depends_on: [BASE01]',
+          'blocked_on: [GATE02]',
+          'title: Wire it up',
+        ],
         '# Wire it up\n\nspec body',
       );
 
@@ -75,6 +93,11 @@ describe('sync-tracker corpus mapping', () => {
       expect(corpus).toHaveLength(1);
       expect(corpus[0]?.type).toBe('feature');
       expect(corpus[0]?.epic).toBe('bridge');
+      expect(corpus[0]?.parent).toBe('PARENT1');
+      expect(corpus[0]?.dependsOn).toEqual(['BASE01']);
+      expect(corpus[0]?.blockedOn).toEqual(['GATE02']);
+      expect(corpus[0]?.slug).toBe('wire-it-up');
+      expect(corpus[0]?.folder).toBe('AB12CD-wire');
       expect(corpus[0]?.ticketUrl).toBe(
         'https://github.com/acme/repo/tree/HEAD/.project/tickets/AB12CD-wire',
       );

--- a/packages/cli/tests/tracker-sync/orchestrator.test.ts
+++ b/packages/cli/tests/tracker-sync/orchestrator.test.ts
@@ -9,19 +9,21 @@ import { syncTracker, type SyncTrackerDependencies } from '../../src/tracker-syn
 import { CREDENTIAL_ENV_VAR } from '../../src/tracker-sync/secrets.js';
 import { loadTrackerMap, TrackerMap } from '../../src/tracker-sync/tracker-map.js';
 import type { Provider, TicketInput, TrackerReference } from '../../src/tracker-sync/types.js';
-import type { TrackerWriter } from '../../src/tracker-sync/writers.js';
+import type { GraphProjection, TrackerWriter } from '../../src/tracker-sync/writers.js';
 
 /** A programmable fake writer that records calls (and can fail create once). */
 function fakeWriter(
   provider: Provider,
   options: { failCreateOnce?: boolean } = {},
-): TrackerWriter & { creates: unknown[]; updates: unknown[] } {
+): TrackerWriter & { creates: unknown[]; graphs: unknown[]; updates: unknown[] } {
   const creates: unknown[] = [];
+  const graphs: unknown[] = [];
   const updates: unknown[] = [];
   let attempts = 0;
   return {
     provider,
     creates,
+    graphs,
     updates,
     create(payload) {
       creates.push(payload);
@@ -36,6 +38,10 @@ function fakeWriter(
       updates.push({ ref, payload });
       return Promise.resolve();
     },
+    projectGraph(ref, payload, graph) {
+      graphs.push({ ref, payload, graph });
+      return Promise.resolve();
+    },
   };
 }
 
@@ -47,6 +53,8 @@ const ticket: TicketInput = {
   epic: 'bridge',
   ticketUrl: 'https://github.com/acme/repo/tree/main/.project/tickets/AB12CD-wire',
   bodyMarkdown: 'internal body',
+  dependsOn: [],
+  blockedOn: [],
 };
 
 describe('sync-tracker orchestrator', () => {
@@ -140,6 +148,7 @@ describe('sync-tracker orchestrator', () => {
     const flaky: ReturnType<typeof fakeWriter> = {
       provider: 'github',
       creates: [],
+      graphs: [],
       updates: [],
       create(payload) {
         calls += 1;
@@ -149,6 +158,10 @@ describe('sync-tracker orchestrator', () => {
         return Promise.resolve(ref);
       },
       update() {
+        return Promise.resolve();
+      },
+      projectGraph(ref, payload, graph) {
+        flaky.graphs.push({ ref, payload, graph });
         return Promise.resolve();
       },
     };
@@ -270,5 +283,55 @@ describe('sync-tracker orchestrator', () => {
     expect(flaky.creates).toHaveLength(2);
     const reloaded = loadTrackerMap(sidecarPath);
     expect(reloaded.ok && reloaded.map.lookup('AB12CD') !== undefined).toBe(true);
+  });
+
+  it('creates parent tickets before children even when IDs sort the other way', async () => {
+    seedEmptySidecar();
+    const child: TicketInput = { ...ticket, id: 'AAA111', title: 'Child', parent: 'ZZZ999' };
+    const parent: TicketInput = { ...ticket, id: 'ZZZ999', title: 'Parent' };
+    const trackingWriter = fakeWriter('github');
+
+    await syncTracker(
+      makeDependencies({
+        tickets: [child, parent],
+        writers: { linear: fakeWriter('linear'), github: trackingWriter },
+      }),
+    );
+
+    expect(trackingWriter.creates.map(payload => (payload as { title: string }).title)).toEqual([
+      'Parent',
+      'Child',
+    ]);
+    const childGraph = trackingWriter.graphs.at(-1) as { graph: GraphProjection } | undefined;
+    expect(childGraph?.graph.parent?.id).toBe('1');
+  });
+
+  it('replays graph links on an idempotent update without creating duplicates', async () => {
+    const map = new TrackerMap();
+    map.record('BASE01', { provider: 'github', id: '10' });
+    map.record('CHILD1', { provider: 'github', id: '20' });
+    map.save(sidecarPath);
+    const base: TicketInput = { ...ticket, id: 'BASE01', title: 'Base' };
+    const child: TicketInput = {
+      ...ticket,
+      id: 'CHILD1',
+      title: 'Child',
+      dependsOn: ['BASE01'],
+      blockedOn: ['MISSING'],
+    };
+    const trackingWriter = fakeWriter('github');
+
+    await syncTracker(
+      makeDependencies({
+        tickets: [child, base],
+        writers: { linear: fakeWriter('linear'), github: trackingWriter },
+      }),
+    );
+
+    expect(trackingWriter.creates).toHaveLength(0);
+    const childGraph = trackingWriter.graphs.find(
+      (call: unknown) => (call as { ref: TrackerReference }).ref.id === '20',
+    ) as { graph: GraphProjection } | undefined;
+    expect(childGraph?.graph.blockedBy.map(ref => ref.id)).toEqual(['10']);
   });
 });

--- a/packages/cli/tests/tracker-sync/payload.test.ts
+++ b/packages/cli/tests/tracker-sync/payload.test.ts
@@ -35,6 +35,12 @@ describe('sync-tracker payload builder (sync-tracker.TB1.AC3, AC10)', () => {
     expect(labels).toContain('type:feature');
   });
 
+  it('keeps the native issue type candidate alongside the fallback type label', () => {
+    const payload = buildPayload(activeTicket, { bodyMode: 'minimal' });
+    expect(payload.issueType).toBe('feature');
+    expect(payload.labels).toContain('type:feature');
+  });
+
   it('puts the mirror banner and a back-link to the ticket in the body', () => {
     const { body } = buildPayload(activeTicket, { bodyMode: 'minimal' });
     expect(body).toContain('Mirror of safeword ticket AB12CD');

--- a/packages/cli/tests/tracker-sync/wiring.test.ts
+++ b/packages/cli/tests/tracker-sync/wiring.test.ts
@@ -32,6 +32,9 @@ function recordingWriter(provider: Provider): TrackerWriter & { creates: unknown
     update() {
       return Promise.resolve();
     },
+    projectGraph() {
+      return Promise.resolve();
+    },
   };
 }
 

--- a/packages/cli/tests/tracker-sync/writers.test.ts
+++ b/packages/cli/tests/tracker-sync/writers.test.ts
@@ -5,6 +5,8 @@ import {
   type CreateRequest,
   createWriter,
   dispatchCreate,
+  type GraphProjection,
+  type GraphRequest,
   type TrackerClient,
   type UpdateRequest,
 } from '../../src/tracker-sync/writers.js';
@@ -18,16 +20,23 @@ import {
 /** A fake client that records every request it receives. */
 function recordingClient(): TrackerClient & {
   creates: CreateRequest[];
+  graphs: GraphRequest[];
   updates: UpdateRequest[];
 } {
   const creates: CreateRequest[] = [];
+  const graphs: GraphRequest[] = [];
   const updates: UpdateRequest[] = [];
   return {
     creates,
+    graphs,
     updates,
     createIssue: (request: CreateRequest) => {
       creates.push(request);
       return Promise.resolve({ id: '42', url: 'https://x/issues/42' });
+    },
+    projectGraph: (request: GraphRequest) => {
+      graphs.push(request);
+      return Promise.resolve();
     },
     updateIssue: (request: UpdateRequest) => {
       updates.push(request);
@@ -39,10 +48,15 @@ function recordingClient(): TrackerClient & {
 const activePayload: IssuePayload = {
   title: 'Wire it up',
   body: 'banner + back-link',
+  issueType: 'feature',
   labels: ['epic:bridge', 'type:feature'],
   state: 'open',
 };
 const ref: TrackerReference = { provider: 'github', id: '42' };
+const graph: GraphProjection = {
+  parent: { provider: 'github', id: '100' },
+  blockedBy: [{ provider: 'github', id: '7' }],
+};
 
 describe('sync-tracker writers (sync-tracker.TB1.AC4, AC7)', () => {
   // AC4 — one call site routes to the provider's writer
@@ -92,5 +106,14 @@ describe('sync-tracker writers (sync-tracker.TB1.AC4, AC7)', () => {
     expect(request?.state).toBe('closed');
     expect(request && 'assignee' in request).toBe(false);
     expect(request && 'priority' in request).toBe(false);
+  });
+
+  it('projects native type, parent, and blocking refs through the graph port', async () => {
+    const client = recordingClient();
+    await createWriter('github', client).projectGraph(ref, activePayload, graph);
+
+    expect(client.graphs).toEqual([
+      { id: '42', issueType: 'feature', parentId: '100', blockedByIds: ['7'] },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Implement sync-tracker v2 graph projection for #347: native issue type candidate, parent/dependency ordering, sidecar-backed graph refs, writer graph port, and GitHub `gh issue edit --type/--parent/--add-blocked-by` support with issue-type fallback.
- Add the missing M1FGRJ behavior artifacts and verification evidence without marking the ticket done pending maintainer confirmation.
- Add an opt-in Codex live parity smoke for #394 and fix Codex block help to use `$explain`; record the current live `file_change` bypass / #360 skill-visibility findings instead of silently treating parity as complete.

## Issue state
- Addresses #347.
- Contributes evidence for #394 and #360, but does not close them.
- #393 and #395 remain blocked by their documented prerequisites.

## Verification
- `bun run --cwd packages/cli vitest run tests/tracker-sync tests/integration/codex-pretooluse-spike.test.ts`
- `SAFEWORD_RUN_CODEX_LIVE_SMOKE=1 bun run --cwd packages/cli vitest run tests/smoke/codex-parity.live.test.ts --config vitest.live.config.ts`
- `bun run --cwd packages/cli typecheck`
- targeted `eslint` on changed tracker/Codex files
- `bunx markdownlint-cli2` on changed ticket docs
- `git diff --check`