### PR TITLE
Fix ESLint 10 install and config regressions

### DIFF
--- a/.project/tickets/9T13K8-eslint-10-install-config-regressions/ticket.md
+++ b/.project/tickets/9T13K8-eslint-10-install-config-regressions/ticket.md
@@ -1,0 +1,62 @@
+---
+id: 9T13K8
+slug: eslint-10-install-config-regressions
+type: task
+phase: done
+status: done
+created: 2026-06-24T22:27:22.090Z
+last_modified: 2026-06-25T00:04:54Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/388
+external_issues:
+  - https://github.com/ArcadeAI/safeword/issues/388
+  - https://github.com/ArcadeAI/safeword/issues/389
+external_prs:
+  - https://github.com/ArcadeAI/safeword/pull/418
+---
+
+# Prevent ESLint 10 install and config regressions
+
+**Goal:** Ship the ESLint 10 follow-up fixes for the generated config crash and the `eslint-plugin-jsx-a11y` peer mismatch as one paired release.
+
+**Why:** Safeword 0.55.0+ advertises ESLint 10 support, so fresh installs and generated hook configs must work without peer-check failures or runtime `ReferenceError`s.
+
+**Type:** Bug
+
+**Scope:** Fix package and generated-config behavior for GitHub issues #388 and #389. Keep the change limited to the ESLint 10 install/config surface and existing preset behavior.
+
+**Out of Scope:** Dropping ESLint 9 support, replacing the full accessibility rule strategy unless required, changing root project lint rules, or changing unrelated templates.
+
+**Done When:**
+
+- [x] pnpm workspaces installing Safeword with ESLint 10 do not fail peer checks because of Safeword's bundled accessibility plugin.
+- [x] Generated `.safeword/eslint.config.mjs` is self-contained for both formatter and formatter-agnostic paths.
+- [x] Focused unit/release tests fail before the fix and pass after it.
+- [x] Focused validation covers both GitHub issues.
+
+**Tests:**
+
+- [x] Unit: `.safeword` flat config generation never emits `safeword.prettierConfig` without importing `safeword`.
+- [x] Release/package: Safeword's published dependency graph has no direct dependency whose ESLint peer excludes the advertised ESLint 10 range without mitigation.
+- [x] Repro: pnpm peer check scenario for `safeword` + `eslint@^10` is validated after implementation.
+
+## Work Log
+
+- 2026-06-25T00:04:54Z CI fix: PR #418 test job failed in `tests/presets/lazy-config-loading.test.ts` because the old structural contract still required Astro to avoid top-level plugin imports. Documented Astro 2.1 as the ESM-only exception while keeping the lazy-loading assertion for CJS-loadable stack plugins. Verified focused failing suite (4 files / 86 tests), broader targeted suite (14 files / 275 tests), and package lint/typecheck.
+- 2026-06-24T23:42:59Z Done: Opened PR https://github.com/ArcadeAI/safeword/pull/418, confirmed all ticket acceptance checks are covered, and marked ticket done with user confirmation.
+- 2026-06-24T23:41:00Z Quality-review: Approved after Astro 2.1 follow-up. Verified `eslint-plugin-astro@2.1.0` is latest and declares ESLint 10 plus optional `eslint-plugin-jsx-a11y`; verified Astro docs still require `eslint-plugin-jsx-a11y` only for Astro a11y configs; verified `eslint-plugin-jsx-a11y@6.10.2` still peers only through ESLint 9; verified packed-consumer `pnpm audit` found 0 advisories. No critical issues. Release note should call out the Node engine tightening to `^22.22.3 || ^24.16.0 || >=26.3.0`.
+- 2026-06-24T23:34:25Z Implemented Astro follow-up: upgraded `eslint-plugin-astro` to `~2.1.0`, matched Safeword's Node engine to Astro 2.1's runtime contract, switched Astro preset loading to ESM import, kept Astro jsx-a11y rules optional, and added tests for the expanded Astro recommended rules. Verified focused paired suite (3 files / 76 tests), packed pnpm consumer with `eslint@10.5.0` and no `eslint-plugin-jsx-a11y` (no peer issues, configs load), broader preset/schema suite (13 files / 265 tests), smoke-fast (46 files / 626 tests), and package lint/typecheck.
+- 2026-06-24T22:52:00Z Quality-review: Approved. Verified pnpm settings/docs, Astro jsx-a11y docs, npm registry metadata, Snyk package security, packed-consumer audit, package lint, and smoke-fast. Non-blocking notes: `@eslint-react/eslint-plugin` is one patch behind (5.9.1 vs 5.9.2); `eslint-plugin-astro@2.1.0` is newer but now peers on `eslint-plugin-jsx-a11y`, so upgrading it would conflict with this regression fix.
+- 2026-06-24T22:43:00Z Verified: `bun run test:smoke:fast` passed 46 files / 626 tests.
+- 2026-06-24T22:42:00Z Verified: `bun run --cwd packages/cli test src/presets/typescript/eslint-configs/__tests__ src/templates/config.test.ts tests/schema.test.ts` passed 13 files / 262 tests.
+- 2026-06-24T22:41:00Z Verified: `bun run --cwd packages/cli lint` passed (`eslint src tests`, Gherkin lint, typecheck).
+- 2026-06-24T22:40:00Z Verified: Packed `safeword-0.56.0.tgz` installed with `eslint@10.5.0` under pnpm; `pnpm peers check` reported no issues and `safeword/eslint` loaded React and Astro configs.
+- 2026-06-24T22:39:00Z Implemented: Moved `eslint-plugin-jsx-a11y` to devDependencies, added optional dependency resolution, made React/Astro a11y configs conditional, and added #389 template regression tests.
+- 2026-06-24T22:37:00Z RED: Focused tests failed on current code for production `eslint-plugin-jsx-a11y`, static React import, and missing optional-config builders.
+- 2026-06-24T22:35:00Z Decided: Remove `eslint-plugin-jsx-a11y` from Safeword's production dependency graph and make React/Astro a11y configs optional when the plugin is present. Package-manager metadata inside Safeword is insufficient because pnpm ignores dependency-local `peerDependencyRules` for consumer peer checks.
+- 2026-06-24T22:34:00Z Reproduced: A pnpm fixture with `peerDependencyRules` inside a dependency package still fails `pnpm peers check` for `eslint-plugin-jsx-a11y@6.10.2` against ESLint 10.
+- 2026-06-24T22:33:00Z Found: `@eslint-react/eslint-plugin@5.9.1` does not provide broad jsx-a11y parity; replacing jsx-a11y with it alone would drop semantic accessibility checks.
+- 2026-06-24T22:32:00Z Found: `eslint-plugin-astro@1.7.0` documents that its Astro jsx-a11y configs require `eslint-plugin-jsx-a11y` installed, so Astro config must become conditional if the production dependency is removed.
+- 2026-06-24T22:27:31Z Found: GitHub issues #388 and #389 are open and both target the ESLint 10 release surface.
+- 2026-06-24T22:27:31Z Found: `eslint-plugin-jsx-a11y@6.10.2` is still latest on npm and still peers only through ESLint 9.
+- 2026-06-24T22:27:31Z Revalidated: Current `getSafewordEslintConfigExtending` imports `safeword` when it emits `safeword.prettierConfig`; #389 needs an explicit regression test for the old 0.55.0 symptom rather than a fresh code fix.
+- 2026-06-24T22:27:22.090Z Started: Created ticket 9T13K8

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.54.0",
+      "version": "0.56.0",
       "bin": {
         "safeword": "dist/cli.js",
       },
@@ -40,11 +40,10 @@
         "commander": "15.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
-        "eslint-plugin-astro": "^1.7.0",
+        "eslint-plugin-astro": "~2.1.0",
         "eslint-plugin-better-tailwindcss": "4.6.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-jsdoc": "^63.0.6",
-        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-playwright": "2.10.4",
         "eslint-plugin-promise": "^7.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -64,6 +63,7 @@
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "knip": "6.17.1",
         "prettier": "^3.8.4",
         "publint": "^0.3.21",
@@ -748,7 +748,7 @@
 
     "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.3", "", {}, "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.61.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.61.1", "@typescript-eslint/tsconfig-utils": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg=="],
 
@@ -898,7 +898,7 @@
 
     "astro": ["astro@6.4.8", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q=="],
 
-    "astro-eslint-parser": ["astro-eslint-parser@1.4.0", "", { "dependencies": { "@astrojs/compiler": "^2.0.0 || ^3.0.0", "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0", "@typescript-eslint/types": "^7.0.0 || ^8.0.0", "astrojs-compiler-sync": "^1.0.0", "debug": "^4.3.4", "entities": "^7.0.0", "eslint-scope": "^8.0.1", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "fast-glob": "^3.3.3", "is-glob": "^4.0.3", "semver": "^7.3.8" } }, "sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w=="],
+    "astro-eslint-parser": ["astro-eslint-parser@2.0.0", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@typescript-eslint/scope-manager": "^8.61.0", "@typescript-eslint/types": "^8.61.0", "astrojs-compiler-sync": "^1.0.0", "debug": "^4.3.4", "entities": "^8.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "fast-glob": "^3.3.3", "is-glob": "^4.0.3", "semver": "^7.3.8" } }, "sha512-wqHbAbrtUvugx7EAcc2kPmwbX6/I2/cqAxKEhFAz/9uwcqrG8khH/reipvtqbGPx1Vxdst08lvHoF4ECtVpcTA=="],
 
     "astro-expressive-code": ["astro-expressive-code@0.43.1", "", { "dependencies": { "rehype-expressive-code": "^0.43.1" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-xddgwQxFRwpnnAnU7kSfrO82SsOAq7sQrYpXxVcrN9k/0aqNlTH2+mLrOMm1wXm6jdFKepst3hd8/qWojwuunw=="],
 
@@ -1264,15 +1264,13 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-compat-utils": ["eslint-compat-utils@0.6.5", "", { "dependencies": { "semver": "^7.5.4" }, "peerDependencies": { "eslint": ">=6.0.0" } }, "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ=="],
-
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
     "eslint-import-context": ["eslint-import-context@0.1.9", "", { "dependencies": { "get-tsconfig": "^4.10.1", "stable-hash-x": "^0.2.0" }, "peerDependencies": { "unrs-resolver": "^1.0.0" }, "optionalPeers": ["unrs-resolver"] }, "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg=="],
 
     "eslint-import-resolver-typescript": ["eslint-import-resolver-typescript@4.4.5", "", { "dependencies": { "debug": "^4.4.1", "eslint-import-context": "^0.1.8", "get-tsconfig": "^4.10.1", "is-bun-module": "^2.0.0", "stable-hash-x": "^0.2.0", "tinyglobby": "^0.2.14", "unrs-resolver": "^1.7.11" }, "peerDependencies": { "eslint": "*", "eslint-plugin-import": "*", "eslint-plugin-import-x": "*" }, "optionalPeers": ["eslint-plugin-import", "eslint-plugin-import-x"] }, "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw=="],
 
-    "eslint-plugin-astro": ["eslint-plugin-astro@1.7.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@jridgewell/sourcemap-codec": "^1.4.14", "@typescript-eslint/types": "^7.7.1 || ^8", "astro-eslint-parser": "^1.3.0", "eslint-compat-utils": "^0.6.0", "globals": "^16.0.0", "postcss": "^8.4.14", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "eslint": ">=8.57.0" } }, "sha512-89xpAn528UKCdmyysbg0AHHqi6sqcK89wXnJIpu4F0mFBN03zATEBNK7pRtMfl6gwtMOm5ECXs+Wz5qDHhwTFw=="],
+    "eslint-plugin-astro": ["eslint-plugin-astro@2.1.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.5.1", "@jridgewell/sourcemap-codec": "^1.5.0", "@typescript-eslint/types": "^8.61.0", "astro-eslint-parser": "^2.0.0", "espree": "^11.0.0", "globals": "^17.0.0", "parse5": "^8.0.0", "postcss": "^8.5.3", "postcss-selector-parser": "^7.1.0" }, "peerDependencies": { "@typescript-eslint/parser": ">=8.61.0", "eslint": ">=10.0.0", "eslint-plugin-jsx-a11y": ">=6.10.2" }, "optionalPeers": ["@typescript-eslint/parser", "eslint-plugin-jsx-a11y"] }, "sha512-ESP/lBX4dD0ZdEQ2e0eQzk+SfhsR0BS3ataSlL/WZ7Rw3nUv1xlGZiZmHDsKbvi/7OLWp+jLqBvDU+Ueuv8cwg=="],
 
     "eslint-plugin-better-tailwindcss": ["eslint-plugin-better-tailwindcss@4.6.0", "", { "dependencies": { "@eslint/css-tree": "^4.0.1", "@valibot/to-json-schema": "^1.6.0", "enhanced-resolve": "^5.20.1", "jiti": "^2.6.1", "synckit": "^0.11.12", "tailwind-csstree": "^0.3.2", "tsconfig-paths-webpack-plugin": "^4.2.0", "valibot": "^1.3.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0", "oxlint": "^1.35.0", "tailwindcss": "^3.3.0 || ^4.1.17" }, "optionalPeers": ["eslint", "oxlint"] }, "sha512-Xeh/6KzLeays6jXSqTKx6iCdJL1qo5ant/mAabbz7dJqADYebKUUPR2zXp1xuiqqJ3HIm+MN+Ql2m4Jp0BxkMQ=="],
 
@@ -1446,7 +1444,7 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
-    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+    "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -1998,7 +1996,7 @@
 
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
-    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
@@ -2654,27 +2652,19 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint-react/ast/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "@eslint-react/ast/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@eslint-react/core/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "@eslint-react/core/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "@eslint-react/core/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@eslint-react/eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "@eslint-react/jsx/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@eslint-react/jsx/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@eslint-react/shared/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@eslint-react/var/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
-
-    "@eslint-react/var/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@eslint-react/var/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
@@ -2702,19 +2692,11 @@
 
     "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
-
-    "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.59.4", "", {}, "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q=="],
 
-    "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
 
@@ -2746,15 +2728,19 @@
 
     "astro/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
-    "astro-eslint-parser/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+    "astro-eslint-parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "astro-eslint-parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.3", "", { "dependencies": { "@typescript-eslint/types": "8.59.3", "@typescript-eslint/visitor-keys": "8.59.3" } }, "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA=="],
+    "astro-eslint-parser/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
-    "astro-eslint-parser/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "astro-eslint-parser/eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "astro-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "astro-eslint-parser/espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
     "astro-eslint-parser/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
-    "astro-eslint-parser/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+    "astro-eslint-parser/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -2792,9 +2778,11 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "eslint-compat-utils/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
-
     "eslint-import-resolver-typescript/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "eslint-plugin-astro/espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "eslint-plugin-import-x/@typescript-eslint/types": ["@typescript-eslint/types@8.59.3", "", {}, "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg=="],
 
     "eslint-plugin-import-x/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -2806,43 +2794,25 @@
 
     "eslint-plugin-jsdoc/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
-    "eslint-plugin-playwright/globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
-
-    "eslint-plugin-react-dom/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "eslint-plugin-react-dom/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "eslint-plugin-react-jsx/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "eslint-plugin-react-jsx/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
-    "eslint-plugin-react-naming-convention/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "eslint-plugin-react-naming-convention/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
-    "eslint-plugin-react-rsc/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "eslint-plugin-react-rsc/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "eslint-plugin-react-web-api/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "eslint-plugin-react-web-api/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "eslint-plugin-react-x/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "eslint-plugin-react-x/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "eslint-plugin-react-x/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "eslint-plugin-sonarjs/globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "eslint-plugin-sonarjs/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.0", "@typescript-eslint/types": "8.61.0", "@typescript-eslint/typescript-estree": "8.61.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA=="],
-
-    "eslint-plugin-unicorn/globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "eslint-plugin-unicorn/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
@@ -2853,6 +2823,10 @@
     "global-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "globby/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -2890,7 +2864,7 @@
 
     "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
@@ -2992,13 +2966,9 @@
 
     "@eslint-react/eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "@eslint-react/eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "@eslint-react/jsx/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
     "@eslint-react/shared/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
-
-    "@eslint-react/shared/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "@eslint-react/var/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
 
@@ -3034,7 +3004,7 @@
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
-    "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.3", "", { "dependencies": { "@typescript-eslint/types": "8.59.3", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg=="],
+    "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
 
     "astro-eslint-parser/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -3047,6 +3017,8 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "eslint-plugin-astro/espree/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "eslint-plugin-import-x/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
@@ -3073,6 +3045,10 @@
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.61.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.61.0", "@typescript-eslint/tsconfig-utils": "8.61.0", "@typescript-eslint/types": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA=="],
 
     "globby/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "istanbul-lib-report/make-dir/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
@@ -3162,8 +3138,6 @@
 
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
 
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -3206,8 +3180,6 @@
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
-    "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
     "eslint-plugin-import-x/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "eslint-plugin-react-dom/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
@@ -3249,10 +3221,6 @@
     "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "templates"
   ],
   "engines": {
-    "node": ">=22.12"
+    "node": "^22.22.3 || ^24.16.0 || >=26.3.0"
   },
   "scripts": {
     "build": "tsup",
@@ -68,11 +68,10 @@
     "commander": "15.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
-    "eslint-plugin-astro": "^1.7.0",
+    "eslint-plugin-astro": "~2.1.0",
     "eslint-plugin-better-tailwindcss": "4.6.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jsdoc": "^63.0.6",
-    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-playwright": "2.10.4",
     "eslint-plugin-promise": "^7.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -92,6 +91,7 @@
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "knip": "6.17.1",
     "prettier": "^3.8.4",
     "publint": "^0.3.21",

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/astro.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/astro.test.ts
@@ -1,13 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- ESLint config types are incompatible across plugin packages */
+import { readFile } from 'node:fs/promises';
+
 import { describe, expect, it } from 'vitest';
 
-import { astroConfig } from '../astro.js';
+import { astroConfig, buildAstroConfig } from '../astro.js';
 import { getAllRules, getRuleConfig, getSeverity } from './test-utilities.js';
+
+async function readCliPackageJson(): Promise<{
+  dependencies?: Record<string, string>;
+  engines?: Record<string, string>;
+}> {
+  const packageJsonUrl = new URL('../../../../../package.json', import.meta.url);
+  return JSON.parse(await readFile(packageJsonUrl, 'utf8')) as {
+    dependencies?: Record<string, string>;
+    engines?: Record<string, string>;
+  };
+}
 
 describe('Astro config', () => {
   it('exports astroConfig as an array', () => {
     expect(Array.isArray(astroConfig)).toBe(true);
     expect(astroConfig.length).toBeGreaterThan(0);
+  });
+
+  it('ships latest Astro 2 linting with a matching Node engine contract', async () => {
+    const packageJson = await readCliPackageJson();
+
+    expect(packageJson.dependencies?.['eslint-plugin-astro']).toBe('~2.1.0');
+    expect(packageJson.engines?.node).toBe('^22.22.3 || ^24.16.0 || >=26.3.0');
   });
 
   it('includes eslint-plugin-astro', () => {
@@ -24,7 +44,7 @@ describe('Astro config', () => {
     expect(hasAstroFiles).toBe(true);
   });
 
-  describe('recommended rules (8 from flat/recommended)', () => {
+  describe('recommended rules from flat/recommended', () => {
     it('astro/missing-client-only-directive-value is error', () => {
       const severity = getSeverity(
         getRuleConfig(astroConfig, 'astro/missing-client-only-directive-value'),
@@ -70,6 +90,18 @@ describe('Astro config', () => {
       expect(severity).toBe('error');
     });
 
+    it('astro/no-omitted-end-tags is error', () => {
+      const severity = getSeverity(getRuleConfig(astroConfig, 'astro/no-omitted-end-tags'));
+      expect(severity).toBe('error');
+    });
+
+    it('astro/no-prerender-export-outside-pages is error', () => {
+      const severity = getSeverity(
+        getRuleConfig(astroConfig, 'astro/no-prerender-export-outside-pages'),
+      );
+      expect(severity).toBe('error');
+    });
+
     it('astro/valid-compile is error', () => {
       const severity = getSeverity(getRuleConfig(astroConfig, 'astro/valid-compile'));
       expect(severity).toBe('error');
@@ -107,13 +139,43 @@ describe('Astro config', () => {
     });
   });
 
-  describe('total rule count', () => {
-    it('has 44 astro rules configured (8 core + 33 a11y + 3 custom)', () => {
+  describe('Astro rule coverage', () => {
+    it('keeps expanded Astro 2.1 coverage plus Safeword custom rules', () => {
       const allRules = getAllRules(astroConfig);
       const astroRules = Object.keys(allRules).filter(name => name.startsWith('astro/'));
 
-      // 8 from flat/recommended + 33 from flat/jsx-a11y-strict + 3 custom LLM rules
-      expect(astroRules).toHaveLength(44);
+      expect(astroRules.length).toBeGreaterThanOrEqual(46);
+    });
+  });
+
+  describe('optional jsx-a11y dependency', () => {
+    it('keeps core Astro rules when eslint-plugin-jsx-a11y is unavailable', () => {
+      const config = buildAstroConfig({
+        astroPlugin: {
+          configs: {
+            'flat/recommended': [
+              {
+                plugins: { astro: {} },
+                rules: {
+                  'astro/valid-compile': 'error',
+                },
+              },
+            ],
+            'flat/jsx-a11y-strict': [
+              {
+                rules: {
+                  'astro/jsx-a11y/alt-text': 'error',
+                },
+              },
+            ],
+          },
+        },
+        hasJsxA11y: false,
+      });
+
+      expect(getSeverity(getRuleConfig(config, 'astro/valid-compile'))).toBe('error');
+      expect(getRuleConfig(config, 'astro/jsx-a11y/alt-text')).toBeUndefined();
+      expect(getSeverity(getRuleConfig(config, 'astro/no-set-html-directive'))).toBe('error');
     });
   });
 });

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/react.test.ts
@@ -13,7 +13,10 @@ import { fileURLToPath } from 'node:url';
 import { Linter } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
-import { recommendedTypeScriptReact } from '../recommended-react.js';
+import {
+  buildRecommendedTypeScriptReact,
+  recommendedTypeScriptReact,
+} from '../recommended-react.js';
 import { getAllRules, getRuleConfig, getSeverityNumber } from './test-utilities.js';
 
 // JSX fixtures below embed `{expr}` JSX braces inside template-literal source
@@ -90,10 +93,34 @@ describe('recommendedTypeScriptReact config', () => {
     expect(packageJson.dependencies).not.toHaveProperty('eslint-plugin-react');
   });
 
+  it('does not ship eslint-plugin-jsx-a11y as a production dependency', async () => {
+    const packageJson = await readCliPackageJson();
+
+    expect(packageJson.dependencies).not.toHaveProperty('eslint-plugin-jsx-a11y');
+    expect(packageJson.devDependencies).toHaveProperty('eslint-plugin-jsx-a11y');
+  });
+
   it('React preset source does not import eslint-plugin-react', async () => {
     const source = await readReactPresetSource();
 
     expect(source).not.toMatch(/from ['"]eslint-plugin-react['"]/u);
+  });
+
+  it('React preset source does not statically import eslint-plugin-jsx-a11y', async () => {
+    const source = await readReactPresetSource();
+
+    expect(source).not.toMatch(/from ['"]eslint-plugin-jsx-a11y['"]/u);
+  });
+
+  it('loads React guardrails when optional jsx-a11y rules are unavailable', () => {
+    const config = buildRecommendedTypeScriptReact({ loadJsxA11yStrictConfig: () => false });
+
+    expect(getRuleConfig(config, '@eslint-react/no-missing-key')).toBeDefined();
+    expect(getRuleConfig(config, 'react-hooks/rules-of-hooks')).toBeDefined();
+    expect(hasPlugin('jsx-a11y')).toBe(true);
+    expect(config.some(entry => entry?.plugins && Object.hasOwn(entry.plugins, 'jsx-a11y'))).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/cli/src/presets/typescript/eslint-configs/astro.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/astro.ts
@@ -7,34 +7,42 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- ESLint config types are incompatible across plugin packages */
 
-import { createRequire } from 'node:module';
+import eslintPluginAstro from 'eslint-plugin-astro';
 
 import { lazyConfigArray } from './lazy.js';
+import { hasOptionalDependency } from './optional-dependency.js';
 
-const requireFromHere = createRequire(import.meta.url);
+interface BuildAstroConfigOptions {
+  astroPlugin?: {
+    configs: Record<string, any[]>;
+  };
+  hasJsxA11y?: boolean;
+}
 
 /**
  * Astro config
  *
  * Includes:
- * - 8 recommended rules (all at error)
+ * - Astro's recommended rules (all at error)
  * - 33 accessibility rules from jsx-a11y-strict (adapted for Astro)
- * - 3 LLM-critical rules: no-set-html-directive (XSS), no-unsafe-inline-scripts (CSP), no-exports-from-components
+ * - LLM-critical rules: no-set-html-directive (XSS), no-unsafe-inline-scripts (CSP), no-exports-from-components
  *
  * Note: jsx-a11y rules work with Astro files because eslint-plugin-astro
  * provides wrapped versions that understand Astro's JSX-like syntax.
  * Using eslint-plugin-jsx-a11y directly on Astro files does NOT work.
  *
- * Plugin is loaded lazily — only when this config is actually accessed.
+ * Config objects are assembled lazily — only when this config is actually accessed.
  */
-export const astroConfig: any[] = lazyConfigArray(() => {
-  const astroPlugin = requireFromHere('eslint-plugin-astro');
+export function buildAstroConfig({
+  astroPlugin = eslintPluginAstro,
+  hasJsxA11y = hasOptionalDependency('eslint-plugin-jsx-a11y'),
+}: BuildAstroConfigOptions = {}): any[] {
   return [
     // Spread flat/recommended (5 config objects: plugin setup, file patterns, prettier overrides, rules)
-    ...astroPlugin.configs['flat/recommended'],
+    ...(astroPlugin.configs['flat/recommended'] ?? []),
 
-    // Accessibility rules adapted for Astro (requires eslint-plugin-jsx-a11y installed)
-    ...astroPlugin.configs['flat/jsx-a11y-strict'],
+    // Accessibility rules adapted for Astro when eslint-plugin-jsx-a11y is installed.
+    ...(hasJsxA11y ? (astroPlugin.configs['flat/jsx-a11y-strict'] ?? []) : []),
 
     // Add LLM-critical rules
     {
@@ -51,4 +59,6 @@ export const astroConfig: any[] = lazyConfigArray(() => {
       },
     },
   ];
-});
+}
+
+export const astroConfig: any[] = lazyConfigArray(() => buildAstroConfig());

--- a/packages/cli/src/presets/typescript/eslint-configs/optional-dependency.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/optional-dependency.ts
@@ -1,0 +1,28 @@
+import { createRequire } from 'node:module';
+import nodePath from 'node:path';
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Load an optional ESLint plugin from the user's project first, then from
+ * safeword's own install context. This lets consumers opt into plugins that
+ * safeword does not ship as production dependencies.
+ */
+export function optionalRequire(packageName: string): unknown {
+  try {
+    const requireFromCwd = createRequire(nodePath.join(process.cwd(), '__placeholder__.js'));
+    return requireFromCwd(packageName);
+  } catch {
+    // Fall back to safeword's context below.
+  }
+
+  try {
+    return requireFromHere(packageName);
+  } catch {
+    return undefined;
+  }
+}
+
+export function hasOptionalDependency(packageName: string): boolean {
+  return optionalRequire(packageName) !== undefined;
+}

--- a/packages/cli/src/presets/typescript/eslint-configs/recommended-react.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/recommended-react.ts
@@ -4,7 +4,7 @@
  * Extends the TypeScript config with React-specific rules:
  * - @eslint-react/eslint-plugin: React, JSX, DOM, RSC, and Web API rules
  * - eslint-plugin-react-hooks 7.x: Hook rules + React Compiler diagnostics
- * - eslint-plugin-jsx-a11y: Accessibility rules (strict preset)
+ * - Optional eslint-plugin-jsx-a11y: Accessibility rules (strict preset)
  *
  * Philosophy: LLMs make React-specific mistakes. These rules catch them.
  */
@@ -12,8 +12,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- ESLint config types are incompatible across plugin packages */
 
 import eslintReactPlugin from '@eslint-react/eslint-plugin';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
 import reactHooksPluginImport from 'eslint-plugin-react-hooks';
+
+import { lazyConfigArray } from './lazy.js';
+import { optionalRequire } from './optional-dependency.js';
+import { recommendedTypeScript } from './recommended-typescript.js';
 
 // Type assertion - react-hooks 7.x exports configs but types don't declare it
 const reactHooksPlugin = reactHooksPluginImport as unknown as {
@@ -25,8 +28,6 @@ const eslintReactConfig = eslintReactPlugin as unknown as {
     'recommended-typescript'?: any;
   };
 };
-
-import { recommendedTypeScript } from './recommended-typescript.js';
 
 // Runtime validation - ensure react-hooks 7.x with flat config support
 const reactHooksConfig = reactHooksPlugin.configs?.flat?.['recommended-latest'];
@@ -91,6 +92,17 @@ const eslintReactRuleOverrides = {
   '@eslint-react/dom-no-unknown-property': 'error', // class -> className, has autofix
 };
 
+interface BuildRecommendedTypeScriptReactOptions {
+  loadJsxA11yStrictConfig?: () => unknown;
+}
+
+function loadJsxA11yStrictConfig(): unknown {
+  const jsxA11y = optionalRequire('eslint-plugin-jsx-a11y') as {
+    flatConfigs?: { strict?: unknown };
+  };
+  return jsxA11y?.flatConfigs?.strict;
+}
+
 /**
  * React + TypeScript recommended config
  *
@@ -103,38 +115,48 @@ const eslintReactRuleOverrides = {
  * Includes React Compiler rules (v7.x) for detecting purity violations,
  * improper memoization, and other compiler-incompatible patterns.
  */
-export const recommendedTypeScriptReact: any[] = [
-  // All TypeScript rules (includes base plugins)
-  ...recommendedTypeScript,
+export function buildRecommendedTypeScriptReact({
+  loadJsxA11yStrictConfig: loadOptionalJsxA11yStrictConfig = loadJsxA11yStrictConfig,
+}: BuildRecommendedTypeScriptReactOptions = {}): any[] {
+  const jsxA11yStrictConfig = loadOptionalJsxA11yStrictConfig();
 
-  // React, JSX, DOM, RSC, and Web API rules
-  eslintReactRecommendedTypeScriptConfig,
+  return [
+    // All TypeScript rules (includes base plugins)
+    ...recommendedTypeScript,
 
-  // React Hooks + Compiler rules (v7.x flat config)
-  // Using recommended-latest which includes void-use-memo
-  reactHooksConfig,
+    // React, JSX, DOM, RSC, and Web API rules
+    eslintReactRecommendedTypeScriptConfig,
 
-  // Accessibility rules - strict preset (all at error level)
-  jsxA11y.flatConfigs.strict,
+    // React Hooks + Compiler rules (v7.x flat config)
+    // Using recommended-latest which includes void-use-memo
+    reactHooksConfig,
 
-  // Escalate warn rules to error + add LLM-critical rules
-  {
-    name: 'safeword/react-hooks-rules',
-    rules: {
-      // Escalate default warns to error (LLMs ignore warnings)
-      'react-hooks/exhaustive-deps': 'error', // Default: warn
-      'react-hooks/incompatible-library': 'error', // Default: warn
-      'react-hooks/unsupported-syntax': 'error', // Default: warn
+    // Accessibility rules - strict preset (all at error level) when installed.
+    ...(jsxA11yStrictConfig ? [jsxA11yStrictConfig] : []),
 
-      // LLM-critical rules NOT in recommended-latest preset
-      'react-hooks/memoized-effect-dependencies': 'error', // LLMs create unstable refs as deps
-      'react-hooks/no-deriving-state-in-effects': 'error', // LLMs derive state in useEffect
+    // Escalate warn rules to error + add LLM-critical rules
+    {
+      name: 'safeword/react-hooks-rules',
+      rules: {
+        // Escalate default warns to error (LLMs ignore warnings)
+        'react-hooks/exhaustive-deps': 'error', // Default: warn
+        'react-hooks/incompatible-library': 'error', // Default: warn
+        'react-hooks/unsupported-syntax': 'error', // Default: warn
+
+        // LLM-critical rules NOT in recommended-latest preset
+        'react-hooks/memoized-effect-dependencies': 'error', // LLMs create unstable refs as deps
+        'react-hooks/no-deriving-state-in-effects': 'error', // LLMs derive state in useEffect
+      },
     },
-  },
 
-  // React rule overrides for TypeScript projects
-  {
-    name: 'safeword/react-rules',
-    rules: eslintReactRuleOverrides,
-  },
-];
+    // React rule overrides for TypeScript projects
+    {
+      name: 'safeword/react-rules',
+      rules: eslintReactRuleOverrides,
+    },
+  ];
+}
+
+export const recommendedTypeScriptReact: any[] = lazyConfigArray(() =>
+  buildRecommendedTypeScriptReact(),
+);

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getEslintConfig, SETTINGS_HOOKS } from './config.js';
+import { getEslintConfig, getSafewordEslintConfig, SETTINGS_HOOKS } from './config.js';
 
 // Element type of any SETTINGS_HOOKS bucket (PostToolUse, PreToolUse, etc.)
 // Each is a list of { matcher?, hooks: { type, command }[] } entries.
@@ -105,6 +105,22 @@ describe('getEslintConfig monorepo support', () => {
     // Should have logic to apply nextOnlyRules with files scoping
     expect(config).toContain('files:');
     expect(config).toContain('nextPaths');
+  });
+});
+
+describe('getSafewordEslintConfig', () => {
+  it('imports safeword when generated config references safeword.prettierConfig', () => {
+    const config = getSafewordEslintConfig('eslint.config.mjs', false);
+
+    expect(config).toContain('import safeword from "safeword/eslint"');
+    expect(config).toContain('const eslintConfigPrettier = safeword.prettierConfig;');
+  });
+
+  it('does not reference safeword.prettierConfig in formatter-agnostic generated config', () => {
+    const config = getSafewordEslintConfig('eslint.config.mjs', true);
+
+    expect(config).not.toContain('safeword.prettierConfig');
+    expect(config).not.toContain('import safeword from "safeword/eslint"');
   });
 });
 

--- a/packages/cli/tests/presets/lazy-config-loading.test.ts
+++ b/packages/cli/tests/presets/lazy-config-loading.test.ts
@@ -1,11 +1,15 @@
 /**
  * Test Suite: Lazy ESLint Plugin Loading
  *
- * Ticket H150ZW: stack-specific ESLint plugins (Storybook, Turbo, Astro, Playwright,
+ * Ticket H150ZW: stack-specific ESLint plugins (Storybook, Turbo, Playwright,
  * TanStack Query, better-tailwindcss, Next.js) must NOT load into Node memory when
  * a consumer simply imports `eslintPlugin`. Customer's generated eslint.config.mjs
  * already gates plugin USE behind `detect.has*(deps)`; this asserts plugin LOAD is
  * gated to match.
+ *
+ * Exception: eslint-plugin-astro 2.x is ESM-only. Safeword's public
+ * `configs.astro` API is a synchronous array, so there is no synchronous lazy
+ * import path for the latest Astro plugin.
  *
  * Two layers of verification:
  *
@@ -16,7 +20,7 @@
  * 2. **Behavioral test (subprocess):** spawn a fresh Node process, import the
  *    built `eslintPlugin`, inspect `require.cache` for the CJS-detectable plugins.
  *    Only reliably catches CJS or CJS-entry-having plugins (turbo, playwright,
- *    @next/eslint-plugin-next); ESM-only plugins are covered by the structural test.
+ *    @next/eslint-plugin-next).
  */
 
 import { spawnSync } from 'node:child_process';
@@ -36,10 +40,6 @@ const STACK_CONFIG_SOURCES: readonly { source: string; pluginPackage: string }[]
   {
     source: 'src/presets/typescript/eslint-configs/turbo.ts',
     pluginPackage: 'eslint-plugin-turbo',
-  },
-  {
-    source: 'src/presets/typescript/eslint-configs/astro.ts',
-    pluginPackage: 'eslint-plugin-astro',
   },
   {
     source: 'src/presets/typescript/eslint-configs/playwright.ts',


### PR DESCRIPTION
## Summary
- remove `eslint-plugin-jsx-a11y` from Safeword production dependencies and make React/Astro a11y config opt-in when the plugin is installed
- upgrade Astro linting to `eslint-plugin-astro@~2.1.0` and align Safeword Node engines with Astro 2.1
- add regression coverage for generated config imports around `safeword.prettierConfig`

## Validation
- `bun run --cwd packages/cli test src/presets/typescript/eslint-configs/__tests__/react.test.ts src/presets/typescript/eslint-configs/__tests__/astro.test.ts src/templates/config.test.ts`
- packed pnpm consumer with `safeword + eslint@10.5.0` and no `eslint-plugin-jsx-a11y`: `pnpm peers check` passed and `safeword/eslint` loaded
- `bun run --cwd packages/cli test src/presets/typescript/eslint-configs/__tests__ src/templates/config.test.ts tests/schema.test.ts`
- `bun run test:smoke:fast`
- `bun run --cwd packages/cli lint`
- `bun run format:check`
- `bun packages/cli/src/cli.ts architecture --check`
- `bun run deps`

## Release note
- Node engine support tightens to `^22.22.3 || ^24.16.0 || >=26.3.0` because `eslint-plugin-astro@2.1.0` requires that range.

Fixes #388
Fixes #389