### PR TITLE
feat(reconcile): `supersedes` swap op — migrate customized Codex installs to the auto-upgrade dispatcher

### DIFF
--- a/packages/cli/src/reconcile.ts
+++ b/packages/cli/src/reconcile.ts
@@ -1036,40 +1036,55 @@ function executeTextPatch(cwd: string, path: string, definition: ResolvedTextPat
   }
 
   const fullPath = nodePath.join(cwd, path);
-  let content = readFileSafe(fullPath) ?? '';
+  const original = readFileSafe(fullPath) ?? '';
 
-  // Check if already patched
+  // Supersede: byte-exact strip of the legacy block this patch replaces (a no-op
+  // when absent), so a customized managed file migrates the old block to `content`
+  // on upgrade. Runs before the marker check so the swap still applies when the
+  // replacement block is being added for the first time.
+  const content =
+    definition.supersedes === undefined ? original : original.replace(definition.supersedes, '');
+
+  // Already patched: re-render/heal in place, persisting any supersede strip.
   if (content.includes(definition.marker)) {
-    // Re-renderable block (#293): when the resolved content has drifted from
-    // what's on disk (e.g. a custom paths.projectRoot was added), replace the
-    // managed block in place so existing installs heal on upgrade. A no-op when
-    // the block is already current, so default installs never churn.
-    if (definition.rerender && !content.includes(definition.content)) {
-      const stripped = stripRerenderBlock(content, definition);
-      writeFile(fullPath, stripped + definition.content);
-      return;
-    }
-    // Heal legacy artifact from safeword <=0.30.1: the prepend templates
-    // (CLAUDE_MD_IMPORT_BLOCK, AGENTS_MD_LINK) ended with bare `---` and no
-    // trailing newline, so the `---` separator glued to the user's first
-    // heading line (e.g. `---# CLAUDE.md`). Templates are fixed going
-    // forward; this pass repairs files already corrupted by past installs.
-    // Narrowly scoped: only fires when the safeword marker is present
-    // (proving the block was authored by us) and the exact artifact matches.
-    if (content.includes('\n\n---#')) {
-      const healed = content.replaceAll('\n\n---#', '\n\n---\n\n#');
-      writeFile(fullPath, healed);
-    }
+    healAlreadyPatchedFile(fullPath, original, content, definition);
     return;
   }
 
-  // Apply patch
-  content =
+  // Apply patch (this write also persists any supersede strip above).
+  const patched =
     definition.operation === 'prepend'
       ? definition.content + content
       : content + definition.content;
+  writeFile(fullPath, patched);
+}
 
-  writeFile(fullPath, content);
+// The marker is already present. Re-render a drifted managed block (#293), heal a
+// legacy `---#` separator artifact from safeword <=0.30.1, and/or persist a
+// supersede strip. `content` is post-supersede; `original` is the on-disk text.
+function healAlreadyPatchedFile(
+  fullPath: string,
+  original: string,
+  content: string,
+  definition: ResolvedTextPatch,
+): void {
+  // Re-renderable block (#293): when the resolved content has drifted from what's
+  // on disk (e.g. a custom paths.projectRoot was added), replace the managed block
+  // in place so existing installs heal on upgrade. A no-op when already current.
+  if (definition.rerender && !content.includes(definition.content)) {
+    writeFile(fullPath, stripRerenderBlock(content, definition) + definition.content);
+    return;
+  }
+  // Heal the bare-`---` separator that glued to a heading (`---# CLAUDE.md`) in
+  // files corrupted by past installs. Narrowly scoped: the marker proves we
+  // authored the block, and only the exact artifact is repaired.
+  let healed = content;
+  if (healed.includes('\n\n---#')) {
+    healed = healed.replaceAll('\n\n---#', '\n\n---\n\n#');
+  }
+  // Persist if a heal and/or supersede strip changed the file (the latter is rare
+  // here — a legacy block lingering alongside its replacement).
+  if (healed !== original) writeFile(fullPath, healed);
 }
 
 function computeUnpatchedContent(content: string, definition: ResolvedTextPatch): string {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -49,6 +49,12 @@ export interface TextPatchDefinition {
   // depend on the resolved namespace root (e.g. a custom paths.projectRoot, #293).
   content: string | ((ctx: ProjectContext) => string);
   marker: string; // Used to detect if already applied & for removal
+  // On apply, first remove this exact legacy block if present, then add `content`
+  // — a byte-exact, idempotent one-block swap for migrating a managed file (e.g.
+  // replacing a superseded SessionStart hook with its replacement) without a
+  // separate imperative path. A no-op when the block is absent; guarded by
+  // applyWhenContentIncludes so it only touches safeword-scaffolded files.
+  supersedes?: string;
   applyWhenContentIncludes?: string[]; // Optional guard for semi-owned config files
   unpatchContent?: string[]; // Additional exact blocks to remove on uninstall/reset
   removeFileIfContentEquals?: string[]; // Delete file only when remaining content is known scaffold
@@ -170,7 +176,7 @@ timeout = 5
 statusMessage = "Adding current timestamp"
 `;
 
-const CODEX_SESSION_START_HOOK_PATCH = `
+export const CODEX_SESSION_START_HOOK_PATCH = `
 [[hooks.SessionStart]]
 matcher = ""
 
@@ -181,7 +187,7 @@ timeout = 120
 statusMessage = "Checking safeword updates and loading standing instructions"
 `;
 
-const CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH = `
+export const CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH = `
 [[hooks.SessionStart]]
 matcher = ""
 
@@ -1109,6 +1115,28 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
           CODEX_PRE_TOOL_QUALITY_HOOK_PATCH,
         ],
         removeFileIfContentEquals: [CODEX_CONFIG_SCAFFOLD_WITHOUT_HOOKS],
+      },
+      // Migrate existing installs (auto-upgrade-codex follow-up to #433): swap the
+      // legacy context-only SessionStart hook for the auto-upgrade dispatcher.
+      // Codex runs same-event hooks concurrently with no ordering, so this must
+      // REPLACE the legacy hook (appending a second SessionStart hook would
+      // double-emit context) — hence `supersedes`. managedFiles is
+      // create-if-missing, so a fresh install gets the dispatcher from the
+      // template while every EXISTING config is skipped by managedFiles and
+      // migrated here. Idempotent: skips when the dispatcher marker is already
+      // present, and the strip no-ops when the legacy block is absent. Guarded to
+      // safeword scaffolds; a user-modified legacy block won't byte-match and is
+      // preserved. Uninstall cleanup is owned by the primary patch's
+      // unpatchContent above.
+      {
+        operation: 'append',
+        content: CODEX_SESSION_START_HOOK_PATCH,
+        marker: '.safeword/hooks/session-codex-start.ts',
+        supersedes: CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH,
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
       },
       // MCP-server retrofit (#269): add-if-missing parity with .mcp.json /
       // .cursor/mcp.json. Marker is the context7 table header, so an existing

--- a/packages/cli/tests/commands/upgrade-reconcile.test.ts
+++ b/packages/cli/tests/commands/upgrade-reconcile.test.ts
@@ -358,6 +358,57 @@ statusMessage = "Checking safeword PreToolUse gates"
       expect(timestampHookCount).toBe(1);
     });
 
+    it('migrates a customized legacy Codex config: swaps the context-only SessionStart hook for the auto-upgrade dispatcher', async () => {
+      const { reconcile } = await import('../../src/reconcile.js');
+      const { SAFEWORD_SCHEMA, CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH } =
+        await import('../../src/schema.js');
+      const { createProjectContext } = await import('../../src/utils/context.js');
+
+      createConfiguredProject('0.5.0');
+      mkdirSync(nodePath.join(temporaryDirectory, '.codex'), { recursive: true });
+      // An existing safeword Codex config — managedFiles is create-if-missing, so
+      // it skips an existing file (never overwrites) and the text-patch migration
+      // runs — still wired to the LEGACY context-only SessionStart hook from
+      // before auto-upgrade-codex.
+      const legacyConfig = `# Safeword Codex project configuration.
+#
+# Project-local Codex config loads only after the project is reviewed and trusted.
+
+[features]
+hooks = true
+${CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH}
+[[hooks.PreToolUse]]
+matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-quality.ts"'
+timeout = 30
+statusMessage = "Checking safeword PreToolUse gates"
+`;
+      writeFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), legacyConfig);
+
+      const ctx = createProjectContext(temporaryDirectory);
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const upgraded = readFileSync(
+        nodePath.join(temporaryDirectory, '.codex/config.toml'),
+        'utf8',
+      );
+      // Legacy context-only hook is gone; the auto-upgrade dispatcher is wired.
+      expect(upgraded).not.toContain('session-safeword-context.ts" --agent=codex');
+      expect(upgraded).toContain('.safeword/hooks/session-codex-start.ts');
+      // Exactly one SessionStart dispatcher — concurrent Codex hooks make a
+      // double-wire double-emit context, so the swap must not leave two.
+      expect(upgraded.split('.safeword/hooks/session-codex-start.ts').length - 1).toBe(1);
+
+      // Idempotent: re-running upgrade keeps exactly one dispatcher, no legacy.
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+      const again = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(again.split('.safeword/hooks/session-codex-start.ts').length - 1).toBe(1);
+      expect(again).not.toContain('session-safeword-context.ts" --agent=codex');
+    });
+
     it('should tell users to trust generated Codex hooks after upgrade creates Codex config', async () => {
       createConfiguredProject('0.5.0');
 


### PR DESCRIPTION
Fast-follow to #433 (Codex auto-upgrade) — closes the customized-existing-install migration gap that PR's review flagged.

## Problem
#433 added a Codex SessionStart auto-upgrade dispatcher (`session-codex-start.ts`). A customized `.codex/config.toml` is in `managedFiles` (rewritten only if it byte-matches the template), so on upgrade it's preserved — and the existing retrofit patches only *append* (timestamp, MCP). Nothing swapped the legacy `session-safeword-context.ts --agent=codex` SessionStart hook for the dispatcher, so customized installs kept context-only behavior and **silently never gained auto-upgrade**.

## Approach (decided via /figure-it-out)
The patch model was append/prepend-only — no way to swap a block. Two options: a one-off imperative migration, or a reusable declarative swap. Chose the reusable **`supersedes`** op because the sibling ticket **Y6HZR7 (auto-upgrade under Cursor, same epic BJX7WR)** needs the identical swap — a one-off would just be written twice.

## Changes
- **`TextPatchDefinition.supersedes?: string`** — on apply, byte-exact strip the named legacy block, then add `content`. Idempotent; guarded by `applyWhenContentIncludes` (safeword scaffolds only); persists on every `executeTextPatch` write path. A **no-op for all existing patches** (none set `supersedes`) → no regression.
- **Codex migration patch** — `supersedes: CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH` → `content: CODEX_SESSION_START_HOOK_PATCH`. Positioned after the primary patch so the unpatch file-removal ordering holds; uninstall cleanup is owned by the primary patch's `unpatchContent` (already lists both blocks).
- Extracted `healAlreadyPatchedFile` (keeps `executeTextPatch` under the complexity limit); exported the two block constants for the test.
- **Test** — a customized legacy config → upgrade swaps the legacy hook for the dispatcher (legacy gone, exactly one dispatcher), idempotent on re-run.

## Why replace, not append
Codex runs same-event SessionStart hooks **concurrently, no ordering** ([docs](https://developers.openai.com/codex/hooks)) — appending the dispatcher alongside the legacy hook would leave two SessionStart hooks both emitting SAFEWORD.md context. The swap must remove the legacy block.

## Edge cases
- Untouched legacy installs migrate via the `managedFiles` byte-overwrite (never hit this patch).
- A user-modified legacy block won't byte-match → preserved (dispatcher still added; rare, degrades to double-context, never a wedge).
- A user's own SessionStart hook is never clobbered (only the byte-matched safeword block is stripped).

Targeted tests green (upgrade-reconcile + setup-reconcile + schema, 61 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)