### PR TITLE
Add PR guard for ticket done flips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Weekly on Sunday at midnight UTC - catches runner image and environmental drift
     - cron: '0 0 * * 0'
@@ -96,6 +97,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -103,6 +107,16 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Ticket closure rides ready PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: |
+          gh pr diff "$PR_NUMBER" --name-only > /tmp/safeword-pr-changed-files.txt
+          unset GH_TOKEN
+          bun scripts/check-pr-ticket-done.ts --changed-files /tmp/safeword-pr-changed-files.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/packages/cli/tests/integration/check-pr-ticket-done.test.ts
+++ b/packages/cli/tests/integration/check-pr-ticket-done.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test for scripts/check-pr-ticket-done.ts (#365).
+ *
+ * Exercises the CI guard the way the workflow invokes it: pass a PR changed-file
+ * list and inspect ticket.md frontmatter in a synthetic checkout.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
+
+const REPO_ROOT = nodePath.resolve(import.meta.dirname, '..', '..', '..', '..');
+const SCRIPT_PATH = nodePath.join(REPO_ROOT, 'scripts', 'check-pr-ticket-done.ts');
+
+function writeTicket(
+  projectDirectory: string,
+  folder: string,
+  frontmatter: { status?: string; phase?: string },
+): void {
+  const directory = nodePath.join(projectDirectory, '.project', 'tickets', folder);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    nodePath.join(directory, 'ticket.md'),
+    [
+      '---',
+      'id: TICKET',
+      'type: task',
+      frontmatter.status ? `status: ${frontmatter.status}` : undefined,
+      frontmatter.phase ? `phase: ${frontmatter.phase}` : undefined,
+      '---',
+      '',
+      '# Test',
+      '',
+    ]
+      .filter(line => line !== undefined)
+      .join('\n'),
+  );
+}
+
+function runGuard(
+  projectDirectory: string,
+  changedFiles: string[],
+): { exitCode: number; stderr: string } {
+  const changedFilesPath = nodePath.join(projectDirectory, 'changed-files.txt');
+  writeFileSync(changedFilesPath, `${changedFiles.join('\n')}\n`);
+
+  const result = spawnSync('bun', [SCRIPT_PATH, '--changed-files', changedFilesPath], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+
+  return { exitCode: result.status ?? -1, stderr: result.stderr };
+}
+
+describe('scripts/check-pr-ticket-done.ts', () => {
+  let projectDirectory: string;
+
+  beforeEach(() => {
+    projectDirectory = createTemporaryDirectory();
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(projectDirectory);
+  });
+
+  it('exits 0 when no safeword ticket folders changed', () => {
+    const { exitCode } = runGuard(projectDirectory, ['packages/cli/src/cli.ts']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('exits 0 when every changed active ticket is closed', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'done', phase: 'done' });
+
+    const { exitCode } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+      '.project/tickets/ABC123-demo/verify.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('exits 0 for legacy closed tickets without phase done', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'done', phase: 'intake' });
+
+    const { exitCode } = runGuard(projectDirectory, ['.project/tickets/ABC123-demo/ticket.md']);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('ignores sibling ticket artifacts when ticket.md did not change', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'implement' });
+
+    const { exitCode } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/verify.md',
+      '.project/tickets/ABC123-demo/test-definitions.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('exits non-zero when a changed active ticket is still in progress', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'done' });
+
+    const { exitCode, stderr } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('ABC123-demo/ticket.md');
+    expect(stderr).toContain('status: in_progress');
+  });
+
+  it('exits non-zero when a changed active ticket.md is missing', () => {
+    const { exitCode, stderr } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('ABC123-demo/ticket.md');
+    expect(stderr).toContain('ticket.md is missing');
+  });
+
+  it('ignores completed archive changes', () => {
+    const { exitCode } = runGuard(projectDirectory, [
+      '.project/tickets/completed/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/cli/tests/integration/check-pr-ticket-done.test.ts
+++ b/packages/cli/tests/integration/check-pr-ticket-done.test.ts
@@ -44,7 +44,7 @@ function writeTicket(
 function runGuard(
   projectDirectory: string,
   changedFiles: string[],
-): { exitCode: number; stderr: string } {
+): { exitCode: number; stderr: string; stdout: string } {
   const changedFilesPath = nodePath.join(projectDirectory, 'changed-files.txt');
   writeFileSync(changedFilesPath, `${changedFiles.join('\n')}\n`);
 
@@ -54,7 +54,7 @@ function runGuard(
     timeout: 10_000,
   });
 
-  return { exitCode: result.status ?? -1, stderr: result.stderr };
+  return { exitCode: result.status ?? -1, stderr: result.stderr, stdout: result.stdout };
 }
 
 describe('scripts/check-pr-ticket-done.ts', () => {
@@ -96,14 +96,26 @@ describe('scripts/check-pr-ticket-done.ts', () => {
     writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'implement' });
 
     const { exitCode } = runGuard(projectDirectory, [
-      '.project/tickets/ABC123-demo/verify.md',
+      '.project/tickets/ABC123-demo/impl-plan.md',
       '.project/tickets/ABC123-demo/test-definitions.md',
     ]);
 
     expect(exitCode).toBe(0);
   });
 
-  it('exits non-zero when a changed active ticket is still in progress', () => {
+  it('warns but exits 0 when a changed active ticket is still in progress', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'implement' });
+
+    const { exitCode, stdout } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('::warning');
+    expect(stdout).toContain('status: in_progress');
+  });
+
+  it('exits non-zero when a changed active ticket enters done phase without closing', () => {
     writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'done' });
 
     const { exitCode, stderr } = runGuard(projectDirectory, [
@@ -112,7 +124,92 @@ describe('scripts/check-pr-ticket-done.ts', () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain('ABC123-demo/ticket.md');
-    expect(stderr).toContain('status: in_progress');
+    expect(stderr).toContain('phase: done');
+  });
+
+  it('exits non-zero when verify evidence changed but the ticket is still in progress', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'verify' });
+
+    const { exitCode, stderr } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/verify.md',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('ABC123-demo/ticket.md');
+    expect(stderr).toContain('verify.md changed');
+  });
+
+  it('warns but exits 0 for terminal non-done statuses', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'cancelled', phase: 'implement' });
+
+    const { exitCode, stdout } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('::warning');
+    expect(stdout).toContain('status: cancelled');
+  });
+
+  it('warns but exits 0 for blocked ticket notes', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'blocked', phase: 'implement' });
+
+    const { exitCode, stdout } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('::warning');
+    expect(stdout).toContain('status: blocked');
+  });
+
+  it('warns but exits 0 for open epic updates', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'open' });
+
+    const { exitCode, stdout } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('::warning');
+    expect(stdout).toContain('status: open');
+  });
+
+  it('warns but exits 0 when done_when boxes are all checked but no close evidence changed', () => {
+    writeTicket(projectDirectory, 'ABC123-demo', { status: 'in_progress', phase: 'implement' });
+
+    const ticketPath = nodePath.join(
+      projectDirectory,
+      '.project',
+      'tickets',
+      'ABC123-demo',
+      'ticket.md',
+    );
+    writeFileSync(
+      ticketPath,
+      [
+        '---',
+        'id: TICKET',
+        'type: task',
+        'status: in_progress',
+        'phase: implement',
+        '---',
+        '',
+        '# Test',
+        '',
+        '- [x] One',
+        '- [x] Two',
+        '',
+      ].join('\n'),
+    );
+
+    const { exitCode, stdout } = runGuard(projectDirectory, [
+      '.project/tickets/ABC123-demo/ticket.md',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('::warning');
+    expect(stdout).toContain('status: in_progress');
   });
 
   it('exits non-zero when a changed active ticket.md is missing', () => {

--- a/scripts/check-pr-ticket-done.ts
+++ b/scripts/check-pr-ticket-done.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * PR guard: if a ready PR includes a safeword ticket.md, the ticket closure
+ * must ride that same PR.
+ *
+ * The workflow skips draft PRs. This script stays deliberately dumb: it receives
+ * the PR changed-file list and checks the corresponding ticket.md frontmatter in
+ * the current checkout.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+interface Violation {
+  ticketDirectory: string;
+  reason: string;
+}
+
+function parseChangedFilesPath(arguments_: string[]): string | null {
+  const index = arguments_.indexOf('--changed-files');
+  if (index === -1) return null;
+  return arguments_[index + 1] ?? null;
+}
+
+function changedTicketDirectories(changedFiles: string[]): string[] {
+  const directories = new Set<string>();
+
+  for (const file of changedFiles) {
+    const match = /^(\.project|\.safeword-project)\/tickets\/([^/]+)\/ticket\.md$/.exec(file);
+    if (!match) continue;
+
+    const root = match[1];
+    const folder = match[2];
+    if (!root || !folder || folder === 'completed' || folder === 'tmp') continue;
+
+    directories.add(`${root}/tickets/${folder}`);
+  }
+
+  return [...directories].sort();
+}
+
+function frontmatterValue(content: string, key: string): string | null {
+  const frontmatterMatch = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!frontmatterMatch) return null;
+
+  const pattern = new RegExp(`^${key}:\\s*([^\\n#]+)`, 'm');
+  const valueMatch = pattern.exec(frontmatterMatch[1] ?? '');
+  return valueMatch?.[1]?.trim() ?? null;
+}
+
+function validateTicketDirectory(
+  projectDirectory: string,
+  ticketDirectory: string,
+): Violation | null {
+  const ticketPath = nodePath.join(projectDirectory, ticketDirectory, 'ticket.md');
+  if (!existsSync(ticketPath)) {
+    return { ticketDirectory, reason: 'ticket.md is missing' };
+  }
+
+  const content = readFileSync(ticketPath, 'utf8');
+  const status = frontmatterValue(content, 'status');
+  if (status === 'done') return null;
+
+  return {
+    ticketDirectory,
+    reason: `ticket.md has status: ${status ?? '(missing)'}`,
+  };
+}
+
+const changedFilesPath = parseChangedFilesPath(process.argv.slice(2));
+if (!changedFilesPath) {
+  process.stderr.write('Usage: bun scripts/check-pr-ticket-done.ts --changed-files <path>\n');
+  process.exit(2);
+}
+
+const changedFiles = readFileSync(changedFilesPath, 'utf8')
+  .split('\n')
+  .map(line => line.trim())
+  .filter(Boolean);
+
+const violations = changedTicketDirectories(changedFiles)
+  .map(ticketDirectory => validateTicketDirectory(process.cwd(), ticketDirectory))
+  .filter((violation): violation is Violation => violation !== null);
+
+if (violations.length === 0) process.exit(0);
+
+process.stderr.write('Safeword ticket closure must ride the ready PR.\n\n');
+for (const violation of violations) {
+  process.stderr.write(`  ${violation.ticketDirectory}/ticket.md: ${violation.reason}\n`);
+}
+process.stderr.write(
+  '\nBefore marking the PR ready to merge, run /verify, let the done gate flip the ticket to `status: done`, and include that ticket.md change in this PR.\n',
+);
+process.exit(1);

--- a/scripts/check-pr-ticket-done.ts
+++ b/scripts/check-pr-ticket-done.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
- * PR guard: if a ready PR includes a safeword ticket.md, the ticket closure
- * must ride that same PR.
+ * PR guard: if a ready PR includes ticket completion evidence, the ticket
+ * closure must ride that same PR.
  *
  * The workflow skips draft PRs. This script stays deliberately dumb: it receives
  * the PR changed-file list and checks the corresponding ticket.md frontmatter in
@@ -17,27 +17,53 @@ interface Violation {
   reason: string;
 }
 
+interface Advisory {
+  ticketDirectory: string;
+  status: string;
+}
+
+interface TicketChange {
+  ticketDirectory: string;
+  ticketRecordChanged: boolean;
+  verifyArtifactChanged: boolean;
+}
+
 function parseChangedFilesPath(arguments_: string[]): string | null {
   const index = arguments_.indexOf('--changed-files');
   if (index === -1) return null;
   return arguments_[index + 1] ?? null;
 }
 
-function changedTicketRecordDirectories(changedFiles: string[]): string[] {
-  const directories = new Set<string>();
+function changedActiveTickets(changedFiles: string[]): TicketChange[] {
+  const changes = new Map<string, TicketChange>();
 
   for (const file of changedFiles) {
-    const match = /^(\.project|\.safeword-project)\/tickets\/([^/]+)\/ticket\.md$/.exec(file);
+    const match =
+      /^(\.project|\.safeword-project)\/tickets\/([^/]+)\/(ticket\.md|verify\.md)$/.exec(file);
     if (!match) continue;
 
     const root = match[1];
     const folder = match[2];
+    const filename = match[3];
     if (!root || !folder || folder === 'completed' || folder === 'tmp') continue;
 
-    directories.add(`${root}/tickets/${folder}`);
+    const ticketDirectory = `${root}/tickets/${folder}`;
+    const change =
+      changes.get(ticketDirectory) ??
+      ({
+        ticketDirectory,
+        ticketRecordChanged: false,
+        verifyArtifactChanged: false,
+      } satisfies TicketChange);
+
+    if (filename === 'ticket.md') change.ticketRecordChanged = true;
+    if (filename === 'verify.md') change.verifyArtifactChanged = true;
+    changes.set(ticketDirectory, change);
   }
 
-  return [...directories].sort();
+  return [...changes.values()].sort((left, right) =>
+    left.ticketDirectory.localeCompare(right.ticketDirectory),
+  );
 }
 
 function frontmatterValue(content: string, key: string): string | null {
@@ -49,23 +75,56 @@ function frontmatterValue(content: string, key: string): string | null {
   return valueMatch?.[1]?.trim() ?? null;
 }
 
-function validateTicketDirectory(
+function validateTicketChange(
   projectDirectory: string,
-  ticketDirectory: string,
-): Violation | null {
-  const ticketPath = nodePath.join(projectDirectory, ticketDirectory, 'ticket.md');
+  change: TicketChange,
+): { violation: Violation | null; advisory: Advisory | null } {
+  const ticketPath = nodePath.join(projectDirectory, change.ticketDirectory, 'ticket.md');
   if (!existsSync(ticketPath)) {
-    return { ticketDirectory, reason: 'ticket.md is missing' };
+    return {
+      violation: { ticketDirectory: change.ticketDirectory, reason: 'ticket.md is missing' },
+      advisory: null,
+    };
   }
 
   const content = readFileSync(ticketPath, 'utf8');
   const status = frontmatterValue(content, 'status');
-  if (status === 'done') return null;
+  const phase = frontmatterValue(content, 'phase');
+  if (status === 'done') return { violation: null, advisory: null };
+
+  if (status === 'in_progress' && phase === 'done') {
+    return {
+      violation: {
+        ticketDirectory: change.ticketDirectory,
+        reason: 'ticket.md has status: in_progress, phase: done',
+      },
+      advisory: null,
+    };
+  }
+
+  if (status === 'in_progress' && change.verifyArtifactChanged) {
+    return {
+      violation: {
+        ticketDirectory: change.ticketDirectory,
+        reason: 'verify.md changed but ticket.md still has status: in_progress',
+      },
+      advisory: null,
+    };
+  }
 
   return {
-    ticketDirectory,
-    reason: `ticket.md has status: ${status ?? '(missing)'}`,
+    violation: null,
+    advisory: change.ticketRecordChanged
+      ? {
+          ticketDirectory: change.ticketDirectory,
+          status: status ?? '(missing)',
+        }
+      : null,
   };
+}
+
+function workflowCommandValue(value: string): string {
+  return value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A');
 }
 
 const changedFilesPath = parseChangedFilesPath(process.argv.slice(2));
@@ -79,9 +138,23 @@ const changedFiles = readFileSync(changedFilesPath, 'utf8')
   .map(line => line.trim())
   .filter(Boolean);
 
-const violations = changedTicketRecordDirectories(changedFiles)
-  .map(ticketDirectory => validateTicketDirectory(process.cwd(), ticketDirectory))
+const results = changedActiveTickets(changedFiles).map(change =>
+  validateTicketChange(process.cwd(), change),
+);
+const violations = results
+  .map(result => result.violation)
   .filter((violation): violation is Violation => violation !== null);
+const advisories = results
+  .map(result => result.advisory)
+  .filter((advisory): advisory is Advisory => advisory !== null);
+
+for (const advisory of advisories) {
+  process.stdout.write(
+    `::warning file=${advisory.ticketDirectory}/ticket.md,title=Safeword ticket still open::${workflowCommandValue(
+      `This PR edits ${advisory.ticketDirectory}/ticket.md and leaves it at status: ${advisory.status}. If this PR completes the work, run /verify and include the done flip.`,
+    )}\n`,
+  );
+}
 
 if (violations.length === 0) process.exit(0);
 
@@ -90,6 +163,6 @@ for (const violation of violations) {
   process.stderr.write(`  ${violation.ticketDirectory}/ticket.md: ${violation.reason}\n`);
 }
 process.stderr.write(
-  '\nBefore marking the PR ready to merge, run /verify, let the done gate flip the ticket to `status: done`, and include that ticket.md change in this PR.\n',
+  '\nThis PR includes completion evidence for the ticket. Before marking it ready to merge, run /verify, let the done gate flip the ticket to `status: done`, and include that ticket.md change in this PR.\n',
 );
 process.exit(1);

--- a/scripts/check-pr-ticket-done.ts
+++ b/scripts/check-pr-ticket-done.ts
@@ -28,6 +28,11 @@ interface TicketChange {
   verifyArtifactChanged: boolean;
 }
 
+interface TicketState {
+  status: string | null;
+  phase: string | null;
+}
+
 function parseChangedFilesPath(arguments_: string[]): string | null {
   const index = arguments_.indexOf('--changed-files');
   if (index === -1) return null;
@@ -75,24 +80,34 @@ function frontmatterValue(content: string, key: string): string | null {
   return valueMatch?.[1]?.trim() ?? null;
 }
 
+function readTicketState(projectDirectory: string, ticketDirectory: string): TicketState | null {
+  const ticketPath = nodePath.join(projectDirectory, ticketDirectory, 'ticket.md');
+  if (!existsSync(ticketPath)) {
+    return null;
+  }
+
+  const content = readFileSync(ticketPath, 'utf8');
+  return {
+    status: frontmatterValue(content, 'status'),
+    phase: frontmatterValue(content, 'phase'),
+  };
+}
+
 function validateTicketChange(
   projectDirectory: string,
   change: TicketChange,
 ): { violation: Violation | null; advisory: Advisory | null } {
-  const ticketPath = nodePath.join(projectDirectory, change.ticketDirectory, 'ticket.md');
-  if (!existsSync(ticketPath)) {
+  const ticketState = readTicketState(projectDirectory, change.ticketDirectory);
+  if (!ticketState) {
     return {
       violation: { ticketDirectory: change.ticketDirectory, reason: 'ticket.md is missing' },
       advisory: null,
     };
   }
 
-  const content = readFileSync(ticketPath, 'utf8');
-  const status = frontmatterValue(content, 'status');
-  const phase = frontmatterValue(content, 'phase');
-  if (status === 'done') return { violation: null, advisory: null };
+  if (ticketState.status === 'done') return { violation: null, advisory: null };
 
-  if (status === 'in_progress' && phase === 'done') {
+  if (ticketState.status === 'in_progress' && ticketState.phase === 'done') {
     return {
       violation: {
         ticketDirectory: change.ticketDirectory,
@@ -102,7 +117,7 @@ function validateTicketChange(
     };
   }
 
-  if (status === 'in_progress' && change.verifyArtifactChanged) {
+  if (ticketState.status === 'in_progress' && change.verifyArtifactChanged) {
     return {
       violation: {
         ticketDirectory: change.ticketDirectory,
@@ -117,7 +132,7 @@ function validateTicketChange(
     advisory: change.ticketRecordChanged
       ? {
           ticketDirectory: change.ticketDirectory,
-          status: status ?? '(missing)',
+          status: ticketState.status ?? '(missing)',
         }
       : null,
   };

--- a/scripts/check-pr-ticket-done.ts
+++ b/scripts/check-pr-ticket-done.ts
@@ -23,7 +23,7 @@ function parseChangedFilesPath(arguments_: string[]): string | null {
   return arguments_[index + 1] ?? null;
 }
 
-function changedTicketDirectories(changedFiles: string[]): string[] {
+function changedTicketRecordDirectories(changedFiles: string[]): string[] {
   const directories = new Set<string>();
 
   for (const file of changedFiles) {
@@ -79,7 +79,7 @@ const changedFiles = readFileSync(changedFilesPath, 'utf8')
   .map(line => line.trim())
   .filter(Boolean);
 
-const violations = changedTicketDirectories(changedFiles)
+const violations = changedTicketRecordDirectories(changedFiles)
   .map(ticketDirectory => validateTicketDirectory(process.cwd(), ticketDirectory))
   .filter((violation): violation is Violation => violation !== null);
 


### PR DESCRIPTION
## Summary
- add a ready-PR CI guard that checks changed active safeword ticket folders
- fail ready PRs when a changed ticket.md is not `status: done` and `phase: done`
- skip draft PRs so work-in-progress branches can still carry open ticket artifacts

Fixes #365

## Figure-it-out decision
Direct post-merge mutation was rejected for this repo: the active ruleset requires PRs for `main`, and GitHub docs say pushes made with `GITHUB_TOKEN` do not trigger ordinary follow-up workflow runs. The smaller reliable slice is to make the ticket done flip ride the reviewed PR and validate that convention in CI.

## Verification
- cd packages/cli && npx vitest run tests/integration/check-pr-ticket-done.test.ts
- bun run --cwd packages/cli typecheck
- bun --bun node_modules/.bin/eslint --no-warn-ignored scripts/check-pr-ticket-done.ts packages/cli/tests/integration/check-pr-ticket-done.test.ts
- node_modules/.bin/prettier --check .github/workflows/ci.yml scripts/check-pr-ticket-done.ts packages/cli/tests/integration/check-pr-ticket-done.test.ts
- git diff --name-only origin/main...HEAD > /tmp/safeword-365-files.txt && bun scripts/check-pr-ticket-done.ts --changed-files /tmp/safeword-365-files.txt
- bun scripts/parity-check.ts --mode=all
- bun scripts/parity-check.ts --mode=contracts-only
- version parity guard
- git diff --check
- staged guards: check-nested-configs, check-ticket-ids, check-dogfood-direction, lint-staged