### PR TITLE
Fix ticket-system CLI resolver guidance

### DIFF
--- a/.agents/skills/ticket-system/SKILL.md
+++ b/.agents/skills/ticket-system/SKILL.md
@@ -13,9 +13,21 @@ allowed-tools: '*'
 
 **Namespace root:** Resolve from `paths.projectRoot` in `.safeword/config.json`; if unset, use `.project/` by default, falling back to legacy `.safeword-project/` only when that directory already exists. Substitute the resolved root in every path below.
 
-**Creating a ticket:** Run `safeword ticket new <slug>` (optionally with `--type=patch|task|feature` and `--title="..."`). The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches.
+**Creating a ticket:** Resolve the Safeword CLI locally first, then run `ticket new` through that resolver:
 
-**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by `safeword ticket new` (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
+```bash
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
+$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+```
+
+The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
 **Folder structure:**
 

--- a/.claude/skills/ticket-system/SKILL.md
+++ b/.claude/skills/ticket-system/SKILL.md
@@ -13,9 +13,21 @@ allowed-tools: '*'
 
 **Namespace root:** Resolve from `paths.projectRoot` in `.safeword/config.json`; if unset, use `.project/` by default, falling back to legacy `.safeword-project/` only when that directory already exists. Substitute the resolved root in every path below.
 
-**Creating a ticket:** Run `safeword ticket new <slug>` (optionally with `--type=patch|task|feature` and `--title="..."`). The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches.
+**Creating a ticket:** Resolve the Safeword CLI locally first, then run `ticket new` through that resolver:
 
-**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by `safeword ticket new` (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
+```bash
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
+$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+```
+
+The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
 **Folder structure:**
 

--- a/packages/cli/templates/skills/ticket-system/SKILL.md
+++ b/packages/cli/templates/skills/ticket-system/SKILL.md
@@ -13,9 +13,21 @@ allowed-tools: '*'
 
 **Namespace root:** Resolve from `paths.projectRoot` in `.safeword/config.json`; if unset, use `.project/` by default, falling back to legacy `.safeword-project/` only when that directory already exists. Substitute the resolved root in every path below.
 
-**Creating a ticket:** Run `safeword ticket new <slug>` (optionally with `--type=patch|task|feature` and `--title="..."`). The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches.
+**Creating a ticket:** Resolve the Safeword CLI locally first, then run `ticket new` through that resolver:
 
-**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by `safeword ticket new` (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
+```bash
+if [ -x node_modules/.bin/safeword ]; then
+  SW="node_modules/.bin/safeword"
+elif [ -f packages/cli/src/cli.ts ]; then
+  SW="bun packages/cli/src/cli.ts"
+else SW="bunx safeword"; fi
+
+$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+```
+
+The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
 **Folder structure:**
 

--- a/packages/cli/tests/skills/ticket-system-prompt.test.ts
+++ b/packages/cli/tests/skills/ticket-system-prompt.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for the ticket-system skill prompt (ticket 158, slice 6).
  *
  * Asserts that the find-max-and-increment guidance is gone and the new
- * `safeword ticket new` instruction is in place. Also walks every shipped
+ * local-first `safeword ticket new` resolver instruction is in place. Also walks every shipped
  * template under packages/cli/templates/ to guard against the same pattern
  * resurfacing elsewhere.
  *
@@ -52,8 +52,15 @@ describe('ticket-system SKILL.md (template)', () => {
     expect(readSkill().toLowerCase()).not.toContain('increment');
   });
 
-  it('references `safeword ticket new` as the way to create a ticket', () => {
-    expect(readSkill()).toContain('safeword ticket new');
+  it('documents the local-first resolver for `safeword ticket new`', () => {
+    const skill = readSkill();
+    expect(skill).toContain('if [ -x node_modules/.bin/safeword ]; then');
+    expect(skill).toContain('SW="node_modules/.bin/safeword"');
+    expect(skill).toContain('elif [ -f packages/cli/src/cli.ts ]; then');
+    expect(skill).toContain('SW="bun packages/cli/src/cli.ts"');
+    expect(skill).toContain('else SW="bunx safeword"; fi');
+    expect(skill).toContain('$SW ticket new <slug>');
+    expect(skill).not.toContain('`safeword ticket new');
   });
 
   it('documents the current ticket folder shape created by the CLI', () => {


### PR DESCRIPTION
## Summary
- Replace the ticket-system skill bare `safeword ticket new` guidance with the local-first resolver chain used by verify/audit
- Sync the `.claude` and `.agents` skill mirrors from the canonical template
- Extend the ticket-system prompt regression test to pin the resolver guidance and reject the bare backticked command form

Fixes #367

## Verification
- `cd packages/cli && npx vitest run tests/skills/ticket-system-prompt.test.ts`
- `bun scripts/parity-check.ts --mode=all`
- `bun scripts/parity-check.ts --mode=contracts-only`
- `bun --bun node_modules/.bin/eslint packages/cli/tests/skills/ticket-system-prompt.test.ts`
- `bun run --cwd packages/cli typecheck`
- staged guards: `bun scripts/check-nested-configs.ts`, version parity node check, `bun scripts/check-ticket-ids.ts`, `bun scripts/check-dogfood-direction.ts`, `node_modules/.bin/lint-staged`