### PR TITLE
Fix ledger validation after rebase

### DIFF
--- a/.safeword/hooks/lib/ledger-git.ts
+++ b/.safeword/hooks/lib/ledger-git.ts
@@ -18,18 +18,9 @@ function git(cwd: string, args: string[], input?: string): string {
   }).trim();
 }
 
-function commitExists(cwd: string, sha: string): boolean {
+function resolveCommitSha(cwd: string, sha: string): string | undefined {
   try {
-    git(cwd, ['cat-file', '-e', `${sha}^{commit}`]);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function fullCommitSha(cwd: string, sha: string): string | undefined {
-  try {
-    return git(cwd, ['rev-parse', `${sha}^{commit}`]);
+    return git(cwd, ['rev-parse', '--verify', `${sha}^{commit}`]);
   } catch {
     return undefined;
   }
@@ -87,9 +78,7 @@ export function createLedgerShaResolver(cwd: string): LedgerShaResolver {
   }
 
   return (sha: string): LedgerShaResolution => {
-    if (!commitExists(cwd, sha)) return false;
-
-    const fullSha = fullCommitSha(cwd, sha);
+    const fullSha = resolveCommitSha(cwd, sha);
     if (!fullSha) return false;
     if (isAncestorOfHead(cwd, fullSha)) return fullSha;
 

--- a/.safeword/hooks/lib/ledger-git.ts
+++ b/.safeword/hooks/lib/ledger-git.ts
@@ -1,0 +1,103 @@
+// Git-backed SHA resolver for the done-gate annotation ledger.
+//
+// Rebase/amend rewrite commit IDs while preserving the patch. The ledger keeps
+// the old SHA annotation, so the done gate accepts it when the same patch is
+// reachable from HEAD under exactly one new commit ID.
+
+import { execFileSync } from 'node:child_process';
+
+export type LedgerShaResolution = string | false;
+export type LedgerShaResolver = (sha: string) => LedgerShaResolution;
+
+function git(cwd: string, args: string[], input?: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    input,
+    encoding: 'utf8',
+    stdio: input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitExists(cwd: string, sha: string): boolean {
+  try {
+    git(cwd, ['cat-file', '-e', `${sha}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fullCommitSha(cwd: string, sha: string): string | undefined {
+  try {
+    return git(cwd, ['rev-parse', `${sha}^{commit}`]);
+  } catch {
+    return undefined;
+  }
+}
+
+function isAncestorOfHead(cwd: string, sha: string): boolean {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', sha, 'HEAD'], {
+      cwd,
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function patchIdForCommit(cwd: string, sha: string): string | undefined {
+  try {
+    const patch = git(cwd, ['show', '--format=format:', '--patch', '--no-ext-diff', sha]);
+    const output = git(cwd, ['patch-id', '--stable'], patch);
+    return output.split(/\s+/)[0] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function allReachableCommits(cwd: string): string[] {
+  try {
+    const output = git(cwd, ['rev-list', '--no-merges', 'HEAD']);
+    return output === '' ? [] : output.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function buildReachablePatchMap(cwd: string): Map<string, string[]> {
+  const patchIdToCommits = new Map<string, string[]>();
+  for (const commit of allReachableCommits(cwd)) {
+    const patchId = patchIdForCommit(cwd, commit);
+    if (!patchId) continue;
+    const commits = patchIdToCommits.get(patchId) ?? [];
+    commits.push(commit);
+    patchIdToCommits.set(patchId, commits);
+  }
+  return patchIdToCommits;
+}
+
+export function createLedgerShaResolver(cwd: string): LedgerShaResolver {
+  let reachablePatchMap: Map<string, string[]> | undefined;
+
+  function patchMap(): Map<string, string[]> {
+    reachablePatchMap ??= buildReachablePatchMap(cwd);
+    return reachablePatchMap;
+  }
+
+  return (sha: string): LedgerShaResolution => {
+    if (!commitExists(cwd, sha)) return false;
+
+    const fullSha = fullCommitSha(cwd, sha);
+    if (!fullSha) return false;
+    if (isAncestorOfHead(cwd, fullSha)) return fullSha;
+
+    const stalePatchId = patchIdForCommit(cwd, fullSha);
+    if (!stalePatchId) return false;
+
+    const candidates = patchMap().get(stalePatchId) ?? [];
+    const [candidate] = candidates;
+    return candidates.length === 1 && candidate ? candidate : false;
+  };
+}

--- a/.safeword/hooks/lib/ledger-validation.ts
+++ b/.safeword/hooks/lib/ledger-validation.ts
@@ -1,7 +1,7 @@
 // Done-gate annotation ledger validator (ticket J7VBGJ, Rules 3 + 4).
-// Pure function over test-definitions.md content + an injected SHA-reachability
-// oracle. Returns { ok, errors[] }. The wiring layer in stop-quality.ts calls
-// the real `git cat-file -e <sha>^{commit}` to provide the oracle.
+// Pure function over test-definitions.md content + an injected SHA resolver.
+// Returns { ok, errors[] }. The wiring layer in stop-quality.ts provides a
+// Git-backed resolver that can canonicalize rebased commits.
 
 import {
   classifyAnnotation,
@@ -15,6 +15,9 @@ export interface LedgerValidationResult {
   ok: boolean;
   errors: string[];
 }
+
+export type ShaResolution = boolean | string;
+export type ShaResolver = (sha: string) => ShaResolution;
 
 interface ScenarioLedger {
   name: string;
@@ -64,24 +67,30 @@ function parseLedger(content: string): {
  */
 function checkSha(
   value: string,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   label: string,
-): { error: string; format: boolean } | null {
+): { error?: string; format: boolean; canonicalSha?: string } {
   if (!isValidSha(value)) {
     return {
       error: `${label}: "${value}" is not a valid commit SHA (expected 7-40 hex chars).`,
       format: true,
     };
   }
-  if (!isReachable(value)) {
+
+  const resolution = resolveSha(value);
+  if (resolution === false) {
     return { error: `${label}: SHA ${value} is not reachable from HEAD.`, format: false };
   }
-  return null;
+
+  return {
+    format: false,
+    canonicalSha: resolution === true ? value : resolution,
+  };
 }
 
 function validateScenario(
   scenario: ScenarioLedger,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   errors: string[],
 ): void {
   const steps: Array<{ name: string; box?: CheckboxAnnotation }> = [
@@ -115,18 +124,19 @@ function validateScenario(
 
     // SHA candidate
     realShaCount++;
-    const problem = checkSha(kind.value, isReachable, `Scenario "${scenario.name}" ${step.name}`);
-    if (problem) {
-      errors.push(problem.error);
-      if (problem.format) continue; // malformed — don't track it for collisions
+    const checkedSha = checkSha(kind.value, resolveSha, `Scenario "${scenario.name}" ${step.name}`);
+    if (checkedSha.error) {
+      errors.push(checkedSha.error);
+      if (checkedSha.format) continue; // malformed — don't track it for collisions
     }
-    const existingStep = shaToStep.get(kind.value);
+    if (!checkedSha.canonicalSha) continue;
+    const existingStep = shaToStep.get(checkedSha.canonicalSha);
     if (existingStep) {
       errors.push(
-        `Scenario "${scenario.name}" SHA collision: ${existingStep} and ${step.name} share SHA ${kind.value}. Each TDD step must correspond to a distinct commit.`,
+        `Scenario "${scenario.name}" SHA collision: ${existingStep} and ${step.name} share SHA ${checkedSha.canonicalSha}. Each TDD step must correspond to a distinct commit.`,
       );
     } else {
-      shaToStep.set(kind.value, step.name);
+      shaToStep.set(checkedSha.canonicalSha, step.name);
     }
   }
 
@@ -139,7 +149,7 @@ function validateScenario(
 
 function validateCrossScenario(
   cs: CheckboxAnnotation | undefined,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   errors: string[],
 ): void {
   if (!cs) {
@@ -169,8 +179,8 @@ function validateCrossScenario(
   }
 
   if (kind.kind === 'sha') {
-    const problem = checkSha(kind.value, isReachable, 'Cross-scenario refactor row');
-    if (problem) errors.push(problem.error);
+    const checkedSha = checkSha(kind.value, resolveSha, 'Cross-scenario refactor row');
+    if (checkedSha.error) errors.push(checkedSha.error);
   }
 }
 
@@ -200,15 +210,12 @@ function wholeTicketPassFromScenarios(scenarios: ScenarioLedger[]): boolean {
   return scenarios.length >= 2 && hasAnyAnnotation;
 }
 
-export function validateLedger(
-  content: string,
-  isReachable: (sha: string) => boolean,
-): LedgerValidationResult {
+export function validateLedger(content: string, resolveSha: ShaResolver): LedgerValidationResult {
   const errors: string[] = [];
   const { scenarios, crossScenario } = parseLedger(content);
 
   for (const scenario of scenarios) {
-    validateScenario(scenario, isReachable, errors);
+    validateScenario(scenario, resolveSha, errors);
   }
 
   // Cross-scenario row enforcement: required iff the whole-ticket pass applies
@@ -216,7 +223,7 @@ export function validateLedger(
   // (back-compat: a present row is always validated). Pure-legacy and single-loop
   // tickets stay exempt.
   if (wholeTicketPassFromScenarios(scenarios) || crossScenario) {
-    validateCrossScenario(crossScenario, isReachable, errors);
+    validateCrossScenario(crossScenario, resolveSha, errors);
   }
 
   return { ok: errors.length === 0, errors };

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -3,7 +3,6 @@
 // Triggers quality review when edit tools (Write/Edit/MultiEdit/NotebookEdit) are used
 // Phase-aware: reads ticket phase for context-appropriate review questions
 
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 import {
@@ -16,6 +15,7 @@ import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependen
 import { checkVerifyArtifact } from './lib/done-gate.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
+import { createLedgerShaResolver } from './lib/ledger-git.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
 import {
   AUTHOR_MODEL_ENV,
@@ -596,21 +596,7 @@ if (currentPhase === 'done') {
   // refactor row present and valid when the whole-ticket pass applies (≥2 annotated
   // loops). Pure-legacy and single-loop tickets are exempt inside validateLedger.
   if (ledgerContent !== undefined) {
-    const isReachable = (sha: string): boolean => {
-      try {
-        // execFileSync (no shell) — sha is a file-derived annotation value;
-        // passing it as an arg, not interpolated into a shell string, closes
-        // the command-injection sink (ledger-validation also rejects non-hex).
-        execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], {
-          cwd: projectDir,
-          stdio: 'pipe',
-        });
-        return true;
-      } catch {
-        return false;
-      }
-    };
-    const validation = validateLedger(ledgerContent, isReachable);
+    const validation = validateLedger(ledgerContent, createLedgerShaResolver(projectDir));
     if (!validation.ok) {
       recordFailure(projectDir, input.session_id, 'done-gate-ledger-invalid');
       hardBlockDone(

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -585,6 +585,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     },
     '.safeword/hooks/lib/review-trigger.ts': { template: 'hooks/lib/review-trigger.ts' },
     '.safeword/hooks/lib/dogfood.ts': { template: 'hooks/lib/dogfood.ts' },
+    '.safeword/hooks/lib/ledger-git.ts': { template: 'hooks/lib/ledger-git.ts' },
     '.safeword/hooks/lib/ledger-validation.ts': { template: 'hooks/lib/ledger-validation.ts' },
     '.safeword/hooks/lib/scenario-format.ts': { template: 'hooks/lib/scenario-format.ts' },
     '.safeword/hooks/lib/test-runner.ts': { template: 'hooks/lib/test-runner.ts' },

--- a/packages/cli/templates/hooks/lib/ledger-git.ts
+++ b/packages/cli/templates/hooks/lib/ledger-git.ts
@@ -18,18 +18,9 @@ function git(cwd: string, args: string[], input?: string): string {
   }).trim();
 }
 
-function commitExists(cwd: string, sha: string): boolean {
+function resolveCommitSha(cwd: string, sha: string): string | undefined {
   try {
-    git(cwd, ['cat-file', '-e', `${sha}^{commit}`]);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function fullCommitSha(cwd: string, sha: string): string | undefined {
-  try {
-    return git(cwd, ['rev-parse', `${sha}^{commit}`]);
+    return git(cwd, ['rev-parse', '--verify', `${sha}^{commit}`]);
   } catch {
     return undefined;
   }
@@ -87,9 +78,7 @@ export function createLedgerShaResolver(cwd: string): LedgerShaResolver {
   }
 
   return (sha: string): LedgerShaResolution => {
-    if (!commitExists(cwd, sha)) return false;
-
-    const fullSha = fullCommitSha(cwd, sha);
+    const fullSha = resolveCommitSha(cwd, sha);
     if (!fullSha) return false;
     if (isAncestorOfHead(cwd, fullSha)) return fullSha;
 

--- a/packages/cli/templates/hooks/lib/ledger-git.ts
+++ b/packages/cli/templates/hooks/lib/ledger-git.ts
@@ -1,0 +1,103 @@
+// Git-backed SHA resolver for the done-gate annotation ledger.
+//
+// Rebase/amend rewrite commit IDs while preserving the patch. The ledger keeps
+// the old SHA annotation, so the done gate accepts it when the same patch is
+// reachable from HEAD under exactly one new commit ID.
+
+import { execFileSync } from 'node:child_process';
+
+export type LedgerShaResolution = string | false;
+export type LedgerShaResolver = (sha: string) => LedgerShaResolution;
+
+function git(cwd: string, args: string[], input?: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    input,
+    encoding: 'utf8',
+    stdio: input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitExists(cwd: string, sha: string): boolean {
+  try {
+    git(cwd, ['cat-file', '-e', `${sha}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fullCommitSha(cwd: string, sha: string): string | undefined {
+  try {
+    return git(cwd, ['rev-parse', `${sha}^{commit}`]);
+  } catch {
+    return undefined;
+  }
+}
+
+function isAncestorOfHead(cwd: string, sha: string): boolean {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', sha, 'HEAD'], {
+      cwd,
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function patchIdForCommit(cwd: string, sha: string): string | undefined {
+  try {
+    const patch = git(cwd, ['show', '--format=format:', '--patch', '--no-ext-diff', sha]);
+    const output = git(cwd, ['patch-id', '--stable'], patch);
+    return output.split(/\s+/)[0] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function allReachableCommits(cwd: string): string[] {
+  try {
+    const output = git(cwd, ['rev-list', '--no-merges', 'HEAD']);
+    return output === '' ? [] : output.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function buildReachablePatchMap(cwd: string): Map<string, string[]> {
+  const patchIdToCommits = new Map<string, string[]>();
+  for (const commit of allReachableCommits(cwd)) {
+    const patchId = patchIdForCommit(cwd, commit);
+    if (!patchId) continue;
+    const commits = patchIdToCommits.get(patchId) ?? [];
+    commits.push(commit);
+    patchIdToCommits.set(patchId, commits);
+  }
+  return patchIdToCommits;
+}
+
+export function createLedgerShaResolver(cwd: string): LedgerShaResolver {
+  let reachablePatchMap: Map<string, string[]> | undefined;
+
+  function patchMap(): Map<string, string[]> {
+    reachablePatchMap ??= buildReachablePatchMap(cwd);
+    return reachablePatchMap;
+  }
+
+  return (sha: string): LedgerShaResolution => {
+    if (!commitExists(cwd, sha)) return false;
+
+    const fullSha = fullCommitSha(cwd, sha);
+    if (!fullSha) return false;
+    if (isAncestorOfHead(cwd, fullSha)) return fullSha;
+
+    const stalePatchId = patchIdForCommit(cwd, fullSha);
+    if (!stalePatchId) return false;
+
+    const candidates = patchMap().get(stalePatchId) ?? [];
+    const [candidate] = candidates;
+    return candidates.length === 1 && candidate ? candidate : false;
+  };
+}

--- a/packages/cli/templates/hooks/lib/ledger-validation.ts
+++ b/packages/cli/templates/hooks/lib/ledger-validation.ts
@@ -1,7 +1,7 @@
 // Done-gate annotation ledger validator (ticket J7VBGJ, Rules 3 + 4).
-// Pure function over test-definitions.md content + an injected SHA-reachability
-// oracle. Returns { ok, errors[] }. The wiring layer in stop-quality.ts calls
-// the real `git cat-file -e <sha>^{commit}` to provide the oracle.
+// Pure function over test-definitions.md content + an injected SHA resolver.
+// Returns { ok, errors[] }. The wiring layer in stop-quality.ts provides a
+// Git-backed resolver that can canonicalize rebased commits.
 
 import {
   classifyAnnotation,
@@ -15,6 +15,9 @@ export interface LedgerValidationResult {
   ok: boolean;
   errors: string[];
 }
+
+export type ShaResolution = boolean | string;
+export type ShaResolver = (sha: string) => ShaResolution;
 
 interface ScenarioLedger {
   name: string;
@@ -64,24 +67,30 @@ function parseLedger(content: string): {
  */
 function checkSha(
   value: string,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   label: string,
-): { error: string; format: boolean } | null {
+): { error?: string; format: boolean; canonicalSha?: string } {
   if (!isValidSha(value)) {
     return {
       error: `${label}: "${value}" is not a valid commit SHA (expected 7-40 hex chars).`,
       format: true,
     };
   }
-  if (!isReachable(value)) {
+
+  const resolution = resolveSha(value);
+  if (resolution === false) {
     return { error: `${label}: SHA ${value} is not reachable from HEAD.`, format: false };
   }
-  return null;
+
+  return {
+    format: false,
+    canonicalSha: resolution === true ? value : resolution,
+  };
 }
 
 function validateScenario(
   scenario: ScenarioLedger,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   errors: string[],
 ): void {
   const steps: Array<{ name: string; box?: CheckboxAnnotation }> = [
@@ -115,18 +124,19 @@ function validateScenario(
 
     // SHA candidate
     realShaCount++;
-    const problem = checkSha(kind.value, isReachable, `Scenario "${scenario.name}" ${step.name}`);
-    if (problem) {
-      errors.push(problem.error);
-      if (problem.format) continue; // malformed — don't track it for collisions
+    const checkedSha = checkSha(kind.value, resolveSha, `Scenario "${scenario.name}" ${step.name}`);
+    if (checkedSha.error) {
+      errors.push(checkedSha.error);
+      if (checkedSha.format) continue; // malformed — don't track it for collisions
     }
-    const existingStep = shaToStep.get(kind.value);
+    if (!checkedSha.canonicalSha) continue;
+    const existingStep = shaToStep.get(checkedSha.canonicalSha);
     if (existingStep) {
       errors.push(
-        `Scenario "${scenario.name}" SHA collision: ${existingStep} and ${step.name} share SHA ${kind.value}. Each TDD step must correspond to a distinct commit.`,
+        `Scenario "${scenario.name}" SHA collision: ${existingStep} and ${step.name} share SHA ${checkedSha.canonicalSha}. Each TDD step must correspond to a distinct commit.`,
       );
     } else {
-      shaToStep.set(kind.value, step.name);
+      shaToStep.set(checkedSha.canonicalSha, step.name);
     }
   }
 
@@ -139,7 +149,7 @@ function validateScenario(
 
 function validateCrossScenario(
   cs: CheckboxAnnotation | undefined,
-  isReachable: (sha: string) => boolean,
+  resolveSha: ShaResolver,
   errors: string[],
 ): void {
   if (!cs) {
@@ -169,8 +179,8 @@ function validateCrossScenario(
   }
 
   if (kind.kind === 'sha') {
-    const problem = checkSha(kind.value, isReachable, 'Cross-scenario refactor row');
-    if (problem) errors.push(problem.error);
+    const checkedSha = checkSha(kind.value, resolveSha, 'Cross-scenario refactor row');
+    if (checkedSha.error) errors.push(checkedSha.error);
   }
 }
 
@@ -200,15 +210,12 @@ function wholeTicketPassFromScenarios(scenarios: ScenarioLedger[]): boolean {
   return scenarios.length >= 2 && hasAnyAnnotation;
 }
 
-export function validateLedger(
-  content: string,
-  isReachable: (sha: string) => boolean,
-): LedgerValidationResult {
+export function validateLedger(content: string, resolveSha: ShaResolver): LedgerValidationResult {
   const errors: string[] = [];
   const { scenarios, crossScenario } = parseLedger(content);
 
   for (const scenario of scenarios) {
-    validateScenario(scenario, isReachable, errors);
+    validateScenario(scenario, resolveSha, errors);
   }
 
   // Cross-scenario row enforcement: required iff the whole-ticket pass applies
@@ -216,7 +223,7 @@ export function validateLedger(
   // (back-compat: a present row is always validated). Pure-legacy and single-loop
   // tickets stay exempt.
   if (wholeTicketPassFromScenarios(scenarios) || crossScenario) {
-    validateCrossScenario(crossScenario, isReachable, errors);
+    validateCrossScenario(crossScenario, resolveSha, errors);
   }
 
   return { ok: errors.length === 0, errors };

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -3,7 +3,6 @@
 // Triggers quality review when edit tools (Write/Edit/MultiEdit/NotebookEdit) are used
 // Phase-aware: reads ticket phase for context-appropriate review questions
 
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 import {
@@ -16,6 +15,7 @@ import { formatDependencyRecovery, getDependencyReadiness } from './lib/dependen
 import { checkVerifyArtifact } from './lib/done-gate.ts';
 import { findNextWork, updateTicketStatus } from './lib/hierarchy.ts';
 import { hasCitation, parseImplPlan, sectionBody } from './lib/impl-plan.ts';
+import { createLedgerShaResolver } from './lib/ledger-git.ts';
 import { validateLedger, wholeTicketPassApplies } from './lib/ledger-validation.ts';
 import {
   AUTHOR_MODEL_ENV,
@@ -596,21 +596,7 @@ if (currentPhase === 'done') {
   // refactor row present and valid when the whole-ticket pass applies (≥2 annotated
   // loops). Pure-legacy and single-loop tickets are exempt inside validateLedger.
   if (ledgerContent !== undefined) {
-    const isReachable = (sha: string): boolean => {
-      try {
-        // execFileSync (no shell) — sha is a file-derived annotation value;
-        // passing it as an arg, not interpolated into a shell string, closes
-        // the command-injection sink (ledger-validation also rejects non-hex).
-        execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], {
-          cwd: projectDir,
-          stdio: 'pipe',
-        });
-        return true;
-      } catch {
-        return false;
-      }
-    };
-    const validation = validateLedger(ledgerContent, isReachable);
+    const validation = validateLedger(ledgerContent, createLedgerShaResolver(projectDir));
     if (!validation.ok) {
       recordFailure(projectDir, input.session_id, 'done-gate-ledger-invalid');
       hardBlockDone(

--- a/packages/cli/tests/hooks/ledger-validation.test.ts
+++ b/packages/cli/tests/hooks/ledger-validation.test.ts
@@ -1,18 +1,27 @@
 /**
  * Unit tests for the done-gate annotation ledger validator (ticket J7VBGJ,
  * Rules 3 + 4). Pure function over test-definitions.md content + an injected
- * SHA-reachability oracle (so tests don't need real git).
+ * SHA resolver (so most tests don't need real git).
  *
- * Returns { ok, errors[] }. The wiring layer in stop-quality.ts calls the
- * real `git cat-file -e <sha>^{commit}` to provide the oracle.
+ * Returns { ok, errors[] }. The wiring layer in stop-quality.ts provides a
+ * Git-backed resolver for real commit reachability and rebase fallback.
  */
+
+import { execSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
+import { createLedgerShaResolver } from '../../templates/hooks/lib/ledger-git.js';
 import {
   validateLedger,
   wholeTicketPassApplies,
 } from '../../templates/hooks/lib/ledger-validation.js';
+import {
+  createTemporaryDirectory,
+  initGitRepo,
+  removeTemporaryDirectory,
+  writeTestFile,
+} from '../helpers.js';
 
 const allReachable = (_sha: string) => true;
 
@@ -114,6 +123,25 @@ describe('validateLedger — Rule 3 (per-scenario SHA validity)', () => {
     expect(result.ok).toBe(false);
     expect(result.errors.join('\n')).toContain('foo');
     expect(result.errors.join('\n')).toMatch(/colli[sz]/i);
+  });
+
+  it('Scenario T2b: RED and GREEN resolving to the same canonical SHA fails', () => {
+    const c = content(
+      [
+        '### Scenario: foo',
+        '',
+        '- [x] RED abc1234',
+        '- [x] GREEN def5678',
+        '- [x] REFACTOR 9abcdef',
+      ].join('\n'),
+    );
+    const result = validateLedger(c, sha =>
+      sha === 'abc1234' || sha === 'def5678' ? 'aaaa1111' : sha,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('foo');
+    expect(result.errors.join('\n')).toMatch(/colli[sz]/i);
+    expect(result.errors.join('\n')).toContain('aaaa1111');
   });
 
   it('Scenario T3: SHA unreachable from HEAD fails, naming the SHA', () => {
@@ -406,5 +434,79 @@ describe('validateLedger — legacy compatibility', () => {
     );
     const result = validateLedger(c, allReachable);
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateLedger — rebased SHA compatibility', () => {
+  it('accepts a ledger SHA when its patch is reachable under a new rebased SHA', () => {
+    const projectDirectory = createTemporaryDirectory();
+    try {
+      initGitRepo(projectDirectory);
+      execSync('git checkout -q -b main', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'base.txt', 'base\n');
+      execSync('git add base.txt && git commit -q -m base', { cwd: projectDirectory });
+
+      execSync('git switch -q -c feature', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'work.txt', 'feature work\n');
+      execSync('git add work.txt && git commit -q -m red-step', { cwd: projectDirectory });
+      const oldSha = execSync('git rev-parse HEAD', { cwd: projectDirectory }).toString().trim();
+
+      execSync('git switch -q main', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'main.txt', 'main work\n');
+      execSync('git add main.txt && git commit -q -m main-step', { cwd: projectDirectory });
+
+      execSync('git switch -q feature && git rebase -q main', { cwd: projectDirectory });
+      const newSha = execSync('git rev-parse HEAD', { cwd: projectDirectory }).toString().trim();
+      expect(newSha).not.toBe(oldSha);
+
+      const ledger = content(
+        [
+          '### Scenario: survives rebase',
+          '',
+          `- [x] RED ${oldSha}`,
+          '- [x] GREEN skip: not needed for this regression',
+          '- [x] REFACTOR skip: not needed for this regression',
+        ].join('\n'),
+        '- [x] cross-scenario skip: single-loop ticket',
+      );
+      const resolver = createLedgerShaResolver(projectDirectory);
+
+      expect(validateLedger(ledger, resolver)).toEqual({ ok: true, errors: [] });
+      expect(resolver(oldSha)).toBe(newSha);
+    } finally {
+      removeTemporaryDirectory(projectDirectory);
+    }
+  });
+
+  it('rejects a stale ledger SHA when its patch-id matches multiple reachable commits', () => {
+    const projectDirectory = createTemporaryDirectory();
+    try {
+      initGitRepo(projectDirectory);
+      execSync('git checkout -q -b main', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'base.txt', 'base\n');
+      execSync('git add base.txt && git commit -q -m base', { cwd: projectDirectory });
+
+      execSync('git switch -q -c feature', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'work.txt', 'same patch\n');
+      execSync('git add work.txt && git commit -q -m stale-step', { cwd: projectDirectory });
+      const oldSha = execSync('git rev-parse HEAD', { cwd: projectDirectory }).toString().trim();
+
+      execSync('git switch -q main', { cwd: projectDirectory });
+      writeTestFile(projectDirectory, 'work.txt', 'same patch\n');
+      execSync('git add work.txt && git commit -q -m first-matching-patch', {
+        cwd: projectDirectory,
+      });
+      execSync('git rm -q work.txt && git commit -q -m remove-first-patch', {
+        cwd: projectDirectory,
+      });
+
+      execSync('git switch -q feature && git rebase -q --reapply-cherry-picks main', {
+        cwd: projectDirectory,
+      });
+      const resolver = createLedgerShaResolver(projectDirectory);
+      expect(resolver(oldSha)).toBe(false);
+    } finally {
+      removeTemporaryDirectory(projectDirectory);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add a Git-backed ledger SHA resolver that accepts rebased/amended commits when their stable patch-id maps to exactly one reachable commit
- canonicalize resolved SHAs before per-scenario collision checks so rewritten duplicate steps still fail closed
- install the new hook helper through the schema and mirror it into dogfood config

Fixes #281

## Verification
- cd packages/cli && npx vitest run tests/hooks/ledger-validation.test.ts tests/integration/whole-ticket-quality-refactor.test.ts
- bun run --cwd packages/cli typecheck
- bun scripts/parity-check.ts --mode=all
- bun scripts/parity-check.ts --mode=contracts-only
- bun --bun node_modules/.bin/eslint --no-warn-ignored packages/cli/templates/hooks/lib/ledger-git.ts packages/cli/templates/hooks/lib/ledger-validation.ts packages/cli/templates/hooks/stop-quality.ts packages/cli/src/schema.ts packages/cli/tests/hooks/ledger-validation.test.ts
- git diff --check
- push schema-drift hook: 624 tests passed

Note: node_modules/.bin/lint-staged still hits the known Node-based safeword/eslint resolver failure in this container; the required Bun ESLint guard above passed.