### PR TITLE
Revalidate Cursor auto-upgrade ticket

### DIFF
--- a/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
+++ b/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
@@ -7,7 +7,7 @@ status: in_progress
 epic: auto-upgrade-cross-agent
 children: [Y6HZR7, 7R1D3B]
 created: 2026-06-20T12:54:31.866Z
-last_modified: 2026-06-25T05:55:00Z
+last_modified: 2026-06-25T06:00:00Z
 ---
 
 # Epic: Cross-agent auto-upgrade (Cursor + Codex)
@@ -41,7 +41,7 @@ The **client session-hook is the primary/universal mechanism** — the only path
 
 Use **one shared apply core plus thin per-agent wrappers**.
 
-- **Slice 0:** extract the agent-agnostic check/apply/commit flow from `session-auto-upgrade.ts` into a reusable hook lib module. Keep one implementation for version lookup, semver policy, release-age cooldown, opt-outs, dirty/detached/merge pre-flight, strike counter, `bunx safeword@<latest> upgrade`, and safeword-owned-file commit staging.
+- **Slice 0:** land PR #433 (or an equivalent extraction) so the agent-agnostic check/apply/commit flow lives in a reusable hook lib module instead of inside `session-auto-upgrade.ts`. Keep one implementation for version lookup, semver policy, release-age cooldown, opt-outs, dirty/detached/merge pre-flight, strike counter, `bunx safeword@<latest> upgrade`, and safeword-owned-file commit staging.
 - **Claude Code wrapper:** keep the current `asyncRewake` behavior. It may continue using exit `2` to surface upgraded / major-available / blocked messages back to Claude as a system reminder.
 - **Cursor wrapper:** call the shared core from `sessionStart`, exit `0`, and treat the auto-upgrade git commit as the durable user-visible record. Do not use exit `2`, `continue:false`, `user_message`, or `failClosed` as a notification strategy; current Cursor docs say `sessionStart` is fire-and-forget and does not enforce blocking responses.
 - **Status / notification:** major-available and repeated-failure outcomes on Cursor should degrade to silent local status plus git history for this slice. A richer user-visible notification path is a follow-up decision, not a blocker for the silent apply path.
@@ -58,7 +58,7 @@ Rejected:
 - [Y6HZR7 — Auto-upgrade under Cursor](../Y6HZR7-auto-upgrade-cursor/ticket.md)
 - [7R1D3B — Auto-upgrade under Codex](../7R1D3B-auto-upgrade-codex/ticket.md)
 
-A likely **slice 0** (shared, before either agent): extract the agent-agnostic apply core out of `session-auto-upgrade.ts` into a reusable `lib/` module so Claude/Cursor/Codex entry points are thin wrappers. Fold into whichever child goes first, or carve a small task.
+Slice 0 is in flight in PR #433: extract the agent-agnostic apply core out of `session-auto-upgrade.ts` into a reusable `lib/` module so Claude/Cursor/Codex entry points are thin wrappers. If #433 lands first, Y6HZR7 should build on that shared core rather than re-extract it.
 
 ## Acceptance (epic-level)
 
@@ -72,3 +72,4 @@ A likely **slice 0** (shared, before either agent): extract the agent-agnostic a
 
 - 2026-06-20T12:54:31.866Z Started: Created epic BJX7WR. Surfaced during XQ9CXA verify: auto-upgrade is Claude-Code-only; the `asyncRewake`/exit-2 contract has no Cursor/Codex equivalent (exit 2 would block those). Apply path is portable; messaging is not. Children: Cursor (Y6HZR7), Codex (7R1D3B).
 - 2026-06-25T05:55:00Z Resolved the Cursor side of the design after `/figure-it-out`: extract one shared apply core first; keep Claude's `asyncRewake` messaging; make Cursor a silent `sessionStart` wrapper that exits `0` and uses the git auto-upgrade commit as the durable record. Cursor notification UX for major-available / repeated-failure outcomes is deferred to a follow-up status strategy. Y6HZR7 remains blocked only on slice 0 extraction before implementation.
+- 2026-06-25T06:00:00Z Checked related PR #433 ("Bring auto-upgrade to Codex users"). It appears to implement slice 0 by adding `hooks/lib/auto-upgrade.ts` and turning Claude auto-upgrade into a wrapper, plus Codex wiring. No file conflict with Y6HZR7's ticket-only PR #440. If #433 lands first, Cursor work should reuse its shared core.

--- a/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
+++ b/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
@@ -7,7 +7,7 @@ status: in_progress
 epic: auto-upgrade-cross-agent
 children: [Y6HZR7, 7R1D3B]
 created: 2026-06-20T12:54:31.866Z
-last_modified: 2026-06-20T12:54:31.866Z
+last_modified: 2026-06-25T05:55:00Z
 ---
 
 # Epic: Cross-agent auto-upgrade (Cursor + Codex)
@@ -37,14 +37,21 @@ The **client session-hook is the primary/universal mechanism** — the only path
 
 **Bigger structural lever ([D6GTXY spike](../D6GTXY-hooks-into-cli-spike/ticket.md)):** moving the **hook layer into the CLI** (`safeword hook <name>` subcommands) would make all three agents' configs point at one shared binary — collapsing the apply logic from triplicated materialized scripts into one implementation. If pursued, it likely **subsumes the per-agent ports** (Y6HZR7/7R1D3B become "wire the agent's config to call `safeword hook`" rather than reimplement). Evaluate this BEFORE committing to per-agent script ports. Evidence: hooks+lib are 52/139 owned files (37%); MCP cannot host hooks/skills (filesystem-only); CLI cold-start +20–60ms (mitigable). Verified 2026-06-20.
 
-## Shared design decision (resolve in epic-level /figure-it-out before the children build)
+## Shared design decision (resolved 2026-06-25)
 
-Likely shape — **silent apply + git-commit-as-record** on Cursor/Codex: do the upgrade + commit (the agent-agnostic core), skip the exit-2 messaging entirely (the commit in git history is the record), and find a per-agent way to avoid blocking session start. Open design questions the figure-it-out must settle:
+Use **one shared apply core plus thin per-agent wrappers**.
 
-- Can Cursor / Codex run a hook **non-blocking** at all? If not, is a bounded one-time blocking apply acceptable (it only fires when an upgrade is actually pending, ≤ once/day via the cooldown)?
-- Where does the **shared apply core** live so all three agents call one implementation (extract from `session-auto-upgrade.ts` into a `lib/` function)?
-- Do Cursor/Codex have a surfacing channel for the **major-available / blocked** messages, or do those degrade to silent + git-history only?
-- Reuse `.update-cache.json` + the strike counter as-is (agent-agnostic) — confirm.
+- **Slice 0:** extract the agent-agnostic check/apply/commit flow from `session-auto-upgrade.ts` into a reusable hook lib module. Keep one implementation for version lookup, semver policy, release-age cooldown, opt-outs, dirty/detached/merge pre-flight, strike counter, `bunx safeword@<latest> upgrade`, and safeword-owned-file commit staging.
+- **Claude Code wrapper:** keep the current `asyncRewake` behavior. It may continue using exit `2` to surface upgraded / major-available / blocked messages back to Claude as a system reminder.
+- **Cursor wrapper:** call the shared core from `sessionStart`, exit `0`, and treat the auto-upgrade git commit as the durable user-visible record. Do not use exit `2`, `continue:false`, `user_message`, or `failClosed` as a notification strategy; current Cursor docs say `sessionStart` is fire-and-forget and does not enforce blocking responses.
+- **Status / notification:** major-available and repeated-failure outcomes on Cursor should degrade to silent local status plus git history for this slice. A richer user-visible notification path is a follow-up decision, not a blocker for the silent apply path.
+- **CI/PR action:** remains an opt-in complement for teams that want scheduled reviewable upgrades. It is not the default cross-agent answer.
+
+Rejected:
+
+- **Wire Claude's `session-auto-upgrade.ts` directly into Cursor.** Cursor has no `asyncRewake`; exit `2` is a block/error path, not a rewake message.
+- **Build a Cursor-only copy now.** It would duplicate the apply logic this epic exists to share.
+- **Wait for hooks-into-CLI before Cursor.** `safeword hook <name>` may still be the best broader hook architecture, but the auto-upgrade slice can stay smaller by extracting only the shared apply core first.
 
 ## Children
 
@@ -64,3 +71,4 @@ A likely **slice 0** (shared, before either agent): extract the agent-agnostic a
 ## Work Log
 
 - 2026-06-20T12:54:31.866Z Started: Created epic BJX7WR. Surfaced during XQ9CXA verify: auto-upgrade is Claude-Code-only; the `asyncRewake`/exit-2 contract has no Cursor/Codex equivalent (exit 2 would block those). Apply path is portable; messaging is not. Children: Cursor (Y6HZR7), Codex (7R1D3B).
+- 2026-06-25T05:55:00Z Resolved the Cursor side of the design after `/figure-it-out`: extract one shared apply core first; keep Claude's `asyncRewake` messaging; make Cursor a silent `sessionStart` wrapper that exits `0` and uses the git auto-upgrade commit as the durable record. Cursor notification UX for major-available / repeated-failure outcomes is deferred to a follow-up status strategy. Y6HZR7 remains blocked only on slice 0 extraction before implementation.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -8,7 +8,7 @@ epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
 created: 2026-06-20T12:54:31.933Z
-last_modified: 2026-06-25T05:55:00Z
+last_modified: 2026-06-25T06:00:00Z
 ---
 
 # Auto-upgrade under Cursor
@@ -17,7 +17,7 @@ last_modified: 2026-06-25T05:55:00Z
 
 **Parent:** [BJX7WR — cross-agent auto-upgrade](../BJX7WR-auto-upgrade-cross-agent/ticket.md)
 
-**Blocked on:** BJX7WR slice 0 — extract the shared apply core from `session-auto-upgrade.ts`. The Cursor contract is now decided: silent `sessionStart` wrapper, exit `0`, git commit as record.
+**Blocked on:** BJX7WR slice 0 landing — PR #433 or an equivalent shared-core extraction. The Cursor contract is now decided: silent `sessionStart` wrapper, exit `0`, git commit as record.
 
 ## Current state
 
@@ -35,7 +35,7 @@ last_modified: 2026-06-25T05:55:00Z
 
 Ran `/figure-it-out` before implementation.
 
-Decision: **still blocked on BJX7WR slice 0 extraction**. The parent now chooses the Cursor contract — silent `sessionStart` wrapper, exit `0`, git commit as record — but the repo still has the full apply path inside `packages/cli/templates/hooks/session-auto-upgrade.ts`. Only smaller helpers (`update-cache`, `version`, owned-path filtering) have been extracted.
+Decision: **still blocked on BJX7WR slice 0 landing**. The parent now chooses the Cursor contract — silent `sessionStart` wrapper, exit `0`, git commit as record. On `main`, the full apply path still lives inside `packages/cli/templates/hooks/session-auto-upgrade.ts`; PR #433 appears to implement the needed shared core in `packages/cli/templates/hooks/lib/auto-upgrade.ts`.
 
 Options considered:
 
@@ -53,11 +53,11 @@ Options considered:
 
 ## Open questions
 
-- Does Cursor surface any hook output to the user at session start (for a "major available" hint), or is silent-with-git-record the only option?
-- Cursor hook exit-code semantics — confirm exit 0 is the only safe code.
+- Deferred: richer Cursor notification UX for major-available / repeated-failure outcomes after silent apply ships.
 
 ## Work Log
 
 - 2026-06-20T12:54:31.933Z Created (child of BJX7WR). Blocked on epic figure-it-out.
 - 2026-06-25T05:50:00Z Revalidated under Cursor after `/figure-it-out`. Current Cursor hooks docs confirm `sessionStart` is fire-and-forget, `continue:false` / `user_message` are not enforced for session creation, exit `2` is a block path rather than a rewake message, and `failClosed` is for blocking hook failure policy only. Parent BJX7WR slice 0 is still missing: no shared apply core exists yet, so Y6HZR7 remains blocked. No implementation started.
 - 2026-06-25T05:55:00Z Parent design updated: Cursor should use a silent `sessionStart` wrapper around the shared apply core, exit `0`, and rely on the git auto-upgrade commit as the durable record. Remaining blocker is implementation slice 0: extract the shared apply core before wiring Cursor.
+- 2026-06-25T06:00:00Z Checked PR #433. It does not conflict with this ticket file, and it likely supplies the shared core this ticket needs. If #433 lands first, Y6HZR7 should proceed directly to a Cursor wrapper around `hooks/lib/auto-upgrade.ts`.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -8,7 +8,7 @@ epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
 created: 2026-06-20T12:54:31.933Z
-last_modified: 2026-06-20T12:54:31.933Z
+last_modified: 2026-06-25T05:50:00Z
 ---
 
 # Auto-upgrade under Cursor
@@ -22,7 +22,26 @@ last_modified: 2026-06-20T12:54:31.933Z
 ## Current state
 
 - `CURSOR_HOOKS.sessionStart` (`packages/cli/src/templates/config.ts`) runs only `session-safeword-context.ts --agent=cursor`. No auto-upgrade.
-- Cursor `.cursor/hooks.json` hook format is `{command}` only — **no async/background, no exit-code rewake**. So the Claude Code `asyncRewake`/exit-2 message channel does not exist, and **exit 2 is a blocking hook error** — wiring the existing hook as-is would stall/error session start.
+- Claude Code `SessionStart` wires `session-auto-upgrade.ts` through `asyncRewake`; that script intentionally exits `2` to surface upgraded / major-available / blocked messages back to Claude as a system reminder.
+- Cursor hooks do **not** have Claude Code's `asyncRewake` / exit-2 rewake messaging contract. Cursor's command-hook docs say exit `2` blocks the action, and non-zero failures otherwise fail-open unless `failClosed: true`.
+- Current Cursor docs say `sessionStart` is **fire-and-forget**: the agent loop does not wait for, block on, or enforce the response. The documented output is only `env` and `additional_context`; docs also say `continue` / `user_message` are accepted by schema but current callers do not enforce them, so session creation is not blocked even when `continue:false`.
+- `failClosed` is available for hook failures, but it is not a session-start messaging channel. It belongs on security-critical blocking hooks, not on the Cursor auto-upgrade path.
+- Cursor team/plugin distribution can package hooks (`.cursor-plugin/plugin.json` `hooks` field; project/team/enterprise hooks), but distribution does not change `sessionStart` semantics.
+- Therefore Cursor auto-upgrade still needs either:
+  - a silent apply path where the git commit is the durable record, or
+  - a separate user-visible notification strategy that does not depend on `sessionStart` output or exit `2`.
+
+## Revalidation — 2026-06-24
+
+Ran `/figure-it-out` before implementation.
+
+Decision: **still blocked on BJX7WR parent design**. The parent still calls for slice 0 — extracting the agent-agnostic apply core from `session-auto-upgrade.ts` so Claude/Cursor/Codex call one implementation — but the repo still has the full apply path inside `packages/cli/templates/hooks/session-auto-upgrade.ts`. Only smaller helpers (`update-cache`, `version`, owned-path filtering) have been extracted.
+
+Options considered:
+
+- **Wire Claude's script directly into Cursor `sessionStart`: reject.** Cursor has no `asyncRewake`; exit `2` is a block/error path, not a rewake message.
+- **Build a Cursor-specific copy now: reject.** It would duplicate the apply logic the parent explicitly says to share.
+- **Update evidence and stay blocked: choose.** This preserves the parent design constraint and records the current Cursor docs needed for the eventual implementation.
 
 ## Scope (pending epic design)
 
@@ -40,3 +59,4 @@ last_modified: 2026-06-20T12:54:31.933Z
 ## Work Log
 
 - 2026-06-20T12:54:31.933Z Created (child of BJX7WR). Blocked on epic figure-it-out.
+- 2026-06-25T05:50:00Z Revalidated under Cursor after `/figure-it-out`. Current Cursor hooks docs confirm `sessionStart` is fire-and-forget, `continue:false` / `user_message` are not enforced for session creation, exit `2` is a block path rather than a rewake message, and `failClosed` is for blocking hook failure policy only. Parent BJX7WR slice 0 is still missing: no shared apply core exists yet, so Y6HZR7 remains blocked. No implementation started.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -8,7 +8,7 @@ epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
 created: 2026-06-20T12:54:31.933Z
-last_modified: 2026-06-25T05:50:00Z
+last_modified: 2026-06-25T05:55:00Z
 ---
 
 # Auto-upgrade under Cursor
@@ -17,7 +17,7 @@ last_modified: 2026-06-25T05:50:00Z
 
 **Parent:** [BJX7WR — cross-agent auto-upgrade](../BJX7WR-auto-upgrade-cross-agent/ticket.md)
 
-**Blocked on:** the epic-level /figure-it-out (shared apply-core extraction + the per-agent non-blocking/messaging contract). Don't start implementation until that lands.
+**Blocked on:** BJX7WR slice 0 — extract the shared apply core from `session-auto-upgrade.ts`. The Cursor contract is now decided: silent `sessionStart` wrapper, exit `0`, git commit as record.
 
 ## Current state
 
@@ -35,13 +35,13 @@ last_modified: 2026-06-25T05:50:00Z
 
 Ran `/figure-it-out` before implementation.
 
-Decision: **still blocked on BJX7WR parent design**. The parent still calls for slice 0 — extracting the agent-agnostic apply core from `session-auto-upgrade.ts` so Claude/Cursor/Codex call one implementation — but the repo still has the full apply path inside `packages/cli/templates/hooks/session-auto-upgrade.ts`. Only smaller helpers (`update-cache`, `version`, owned-path filtering) have been extracted.
+Decision: **still blocked on BJX7WR slice 0 extraction**. The parent now chooses the Cursor contract — silent `sessionStart` wrapper, exit `0`, git commit as record — but the repo still has the full apply path inside `packages/cli/templates/hooks/session-auto-upgrade.ts`. Only smaller helpers (`update-cache`, `version`, owned-path filtering) have been extracted.
 
 Options considered:
 
 - **Wire Claude's script directly into Cursor `sessionStart`: reject.** Cursor has no `asyncRewake`; exit `2` is a block/error path, not a rewake message.
 - **Build a Cursor-specific copy now: reject.** It would duplicate the apply logic the parent explicitly says to share.
-- **Update evidence and stay blocked: choose.** This preserves the parent design constraint and records the current Cursor docs needed for the eventual implementation.
+- **Update evidence and stay blocked on extraction: choose.** This preserves the parent design constraint and records the current Cursor docs needed for the eventual implementation.
 
 ## Scope (pending epic design)
 
@@ -60,3 +60,4 @@ Options considered:
 
 - 2026-06-20T12:54:31.933Z Created (child of BJX7WR). Blocked on epic figure-it-out.
 - 2026-06-25T05:50:00Z Revalidated under Cursor after `/figure-it-out`. Current Cursor hooks docs confirm `sessionStart` is fire-and-forget, `continue:false` / `user_message` are not enforced for session creation, exit `2` is a block path rather than a rewake message, and `failClosed` is for blocking hook failure policy only. Parent BJX7WR slice 0 is still missing: no shared apply core exists yet, so Y6HZR7 remains blocked. No implementation started.
+- 2026-06-25T05:55:00Z Parent design updated: Cursor should use a silent `sessionStart` wrapper around the shared apply core, exit `0`, and rely on the git auto-upgrade commit as the durable record. Remaining blocker is implementation slice 0: extract the shared apply core before wiring Cursor.


### PR DESCRIPTION
## Summary
- Revalidates Y6HZR7 against current Cursor hook docs and live repo wiring.
- Records the chosen Cursor path: shared apply core first, then a silent `sessionStart` wrapper that exits `0` and uses the git commit as the record.
- Notes that PR #433 appears to implement the shared-core slice; if it lands first, Cursor work should reuse `hooks/lib/auto-upgrade.ts` rather than re-extracting it.

## Test plan
- `bun run test -- tests/commands/setup-cursor.test.ts src/templates/config.test.ts tests/utils/auto-upgrade.test.ts tests/utils/update-cache.test.ts tests/utils/version.test.ts`