### PR TITLE
feat(cursor): enforce done gate at the edit layer (AKNWZK)

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -10,7 +10,8 @@
       {
         "command": "bun ./.safeword/hooks/cursor/pre-tool-quality.ts",
         "matcher": "Write",
-        "failClosed": true
+        "failClosed": true,
+        "timeout": 90
       }
     ],
     "beforeShellExecution": [
@@ -32,7 +33,8 @@
     ],
     "stop": [
       {
-        "command": "bun ./.safeword/hooks/cursor/stop.ts"
+        "command": "bun ./.safeword/hooks/cursor/stop.ts",
+        "loop_limit": 1
       }
     ]
   }

--- a/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
+++ b/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
@@ -16,13 +16,27 @@ relates_to: VAX3Z2
 
 ## Approach
 
-- Move the real enforcement upstream to `beforeSubmitPrompt` (F2TKR3): refuse the _next_ turn's progression until `verify.md` exists, rather than trying to block the stop.
-- Use `stop` `followup_message` to nudge; set `loop_limit` deliberately (`null` for persistent nudging, or a number to cap).
-- Document the Cursor-vs-Claude-Code divergence in the integration notes.
+F2TKR3 removed the `beforeSubmitPrompt` block (it sees only prompt text, so it
+deadlocked the prompt that asks for the evidence). So the real enforcement moves
+**down** to the edit layer, not up to prompt-send:
+
+- **Edit-layer block (`preToolUse`):** deny the Write that flips `ticket.md` to
+  `status: done` unless the done evidence holds. "Full" enforcement — it runs the
+  test suite plus the verify.md / scenario checks. Logic is shared with the Claude
+  Stop gate via `hooks/lib/done-gate.ts` (`evaluateDoneEvidence`), so the two
+  gates can't drift.
+- **Stop nudge (`stop`):** keep `followup_message` for the quality-review reminder.
+  `loop_limit: 1` is intentional — it's a one-shot reminder (the hook clears its
+  edit marker after firing), not a drive-to-done loop, so one auto-continue is
+  enough and a higher cap would just re-nudge noisily.
+- **Documented divergence:** Claude enforces done at the blocking Stop hook; Cursor
+  can't block stop, so it enforces one layer earlier at the close edit. Captured in
+  `config.ts` (CURSOR_HOOKS) and `hooks/lib/done-gate.ts`.
 
 ## Done when
 
-- Done-gate behavior on Cursor is defined and implemented (upstream block + nudge), with `loop_limit` set intentionally and the divergence documented.
+- Done-gate behavior on Cursor is defined and implemented (edit-layer block + stop
+  nudge), with `loop_limit` set intentionally and the divergence documented.
 
 ## Source
 
@@ -31,3 +45,11 @@ cursor.com/docs/hooks (`stop` non-blocking, `loop_limit` default 5 / null)
 ## Work Log
 
 - 2026-05-31 Created from Cursor research — `stop` is observe-only.
+- 2026-06-24 Implemented edit-layer done gate. Extracted `checkVerifyArtifact` +
+  new `evaluateDoneEvidence` into `hooks/lib/done-gate.ts` (single source of
+  truth); Stop gate now imports it. Cursor `preToolUse` adapter detects a
+  `status: done` transition on `ticket.md`, derives the ticket type, and runs the
+  full evidence check (deps → tests → verify.md → scenarios), denying on failure.
+  Set `preToolUse` `timeout: 90` (close edit runs the suite) and `stop`
+  `loop_limit: 1`. Tests: lib unit (`done-gate.test.ts`), adapter helper units
+  (`cursor-gate-adapter.test.ts`), and end-to-end (`cursor-pretooluse-gate.test.ts`).

--- a/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
+++ b/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
@@ -53,3 +53,10 @@ cursor.com/docs/hooks (`stop` non-blocking, `loop_limit` default 5 / null)
   Set `preToolUse` `timeout: 90` (close edit runs the suite) and `stop`
   `loop_limit: 1`. Tests: lib unit (`done-gate.test.ts`), adapter helper units
   (`cursor-gate-adapter.test.ts`), and end-to-end (`cursor-pretooluse-gate.test.ts`).
+- 2026-06-24 /quality-review (fresh-context pass) → APPROVE, no criticals. Took two
+  fixes: match ticket.md by `basename` not `endsWith` (a `*ticket.md` file can no
+  longer be mis-gated), and added `done-gate-failing-suite.test.ts` (mocked) to pin
+  the "failing suite blocks the close" premise. Known limitation (deferred,
+  negligible): if a `status: done` edit's content can't be read, detection fails
+  open at the logic layer — only a wrapper crash hits Cursor's `failClosed`. Cursor's
+  sole edit tool sends full content, so the multi-line frontmatter is always present.

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -76,6 +76,52 @@ export function extractFilePath(
   return undefined;
 }
 
+// Cursor's `Write` tool_input field name for the file *content* is undocumented,
+// just like the path field. Accept the plausible spellings; the done-transition
+// detection only needs to read the proposed text.
+const CONTENT_KEYS = ['content', 'contents', 'new_string', 'text', 'file_text', 'code'] as const;
+
+/**
+ * Extract the proposed file content from a Cursor tool_input, tolerating field-name
+ * variants. Falls back to the longest multi-line string value present — a Write's
+ * body is far longer than any path/flag field, so this recovers the content even
+ * under an unknown field name.
+ */
+export function extractWriteContent(
+  toolInput: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!toolInput) return undefined;
+  for (const key of CONTENT_KEYS) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value !== '') return value;
+  }
+  let longest: string | undefined;
+  for (const value of Object.values(toolInput)) {
+    if (typeof value === 'string' && value.includes('\n')) {
+      if (longest === undefined || value.length > longest.length) longest = value;
+    }
+  }
+  return longest;
+}
+
+/**
+ * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
+ * sets `status: done`. Marking `phase: done` (entering the done phase to run /verify)
+ * is deliberately NOT a transition: that is the step that produces the evidence the
+ * gate later checks. Matches the closing edit only.
+ */
+export function detectDoneTransition(content: string | undefined): boolean {
+  if (!content) return false;
+  return /^status:\s*["']?done["']?\s*$/im.test(content);
+}
+
+/** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
+export function parseTicketType(content: string | undefined): string | undefined {
+  if (!content) return undefined;
+  const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
+  return match?.groups?.type;
+}
+
 /**
  * Parse the Claude gate's stdout. The gate denies with
  * `{ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason } }`

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -24,6 +24,7 @@ import {
   mapCursorToolName,
   parseTicketType,
   runClaudeHook,
+  toCursorDecision,
 } from './gate-adapter.ts';
 
 async function readInput(): Promise<CursorPreToolInput> {
@@ -76,11 +77,7 @@ if (nodePath.basename(filePath) === 'ticket.md') {
 
     const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
     if (!verdict.ok) {
-      emitDecisionAndExit({
-        permission: 'deny',
-        user_message: verdict.reason,
-        agent_message: verdict.reason,
-      });
+      emitDecisionAndExit(toCursorDecision(verdict.reason));
     }
     // Evidence present — allow. ticket.md is a meta path the edit gate permits
     // anyway, so there is nothing further to check.

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -34,9 +34,13 @@ async function readInput(): Promise<CursorPreToolInput> {
   }
 }
 
-function emitAllowAndExit(): never {
-  process.stdout.write(JSON.stringify({ permission: 'allow' }) + '\n');
+function emitDecisionAndExit(decision: CursorDecision): never {
+  process.stdout.write(JSON.stringify(decision) + '\n');
   process.exit(0);
+}
+
+function emitAllowAndExit(): never {
+  emitDecisionAndExit({ permission: 'allow' });
 }
 
 const input = await readInput();
@@ -72,13 +76,11 @@ if (nodePath.basename(filePath) === 'ticket.md') {
 
     const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
     if (!verdict.ok) {
-      const denial: CursorDecision = {
+      emitDecisionAndExit({
         permission: 'deny',
         user_message: verdict.reason,
         agent_message: verdict.reason,
-      };
-      process.stdout.write(JSON.stringify(denial) + '\n');
-      process.exit(0);
+      });
     }
     // Evidence present — allow. ticket.md is a meta path the edit gate permits
     // anyway, so there is nothing further to check.
@@ -99,6 +101,4 @@ const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
 // Fail-closed: a gate that crashed or never started denies the edit (ANAXG4).
-const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
-process.stdout.write(JSON.stringify(decision) + '\n');
-process.exit(0);
+emitDecisionAndExit(decideFromGate(runClaudeHook(claudeHookPath, translated)));

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -8,16 +8,21 @@
 // denial onto Cursor's { permission: 'deny' } decision. Enforces the
 // implement-phase test-definitions gate and the LOC blast-radius gate.
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { evaluateDoneEvidence } from '../lib/done-gate.ts';
 import {
   type ClaudeGateInput,
+  type CursorDecision,
   type CursorPreToolInput,
   decideFromGate,
+  detectDoneTransition,
   extractFilePath,
+  extractWriteContent,
   mapCursorToolName,
+  parseTicketType,
   runClaudeHook,
 } from './gate-adapter.ts';
 
@@ -46,6 +51,40 @@ if (claudeTool !== 'Write' || !existsSync('.safeword')) {
 
 const filePath = extractFilePath(input.tool_input);
 if (!filePath) emitAllowAndExit();
+
+// Done-edit gate (AKNWZK): Cursor's `stop` cannot block, so the done gate that
+// lives in Claude's Stop hook is enforced here instead — at the edit that flips a
+// ticket.md to `status: done`. "Full" enforcement: evaluateDoneEvidence runs the
+// test suite (the one artifact prose can't fake) plus the verify.md/scenario
+// checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
+if (filePath.endsWith('ticket.md')) {
+  const proposedContent = extractWriteContent(input.tool_input);
+  if (detectDoneTransition(proposedContent)) {
+    const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
+    // Type comes from the proposed frontmatter; fall back to the on-disk ticket
+    // (the closing edit rarely changes `type`) so features still require scenarios.
+    let ticketType = parseTicketType(proposedContent);
+    if (!ticketType) {
+      const onDiskTicket = nodePath.join(ticketDir, 'ticket.md');
+      if (existsSync(onDiskTicket))
+        ticketType = parseTicketType(readFileSync(onDiskTicket, 'utf8'));
+    }
+
+    const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
+    if (!verdict.ok) {
+      const denial: CursorDecision = {
+        permission: 'deny',
+        user_message: verdict.reason,
+        agent_message: verdict.reason,
+      };
+      process.stdout.write(JSON.stringify(denial) + '\n');
+      process.exit(0);
+    }
+    // Evidence present — allow. ticket.md is a meta path the edit gate permits
+    // anyway, so there is nothing further to check.
+    emitAllowAndExit();
+  }
+}
 
 // Pass the original tool_input through (so content-aware checks still see their
 // fields) with a normalized file_path the gate is guaranteed to read.

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -57,7 +57,7 @@ if (!filePath) emitAllowAndExit();
 // ticket.md to `status: done`. "Full" enforcement: evaluateDoneEvidence runs the
 // test suite (the one artifact prose can't fake) plus the verify.md/scenario
 // checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
-if (filePath.endsWith('ticket.md')) {
+if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
   if (detectDoneTransition(proposedContent)) {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));

--- a/.safeword/hooks/lib/done-gate.ts
+++ b/.safeword/hooks/lib/done-gate.ts
@@ -1,0 +1,172 @@
+// Safeword: shared done-gate evidence checks.
+//
+// The done gate is the "you may close this ticket" chokepoint. On Claude Code it
+// runs inside the blocking Stop hook (stop-quality.ts). Cursor's `stop` cannot
+// block, so the same enforcement is applied one layer earlier — at the edit that
+// flips `ticket.md` to `status: done` (the Cursor preToolUse adapter). Both paths
+// MUST agree on what counts as evidence, so the shared logic lives here:
+//
+//   - `checkVerifyArtifact` is the exact PR-scope check the Stop hook uses (it
+//     imports this function — there is no second copy to drift).
+//   - `evaluateDoneEvidence` is the composite the Cursor edit gate calls. It runs
+//     the same dependency -> tests -> verify.md -> scenarios sequence the Stop
+//     hook performs inline, returning a plain verdict instead of exiting.
+
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { formatDependencyRecovery, getDependencyReadiness } from './dependency-readiness.js';
+import { analyzeScenarioFormat } from './scenario-format.js';
+import { runTests } from './test-runner.js';
+
+/** A single line of verify.md that records whether the closing diff stayed in scope. */
+const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
+
+export interface VerifyArtifactStatus {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate the PR-scope evidence inside verify.md. The /verify skill records a
+ * `**PR Scope:**` line stating whether the closing diff matched the ticket; a
+ * missing line or a failed/❌ status blocks done so unrelated work can't ride
+ * along in the closing change. Shared verbatim with the Claude Stop gate.
+ */
+export function checkVerifyArtifact(content: string): VerifyArtifactStatus {
+  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
+  if (!prScopeMatch?.groups?.status) {
+    return {
+      ok: false,
+      reason:
+        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
+    };
+  }
+
+  const status = prScopeMatch.groups.status;
+  if (/❌|piggybacked changes/i.test(status)) {
+    return {
+      ok: false,
+      reason:
+        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
+    };
+  }
+
+  return { ok: true };
+}
+
+export interface DoneEvidenceParams {
+  /** Project root — where dependencies and the test suite live. */
+  projectDir: string;
+  /** Absolute path to the ticket folder being closed (holds verify.md, test-definitions.md). */
+  ticketDir: string;
+  /** The ticket's `type` frontmatter ('feature' | 'task' | ...); features also need scenarios. */
+  ticketType: string | undefined;
+}
+
+export interface DoneEvidenceVerdict {
+  /** True when every applicable check passed and the ticket may be closed. */
+  ok: boolean;
+  /** Human-readable explanation of the first failing check (undefined when ok). */
+  reason?: string;
+}
+
+/**
+ * Evaluate whether a ticket has the evidence required to be marked done.
+ *
+ * Mirrors the Claude Stop gate's done sequence — dependencies ready, tests green,
+ * verify.md present and in-scope, and (for features) all scenarios complete — but
+ * returns a verdict instead of blocking, so the Cursor edit gate can translate it
+ * into a `deny` decision. Tests run here ("full" enforcement, ticket AKNWZK): the
+ * test suite is the one piece of evidence prose can't fake.
+ *
+ * Cursor divergence: where the Claude gate falls back to scanning the agent's last
+ * message for "X/X tests pass" on a task with no test command, this requires a
+ * valid verify.md instead — Cursor's preToolUse payload has no transcript to scan,
+ * and verify.md is the stronger artifact anyway.
+ */
+export function evaluateDoneEvidence(params: DoneEvidenceParams): DoneEvidenceVerdict {
+  const { projectDir, ticketDir, ticketType } = params;
+
+  // 1. Dependencies must be installed, or a missing toolchain masquerades as a
+  //    test failure (the runner exits 127). A verification gate that cannot run
+  //    its check must not pass — fail closed with the install recovery.
+  const readiness = getDependencyReadiness(projectDir);
+  if (readiness.status === 'missing' || readiness.status === 'stale') {
+    return { ok: false, reason: formatDependencyRecovery(readiness) };
+  }
+
+  // 2. Tests are the authoritative external gate — they can't be gamed by prose.
+  //    skipped=true means no test command exists; verify.md (step 3) carries the
+  //    evidence in that case.
+  const testResult = runTests(projectDir);
+  if (!testResult.skipped && !testResult.passed) {
+    if (testResult.toolchainMissing) {
+      return {
+        ok: false,
+        reason: `Test toolchain not found — dependencies are likely not installed. Install them, then retry.\n\n${testResult.output}`,
+      };
+    }
+    return {
+      ok: false,
+      reason: `Tests failed. Fix failures before marking done.\n\n${testResult.output}`,
+    };
+  }
+
+  // 3. verify.md — written by /verify when all checks pass, including the PR-scope
+  //    evidence that keeps unrelated work out of the closing change.
+  const verifyPath = nodePath.join(ticketDir, 'verify.md');
+  const verifyContent = existsSync(verifyPath) ? readFileSync(verifyPath, 'utf8') : '';
+  if (verifyContent.trim().length === 0) {
+    return {
+      ok: false,
+      reason:
+        'No valid verify.md found in the ticket folder. Run /verify to generate evidence before marking done.',
+    };
+  }
+  const verifyStatus = checkVerifyArtifact(verifyContent);
+  if (!verifyStatus.ok) {
+    return { ok: false, reason: verifyStatus.reason };
+  }
+
+  // 4. Features must have every scenario checked off in test-definitions.md.
+  if (ticketType === 'feature') {
+    const scenarioVerdict = checkFeatureScenarios(ticketDir);
+    if (!scenarioVerdict.ok) return scenarioVerdict;
+  }
+
+  return { ok: true };
+}
+
+/** Require test-definitions.md to exist and have all GFM scenario checkboxes ticked. */
+function checkFeatureScenarios(ticketDir: string): DoneEvidenceVerdict {
+  const testDefsPath = nodePath.join(ticketDir, 'test-definitions.md');
+  if (!existsSync(testDefsPath)) {
+    return {
+      ok: false,
+      reason:
+        'Feature done requires test-definitions.md with at least one scenario. Create it before marking done.',
+    };
+  }
+
+  const { checked, unchecked, isUnrecognized } = analyzeScenarioFormat(
+    readFileSync(testDefsPath, 'utf8'),
+  );
+  if (isUnrecognized) {
+    return {
+      ok: false,
+      reason:
+        'test-definitions.md has content but no GFM checkboxes (- [ ] / - [x]). Convert scenarios to GFM task-list items.',
+    };
+  }
+  const total = checked + unchecked;
+  if (total === 0 || unchecked > 0) {
+    return {
+      ok: false,
+      reason:
+        'Not all scenarios are complete in test-definitions.md. Mark every scenario checkbox [x] before marking done.',
+    };
+  }
+
+  return { ok: true };
+}

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -13,6 +13,7 @@ import {
   resolveStopPhase,
 } from './lib/active-ticket.ts';
 import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependency-readiness.ts';
+import { checkVerifyArtifact } from './lib/done-gate.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
@@ -68,7 +69,6 @@ const MAX_MESSAGES_FOR_TOOLS = 5;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
-const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
 const USAGE_LIMIT_PATTERN = /\b(usage limit reached|5-hour limit reached)\b/i;
 
 const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
@@ -79,11 +79,6 @@ interface TicketInfo {
   phase: BddPhase | undefined;
   type: string | undefined;
   folder: string | undefined;
-}
-
-interface VerifyArtifactStatus {
-  ok: boolean;
-  reason?: string;
 }
 
 /**
@@ -445,28 +440,6 @@ Expected evidence formats:
 - "**PR Scope:** ✅ Diff matches ticket scope" or a skipped status with a reason
 
 Run /verify, show output, then try again.`;
-}
-
-function checkVerifyArtifact(content: string): VerifyArtifactStatus {
-  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
-  if (!prScopeMatch?.groups?.status) {
-    return {
-      ok: false,
-      reason:
-        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
-    };
-  }
-
-  const status = prScopeMatch.groups.status;
-  if (/❌|piggybacked changes/i.test(status)) {
-    return {
-      ok: false,
-      reason:
-        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
-    };
-  }
-
-  return { ok: true };
 }
 
 /**

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -542,6 +542,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/lib/dependency-readiness.ts': {
       template: 'hooks/lib/dependency-readiness.ts',
     },
+    '.safeword/hooks/lib/done-gate.ts': { template: 'hooks/lib/done-gate.ts' },
     '.safeword/hooks/lib/namespace-root.ts': { template: 'hooks/lib/namespace-root.ts' },
     '.safeword/hooks/lib/skill-invocation-log.ts': {
       template: 'hooks/lib/skill-invocation-log.ts',

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -317,11 +317,18 @@ export const CURSOR_HOOKS = {
   // Blocking edit gate. Matcher limits it to the `Write` tool (Cursor's only edit
   // tool) so it never spawns on Read/Grep/Task. Denies edits when a feature at the
   // implement phase has no test-definitions.md, and on LOC blast-radius overflow.
+  //
+  // Done gate (AKNWZK): this same hook also enforces the done gate. Cursor's `stop`
+  // cannot block, so closing a ticket is gated here — a Write that flips ticket.md to
+  // `status: done` is denied unless the evidence holds (tests green, verify.md in
+  // scope, scenarios complete). That makes done the only edit that runs the test
+  // suite, so the timeout is raised to cover a full run (the suite self-caps at 60s).
   preToolUse: [
     {
       command: 'bun ./.safeword/hooks/cursor/pre-tool-quality.ts',
       matcher: 'Write',
       failClosed: true,
+      timeout: 90,
     },
   ],
   // Blocking commit gate (a REFACTOR commit may not touch test files).
@@ -338,8 +345,12 @@ export const CURSOR_HOOKS = {
   postToolUse: [
     { command: 'bun ./.safeword/hooks/cursor/post-tool-quality.ts', matcher: 'Write|Shell' },
   ],
-  // Observational: nudges a quality review. Cursor `stop` cannot block anyway.
-  stop: [{ command: 'bun ./.safeword/hooks/cursor/stop.ts' }],
+  // Observational: nudges a quality review. Cursor `stop` cannot block anyway —
+  // the real done enforcement lives in preToolUse (above). loop_limit:1 is
+  // intentional: this is a one-shot reminder (the hook clears its edit marker after
+  // firing), NOT a drive-to-done loop, so a single auto-continue is enough and a
+  // higher cap would just re-nudge noisily.
+  stop: [{ command: 'bun ./.safeword/hooks/cursor/stop.ts', loop_limit: 1 }],
 };
 
 // Claude Code hooks configuration (.claude/settings.json format)

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -76,6 +76,52 @@ export function extractFilePath(
   return undefined;
 }
 
+// Cursor's `Write` tool_input field name for the file *content* is undocumented,
+// just like the path field. Accept the plausible spellings; the done-transition
+// detection only needs to read the proposed text.
+const CONTENT_KEYS = ['content', 'contents', 'new_string', 'text', 'file_text', 'code'] as const;
+
+/**
+ * Extract the proposed file content from a Cursor tool_input, tolerating field-name
+ * variants. Falls back to the longest multi-line string value present — a Write's
+ * body is far longer than any path/flag field, so this recovers the content even
+ * under an unknown field name.
+ */
+export function extractWriteContent(
+  toolInput: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!toolInput) return undefined;
+  for (const key of CONTENT_KEYS) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value !== '') return value;
+  }
+  let longest: string | undefined;
+  for (const value of Object.values(toolInput)) {
+    if (typeof value === 'string' && value.includes('\n')) {
+      if (longest === undefined || value.length > longest.length) longest = value;
+    }
+  }
+  return longest;
+}
+
+/**
+ * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
+ * sets `status: done`. Marking `phase: done` (entering the done phase to run /verify)
+ * is deliberately NOT a transition: that is the step that produces the evidence the
+ * gate later checks. Matches the closing edit only.
+ */
+export function detectDoneTransition(content: string | undefined): boolean {
+  if (!content) return false;
+  return /^status:\s*["']?done["']?\s*$/im.test(content);
+}
+
+/** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
+export function parseTicketType(content: string | undefined): string | undefined {
+  if (!content) return undefined;
+  const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
+  return match?.groups?.type;
+}
+
 /**
  * Parse the Claude gate's stdout. The gate denies with
  * `{ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason } }`

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -24,6 +24,7 @@ import {
   mapCursorToolName,
   parseTicketType,
   runClaudeHook,
+  toCursorDecision,
 } from './gate-adapter.ts';
 
 async function readInput(): Promise<CursorPreToolInput> {
@@ -76,11 +77,7 @@ if (nodePath.basename(filePath) === 'ticket.md') {
 
     const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
     if (!verdict.ok) {
-      emitDecisionAndExit({
-        permission: 'deny',
-        user_message: verdict.reason,
-        agent_message: verdict.reason,
-      });
+      emitDecisionAndExit(toCursorDecision(verdict.reason));
     }
     // Evidence present — allow. ticket.md is a meta path the edit gate permits
     // anyway, so there is nothing further to check.

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -34,9 +34,13 @@ async function readInput(): Promise<CursorPreToolInput> {
   }
 }
 
-function emitAllowAndExit(): never {
-  process.stdout.write(JSON.stringify({ permission: 'allow' }) + '\n');
+function emitDecisionAndExit(decision: CursorDecision): never {
+  process.stdout.write(JSON.stringify(decision) + '\n');
   process.exit(0);
+}
+
+function emitAllowAndExit(): never {
+  emitDecisionAndExit({ permission: 'allow' });
 }
 
 const input = await readInput();
@@ -72,13 +76,11 @@ if (nodePath.basename(filePath) === 'ticket.md') {
 
     const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
     if (!verdict.ok) {
-      const denial: CursorDecision = {
+      emitDecisionAndExit({
         permission: 'deny',
         user_message: verdict.reason,
         agent_message: verdict.reason,
-      };
-      process.stdout.write(JSON.stringify(denial) + '\n');
-      process.exit(0);
+      });
     }
     // Evidence present — allow. ticket.md is a meta path the edit gate permits
     // anyway, so there is nothing further to check.
@@ -99,6 +101,4 @@ const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
 // Fail-closed: a gate that crashed or never started denies the edit (ANAXG4).
-const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
-process.stdout.write(JSON.stringify(decision) + '\n');
-process.exit(0);
+emitDecisionAndExit(decideFromGate(runClaudeHook(claudeHookPath, translated)));

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -8,16 +8,21 @@
 // denial onto Cursor's { permission: 'deny' } decision. Enforces the
 // implement-phase test-definitions gate and the LOC blast-radius gate.
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { evaluateDoneEvidence } from '../lib/done-gate.ts';
 import {
   type ClaudeGateInput,
+  type CursorDecision,
   type CursorPreToolInput,
   decideFromGate,
+  detectDoneTransition,
   extractFilePath,
+  extractWriteContent,
   mapCursorToolName,
+  parseTicketType,
   runClaudeHook,
 } from './gate-adapter.ts';
 
@@ -46,6 +51,40 @@ if (claudeTool !== 'Write' || !existsSync('.safeword')) {
 
 const filePath = extractFilePath(input.tool_input);
 if (!filePath) emitAllowAndExit();
+
+// Done-edit gate (AKNWZK): Cursor's `stop` cannot block, so the done gate that
+// lives in Claude's Stop hook is enforced here instead — at the edit that flips a
+// ticket.md to `status: done`. "Full" enforcement: evaluateDoneEvidence runs the
+// test suite (the one artifact prose can't fake) plus the verify.md/scenario
+// checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
+if (filePath.endsWith('ticket.md')) {
+  const proposedContent = extractWriteContent(input.tool_input);
+  if (detectDoneTransition(proposedContent)) {
+    const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
+    // Type comes from the proposed frontmatter; fall back to the on-disk ticket
+    // (the closing edit rarely changes `type`) so features still require scenarios.
+    let ticketType = parseTicketType(proposedContent);
+    if (!ticketType) {
+      const onDiskTicket = nodePath.join(ticketDir, 'ticket.md');
+      if (existsSync(onDiskTicket))
+        ticketType = parseTicketType(readFileSync(onDiskTicket, 'utf8'));
+    }
+
+    const verdict = evaluateDoneEvidence({ projectDir: process.cwd(), ticketDir, ticketType });
+    if (!verdict.ok) {
+      const denial: CursorDecision = {
+        permission: 'deny',
+        user_message: verdict.reason,
+        agent_message: verdict.reason,
+      };
+      process.stdout.write(JSON.stringify(denial) + '\n');
+      process.exit(0);
+    }
+    // Evidence present — allow. ticket.md is a meta path the edit gate permits
+    // anyway, so there is nothing further to check.
+    emitAllowAndExit();
+  }
+}
 
 // Pass the original tool_input through (so content-aware checks still see their
 // fields) with a normalized file_path the gate is guaranteed to read.

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -57,7 +57,7 @@ if (!filePath) emitAllowAndExit();
 // ticket.md to `status: done`. "Full" enforcement: evaluateDoneEvidence runs the
 // test suite (the one artifact prose can't fake) plus the verify.md/scenario
 // checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
-if (filePath.endsWith('ticket.md')) {
+if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
   if (detectDoneTransition(proposedContent)) {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));

--- a/packages/cli/templates/hooks/lib/done-gate.ts
+++ b/packages/cli/templates/hooks/lib/done-gate.ts
@@ -1,0 +1,172 @@
+// Safeword: shared done-gate evidence checks.
+//
+// The done gate is the "you may close this ticket" chokepoint. On Claude Code it
+// runs inside the blocking Stop hook (stop-quality.ts). Cursor's `stop` cannot
+// block, so the same enforcement is applied one layer earlier — at the edit that
+// flips `ticket.md` to `status: done` (the Cursor preToolUse adapter). Both paths
+// MUST agree on what counts as evidence, so the shared logic lives here:
+//
+//   - `checkVerifyArtifact` is the exact PR-scope check the Stop hook uses (it
+//     imports this function — there is no second copy to drift).
+//   - `evaluateDoneEvidence` is the composite the Cursor edit gate calls. It runs
+//     the same dependency -> tests -> verify.md -> scenarios sequence the Stop
+//     hook performs inline, returning a plain verdict instead of exiting.
+
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { formatDependencyRecovery, getDependencyReadiness } from './dependency-readiness.js';
+import { analyzeScenarioFormat } from './scenario-format.js';
+import { runTests } from './test-runner.js';
+
+/** A single line of verify.md that records whether the closing diff stayed in scope. */
+const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
+
+export interface VerifyArtifactStatus {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate the PR-scope evidence inside verify.md. The /verify skill records a
+ * `**PR Scope:**` line stating whether the closing diff matched the ticket; a
+ * missing line or a failed/❌ status blocks done so unrelated work can't ride
+ * along in the closing change. Shared verbatim with the Claude Stop gate.
+ */
+export function checkVerifyArtifact(content: string): VerifyArtifactStatus {
+  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
+  if (!prScopeMatch?.groups?.status) {
+    return {
+      ok: false,
+      reason:
+        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
+    };
+  }
+
+  const status = prScopeMatch.groups.status;
+  if (/❌|piggybacked changes/i.test(status)) {
+    return {
+      ok: false,
+      reason:
+        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
+    };
+  }
+
+  return { ok: true };
+}
+
+export interface DoneEvidenceParams {
+  /** Project root — where dependencies and the test suite live. */
+  projectDir: string;
+  /** Absolute path to the ticket folder being closed (holds verify.md, test-definitions.md). */
+  ticketDir: string;
+  /** The ticket's `type` frontmatter ('feature' | 'task' | ...); features also need scenarios. */
+  ticketType: string | undefined;
+}
+
+export interface DoneEvidenceVerdict {
+  /** True when every applicable check passed and the ticket may be closed. */
+  ok: boolean;
+  /** Human-readable explanation of the first failing check (undefined when ok). */
+  reason?: string;
+}
+
+/**
+ * Evaluate whether a ticket has the evidence required to be marked done.
+ *
+ * Mirrors the Claude Stop gate's done sequence — dependencies ready, tests green,
+ * verify.md present and in-scope, and (for features) all scenarios complete — but
+ * returns a verdict instead of blocking, so the Cursor edit gate can translate it
+ * into a `deny` decision. Tests run here ("full" enforcement, ticket AKNWZK): the
+ * test suite is the one piece of evidence prose can't fake.
+ *
+ * Cursor divergence: where the Claude gate falls back to scanning the agent's last
+ * message for "X/X tests pass" on a task with no test command, this requires a
+ * valid verify.md instead — Cursor's preToolUse payload has no transcript to scan,
+ * and verify.md is the stronger artifact anyway.
+ */
+export function evaluateDoneEvidence(params: DoneEvidenceParams): DoneEvidenceVerdict {
+  const { projectDir, ticketDir, ticketType } = params;
+
+  // 1. Dependencies must be installed, or a missing toolchain masquerades as a
+  //    test failure (the runner exits 127). A verification gate that cannot run
+  //    its check must not pass — fail closed with the install recovery.
+  const readiness = getDependencyReadiness(projectDir);
+  if (readiness.status === 'missing' || readiness.status === 'stale') {
+    return { ok: false, reason: formatDependencyRecovery(readiness) };
+  }
+
+  // 2. Tests are the authoritative external gate — they can't be gamed by prose.
+  //    skipped=true means no test command exists; verify.md (step 3) carries the
+  //    evidence in that case.
+  const testResult = runTests(projectDir);
+  if (!testResult.skipped && !testResult.passed) {
+    if (testResult.toolchainMissing) {
+      return {
+        ok: false,
+        reason: `Test toolchain not found — dependencies are likely not installed. Install them, then retry.\n\n${testResult.output}`,
+      };
+    }
+    return {
+      ok: false,
+      reason: `Tests failed. Fix failures before marking done.\n\n${testResult.output}`,
+    };
+  }
+
+  // 3. verify.md — written by /verify when all checks pass, including the PR-scope
+  //    evidence that keeps unrelated work out of the closing change.
+  const verifyPath = nodePath.join(ticketDir, 'verify.md');
+  const verifyContent = existsSync(verifyPath) ? readFileSync(verifyPath, 'utf8') : '';
+  if (verifyContent.trim().length === 0) {
+    return {
+      ok: false,
+      reason:
+        'No valid verify.md found in the ticket folder. Run /verify to generate evidence before marking done.',
+    };
+  }
+  const verifyStatus = checkVerifyArtifact(verifyContent);
+  if (!verifyStatus.ok) {
+    return { ok: false, reason: verifyStatus.reason };
+  }
+
+  // 4. Features must have every scenario checked off in test-definitions.md.
+  if (ticketType === 'feature') {
+    const scenarioVerdict = checkFeatureScenarios(ticketDir);
+    if (!scenarioVerdict.ok) return scenarioVerdict;
+  }
+
+  return { ok: true };
+}
+
+/** Require test-definitions.md to exist and have all GFM scenario checkboxes ticked. */
+function checkFeatureScenarios(ticketDir: string): DoneEvidenceVerdict {
+  const testDefsPath = nodePath.join(ticketDir, 'test-definitions.md');
+  if (!existsSync(testDefsPath)) {
+    return {
+      ok: false,
+      reason:
+        'Feature done requires test-definitions.md with at least one scenario. Create it before marking done.',
+    };
+  }
+
+  const { checked, unchecked, isUnrecognized } = analyzeScenarioFormat(
+    readFileSync(testDefsPath, 'utf8'),
+  );
+  if (isUnrecognized) {
+    return {
+      ok: false,
+      reason:
+        'test-definitions.md has content but no GFM checkboxes (- [ ] / - [x]). Convert scenarios to GFM task-list items.',
+    };
+  }
+  const total = checked + unchecked;
+  if (total === 0 || unchecked > 0) {
+    return {
+      ok: false,
+      reason:
+        'Not all scenarios are complete in test-definitions.md. Mark every scenario checkbox [x] before marking done.',
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -13,6 +13,7 @@ import {
   resolveStopPhase,
 } from './lib/active-ticket.ts';
 import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependency-readiness.ts';
+import { checkVerifyArtifact } from './lib/done-gate.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
@@ -68,7 +69,6 @@ const MAX_MESSAGES_FOR_TOOLS = 5;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
-const PR_SCOPE_LINE_PATTERN = /^\*\*PR Scope:\*\*\s*(?<status>.+)$/im;
 const USAGE_LIMIT_PATTERN = /\b(usage limit reached|5-hour limit reached)\b/i;
 
 const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
@@ -79,11 +79,6 @@ interface TicketInfo {
   phase: BddPhase | undefined;
   type: string | undefined;
   folder: string | undefined;
-}
-
-interface VerifyArtifactStatus {
-  ok: boolean;
-  reason?: string;
 }
 
 /**
@@ -445,28 +440,6 @@ Expected evidence formats:
 - "**PR Scope:** ✅ Diff matches ticket scope" or a skipped status with a reason
 
 Run /verify, show output, then try again.`;
-}
-
-function checkVerifyArtifact(content: string): VerifyArtifactStatus {
-  const prScopeMatch = PR_SCOPE_LINE_PATTERN.exec(content);
-  if (!prScopeMatch?.groups?.status) {
-    return {
-      ok: false,
-      reason:
-        'verify.md is missing PR scope evidence. Run /verify again so it records `**PR Scope:**` before marking done.',
-    };
-  }
-
-  const status = prScopeMatch.groups.status;
-  if (/❌|piggybacked changes/i.test(status)) {
-    return {
-      ok: false,
-      reason:
-        'verify.md says PR scope failed. Revert or split the piggybacked work, or explicitly accept the scope change in the ticket artifacts before marking done.',
-    };
-  }
-
-  return { ok: true };
 }
 
 /**

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -127,6 +127,10 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       );
       // preToolUse is scoped to the edit tool so it never spawns on reads/searches.
       expect(hooksConfig.hooks.preToolUse[0].matcher).toBe('Write');
+      // AKNWZK: the done gate runs the suite on the close edit, so the preToolUse
+      // timeout is raised, and the stop nudge is capped at one auto-continue.
+      expect(hooksConfig.hooks.preToolUse[0].timeout).toBe(90);
+      expect(hooksConfig.hooks.stop[0].loop_limit).toBe(1);
       expect(hooksConfig.hooks.beforeShellExecution[0].command).toBe(
         'bun ./.safeword/hooks/cursor/before-shell-execution.ts',
       );

--- a/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
+++ b/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   claudeDenialReason,
   decideFromGate,
+  detectDoneTransition,
   extractFilePath,
+  extractWriteContent,
   GATE_UNAVAILABLE_REASON,
   mapCursorToolName,
+  parseTicketType,
   toCursorDecision,
 } from '../../templates/hooks/cursor/gate-adapter.js';
 
@@ -80,6 +83,54 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
         user_message: 'blocked',
         agent_message: 'blocked',
       });
+    });
+  });
+
+  describe('extractWriteContent (AKNWZK done-edit)', () => {
+    it('reads the common content field names', () => {
+      expect(extractWriteContent({ content: 'a' })).toBe('a');
+      expect(extractWriteContent({ contents: 'b' })).toBe('b');
+      expect(extractWriteContent({ new_string: 'c' })).toBe('c');
+    });
+
+    it('falls back to the longest multi-line string under an unknown field name', () => {
+      const body = 'line one\nline two\nstatus: done\n';
+      expect(extractWriteContent({ mystery_field: body, file_path: 'x/ticket.md' })).toBe(body);
+    });
+
+    it('returns undefined when there is no content-like value', () => {
+      expect(extractWriteContent({ file_path: 'x/ticket.md' })).toBeUndefined();
+      expect(extractWriteContent({})).toBeUndefined();
+      expect(extractWriteContent(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('detectDoneTransition (AKNWZK done-edit)', () => {
+    it('matches frontmatter that closes the ticket', () => {
+      expect(detectDoneTransition('---\nstatus: done\n---')).toBe(true);
+      expect(detectDoneTransition('---\nstatus: "done"\n---')).toBe(true);
+    });
+
+    it('does NOT match entering the done phase (phase: done, still in progress)', () => {
+      expect(detectDoneTransition('---\nphase: done\nstatus: in_progress\n---')).toBe(false);
+    });
+
+    it('does NOT match prose mentioning done or other statuses', () => {
+      expect(detectDoneTransition('We are status: in_progress and nearly done')).toBe(false);
+      expect(detectDoneTransition('status: blocked')).toBe(false);
+      expect(detectDoneTransition(undefined)).toBe(false);
+    });
+  });
+
+  describe('parseTicketType (AKNWZK done-edit)', () => {
+    it('reads the type frontmatter', () => {
+      expect(parseTicketType('---\ntype: feature\n---')).toBe('feature');
+      expect(parseTicketType('---\ntype: task\n---')).toBe('task');
+    });
+
+    it('returns undefined when type is absent', () => {
+      expect(parseTicketType('---\nstatus: done\n---')).toBeUndefined();
+      expect(parseTicketType(undefined)).toBeUndefined();
     });
   });
 

--- a/packages/cli/tests/hooks/done-gate-failing-suite.test.ts
+++ b/packages/cli/tests/hooks/done-gate-failing-suite.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Pins the headline premise of AKNWZK: the done gate runs the test suite on the
+ * close edit, and a FAILING suite blocks the close. The other done-gate tests use
+ * temp projects with no package.json (suite skipped), so this is the only place
+ * the "tests are the one artifact prose can't fake" path is exercised. The runner
+ * and dependency check are mocked so the assertion is fast and deterministic — the
+ * real spawn/timeout behaviour is covered by test-runner's own suite.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../templates/hooks/lib/dependency-readiness.js', () => ({
+  getDependencyReadiness: () => ({ status: 'ready', reason: 'install_artifact_current' }),
+  formatDependencyRecovery: () => 'install dependencies',
+}));
+
+vi.mock('../../templates/hooks/lib/test-runner.js', () => ({
+  runTests: () => ({ passed: false, skipped: false, output: 'FAIL src/x.test.ts\n  1 failed' }),
+}));
+
+import { evaluateDoneEvidence } from '../../templates/hooks/lib/done-gate.js';
+
+describe('evaluateDoneEvidence — failing suite (AKNWZK)', () => {
+  it('blocks the close when the test suite fails, before verify.md is even read', () => {
+    // Dependencies mock "ready"; tests mock "failed". The test gate runs before the
+    // verify.md check, so the dummy paths are never touched — the verdict is the
+    // failure reason, proving the suite gates the close.
+    const verdict = evaluateDoneEvidence({
+      projectDir: '/tmp/does-not-exist',
+      ticketDir: '/tmp/does-not-exist/ticket',
+      ticketType: 'task',
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('Tests failed');
+  });
+});

--- a/packages/cli/tests/hooks/done-gate.test.ts
+++ b/packages/cli/tests/hooks/done-gate.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the shared done-gate evidence checks (AKNWZK).
+ *
+ * `checkVerifyArtifact` is the source of truth both the Claude Stop gate and the
+ * Cursor done-edit gate import. `evaluateDoneEvidence` is the composite the Cursor
+ * gate runs. The temp projects have no package.json, so the test suite is skipped
+ * (no command resolves) and the verify.md / scenario checks carry the verdict —
+ * which is exactly the surface these tests pin.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { checkVerifyArtifact, evaluateDoneEvidence } from '../../templates/hooks/lib/done-gate.js';
+
+const VALID_VERIFY = '# Verify\n\n**PR Scope:** ✅ Diff matches ticket scope\n';
+
+describe('checkVerifyArtifact', () => {
+  it('passes when a PR-scope line is present and in scope', () => {
+    expect(checkVerifyArtifact(VALID_VERIFY)).toEqual({ ok: true });
+  });
+
+  it('fails when the PR-scope line is missing', () => {
+    const verdict = checkVerifyArtifact('# Verify\n\nlooks fine\n');
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('PR scope');
+  });
+
+  it('fails when the PR-scope line reports a failure', () => {
+    const verdict = checkVerifyArtifact('**PR Scope:** ❌ piggybacked changes\n');
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('piggybacked');
+  });
+});
+
+describe('evaluateDoneEvidence', () => {
+  // Pin the CLI to repo source so the test-runner resolves locally instead of
+  // reaching for `bunx safeword`; an empty temp project resolves no test command.
+  const previousCli = process.env.SAFEWORD_CLI;
+  beforeAll(() => {
+    process.env.SAFEWORD_CLI = nodePath.resolve(__dirname, '../../src/cli.ts');
+  });
+  afterAll(() => {
+    if (previousCli === undefined) delete process.env.SAFEWORD_CLI;
+    else process.env.SAFEWORD_CLI = previousCli;
+  });
+
+  let projectDirectory: string;
+  let ticketDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'done-gate-'));
+    ticketDirectory = nodePath.join(projectDirectory, '.project', 'tickets', 'T1-x');
+    mkdirSync(ticketDirectory, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  });
+
+  it('blocks a task close when verify.md is absent', () => {
+    const verdict = evaluateDoneEvidence({
+      projectDir: projectDirectory,
+      ticketDir: ticketDirectory,
+      ticketType: 'task',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('verify.md');
+  });
+
+  it('allows a task close when verify.md is valid', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), VALID_VERIFY);
+    expect(
+      evaluateDoneEvidence({
+        projectDir: projectDirectory,
+        ticketDir: ticketDirectory,
+        ticketType: 'task',
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('blocks a feature close when test-definitions.md is missing', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), VALID_VERIFY);
+    const verdict = evaluateDoneEvidence({
+      projectDir: projectDirectory,
+      ticketDir: ticketDirectory,
+      ticketType: 'feature',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('test-definitions.md');
+  });
+
+  it('blocks a feature close when a scenario is still unchecked', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), VALID_VERIFY);
+    writeFileSync(
+      nodePath.join(ticketDirectory, 'test-definitions.md'),
+      '## Rule: x\n- [x] one\n- [ ] two\n',
+    );
+    const verdict = evaluateDoneEvidence({
+      projectDir: projectDirectory,
+      ticketDir: ticketDirectory,
+      ticketType: 'feature',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('scenarios');
+  });
+
+  it('allows a feature close when verify.md and all scenarios are complete', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), VALID_VERIFY);
+    writeFileSync(
+      nodePath.join(ticketDirectory, 'test-definitions.md'),
+      '## Rule: x\n- [x] one\n- [x] two\n',
+    );
+    expect(
+      evaluateDoneEvidence({
+        projectDir: projectDirectory,
+        ticketDir: ticketDirectory,
+        ticketType: 'feature',
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
+++ b/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
@@ -42,17 +42,28 @@ interface CursorDecision {
  */
 function runAdapter(
   projectRoot: string,
-  options: { toolName?: string; filePath?: string } = {},
+  options: { toolName?: string; filePath?: string; content?: string } = {},
 ): CursorDecision {
-  const env: NodeJS.ProcessEnv = { ...process.env, CLAUDE_PROJECT_DIR: projectRoot };
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: projectRoot,
+    // Pin the CLI to repo source so the done-gate's test-runner resolves locally
+    // (no `bunx safeword` network fetch); an empty temp project yields no test
+    // command, so the suite is skipped and verify.md/scenarios carry the verdict.
+    SAFEWORD_CLI: nodePath.resolve(__dirname, '../../src/cli.ts'),
+  };
   delete env.SAFEWORD_AGENT_RUNTIME;
+
+  const toolInput: Record<string, unknown> = {};
+  if (options.filePath) toolInput.file_path = options.filePath;
+  if (options.content !== undefined) toolInput.content = options.content;
 
   const result = spawnSync('bun', [ADAPTER], {
     cwd: projectRoot,
     input: JSON.stringify({
       conversation_id: SESSION_ID,
       tool_name: options.toolName ?? 'Write',
-      tool_input: options.filePath ? { file_path: options.filePath } : {},
+      tool_input: toolInput,
       workspace_roots: [projectRoot],
     }),
     encoding: 'utf8',
@@ -148,6 +159,117 @@ describe('Cursor preToolUse edit-gate parity (F2TKR3)', () => {
     seedActiveTicket(projectRoot);
 
     const decision = runAdapter(projectRoot, { toolName: 'Read', filePath: 'src/app.ts' });
+
+    expect(decision.permission).toBe('allow');
+  });
+});
+
+/**
+ * Cursor done-edit gate (AKNWZK). Cursor's `stop` cannot block, so closing a
+ * ticket is gated at the edit that flips ticket.md to `status: done`. The temp
+ * project has no package.json, so the test suite is skipped (no command found) and
+ * the verify.md / scenario checks carry the verdict — exactly what we want to pin.
+ */
+describe('Cursor done-edit gate (AKNWZK)', () => {
+  let projectRoot: string;
+  let ticketDirectory: string;
+  const ticketRelativePath = `.project/tickets/${TICKET_FOLDER}/ticket.md`;
+
+  const doneFrontmatter = (type: string): string =>
+    [
+      '---',
+      `id: ${TICKET_ID}`,
+      'slug: cursor-gate',
+      `type: ${type}`,
+      'phase: done',
+      'status: done',
+      '---',
+      '',
+    ].join('\n');
+
+  const validVerify = '# Verify\n\n**PR Scope:** ✅ Diff matches ticket scope\n';
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'cursor-done-'));
+    mkdirSync(nodePath.join(projectRoot, '.safeword'), { recursive: true });
+    ticketDirectory = nodePath.join(projectRoot, '.project', 'tickets', TICKET_FOLDER);
+    mkdirSync(ticketDirectory, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('denies the close edit when verify.md is missing', () => {
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: doneFrontmatter('task'),
+    });
+
+    expect(decision.permission).toBe('deny');
+    expect(decision.user_message).toContain('verify.md');
+  });
+
+  it('allows the close edit for a task with a valid verify.md', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), validVerify);
+
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: doneFrontmatter('task'),
+    });
+
+    expect(decision.permission).toBe('allow');
+  });
+
+  it('denies a feature close when scenarios are incomplete', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), validVerify);
+    writeFileSync(
+      nodePath.join(ticketDirectory, 'test-definitions.md'),
+      '## Rule: x\n- [x] done one\n- [ ] not yet\n',
+    );
+
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: doneFrontmatter('feature'),
+    });
+
+    expect(decision.permission).toBe('deny');
+    expect(decision.user_message).toContain('scenarios');
+  });
+
+  it('allows a feature close when verify.md and all scenarios are complete', () => {
+    writeFileSync(nodePath.join(ticketDirectory, 'verify.md'), validVerify);
+    writeFileSync(
+      nodePath.join(ticketDirectory, 'test-definitions.md'),
+      '## Rule: x\n- [x] done one\n- [x] done two\n',
+    );
+
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: doneFrontmatter('feature'),
+    });
+
+    expect(decision.permission).toBe('allow');
+  });
+
+  it('does not gate a ticket.md edit that only sets phase: done (not closing)', () => {
+    // Entering the done phase to run /verify is not a close — it must be allowed,
+    // otherwise the agent can never produce the evidence the close later needs.
+    const enteringDone = [
+      '---',
+      `id: ${TICKET_ID}`,
+      'slug: cursor-gate',
+      'type: task',
+      'phase: done',
+      'status: in_progress',
+      '---',
+      '',
+    ].join('\n');
+
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: enteringDone,
+    });
 
     expect(decision.permission).toBe('allow');
   });


### PR DESCRIPTION
## Summary

Cursor's `stop` hook cannot block, so safeword's done gate silently degraded to an advisory nudge on Cursor. This moves the real enforcement one layer earlier — to the edit that flips a `ticket.md` to `status: done`.

- **Shared source of truth** — new `hooks/lib/done-gate.ts` holds `checkVerifyArtifact` (now imported by the Claude Stop gate, so the two gates can't drift) and `evaluateDoneEvidence` (deps → tests → verify.md → scenarios).
- **Cursor edit gate** — the `preToolUse` adapter detects a `status: done` transition on `ticket.md`, derives the ticket type, and runs the **full** evidence check (the test suite runs on the close edit), denying on failure. `phase: done` (entering the done phase to run `/verify`) is deliberately not gated.
- **Intentional knobs** — `preToolUse` timeout raised to 90s (the close edit runs the suite); `stop` `loop_limit: 1` (the nudge is a one-shot reminder, not a drive-to-done loop).
- **Divergence documented** in `config.ts` and the AKNWZK ticket: Claude enforces done at the blocking Stop hook; Cursor enforces it at the close edit.

## Test plan

- [x] `done-gate.test.ts` — `checkVerifyArtifact` + `evaluateDoneEvidence` (task/feature, missing/valid verify.md, incomplete/complete scenarios)
- [x] `cursor-gate-adapter.test.ts` — `extractWriteContent` / `detectDoneTransition` / `parseTicketType`
- [x] `cursor-pretooluse-gate.test.ts` — end-to-end allow/deny across task + feature; `phase: done` not gated
- [x] Claude Stop gate unchanged (`status-close-gate`, `stop-done-dependencies-gate` green after the `checkVerifyArtifact` extraction)
- [x] schema entry, owned-paths, dogfood parity, hook-coverage green
- [x] `bun run lint` (eslint + gherkin + tsc) clean

Made with [Cursor](https://cursor.com)