### PR TITLE
chore(tickets): split Cursor MCP safety gate

### DIFF
--- a/.project/tickets/DXYKJX-cursor-marketplace-plugin-packaging/ticket.md
+++ b/.project/tickets/DXYKJX-cursor-marketplace-plugin-packaging/ticket.md
@@ -16,17 +16,31 @@ relates_to: VAX3Z2
 
 ## Notes / caveat
 
-- Enterprise third-party plugin imports default **off** since 3.0 — document that an admin must opt in, or safeword won't load for enterprise users.
+- Current Cursor docs say plugins require `.cursor-plugin/plugin.json` and can bundle rules, skills, agents, commands, hooks, and MCP servers.
+- Team Marketplace supports Required and Optional distribution. Required auto-installs the plugin for everyone in the distribution group after an admin saves it.
+- Team marketplaces are available on Teams and Enterprise plans; Enterprise plans can have unlimited team marketplaces.
+- Enterprise third-party plugin imports / third-party skills may require admin enablement; document that admin setup is part of the install path.
 - Consider whether `.cursor/` file install stays the default and the plugin is the team/enterprise path.
+- Coordinate with `JFBFEP` before bundling MCP defaults. Arcade should keep MCP first-class, but plugin packaging must not silently grant side-effecting MCP tools.
 
 ## Done when
 
-- A Cursor plugin manifest bundles safeword's surfaces; install modes (incl. Required) documented; enterprise default-off caveat called out.
+- A `.cursor-plugin/plugin.json` manifest bundles safeword's Cursor surfaces.
+- Team Marketplace install modes, including Required, are documented.
+- Local plugin testing path (`~/.cursor/plugins/local`) is documented.
+- MCP bundling either uses the action-based policy from `JFBFEP` or explicitly stays out of scope for the first plugin release.
+- Enterprise/team admin caveats are called out.
 
 ## Source
 
-cursor.com/changelog (3.0 enterprise plugin default-off; May 1 Team Marketplace / Required mode)
+- Cursor plugins docs and plugin reference (`.cursor-plugin/plugin.json`, component discovery, hooks, MCP servers, local testing).
+- Cursor Team Marketplace docs (Required vs Optional distribution).
+- Cursor May 1 2026 changelog (Team Marketplace Required mode).
 
 ## Work Log
 
 - 2026-05-31 Created from Cursor research.
+- 2026-06-24 `/quality-review` refreshed against current Cursor plugin docs. The
+  ticket is still needed, but the source should be docs-first now: plugin manifest,
+  local plugin testing, Team Marketplace Required/Optional distribution, and MCP
+  bundling coordination with `JFBFEP`.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (332)
+## Tickets (333)
 
 ### agent-surface-refactor
 
@@ -292,6 +292,9 @@
   → `.project/tickets/DXYKJX-cursor-marketplace-plugin-packaging`
 - **Wire beforeSubmitPrompt as Cursor turn-start blocking gate (F2TKR3)** (in_progress, epic: cursor-optimization)
   → `.project/tickets/F2TKR3-cursor-before-submit-prompt-gate`
+- **Add an action-based MCP safety gate for Cursor (JFBFEP)** (in_progress, epic: cursor-optimization)
+  Add a Cursor `beforeMCPExecution` safety gate that keeps MCP first-class while blocking only risky actions.
+  → `.project/tickets/JFBFEP-cursor-mcp-safety-gate`
 - **Prevent the Cursor done gate from silently missing ticket closes (P9K783)** (in_progress, epic: cursor-optimization)
   Make the Cursor done gate's "is this edit closing a ticket?" detection robust against Cursor's actual `Write` payload, instead of relying on guessed field names that fail open.
   → `.project/tickets/P9K783-cursor-done-gate-payload-detection`
@@ -302,7 +305,7 @@
   Replace observe-only `afterFileEdit` with real blocking: `preToolUse` (deny edits before `test-definitions.md`) and `beforeShellExecution` (LOC/commit gate, dangerous-command policy).
   → `.project/tickets/T3DV1K-cursor-blocking-edit-shell-gates`
 - **Verify hook deny wins over Cursor Auto-review Run Mode (3.6) (TDX8NT)** (in_progress, epic: cursor-optimization)
-  Confirm that safeword's `beforeShellExecution` / `beforeMCPExecution` deny still wins when Cursor's Auto-review Run Mode classifier auto-approves Shell/MCP/Fetch calls.
+  Confirm that safeword's `beforeShellExecution` deny still wins when Cursor's Auto-review Run Mode would otherwise auto-approve a shell command.
   → `.project/tickets/TDX8NT-cursor-autoreview-deny-precedence`
 - **Epic: Cursor optimization (VAX3Z2)** (open, epic: cursor-optimization)
   Restore real enforcement to safeword's Cursor integration — it currently relies on the two _non-blocking_ hook events — and pick up the blocking chokepoints + distribution path Cursor now offers.

--- a/.project/tickets/JFBFEP-cursor-mcp-safety-gate/ticket.md
+++ b/.project/tickets/JFBFEP-cursor-mcp-safety-gate/ticket.md
@@ -1,0 +1,48 @@
+---
+id: JFBFEP
+slug: cursor-mcp-safety-gate
+type: task
+phase: intake
+status: in_progress
+epic: cursor-optimization
+relates_to: VAX3Z2
+created: 2026-06-25T01:15:28.347Z
+last_modified: 2026-06-25T01:15:28.347Z
+---
+
+# Add an action-based MCP safety gate for Cursor
+
+**Goal:** Add a Cursor `beforeMCPExecution` safety gate that keeps MCP first-class while blocking only risky actions.
+
+**Why:** Arcade is MCP-heavy, and popular servers like Slack, Linear, and GitHub should stay useful without letting Auto-review silently run side-effecting tool calls.
+
+## Decision
+
+Use an action-based policy, not a blanket MCP block:
+
+- Allow read-only MCP calls by default.
+- Ask before side effects, like posting to Slack, updating Linear, or mutating GitHub.
+- Deny clearly dangerous or administrative actions unless the project explicitly opts in.
+
+This split keeps `TDX8NT` focused on verifying the shell gate that already exists. This ticket owns the MCP policy and the implementation of a new `beforeMCPExecution` gate.
+
+## Done when
+
+- Cursor wires a `beforeMCPExecution` hook for MCP tools that can return `allow`, `ask`, or `deny`.
+- The default policy treats Slack, Linear, and GitHub as normal MCP servers: reads allowed, writes ask, dangerous/admin actions denied.
+- The policy is project-configurable without making MCP feel blocked by default.
+- Tests prove the gate blocks or asks before side-effecting MCP tool calls, including under Auto-review.
+
+## Source
+
+- Cursor MCP docs: MCP tools follow the same Run Modes as terminal commands; Auto-review routes allowlisted MCP tools immediately and sends the rest to the classifier.
+- Cursor hooks docs: `beforeMCPExecution` can return `allow`, `deny`, or `ask`; hook failures fail open unless `failClosed:true`.
+- Cursor plugin docs: plugins can bundle MCP servers and hooks, so MCP safety matters for plugin packaging too.
+
+## Work Log
+
+- 2026-06-25T01:15:28.347Z Started: Created ticket JFBFEP
+- 2026-06-24 Decision from `/figure-it-out`: keep TDX8NT as Shell-only verification
+  and split MCP into this ticket because safeword does not currently wire a
+  `beforeMCPExecution` gate. Picked an action-based policy so MCP remains a
+  first-class Arcade workflow instead of being globally blocked.

--- a/.project/tickets/TDX8NT-cursor-autoreview-deny-precedence/ticket.md
+++ b/.project/tickets/TDX8NT-cursor-autoreview-deny-precedence/ticket.md
@@ -10,18 +10,29 @@ relates_to: VAX3Z2
 
 # Verify hook deny wins over Cursor Auto-review Run Mode (3.6)
 
-**Goal:** Confirm that safeword's `beforeShellExecution` / `beforeMCPExecution` deny still wins when Cursor's Auto-review Run Mode classifier auto-approves Shell/MCP/Fetch calls.
+**Goal:** Confirm that safeword's `beforeShellExecution` deny still wins when Cursor's Auto-review Run Mode would otherwise auto-approve a shell command.
 
-**Why:** Cursor 3.6 (May 29) added a classifier subagent that auto-approves those tool calls. If it can short-circuit or race the hook decision, safeword's command gate is undermined.
+**Why:** Cursor 3.6 (May 29) added Auto-review for Shell, MCP, and Fetch calls. If Auto-review can short-circuit or race the shell hook decision, safeword's command gate is undermined.
+
+## Scope
+
+This ticket is Shell-only because safeword already wires `beforeShellExecution`.
+MCP safety is split to `JFBFEP` because safeword does not yet wire
+`beforeMCPExecution`; that needs a policy decision and implementation, not just a
+precedence test.
 
 ## Done when
 
-- Empirically verified, with Auto-review Run Mode on, that a safeword hook `deny` still blocks the shell/MCP call (or documented otherwise + mitigation).
+- Empirically verified, with Auto-review Run Mode on, that a safeword `beforeShellExecution` `deny` still blocks a shell command (or documented otherwise + mitigation).
 
 ## Source
 
-cursor.com/changelog (3.6 Auto-review Run Mode)
+- Cursor changelog: Auto-review applies to Shell, MCP, and Fetch calls.
+- Cursor hooks docs: `beforeShellExecution` can return `allow`, `deny`, or `ask`.
 
 ## Work Log
 
 - 2026-05-31 Created from Cursor research — flagged as a race risk.
+- 2026-06-24 `/figure-it-out` decision: keep this ticket focused on the shell gate
+  that exists today. Split MCP to `JFBFEP` because adding a `beforeMCPExecution`
+  gate is policy/design/build work, not just verification.

--- a/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
+++ b/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
@@ -57,18 +57,19 @@ cursor.com/docs/hooks(.md), /docs/context/rules, /docs/context/commands, cursor.
 
 ## Tickets
 
-Core children (own the `cursor-optimization` epic key). Status revalidated 2026-06-24:
+Core children (own the `cursor-optimization` epic key). Status revalidated 2026-06-24, refreshed again against current Cursor docs on 2026-06-24 after P9K783:
 
 | ID         | Title                                                              | Tier                | Status           |
 | ---------- | ------------------------------------------------------------------ | ------------------- | ---------------- |
 | **RBZR3F** | Add `sessionStart` context injection                               | restore enforcement | ✅ done          |
 | **151**    | Migrate four Cursor rules to `@reference` pattern                  | drift/parity        | ✅ done (folded) |
-| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | open             |
-| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | open             |
-| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | open             |
-| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | open             |
-| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | open             |
-| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | open             |
+| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | ready to close (rejected; no hook ships) |
+| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | ready to close |
+| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | ready to close |
+| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | ready to close |
+| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | PR #424 open |
+| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | open (Shell-only) |
+| **JFBFEP** | Add an action-based MCP safety gate for Cursor                     | correctness         | open             |
 | **DXYKJX** | Package as Team-Marketplace plugin (Required mode)                 | distribution        | open             |
 
 ### Cross-epic Cursor work (soft-linked, not re-parented)
@@ -83,7 +84,7 @@ These are Cursor-specific deliverables whose natural home is a cross-agent epic.
 
 ## Sequencing
 
-F2TKR3 / RBZR3F / T3DV1K first — they close the silent gate gap. ANAXG4 ships alongside (one-line per-hook flag). AKNWZK documents the unavoidable Cursor limitation. TDX8NT + DXYKJX after the gates work.
+Remaining sequencing: land P9K783 (#424), then empirically verify `TDX8NT` for Shell deny precedence under Auto-review. Design/build `JFBFEP` before letting `DXYKJX` bundle MCP defaults; plugin packaging can proceed in parallel for non-MCP surfaces.
 
 ## Related
 
@@ -96,3 +97,4 @@ Epic **8R54HV** (Claude Code) — reuse gate logic; note Cursor's `stop` can't b
 - 2026-05-31 Researched Cursor hooks/rules/commands/changelog (live docs). Found current gates non-blocking; filed 7 child tickets.
 - 2026-06-16 Gap noted (from FJKM4X): guides loaded via `.safeword/guides/` tell agents to "call `/figure-it-out`" — a literal slash command in Claude Code. In Cursor, `safeword-figure-it-out.mdc` already uses the `@reference` pattern correctly, but it has `alwaysApply: false` and activates by description match, not by explicit invocation from guide text. There is no direct bridge from "guide says call figure-it-out" to "MDC rule loads the procedure." In practice the context conditions overlap so the rule likely activates correctly, but it is not mechanically guaranteed the way Claude Code's slash command invocation is. Consider: (a) `alwaysApply: true` for figure-it-out.mdc since it's always relevant when a design choice surfaces, or (b) a guide-aware rule activation mechanism if Cursor exposes one.
 - 2026-06-24 **Consolidated all Cursor work under this epic + revalidated; broadened title to "Cursor optimization."** Checked GitHub issues — no Cursor epic exists there (ticket-system-only); only tangential open issues are #292 (Claude Code plugin spike) and #19 (MCP-in-plugin), nothing to fold. Folded pure-Cursor **151** (rules → `@reference`) in as a core child. Soft-linked three cross-agent Cursor tickets via `relates_to` without re-parenting: **1833FW**, **F1HTQ4** (agent-surface-refactor), **Y6HZR7** (auto-upgrade-cross-agent). **Revalidation against live code closed two as done:** RBZR3F (`sessionStart` already wired in `.cursor/hooks.json` → `session-safeword-context.ts`, emits `additional_context` for cursor) and 151 (the four rules are already 6-line `@reference` pointers; structural `checkCursorRulesThin` guard live; status was just never flipped). Remaining open children re-verified as still needed: F2TKR3/T3DV1K (`beforeSubmitPrompt`/`preToolUse`/`beforeShellExecution` not wired in `.cursor/hooks.json`), ANAXG4 (no `failClosed` anywhere), AKNWZK (done-gate rearchitect still pending — note: the `followup_message` nudge mechanism already exists in `cursor/stop.ts` for quality-review, useful precedent), TDX8NT + DXYKJX (unstarted). No duplicate tickets found; 151↔G1A6BS cover disjoint rule sets.
+- 2026-06-24 `/quality-review` + `/figure-it-out` refresh after P9K783: current Cursor docs confirm the implemented hook shape (`preToolUse`, `beforeShellExecution`, `failClosed`, stop `loop_limit`) and current plugin shape (`.cursor-plugin/plugin.json`, hooks/MCP bundling, Team Marketplace Required/Optional). Marked F2TKR3/T3DV1K/ANAXG4/AKNWZK as ready to close in this index pending explicit close confirmation; P9K783 is PR #424. Split MCP out of TDX8NT into new ticket JFBFEP because safeword has no `beforeMCPExecution` gate today and Arcade should use an action-based MCP policy instead of blocking MCP wholesale.


### PR DESCRIPTION
## Summary
- Add `JFBFEP` for an action-based Cursor MCP safety gate.
- Narrow `TDX8NT` to Shell-only Auto-review deny precedence.
- Refresh Cursor plugin packaging notes and epic sequencing against current docs.

## Test plan
- Not run: ticket-only documentation update.


Made with [Cursor](https://cursor.com)