### PR TITLE
Fix check CLI version repair hint

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -10,6 +10,7 @@ import process from 'node:process';
 
 import { checkHealth, type HealthStatus, reportHealthSummary } from '../health.js';
 import { syncTickets } from '../ticket-sync/index.js';
+import { detectPackageManager } from '../utils/install.js';
 import { header, info, keyValue, success, warn } from '../utils/output.js';
 import { buildIndexConflictListMessage } from '../utils/ticket-index-warnings.js';
 import { isNewerVersion } from '../utils/version.js';
@@ -68,16 +69,51 @@ async function reportUpdateStatus(health: HealthStatus): Promise<void> {
   }
 }
 
+function isDigit(char: string): boolean {
+  return char >= '0' && char <= '9';
+}
+
+function isPackageVersionSpecChar(char: string): boolean {
+  return (
+    (char >= 'a' && char <= 'z') ||
+    (char >= 'A' && char <= 'Z') ||
+    isDigit(char) ||
+    char === '.' ||
+    char === '-' ||
+    char === '+'
+  );
+}
+
+function isSafePackageVersion(version: string): boolean {
+  if (version.length === 0 || !version.includes('.')) return false;
+  for (const char of version) {
+    if (!isPackageVersionSpecChar(char)) return false;
+  }
+  return true;
+}
+
 /**
  * Compare project version vs CLI version and report
  * @param health
  */
-function reportVersionMismatch(health: HealthStatus): void {
+function reportVersionMismatch(health: HealthStatus, cwd: string): void {
   if (!health.projectVersion) return;
 
   if (isNewerVersion(health.cliVersion, health.projectVersion)) {
     warn(`Project config (v${health.projectVersion}) is newer than CLI (v${health.cliVersion})`);
-    info('Consider upgrading the CLI');
+
+    if (!isSafePackageVersion(health.projectVersion)) {
+      warn(
+        'Project version is not safe to use in a package install command; inspect .safeword/version.',
+      );
+      return;
+    }
+
+    const pm = detectPackageManager(cwd);
+    const runSafewordUpgrade =
+      pm === 'bun' || pm === 'yarn' ? `${pm} run safeword upgrade` : `${pm} exec safeword upgrade`;
+    info('Update the project-local CLI first:');
+    info(`${pm} add -D safeword@${health.projectVersion} && ${runSafewordUpgrade}`);
   } else if (isNewerVersion(health.projectVersion, health.cliVersion)) {
     info(`\nUpgrade available for project config`);
     info(
@@ -143,7 +179,7 @@ export async function check(options: CheckOptions): Promise<void> {
     await reportUpdateStatus(health);
   }
 
-  reportVersionMismatch(health);
+  reportVersionMismatch(health, cwd);
   const hasIssues = reportHealthSummary(health);
 
   if (hasIssues) {

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -9,6 +9,7 @@ import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { VERSION } from '../../src/version.js';
 import {
   createConfiguredProject,
   createTemporaryDirectory,
@@ -80,6 +81,54 @@ describe('Test Suite 8: Health Check', () => {
       expect(result.exitCode).toBe(0);
       // Should mention available update or version difference
       expect(result.stdout.toLowerCase()).toMatch(/update|available|upgrade|newer/i);
+    });
+
+    it('prints a package-manager repair command when project config is newer than CLI', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, 'pnpm-lock.yaml', 'lockfileVersion: 9.0\n');
+      writeTestFile(temporaryDirectory, '.safeword/version', '999.0.0');
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(`Project config (v999.0.0) is newer than CLI (v${VERSION})`);
+      expect(result.stdout).toContain('pnpm add -D safeword@999.0.0 && pnpm exec safeword upgrade');
+    });
+
+    it('uses bun run for the Bun package-manager repair command', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, 'bun.lock', '');
+      writeTestFile(temporaryDirectory, '.safeword/version', '999.0.0');
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('bun add -D safeword@999.0.0 && bun run safeword upgrade');
+    });
+
+    it('uses yarn run for the Yarn package-manager repair command', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, 'yarn.lock', '');
+      writeTestFile(temporaryDirectory, '.safeword/version', '999.0.0');
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('yarn add -D safeword@999.0.0 && yarn run safeword upgrade');
+    });
+
+    it('does not print a shell command when project version is not a package version', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(temporaryDirectory, 'pnpm-lock.yaml', 'lockfileVersion: 9.0\n');
+      writeTestFile(temporaryDirectory, '.safeword/version', '999.0.0; echo owned');
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(
+        'Project version is not safe to use in a package install command',
+      );
+      expect(result.stdout).not.toContain('safeword@999.0.0; echo owned');
     });
   });
 


### PR DESCRIPTION
## Summary
- detect the project package manager when `safeword check` finds config newer than the CLI
- print an install-and-upgrade repair command for the detected package manager
- cover pnpm and Bun repair hints in `check` command tests

Fixes #386

## Verification
- `bun run --cwd packages/cli build`
- `cd packages/cli && npx vitest run tests/commands/check.test.ts`
- `bun --bun node_modules/.bin/eslint packages/cli/src/commands/check.ts packages/cli/tests/commands/check.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun scripts/parity-check.ts --mode=all`
- `bun scripts/parity-check.ts --mode=contracts-only`
- version parity guard (`packages/cli/package.json` vs `marketplace.json` `plugins[0].version`)
- `git diff --check`
- staged guards: `check-nested-configs`, `check-ticket-ids`, `check-dogfood-direction`, `lint-staged`