### PR TITLE
Add eval and verification lane guides

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -307,6 +307,8 @@ it('preserves user input after validation error');
 | Need                             | Action                                            |
 | -------------------------------- | ------------------------------------------------- |
 | Full test type selection guide   | `.safeword/guides/testing-guide.md`               |
+| Smoke/live/release lane guidance | `.safeword/guides/verification-lanes-guide.md`    |
+| LLM eval design guide            | `.safeword/guides/llm-evals-guide.md`             |
 | Test definition template (BDD)   | `.safeword/templates/test-definitions-feature.md` |
 | Test quality review              | `/audit`                                          |
 | Feature-level TDD with scenarios | `/bdd`                                            |

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -307,6 +307,8 @@ it('preserves user input after validation error');
 | Need                             | Action                                            |
 | -------------------------------- | ------------------------------------------------- |
 | Full test type selection guide   | `.safeword/guides/testing-guide.md`               |
+| Smoke/live/release lane guidance | `.safeword/guides/verification-lanes-guide.md`    |
+| LLM eval design guide            | `.safeword/guides/llm-evals-guide.md`             |
 | Test definition template (BDD)   | `.safeword/templates/test-definitions-feature.md` |
 | Test quality review              | `/audit`                                          |
 | Feature-level TDD with scenarios | `/bdd`                                            |

--- a/.safeword/guides/llm-evals-guide.md
+++ b/.safeword/guides/llm-evals-guide.md
@@ -1,0 +1,485 @@
+# LLM Evals Guide
+
+How to evaluate AI features: deterministic checks, datasets, rubrics,
+LLM-as-judge, pairwise comparisons, cost, and failure triage.
+
+---
+
+## Core Idea
+
+LLM evals test whether an AI system produces acceptable outputs for real tasks.
+They are behavior tests for probabilistic systems.
+
+Use evals when normal assertions cannot fully capture quality:
+
+- Reasoning quality
+- Factuality against provided context
+- Extraction or classification quality
+- Summarization quality
+- Tool choice and tool-use discipline
+- Retrieval quality
+- Tone, style, or policy adherence
+- Safety, refusal, or escalation behavior
+
+Do not use evals for deterministic behavior that normal tests can prove faster.
+
+```text
+JSON parses and matches schema     → normal unit/integration assertion
+API returns 401 without API key    → integration test
+Button opens the dialog            → E2E test
+Summary preserves key obligations  → eval
+Agent chooses the right tool       → eval or trace eval
+```
+
+---
+
+## Eval Decision Tree
+
+Answer in order. Stop at the first match.
+
+1. **Can a normal deterministic test fully prove the behavior?**
+   - YES → Use unit, integration, E2E, or migration coverage instead
+   - NO → Continue
+
+2. **Can a deterministic eval assertion prove part of the AI output contract?**
+   - YES → Add that assertion before any model-graded scorer
+   - NO → Continue
+
+3. **Is there a known correct output, label, or fact set?**
+   - YES → Use reference-based evals
+   - NO → Continue
+
+4. **Is it easier to compare two outputs than score one output absolutely?**
+   - YES → Use pairwise evals
+   - NO → Continue
+
+5. **Is the desired quality subjective but describable?**
+   - YES → Use rubric-based LLM-as-judge evals
+   - NO → Continue
+
+6. **Does the behavior involve multiple steps, tools, retrieval, or agents?**
+   - YES → Use trace or trajectory evals
+   - NO → Write the missing acceptance criteria before creating the eval
+
+**Tie-breaker:** deterministic checks first, reference-based checks second,
+LLM-as-judge last. Model-graded evals are powerful but add cost, latency, and
+grader failure modes.
+
+---
+
+## Eval Types
+
+| Type                    | Best For                                  | Avoid When                              |
+| ----------------------- | ----------------------------------------- | --------------------------------------- |
+| Deterministic assertion | Schema, required fields, exact labels     | Quality is semantic or subjective       |
+| Reference-based eval    | Known answers, extraction, classification | Many valid answers exist                |
+| Rubric judge            | Helpfulness, tone, reasoning, policy      | Criteria are vague or multi-dimensional |
+| Pairwise comparison     | Prompt/model comparison                   | Absolute pass/fail is required          |
+| Trace eval              | Agents, tool calls, retrieval paths       | Only final output matters               |
+| Online eval             | Production monitoring                     | You need a release-blocking gate        |
+
+---
+
+## When to Use Evals
+
+Use evals for AI behavior that can regress even when code still passes tests.
+
+**Good eval candidates:**
+
+- Customer-support answer uses supplied policy and does not invent terms
+- Contract summary captures parties, renewal date, payment terms, and risk
+- Classifier picks the correct intent from ambiguous user text
+- Agent chooses search before answering time-sensitive questions
+- Retrieval answer cites the provided source and refuses missing facts
+- Style rewrite preserves meaning while matching voice guidelines
+- Safety response refuses disallowed content and offers allowed alternatives
+
+**Bad eval candidates:**
+
+- Function returns an enum for a fixed input
+- JSON schema validation
+- HTTP status code behavior
+- Button click opens a modal
+- Database migration preserves a column
+
+Those belong in unit, integration, E2E, or migration tests.
+
+---
+
+## Good Eval Or Token Waste
+
+A good eval catches a plausible AI failure that users would notice, and it tells
+the team what to do when it fails. A wasteful eval spends model calls without
+raising confidence.
+
+Before writing a new eval, answer in order. Stop at the first failure.
+
+1. **What user-visible failure would this catch?**
+   - Clear answer → Continue
+   - No clear answer → Do not write the eval; define the risk first
+
+2. **Could a deterministic test catch the same failure faster?**
+   - YES → Write the deterministic test instead
+   - NO → Continue
+
+3. **Does the dataset include cases the model could plausibly get wrong?**
+   - YES → Continue
+   - NO → Add boundary, adversarial, historical, or production-inspired cases first
+
+4. **Can the scorer catch known bad outputs?**
+   - YES → Continue
+   - NO → Calibrate the scorer before trusting the eval
+
+5. **Is there a clear action when the eval fails?**
+   - YES → Keep the eval
+   - NO → Define the triage owner and likely fix path first
+
+### Good Eval Signals
+
+| Signal               | What It Means                                      |
+| -------------------- | -------------------------------------------------- |
+| Specific risk        | Names the bad user outcome it prevents             |
+| Representative cases | Includes realistic, boundary, and historical cases |
+| Sharp scorer         | Has pass/fail criteria and failure examples        |
+| Calibrated judge     | Catches known bad outputs before blocking release  |
+| Clear threshold      | Says what score or failure rate blocks progress    |
+| Triage path          | Names what to inspect when it fails                |
+| Right cadence        | Runs where the signal is worth the cost            |
+
+### Token-Waste Smells
+
+| Smell                   | Why It Wastes Tokens                            | Better Move                                 |
+| ----------------------- | ----------------------------------------------- | ------------------------------------------- |
+| Deterministic behavior  | Model judgment adds cost and nondeterminism     | Unit, integration, E2E, or schema test      |
+| Vibe rubric             | "Good quality" cannot fail reliably             | Define pass/fail examples                   |
+| Happy-path-only dataset | It will pass even when risky behavior regresses | Add edge, adversarial, and historical cases |
+| Uncalibrated judge      | The scorer may agree with bad outputs           | Test against human-labeled examples         |
+| No owner                | Failures do not lead to action                  | Assign triage ownership                     |
+| Always-on expensive run | Cost grows without matching signal              | Split smoke eval from full eval             |
+| Duplicate scorer        | Two scorers measure the same thing              | Keep the sharper scorer                     |
+
+### Examples
+
+Good eval:
+
+```text
+Risk: Support answer invents refund exceptions.
+Dataset: refund-window happy path, late refund, ambiguous goodwill request,
+historical bug where the model offered an unsupported exception.
+Scorer: PASS only if the answer states the policy limit, refuses unsupported
+exceptions, and gives the approved next step.
+Action on fail: inspect prompt policy section and retrieved policy document.
+```
+
+Token waste:
+
+```text
+Risk: "Answer should be good."
+Dataset: three easy happy-path questions.
+Scorer: "Rate from 1 to 5."
+Action on fail: unclear.
+```
+
+If an eval fails this gate, do not delete the idea. Convert it into one of:
+
+- A deterministic test
+- A better acceptance criterion
+- A production-log mining task
+- A scorer-calibration task
+- A future eval idea with the missing risk named
+
+---
+
+## Eval Anatomy
+
+Every eval should define these fields before implementation.
+
+| Field             | Required Question                                    |
+| ----------------- | ---------------------------------------------------- |
+| Objective         | What user-visible AI behavior must be protected?     |
+| Inputs            | What prompts, documents, context, or tools are used? |
+| Expected evidence | What makes an output pass?                           |
+| Scorer            | How is pass/fail computed?                           |
+| Dataset           | Which examples represent real risk?                  |
+| Cadence           | When does it run?                                    |
+| Threshold         | What result blocks release?                          |
+| Triage owner      | Who decides prompt vs model vs scorer vs data?       |
+
+Minimal pseudo-YAML example:
+
+```yaml
+description: 'Support answer follows refund policy'
+input:
+  question: 'Can I get a refund after 45 days?'
+  policy: 'Refunds are available within 30 days of purchase.'
+checks:
+  - kind: json_schema
+    rule: '{ answer: string, cites_policy: boolean }'
+  - kind: required_text
+    rule: '30 days'
+  - kind: judge_rubric
+    rule: |
+      PASS if the answer states that refunds are only available within 30 days,
+      does not invent an exception, and remains polite.
+      FAIL if it offers a refund after 45 days, omits the policy limit, or invents policy.
+```
+
+Use the syntax of the project's chosen eval tool. The structure above is a
+portable pattern, not a required framework.
+
+---
+
+## Scorer Design
+
+Scorers are tests. Treat them with the same rigor as code.
+
+### Prefer Binary Outcomes
+
+Use pass/fail when the eval gates a release.
+
+```text
+PASS: Includes the 30-day limit and refuses the 45-day refund.
+FAIL: Offers a refund, omits the limit, or invents an escalation path.
+```
+
+Avoid vague scales unless the team has calibration examples.
+
+```text
+Bad: Score quality from 1 to 5.
+Good: PASS only if all required facts are present and no unsupported facts appear.
+```
+
+### One Dimension Per Scorer
+
+Split factuality, completeness, tone, and safety into separate scorers.
+
+```yaml
+scorers:
+  - name: factuality
+    rubric: 'PASS if every factual claim is supported by the provided policy.'
+  - name: completeness
+    rubric: 'PASS if the answer covers eligibility, deadline, and next step.'
+  - name: tone
+    rubric: 'PASS if the answer is direct and respectful.'
+```
+
+Do not bundle unrelated dimensions into one vague judgment.
+
+### Include Failure Examples
+
+Rubrics should say what fails.
+
+```text
+PASS: Mentions the renewal date and cancellation window.
+FAIL: Gives only a generic summary, misses the cancellation window, or invents a date.
+```
+
+### Calibrate Judge Evals
+
+Before trusting an LLM-as-judge scorer:
+
+1. Run it on examples humans already labeled
+2. Inspect disagreements
+3. Tighten the rubric
+4. Add few-shot grading examples when useful
+5. Re-run until the scorer catches known bad outputs
+
+If the scorer cannot reliably catch known failures, it cannot block release.
+
+---
+
+## Dataset Design
+
+An eval is only as good as its dataset.
+
+### Dataset Mix
+
+Include:
+
+- Happy-path examples
+- Boundary cases
+- Adversarial prompts
+- Ambiguous user requests
+- Production-inspired cases with private data removed
+- Historical bugs
+- Examples from domain experts
+- Holdout cases not used during prompt tuning
+
+### Dataset Size
+
+Start small and useful:
+
+```text
+5-10 cases    → smoke eval while designing a prompt
+20-50 cases   → PR or feature gate
+100+ cases    → release, scheduled, or model migration gate
+```
+
+The numbers are starting points. Increase size when behavior is high-risk,
+inputs are diverse, or the model/provider is changing.
+
+### Privacy Rules
+
+Before adding production data:
+
+- Remove personal data not needed for the eval
+- Replace secrets, tokens, emails, addresses, and account IDs
+- Preserve the structure that made the case hard
+- Record the source and scrub date if policy allows
+
+Never copy sensitive production data into a prompt, fixture, or third-party eval
+system without approval.
+
+---
+
+## Eval Cadence
+
+| Event                 | Recommended Eval Set                      |
+| --------------------- | ----------------------------------------- |
+| Prompt editing        | 5-10 smoke cases                          |
+| Code change           | Deterministic assertions + affected cases |
+| Pull request          | Smoke eval + known regression cases       |
+| Prompt/model change   | Full task eval                            |
+| Retrieval data change | Retrieval/factuality eval                 |
+| Release               | Full eval for critical AI workflows       |
+| Scheduled monitoring  | Drift and production-inspired evals       |
+| Production monitoring | Sampled online evals with cost controls   |
+
+**Tie-breaker:** run the cheapest eval that can catch the likely regression at
+the point where it is cheapest to fix.
+
+---
+
+## Cost and Runtime Controls
+
+Evals can become expensive because they multiply:
+
+```text
+cases × prompts × models × scorers × repetitions
+```
+
+Control cost with:
+
+- A smoke eval suite
+- Deterministic assertions before model-graded assertions
+- Sampling for online evals
+- Caching where the tool supports it
+- Smaller judge models for low-risk rubrics
+- Full evals only on prompt, model, retrieval, or release changes
+- Repetitions only for nondeterminism-sensitive tasks
+
+Do not hide expensive evals inside default unit test commands.
+
+---
+
+## Trace and Agent Evals
+
+Use trace evals when the path matters, not just the final answer.
+
+**Use for:**
+
+- Tool choice
+- Tool arguments
+- Retrieval query quality
+- Whether the agent asked for clarification
+- Whether the agent stopped after enough evidence
+- Whether the agent avoided disallowed tools
+
+**Good trace assertions:**
+
+```text
+PASS if the agent searches the knowledge base before answering a policy question.
+PASS if the agent calls the refund tool with the user_id from context, not from user text.
+FAIL if the agent sends an email before explicit confirmation.
+```
+
+**Bad trace assertion:**
+
+```text
+PASS if the agent thinks carefully.
+```
+
+That is not observable.
+
+Avoid over-constraining harmless internal reasoning. Grade path only when the
+path affects correctness, cost, safety, privacy, or user-visible behavior.
+
+---
+
+## Failure Triage
+
+When an eval fails, classify the failure before changing prompts or tests.
+
+| Failure Source      | Symptom                                       | First Action                                  |
+| ------------------- | --------------------------------------------- | --------------------------------------------- |
+| Prompt              | Same model misses instruction consistently    | Clarify prompt or examples                    |
+| Model               | Regression appears after model change         | Compare old/new model on same dataset         |
+| Retrieval           | Answer lacks facts that context should supply | Inspect retrieved documents and query         |
+| Tool use            | Wrong tool or wrong arguments                 | Add trace eval and tool contract tests        |
+| Dataset             | Case no longer represents desired behavior    | Update with approval and preserve history     |
+| Scorer              | Human disagrees with judge                    | Calibrate rubric and add examples             |
+| Product requirement | Desired behavior changed                      | Update acceptance criteria before eval update |
+
+Do not weaken a scorer because the model failed. First prove the scorer is wrong
+or the requirement changed.
+
+---
+
+## Regression Workflow
+
+When a user reports a bad AI output:
+
+1. Save the input, retrieved context, tool trace, and output if privacy allows
+2. Scrub sensitive data
+3. Add a failing eval case
+4. Confirm the eval fails for the reported behavior
+5. Fix prompt, retrieval, tools, model choice, or product logic
+6. Confirm the eval passes
+7. Keep the case to prevent regression
+
+If the reported issue depends on current facts, use a fixture with frozen facts
+or a search-capable scorer with clear source requirements.
+
+---
+
+## Project Documentation
+
+Each AI-enabled project should document eval conventions in `evals/README.md`,
+`tests/SAFEWORD.md`, `tests/AGENTS.md`, or the nearest existing testing docs.
+
+Include:
+
+- Eval command names
+- Eval tool or framework
+- Dataset locations
+- Scorer types
+- Required API keys or local models
+- Cost expectations
+- Which evals block PRs or releases
+- Human review process for scorer changes
+- Privacy rules for production examples
+- Ownership for failures
+
+Minimal template:
+
+```markdown
+# Eval Lanes
+
+| Eval          | Command              | Runs    | Blocks         | Dataset           | Owner   |
+| ------------- | -------------------- | ------- | -------------- | ----------------- | ------- |
+| AI smoke      | `npm run eval:smoke` | PR      | yes            | `evals/smoke.yml` | AI team |
+| Full AI eval  | `npm run eval:full`  | release | yes            | `evals/full.yml`  | AI team |
+| Drift monitor | scheduled            | no      | sampled traces | platform          |
+```
+
+---
+
+## Key Takeaways
+
+- Use deterministic tests before judge evals.
+- Evals need objectives, datasets, scorers, cadence, thresholds, and owners.
+- Judge one quality dimension at a time.
+- Calibrate LLM-as-judge scorers against human-labeled examples.
+- Keep historical failures as regression cases.
+- Separate cheap smoke evals from full, expensive eval suites.
+- Never put sensitive production data into eval fixtures without approval.

--- a/.safeword/guides/testing-guide.md
+++ b/.safeword/guides/testing-guide.md
@@ -57,7 +57,7 @@ Tests are the specification. When a test fails, the implementation is wrong—no
 ```text
 E2E (seconds-minutes)    ← Full browser, user flows         ↑ prefer
   ↑
-LLM Eval (seconds)       ← AI judgment, costs $0.01-0.30
+LLM Eval (seconds+)      ← AI judgment, model-dependent cost
   ↑
 Integration (seconds)    ← Multiple modules, database, API
   ↑
@@ -97,6 +97,8 @@ Answer these questions in order. Stop at first match.
 - Non-deterministic functions (Math.random, Date.now) → Unit test with mocked randomness
 - Functions with environment dependencies (process.env) → Integration test
 - Mixed pure + I/O logic → Extract pure logic, unit test it, integration test I/O
+- DOM tests with jsdom or Testing Library → Integration test unless the bug
+  depends on real browser layout, CSS, navigation, or browser APIs
 
 ---
 
@@ -350,7 +352,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 ❌ **Implementation details** - Private methods, CSS classes, internal state
 ❌ **Third-party libraries** - Assume React/Axios work, test YOUR code
 ❌ **Trivial code** - Getters/setters with no logic, pass-through functions
-❌ **UI copy** - Use regex `/submit/i`, not exact text matching
+❌ **Incidental UI copy** - Do not pin marketing/help text unless copy is the contract. Prefer role/name or resilient regex for controls. Assert exact text for legal, safety, error, or required user-facing messages.
 
 ---
 
@@ -359,7 +361,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 - **Unit tests:** 80%+ coverage of pure functions
 - **Integration tests:** All critical paths covered
 - **E2E tests:** All critical multi-page user flows
-- **LLM evals:** All AI features have evaluation scenarios
+- **LLM evals:** AI features with probabilistic output quality have evaluation scenarios; deterministic AI plumbing has normal tests
 
 **What are "critical paths"?**
 
@@ -372,15 +374,19 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 
 ## LLM Eval Cost Considerations
 
-**Cost:** $0.01-0.30 per run depending on prompt size.
+**Cost:** Model-, prompt-, provider-, and scenario-dependent. Estimate from
+current provider pricing before deciding cadence.
 
-**Prompt caching reduces costs by 90%** (30 scenarios: $0.30 → $0.03 after first run).
+**Prompt caching can reduce repeated input-token costs on supported providers.**
+OpenAI currently documents up to 90% input-token savings for qualifying cached
+prompts. Treat caching as provider-specific, not guaranteed.
 
 **Cost reduction strategies:**
 
 - Cache static content (system prompts, examples, rules)
 - Batch multiple scenarios in one run
-- Run full evals on PR/schedule, not every commit
+- Split cheap smoke evals from full eval suites
+- Run full evals on PR, release, or schedule only when the signal is worth the cost
 
 ---
 
@@ -388,7 +394,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 
 - Run unit + integration tests on every commit (fast feedback)
 - Run E2E tests on every PR
-- Run LLM evals on schedule (weekly catches regressions without per-commit cost)
+- Run smoke evals on PR for high-risk AI behavior; run full evals on release or schedule
 
 ---
 
@@ -399,7 +405,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 | Pure function        | Unit        | Vitest     | Fast   | Free       |
 | Service integration  | Integration | Vitest     | Medium | Free       |
 | Full user flow       | E2E         | Playwright | Slow   | Free       |
-| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | $0.01-0.30 |
+| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | Varies     |
 
 ---
 

--- a/.safeword/guides/testing-guide.md
+++ b/.safeword/guides/testing-guide.md
@@ -4,6 +4,16 @@ Test methodology, TDD workflow, and test type selection.
 
 ---
 
+## Related Guides
+
+| Need                              | Guide                                          |
+| --------------------------------- | ---------------------------------------------- |
+| Choose unit/integration/E2E/eval  | This guide                                     |
+| Choose smoke/live/release cadence | `.safeword/guides/verification-lanes-guide.md` |
+| Design AI output evaluations      | `.safeword/guides/llm-evals-guide.md`          |
+
+---
+
 ## Test Philosophy
 
 **Behavior-biased testing:** At every test level, assert on what the system _does_ (outputs, side effects, user-visible outcomes) — never on _how_ it does it (internal state, mock call counts, private methods). Tests coupled to implementation break on every refactor. Behavioral tests survive.

--- a/.safeword/guides/testing-guide.md
+++ b/.safeword/guides/testing-guide.md
@@ -352,7 +352,13 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 ❌ **Implementation details** - Private methods, CSS classes, internal state
 ❌ **Third-party libraries** - Assume React/Axios work, test YOUR code
 ❌ **Trivial code** - Getters/setters with no logic, pass-through functions
-❌ **Incidental UI copy** - Do not pin marketing/help text unless copy is the contract. Prefer role/name or resilient regex for controls. Assert exact text for legal, safety, error, or required user-facing messages.
+❌ **Incidental UI copy** - Marketing/help text when exact wording is not the
+contract
+
+**Copy assertions:**
+
+- Prefer role/name or resilient regex for controls
+- Assert exact text for legal, safety, error, or required user-facing messages
 
 ---
 
@@ -400,12 +406,12 @@ prompts. Treat caching as provider-specific, not guaranteed.
 
 ## Quick Reference
 
-| Need to test...      | Test type   | Technology | Speed  | Cost       |
-| -------------------- | ----------- | ---------- | ------ | ---------- |
-| Pure function        | Unit        | Vitest     | Fast   | Free       |
-| Service integration  | Integration | Vitest     | Medium | Free       |
-| Full user flow       | E2E         | Playwright | Slow   | Free       |
-| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | Varies     |
+| Need to test...      | Test type   | Technology | Speed  | Cost   |
+| -------------------- | ----------- | ---------- | ------ | ------ |
+| Pure function        | Unit        | Vitest     | Fast   | Free   |
+| Service integration  | Integration | Vitest     | Medium | Free   |
+| Full user flow       | E2E         | Playwright | Slow   | Free   |
+| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | Varies |
 
 ---
 

--- a/.safeword/guides/verification-lanes-guide.md
+++ b/.safeword/guides/verification-lanes-guide.md
@@ -1,0 +1,574 @@
+# Verification Lanes Guide
+
+How to choose when a test or check should run: focused, smoke, live-fire,
+release, migration, static, or slow/performance.
+
+---
+
+## Core Idea
+
+Test type answers **what behavior is being proved**. Verification lane answers
+**when and how much evidence is needed**.
+
+Use both labels:
+
+```text
+Unit test + focused lane        → fast proof while implementing
+E2E test + smoke lane           → quick proof the main journey still works
+Acceptance test + release lane  → proof the shipped artifact satisfies requirements
+Integration test + migration    → proof old data still upgrades correctly
+```
+
+Do not force every lane into the unit/integration/E2E taxonomy. Smoke,
+live-fire, release, migration, static, and slow/performance are execution
+strategies. They can contain any test type.
+
+Choose the lane for a specific verification run, not for the test file forever.
+The same test can be focused while developing, smoke before a PR, and release
+before publishing. If a run touches real external systems, real credentials, or
+customer-like infrastructure, apply the live-fire guardrails even when its
+primary lane is smoke, release, or slow/performance.
+
+---
+
+## Lane Decision Tree
+
+Answer in order. Stop at the first match. Choose the lane that explains why this
+run exists now.
+
+1. **Are you proving only the current change while writing code?**
+   - YES → Focused lane
+   - NO → Continue
+
+2. **Do you need a quick signal that the product is basically usable?**
+   - YES → Smoke lane
+   - NO → Continue
+
+3. **Is the main reason for this run to prove behavior against real external
+   systems, real credentials, production-like infrastructure, or a real
+   customer-like workspace?**
+   - YES → Live-fire lane
+   - NO → Continue
+
+4. **Are you proving that a built, packaged, or deployed artifact is ready to ship?**
+   - YES → Release lane
+   - NO → Continue
+
+5. **Are you proving old data, old config, or old installs still work after an upgrade?**
+   - YES → Migration lane
+   - NO → Continue
+
+6. **Is the check static analysis rather than runtime behavior?**
+   - YES → Static gate
+   - NO → Continue
+
+7. **Is the check too expensive for normal local or per-commit runs?**
+   - YES → Slow/performance lane
+   - NO → Re-evaluate the test type in `.safeword/guides/testing-guide.md`
+
+**Tie-breaker:** if a check fits two lanes, choose the lane that explains why it
+is run at its cadence. Example: a Playwright checkout test that runs in two
+minutes before every PR is a smoke lane test; the same journey run across
+browsers, locales, and payment providers before release is a release lane test.
+
+---
+
+## Lane Reference
+
+| Lane             | Purpose                                      | Typical Cadence             | Example Command                     |
+| ---------------- | -------------------------------------------- | --------------------------- | ----------------------------------- |
+| Focused          | Prove the behavior currently being changed   | During TDD                  | `npm test -- path/to/test`          |
+| Smoke            | Prove core product paths are not broken      | Before handoff, PR, deploy  | `npm run test:smoke`                |
+| Live-fire        | Prove real-environment behavior              | Manual, scheduled, pre-prod | `npm run test:live`                 |
+| Release          | Prove the artifact is shippable              | Before release              | `npm run test:release`              |
+| Migration        | Prove old state upgrades safely              | Before release              | `npm run test:migration`            |
+| Static gate      | Catch non-runtime correctness issues         | Every verify or CI run      | `npm run lint && npm run typecheck` |
+| Slow/performance | Prove scale, speed, or long-running behavior | Scheduled or release        | `npm run test:slow`                 |
+
+Commands are placeholders. Use the package manager and scripts the project
+already has.
+
+---
+
+## Good Verification Lane Or Busywork
+
+A good verification lane changes an engineering decision. It tells the team
+whether to keep coding, hand off, merge, release, roll back, or investigate the
+environment. A busywork lane consumes time without changing the next action.
+
+Before adding a new lane or check, answer in order. Stop at the first failure.
+
+1. **What decision will this run unblock?**
+   - Clear answer → Continue
+   - No clear answer → Do not add the lane; name the decision first
+
+2. **What plausible failure would cheaper checks miss?**
+   - Clear answer → Continue
+   - No clear answer → Use a focused test, static gate, or existing suite
+
+3. **Is the cadence matched to cost and flake risk?**
+   - YES → Continue
+   - NO → Move it later, make it opt-in, or split a cheaper smoke check
+
+4. **Will the evidence identify what ran and what failed?**
+   - YES → Continue
+   - NO → Add artifact, environment, command, data, and failure-action details
+
+5. **Is ownership clear for expensive, slow, or side-effecting runs?**
+   - YES → Keep the lane
+   - NO → Define the triage owner, cleanup rule, and escalation path first
+
+### Good Lane Signals
+
+| Signal                    | What It Means                                            |
+| ------------------------- | -------------------------------------------------------- |
+| Decision-linked           | The result changes whether work proceeds                 |
+| Cheapest sufficient proof | The lane runs no earlier or broader than needed          |
+| Distinct risk             | It catches a failure cheaper checks cannot catch         |
+| Specific evidence         | Output names command, artifact, environment, and scope   |
+| Clear owner               | Someone knows how to diagnose and maintain failures      |
+| Controlled side effects   | Cost, data mutation, notifications, and cleanup are safe |
+| Failure action            | The guide says whether to fix, retry, rollback, or skip  |
+
+### Busywork Smells
+
+| Smell                      | Why It Wastes Time                        | Better Move                             |
+| -------------------------- | ----------------------------------------- | --------------------------------------- |
+| Runs because it exists     | No decision depends on the result         | Remove it or document the decision      |
+| Full suite labeled smoke   | Slow signal blocks fast feedback          | Keep only core alive checks             |
+| Accidental live-fire       | Real side effects hide in default tests   | Make it opt-in with guardrails          |
+| Source tests as release    | Does not prove packaged artifact behavior | Install and test the built artifact     |
+| Performance without metric | Cannot fail deterministically             | Define workload, threshold, and runtime |
+| Static gate as behavior    | Type/lint success does not prove workflow | Add runtime behavior coverage           |
+| Anonymous environment      | Failure cannot be reproduced              | Record environment and artifact         |
+| No owner                   | Failures rot or get ignored               | Assign triage ownership                 |
+
+### Examples
+
+Good verification lane:
+
+```text
+Decision: Can we publish the package?
+Risk: Published artifact is missing the CLI bin or template files.
+Lane: Release
+Command: npm pack, install tarball into a temporary project, run public CLI.
+Evidence: tarball name, temp project path, CLI command output, files verified.
+Failure action: block release and inspect package file inclusion.
+```
+
+Busywork lane:
+
+```text
+Decision: unclear.
+Lane: Smoke.
+Command: npm test.
+Risk: "General confidence."
+Evidence: pass/fail only.
+```
+
+If a lane fails this gate, convert it into one of:
+
+- A focused test for the specific behavior
+- A static gate for source or metadata validity
+- A smaller smoke check
+- A release or migration check with artifact and fixture details
+- A scheduled slow/performance run with a metric and owner
+- A live-fire run with explicit opt-in guardrails
+
+---
+
+## Focused Lane
+
+Use focused tests while implementing. They should be narrow enough to run
+repeatedly and strong enough to fail when the behavior is wrong.
+
+**Use when:**
+
+- Working through RED/GREEN/REFACTOR
+- Fixing a bug with a known reproduction
+- Refactoring and protecting the touched behavior
+
+**Evidence required:**
+
+- The specific failing test fails for the right reason before implementation
+- The same test passes after implementation
+- Nearby affected tests pass when practical
+
+**Good examples:**
+
+```bash
+npm test -- src/cart/discount.test.ts
+npm test -- --runInBand auth
+pytest tests/test_invoice_totals.py::test_rejects_negative_quantity
+```
+
+**Bad examples:**
+
+```bash
+npm test
+```
+
+This is too broad for a focused lane if it hides which behavior drove the
+change.
+
+```bash
+npm test -- --updateSnapshot
+```
+
+This is not proof unless the snapshot change was reviewed as the intended
+behavior.
+
+---
+
+## Smoke Lane
+
+Smoke tests are a small, curated set of high-value checks that answer: "Is the
+product basically alive?"
+
+**Use when:**
+
+- Before handing work back to a user
+- Before opening or merging a PR
+- After building or deploying
+- Before running expensive full suites
+
+**Include:**
+
+- One or two primary user journeys
+- Startup/import/bootstrap checks
+- Critical write/read loops
+- Core authentication or authorization path when the app has one
+- One representative integration with important dependencies
+
+**Exclude:**
+
+- Exhaustive edge cases
+- Full browser/device matrices
+- Long-running performance workloads
+- Tests that require fragile shared state
+
+**Good smoke suite:**
+
+```text
+- App starts
+- User signs in
+- User creates the central resource
+- User reloads and sees the resource
+- Health endpoint returns OK
+```
+
+**Bad smoke suite:**
+
+```text
+- Every checkout edge case
+- Every supported browser and locale
+- Every admin flow
+- Full load test
+```
+
+That is a regression or release suite, not smoke.
+
+**Smoke failure rule:** treat a smoke failure as a stop signal. Either fix it,
+prove the test is wrong, or explicitly record why the product is intentionally
+not smoke-green.
+
+---
+
+## Live-Fire Lane
+
+Live-fire tests run against real or production-like boundaries. They are useful
+because high-fidelity tests catch configuration, packaging, credential,
+network, permission, and provider behavior that hermetic tests miss.
+
+**Use when the risk is at the boundary:**
+
+- Real third-party APIs
+- Real auth providers
+- Real queues, webhooks, storage, browsers, CLIs, or installed packages
+- Production-like config, routing, permissions, or infrastructure
+- Installed behavior in a real project workspace
+
+**Do not run live-fire tests by default when they can:**
+
+- Spend money
+- Send email, texts, webhooks, or customer-visible notifications
+- Modify production data
+- Depend on rate-limited or flaky external services
+- Require secrets unavailable in normal CI
+
+**Required guardrails:**
+
+- Opt-in command or tag, never hidden inside the default unit suite
+- Dedicated test accounts, projects, tenants, or sandboxes
+- Clear cleanup strategy
+- Idempotent setup where possible
+- Explicit cost and side-effect notes
+- Separate failure triage for "product failed" vs "environment unavailable"
+
+**Good live-fire evidence:**
+
+```text
+Live-fire: PASS
+Environment: staging
+Account: test tenant
+Side effects: created and deleted one test resource
+Cost: none expected
+Cleanup: confirmed
+```
+
+**Bad live-fire evidence:**
+
+```text
+Ran live tests. One failed but probably network.
+```
+
+That does not say what environment ran, what changed, or whether cleanup
+happened.
+
+---
+
+## Release Lane
+
+Release tests prove that the artifact users receive works, not just that source
+code passes tests.
+
+**Use before:**
+
+- Publishing a package
+- Cutting a binary or container image
+- Deploying a build to production
+- Shipping a plugin, extension, CLI, SDK, or template bundle
+
+**Common release checks:**
+
+- Build from a clean checkout
+- Install the packaged artifact into a temporary project
+- Run the public CLI or API entrypoint
+- Verify package exports, file inclusion, and executable permissions
+- Verify peer dependency and engine compatibility
+- Run the smoke suite against the built artifact
+- Validate generated assets are present and usable
+
+**Good release check:**
+
+```bash
+npm pack
+tmp=$(mktemp -d)
+cd "$tmp"
+npm init -y
+npm install /path/to/package.tgz
+npx your-cli --version
+npx your-cli init --dry-run
+```
+
+**Bad release check:**
+
+```bash
+npm test
+```
+
+Source tests can pass while the published package is missing files, exports, or
+runtime permissions.
+
+---
+
+## Migration Lane
+
+Migration tests prove that existing users can upgrade safely.
+
+**Use when changing:**
+
+- Data schema
+- Config file format
+- File layout
+- Generated code or templates
+- Package names, exports, or command names
+- Storage, cache, or queue semantics
+- Authentication or authorization policy
+
+**Test fixtures should include:**
+
+- Current version state
+- Previous supported version state
+- Partially customized state
+- Missing optional files
+- Unknown future fields
+- Corrupt or invalid state with expected recovery behavior
+
+**Core assertions:**
+
+- User-owned data is preserved
+- Generated or managed data updates correctly
+- The migration is idempotent
+- Rollback or retry behavior is clear
+- Warnings are actionable
+
+**Good migration test names:**
+
+```text
+preserves_user_edits_when_upgrading_config
+adds_missing_managed_files_without_deleting_custom_files
+rerunning_migration_after_partial_failure_is_safe
+```
+
+**Bad migration test name:**
+
+```text
+migration works
+```
+
+It does not identify the user value or failure mode.
+
+---
+
+## Static Gates
+
+Static gates do not run product behavior. They inspect source, generated files,
+types, dependency graphs, formatting, or policy rules.
+
+**Common static gates:**
+
+- Typecheck
+- Lint
+- Format check
+- Markdown or documentation lint
+- Gherkin lint
+- Dependency graph validation
+- Dead-code detection
+- Security/static analysis
+- Package metadata validation
+
+**Use static gates to catch:**
+
+- Type and API mismatches
+- Invalid generated files
+- Broken documentation syntax
+- Unsafe dependency edges
+- Missing package metadata
+- Policy violations that do not require runtime execution
+
+**Do not use static gates as a substitute for behavior tests.**
+
+```text
+Typecheck passing means the program is type-compatible.
+It does not mean the user workflow works.
+```
+
+---
+
+## Slow and Performance Lane
+
+Slow/performance tests prove behavior that is too expensive for routine local
+or per-commit feedback.
+
+**Use when testing:**
+
+- Large datasets
+- Long-running jobs
+- Concurrency, retries, and backpressure
+- Load, latency, memory, or throughput
+- Cross-browser/device/locale matrices
+- Full regression suites
+
+**Required metadata:**
+
+- Expected runtime
+- Resource requirements
+- What metric fails the test
+- How to reproduce locally or in CI
+- Owner or escalation path
+
+**Good performance assertion:**
+
+```text
+95th percentile response time stays under 300 ms for 500 requests/minute
+with the standard test dataset.
+```
+
+**Bad performance assertion:**
+
+```text
+App should be fast.
+```
+
+That cannot fail deterministically.
+
+---
+
+## CI Cadence
+
+Use this default cadence unless the project has a stronger local convention.
+
+| Event             | Recommended Lanes                   |
+| ----------------- | ----------------------------------- |
+| During coding     | Focused                             |
+| Before handoff    | Focused + relevant static gates     |
+| Pull request      | Static gates + smoke + affected BDD |
+| Before release    | Release + migration + full smoke    |
+| Scheduled nightly | Slow/performance + broader matrices |
+| Manual high-risk  | Live-fire                           |
+| After deployment  | Smoke + selected live-fire health   |
+
+**Tie-breaker:** move a lane earlier only when the failure is cheap to diagnose
+there. Expensive checks that frequently fail for environmental reasons belong
+later, with clearer ownership and artifacts.
+
+---
+
+## Failure Triage
+
+Classify the failure before fixing.
+
+| Failure Type              | First Action                                      |
+| ------------------------- | ------------------------------------------------- |
+| Product behavior changed  | Fix implementation or update requirements         |
+| Test assertion is wrong   | Explain and get approval before changing the test |
+| Environment unavailable   | Record outage evidence and retry once             |
+| Fixture drift             | Repair fixture or add migration coverage          |
+| Flaky timing              | Replace sleeps with condition-based waits         |
+| External provider changed | Decide whether to adapt, pin, mock, or escalate   |
+
+Never skip, weaken, or delete tests just to pass a lane. If the lane is too
+expensive or noisy, change its cadence or ownership deliberately.
+
+---
+
+## Project Documentation
+
+Each project should document its local lanes in `tests/SAFEWORD.md`,
+`tests/AGENTS.md`, or the nearest existing testing documentation.
+
+Include:
+
+- Lane names and commands
+- What each lane proves
+- Cadence: local, PR, release, scheduled, manual
+- Required secrets or services
+- Expected runtime
+- Owners for live-fire, release, migration, and slow lanes
+- Cleanup and side-effect rules
+- What evidence to include when reporting results
+
+Minimal template:
+
+```markdown
+# Test Lanes
+
+| Lane      | Command                | Runs       | Proves             | Owner         |
+| --------- | ---------------------- | ---------- | ------------------ | ------------- |
+| Focused   | `npm test -- <file>`   | during TDD | touched behavior   | feature owner |
+| Smoke     | `npm run test:smoke`   | PR         | core journeys      | app team      |
+| Live-fire | `npm run test:live`    | manual     | real provider path | platform team |
+| Release   | `npm run test:release` | release    | packaged artifact  | release owner |
+```
+
+---
+
+## Key Takeaways
+
+- Test type is about behavior scope; verification lane is about cadence and risk.
+- Smoke is small and curated. It is not the full regression suite.
+- Live-fire is opt-in and guarded because it touches real boundaries.
+- Release tests prove the artifact users receive, not just source code.
+- Migration tests protect existing users and customized state.
+- Static gates are verification lanes, but they do not replace behavior tests.

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -717,11 +717,17 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/guides/llm-writing-guide.md': {
       template: 'guides/llm-writing-guide.md',
     },
+    '.safeword/guides/llm-evals-guide.md': {
+      template: 'guides/llm-evals-guide.md',
+    },
     '.safeword/guides/planning-guide.md': {
       template: 'guides/planning-guide.md',
     },
     '.safeword/guides/testing-guide.md': {
       template: 'guides/testing-guide.md',
+    },
+    '.safeword/guides/verification-lanes-guide.md': {
+      template: 'guides/verification-lanes-guide.md',
     },
     '.safeword/guides/zombie-process-cleanup.md': {
       template: 'guides/zombie-process-cleanup.md',

--- a/packages/cli/templates/guides/llm-evals-guide.md
+++ b/packages/cli/templates/guides/llm-evals-guide.md
@@ -1,0 +1,485 @@
+# LLM Evals Guide
+
+How to evaluate AI features: deterministic checks, datasets, rubrics,
+LLM-as-judge, pairwise comparisons, cost, and failure triage.
+
+---
+
+## Core Idea
+
+LLM evals test whether an AI system produces acceptable outputs for real tasks.
+They are behavior tests for probabilistic systems.
+
+Use evals when normal assertions cannot fully capture quality:
+
+- Reasoning quality
+- Factuality against provided context
+- Extraction or classification quality
+- Summarization quality
+- Tool choice and tool-use discipline
+- Retrieval quality
+- Tone, style, or policy adherence
+- Safety, refusal, or escalation behavior
+
+Do not use evals for deterministic behavior that normal tests can prove faster.
+
+```text
+JSON parses and matches schema     → normal unit/integration assertion
+API returns 401 without API key    → integration test
+Button opens the dialog            → E2E test
+Summary preserves key obligations  → eval
+Agent chooses the right tool       → eval or trace eval
+```
+
+---
+
+## Eval Decision Tree
+
+Answer in order. Stop at the first match.
+
+1. **Can a normal deterministic test fully prove the behavior?**
+   - YES → Use unit, integration, E2E, or migration coverage instead
+   - NO → Continue
+
+2. **Can a deterministic eval assertion prove part of the AI output contract?**
+   - YES → Add that assertion before any model-graded scorer
+   - NO → Continue
+
+3. **Is there a known correct output, label, or fact set?**
+   - YES → Use reference-based evals
+   - NO → Continue
+
+4. **Is it easier to compare two outputs than score one output absolutely?**
+   - YES → Use pairwise evals
+   - NO → Continue
+
+5. **Is the desired quality subjective but describable?**
+   - YES → Use rubric-based LLM-as-judge evals
+   - NO → Continue
+
+6. **Does the behavior involve multiple steps, tools, retrieval, or agents?**
+   - YES → Use trace or trajectory evals
+   - NO → Write the missing acceptance criteria before creating the eval
+
+**Tie-breaker:** deterministic checks first, reference-based checks second,
+LLM-as-judge last. Model-graded evals are powerful but add cost, latency, and
+grader failure modes.
+
+---
+
+## Eval Types
+
+| Type                    | Best For                                  | Avoid When                              |
+| ----------------------- | ----------------------------------------- | --------------------------------------- |
+| Deterministic assertion | Schema, required fields, exact labels     | Quality is semantic or subjective       |
+| Reference-based eval    | Known answers, extraction, classification | Many valid answers exist                |
+| Rubric judge            | Helpfulness, tone, reasoning, policy      | Criteria are vague or multi-dimensional |
+| Pairwise comparison     | Prompt/model comparison                   | Absolute pass/fail is required          |
+| Trace eval              | Agents, tool calls, retrieval paths       | Only final output matters               |
+| Online eval             | Production monitoring                     | You need a release-blocking gate        |
+
+---
+
+## When to Use Evals
+
+Use evals for AI behavior that can regress even when code still passes tests.
+
+**Good eval candidates:**
+
+- Customer-support answer uses supplied policy and does not invent terms
+- Contract summary captures parties, renewal date, payment terms, and risk
+- Classifier picks the correct intent from ambiguous user text
+- Agent chooses search before answering time-sensitive questions
+- Retrieval answer cites the provided source and refuses missing facts
+- Style rewrite preserves meaning while matching voice guidelines
+- Safety response refuses disallowed content and offers allowed alternatives
+
+**Bad eval candidates:**
+
+- Function returns an enum for a fixed input
+- JSON schema validation
+- HTTP status code behavior
+- Button click opens a modal
+- Database migration preserves a column
+
+Those belong in unit, integration, E2E, or migration tests.
+
+---
+
+## Good Eval Or Token Waste
+
+A good eval catches a plausible AI failure that users would notice, and it tells
+the team what to do when it fails. A wasteful eval spends model calls without
+raising confidence.
+
+Before writing a new eval, answer in order. Stop at the first failure.
+
+1. **What user-visible failure would this catch?**
+   - Clear answer → Continue
+   - No clear answer → Do not write the eval; define the risk first
+
+2. **Could a deterministic test catch the same failure faster?**
+   - YES → Write the deterministic test instead
+   - NO → Continue
+
+3. **Does the dataset include cases the model could plausibly get wrong?**
+   - YES → Continue
+   - NO → Add boundary, adversarial, historical, or production-inspired cases first
+
+4. **Can the scorer catch known bad outputs?**
+   - YES → Continue
+   - NO → Calibrate the scorer before trusting the eval
+
+5. **Is there a clear action when the eval fails?**
+   - YES → Keep the eval
+   - NO → Define the triage owner and likely fix path first
+
+### Good Eval Signals
+
+| Signal               | What It Means                                      |
+| -------------------- | -------------------------------------------------- |
+| Specific risk        | Names the bad user outcome it prevents             |
+| Representative cases | Includes realistic, boundary, and historical cases |
+| Sharp scorer         | Has pass/fail criteria and failure examples        |
+| Calibrated judge     | Catches known bad outputs before blocking release  |
+| Clear threshold      | Says what score or failure rate blocks progress    |
+| Triage path          | Names what to inspect when it fails                |
+| Right cadence        | Runs where the signal is worth the cost            |
+
+### Token-Waste Smells
+
+| Smell                   | Why It Wastes Tokens                            | Better Move                                 |
+| ----------------------- | ----------------------------------------------- | ------------------------------------------- |
+| Deterministic behavior  | Model judgment adds cost and nondeterminism     | Unit, integration, E2E, or schema test      |
+| Vibe rubric             | "Good quality" cannot fail reliably             | Define pass/fail examples                   |
+| Happy-path-only dataset | It will pass even when risky behavior regresses | Add edge, adversarial, and historical cases |
+| Uncalibrated judge      | The scorer may agree with bad outputs           | Test against human-labeled examples         |
+| No owner                | Failures do not lead to action                  | Assign triage ownership                     |
+| Always-on expensive run | Cost grows without matching signal              | Split smoke eval from full eval             |
+| Duplicate scorer        | Two scorers measure the same thing              | Keep the sharper scorer                     |
+
+### Examples
+
+Good eval:
+
+```text
+Risk: Support answer invents refund exceptions.
+Dataset: refund-window happy path, late refund, ambiguous goodwill request,
+historical bug where the model offered an unsupported exception.
+Scorer: PASS only if the answer states the policy limit, refuses unsupported
+exceptions, and gives the approved next step.
+Action on fail: inspect prompt policy section and retrieved policy document.
+```
+
+Token waste:
+
+```text
+Risk: "Answer should be good."
+Dataset: three easy happy-path questions.
+Scorer: "Rate from 1 to 5."
+Action on fail: unclear.
+```
+
+If an eval fails this gate, do not delete the idea. Convert it into one of:
+
+- A deterministic test
+- A better acceptance criterion
+- A production-log mining task
+- A scorer-calibration task
+- A future eval idea with the missing risk named
+
+---
+
+## Eval Anatomy
+
+Every eval should define these fields before implementation.
+
+| Field             | Required Question                                    |
+| ----------------- | ---------------------------------------------------- |
+| Objective         | What user-visible AI behavior must be protected?     |
+| Inputs            | What prompts, documents, context, or tools are used? |
+| Expected evidence | What makes an output pass?                           |
+| Scorer            | How is pass/fail computed?                           |
+| Dataset           | Which examples represent real risk?                  |
+| Cadence           | When does it run?                                    |
+| Threshold         | What result blocks release?                          |
+| Triage owner      | Who decides prompt vs model vs scorer vs data?       |
+
+Minimal pseudo-YAML example:
+
+```yaml
+description: 'Support answer follows refund policy'
+input:
+  question: 'Can I get a refund after 45 days?'
+  policy: 'Refunds are available within 30 days of purchase.'
+checks:
+  - kind: json_schema
+    rule: '{ answer: string, cites_policy: boolean }'
+  - kind: required_text
+    rule: '30 days'
+  - kind: judge_rubric
+    rule: |
+      PASS if the answer states that refunds are only available within 30 days,
+      does not invent an exception, and remains polite.
+      FAIL if it offers a refund after 45 days, omits the policy limit, or invents policy.
+```
+
+Use the syntax of the project's chosen eval tool. The structure above is a
+portable pattern, not a required framework.
+
+---
+
+## Scorer Design
+
+Scorers are tests. Treat them with the same rigor as code.
+
+### Prefer Binary Outcomes
+
+Use pass/fail when the eval gates a release.
+
+```text
+PASS: Includes the 30-day limit and refuses the 45-day refund.
+FAIL: Offers a refund, omits the limit, or invents an escalation path.
+```
+
+Avoid vague scales unless the team has calibration examples.
+
+```text
+Bad: Score quality from 1 to 5.
+Good: PASS only if all required facts are present and no unsupported facts appear.
+```
+
+### One Dimension Per Scorer
+
+Split factuality, completeness, tone, and safety into separate scorers.
+
+```yaml
+scorers:
+  - name: factuality
+    rubric: 'PASS if every factual claim is supported by the provided policy.'
+  - name: completeness
+    rubric: 'PASS if the answer covers eligibility, deadline, and next step.'
+  - name: tone
+    rubric: 'PASS if the answer is direct and respectful.'
+```
+
+Do not bundle unrelated dimensions into one vague judgment.
+
+### Include Failure Examples
+
+Rubrics should say what fails.
+
+```text
+PASS: Mentions the renewal date and cancellation window.
+FAIL: Gives only a generic summary, misses the cancellation window, or invents a date.
+```
+
+### Calibrate Judge Evals
+
+Before trusting an LLM-as-judge scorer:
+
+1. Run it on examples humans already labeled
+2. Inspect disagreements
+3. Tighten the rubric
+4. Add few-shot grading examples when useful
+5. Re-run until the scorer catches known bad outputs
+
+If the scorer cannot reliably catch known failures, it cannot block release.
+
+---
+
+## Dataset Design
+
+An eval is only as good as its dataset.
+
+### Dataset Mix
+
+Include:
+
+- Happy-path examples
+- Boundary cases
+- Adversarial prompts
+- Ambiguous user requests
+- Production-inspired cases with private data removed
+- Historical bugs
+- Examples from domain experts
+- Holdout cases not used during prompt tuning
+
+### Dataset Size
+
+Start small and useful:
+
+```text
+5-10 cases    → smoke eval while designing a prompt
+20-50 cases   → PR or feature gate
+100+ cases    → release, scheduled, or model migration gate
+```
+
+The numbers are starting points. Increase size when behavior is high-risk,
+inputs are diverse, or the model/provider is changing.
+
+### Privacy Rules
+
+Before adding production data:
+
+- Remove personal data not needed for the eval
+- Replace secrets, tokens, emails, addresses, and account IDs
+- Preserve the structure that made the case hard
+- Record the source and scrub date if policy allows
+
+Never copy sensitive production data into a prompt, fixture, or third-party eval
+system without approval.
+
+---
+
+## Eval Cadence
+
+| Event                 | Recommended Eval Set                      |
+| --------------------- | ----------------------------------------- |
+| Prompt editing        | 5-10 smoke cases                          |
+| Code change           | Deterministic assertions + affected cases |
+| Pull request          | Smoke eval + known regression cases       |
+| Prompt/model change   | Full task eval                            |
+| Retrieval data change | Retrieval/factuality eval                 |
+| Release               | Full eval for critical AI workflows       |
+| Scheduled monitoring  | Drift and production-inspired evals       |
+| Production monitoring | Sampled online evals with cost controls   |
+
+**Tie-breaker:** run the cheapest eval that can catch the likely regression at
+the point where it is cheapest to fix.
+
+---
+
+## Cost and Runtime Controls
+
+Evals can become expensive because they multiply:
+
+```text
+cases × prompts × models × scorers × repetitions
+```
+
+Control cost with:
+
+- A smoke eval suite
+- Deterministic assertions before model-graded assertions
+- Sampling for online evals
+- Caching where the tool supports it
+- Smaller judge models for low-risk rubrics
+- Full evals only on prompt, model, retrieval, or release changes
+- Repetitions only for nondeterminism-sensitive tasks
+
+Do not hide expensive evals inside default unit test commands.
+
+---
+
+## Trace and Agent Evals
+
+Use trace evals when the path matters, not just the final answer.
+
+**Use for:**
+
+- Tool choice
+- Tool arguments
+- Retrieval query quality
+- Whether the agent asked for clarification
+- Whether the agent stopped after enough evidence
+- Whether the agent avoided disallowed tools
+
+**Good trace assertions:**
+
+```text
+PASS if the agent searches the knowledge base before answering a policy question.
+PASS if the agent calls the refund tool with the user_id from context, not from user text.
+FAIL if the agent sends an email before explicit confirmation.
+```
+
+**Bad trace assertion:**
+
+```text
+PASS if the agent thinks carefully.
+```
+
+That is not observable.
+
+Avoid over-constraining harmless internal reasoning. Grade path only when the
+path affects correctness, cost, safety, privacy, or user-visible behavior.
+
+---
+
+## Failure Triage
+
+When an eval fails, classify the failure before changing prompts or tests.
+
+| Failure Source      | Symptom                                       | First Action                                  |
+| ------------------- | --------------------------------------------- | --------------------------------------------- |
+| Prompt              | Same model misses instruction consistently    | Clarify prompt or examples                    |
+| Model               | Regression appears after model change         | Compare old/new model on same dataset         |
+| Retrieval           | Answer lacks facts that context should supply | Inspect retrieved documents and query         |
+| Tool use            | Wrong tool or wrong arguments                 | Add trace eval and tool contract tests        |
+| Dataset             | Case no longer represents desired behavior    | Update with approval and preserve history     |
+| Scorer              | Human disagrees with judge                    | Calibrate rubric and add examples             |
+| Product requirement | Desired behavior changed                      | Update acceptance criteria before eval update |
+
+Do not weaken a scorer because the model failed. First prove the scorer is wrong
+or the requirement changed.
+
+---
+
+## Regression Workflow
+
+When a user reports a bad AI output:
+
+1. Save the input, retrieved context, tool trace, and output if privacy allows
+2. Scrub sensitive data
+3. Add a failing eval case
+4. Confirm the eval fails for the reported behavior
+5. Fix prompt, retrieval, tools, model choice, or product logic
+6. Confirm the eval passes
+7. Keep the case to prevent regression
+
+If the reported issue depends on current facts, use a fixture with frozen facts
+or a search-capable scorer with clear source requirements.
+
+---
+
+## Project Documentation
+
+Each AI-enabled project should document eval conventions in `evals/README.md`,
+`tests/SAFEWORD.md`, `tests/AGENTS.md`, or the nearest existing testing docs.
+
+Include:
+
+- Eval command names
+- Eval tool or framework
+- Dataset locations
+- Scorer types
+- Required API keys or local models
+- Cost expectations
+- Which evals block PRs or releases
+- Human review process for scorer changes
+- Privacy rules for production examples
+- Ownership for failures
+
+Minimal template:
+
+```markdown
+# Eval Lanes
+
+| Eval          | Command              | Runs    | Blocks         | Dataset           | Owner   |
+| ------------- | -------------------- | ------- | -------------- | ----------------- | ------- |
+| AI smoke      | `npm run eval:smoke` | PR      | yes            | `evals/smoke.yml` | AI team |
+| Full AI eval  | `npm run eval:full`  | release | yes            | `evals/full.yml`  | AI team |
+| Drift monitor | scheduled            | no      | sampled traces | platform          |
+```
+
+---
+
+## Key Takeaways
+
+- Use deterministic tests before judge evals.
+- Evals need objectives, datasets, scorers, cadence, thresholds, and owners.
+- Judge one quality dimension at a time.
+- Calibrate LLM-as-judge scorers against human-labeled examples.
+- Keep historical failures as regression cases.
+- Separate cheap smoke evals from full, expensive eval suites.
+- Never put sensitive production data into eval fixtures without approval.

--- a/packages/cli/templates/guides/testing-guide.md
+++ b/packages/cli/templates/guides/testing-guide.md
@@ -57,7 +57,7 @@ Tests are the specification. When a test fails, the implementation is wrong—no
 ```text
 E2E (seconds-minutes)    ← Full browser, user flows         ↑ prefer
   ↑
-LLM Eval (seconds)       ← AI judgment, costs $0.01-0.30
+LLM Eval (seconds+)      ← AI judgment, model-dependent cost
   ↑
 Integration (seconds)    ← Multiple modules, database, API
   ↑
@@ -97,6 +97,8 @@ Answer these questions in order. Stop at first match.
 - Non-deterministic functions (Math.random, Date.now) → Unit test with mocked randomness
 - Functions with environment dependencies (process.env) → Integration test
 - Mixed pure + I/O logic → Extract pure logic, unit test it, integration test I/O
+- DOM tests with jsdom or Testing Library → Integration test unless the bug
+  depends on real browser layout, CSS, navigation, or browser APIs
 
 ---
 
@@ -350,7 +352,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 ❌ **Implementation details** - Private methods, CSS classes, internal state
 ❌ **Third-party libraries** - Assume React/Axios work, test YOUR code
 ❌ **Trivial code** - Getters/setters with no logic, pass-through functions
-❌ **UI copy** - Use regex `/submit/i`, not exact text matching
+❌ **Incidental UI copy** - Do not pin marketing/help text unless copy is the contract. Prefer role/name or resilient regex for controls. Assert exact text for legal, safety, error, or required user-facing messages.
 
 ---
 
@@ -359,7 +361,7 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 - **Unit tests:** 80%+ coverage of pure functions
 - **Integration tests:** All critical paths covered
 - **E2E tests:** All critical multi-page user flows
-- **LLM evals:** All AI features have evaluation scenarios
+- **LLM evals:** AI features with probabilistic output quality have evaluation scenarios; deterministic AI plumbing has normal tests
 
 **What are "critical paths"?**
 
@@ -372,15 +374,19 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 
 ## LLM Eval Cost Considerations
 
-**Cost:** $0.01-0.30 per run depending on prompt size.
+**Cost:** Model-, prompt-, provider-, and scenario-dependent. Estimate from
+current provider pricing before deciding cadence.
 
-**Prompt caching reduces costs by 90%** (30 scenarios: $0.30 → $0.03 after first run).
+**Prompt caching can reduce repeated input-token costs on supported providers.**
+OpenAI currently documents up to 90% input-token savings for qualifying cached
+prompts. Treat caching as provider-specific, not guaranteed.
 
 **Cost reduction strategies:**
 
 - Cache static content (system prompts, examples, rules)
 - Batch multiple scenarios in one run
-- Run full evals on PR/schedule, not every commit
+- Split cheap smoke evals from full eval suites
+- Run full evals on PR, release, or schedule only when the signal is worth the cost
 
 ---
 
@@ -388,18 +394,18 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 
 - Run unit + integration tests on every commit (fast feedback)
 - Run E2E tests on every PR
-- Run LLM evals on schedule (weekly catches regressions without per-commit cost)
+- Run smoke evals on PR for high-risk AI behavior; run full evals on release or schedule
 
 ---
 
 ## Quick Reference
 
-| Need to test...      | Test type   | Technology | Speed  | Cost       |
-| -------------------- | ----------- | ---------- | ------ | ---------- |
-| Pure function        | Unit        | Vitest     | Fast   | Free       |
-| Service integration  | Integration | Vitest     | Medium | Free       |
-| Full user flow       | E2E         | Playwright | Slow   | Free       |
-| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | $0.01-0.30 |
+| Need to test...      | Test type   | Technology | Speed  | Cost   |
+| -------------------- | ----------- | ---------- | ------ | ------ |
+| Pure function        | Unit        | Vitest     | Fast   | Free   |
+| Service integration  | Integration | Vitest     | Medium | Free   |
+| Full user flow       | E2E         | Playwright | Slow   | Free   |
+| AI reasoning quality | LLM eval    | Promptfoo  | Slow   | Varies |
 
 ---
 

--- a/packages/cli/templates/guides/testing-guide.md
+++ b/packages/cli/templates/guides/testing-guide.md
@@ -352,7 +352,13 @@ await waitFor(() => expect(screen.getByText('Success')).toBeVisible());
 ❌ **Implementation details** - Private methods, CSS classes, internal state
 ❌ **Third-party libraries** - Assume React/Axios work, test YOUR code
 ❌ **Trivial code** - Getters/setters with no logic, pass-through functions
-❌ **Incidental UI copy** - Do not pin marketing/help text unless copy is the contract. Prefer role/name or resilient regex for controls. Assert exact text for legal, safety, error, or required user-facing messages.
+❌ **Incidental UI copy** - Marketing/help text when exact wording is not the
+contract
+
+**Copy assertions:**
+
+- Prefer role/name or resilient regex for controls
+- Assert exact text for legal, safety, error, or required user-facing messages
 
 ---
 

--- a/packages/cli/templates/guides/testing-guide.md
+++ b/packages/cli/templates/guides/testing-guide.md
@@ -4,6 +4,16 @@ Test methodology, TDD workflow, and test type selection.
 
 ---
 
+## Related Guides
+
+| Need                              | Guide                                          |
+| --------------------------------- | ---------------------------------------------- |
+| Choose unit/integration/E2E/eval  | This guide                                     |
+| Choose smoke/live/release cadence | `.safeword/guides/verification-lanes-guide.md` |
+| Design AI output evaluations      | `.safeword/guides/llm-evals-guide.md`          |
+
+---
+
 ## Test Philosophy
 
 **Behavior-biased testing:** At every test level, assert on what the system _does_ (outputs, side effects, user-visible outcomes) — never on _how_ it does it (internal state, mock call counts, private methods). Tests coupled to implementation break on every refactor. Behavioral tests survive.

--- a/packages/cli/templates/guides/verification-lanes-guide.md
+++ b/packages/cli/templates/guides/verification-lanes-guide.md
@@ -1,0 +1,574 @@
+# Verification Lanes Guide
+
+How to choose when a test or check should run: focused, smoke, live-fire,
+release, migration, static, or slow/performance.
+
+---
+
+## Core Idea
+
+Test type answers **what behavior is being proved**. Verification lane answers
+**when and how much evidence is needed**.
+
+Use both labels:
+
+```text
+Unit test + focused lane        → fast proof while implementing
+E2E test + smoke lane           → quick proof the main journey still works
+Acceptance test + release lane  → proof the shipped artifact satisfies requirements
+Integration test + migration    → proof old data still upgrades correctly
+```
+
+Do not force every lane into the unit/integration/E2E taxonomy. Smoke,
+live-fire, release, migration, static, and slow/performance are execution
+strategies. They can contain any test type.
+
+Choose the lane for a specific verification run, not for the test file forever.
+The same test can be focused while developing, smoke before a PR, and release
+before publishing. If a run touches real external systems, real credentials, or
+customer-like infrastructure, apply the live-fire guardrails even when its
+primary lane is smoke, release, or slow/performance.
+
+---
+
+## Lane Decision Tree
+
+Answer in order. Stop at the first match. Choose the lane that explains why this
+run exists now.
+
+1. **Are you proving only the current change while writing code?**
+   - YES → Focused lane
+   - NO → Continue
+
+2. **Do you need a quick signal that the product is basically usable?**
+   - YES → Smoke lane
+   - NO → Continue
+
+3. **Is the main reason for this run to prove behavior against real external
+   systems, real credentials, production-like infrastructure, or a real
+   customer-like workspace?**
+   - YES → Live-fire lane
+   - NO → Continue
+
+4. **Are you proving that a built, packaged, or deployed artifact is ready to ship?**
+   - YES → Release lane
+   - NO → Continue
+
+5. **Are you proving old data, old config, or old installs still work after an upgrade?**
+   - YES → Migration lane
+   - NO → Continue
+
+6. **Is the check static analysis rather than runtime behavior?**
+   - YES → Static gate
+   - NO → Continue
+
+7. **Is the check too expensive for normal local or per-commit runs?**
+   - YES → Slow/performance lane
+   - NO → Re-evaluate the test type in `.safeword/guides/testing-guide.md`
+
+**Tie-breaker:** if a check fits two lanes, choose the lane that explains why it
+is run at its cadence. Example: a Playwright checkout test that runs in two
+minutes before every PR is a smoke lane test; the same journey run across
+browsers, locales, and payment providers before release is a release lane test.
+
+---
+
+## Lane Reference
+
+| Lane             | Purpose                                      | Typical Cadence             | Example Command                     |
+| ---------------- | -------------------------------------------- | --------------------------- | ----------------------------------- |
+| Focused          | Prove the behavior currently being changed   | During TDD                  | `npm test -- path/to/test`          |
+| Smoke            | Prove core product paths are not broken      | Before handoff, PR, deploy  | `npm run test:smoke`                |
+| Live-fire        | Prove real-environment behavior              | Manual, scheduled, pre-prod | `npm run test:live`                 |
+| Release          | Prove the artifact is shippable              | Before release              | `npm run test:release`              |
+| Migration        | Prove old state upgrades safely              | Before release              | `npm run test:migration`            |
+| Static gate      | Catch non-runtime correctness issues         | Every verify or CI run      | `npm run lint && npm run typecheck` |
+| Slow/performance | Prove scale, speed, or long-running behavior | Scheduled or release        | `npm run test:slow`                 |
+
+Commands are placeholders. Use the package manager and scripts the project
+already has.
+
+---
+
+## Good Verification Lane Or Busywork
+
+A good verification lane changes an engineering decision. It tells the team
+whether to keep coding, hand off, merge, release, roll back, or investigate the
+environment. A busywork lane consumes time without changing the next action.
+
+Before adding a new lane or check, answer in order. Stop at the first failure.
+
+1. **What decision will this run unblock?**
+   - Clear answer → Continue
+   - No clear answer → Do not add the lane; name the decision first
+
+2. **What plausible failure would cheaper checks miss?**
+   - Clear answer → Continue
+   - No clear answer → Use a focused test, static gate, or existing suite
+
+3. **Is the cadence matched to cost and flake risk?**
+   - YES → Continue
+   - NO → Move it later, make it opt-in, or split a cheaper smoke check
+
+4. **Will the evidence identify what ran and what failed?**
+   - YES → Continue
+   - NO → Add artifact, environment, command, data, and failure-action details
+
+5. **Is ownership clear for expensive, slow, or side-effecting runs?**
+   - YES → Keep the lane
+   - NO → Define the triage owner, cleanup rule, and escalation path first
+
+### Good Lane Signals
+
+| Signal                    | What It Means                                            |
+| ------------------------- | -------------------------------------------------------- |
+| Decision-linked           | The result changes whether work proceeds                 |
+| Cheapest sufficient proof | The lane runs no earlier or broader than needed          |
+| Distinct risk             | It catches a failure cheaper checks cannot catch         |
+| Specific evidence         | Output names command, artifact, environment, and scope   |
+| Clear owner               | Someone knows how to diagnose and maintain failures      |
+| Controlled side effects   | Cost, data mutation, notifications, and cleanup are safe |
+| Failure action            | The guide says whether to fix, retry, rollback, or skip  |
+
+### Busywork Smells
+
+| Smell                      | Why It Wastes Time                        | Better Move                             |
+| -------------------------- | ----------------------------------------- | --------------------------------------- |
+| Runs because it exists     | No decision depends on the result         | Remove it or document the decision      |
+| Full suite labeled smoke   | Slow signal blocks fast feedback          | Keep only core alive checks             |
+| Accidental live-fire       | Real side effects hide in default tests   | Make it opt-in with guardrails          |
+| Source tests as release    | Does not prove packaged artifact behavior | Install and test the built artifact     |
+| Performance without metric | Cannot fail deterministically             | Define workload, threshold, and runtime |
+| Static gate as behavior    | Type/lint success does not prove workflow | Add runtime behavior coverage           |
+| Anonymous environment      | Failure cannot be reproduced              | Record environment and artifact         |
+| No owner                   | Failures rot or get ignored               | Assign triage ownership                 |
+
+### Examples
+
+Good verification lane:
+
+```text
+Decision: Can we publish the package?
+Risk: Published artifact is missing the CLI bin or template files.
+Lane: Release
+Command: npm pack, install tarball into a temporary project, run public CLI.
+Evidence: tarball name, temp project path, CLI command output, files verified.
+Failure action: block release and inspect package file inclusion.
+```
+
+Busywork lane:
+
+```text
+Decision: unclear.
+Lane: Smoke.
+Command: npm test.
+Risk: "General confidence."
+Evidence: pass/fail only.
+```
+
+If a lane fails this gate, convert it into one of:
+
+- A focused test for the specific behavior
+- A static gate for source or metadata validity
+- A smaller smoke check
+- A release or migration check with artifact and fixture details
+- A scheduled slow/performance run with a metric and owner
+- A live-fire run with explicit opt-in guardrails
+
+---
+
+## Focused Lane
+
+Use focused tests while implementing. They should be narrow enough to run
+repeatedly and strong enough to fail when the behavior is wrong.
+
+**Use when:**
+
+- Working through RED/GREEN/REFACTOR
+- Fixing a bug with a known reproduction
+- Refactoring and protecting the touched behavior
+
+**Evidence required:**
+
+- The specific failing test fails for the right reason before implementation
+- The same test passes after implementation
+- Nearby affected tests pass when practical
+
+**Good examples:**
+
+```bash
+npm test -- src/cart/discount.test.ts
+npm test -- --runInBand auth
+pytest tests/test_invoice_totals.py::test_rejects_negative_quantity
+```
+
+**Bad examples:**
+
+```bash
+npm test
+```
+
+This is too broad for a focused lane if it hides which behavior drove the
+change.
+
+```bash
+npm test -- --updateSnapshot
+```
+
+This is not proof unless the snapshot change was reviewed as the intended
+behavior.
+
+---
+
+## Smoke Lane
+
+Smoke tests are a small, curated set of high-value checks that answer: "Is the
+product basically alive?"
+
+**Use when:**
+
+- Before handing work back to a user
+- Before opening or merging a PR
+- After building or deploying
+- Before running expensive full suites
+
+**Include:**
+
+- One or two primary user journeys
+- Startup/import/bootstrap checks
+- Critical write/read loops
+- Core authentication or authorization path when the app has one
+- One representative integration with important dependencies
+
+**Exclude:**
+
+- Exhaustive edge cases
+- Full browser/device matrices
+- Long-running performance workloads
+- Tests that require fragile shared state
+
+**Good smoke suite:**
+
+```text
+- App starts
+- User signs in
+- User creates the central resource
+- User reloads and sees the resource
+- Health endpoint returns OK
+```
+
+**Bad smoke suite:**
+
+```text
+- Every checkout edge case
+- Every supported browser and locale
+- Every admin flow
+- Full load test
+```
+
+That is a regression or release suite, not smoke.
+
+**Smoke failure rule:** treat a smoke failure as a stop signal. Either fix it,
+prove the test is wrong, or explicitly record why the product is intentionally
+not smoke-green.
+
+---
+
+## Live-Fire Lane
+
+Live-fire tests run against real or production-like boundaries. They are useful
+because high-fidelity tests catch configuration, packaging, credential,
+network, permission, and provider behavior that hermetic tests miss.
+
+**Use when the risk is at the boundary:**
+
+- Real third-party APIs
+- Real auth providers
+- Real queues, webhooks, storage, browsers, CLIs, or installed packages
+- Production-like config, routing, permissions, or infrastructure
+- Installed behavior in a real project workspace
+
+**Do not run live-fire tests by default when they can:**
+
+- Spend money
+- Send email, texts, webhooks, or customer-visible notifications
+- Modify production data
+- Depend on rate-limited or flaky external services
+- Require secrets unavailable in normal CI
+
+**Required guardrails:**
+
+- Opt-in command or tag, never hidden inside the default unit suite
+- Dedicated test accounts, projects, tenants, or sandboxes
+- Clear cleanup strategy
+- Idempotent setup where possible
+- Explicit cost and side-effect notes
+- Separate failure triage for "product failed" vs "environment unavailable"
+
+**Good live-fire evidence:**
+
+```text
+Live-fire: PASS
+Environment: staging
+Account: test tenant
+Side effects: created and deleted one test resource
+Cost: none expected
+Cleanup: confirmed
+```
+
+**Bad live-fire evidence:**
+
+```text
+Ran live tests. One failed but probably network.
+```
+
+That does not say what environment ran, what changed, or whether cleanup
+happened.
+
+---
+
+## Release Lane
+
+Release tests prove that the artifact users receive works, not just that source
+code passes tests.
+
+**Use before:**
+
+- Publishing a package
+- Cutting a binary or container image
+- Deploying a build to production
+- Shipping a plugin, extension, CLI, SDK, or template bundle
+
+**Common release checks:**
+
+- Build from a clean checkout
+- Install the packaged artifact into a temporary project
+- Run the public CLI or API entrypoint
+- Verify package exports, file inclusion, and executable permissions
+- Verify peer dependency and engine compatibility
+- Run the smoke suite against the built artifact
+- Validate generated assets are present and usable
+
+**Good release check:**
+
+```bash
+npm pack
+tmp=$(mktemp -d)
+cd "$tmp"
+npm init -y
+npm install /path/to/package.tgz
+npx your-cli --version
+npx your-cli init --dry-run
+```
+
+**Bad release check:**
+
+```bash
+npm test
+```
+
+Source tests can pass while the published package is missing files, exports, or
+runtime permissions.
+
+---
+
+## Migration Lane
+
+Migration tests prove that existing users can upgrade safely.
+
+**Use when changing:**
+
+- Data schema
+- Config file format
+- File layout
+- Generated code or templates
+- Package names, exports, or command names
+- Storage, cache, or queue semantics
+- Authentication or authorization policy
+
+**Test fixtures should include:**
+
+- Current version state
+- Previous supported version state
+- Partially customized state
+- Missing optional files
+- Unknown future fields
+- Corrupt or invalid state with expected recovery behavior
+
+**Core assertions:**
+
+- User-owned data is preserved
+- Generated or managed data updates correctly
+- The migration is idempotent
+- Rollback or retry behavior is clear
+- Warnings are actionable
+
+**Good migration test names:**
+
+```text
+preserves_user_edits_when_upgrading_config
+adds_missing_managed_files_without_deleting_custom_files
+rerunning_migration_after_partial_failure_is_safe
+```
+
+**Bad migration test name:**
+
+```text
+migration works
+```
+
+It does not identify the user value or failure mode.
+
+---
+
+## Static Gates
+
+Static gates do not run product behavior. They inspect source, generated files,
+types, dependency graphs, formatting, or policy rules.
+
+**Common static gates:**
+
+- Typecheck
+- Lint
+- Format check
+- Markdown or documentation lint
+- Gherkin lint
+- Dependency graph validation
+- Dead-code detection
+- Security/static analysis
+- Package metadata validation
+
+**Use static gates to catch:**
+
+- Type and API mismatches
+- Invalid generated files
+- Broken documentation syntax
+- Unsafe dependency edges
+- Missing package metadata
+- Policy violations that do not require runtime execution
+
+**Do not use static gates as a substitute for behavior tests.**
+
+```text
+Typecheck passing means the program is type-compatible.
+It does not mean the user workflow works.
+```
+
+---
+
+## Slow and Performance Lane
+
+Slow/performance tests prove behavior that is too expensive for routine local
+or per-commit feedback.
+
+**Use when testing:**
+
+- Large datasets
+- Long-running jobs
+- Concurrency, retries, and backpressure
+- Load, latency, memory, or throughput
+- Cross-browser/device/locale matrices
+- Full regression suites
+
+**Required metadata:**
+
+- Expected runtime
+- Resource requirements
+- What metric fails the test
+- How to reproduce locally or in CI
+- Owner or escalation path
+
+**Good performance assertion:**
+
+```text
+95th percentile response time stays under 300 ms for 500 requests/minute
+with the standard test dataset.
+```
+
+**Bad performance assertion:**
+
+```text
+App should be fast.
+```
+
+That cannot fail deterministically.
+
+---
+
+## CI Cadence
+
+Use this default cadence unless the project has a stronger local convention.
+
+| Event             | Recommended Lanes                   |
+| ----------------- | ----------------------------------- |
+| During coding     | Focused                             |
+| Before handoff    | Focused + relevant static gates     |
+| Pull request      | Static gates + smoke + affected BDD |
+| Before release    | Release + migration + full smoke    |
+| Scheduled nightly | Slow/performance + broader matrices |
+| Manual high-risk  | Live-fire                           |
+| After deployment  | Smoke + selected live-fire health   |
+
+**Tie-breaker:** move a lane earlier only when the failure is cheap to diagnose
+there. Expensive checks that frequently fail for environmental reasons belong
+later, with clearer ownership and artifacts.
+
+---
+
+## Failure Triage
+
+Classify the failure before fixing.
+
+| Failure Type              | First Action                                      |
+| ------------------------- | ------------------------------------------------- |
+| Product behavior changed  | Fix implementation or update requirements         |
+| Test assertion is wrong   | Explain and get approval before changing the test |
+| Environment unavailable   | Record outage evidence and retry once             |
+| Fixture drift             | Repair fixture or add migration coverage          |
+| Flaky timing              | Replace sleeps with condition-based waits         |
+| External provider changed | Decide whether to adapt, pin, mock, or escalate   |
+
+Never skip, weaken, or delete tests just to pass a lane. If the lane is too
+expensive or noisy, change its cadence or ownership deliberately.
+
+---
+
+## Project Documentation
+
+Each project should document its local lanes in `tests/SAFEWORD.md`,
+`tests/AGENTS.md`, or the nearest existing testing documentation.
+
+Include:
+
+- Lane names and commands
+- What each lane proves
+- Cadence: local, PR, release, scheduled, manual
+- Required secrets or services
+- Expected runtime
+- Owners for live-fire, release, migration, and slow lanes
+- Cleanup and side-effect rules
+- What evidence to include when reporting results
+
+Minimal template:
+
+```markdown
+# Test Lanes
+
+| Lane      | Command                | Runs       | Proves             | Owner         |
+| --------- | ---------------------- | ---------- | ------------------ | ------------- |
+| Focused   | `npm test -- <file>`   | during TDD | touched behavior   | feature owner |
+| Smoke     | `npm run test:smoke`   | PR         | core journeys      | app team      |
+| Live-fire | `npm run test:live`    | manual     | real provider path | platform team |
+| Release   | `npm run test:release` | release    | packaged artifact  | release owner |
+```
+
+---
+
+## Key Takeaways
+
+- Test type is about behavior scope; verification lane is about cadence and risk.
+- Smoke is small and curated. It is not the full regression suite.
+- Live-fire is opt-in and guarded because it touches real boundaries.
+- Release tests prove the artifact users receive, not just source code.
+- Migration tests protect existing users and customized state.
+- Static gates are verification lanes, but they do not replace behavior tests.

--- a/packages/cli/templates/skills/testing/SKILL.md
+++ b/packages/cli/templates/skills/testing/SKILL.md
@@ -307,6 +307,8 @@ it('preserves user input after validation error');
 | Need                             | Action                                            |
 | -------------------------------- | ------------------------------------------------- |
 | Full test type selection guide   | `.safeword/guides/testing-guide.md`               |
+| Smoke/live/release lane guidance | `.safeword/guides/verification-lanes-guide.md`    |
+| LLM eval design guide            | `.safeword/guides/llm-evals-guide.md`             |
 | Test definition template (BDD)   | `.safeword/templates/test-definitions-feature.md` |
 | Test quality review              | `/audit`                                          |
 | Feature-level TDD with scenarios | `/bdd`                                            |


### PR DESCRIPTION
## Summary
- Add a generic LLM evals guide covering when evals are worthwhile, scorer design, datasets, cost controls, and failure triage.
- Add a generic verification lanes guide covering focused, smoke, live-fire, release, migration, static, and slow/performance lanes.
- Register both guides in the template schema and link them from the testing guide and testing skill surfaces.

## Validation
- bunx markdownlint-cli2 packages/cli/templates/guides/llm-evals-guide.md packages/cli/templates/guides/verification-lanes-guide.md packages/cli/templates/guides/testing-guide.md .safeword/guides/llm-evals-guide.md .safeword/guides/verification-lanes-guide.md .safeword/guides/testing-guide.md
- bun run --cwd packages/cli typecheck
- pre-push schema-drift gate: 2 files, 624 tests passed