### PR TITLE
Fix diff upgrade target version

### DIFF
--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -9,8 +9,9 @@ import nodePath from 'node:path';
 import { type Action, reconcile } from '../reconcile.js';
 import { SAFEWORD_SCHEMA } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
-import { exists, readFileSafe } from '../utils/fs.js';
-import { error, header, info, listItem, success } from '../utils/output.js';
+import { exists, readFileSafe, readJson } from '../utils/fs.js';
+import { error, header, info, listItem, success, warn } from '../utils/output.js';
+import { compareVersions } from '../utils/version.js';
 import { VERSION } from '../version.js';
 
 interface DiffOptions {
@@ -22,6 +23,69 @@ interface FileDiff {
   status: 'added' | 'modified' | 'unchanged';
   currentContent?: string;
   newContent?: string;
+}
+
+interface UpdateCache {
+  latestVersion?: unknown;
+}
+
+const REGISTRY_TIMEOUT_MS = 3000;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+function isComparableVersion(value: unknown): value is string {
+  return typeof value === 'string' && VERSION_PATTERN.test(value);
+}
+
+function newerOfCliAnd(candidate: string): string {
+  return compareVersions(VERSION, candidate) < 0 ? candidate : VERSION;
+}
+
+function readCachedTargetVersion(safewordDirectory: string): string | undefined {
+  const cachePath = nodePath.join(safewordDirectory, '.update-cache.json');
+  const cache = readJson(cachePath) as UpdateCache | undefined;
+  return isComparableVersion(cache?.latestVersion) ? cache.latestVersion : undefined;
+}
+
+async function fetchRegistryLatestVersion(
+  timeout = REGISTRY_TIMEOUT_MS,
+): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeout);
+
+  try {
+    const response = await fetch('https://registry.npmjs.org/safeword/latest', {
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+
+    const data = (await response.json()) as { version?: unknown };
+    return isComparableVersion(data.version) ? data.version : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function resolveDiffTargetVersion(safewordDirectory: string): Promise<string> {
+  const registryLatest = await fetchRegistryLatestVersion();
+  if (registryLatest !== undefined) return newerOfCliAnd(registryLatest);
+
+  const cachedLatest = readCachedTargetVersion(safewordDirectory);
+  if (cachedLatest !== undefined) return newerOfCliAnd(cachedLatest);
+
+  return VERSION;
+}
+
+function warnIfCliOlderThanProject(projectVersion: string, targetVersion: string): void {
+  if (!isComparableVersion(projectVersion)) return;
+  if (compareVersions(VERSION, projectVersion) >= 0) return;
+
+  const targetSpec = compareVersions(targetVersion, projectVersion) < 0 ? 'latest' : targetVersion;
+  warn(`CLI v${VERSION} is older than project v${projectVersion}.`);
+  warn(`Run \`bunx safeword@${targetSpec} diff\` for an accurate preview.`);
 }
 
 /**
@@ -190,9 +254,11 @@ export async function diff(options: DiffOptions): Promise<void> {
   // Read project version
   const versionPath = nodePath.join(safewordDirectory, 'version');
   const projectVersion = readFileSafe(versionPath)?.trim() ?? 'unknown';
+  const targetVersion = await resolveDiffTargetVersion(safewordDirectory);
+  warnIfCliOlderThanProject(projectVersion, targetVersion);
 
   header('Safeword Diff');
-  info(`Changes from v${projectVersion} → v${VERSION}`);
+  info(`Changes from v${projectVersion} → v${targetVersion}`);
 
   // Use reconcile with dryRun to compute changes
   const ctx = createProjectContext(cwd);

--- a/packages/cli/tests/commands/diff.test.ts
+++ b/packages/cli/tests/commands/diff.test.ts
@@ -4,8 +4,12 @@
  * Tests for `safeword diff` command.
  */
 
+import nodePath from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { VERSION } from '../../src/version.js';
 import {
   createConfiguredProject,
   createTemporaryDirectory,
@@ -25,6 +29,39 @@ describe('Test Suite 10: Diff', () => {
   afterEach(() => {
     removeTemporaryDirectory(temporaryDirectory);
   });
+
+  function writeUpdateCache(latestVersion: string): void {
+    writeTestFile(
+      temporaryDirectory,
+      '.safeword/.update-cache.json',
+      JSON.stringify({ latestVersion }),
+    );
+  }
+
+  function registryMockEnvironment(script: string): Record<string, string> {
+    writeTestFile(temporaryDirectory, 'mock-registry.mjs', script);
+    const mockPath = nodePath.join(temporaryDirectory, 'mock-registry.mjs');
+    return {
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${pathToFileURL(mockPath).href}`]
+        .filter(Boolean)
+        .join(' '),
+    };
+  }
+
+  function registryLatestEnvironment(latestVersion: string): Record<string, string> {
+    return registryMockEnvironment(`globalThis.fetch = async () => ({
+  ok: true,
+  json: async () => ({ version: ${JSON.stringify(latestVersion)} }),
+});
+`);
+  }
+
+  function registryFailureEnvironment(): Record<string, string> {
+    return registryMockEnvironment(`globalThis.fetch = async () => {
+  throw new Error('offline');
+};
+`);
+  }
 
   describe('Test 10.1: Shows summary by default', () => {
     it('should show file counts without full diff', async () => {
@@ -78,6 +115,48 @@ describe('Test Suite 10: Diff', () => {
       expect(result.stdout).toContain('1.0.0');
       // Should show transition (→ or similar)
       expect(result.stdout).toMatch(/→|->|to|from/);
+    });
+
+    it('uses the registry latest version as the upgrade target', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, '.safeword/version', '0.0.1');
+
+      const result = await runCli(['diff'], {
+        cwd: temporaryDirectory,
+        env: registryLatestEnvironment('999.0.0'),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Changes from v0.0.1 → v999.0.0');
+      expect(result.stdout).not.toContain(`→ v${VERSION}`);
+    });
+
+    it('falls back to the cached latest version when the registry is unavailable', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, '.safeword/version', '0.0.1');
+      writeUpdateCache('999.0.0');
+
+      const result = await runCli(['diff'], {
+        cwd: temporaryDirectory,
+        env: registryFailureEnvironment(),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Changes from v0.0.1 → v999.0.0');
+    });
+
+    it('warns when the project config is newer than the running CLI', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, '.safeword/version', '999.0.0');
+
+      const result = await runCli(['diff'], {
+        cwd: temporaryDirectory,
+        env: registryLatestEnvironment('999.1.0'),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(`CLI v${VERSION} is older than project v999.0.0`);
+      expect(result.stderr).toContain('bunx safeword@999.1.0 diff');
     });
   });
 


### PR DESCRIPTION
## Summary
- resolve `safeword diff` target version from npm registry latest, with `.safeword/.update-cache.json` fallback
- keep the displayed target from falling behind the running CLI version
- warn when the project config is newer than the local CLI and point users at `bunx safeword@<target> diff`
- add command-level regression tests for registry latest, cache fallback, and stale-local-CLI warning

## Verification
- `bun run --cwd packages/cli build`
- `cd packages/cli && npx vitest run tests/commands/diff.test.ts`
- `bun --bun node_modules/.bin/eslint packages/cli/src/commands/diff.ts packages/cli/tests/commands/diff.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun scripts/parity-check.ts --mode=all`
- `bun scripts/parity-check.ts --mode=contracts-only`
- package/marketplace version parity check
- `git diff --check` / `git diff --cached --check`
- staged guards: `check-nested-configs`, `check-ticket-ids`, `check-dogfood-direction`, `lint-staged`

Fixes #441