### PR TITLE
Keep /refactor commit guidance scoped

### DIFF
--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -3,8 +3,8 @@ name: refactor
 description: Improve code structure without changing behavior. Use when
   refactoring, restructuring, simplifying, or extracting code. Also for reducing
   duplication, renaming for clarity, or addressing code smells. Enforces one
-  change → test → commit cycle. NOT for style/formatting (use /lint), features,
-  or bug fixes.
+  change → test → commit when the commit can stay scoped. NOT for
+  style/formatting (use /lint), features, or bug fixes.
 allowed-tools: '*'
 ---
 
@@ -162,8 +162,30 @@ After each refactoring:
 
 1. **Run tests** - Must pass
 2. **Regression checklist** (tests can miss these) - did the change silently drop a guard/anchor an extract or move was carrying, introduce setup/teardown asymmetry in a test, give a predicate method a side effect, or flip a config default? If any, fix or revert before continuing.
-3. **If tests pass (and the checklist is clean):** Commit with `refactor: [what changed]`
+3. **If tests pass (and the checklist is clean):** Run the commit safety check below, then commit with `refactor: [what changed]` only when the commit can stay scoped.
 4. **If tests fail:** Revert immediately
+
+### Commit Safety Check
+
+Before committing a green refactor, inspect `git status --short --branch` and
+the files changed by this refactor.
+
+Choose exactly one outcome:
+
+- **clean branch** — if the branch is named and the only changes are this
+  refactor plus its required tests/generated mirrors, commit with
+  `refactor: [what changed]`.
+- **mixed dirty tree** — if pre-existing feature or user changes are present,
+  commit only the isolated refactor files when they can be staged without
+  unrelated work. If isolation is not obvious, do not create a mixed
+  feature+refactor commit; defer the commit, report why, and leave unrelated
+  work untouched.
+- **detached HEAD** — create or switch to a branch before committing. If branch
+  creation would disturb the user's state or unrelated work is already present,
+  defer the commit and report the exact branch/worktree reason.
+
+Deferring a commit is not skipping the Iron Law; it is preserving the same
+single-change attribution the Iron Law exists to protect.
 
 ### Revert Protocol
 
@@ -233,13 +255,14 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 ## Anti-Patterns
 
-| Don't                           | Do                                    |
-| ------------------------------- | ------------------------------------- |
-| Batch multiple refactorings     | One refactoring → test → commit       |
-| "Fix" a failed refactoring      | Revert, then try smaller step         |
-| Refactor without tests          | Add characterization tests first      |
-| Change behavior during refactor | That's a feature/fix, not refactoring |
-| Skip the commit                 | Commit after every green test         |
+| Don't                                  | Do                                                            |
+| -------------------------------------- | ------------------------------------------------------------- |
+| Batch multiple refactorings            | One refactoring → test → commit                               |
+| "Fix" a failed refactoring             | Revert, then try smaller step                                 |
+| Refactor without tests                 | Add characterization tests first                              |
+| Change behavior during refactor        | That's a feature/fix, not refactoring                         |
+| Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
+| Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
 
 ---
 
@@ -248,6 +271,6 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 1. **One change at a time** - Never batch refactorings
 2. **Tests before refactoring** - No safety net = no refactoring
 3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success** - `refactor: [description]`
+4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
 5. **Smallest scope first** - Rename < Extract < Move < Restructure
 6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -3,8 +3,8 @@ name: refactor
 description: Improve code structure without changing behavior. Use when
   refactoring, restructuring, simplifying, or extracting code. Also for reducing
   duplication, renaming for clarity, or addressing code smells. Enforces one
-  change → test → commit cycle. NOT for style/formatting (use /lint), features,
-  or bug fixes.
+  change → test → commit when the commit can stay scoped. NOT for
+  style/formatting (use /lint), features, or bug fixes.
 allowed-tools: '*'
 ---
 
@@ -162,8 +162,30 @@ After each refactoring:
 
 1. **Run tests** - Must pass
 2. **Regression checklist** (tests can miss these) - did the change silently drop a guard/anchor an extract or move was carrying, introduce setup/teardown asymmetry in a test, give a predicate method a side effect, or flip a config default? If any, fix or revert before continuing.
-3. **If tests pass (and the checklist is clean):** Commit with `refactor: [what changed]`
+3. **If tests pass (and the checklist is clean):** Run the commit safety check below, then commit with `refactor: [what changed]` only when the commit can stay scoped.
 4. **If tests fail:** Revert immediately
+
+### Commit Safety Check
+
+Before committing a green refactor, inspect `git status --short --branch` and
+the files changed by this refactor.
+
+Choose exactly one outcome:
+
+- **clean branch** — if the branch is named and the only changes are this
+  refactor plus its required tests/generated mirrors, commit with
+  `refactor: [what changed]`.
+- **mixed dirty tree** — if pre-existing feature or user changes are present,
+  commit only the isolated refactor files when they can be staged without
+  unrelated work. If isolation is not obvious, do not create a mixed
+  feature+refactor commit; defer the commit, report why, and leave unrelated
+  work untouched.
+- **detached HEAD** — create or switch to a branch before committing. If branch
+  creation would disturb the user's state or unrelated work is already present,
+  defer the commit and report the exact branch/worktree reason.
+
+Deferring a commit is not skipping the Iron Law; it is preserving the same
+single-change attribution the Iron Law exists to protect.
 
 ### Revert Protocol
 
@@ -233,13 +255,14 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 ## Anti-Patterns
 
-| Don't                           | Do                                    |
-| ------------------------------- | ------------------------------------- |
-| Batch multiple refactorings     | One refactoring → test → commit       |
-| "Fix" a failed refactoring      | Revert, then try smaller step         |
-| Refactor without tests          | Add characterization tests first      |
-| Change behavior during refactor | That's a feature/fix, not refactoring |
-| Skip the commit                 | Commit after every green test         |
+| Don't                                  | Do                                                            |
+| -------------------------------------- | ------------------------------------------------------------- |
+| Batch multiple refactorings            | One refactoring → test → commit                               |
+| "Fix" a failed refactoring             | Revert, then try smaller step                                 |
+| Refactor without tests                 | Add characterization tests first                              |
+| Change behavior during refactor        | That's a feature/fix, not refactoring                         |
+| Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
+| Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
 
 ---
 
@@ -248,6 +271,6 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 1. **One change at a time** - Never batch refactorings
 2. **Tests before refactoring** - No safety net = no refactoring
 3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success** - `refactor: [description]`
+4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
 5. **Smallest scope first** - Rename < Extract < Move < Restructure
 6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/.cursor/commands/refactor.md
+++ b/.cursor/commands/refactor.md
@@ -1,5 +1,5 @@
 ---
-description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit cycle. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
+description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
 ---
 
 Read and follow the instructions in .claude/skills/refactor/SKILL.md

--- a/.project/tickets/E5VDEF-refactor-commit-mixed-worktrees/ticket.md
+++ b/.project/tickets/E5VDEF-refactor-commit-mixed-worktrees/ticket.md
@@ -2,10 +2,11 @@
 id: E5VDEF
 slug: refactor-commit-mixed-worktrees
 type: task
-phase: intake
+phase: verify
 status: in_progress
 created: 2026-06-24T18:17:30.463Z
-last_modified: 2026-06-24T18:20:00.000Z
+last_modified: 2026-06-24T19:47:13.000Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/407
 scope:
   - 'Update the `/refactor` guidance so its one-refactoring -> test -> commit rule handles mixed or detached worktrees without encouraging a commit that bundles unrelated feature work.'
   - 'Teach the skill to inspect git state before the commit step and choose one of three explicit outcomes: commit the isolated refactor files, defer the commit with a reason, or stop and ask when safe isolation is impossible.'
@@ -32,3 +33,7 @@ done_when:
 - 2026-06-24T18:17:30.463Z Started: Created ticket E5VDEF
 - 2026-06-24T18:18:30.000Z Origin: Session rough edge from the PR-scope gate work. `/refactor` asked for "ONE REFACTORING -> TEST -> COMMIT" after a small test-fixture extraction, but the worktree already contained the larger PR-scope feature diff and was detached at the time. A literal refactor commit would have mixed feature and cleanup work, so the agent had to override the skill and explain the deferral manually.
 - 2026-06-24T18:20:00.000Z Filed matching GitHub issue: [#407](https://github.com/ArcadeAI/safeword/issues/407).
+- 2026-06-24T19:41:00.000Z RED: Added `packages/cli/tests/refactor-skill.test.ts` to assert `/refactor` preserves clean-branch commit behavior, prevents mixed feature+refactor commits in dirty worktrees, and gives detached HEAD a branch-or-defer path. The focused test failed 9/9 for the missing guidance.
+- 2026-06-24T19:43:00.000Z GREEN: Updated the canonical `/refactor` skill and synced dogfood surfaces with `safeword upgrade`. Focused `refactor-skill.test.ts` now passes 9/9. Removed unrelated `.safeword/version` churn from the branch.
+- 2026-06-24T19:45:17.000Z VERIFY: `refactor-skill.test.ts`, skill/command integration validation, dogfood parity, typecheck, Prettier check, and `git diff --check` all pass.
+- 2026-06-24T19:47:13.000Z PR: Opened [#413](https://github.com/ArcadeAI/safeword/pull/413) to close GitHub issue #407.

--- a/packages/cli/templates/commands/refactor.md
+++ b/packages/cli/templates/commands/refactor.md
@@ -1,5 +1,5 @@
 ---
-description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit cycle. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
+description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
 ---
 
 Read and follow the instructions in .claude/skills/refactor/SKILL.md

--- a/packages/cli/templates/skills/refactor/SKILL.md
+++ b/packages/cli/templates/skills/refactor/SKILL.md
@@ -3,8 +3,8 @@ name: refactor
 description: Improve code structure without changing behavior. Use when
   refactoring, restructuring, simplifying, or extracting code. Also for reducing
   duplication, renaming for clarity, or addressing code smells. Enforces one
-  change → test → commit cycle. NOT for style/formatting (use /lint), features,
-  or bug fixes.
+  change → test → commit when the commit can stay scoped. NOT for
+  style/formatting (use /lint), features, or bug fixes.
 allowed-tools: '*'
 ---
 
@@ -162,8 +162,30 @@ After each refactoring:
 
 1. **Run tests** - Must pass
 2. **Regression checklist** (tests can miss these) - did the change silently drop a guard/anchor an extract or move was carrying, introduce setup/teardown asymmetry in a test, give a predicate method a side effect, or flip a config default? If any, fix or revert before continuing.
-3. **If tests pass (and the checklist is clean):** Commit with `refactor: [what changed]`
+3. **If tests pass (and the checklist is clean):** Run the commit safety check below, then commit with `refactor: [what changed]` only when the commit can stay scoped.
 4. **If tests fail:** Revert immediately
+
+### Commit Safety Check
+
+Before committing a green refactor, inspect `git status --short --branch` and
+the files changed by this refactor.
+
+Choose exactly one outcome:
+
+- **clean branch** — if the branch is named and the only changes are this
+  refactor plus its required tests/generated mirrors, commit with
+  `refactor: [what changed]`.
+- **mixed dirty tree** — if pre-existing feature or user changes are present,
+  commit only the isolated refactor files when they can be staged without
+  unrelated work. If isolation is not obvious, do not create a mixed
+  feature+refactor commit; defer the commit, report why, and leave unrelated
+  work untouched.
+- **detached HEAD** — create or switch to a branch before committing. If branch
+  creation would disturb the user's state or unrelated work is already present,
+  defer the commit and report the exact branch/worktree reason.
+
+Deferring a commit is not skipping the Iron Law; it is preserving the same
+single-change attribution the Iron Law exists to protect.
 
 ### Revert Protocol
 
@@ -233,13 +255,14 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 ## Anti-Patterns
 
-| Don't                           | Do                                    |
-| ------------------------------- | ------------------------------------- |
-| Batch multiple refactorings     | One refactoring → test → commit       |
-| "Fix" a failed refactoring      | Revert, then try smaller step         |
-| Refactor without tests          | Add characterization tests first      |
-| Change behavior during refactor | That's a feature/fix, not refactoring |
-| Skip the commit                 | Commit after every green test         |
+| Don't                                  | Do                                                            |
+| -------------------------------------- | ------------------------------------------------------------- |
+| Batch multiple refactorings            | One refactoring → test → commit                               |
+| "Fix" a failed refactoring             | Revert, then try smaller step                                 |
+| Refactor without tests                 | Add characterization tests first                              |
+| Change behavior during refactor        | That's a feature/fix, not refactoring                         |
+| Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
+| Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
 
 ---
 
@@ -248,6 +271,6 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 1. **One change at a time** - Never batch refactorings
 2. **Tests before refactoring** - No safety net = no refactoring
 3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success** - `refactor: [description]`
+4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
 5. **Smallest scope first** - Rename < Extract < Move < Restructure
 6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/packages/cli/tests/refactor-skill.test.ts
+++ b/packages/cli/tests/refactor-skill.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../..');
+
+const refactorSkillSurfaces: [string, string][] = [
+  [
+    'template skill',
+    readFileSync(
+      nodePath.join(repoRoot, 'packages/cli/templates/skills/refactor/SKILL.md'),
+      'utf8',
+    ),
+  ],
+  [
+    'dogfood agents skill',
+    readFileSync(nodePath.join(repoRoot, '.agents/skills/refactor/SKILL.md'), 'utf8'),
+  ],
+  [
+    'dogfood claude skill',
+    readFileSync(nodePath.join(repoRoot, '.claude/skills/refactor/SKILL.md'), 'utf8'),
+  ],
+];
+
+describe('refactor skill commit guidance (E5VDEF / #407)', () => {
+  it.each(refactorSkillSurfaces)(
+    '%s preserves commit-after-green on a clean branch',
+    (_name, content) => {
+      expect(content).toContain('clean branch');
+      expect(content).toContain('commit with `refactor: [what changed]`');
+    },
+  );
+
+  it.each(refactorSkillSurfaces)(
+    '%s prevents mixed feature+refactor commits in dirty worktrees',
+    (_name, content) => {
+      expect(content).toContain('mixed dirty tree');
+      expect(content).toContain('commit only the isolated refactor files');
+      expect(content).toContain('defer the commit');
+      expect(content).toContain('mixed feature+refactor commit');
+    },
+  );
+
+  it.each(refactorSkillSurfaces)(
+    '%s gives detached HEAD an explicit branch-or-defer path',
+    (_name, content) => {
+      expect(content).toContain('detached HEAD');
+      expect(content).toContain('create or switch to a branch');
+      expect(content).toContain('defer the commit');
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds commit safety guidance to `/refactor` for clean branches, mixed dirty trees, and detached HEAD worktrees.
- Syncs the canonical template into dogfood agent surfaces and updates the command description.
- Adds a focused regression test for the commit guidance expectations.

## Tests
- `bun run --cwd packages/cli test -- tests/refactor-skill.test.ts`
- `bun run --cwd packages/cli test -- tests/integration/skills-commands-validation.test.ts tests/commands/upgrade-reconcile.test.ts`
- `bun run --cwd packages/cli test:release -- tests/dogfood-parity.release.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bunx prettier --check packages/cli/tests/refactor-skill.test.ts packages/cli/templates/skills/refactor/SKILL.md packages/cli/templates/commands/refactor.md .agents/skills/refactor/SKILL.md .claude/skills/refactor/SKILL.md .cursor/commands/refactor.md .project/tickets/E5VDEF-refactor-commit-mixed-worktrees/ticket.md`
- `git diff --check`

Closes #407