### PR TITLE
Fix feature ticket frontmatter scaffold

### DIFF
--- a/packages/cli/src/utils/ticket-writer.ts
+++ b/packages/cli/src/utils/ticket-writer.ts
@@ -133,6 +133,13 @@ function renderTicketMarkdown(id: string, options: NewTicketOptions): string {
   const type = options.type ?? 'task';
   const now = (options.now ?? (() => new Date()))().toISOString();
   const title = options.title ?? options.slug;
+  const featureReadinessFrontmatter =
+    type === 'feature'
+      ? `scope:
+out_of_scope:
+done_when:
+`
+      : '';
 
   // Features keep motivation in spec.md's ## Intent (single source of truth)
   // and point there; tasks/patches have no spec.md, so they keep **Why:**.
@@ -147,7 +154,7 @@ slug: ${options.slug}
 type: ${type}
 phase: intake
 status: in_progress
-created: ${now}
+${featureReadinessFrontmatter}created: ${now}
 last_modified: ${now}
 ---
 

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -121,6 +121,27 @@ describe('safeword ticket new', () => {
   );
 
   it(
+    'feature tickets scaffold scenario-gate prerequisite frontmatter',
+    async () => {
+      await runCli(['ticket', 'new', 'auth-flow', '--type', 'feature'], {
+        cwd: temporaryDirectory,
+      });
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const ticketContent = readFileSync(
+        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
+        'utf8',
+      );
+
+      expect(ticketContent).toMatch(/^scope:\s*$/m);
+      expect(ticketContent).toMatch(/^out_of_scope:\s*$/m);
+      expect(ticketContent).toMatch(/^done_when:\s*$/m);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  it(
     'rejects invalid --type values with exit code 1',
     async () => {
       const result = await runCli(['ticket', 'new', 'foo', '--type', 'bogus'], {


### PR DESCRIPTION
## Summary
- scaffold `scope`, `out_of_scope`, and `done_when` placeholders for `ticket new --type feature`
- add command-level regression coverage for the generated `ticket.md`

Note: the placeholders are intentionally blank; existing readiness gates still treat blank values as missing until humans fill them in.

## Verification
- `bun run --cwd packages/cli build`
- `cd packages/cli && npx vitest run tests/utils/ticket-writer.test.ts tests/commands/ticket-new.test.ts`
- `bun --bun node_modules/.bin/eslint packages/cli/src/utils/ticket-writer.ts packages/cli/tests/commands/ticket-new.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun scripts/parity-check.ts --mode=all`
- `bun scripts/parity-check.ts --mode=contracts-only`
- package/marketplace version parity check
- `git diff --check`
- staged guards: `check-nested-configs`, `check-ticket-ids`, `check-dogfood-direction`, `lint-staged`

Fixes #384