### PR TITLE
docs(cursor): align safeword-refactoring rule description with #413

### DIFF
--- a/.cursor/rules/safeword-refactoring.mdc
+++ b/.cursor/rules/safeword-refactoring.mdc
@@ -1,6 +1,6 @@
 ---
 alwaysApply: false
-description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit cycle. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
+description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
 ---
 
 @.claude/skills/refactor/SKILL.md

--- a/packages/cli/templates/cursor/rules/safeword-refactoring.mdc
+++ b/packages/cli/templates/cursor/rules/safeword-refactoring.mdc
@@ -1,6 +1,6 @@
 ---
 alwaysApply: false
-description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit cycle. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
+description: Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.
 ---
 
 @.claude/skills/refactor/SKILL.md


### PR DESCRIPTION
Follow-up to #413 (surfaced in its review). The `safeword-refactoring.mdc` Cursor-rule pair still carried the old frontmatter `description: "...Enforces one change → test → commit cycle."`, while #413 softened that wording everywhere else — the refactor SKILL trio (`.agents/`+`.claude/`+`templates/skills/`) and the command pair (`.cursor/commands/`+`templates/commands/`) — to "...commit **when the commit can stay scoped**" (for deferred commits in mixed/detached worktrees).

This aligns the `.mdc` pair's description to match the command/SKILL phrasing verbatim.

- Both `.mdc` files edited identically (kept byte-identical — verified `diff`).
- Rule **body** (thin `@.claude/skills/refactor/SKILL.md` reference) is unchanged.
- Cosmetic only, no behavior change. `parity.ts` validates only that the body is a thin `@`-reference and ignores the frontmatter description, so CI never caught this drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)