### PR TITLE
fix(cursor): restore skill invocation proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ examples/
 # Safeword - Local cache and transient state
 .safeword/.update-cache.json
 .safeword-project/quality-state*.json
+.safeword-project/cursor-run-identity.json
 .safeword-project/failure-counts.json
 .safeword-project/skill-invocations.log
 .safeword-project/re-entry.md
@@ -43,11 +44,13 @@ brand/
 # Safeword - Local cache and transient state
 .safeword/.update-cache.json
 .project/quality-state*.json
+.project/cursor-run-identity.json
 .project/failure-counts.json
 .project/skill-invocations.log
 .project/re-entry.md
 .project/dependency-readiness.json
 .safeword-project/quality-state*.json
+.safeword-project/cursor-run-identity.json
 .safeword-project/failure-counts.json
 .safeword-project/skill-invocations.log
 .safeword-project/re-entry.md

--- a/.project/.gitignore
+++ b/.project/.gitignore
@@ -1,5 +1,6 @@
 # Safeword - transient session state (auto-managed)
 /quality-state*.json
+/cursor-run-identity.json
 /failure-counts.json
 /skill-invocations.log
 /re-entry.md

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -55,7 +55,8 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed: a gate that crashed or never started denies the command (ANAXG4).
 const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
-const proofCommand = decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
+const proofCommand =
+  decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
 if (proofCommand !== undefined) {
   rememberCursorRunIdentity({
     projectDirectory: process.cwd(),

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { rememberCursorRunIdentity } from '../lib/cursor-run-identity.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
@@ -37,6 +38,13 @@ if (workspace) process.chdir(workspace);
 const command = input.command ?? '';
 if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (command.includes('record-skill-invocation.ts')) {
+  rememberCursorRunIdentity({
+    projectDirectory: process.cwd(),
+    conversationId: input.conversation_id,
+  });
 }
 
 const translated: ClaudeGateInput = {

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -10,7 +10,10 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { rememberCursorRunIdentity } from '../lib/cursor-run-identity.ts';
+import {
+  parseRecordSkillInvocationCommand,
+  rememberCursorRunIdentity,
+} from '../lib/cursor-run-identity.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
@@ -40,13 +43,6 @@ if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
 }
 
-if (command.includes('record-skill-invocation.ts')) {
-  rememberCursorRunIdentity({
-    projectDirectory: process.cwd(),
-    conversationId: input.conversation_id,
-  });
-}
-
 const translated: ClaudeGateInput = {
   session_id: input.conversation_id,
   hook_event_name: 'PreToolUse',
@@ -59,5 +55,13 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed: a gate that crashed or never started denies the command (ANAXG4).
 const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
+const proofCommand = decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
+if (proofCommand !== undefined) {
+  rememberCursorRunIdentity({
+    projectDirectory: process.cwd(),
+    conversationId: input.conversation_id,
+    skillName: proofCommand.skillName,
+  });
+}
 process.stdout.write(JSON.stringify(decision) + '\n');
 process.exit(0);

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.ts';
@@ -9,20 +9,26 @@ const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 
 interface CursorRunIdentityCache {
   conversationId: string;
+  skillName: string;
   recordedAt: string;
 }
 
 interface RememberCursorRunIdentityInput {
   projectDirectory: string;
   conversationId: string | undefined;
+  skillName: string | undefined;
   now?: Date;
 }
 
 interface ReadFreshCursorRunIdentityInput {
   projectDirectory: string;
+  skillName: string;
   now?: Date;
   maxAgeMs?: number;
 }
+
+const SHELL_OPERATORS = new Set([';', '&&', '||', '|']);
+const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function nonEmptyString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -33,6 +39,125 @@ function cachePathForProject(projectDirectory: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), CURSOR_RUN_IDENTITY_CACHE);
 }
 
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function isBunExecutable(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  return nodePath.basename(token) === 'bun';
+}
+
+function isInvocationHelperPath(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  return token
+    .replaceAll('\\', '/')
+    .endsWith('/.safeword/hooks/record-skill-invocation.ts');
+}
+
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  function flush(): void {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = '';
+    }
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === undefined) continue;
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      flush();
+      continue;
+    }
+
+    if (char === '&' && command[index + 1] === '&') {
+      flush();
+      tokens.push('&&');
+      index += 1;
+      continue;
+    }
+
+    if (char === '|' && command[index + 1] === '|') {
+      flush();
+      tokens.push('||');
+      index += 1;
+      continue;
+    }
+
+    if (char === ';' || char === '|') {
+      flush();
+      tokens.push(char);
+      continue;
+    }
+
+    current += char;
+  }
+
+  flush();
+  return tokens;
+}
+
+export function parseRecordSkillInvocationCommand(command: string): { skillName: string } | undefined {
+  const tokens = tokenizeShellCommand(command);
+  let segmentStart = 0;
+
+  for (let index = 0; index <= tokens.length; index += 1) {
+    if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
+      continue;
+    }
+
+    const segment = tokens.slice(segmentStart, index);
+    segmentStart = index + 1;
+
+    let executableIndex = 0;
+    while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
+      executableIndex += 1;
+    }
+
+    if (!isBunExecutable(segment[executableIndex])) continue;
+    if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
+
+    const skillName = nonEmptyString(segment[executableIndex + 3]);
+    if (skillName !== undefined && SKILL_NAME_PATTERN.test(skillName)) {
+      return { skillName };
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Cursor slash-command fallback commands run as Shell tool calls. The
  * beforeShellExecution hook sees the active `conversation_id` immediately before
@@ -41,7 +166,8 @@ function cachePathForProject(projectDirectory: string): string {
  */
 export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput): boolean {
   const conversationId = nonEmptyString(input.conversationId);
-  if (conversationId === undefined) return false;
+  const skillName = nonEmptyString(input.skillName);
+  if (conversationId === undefined || skillName === undefined) return false;
 
   try {
     const cachePath = cachePathForProject(input.projectDirectory);
@@ -50,6 +176,7 @@ export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput)
       cachePath,
       JSON.stringify({
         conversationId,
+        skillName,
         recordedAt: (input.now ?? new Date()).toISOString(),
       }),
       'utf8',
@@ -71,6 +198,7 @@ export function readFreshCursorRunIdentity(
     const parsed = JSON.parse(readFileSync(cachePath, 'utf8')) as Partial<CursorRunIdentityCache>;
     const conversationId = nonEmptyString(parsed.conversationId);
     if (conversationId === undefined) return undefined;
+    if (parsed.skillName !== input.skillName) return undefined;
 
     const recordedAtMs = Date.parse(parsed.recordedAt ?? '');
     if (!Number.isFinite(recordedAtMs)) return undefined;
@@ -82,5 +210,7 @@ export function readFreshCursorRunIdentity(
     return conversationId;
   } catch {
     return undefined;
+  } finally {
+    rmSync(cachePath, { force: true });
   }
 }

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -50,9 +50,7 @@ function isBunExecutable(token: string | undefined): boolean {
 
 function isInvocationHelperPath(token: string | undefined): boolean {
   if (token === undefined) return false;
-  return token
-    .replaceAll('\\', '/')
-    .endsWith('/.safeword/hooks/record-skill-invocation.ts');
+  return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
 }
 
 function tokenizeShellCommand(command: string): string[] {
@@ -129,7 +127,9 @@ function tokenizeShellCommand(command: string): string[] {
   return tokens;
 }
 
-export function parseRecordSkillInvocationCommand(command: string): { skillName: string } | undefined {
+export function parseRecordSkillInvocationCommand(
+  command: string,
+): { skillName: string } | undefined {
   const tokens = tokenizeShellCommand(command);
   let segmentStart = 0;
 

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { resolveNamespaceRoot } from './namespace-root.ts';
+
+export const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
+
+const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
+
+interface CursorRunIdentityCache {
+  conversationId: string;
+  recordedAt: string;
+}
+
+interface RememberCursorRunIdentityInput {
+  projectDirectory: string;
+  conversationId: string | undefined;
+  now?: Date;
+}
+
+interface ReadFreshCursorRunIdentityInput {
+  projectDirectory: string;
+  now?: Date;
+  maxAgeMs?: number;
+}
+
+function nonEmptyString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function cachePathForProject(projectDirectory: string): string {
+  return nodePath.join(resolveNamespaceRoot(projectDirectory), CURSOR_RUN_IDENTITY_CACHE);
+}
+
+/**
+ * Cursor slash-command fallback commands run as Shell tool calls. The
+ * beforeShellExecution hook sees the active `conversation_id` immediately before
+ * that command runs, while the command process itself does not receive the hook
+ * payload. This small cache bridges that one-step gap.
+ */
+export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput): boolean {
+  const conversationId = nonEmptyString(input.conversationId);
+  if (conversationId === undefined) return false;
+
+  try {
+    const cachePath = cachePathForProject(input.projectDirectory);
+    mkdirSync(nodePath.dirname(cachePath), { recursive: true });
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        conversationId,
+        recordedAt: (input.now ?? new Date()).toISOString(),
+      }),
+      'utf8',
+    );
+    return true;
+  } catch {
+    // This cache is a proof-path aid. It must not make the shell gate crash.
+    return false;
+  }
+}
+
+export function readFreshCursorRunIdentity(
+  input: ReadFreshCursorRunIdentityInput,
+): string | undefined {
+  const cachePath = cachePathForProject(input.projectDirectory);
+  if (!existsSync(cachePath)) return undefined;
+
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8')) as Partial<CursorRunIdentityCache>;
+    const conversationId = nonEmptyString(parsed.conversationId);
+    if (conversationId === undefined) return undefined;
+
+    const recordedAtMs = Date.parse(parsed.recordedAt ?? '');
+    if (!Number.isFinite(recordedAtMs)) return undefined;
+
+    const nowMs = (input.now ?? new Date()).getTime();
+    const maxAgeMs = input.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    if (nowMs - recordedAtMs > maxAgeMs) return undefined;
+
+    return conversationId;
+  } catch {
+    return undefined;
+  }
+}

--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -13,9 +13,10 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function resolveProofSessionKey(input: {
   projectDirectory: string;
+  skillName: string;
   explicitSessionId?: string;
 }): string | undefined {
-  const { projectDirectory, explicitSessionId } = input;
+  const { projectDirectory, skillName, explicitSessionId } = input;
   if (explicitSessionId !== undefined && explicitSessionId.trim().length > 0) {
     return explicitSessionId.trim();
   }
@@ -25,7 +26,7 @@ function resolveProofSessionKey(input: {
   if (process.env.CODEX_THREAD_ID) {
     return resolveRunIdentity({}, { runtime: 'codex', env: process.env }).sessionKey ?? undefined;
   }
-  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory });
+  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory, skillName });
   if (cursorSessionKey !== undefined) {
     return cursorSessionKey;
   }
@@ -42,6 +43,7 @@ export function recordSkillInvocation(
   }
   const proofSessionKey = resolveProofSessionKey({
     projectDirectory,
+    skillName,
     explicitSessionId: sessionId,
   });
   if (proofSessionKey === undefined) {
@@ -61,15 +63,21 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = resolveProofSessionKey({
-    projectDirectory,
-    explicitSessionId: process.argv[4],
-  });
 
   try {
     if (skillName === undefined) {
       throw new Error('Missing skill name');
     }
+
+    if (!SKILL_NAME_PATTERN.test(skillName)) {
+      throw new Error(`Invalid skill name "${skillName}"`);
+    }
+
+    const sessionId = resolveProofSessionKey({
+      projectDirectory,
+      skillName,
+      explicitSessionId: process.argv[4],
+    });
 
     if (!sessionId) {
       console.log(

--- a/.safeword/hooks/record-skill-invocation.ts
+++ b/.safeword/hooks/record-skill-invocation.ts
@@ -4,13 +4,18 @@ import { appendFileSync, mkdirSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
+import { readFreshCursorRunIdentity } from './lib/cursor-run-identity.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 import { resolveRunIdentity } from './lib/run-identity.ts';
+import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
-function resolveProofSessionKey(explicitSessionId?: string): string | undefined {
+function resolveProofSessionKey(input: {
+  projectDirectory: string;
+  explicitSessionId?: string;
+}): string | undefined {
+  const { projectDirectory, explicitSessionId } = input;
   if (explicitSessionId !== undefined && explicitSessionId.trim().length > 0) {
     return explicitSessionId.trim();
   }
@@ -19,6 +24,10 @@ function resolveProofSessionKey(explicitSessionId?: string): string | undefined 
   }
   if (process.env.CODEX_THREAD_ID) {
     return resolveRunIdentity({}, { runtime: 'codex', env: process.env }).sessionKey ?? undefined;
+  }
+  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory });
+  if (cursorSessionKey !== undefined) {
+    return cursorSessionKey;
   }
   return resolveRunIdentity({}, { env: process.env }).sessionKey ?? undefined;
 }
@@ -31,9 +40,12 @@ export function recordSkillInvocation(
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
   }
-  const proofSessionKey = resolveProofSessionKey(sessionId);
+  const proofSessionKey = resolveProofSessionKey({
+    projectDirectory,
+    explicitSessionId: sessionId,
+  });
   if (proofSessionKey === undefined) {
-    // Runtimes without a compatible run identity skip silently.
+    // Runtimes without a compatible run identity cannot produce gate proof.
     return;
   }
 
@@ -49,7 +61,10 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = resolveProofSessionKey(process.argv[4]);
+  const sessionId = resolveProofSessionKey({
+    projectDirectory,
+    explicitSessionId: process.argv[4],
+  });
 
   try {
     if (skillName === undefined) {
@@ -57,7 +72,10 @@ if (import.meta.main) {
     }
 
     if (!sessionId) {
-      console.log(`[skill-invocation-log] no run identity — skipped`);
+      console.log(
+        '[skill-invocation-log] no run identity — no proof logged. ' +
+          'Run this from an agent session with a current run identity; Cursor users should retry after safeword hooks are active so beforeShellExecution can bind conversation_id.',
+      );
       process.exit(0);
     }
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -270,6 +270,7 @@ const CODEX_SKILL_OWNED_FILES: Record<string, FileDefinition> = Object.fromEntri
  */
 const NAMESPACE_TRANSIENT_BASENAMES: readonly string[] = [
   'quality-state*.json',
+  'cursor-run-identity.json',
   'failure-counts.json',
   'skill-invocations.log',
   're-entry.md',
@@ -532,6 +533,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     // Hooks shared library - TypeScript with Bun runtime
     '.safeword/hooks/lib/active-ticket.ts': { template: 'hooks/lib/active-ticket.ts' },
     '.safeword/hooks/lib/blocked-on-gate.ts': { template: 'hooks/lib/blocked-on-gate.ts' },
+    '.safeword/hooks/lib/cursor-run-identity.ts': {
+      template: 'hooks/lib/cursor-run-identity.ts',
+    },
     '.safeword/hooks/lib/git-operation.ts': { template: 'hooks/lib/git-operation.ts' },
     '.safeword/hooks/lib/re-entry.ts': { template: 'hooks/lib/re-entry.ts' },
     '.safeword/hooks/lib/hierarchy.ts': { template: 'hooks/lib/hierarchy.ts' },

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { rememberCursorRunIdentity } from '../lib/cursor-run-identity.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
@@ -37,6 +38,13 @@ if (workspace) process.chdir(workspace);
 const command = input.command ?? '';
 if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (command.includes('record-skill-invocation.ts')) {
+  rememberCursorRunIdentity({
+    projectDirectory: process.cwd(),
+    conversationId: input.conversation_id,
+  });
 }
 
 const translated: ClaudeGateInput = {

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -10,7 +10,10 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { rememberCursorRunIdentity } from '../lib/cursor-run-identity.ts';
+import {
+  parseRecordSkillInvocationCommand,
+  rememberCursorRunIdentity,
+} from '../lib/cursor-run-identity.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
@@ -40,13 +43,6 @@ if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
 }
 
-if (command.includes('record-skill-invocation.ts')) {
-  rememberCursorRunIdentity({
-    projectDirectory: process.cwd(),
-    conversationId: input.conversation_id,
-  });
-}
-
 const translated: ClaudeGateInput = {
   session_id: input.conversation_id,
   hook_event_name: 'PreToolUse',
@@ -59,5 +55,14 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed: a gate that crashed or never started denies the command (ANAXG4).
 const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
+const proofCommand =
+  decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
+if (proofCommand !== undefined) {
+  rememberCursorRunIdentity({
+    projectDirectory: process.cwd(),
+    conversationId: input.conversation_id,
+    skillName: proofCommand.skillName,
+  });
+}
 process.stdout.write(JSON.stringify(decision) + '\n');
 process.exit(0);

--- a/packages/cli/templates/hooks/lib/cursor-run-identity.ts
+++ b/packages/cli/templates/hooks/lib/cursor-run-identity.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { resolveNamespaceRoot } from './namespace-root.ts';
+
+export const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
+
+const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
+
+interface CursorRunIdentityCache {
+  conversationId: string;
+  recordedAt: string;
+}
+
+interface RememberCursorRunIdentityInput {
+  projectDirectory: string;
+  conversationId: string | undefined;
+  now?: Date;
+}
+
+interface ReadFreshCursorRunIdentityInput {
+  projectDirectory: string;
+  now?: Date;
+  maxAgeMs?: number;
+}
+
+function nonEmptyString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function cachePathForProject(projectDirectory: string): string {
+  return nodePath.join(resolveNamespaceRoot(projectDirectory), CURSOR_RUN_IDENTITY_CACHE);
+}
+
+/**
+ * Cursor slash-command fallback commands run as Shell tool calls. The
+ * beforeShellExecution hook sees the active `conversation_id` immediately before
+ * that command runs, while the command process itself does not receive the hook
+ * payload. This small cache bridges that one-step gap.
+ */
+export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput): boolean {
+  const conversationId = nonEmptyString(input.conversationId);
+  if (conversationId === undefined) return false;
+
+  try {
+    const cachePath = cachePathForProject(input.projectDirectory);
+    mkdirSync(nodePath.dirname(cachePath), { recursive: true });
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        conversationId,
+        recordedAt: (input.now ?? new Date()).toISOString(),
+      }),
+      'utf8',
+    );
+    return true;
+  } catch {
+    // This cache is a proof-path aid. It must not make the shell gate crash.
+    return false;
+  }
+}
+
+export function readFreshCursorRunIdentity(
+  input: ReadFreshCursorRunIdentityInput,
+): string | undefined {
+  const cachePath = cachePathForProject(input.projectDirectory);
+  if (!existsSync(cachePath)) return undefined;
+
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8')) as Partial<CursorRunIdentityCache>;
+    const conversationId = nonEmptyString(parsed.conversationId);
+    if (conversationId === undefined) return undefined;
+
+    const recordedAtMs = Date.parse(parsed.recordedAt ?? '');
+    if (!Number.isFinite(recordedAtMs)) return undefined;
+
+    const nowMs = (input.now ?? new Date()).getTime();
+    const maxAgeMs = input.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    if (nowMs - recordedAtMs > maxAgeMs) return undefined;
+
+    return conversationId;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/templates/hooks/lib/cursor-run-identity.ts
+++ b/packages/cli/templates/hooks/lib/cursor-run-identity.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.ts';
@@ -9,20 +9,26 @@ const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 
 interface CursorRunIdentityCache {
   conversationId: string;
+  skillName: string;
   recordedAt: string;
 }
 
 interface RememberCursorRunIdentityInput {
   projectDirectory: string;
   conversationId: string | undefined;
+  skillName: string | undefined;
   now?: Date;
 }
 
 interface ReadFreshCursorRunIdentityInput {
   projectDirectory: string;
+  skillName: string;
   now?: Date;
   maxAgeMs?: number;
 }
+
+const SHELL_OPERATORS = new Set([';', '&&', '||', '|']);
+const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function nonEmptyString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -33,6 +39,125 @@ function cachePathForProject(projectDirectory: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), CURSOR_RUN_IDENTITY_CACHE);
 }
 
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function isBunExecutable(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  return nodePath.basename(token) === 'bun';
+}
+
+function isInvocationHelperPath(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
+}
+
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  function flush(): void {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = '';
+    }
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === undefined) continue;
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      flush();
+      continue;
+    }
+
+    if (char === '&' && command[index + 1] === '&') {
+      flush();
+      tokens.push('&&');
+      index += 1;
+      continue;
+    }
+
+    if (char === '|' && command[index + 1] === '|') {
+      flush();
+      tokens.push('||');
+      index += 1;
+      continue;
+    }
+
+    if (char === ';' || char === '|') {
+      flush();
+      tokens.push(char);
+      continue;
+    }
+
+    current += char;
+  }
+
+  flush();
+  return tokens;
+}
+
+export function parseRecordSkillInvocationCommand(
+  command: string,
+): { skillName: string } | undefined {
+  const tokens = tokenizeShellCommand(command);
+  let segmentStart = 0;
+
+  for (let index = 0; index <= tokens.length; index += 1) {
+    if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
+      continue;
+    }
+
+    const segment = tokens.slice(segmentStart, index);
+    segmentStart = index + 1;
+
+    let executableIndex = 0;
+    while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
+      executableIndex += 1;
+    }
+
+    if (!isBunExecutable(segment[executableIndex])) continue;
+    if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
+
+    const skillName = nonEmptyString(segment[executableIndex + 3]);
+    if (skillName !== undefined && SKILL_NAME_PATTERN.test(skillName)) {
+      return { skillName };
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Cursor slash-command fallback commands run as Shell tool calls. The
  * beforeShellExecution hook sees the active `conversation_id` immediately before
@@ -41,7 +166,8 @@ function cachePathForProject(projectDirectory: string): string {
  */
 export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput): boolean {
   const conversationId = nonEmptyString(input.conversationId);
-  if (conversationId === undefined) return false;
+  const skillName = nonEmptyString(input.skillName);
+  if (conversationId === undefined || skillName === undefined) return false;
 
   try {
     const cachePath = cachePathForProject(input.projectDirectory);
@@ -50,6 +176,7 @@ export function rememberCursorRunIdentity(input: RememberCursorRunIdentityInput)
       cachePath,
       JSON.stringify({
         conversationId,
+        skillName,
         recordedAt: (input.now ?? new Date()).toISOString(),
       }),
       'utf8',
@@ -71,6 +198,7 @@ export function readFreshCursorRunIdentity(
     const parsed = JSON.parse(readFileSync(cachePath, 'utf8')) as Partial<CursorRunIdentityCache>;
     const conversationId = nonEmptyString(parsed.conversationId);
     if (conversationId === undefined) return undefined;
+    if (parsed.skillName !== input.skillName) return undefined;
 
     const recordedAtMs = Date.parse(parsed.recordedAt ?? '');
     if (!Number.isFinite(recordedAtMs)) return undefined;
@@ -82,5 +210,7 @@ export function readFreshCursorRunIdentity(
     return conversationId;
   } catch {
     return undefined;
+  } finally {
+    rmSync(cachePath, { force: true });
   }
 }

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -13,9 +13,10 @@ const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function resolveProofSessionKey(input: {
   projectDirectory: string;
+  skillName: string;
   explicitSessionId?: string;
 }): string | undefined {
-  const { projectDirectory, explicitSessionId } = input;
+  const { projectDirectory, skillName, explicitSessionId } = input;
   if (explicitSessionId !== undefined && explicitSessionId.trim().length > 0) {
     return explicitSessionId.trim();
   }
@@ -25,7 +26,7 @@ function resolveProofSessionKey(input: {
   if (process.env.CODEX_THREAD_ID) {
     return resolveRunIdentity({}, { runtime: 'codex', env: process.env }).sessionKey ?? undefined;
   }
-  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory });
+  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory, skillName });
   if (cursorSessionKey !== undefined) {
     return cursorSessionKey;
   }
@@ -42,6 +43,7 @@ export function recordSkillInvocation(
   }
   const proofSessionKey = resolveProofSessionKey({
     projectDirectory,
+    skillName,
     explicitSessionId: sessionId,
   });
   if (proofSessionKey === undefined) {
@@ -61,15 +63,21 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = resolveProofSessionKey({
-    projectDirectory,
-    explicitSessionId: process.argv[4],
-  });
 
   try {
     if (skillName === undefined) {
       throw new Error('Missing skill name');
     }
+
+    if (!SKILL_NAME_PATTERN.test(skillName)) {
+      throw new Error(`Invalid skill name "${skillName}"`);
+    }
+
+    const sessionId = resolveProofSessionKey({
+      projectDirectory,
+      skillName,
+      explicitSessionId: process.argv[4],
+    });
 
     if (!sessionId) {
       console.log(

--- a/packages/cli/templates/hooks/record-skill-invocation.ts
+++ b/packages/cli/templates/hooks/record-skill-invocation.ts
@@ -4,13 +4,18 @@ import { appendFileSync, mkdirSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
+import { readFreshCursorRunIdentity } from './lib/cursor-run-identity.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 import { resolveRunIdentity } from './lib/run-identity.ts';
+import { SKILL_INVOCATIONS_LOG } from './lib/skill-invocation-log.ts';
 
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
-function resolveProofSessionKey(explicitSessionId?: string): string | undefined {
+function resolveProofSessionKey(input: {
+  projectDirectory: string;
+  explicitSessionId?: string;
+}): string | undefined {
+  const { projectDirectory, explicitSessionId } = input;
   if (explicitSessionId !== undefined && explicitSessionId.trim().length > 0) {
     return explicitSessionId.trim();
   }
@@ -19,6 +24,10 @@ function resolveProofSessionKey(explicitSessionId?: string): string | undefined 
   }
   if (process.env.CODEX_THREAD_ID) {
     return resolveRunIdentity({}, { runtime: 'codex', env: process.env }).sessionKey ?? undefined;
+  }
+  const cursorSessionKey = readFreshCursorRunIdentity({ projectDirectory });
+  if (cursorSessionKey !== undefined) {
+    return cursorSessionKey;
   }
   return resolveRunIdentity({}, { env: process.env }).sessionKey ?? undefined;
 }
@@ -31,9 +40,12 @@ export function recordSkillInvocation(
   if (!SKILL_NAME_PATTERN.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}"`);
   }
-  const proofSessionKey = resolveProofSessionKey(sessionId);
+  const proofSessionKey = resolveProofSessionKey({
+    projectDirectory,
+    explicitSessionId: sessionId,
+  });
   if (proofSessionKey === undefined) {
-    // Runtimes without a compatible run identity skip silently.
+    // Runtimes without a compatible run identity cannot produce gate proof.
     return;
   }
 
@@ -49,7 +61,10 @@ export function recordSkillInvocation(
 if (import.meta.main) {
   const projectDirectory = process.argv[2] ?? process.cwd();
   const skillName = process.argv[3];
-  const sessionId = resolveProofSessionKey(process.argv[4]);
+  const sessionId = resolveProofSessionKey({
+    projectDirectory,
+    explicitSessionId: process.argv[4],
+  });
 
   try {
     if (skillName === undefined) {
@@ -57,7 +72,10 @@ if (import.meta.main) {
     }
 
     if (!sessionId) {
-      console.log(`[skill-invocation-log] no run identity — skipped`);
+      console.log(
+        '[skill-invocation-log] no run identity — no proof logged. ' +
+          'Run this from an agent session with a current run identity; Cursor users should retry after safeword hooks are active so beforeShellExecution can bind conversation_id.',
+      );
       process.exit(0);
     }
 

--- a/packages/cli/tests/hooks/record-skill-invocation.test.ts
+++ b/packages/cli/tests/hooks/record-skill-invocation.test.ts
@@ -60,6 +60,10 @@ function runCursorBeforeShell(input: {
   expect(JSON.parse(result.stdout) as { permission?: string }).toEqual({ permission: 'allow' });
 }
 
+function installedProofCommand(projectDirectory: string, skillName: string): string {
+  return `bun "${projectDirectory}/.safeword/hooks/record-skill-invocation.ts" "${projectDirectory}" ${skillName}`;
+}
+
 describe('record-skill-invocation helper (88QCHJ)', () => {
   it('prints the configured namespace root for command snippets', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
@@ -194,7 +198,7 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
 
     runCursorBeforeShell({
       projectDirectory,
-      command: `bun "${helperPath}" "${projectDirectory}" quality-review`,
+      command: installedProofCommand(projectDirectory, 'quality-review'),
       conversationId: 'cursor-conversation-uuid',
     });
 
@@ -211,6 +215,107 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
     expect(logContent).toMatch(/ cursor-conversation-uuid quality-review$/m);
   });
 
+  it('does not bind Cursor proof when a shell command only mentions the helper', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+
+    runCursorBeforeShell({
+      projectDirectory,
+      command: `echo "${installedProofCommand(projectDirectory, 'quality-review')}"`,
+      conversationId: 'cursor-conversation-uuid',
+    });
+
+    const result = spawnSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no proof logged');
+    expect(existsSync(nodePath.join(projectDirectory, '.project', 'skill-invocations.log'))).toBe(
+      false,
+    );
+  });
+
+  it('does not bind Cursor proof for a helper-looking path that is not the helper', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+
+    runCursorBeforeShell({
+      projectDirectory,
+      command: `bun "${projectDirectory}/.safeword/hooks/record-skill-invocation.ts.bak" "${projectDirectory}" quality-review`,
+      conversationId: 'cursor-conversation-uuid',
+    });
+
+    const result = spawnSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no proof logged');
+    expect(existsSync(nodePath.join(projectDirectory, '.project', 'skill-invocations.log'))).toBe(
+      false,
+    );
+  });
+
+  it('does not replay a Cursor proof cache for a different skill', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+
+    runCursorBeforeShell({
+      projectDirectory,
+      command: installedProofCommand(projectDirectory, 'quality-review'),
+      conversationId: 'cursor-conversation-uuid',
+    });
+
+    const result = spawnSync('bun', [helperPath, projectDirectory, 'audit'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+    const retryOriginalSkill = spawnSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no proof logged');
+    expect(retryOriginalSkill.status).toBe(0);
+    expect(retryOriginalSkill.stdout).toContain('no proof logged');
+    expect(existsSync(nodePath.join(projectDirectory, '.project', 'skill-invocations.log'))).toBe(
+      false,
+    );
+  });
+
+  it('consumes Cursor proof cache after one successful helper run', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+
+    runCursorBeforeShell({
+      projectDirectory,
+      command: installedProofCommand(projectDirectory, 'quality-review'),
+      conversationId: 'cursor-conversation-uuid',
+    });
+
+    const firstOutput = execFileSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+    const secondResult = spawnSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(firstOutput.trim()).toBe('[skill-invocation-log] quality-review ✓');
+    expect(secondResult.status).toBe(0);
+    expect(secondResult.stdout).toContain('no proof logged');
+    const logContent = readFileSync(
+      nodePath.join(projectDirectory, '.project', 'skill-invocations.log'),
+      'utf8',
+    );
+    expect(logContent.match(/quality-review/g)).toHaveLength(1);
+  });
+
   it('does not reuse stale Cursor identity cache entries for local shell runs', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
     const projectMetadataDirectory = nodePath.join(projectDirectory, '.project');
@@ -219,6 +324,7 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
       nodePath.join(projectMetadataDirectory, 'cursor-run-identity.json'),
       JSON.stringify({
         conversationId: 'old-cursor-conversation',
+        skillName: 'verify',
         recordedAt: '2000-01-01T00:00:00.000Z',
       }),
     );

--- a/packages/cli/tests/hooks/record-skill-invocation.test.ts
+++ b/packages/cli/tests/hooks/record-skill-invocation.test.ts
@@ -11,6 +11,10 @@ const helperPath = nodePath.join(
   repoRoot,
   'packages/cli/templates/hooks/record-skill-invocation.ts',
 );
+const beforeShellAdapterPath = nodePath.join(
+  repoRoot,
+  'packages/cli/templates/hooks/cursor/before-shell-execution.ts',
+);
 const resolverPath = nodePath.join(
   repoRoot,
   'packages/cli/templates/hooks/resolve-namespace-root.ts',
@@ -21,6 +25,39 @@ function runHelper(projectDirectory: string, skillName: string, sessionId = 'ses
     encoding: 'utf8',
     env: { ...process.env, CLAUDE_SESSION_ID: sessionId },
   });
+}
+
+function envWithoutRunIdentity(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  delete environment.CLAUDE_SESSION_ID;
+  delete environment.CLAUDE_CODE_SESSION_ID;
+  delete environment.CODEX_THREAD_ID;
+  delete environment.SAFEWORD_AGENT_RUNTIME;
+  return environment;
+}
+
+function runCursorBeforeShell(input: {
+  projectDirectory: string;
+  command: string;
+  conversationId: string;
+}): void {
+  const result = spawnSync('bun', [beforeShellAdapterPath], {
+    cwd: input.projectDirectory,
+    input: JSON.stringify({
+      conversation_id: input.conversationId,
+      command: input.command,
+      workspace_roots: [input.projectDirectory],
+    }),
+    encoding: 'utf8',
+    env: {
+      ...envWithoutRunIdentity(),
+      CLAUDE_PROJECT_DIR: input.projectDirectory,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout) as { permission?: string }).toEqual({ permission: 'allow' });
 }
 
 describe('record-skill-invocation helper (88QCHJ)', () => {
@@ -151,20 +188,65 @@ describe('record-skill-invocation helper (88QCHJ)', () => {
     expect(logContent).toMatch(/ codex-thread-uuid quality-review$/m);
   });
 
-  it('exits 0 and skips when no session id is available (non-Claude runtime graceful)', () => {
+  it('records Cursor proof after beforeShellExecution binds the current conversation id', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
-    const env = { ...process.env };
-    delete env.CLAUDE_SESSION_ID;
-    delete env.CLAUDE_CODE_SESSION_ID;
-    delete env.CODEX_THREAD_ID;
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+
+    runCursorBeforeShell({
+      projectDirectory,
+      command: `bun "${helperPath}" "${projectDirectory}" quality-review`,
+      conversationId: 'cursor-conversation-uuid',
+    });
+
+    const output = execFileSync('bun', [helperPath, projectDirectory, 'quality-review'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(output.trim()).toBe('[skill-invocation-log] quality-review ✓');
+    const logContent = readFileSync(
+      nodePath.join(projectDirectory, '.project', 'skill-invocations.log'),
+      'utf8',
+    );
+    expect(logContent).toMatch(/ cursor-conversation-uuid quality-review$/m);
+  });
+
+  it('does not reuse stale Cursor identity cache entries for local shell runs', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+    const projectMetadataDirectory = nodePath.join(projectDirectory, '.project');
+    mkdirSync(projectMetadataDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(projectMetadataDirectory, 'cursor-run-identity.json'),
+      JSON.stringify({
+        conversationId: 'old-cursor-conversation',
+        recordedAt: '2000-01-01T00:00:00.000Z',
+      }),
+    );
 
     const result = spawnSync('bun', [helperPath, projectDirectory, 'verify'], {
       encoding: 'utf8',
-      env,
+      env: envWithoutRunIdentity(),
     });
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('no run identity');
+    expect(result.stdout).toContain('no proof logged');
+    expect(existsSync(nodePath.join(projectMetadataDirectory, 'skill-invocations.log'))).toBe(
+      false,
+    );
+  });
+
+  it('exits 0 and skips when no session id is available (non-Claude runtime graceful)', () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'record-skill-'));
+
+    const result = spawnSync('bun', [helperPath, projectDirectory, 'verify'], {
+      encoding: 'utf8',
+      env: envWithoutRunIdentity(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no run identity');
+    expect(result.stdout).toContain('no proof logged');
     expect(existsSync(nodePath.join(projectDirectory, '.project', 'skill-invocations.log'))).toBe(
       false,
     );


### PR DESCRIPTION
## Summary
- Cache Cursor `conversation_id` from `beforeShellExecution` immediately before `record-skill-invocation.ts` shell fallbacks run.
- Let the proof helper use a fresh cached Cursor identity when Claude/Codex env identities are absent, and emit a clearer no-proof message otherwise.
- Register the new shipped helper in the schema and ignore its transient namespace cache.

Closes #435

## Test plan
- `bun run lint`
- `bun run test -- tests/hooks/record-skill-invocation.test.ts tests/schema.test.ts`
- `bun run test`

## Revalidation
- GitHub duplicate search found only the known related closed issues (#401, #372, #295) and no open duplicate.
- Cursor hooks docs (`https://cursor.com/docs/hooks.md`) confirm hook input includes stable `conversation_id` and `workspace_roots`, and `beforeShellExecution` runs before shell commands with allow/deny/ask decisions.

Made with [Cursor](https://cursor.com)