### PR TITLE
Run silent Cursor auto-upgrade at session start

### DIFF
--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -2,13 +2,13 @@
 id: Y6HZR7
 slug: auto-upgrade-cursor
 type: feature
-phase: intake
-status: blocked
+phase: verify
+status: in_progress
 epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
 created: 2026-06-20T12:54:31.933Z
-last_modified: 2026-06-25T06:00:00Z
+last_modified: 2026-06-25T23:45:00Z
 ---
 
 # Auto-upgrade under Cursor
@@ -17,11 +17,13 @@ last_modified: 2026-06-25T06:00:00Z
 
 **Parent:** [BJX7WR — cross-agent auto-upgrade](../BJX7WR-auto-upgrade-cross-agent/ticket.md)
 
-**Blocked on:** BJX7WR slice 0 landing — PR #433 or an equivalent shared-core extraction. The Cursor contract is now decided: silent `sessionStart` wrapper, exit `0`, git commit as record.
+**Implementation state:** PR #433 landed the shared core. This branch wires Cursor to that core with a silent `sessionStart` wrapper that exits `0`; the auto-upgrade git commit remains the durable record.
 
 ## Current state
 
-- `CURSOR_HOOKS.sessionStart` (`packages/cli/src/templates/config.ts`) runs only `session-safeword-context.ts --agent=cursor`. No auto-upgrade.
+- `CURSOR_HOOKS.sessionStart` (`packages/cli/src/templates/config.ts`) now runs:
+  - `session-safeword-context.ts --agent=cursor` for SAFEWORD.md context
+  - `session-cursor-auto-upgrade.ts` for silent auto-upgrade
 - Claude Code `SessionStart` wires `session-auto-upgrade.ts` through `asyncRewake`; that script intentionally exits `2` to surface upgraded / major-available / blocked messages back to Claude as a system reminder.
 - Cursor hooks do **not** have Claude Code's `asyncRewake` / exit-2 rewake messaging contract. Cursor's command-hook docs say exit `2` blocks the action, and non-zero failures otherwise fail-open unless `failClosed: true`.
 - Current Cursor docs say `sessionStart` is **fire-and-forget**: the agent loop does not wait for, block on, or enforce the response. The documented output is only `env` and `additional_context`; docs also say `continue` / `user_message` are accepted by schema but current callers do not enforce them, so session creation is not blocked even when `continue:false`.
@@ -43,13 +45,13 @@ Options considered:
 - **Build a Cursor-specific copy now: reject.** It would duplicate the apply logic the parent explicitly says to share.
 - **Update evidence and stay blocked on extraction: choose.** This preserves the parent design constraint and records the current Cursor docs needed for the eventual implementation.
 
-## Scope (pending epic design)
+## Scope
 
-- Wire a Cursor sessionStart entry that invokes the **shared apply core** (extracted in the epic's slice 0).
-- Apply silently: do the upgrade + commit-only-safeword-files; the git commit is the record (no exit-2 messaging on Cursor).
-- Confirm whether Cursor can run the hook non-blocking; if not, decide whether a bounded one-time apply (fires ≤ once/day, only when an upgrade is pending) is acceptable.
-- Reuse `.update-cache.json`, the 24h cooldown, strike counter, and git-state pre-flight unchanged (agent-agnostic).
-- Verify Claude Code behavior is untouched; update parity/coverage.
+- [x] Wire a Cursor sessionStart entry that invokes the shared apply core extracted in PR #433.
+- [x] Apply silently: do the upgrade + commit-only-safeword-files; the git commit is the record (no exit-2 messaging on Cursor).
+- [x] Keep the hook fail-open for Cursor session start; no `failClosed`, `continue:false`, `user_message`, or exit `2`.
+- [x] Reuse `.update-cache.json`, the 24h cooldown, strike counter, git-state pre-flight, and shared apply core unchanged.
+- [x] Verify Claude Code behavior is untouched by using a Cursor-only wrapper and focused setup/hook/schema tests.
 
 ## Open questions
 
@@ -61,3 +63,4 @@ Options considered:
 - 2026-06-25T05:50:00Z Revalidated under Cursor after `/figure-it-out`. Current Cursor hooks docs confirm `sessionStart` is fire-and-forget, `continue:false` / `user_message` are not enforced for session creation, exit `2` is a block path rather than a rewake message, and `failClosed` is for blocking hook failure policy only. Parent BJX7WR slice 0 is still missing: no shared apply core exists yet, so Y6HZR7 remains blocked. No implementation started.
 - 2026-06-25T05:55:00Z Parent design updated: Cursor should use a silent `sessionStart` wrapper around the shared apply core, exit `0`, and rely on the git auto-upgrade commit as the durable record. Remaining blocker is implementation slice 0: extract the shared apply core before wiring Cursor.
 - 2026-06-25T06:00:00Z Checked PR #433. It does not conflict with this ticket file, and it likely supplies the shared core this ticket needs. If #433 lands first, Y6HZR7 should proceed directly to a Cursor wrapper around `hooks/lib/auto-upgrade.ts`.
+- 2026-06-25T23:45:00Z Implemented Cursor wrapper on `cursor/y6hzr7-cursor-auto-upgrade-wrapper`: added `session-cursor-auto-upgrade.ts`, wired it as a second Cursor `sessionStart` command, registered it in schema/package/hook coverage, and added setup + integration tests. Focused tests green: 127/127.

--- a/.safeword/hooks/session-cursor-auto-upgrade.ts
+++ b/.safeword/hooks/session-cursor-auto-upgrade.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+// Safeword: Cursor silent auto-upgrade wrapper (sessionStart).
+//
+// Cursor's sessionStart hook is fire-and-forget: it has no Claude-style
+// asyncRewake message channel, and exit 2 is a block/error path. Run the shared
+// auto-upgrade core silently and always return success so startup never breaks.
+
+import process from 'node:process';
+
+import { runAutoUpgrade } from './lib/auto-upgrade.ts';
+import { filterSafewordFiles } from './lib/owned-paths.ts';
+import { readHookInput, resolveProjectDir } from './lib/safeword-context.ts';
+
+export async function runCursorAutoUpgrade(): Promise<number> {
+  const hookInput = await readHookInput();
+  const projectDir = resolveProjectDir(hookInput);
+
+  try {
+    await runAutoUpgrade({ projectDir, filterSafewordFiles });
+  } catch {
+    // Cursor has no reliable sessionStart notification channel. The next
+    // session retries through the shared core's normal gates.
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(await runCursorAutoUpgrade());
+}

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -607,6 +607,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/session-codex-start.ts': {
       template: 'hooks/session-codex-start.ts',
     },
+    '.safeword/hooks/session-cursor-auto-upgrade.ts': {
+      template: 'hooks/session-cursor-auto-upgrade.ts',
+    },
     '.safeword/hooks/session-dependency-readiness.ts': {
       template: 'hooks/session-dependency-readiness.ts',
     },

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -303,9 +303,12 @@ ${prettier.configEntry}
 // OBSERVATIONAL hooks are deliberately left fail-open (the default): a crashing
 // lint/state/nudge hook must never block legitimate work.
 export const CURSOR_HOOKS = {
-  // Observational: injects standing context. Fail-open — a failed inject must not
-  // block the session from starting.
-  sessionStart: [{ command: 'bun ./.safeword/hooks/session-safeword-context.ts --agent=cursor' }],
+  // Observational: injects standing context and checks for auto-upgrades.
+  // Fail-open — neither hook may block the session from starting.
+  sessionStart: [
+    { command: 'bun ./.safeword/hooks/session-safeword-context.ts --agent=cursor' },
+    { command: 'bun ./.safeword/hooks/session-cursor-auto-upgrade.ts' },
+  ],
   // NOTE (F2TKR3): there is deliberately NO beforeSubmitPrompt gate. That hook
   // fires at prompt-send time, where Cursor exposes only the prompt text — no tool
   // name or file path — so it cannot tell "create test-definitions.md" from "write

--- a/packages/cli/templates/hooks/session-cursor-auto-upgrade.ts
+++ b/packages/cli/templates/hooks/session-cursor-auto-upgrade.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+// Safeword: Cursor silent auto-upgrade wrapper (sessionStart).
+//
+// Cursor's sessionStart hook is fire-and-forget: it has no Claude-style
+// asyncRewake message channel, and exit 2 is a block/error path. Run the shared
+// auto-upgrade core silently and always return success so startup never breaks.
+
+import process from 'node:process';
+
+import { runAutoUpgrade } from './lib/auto-upgrade.ts';
+import { filterSafewordFiles } from './lib/owned-paths.ts';
+import { readHookInput, resolveProjectDir } from './lib/safeword-context.ts';
+
+export async function runCursorAutoUpgrade(): Promise<number> {
+  const hookInput = await readHookInput();
+  const projectDir = resolveProjectDir(hookInput);
+
+  try {
+    await runAutoUpgrade({ projectDir, filterSafewordFiles });
+  } catch {
+    // Cursor has no reliable sessionStart notification channel. The next
+    // session retries through the shared core's normal gates.
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(await runCursorAutoUpgrade());
+}

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -93,6 +93,9 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       );
       expect(fileExists(temporaryDirectory, '.safeword/hooks/cursor/stop.ts')).toBe(true);
       expect(fileExists(temporaryDirectory, '.safeword/hooks/cursor/gate-adapter.ts')).toBe(true);
+      expect(fileExists(temporaryDirectory, '.safeword/hooks/session-cursor-auto-upgrade.ts')).toBe(
+        true,
+      );
       expect(fileExists(temporaryDirectory, '.safeword/hooks/cursor/pre-tool-quality.ts')).toBe(
         true,
       );
@@ -114,6 +117,9 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       const hooksConfig = JSON.parse(readTestFile(temporaryDirectory, '.cursor/hooks.json'));
       expect(hooksConfig.hooks.sessionStart[0].command).toBe(
         'bun ./.safeword/hooks/session-safeword-context.ts --agent=cursor',
+      );
+      expect(hooksConfig.hooks.sessionStart[1].command).toBe(
+        'bun ./.safeword/hooks/session-cursor-auto-upgrade.ts',
       );
       expect(hooksConfig.hooks.afterFileEdit[0].command).toBe(
         'bun ./.safeword/hooks/cursor/after-file-edit.ts',
@@ -155,6 +161,7 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       // Observational hooks stay fail-open (default) — a crashing lint/state/nudge
       // hook must never block legitimate work.
       expect(hooksConfig.hooks.sessionStart[0].failClosed).toBeUndefined();
+      expect(hooksConfig.hooks.sessionStart[1].failClosed).toBeUndefined();
       expect(hooksConfig.hooks.afterFileEdit[0].failClosed).toBeUndefined();
       expect(hooksConfig.hooks.postToolUse[0].failClosed).toBeUndefined();
       expect(hooksConfig.hooks.stop[0].failClosed).toBeUndefined();

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -1315,3 +1315,18 @@ describe('session-codex-start.ts', () => {
     expect(output.hookSpecificOutput.additionalContext).toContain('## Workflow');
   });
 });
+
+describe('session-cursor-auto-upgrade.ts', () => {
+  it('runs silently and exits successfully when no upgrade should apply', () => {
+    const result = spawnSync('bun', ['.safeword/hooks/session-cursor-auto-upgrade.ts'], {
+      cwd: shared.projectDirectory,
+      env: { ...process.env, SAFEWORD_NO_AUTO_UPGRADE: '1' },
+      input: JSON.stringify({ workspace_root: shared.projectDirectory }),
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/packages/cli/tests/npm-package.test.ts
+++ b/packages/cli/tests/npm-package.test.ts
@@ -53,6 +53,7 @@ describe('NPM Package Structure', () => {
     // Session hooks
     expect(files).toContain('session-safeword-context.ts');
     expect(files).toContain('session-codex-start.ts');
+    expect(files).toContain('session-cursor-auto-upgrade.ts');
     expect(files).toContain('session-version.ts');
     expect(files).toContain('session-lint-check.ts');
 

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -517,6 +517,8 @@ describe('Schema - Single Source of Truth', () => {
       const NON_LIFECYCLE_HOOK_MODULES = new Set([
         // Codex-only dispatcher wired through .codex/config.toml, not Claude SETTINGS_HOOKS.
         'session-codex-start.ts',
+        // Cursor-only wrapper wired through .cursor/hooks.json, not Claude SETTINGS_HOOKS.
+        'session-cursor-auto-upgrade.ts',
         'write-review-stamp.ts',
         'resolve-namespace-root.ts',
         'record-skill-invocation.ts',

--- a/packages/cli/tests/smoke/hook-coverage.test.ts
+++ b/packages/cli/tests/smoke/hook-coverage.test.ts
@@ -36,6 +36,7 @@ const EXEMPT_HOOKS: Record<string, string> = {
   // Session/startup hooks fire at session start, not on tool calls.
   'session-safeword-context.ts': SESSION_STARTUP,
   'session-codex-start.ts': SESSION_STARTUP,
+  'session-cursor-auto-upgrade.ts': SESSION_STARTUP,
   'session-version.ts': SESSION_STARTUP,
   'session-lint-check.ts': SESSION_STARTUP,
   'session-compact-context.ts': SESSION_STARTUP,


### PR DESCRIPTION
## Summary
- Adds `session-cursor-auto-upgrade.ts`, a silent Cursor `sessionStart` wrapper around the shared auto-upgrade core from #433.
- Wires Cursor setup to run SAFEWORD.md context first, then silent auto-upgrade, both fail-open for startup safety.
- Registers the new hook in schema/package/hook coverage and updates Y6HZR7 to verification phase without marking it done.

## Test plan
- `bun run test -- tests/commands/setup-cursor.test.ts tests/integration/hooks.test.ts tests/hooks/auto-upgrade-core.test.ts tests/npm-package.test.ts tests/smoke/hook-coverage.test.ts tests/schema.test.ts src/templates/config.test.ts`


Made with [Cursor](https://cursor.com)