### PR TITLE
fix(cursor): harden done-gate payload detection

### DIFF
--- a/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
+++ b/.project/tickets/AKNWZK-cursor-stop-gate-rearchitect/ticket.md
@@ -31,7 +31,9 @@ deadlocked the prompt that asks for the evidence). So the real enforcement moves
   enough and a higher cap would just re-nudge noisily.
 - **Documented divergence:** Claude enforces done at the blocking Stop hook; Cursor
   can't block stop, so it enforces one layer earlier at the close edit. Captured in
-  `config.ts` (CURSOR_HOOKS) and `hooks/lib/done-gate.ts`.
+  `config.ts` (CURSOR_HOOKS) and `hooks/lib/done-gate.ts`. Cursor mirrors the
+  dependency/test/verify/scenario evidence subset; it intentionally omits
+  transcript-only Claude checks that are unavailable in Cursor's preToolUse input.
 
 ## Done when
 
@@ -60,3 +62,7 @@ cursor.com/docs/hooks (`stop` non-blocking, `loop_limit` default 5 / null)
   negligible): if a `status: done` edit's content can't be read, detection fails
   open at the logic layer — only a wrapper crash hits Cursor's `failClosed`. Cursor's
   sole edit tool sends full content, so the multi-line frontmatter is always present.
+- 2026-06-24 PR #415 was merged with green CI (`test (node 22)` and `lint`). Merge
+  comment follow-ups landed with P9K783: softened the done-gate parity wording to
+  name the shared subset, documented the transcript-only Cursor/Claude divergence,
+  and made `type: Feature` parse as `feature` so scenario evidence is still required.

--- a/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
+++ b/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
@@ -68,3 +68,6 @@ Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-
   accepting the documented non-done statuses and pinning them in unit tests.
 - 2026-06-24 Verification: targeted Cursor gate tests passed (38/38), then full
   suite passed (253 files, 3695 tests passed, 3 skipped).
+- 2026-06-24 PR #424 follow-up: CI lint caught strict TypeScript errors in
+  named regex group handling. Fixed the template and dogfood copies, then reran
+  package typecheck and targeted Cursor gate tests.

--- a/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
+++ b/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
@@ -28,7 +28,7 @@ If the real field isn't in the list and the fallback picks the wrong value (or n
 ## Approach
 
 1. **Verify, don't guess.** Capture a real Cursor `preToolUse` Write payload (a `ticket.md` edit) and pin the actual `tool_input` field names for path and content. Update `PATH_KEYS` / `CONTENT_KEYS` to the verified names (keep the others as tolerant fallbacks).
-2. **Decide the miss-direction deliberately.** For a confirmed `ticket.md` edit whose content can't be read at all, choose fail-open vs fail-closed and document it. (Fail-closed on every unreadable ticket.md edit would block ordinary work-log saves, so the likely answer is a narrower signal — e.g. only when a `status:` line is present but unparseable.)
+2. **Decide the miss-direction deliberately.** For a confirmed `ticket.md` edit whose content can't be read at all, choose fail-open vs fail-closed and document it. The final gate should stay narrow enough to block real closes without deadlocking ordinary ticket edits.
 3. **Regression test** the verified field names so a future Cursor payload change is caught.
 
 ## Done when
@@ -47,7 +47,7 @@ If the real field isn't in the list and the fallback picks the wrong value (or n
 
 Verified source: a temporary dogfood hook captured a real Cursor `preToolUse` `Write` payload for this ticket file. The path extractor keeps verified `file_path` first. The content extractor keeps verified `content` first and adds documented `edits[].new_string` support before the older guessed fallbacks.
 
-Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-log edits do not deadlock. A readable but malformed `status:` line fails closed because safeword can confirm this is a status edit but cannot safely tell whether it is closing the ticket.
+Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-log edits do not deadlock. Readable non-`done` statuses also stay allowed because this hook is a close detector, not a full ticket-status validator.
 
 ## Work Log
 
@@ -60,8 +60,8 @@ Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-
   for a `ticket.md` edit.
 - 2026-06-24 Implemented payload hardening: `file_path` and `content` are pinned
   by regression tests, `edits[].new_string` is supported as the documented
-  file-edit fallback, malformed status lines deny, and unreadable ticket content
-  remains allowed by design. Also folded the PR #415 merge-comment follow-up that
+  file-edit fallback, only `status: done` triggers the done gate, and unreadable
+  ticket content remains allowed by design. Also folded the PR #415 merge-comment follow-up that
   makes `type: Feature` still require feature scenario evidence.
 - 2026-06-24 /quality-review found one regression: valid terminal statuses
   (`cancelled`, `superseded`, `wontfix`) were treated as malformed. Fixed by
@@ -71,3 +71,6 @@ Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-
 - 2026-06-24 PR #424 follow-up: CI lint caught strict TypeScript errors in
   named regex group handling. Fixed the template and dogfood copies, then reran
   package typecheck and targeted Cursor gate tests.
+- 2026-06-24 PR #424 review follow-up: switched status classification to
+  close-only detection after review found legacy repo statuses (`backlog`,
+  `pending`, `complete`) would be falsely blocked by a hand-maintained allowlist.

--- a/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
+++ b/.project/tickets/P9K783-cursor-done-gate-payload-detection/ticket.md
@@ -40,7 +40,14 @@ If the real field isn't in the list and the fallback picks the wrong value (or n
 
 - AKNWZK work log (deferred limitation noted there).
 - `packages/cli/templates/hooks/cursor/gate-adapter.ts` (`extractFilePath`, `extractWriteContent`, `detectDoneTransition`).
-- Cursor docs: `preToolUse` input exposes `tool_input` but does not document per-tool field names.
+- Live Cursor payload capture, 2026-06-24 on Cursor `3.8.23`: `preToolUse` `Write` sends `tool_input.file_path` and `tool_input.content` for a `ticket.md` edit.
+- Cursor docs, 2026-06-24: `preToolUse` input exposes the generic `tool_input` envelope; file hooks document `file_path`, `content`, and `edits[].new_string`, but the page still does not publish a Write-specific `tool_input` schema.
+
+## Decision
+
+Verified source: a temporary dogfood hook captured a real Cursor `preToolUse` `Write` payload for this ticket file. The path extractor keeps verified `file_path` first. The content extractor keeps verified `content` first and adds documented `edits[].new_string` support before the older guessed fallbacks.
+
+Miss-direction: unreadable `ticket.md` content stays fail-open so ordinary work-log edits do not deadlock. A readable but malformed `status:` line fails closed because safeword can confirm this is a status edit but cannot safely tell whether it is closing the ticket.
 
 ## Work Log
 
@@ -48,3 +55,16 @@ If the real field isn't in the list and the fallback picks the wrong value (or n
 - 2026-06-24 Filed from session review after AKNWZK shipped (PR #415) — the done
   gate's close-detection depends on guessed Cursor payload field names and fails
   open if they're wrong.
+- 2026-06-24 Captured a live Cursor `preToolUse` `Write` payload from this
+  worktree: Cursor `3.8.23` sends `tool_input.file_path` and `tool_input.content`
+  for a `ticket.md` edit.
+- 2026-06-24 Implemented payload hardening: `file_path` and `content` are pinned
+  by regression tests, `edits[].new_string` is supported as the documented
+  file-edit fallback, malformed status lines deny, and unreadable ticket content
+  remains allowed by design. Also folded the PR #415 merge-comment follow-up that
+  makes `type: Feature` still require feature scenario evidence.
+- 2026-06-24 /quality-review found one regression: valid terminal statuses
+  (`cancelled`, `superseded`, `wontfix`) were treated as malformed. Fixed by
+  accepting the documented non-done statuses and pinning them in unit tests.
+- 2026-06-24 Verification: targeted Cursor gate tests passed (38/38), then full
+  suite passed (253 files, 3695 tests passed, 3 skipped).

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -154,7 +154,10 @@ export function classifyDoneTransition(params: {
   const match = STATUS_LINE_PATTERN.exec(content);
   if (!match?.groups) return 'not_done';
 
-  const normalizedStatus = normalizeFrontmatterScalar(match.groups.status);
+  const rawStatus = match.groups.status;
+  if (rawStatus === undefined) return 'not_done';
+
+  const normalizedStatus = normalizeFrontmatterScalar(rawStatus);
   if (normalizedStatus === 'done') return 'done';
   if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
   return 'unparseable';
@@ -164,7 +167,7 @@ export function classifyDoneTransition(params: {
 export function parseTicketType(content: string | undefined): string | undefined {
   if (!content) return undefined;
   const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
-  return match?.groups?.type.toLowerCase();
+  return match?.groups?.type?.toLowerCase();
 }
 
 function normalizeFrontmatterScalar(value: string): string {

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -59,9 +59,8 @@ export function mapCursorToolName(cursorTool: string | undefined): string | unde
   return cursorTool ? TOOL_NAME_MAP[cursorTool] : undefined;
 }
 
-// Cursor's `Write` tool_input field name for the path is not documented, so accept
-// the plausible spellings. The gate only needs the path to decide; content fields
-// are passed through untouched for the checks that use them.
+// Cursor's file-hook docs use `file_path`; keep historical fallbacks after the
+// verified name so old or drifted payloads remain readable without taking priority.
 const PATH_KEYS = ['file_path', 'path', 'target_file'] as const;
 
 /** Extract the edited file path from a Cursor tool_input, tolerating field-name variants. */
@@ -76,9 +75,9 @@ export function extractFilePath(
   return undefined;
 }
 
-// Cursor's `Write` tool_input field name for the file *content* is undocumented,
-// just like the path field. Accept the plausible spellings; the done-transition
-// detection only needs to read the proposed text.
+// Cursor's generic preToolUse docs do not publish a Write-specific schema. Current
+// Write payloads use `content`; Cursor's file-edit docs use `edits[].new_string`.
+// Keep older guessed names after the verified name as tolerant fallbacks.
 const CONTENT_KEYS = ['content', 'contents', 'new_string', 'text', 'file_text', 'code'] as const;
 
 /**
@@ -95,6 +94,8 @@ export function extractWriteContent(
     const value = toolInput[key];
     if (typeof value === 'string' && value !== '') return value;
   }
+  const editContent = extractNewStringsFromEdits(toolInput.edits);
+  if (editContent) return editContent;
   let longest: string | undefined;
   for (const value of Object.values(toolInput)) {
     if (typeof value === 'string' && value.includes('\n')) {
@@ -104,6 +105,29 @@ export function extractWriteContent(
   return longest;
 }
 
+function extractNewStringsFromEdits(edits: unknown): string | undefined {
+  if (!Array.isArray(edits)) return undefined;
+  const newStrings = edits.flatMap(edit => {
+    if (typeof edit !== 'object' || edit === null) return [];
+    const value = (edit as Record<string, unknown>).new_string;
+    return typeof value === 'string' && value !== '' ? [value] : [];
+  });
+  if (newStrings.length === 0) return undefined;
+  return newStrings.join('\n');
+}
+
+export type DoneTransitionStatus = 'done' | 'not_done' | 'unparseable' | 'unknown';
+
+const STATUS_LINE_PATTERN = /^status:\s*(?<status>.*)$/im;
+const KNOWN_NOT_DONE_STATUSES = new Set([
+  'open',
+  'in_progress',
+  'blocked',
+  'cancelled',
+  'superseded',
+  'wontfix',
+]);
+
 /**
  * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
  * sets `status: done`. Marking `phase: done` (entering the done phase to run /verify)
@@ -111,15 +135,44 @@ export function extractWriteContent(
  * gate later checks. Matches the closing edit only.
  */
 export function detectDoneTransition(content: string | undefined): boolean {
-  if (!content) return false;
-  return /^status:\s*["']?done["']?\s*$/im.test(content);
+  return classifyDoneTransition({ content }) === 'done';
+}
+
+/**
+ * Classify a proposed ticket status line.
+ *
+ * Deliberate miss-direction (P9K783): no readable content remains fail-open so
+ * ordinary ticket work-log saves do not deadlock. A readable but malformed
+ * `status:` line fails closed at the caller, because that is a confirmed status
+ * edit whose close intent cannot be safely classified.
+ */
+export function classifyDoneTransition(params: {
+  content: string | undefined;
+}): DoneTransitionStatus {
+  const { content } = params;
+  if (!content) return 'unknown';
+  const match = STATUS_LINE_PATTERN.exec(content);
+  if (!match?.groups) return 'not_done';
+
+  const normalizedStatus = normalizeFrontmatterScalar(match.groups.status);
+  if (normalizedStatus === 'done') return 'done';
+  if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
+  return 'unparseable';
 }
 
 /** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
 export function parseTicketType(content: string | undefined): string | undefined {
   if (!content) return undefined;
   const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
-  return match?.groups?.type;
+  return match?.groups?.type.toLowerCase();
+}
+
+function normalizeFrontmatterScalar(value: string): string {
+  return value
+    .trim()
+    .replace(/^['"](?<inner>.*)['"]$/, '$<inner>')
+    .trim()
+    .toLowerCase();
 }
 
 /**

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -116,17 +116,9 @@ function extractNewStringsFromEdits(edits: unknown): string | undefined {
   return newStrings.join('\n');
 }
 
-export type DoneTransitionStatus = 'done' | 'not_done' | 'unparseable' | 'unknown';
+export type DoneTransitionStatus = 'done' | 'not_done' | 'unknown';
 
 const STATUS_LINE_PATTERN = /^status:\s*(?<status>.*)$/im;
-const KNOWN_NOT_DONE_STATUSES = new Set([
-  'open',
-  'in_progress',
-  'blocked',
-  'cancelled',
-  'superseded',
-  'wontfix',
-]);
 
 /**
  * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
@@ -142,9 +134,9 @@ export function detectDoneTransition(content: string | undefined): boolean {
  * Classify a proposed ticket status line.
  *
  * Deliberate miss-direction (P9K783): no readable content remains fail-open so
- * ordinary ticket work-log saves do not deadlock. A readable but malformed
- * `status:` line fails closed at the caller, because that is a confirmed status
- * edit whose close intent cannot be safely classified.
+ * ordinary ticket work-log saves do not deadlock. This is a close detector, not
+ * a ticket status validator: only `status: done` triggers the done gate, and
+ * every other readable status remains an ordinary ticket edit.
  */
 export function classifyDoneTransition(params: {
   content: string | undefined;
@@ -159,8 +151,7 @@ export function classifyDoneTransition(params: {
 
   const normalizedStatus = normalizeFrontmatterScalar(rawStatus);
   if (normalizedStatus === 'done') return 'done';
-  if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
-  return 'unparseable';
+  return 'not_done';
 }
 
 /** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
@@ -171,11 +162,29 @@ export function parseTicketType(content: string | undefined): string | undefined
 }
 
 function normalizeFrontmatterScalar(value: string): string {
-  return value
-    .trim()
+  return stripYamlInlineComment(value)
     .replace(/^['"](?<inner>.*)['"]$/, '$<inner>')
     .trim()
     .toLowerCase();
+}
+
+function stripYamlInlineComment(value: string): string {
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (char === '#' && quote === undefined && /\s/.test(value[index - 1] ?? '')) {
+      return value.slice(0, index).trim();
+    }
+  }
+  return value.trim();
 }
 
 /**

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -44,10 +44,6 @@ function emitAllowAndExit(): never {
   emitDecisionAndExit({ permission: 'allow' });
 }
 
-const UNPARSEABLE_STATUS_REASON =
-  'Safeword could not parse the ticket status line in this ticket.md edit. ' +
-  'Use a plain status value like `status: in_progress` or `status: done`, then retry.';
-
 const input = await readInput();
 const workspace = input.workspace_roots?.[0];
 if (workspace) process.chdir(workspace);
@@ -69,9 +65,6 @@ if (!filePath) emitAllowAndExit();
 if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
   const doneTransition = classifyDoneTransition({ content: proposedContent });
-  if (doneTransition === 'unparseable') {
-    emitDecisionAndExit(toCursorDecision(UNPARSEABLE_STATUS_REASON));
-  }
   if (doneTransition === 'done') {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
     // Type comes from the proposed frontmatter; fall back to the on-disk ticket

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -17,8 +17,8 @@ import {
   type ClaudeGateInput,
   type CursorDecision,
   type CursorPreToolInput,
+  classifyDoneTransition,
   decideFromGate,
-  detectDoneTransition,
   extractFilePath,
   extractWriteContent,
   mapCursorToolName,
@@ -44,6 +44,10 @@ function emitAllowAndExit(): never {
   emitDecisionAndExit({ permission: 'allow' });
 }
 
+const UNPARSEABLE_STATUS_REASON =
+  'Safeword could not parse the ticket status line in this ticket.md edit. ' +
+  'Use a plain status value like `status: in_progress` or `status: done`, then retry.';
+
 const input = await readInput();
 const workspace = input.workspace_roots?.[0];
 if (workspace) process.chdir(workspace);
@@ -64,7 +68,11 @@ if (!filePath) emitAllowAndExit();
 // checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
 if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
-  if (detectDoneTransition(proposedContent)) {
+  const doneTransition = classifyDoneTransition({ content: proposedContent });
+  if (doneTransition === 'unparseable') {
+    emitDecisionAndExit(toCursorDecision(UNPARSEABLE_STATUS_REASON));
+  }
+  if (doneTransition === 'done') {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
     // Type comes from the proposed frontmatter; fall back to the on-disk ticket
     // (the closing edit rarely changes `type`) so features still require scenarios.

--- a/.safeword/hooks/lib/done-gate.ts
+++ b/.safeword/hooks/lib/done-gate.ts
@@ -10,7 +10,9 @@
 //     imports this function — there is no second copy to drift).
 //   - `evaluateDoneEvidence` is the composite the Cursor edit gate calls. It runs
 //     the same dependency -> tests -> verify.md -> scenarios sequence the Stop
-//     hook performs inline, returning a plain verdict instead of exiting.
+//     hook's dependency/test/verify/scenario subset, returning a plain verdict
+//     instead of exiting. Claude still has transcript-only checks Cursor cannot
+//     run from preToolUse, so the two gates intentionally diverge there.
 
 import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -74,11 +76,12 @@ export interface DoneEvidenceVerdict {
 /**
  * Evaluate whether a ticket has the evidence required to be marked done.
  *
- * Mirrors the Claude Stop gate's done sequence — dependencies ready, tests green,
- * verify.md present and in-scope, and (for features) all scenarios complete — but
- * returns a verdict instead of blocking, so the Cursor edit gate can translate it
- * into a `deny` decision. Tests run here ("full" enforcement, ticket AKNWZK): the
- * test suite is the one piece of evidence prose can't fake.
+ * Mirrors the Claude Stop gate's dependency/test/verify/scenario subset — deps
+ * ready, tests green, verify.md present and in-scope, and (for features) all
+ * scenarios complete — but returns a verdict instead of blocking, so the Cursor
+ * edit gate can translate it into a `deny` decision. Tests run here ("full"
+ * enforcement for this subset, ticket AKNWZK): the suite is the one piece of
+ * evidence prose can't fake.
  *
  * Cursor divergence: where the Claude gate falls back to scanning the agent's last
  * message for "X/X tests pass" on a task with no test command, this requires a

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -154,7 +154,10 @@ export function classifyDoneTransition(params: {
   const match = STATUS_LINE_PATTERN.exec(content);
   if (!match?.groups) return 'not_done';
 
-  const normalizedStatus = normalizeFrontmatterScalar(match.groups.status);
+  const rawStatus = match.groups.status;
+  if (rawStatus === undefined) return 'not_done';
+
+  const normalizedStatus = normalizeFrontmatterScalar(rawStatus);
   if (normalizedStatus === 'done') return 'done';
   if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
   return 'unparseable';
@@ -164,7 +167,7 @@ export function classifyDoneTransition(params: {
 export function parseTicketType(content: string | undefined): string | undefined {
   if (!content) return undefined;
   const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
-  return match?.groups?.type.toLowerCase();
+  return match?.groups?.type?.toLowerCase();
 }
 
 function normalizeFrontmatterScalar(value: string): string {

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -59,9 +59,8 @@ export function mapCursorToolName(cursorTool: string | undefined): string | unde
   return cursorTool ? TOOL_NAME_MAP[cursorTool] : undefined;
 }
 
-// Cursor's `Write` tool_input field name for the path is not documented, so accept
-// the plausible spellings. The gate only needs the path to decide; content fields
-// are passed through untouched for the checks that use them.
+// Cursor's file-hook docs use `file_path`; keep historical fallbacks after the
+// verified name so old or drifted payloads remain readable without taking priority.
 const PATH_KEYS = ['file_path', 'path', 'target_file'] as const;
 
 /** Extract the edited file path from a Cursor tool_input, tolerating field-name variants. */
@@ -76,9 +75,9 @@ export function extractFilePath(
   return undefined;
 }
 
-// Cursor's `Write` tool_input field name for the file *content* is undocumented,
-// just like the path field. Accept the plausible spellings; the done-transition
-// detection only needs to read the proposed text.
+// Cursor's generic preToolUse docs do not publish a Write-specific schema. Current
+// Write payloads use `content`; Cursor's file-edit docs use `edits[].new_string`.
+// Keep older guessed names after the verified name as tolerant fallbacks.
 const CONTENT_KEYS = ['content', 'contents', 'new_string', 'text', 'file_text', 'code'] as const;
 
 /**
@@ -95,6 +94,8 @@ export function extractWriteContent(
     const value = toolInput[key];
     if (typeof value === 'string' && value !== '') return value;
   }
+  const editContent = extractNewStringsFromEdits(toolInput.edits);
+  if (editContent) return editContent;
   let longest: string | undefined;
   for (const value of Object.values(toolInput)) {
     if (typeof value === 'string' && value.includes('\n')) {
@@ -104,6 +105,29 @@ export function extractWriteContent(
   return longest;
 }
 
+function extractNewStringsFromEdits(edits: unknown): string | undefined {
+  if (!Array.isArray(edits)) return undefined;
+  const newStrings = edits.flatMap(edit => {
+    if (typeof edit !== 'object' || edit === null) return [];
+    const value = (edit as Record<string, unknown>).new_string;
+    return typeof value === 'string' && value !== '' ? [value] : [];
+  });
+  if (newStrings.length === 0) return undefined;
+  return newStrings.join('\n');
+}
+
+export type DoneTransitionStatus = 'done' | 'not_done' | 'unparseable' | 'unknown';
+
+const STATUS_LINE_PATTERN = /^status:\s*(?<status>.*)$/im;
+const KNOWN_NOT_DONE_STATUSES = new Set([
+  'open',
+  'in_progress',
+  'blocked',
+  'cancelled',
+  'superseded',
+  'wontfix',
+]);
+
 /**
  * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
  * sets `status: done`. Marking `phase: done` (entering the done phase to run /verify)
@@ -111,15 +135,44 @@ export function extractWriteContent(
  * gate later checks. Matches the closing edit only.
  */
 export function detectDoneTransition(content: string | undefined): boolean {
-  if (!content) return false;
-  return /^status:\s*["']?done["']?\s*$/im.test(content);
+  return classifyDoneTransition({ content }) === 'done';
+}
+
+/**
+ * Classify a proposed ticket status line.
+ *
+ * Deliberate miss-direction (P9K783): no readable content remains fail-open so
+ * ordinary ticket work-log saves do not deadlock. A readable but malformed
+ * `status:` line fails closed at the caller, because that is a confirmed status
+ * edit whose close intent cannot be safely classified.
+ */
+export function classifyDoneTransition(params: {
+  content: string | undefined;
+}): DoneTransitionStatus {
+  const { content } = params;
+  if (!content) return 'unknown';
+  const match = STATUS_LINE_PATTERN.exec(content);
+  if (!match?.groups) return 'not_done';
+
+  const normalizedStatus = normalizeFrontmatterScalar(match.groups.status);
+  if (normalizedStatus === 'done') return 'done';
+  if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
+  return 'unparseable';
 }
 
 /** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
 export function parseTicketType(content: string | undefined): string | undefined {
   if (!content) return undefined;
   const match = /^type:\s*["']?(?<type>[A-Za-z]+)/im.exec(content);
-  return match?.groups?.type;
+  return match?.groups?.type.toLowerCase();
+}
+
+function normalizeFrontmatterScalar(value: string): string {
+  return value
+    .trim()
+    .replace(/^['"](?<inner>.*)['"]$/, '$<inner>')
+    .trim()
+    .toLowerCase();
 }
 
 /**

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -116,17 +116,9 @@ function extractNewStringsFromEdits(edits: unknown): string | undefined {
   return newStrings.join('\n');
 }
 
-export type DoneTransitionStatus = 'done' | 'not_done' | 'unparseable' | 'unknown';
+export type DoneTransitionStatus = 'done' | 'not_done' | 'unknown';
 
 const STATUS_LINE_PATTERN = /^status:\s*(?<status>.*)$/im;
-const KNOWN_NOT_DONE_STATUSES = new Set([
-  'open',
-  'in_progress',
-  'blocked',
-  'cancelled',
-  'superseded',
-  'wontfix',
-]);
 
 /**
  * True when the proposed ticket.md content closes the ticket — i.e. its frontmatter
@@ -142,9 +134,9 @@ export function detectDoneTransition(content: string | undefined): boolean {
  * Classify a proposed ticket status line.
  *
  * Deliberate miss-direction (P9K783): no readable content remains fail-open so
- * ordinary ticket work-log saves do not deadlock. A readable but malformed
- * `status:` line fails closed at the caller, because that is a confirmed status
- * edit whose close intent cannot be safely classified.
+ * ordinary ticket work-log saves do not deadlock. This is a close detector, not
+ * a ticket status validator: only `status: done` triggers the done gate, and
+ * every other readable status remains an ordinary ticket edit.
  */
 export function classifyDoneTransition(params: {
   content: string | undefined;
@@ -159,8 +151,7 @@ export function classifyDoneTransition(params: {
 
   const normalizedStatus = normalizeFrontmatterScalar(rawStatus);
   if (normalizedStatus === 'done') return 'done';
-  if (KNOWN_NOT_DONE_STATUSES.has(normalizedStatus)) return 'not_done';
-  return 'unparseable';
+  return 'not_done';
 }
 
 /** Read the `type:` frontmatter value ('feature' | 'task' | ...) from ticket.md content. */
@@ -171,11 +162,29 @@ export function parseTicketType(content: string | undefined): string | undefined
 }
 
 function normalizeFrontmatterScalar(value: string): string {
-  return value
-    .trim()
+  return stripYamlInlineComment(value)
     .replace(/^['"](?<inner>.*)['"]$/, '$<inner>')
     .trim()
     .toLowerCase();
+}
+
+function stripYamlInlineComment(value: string): string {
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (char === '#' && quote === undefined && /\s/.test(value[index - 1] ?? '')) {
+      return value.slice(0, index).trim();
+    }
+  }
+  return value.trim();
 }
 
 /**

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -44,10 +44,6 @@ function emitAllowAndExit(): never {
   emitDecisionAndExit({ permission: 'allow' });
 }
 
-const UNPARSEABLE_STATUS_REASON =
-  'Safeword could not parse the ticket status line in this ticket.md edit. ' +
-  'Use a plain status value like `status: in_progress` or `status: done`, then retry.';
-
 const input = await readInput();
 const workspace = input.workspace_roots?.[0];
 if (workspace) process.chdir(workspace);
@@ -69,9 +65,6 @@ if (!filePath) emitAllowAndExit();
 if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
   const doneTransition = classifyDoneTransition({ content: proposedContent });
-  if (doneTransition === 'unparseable') {
-    emitDecisionAndExit(toCursorDecision(UNPARSEABLE_STATUS_REASON));
-  }
   if (doneTransition === 'done') {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
     // Type comes from the proposed frontmatter; fall back to the on-disk ticket

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -17,8 +17,8 @@ import {
   type ClaudeGateInput,
   type CursorDecision,
   type CursorPreToolInput,
+  classifyDoneTransition,
   decideFromGate,
-  detectDoneTransition,
   extractFilePath,
   extractWriteContent,
   mapCursorToolName,
@@ -44,6 +44,10 @@ function emitAllowAndExit(): never {
   emitDecisionAndExit({ permission: 'allow' });
 }
 
+const UNPARSEABLE_STATUS_REASON =
+  'Safeword could not parse the ticket status line in this ticket.md edit. ' +
+  'Use a plain status value like `status: in_progress` or `status: done`, then retry.';
+
 const input = await readInput();
 const workspace = input.workspace_roots?.[0];
 if (workspace) process.chdir(workspace);
@@ -64,7 +68,11 @@ if (!filePath) emitAllowAndExit();
 // checks, sharing its logic with the Stop gate via lib/done-gate.ts (no drift).
 if (nodePath.basename(filePath) === 'ticket.md') {
   const proposedContent = extractWriteContent(input.tool_input);
-  if (detectDoneTransition(proposedContent)) {
+  const doneTransition = classifyDoneTransition({ content: proposedContent });
+  if (doneTransition === 'unparseable') {
+    emitDecisionAndExit(toCursorDecision(UNPARSEABLE_STATUS_REASON));
+  }
+  if (doneTransition === 'done') {
     const ticketDir = nodePath.resolve(nodePath.dirname(filePath));
     // Type comes from the proposed frontmatter; fall back to the on-disk ticket
     // (the closing edit rarely changes `type`) so features still require scenarios.

--- a/packages/cli/templates/hooks/lib/done-gate.ts
+++ b/packages/cli/templates/hooks/lib/done-gate.ts
@@ -10,7 +10,9 @@
 //     imports this function — there is no second copy to drift).
 //   - `evaluateDoneEvidence` is the composite the Cursor edit gate calls. It runs
 //     the same dependency -> tests -> verify.md -> scenarios sequence the Stop
-//     hook performs inline, returning a plain verdict instead of exiting.
+//     hook's dependency/test/verify/scenario subset, returning a plain verdict
+//     instead of exiting. Claude still has transcript-only checks Cursor cannot
+//     run from preToolUse, so the two gates intentionally diverge there.
 
 import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -74,11 +76,12 @@ export interface DoneEvidenceVerdict {
 /**
  * Evaluate whether a ticket has the evidence required to be marked done.
  *
- * Mirrors the Claude Stop gate's done sequence — dependencies ready, tests green,
- * verify.md present and in-scope, and (for features) all scenarios complete — but
- * returns a verdict instead of blocking, so the Cursor edit gate can translate it
- * into a `deny` decision. Tests run here ("full" enforcement, ticket AKNWZK): the
- * test suite is the one piece of evidence prose can't fake.
+ * Mirrors the Claude Stop gate's dependency/test/verify/scenario subset — deps
+ * ready, tests green, verify.md present and in-scope, and (for features) all
+ * scenarios complete — but returns a verdict instead of blocking, so the Cursor
+ * edit gate can translate it into a `deny` decision. Tests run here ("full"
+ * enforcement for this subset, ticket AKNWZK): the suite is the one piece of
+ * evidence prose can't fake.
  *
  * Cursor divergence: where the Claude gate falls back to scanning the agent's last
  * message for "X/X tests pass" on a task with no test command, this requires a

--- a/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
+++ b/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
@@ -119,6 +119,7 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
     it('matches frontmatter that closes the ticket', () => {
       expect(detectDoneTransition('---\nstatus: done\n---')).toBe(true);
       expect(detectDoneTransition('---\nstatus: "done"\n---')).toBe(true);
+      expect(detectDoneTransition('---\nstatus: done # verified manually\n---')).toBe(true);
     });
 
     it('does NOT match entering the done phase (phase: done, still in progress)', () => {
@@ -131,16 +132,20 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
       expect(detectDoneTransition(undefined)).toBe(false);
     });
 
-    it('classifies unreadable content as unknown and malformed status as unparseable', () => {
+    it('classifies unreadable content as unknown and non-done statuses as not closing', () => {
       expect(classifyDoneTransition({ content: undefined })).toBe('unknown');
-      expect(classifyDoneTransition({ content: '---\nstatus:\n---' })).toBe('unparseable');
-      expect(classifyDoneTransition({ content: '---\nstatus: done-ish\n---' })).toBe('unparseable');
+      expect(classifyDoneTransition({ content: '---\nstatus:\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: done-ish\n---' })).toBe('not_done');
     });
 
-    it('treats documented non-done terminal statuses as readable but not closing', () => {
+    it('treats known and legacy non-done statuses as readable but not closing', () => {
+      expect(classifyDoneTransition({ content: '---\nstatus: open\n---' })).toBe('not_done');
       expect(classifyDoneTransition({ content: '---\nstatus: cancelled\n---' })).toBe('not_done');
       expect(classifyDoneTransition({ content: '---\nstatus: superseded\n---' })).toBe('not_done');
       expect(classifyDoneTransition({ content: '---\nstatus: wontfix\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: backlog\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: pending\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: complete\n---' })).toBe('not_done');
     });
   });
 

--- a/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
+++ b/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  classifyDoneTransition,
   claudeDenialReason,
   decideFromGate,
   detectDoneTransition,
@@ -30,7 +31,7 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
   });
 
   describe('extractFilePath', () => {
-    it('reads the documented file_path field', () => {
+    it('pins Cursor Write path payload to file_path', () => {
       expect(extractFilePath({ file_path: 'src/app.ts' })).toBe('src/app.ts');
     });
 
@@ -87,10 +88,19 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
   });
 
   describe('extractWriteContent (AKNWZK done-edit)', () => {
-    it('reads the common content field names', () => {
-      expect(extractWriteContent({ content: 'a' })).toBe('a');
+    it('pins Cursor Write content payload to content', () => {
+      expect(extractWriteContent({ content: '---\nstatus: done\n---\n' })).toBe(
+        '---\nstatus: done\n---\n',
+      );
+    });
+
+    it('tolerates alternate content field names', () => {
       expect(extractWriteContent({ contents: 'b' })).toBe('b');
       expect(extractWriteContent({ new_string: 'c' })).toBe('c');
+    });
+
+    it('reads Cursor file-edit new_string entries as a documented fallback', () => {
+      expect(extractWriteContent({ edits: [{ new_string: 'status: done' }] })).toBe('status: done');
     });
 
     it('falls back to the longest multi-line string under an unknown field name', () => {
@@ -120,12 +130,25 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
       expect(detectDoneTransition('status: blocked')).toBe(false);
       expect(detectDoneTransition(undefined)).toBe(false);
     });
+
+    it('classifies unreadable content as unknown and malformed status as unparseable', () => {
+      expect(classifyDoneTransition({ content: undefined })).toBe('unknown');
+      expect(classifyDoneTransition({ content: '---\nstatus:\n---' })).toBe('unparseable');
+      expect(classifyDoneTransition({ content: '---\nstatus: done-ish\n---' })).toBe('unparseable');
+    });
+
+    it('treats documented non-done terminal statuses as readable but not closing', () => {
+      expect(classifyDoneTransition({ content: '---\nstatus: cancelled\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: superseded\n---' })).toBe('not_done');
+      expect(classifyDoneTransition({ content: '---\nstatus: wontfix\n---' })).toBe('not_done');
+    });
   });
 
   describe('parseTicketType (AKNWZK done-edit)', () => {
     it('reads the type frontmatter', () => {
       expect(parseTicketType('---\ntype: feature\n---')).toBe('feature');
       expect(parseTicketType('---\ntype: task\n---')).toBe('task');
+      expect(parseTicketType('---\ntype: Feature\n---')).toBe('feature');
     });
 
     it('returns undefined when type is absent', () => {

--- a/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
+++ b/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
@@ -210,23 +210,24 @@ describe('Cursor done-edit gate (AKNWZK)', () => {
     expect(decision.user_message).toContain('verify.md');
   });
 
-  it('denies a ticket status edit safeword can read but cannot classify', () => {
-    const decision = runAdapter(projectRoot, {
-      filePath: ticketRelativePath,
-      content: [
-        '---',
-        `id: ${TICKET_ID}`,
-        'slug: cursor-gate',
-        'type: task',
-        'phase: done',
-        'status:',
-        '---',
-        '',
-      ].join('\n'),
-    });
+  it('allows readable ticket status edits that are not closing the ticket', () => {
+    for (const status of ['backlog', 'pending', 'complete', 'open']) {
+      const decision = runAdapter(projectRoot, {
+        filePath: ticketRelativePath,
+        content: [
+          '---',
+          `id: ${TICKET_ID}`,
+          'slug: cursor-gate',
+          'type: task',
+          'phase: done',
+          `status: ${status}`,
+          '---',
+          '',
+        ].join('\n'),
+      });
 
-    expect(decision.permission).toBe('deny');
-    expect(decision.user_message).toContain('could not parse');
+      expect(decision.permission).toBe('allow');
+    }
   });
 
   it('allows an unreadable ticket.md edit instead of blocking ordinary work-log saves', () => {

--- a/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
+++ b/packages/cli/tests/integration/cursor-pretooluse-gate.test.ts
@@ -200,7 +200,7 @@ describe('Cursor done-edit gate (AKNWZK)', () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('denies the close edit when verify.md is missing', () => {
+  it('denies the close edit when verified file_path/content fields show missing verify.md', () => {
     const decision = runAdapter(projectRoot, {
       filePath: ticketRelativePath,
       content: doneFrontmatter('task'),
@@ -208,6 +208,33 @@ describe('Cursor done-edit gate (AKNWZK)', () => {
 
     expect(decision.permission).toBe('deny');
     expect(decision.user_message).toContain('verify.md');
+  });
+
+  it('denies a ticket status edit safeword can read but cannot classify', () => {
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+      content: [
+        '---',
+        `id: ${TICKET_ID}`,
+        'slug: cursor-gate',
+        'type: task',
+        'phase: done',
+        'status:',
+        '---',
+        '',
+      ].join('\n'),
+    });
+
+    expect(decision.permission).toBe('deny');
+    expect(decision.user_message).toContain('could not parse');
+  });
+
+  it('allows an unreadable ticket.md edit instead of blocking ordinary work-log saves', () => {
+    const decision = runAdapter(projectRoot, {
+      filePath: ticketRelativePath,
+    });
+
+    expect(decision.permission).toBe('allow');
   });
 
   it('allows the close edit for a task with a valid verify.md', () => {


### PR DESCRIPTION
## Summary
- Verify Cursor `Write` payload fields and pin `file_path` / `content` in regression tests.
- Make unreadable ticket content deliberately fail-open while malformed readable `status:` lines fail closed.
- Address #415 follow-ups by documenting the Cursor/Claude done-gate divergence and preserving feature scenario checks for `type: Feature`.

## Test plan
- `bun run test -- tests/hooks/cursor-gate-adapter.test.ts tests/integration/cursor-pretooluse-gate.test.ts`
- `bun run test`


Made with [Cursor](https://cursor.com)