### PR TITLE
Serialize package tests machine-wide

### DIFF
--- a/.project/tickets/419-global-package-test-lock/ticket.md
+++ b/.project/tickets/419-global-package-test-lock/ticket.md
@@ -1,0 +1,62 @@
+---
+id: "419"
+slug: global-package-test-lock
+type: task
+phase: done
+status: done
+scope:
+  - Serialize default `packages/cli` package test runs across safeword checkouts on one machine.
+  - Keep `SAFEWORD_TEST_LOCK_DIR` as an explicit isolation override for tests.
+  - Bound lock waiting so a non-reapable holder cannot block every checkout indefinitely.
+out_of_scope:
+  - Changing Vitest worker counts or suite partitioning.
+  - Adding OS-level CPU or memory throttling.
+  - Changing package scripts other than the existing test runner wrapper.
+done_when:
+  - Default test runner invocations in different checkouts share one lock and serialize.
+  - Override lock directories still isolate test runner checks.
+  - Dead-owner stale locks are reaped.
+  - Waiters proceed with a warning after a configurable cap.
+created: 2026-06-24T17:02:00-07:00
+last_modified: 2026-06-24T17:15:13-07:00
+---
+
+# Serialize package tests across checkouts
+
+**GitHub:** https://github.com/ArcadeAI/safeword/issues/419
+
+**Type:** Bug
+
+**Scope:** The `packages/cli` test wrapper should prevent multiple safeword checkout/worktree package test runs from competing for the same local CPU/RAM by sharing one default machine-wide lock.
+
+**Out of Scope:** Suite speed work, Vitest pool configuration, OS priority tuning, and broader process management.
+
+## Figure-It-Out Decision
+
+Decision: choose a machine-global mutex for `bun run --cwd packages/cli test`.
+
+Options considered:
+
+- Machine-global mutex: use one constant default lock name for all safeword checkouts.
+- Capacity semaphore: allow N concurrent runs through multiple lock slots.
+- OS priority throttling: lower runner priority with `nice`/similar scheduling controls.
+
+Recommend the machine-global mutex because the observed safe concurrency is exactly one and the existing wrapper already has the correct atomic lock and stale-lock reaper primitives. A semaphore is only justified after measured evidence that N>1 is stable under full load; priority throttling does not control memory pressure.
+
+Premortem: the mutex could over-serialize short focused runs behind a long full suite, so keep the wait notice clear and add a configurable bounded wait escape hatch.
+
+Next: edit `packages/cli/scripts/run-vitest-with-build-lock.mjs` and extend `packages/cli/tests/test-runner-lock.test.ts`.
+
+## Tests
+
+- [x] Default lock path is stable across distinct checkout roots.
+- [x] Concurrent package test runners serialize when using the default global lock.
+- [x] `SAFEWORD_TEST_LOCK_DIR` still isolates focused test cases.
+- [x] A dead-owner lock is reaped before acquiring.
+- [x] A held lock stops blocking after the configured wait cap and emits a warning.
+
+## Work Log
+
+- 2026-06-24T17:02:00-07:00 Started from GitHub issue #419 after syncing to `origin/main` (`abe156a`).
+- 2026-06-24T17:06:00-07:00 Revalidated current bug with two temporary checkout-shaped runner copies: default pre-fix locks overlapped because the key was derived from each checkout root.
+- 2026-06-24T17:15:13-07:00 Implemented constant default lock name plus `SAFEWORD_TEST_LOCK_MAX_WAIT_MS`; verified with `bun run --cwd packages/cli test tests/test-runner-lock.test.ts --reporter=dot`, `bun run lint`, and `git diff --check`.

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -1,6 +1,5 @@
 import { spawnSync } from 'node:child_process';
 import console from 'node:console';
-import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -10,11 +9,24 @@ const scriptDirectory = import.meta.dirname;
 const cliRoot = nodePath.resolve(scriptDirectory, '..');
 const vitestArguments = process.argv.slice(2);
 const lockParent = nodePath.join(tmpdir(), 'safeword-test-locks');
-const lockName = createHash('sha256').update(cliRoot).digest('hex').slice(0, 16);
+const lockName = 'safeword-package-test';
+const defaultMaximumLockWaitMilliseconds = 20 * 60 * 1000;
 const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
   ? nodePath.resolve(process.env.SAFEWORD_TEST_LOCK_DIR)
   : nodePath.join(lockParent, `${lockName}.lock`);
 const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+
+function resolveMaximumLockWaitMilliseconds() {
+  const raw = process.env.SAFEWORD_TEST_LOCK_MAX_WAIT_MS;
+  if (raw === undefined) {
+    return defaultMaximumLockWaitMilliseconds;
+  }
+
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : defaultMaximumLockWaitMilliseconds;
+}
+
+const maximumLockWaitMilliseconds = resolveMaximumLockWaitMilliseconds();
 
 function sleep(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -60,6 +72,7 @@ function acquireLock() {
   mkdirSync(nodePath.dirname(lockDirectory), { recursive: true });
 
   let waitedMilliseconds = 0;
+  let showedWaitNotice = false;
   for (;;) {
     let mkdirError;
     try {
@@ -75,7 +88,7 @@ function acquireLock() {
           2,
         )}\n`,
       );
-      return;
+      return true;
     } catch (error) {
       mkdirError = error;
     }
@@ -88,12 +101,21 @@ function acquireLock() {
       continue;
     }
 
-    if (waitedMilliseconds >= 1000) {
-      console.error('Waiting for another safeword package test run to finish...');
-      waitedMilliseconds = -Infinity;
+    if (waitedMilliseconds >= maximumLockWaitMilliseconds) {
+      console.error(
+        `Proceeding without safeword package test lock after waiting ${maximumLockWaitMilliseconds}ms.`,
+      );
+      return false;
     }
-    sleep(250);
-    waitedMilliseconds += 250;
+
+    if (!showedWaitNotice && waitedMilliseconds >= 1000) {
+      console.error('Waiting for another safeword package test run to finish...');
+      showedWaitNotice = true;
+    }
+
+    const nextSleepMilliseconds = Math.min(250, maximumLockWaitMilliseconds - waitedMilliseconds);
+    sleep(nextSleepMilliseconds);
+    waitedMilliseconds += nextSleepMilliseconds;
   }
 }
 
@@ -124,8 +146,7 @@ function run(command, args) {
 let acquiredLock = false;
 let status;
 try {
-  acquireLock();
-  acquiredLock = true;
+  acquiredLock = acquireLock();
   status = run('bun', ['run', 'build']);
   if (status === 0) {
     status = run('vitest', ['run', ...vitestArguments]);

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -47,17 +47,14 @@ async function runNodeScript(scriptPath: string, args: string[], env: NodeJS.Pro
   });
 }
 
-describe('package test runner lock (379)', () => {
-  it('serializes build and vitest for concurrent focused test commands', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
-    await mkdir(binaryDirectory, { recursive: true });
-    const logPath = nodePath.join(temporaryDirectory, 'events.log');
-    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+async function createFakeTestBinaries(temporaryDirectory: string) {
+  const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
+  await mkdir(binaryDirectory, { recursive: true });
+  const logPath = nodePath.join(temporaryDirectory, 'events.log');
 
-    writeFileSync(
-      nodePath.join(binaryDirectory, 'bun'),
-      `#!/usr/bin/env node
+  writeFileSync(
+    nodePath.join(binaryDirectory, 'bun'),
+    `#!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
 const log = ${JSON.stringify(logPath)};
 const parent = process.ppid;
@@ -65,12 +62,12 @@ appendFileSync(log, \`build:start:\${parent}\\n\`);
 await new Promise(resolve => setTimeout(resolve, 120));
 appendFileSync(log, \`build:end:\${parent}\\n\`);
 `,
-      { mode: 0o755 },
-    );
+    { mode: 0o755 },
+  );
 
-    writeFileSync(
-      nodePath.join(binaryDirectory, 'vitest'),
-      `#!/usr/bin/env node
+  writeFileSync(
+    nodePath.join(binaryDirectory, 'vitest'),
+    `#!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
 const log = ${JSON.stringify(logPath)};
 const parent = process.ppid;
@@ -78,8 +75,57 @@ appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')
 await new Promise(resolve => setTimeout(resolve, 120));
 appendFileSync(log, \`vitest:end:\${parent}\\n\`);
 `,
-      { mode: 0o755 },
-    );
+    { mode: 0o755 },
+  );
+
+  return { binaryDirectory, logPath };
+}
+
+async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
+  const checkoutCliRoot = nodePath.join(temporaryDirectory, name, 'packages', 'cli');
+  const scriptDirectory = nodePath.join(checkoutCliRoot, 'scripts');
+  await mkdir(scriptDirectory, { recursive: true });
+  const copiedRunnerPath = nodePath.join(scriptDirectory, 'run-vitest-with-build-lock.mjs');
+  copyFileSync(runnerPath, copiedRunnerPath);
+  return copiedRunnerPath;
+}
+
+function readEvents(logPath: string): string[] {
+  return readFileSync(logPath, 'utf8').trim().split('\n');
+}
+
+function expectSerializedByRunner(events: string[]) {
+  const parentIds = [...new Set(events.map(event => event.split(':', 3)[2]))];
+  expect(parentIds).toHaveLength(2);
+
+  for (const parentId of parentIds) {
+    const parentEvents = events.filter(event => event.includes(`:${parentId}`));
+    expect(parentEvents[0]).toBe(`build:start:${parentId}`);
+    expect(parentEvents[1]).toBe(`build:end:${parentId}`);
+    expect([
+      `vitest:start:${parentId}:run,tests/first.test.ts`,
+      `vitest:start:${parentId}:run,tests/second.test.ts`,
+    ]).toContain(parentEvents[2]);
+    expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
+  }
+
+  const firstParentEnd = events.findLastIndex(event => event.includes(`:${parentIds[0]}`));
+  const secondParentStart = events.findIndex(event => event.includes(`:${parentIds[1]}`));
+  expect(secondParentStart).toBeGreaterThan(firstParentEnd);
+}
+
+function expectSuccessfulSerializedRun(result: { stderr: string; status: number | null }) {
+  expect(result.status).toBe(0);
+  expect(['', 'Waiting for another safeword package test run to finish...\n']).toContain(
+    result.stderr,
+  );
+}
+
+describe('package test runner lock (379)', () => {
+  it('serializes build and vitest for concurrent focused test commands', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
 
     const env = {
       ...process.env,
@@ -92,26 +138,86 @@ appendFileSync(log, \`vitest:end:\${parent}\\n\`);
       runNodeScript(runnerPath, ['tests/second.test.ts'], env),
     ]);
 
-    expect(first).toMatchObject({ status: 0, stderr: '' });
-    expect(second).toMatchObject({ status: 0, stderr: '' });
+    expectSuccessfulSerializedRun(first);
+    expectSuccessfulSerializedRun(second);
 
-    const events = readFileSync(logPath, 'utf8').trim().split('\n');
-    const parentIds = [...new Set(events.map(event => event.split(':', 3)[2]))];
-    expect(parentIds).toHaveLength(2);
+    expectSerializedByRunner(readEvents(logPath));
+  });
 
-    for (const parentId of parentIds) {
-      const parentEvents = events.filter(event => event.includes(`:${parentId}`));
-      expect(parentEvents[0]).toBe(`build:start:${parentId}`);
-      expect(parentEvents[1]).toBe(`build:end:${parentId}`);
-      expect([
-        `vitest:start:${parentId}:run,tests/first.test.ts`,
-        `vitest:start:${parentId}:run,tests/second.test.ts`,
-      ]).toContain(parentEvents[2]);
-      expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
-    }
+  it('serializes default package test locks across checkout roots', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const firstRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-a');
+    const secondRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-b');
 
-    const firstParentEnd = events.findLastIndex(event => event.includes(`:${parentIds[0]}`));
-    const secondParentStart = events.findIndex(event => event.includes(`:${parentIds[1]}`));
-    expect(secondParentStart).toBeGreaterThan(firstParentEnd);
+    const env = {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TMPDIR: temporaryDirectory,
+      SAFEWORD_TEST_LOCK_DIR: undefined,
+    };
+
+    const [first, second] = await Promise.all([
+      runNodeScript(firstRunner, ['tests/first.test.ts'], env),
+      runNodeScript(secondRunner, ['tests/second.test.ts'], env),
+    ]);
+
+    expectSuccessfulSerializedRun(first);
+    expectSuccessfulSerializedRun(second);
+    expectSerializedByRunner(readEvents(logPath));
+  });
+
+  it('reaps dead-owner stale locks before acquiring', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await mkdir(lockDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(lockDirectory, 'owner.json'),
+      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: 2_147_483_647 })}\n`,
+    );
+
+    const result = await runNodeScript(runnerPath, ['tests/stale.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/stale\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+  });
+
+  it('proceeds with a warning after the configured wait cap', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await mkdir(lockDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(lockDirectory, 'owner.json'),
+      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+    );
+
+    const result = await runNodeScript(runnerPath, ['tests/wait-cap.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      'Proceeding without safeword package test lock after waiting 0ms.',
+    );
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/wait-cap\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Use one machine-global default lock for packages/cli test runs across safeword checkouts/worktrees
- Keep SAFEWORD_TEST_LOCK_DIR as an explicit isolation override
- Add SAFEWORD_TEST_LOCK_MAX_WAIT_MS so waiters can proceed with a warning after a cap
- Extend lock runner tests for cross-checkout serialization, stale dead-owner reaping, and bounded wait

Fixes #419

## Verification
- bun run --cwd packages/cli test tests/test-runner-lock.test.ts --reporter=dot
- bun run lint
- git diff --check

## Quality review
- quality-review invoked and approved
- live docs checked for Node fs/process APIs and Vitest CLI
- bun audit reported existing unrelated low/moderate repo advisories
