### PR TITLE
Quiet expected negative-path test output

### DIFF
--- a/.project/tickets/GJGSS3-quiet-expected-negative-path-test-output/test-definitions.md
+++ b/.project/tickets/GJGSS3-quiet-expected-negative-path-test-output/test-definitions.md
@@ -1,0 +1,25 @@
+# Test Definitions: Quiet Expected Negative-Path Test Output
+
+## Rule: Expected diagnostics are captured
+
+### Scenario: GJGSS3.QT1.AC1.duplicate_ticket_warning_is_asserted_without_leaking
+
+Given two active ticket folders resolve to the same ticket ID
+When the active-ticket lookup runs inside the unit test
+Then the test captures the ambiguity warning from stderr
+And the lookup still returns empty details instead of picking a folder
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: GJGSS3.QT1.AC2.formatter_commands_do_not_stream_success_output
+
+Given golden-path integration tests run external formatters
+When the formatter command succeeds
+Then stdout and stderr are piped instead of inherited by the test process
+And the test continues to assert the formatted file contents
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR

--- a/.project/tickets/GJGSS3-quiet-expected-negative-path-test-output/ticket.md
+++ b/.project/tickets/GJGSS3-quiet-expected-negative-path-test-output/ticket.md
@@ -2,8 +2,17 @@
 id: GJGSS3
 slug: quiet-expected-negative-path-test-output
 type: task
-phase: intake
+phase: define-behavior
 status: in_progress
+scope:
+  - Capture expected negative-path diagnostics in tests instead of leaking them into passing suite output.
+  - Cover the known noisy duplicate-ticket lookup fixture and formatter command fixtures.
+out_of_scope:
+  - Changing user-facing CLI warning text.
+  - Hiding unexpected subprocess failures.
+done_when:
+  - Expected noisy diagnostics are captured and asserted inside tests.
+  - Focused verification passes for the touched tests.
 created: 2026-06-24T14:49:00.471Z
 last_modified: 2026-06-24T14:56:44.000Z
 ---

--- a/packages/cli/tests/hooks/active-ticket-lookup.test.ts
+++ b/packages/cli/tests/hooks/active-ticket-lookup.test.ts
@@ -10,7 +10,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTicketInfo } from '../../../../.safeword/hooks/lib/active-ticket';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
@@ -30,6 +30,21 @@ function makeTicket(projectDirectory: string, folder: string, id: string): void 
   const ticketsDirectory = nodePath.join(projectDirectory, '.safeword-project', 'tickets', folder);
   mkdirSync(ticketsDirectory, { recursive: true });
   writeFileSync(nodePath.join(ticketsDirectory, 'ticket.md'), FRONTMATTER(id));
+}
+
+function captureStderr<T>(callback: () => T): { stderr: string; result: T } {
+  let stderr = '';
+  const writeSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+      return true;
+    });
+  try {
+    return { result: callback(), stderr };
+  } finally {
+    writeSpy.mockRestore();
+  }
 }
 
 describe('getTicketInfo — dual-format lookup', () => {
@@ -87,7 +102,8 @@ describe('getTicketInfo — dual-format lookup', () => {
   it('returns empty details (does not silently pick) when two folders match the same ID', () => {
     makeTicket(projectDirectory, '7K9M3P', '7K9M3P');
     makeTicket(projectDirectory, '7K9M3P-spurious', '7K9M3P');
-    const result = getTicketInfo(projectDirectory, '7K9M3P');
+    const { result, stderr } = captureStderr(() => getTicketInfo(projectDirectory, '7K9M3P'));
     expect(result.folder).toBeUndefined();
+    expect(stderr).toContain('Ambiguous ticket ID "7K9M3P": 7K9M3P, 7K9M3P-spurious');
   });
 });

--- a/packages/cli/tests/integration/golang-golden-path.test.ts
+++ b/packages/cli/tests/integration/golang-golden-path.test.ts
@@ -118,7 +118,7 @@ func main(){println("no spaces")}`,
     );
 
     // Run golangci-lint fmt
-    execSync('golangci-lint fmt ugly.go', { cwd: projectDirectory });
+    execSync('golangci-lint fmt ugly.go', { cwd: projectDirectory, stdio: 'pipe' });
 
     const formatted = readTestFile(projectDirectory, 'ugly.go');
     // gofumpt adds proper spacing

--- a/packages/cli/tests/integration/golden-path.test.ts
+++ b/packages/cli/tests/integration/golden-path.test.ts
@@ -82,7 +82,7 @@ describe('E2E: Golden Path', () => {
   it('prettier formats files', () => {
     writeTestFile(projectDirectory, 'src/ugly.ts', 'const x=1;const y=2;\n');
 
-    execSync('bunx prettier --write src/ugly.ts', { cwd: projectDirectory });
+    execSync('bunx prettier --write src/ugly.ts', { cwd: projectDirectory, stdio: 'pipe' });
 
     const formatted = readTestFile(projectDirectory, 'src/ugly.ts');
     // Prettier adds spaces and may split lines

--- a/packages/cli/tests/integration/python-golden-path.test.ts
+++ b/packages/cli/tests/integration/python-golden-path.test.ts
@@ -98,7 +98,7 @@ describe('E2E: Python Golden Path', () => {
     // Badly formatted Python - extra spaces, missing newline
     writeTestFile(projectDirectory, 'src/ugly.py', 'x=1;y=2');
 
-    execSync('ruff format src/ugly.py', { cwd: projectDirectory });
+    execSync('ruff format src/ugly.py', { cwd: projectDirectory, stdio: 'pipe' });
 
     const formatted = readTestFile(projectDirectory, 'src/ugly.py');
     // Ruff format adds spaces around = and newlines


### PR DESCRIPTION
## Summary
- capture and assert the duplicate active-ticket ambiguity warning instead of leaking it into passing test output
- pipe known formatter subprocess output in golden-path tests
- add #399 ticket test definitions and required ticket metadata

## Verification
- bun run --cwd packages/cli test -- tests/hooks/active-ticket-lookup.test.ts --reporter=dot
- bun run --cwd packages/cli typecheck
- bun run lint

Closes #399