### PR TITLE
chore(release): v0.57.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.57.0** — minor (additive features + fixes; auto-upgradeable). 15 commits since v0.56.0.

## Features
- **Cursor real blocking enforcement:** edit/shell quality gates, fail-closed, via `gate-adapter` (#400); ticket **done-gate at the edit layer** (#415, AKNWZK)
- **Feature-readiness gate:** validate intake artifacts before `define-behavior` (#417)
- **Hook run identity** normalized across Claude / Codex / Cursor (#408)
- **Project tracker graph** + Codex live smoke (#406)

## Fixes
- ESLint 10 install compatibility — jsx-a11y opt-in, astro 2.1, engines bump (#418) — ⚠️ see note
- Ticket index markdown formatter corruption (range-ignore markers) (#420)
- Detect + warn on ticket index merge-conflict files (#402)
- Capture expected negative-path test output (#411)

## Docs / chore
- `/refactor` commit-guidance scoping (#413, #414); ticket housekeeping (#409, #412, #416, #421)

## ⚠️ Note — breaking-ish, ships as 0.x minor (pre-1.0 convention)
#418 tightens `engines.node` to `^22.22.3 || ^24.16.0 || >=26.3.0` (mirrors `eslint-plugin-astro` 2.1), dropping Node 22.12–22.21. Consumers on those older Node 22 patches will see an npm `engines` warning. Per safeword's pre-1.0 convention (cf. the v0.54.0 eslint-peer drop), this ships as a minor, not 1.0.0.

Both version files bumped to 0.57.0; `bun.lock` unchanged (workspace self-version not embedded under bun 1.3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)