### PR TITLE
Guard silent Cursor auto-upgrade

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -4,6 +4,9 @@
     "sessionStart": [
       {
         "command": "bun ./.safeword/hooks/session-safeword-context.ts --agent=cursor"
+      },
+      {
+        "command": "bun ./.safeword/hooks/session-cursor-auto-upgrade.ts"
       }
     ],
     "preToolUse": [

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/impl-plan.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/impl-plan.md
@@ -1,0 +1,62 @@
+# Impl Plan: Auto-upgrade under Cursor
+
+**Status:** implemented
+
+## Approach
+
+Riskiest assumption: Cursor can run auto-upgrade as a second, silent
+`sessionStart` hook without harming existing SAFEWORD.md context injection.
+The cheapest proof is setup + hook integration coverage: generated
+`.cursor/hooks.json` must keep the context hook first, add the auto-upgrade hook
+second, keep both fail-open, and the installed auto-upgrade hook must exit
+successfully with no output when no upgrade should apply.
+
+| Behavior | Layer | Implementation path |
+| --- | --- | --- |
+| Cursor setup wires auto-upgrade at session start | Integration | Extend `setup-cursor.test.ts` to assert `.cursor/hooks.json` includes `session-safeword-context.ts --agent=cursor` first and `session-cursor-auto-upgrade.ts` second. |
+| Cursor session start never uses blocking/error notification paths | Integration | Assert the new Cursor hook has no `failClosed` and the wrapper exits `0` with empty stdout/stderr when auto-upgrade is disabled. |
+| Cursor reuses the shared cross-agent apply core | Schema/package guards | Register `session-cursor-auto-upgrade.ts` in `SAFEWORD_SCHEMA`, package inventory, hook coverage, and Claude hook-wiring exclusions. |
+| Claude and Codex behavior stay unchanged | Focused regression | Keep existing auto-upgrade core and setup tests in the focused run; the Cursor wrapper calls `runAutoUpgrade()` but does not alter shared outcome mapping. |
+
+Build order: add the failing setup expectation for the new Cursor hook, add the
+silent wrapper, register it in schema/package inventories, add the installed
+hook integration test, then run the focused setup/schema/hook suite.
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| --- | --- | --- | --- |
+| Cursor hook shape | Separate silent `sessionStart` hook after the context hook | Combined Cursor dispatcher | Cursor `sessionStart` context injection already exists; combining it with upgrade work risks delaying or weakening context delivery. |
+| Cursor output contract | Exit `0`, write no stdout/stderr | Exit `2`, `user_message`, `continue:false`, `failClosed` | Current Cursor docs say `sessionStart` is fire-and-forget, `continue:false` is not enforced, and exit `2` is a blocking/error path. |
+| Upgrade implementation | Call PR #433's shared `runAutoUpgrade()` core | Cursor-only copy of upgrade logic | Duplicating apply logic would violate the parent epic's shared-core decision. |
+| Failure behavior | Catch wrapper-level errors and stay silent | Surface hook errors to Cursor | Cursor has no reliable session-start notification channel; failing open preserves startup and retries next session. |
+
+## Arch alignment
+
+- Honors "Schema as Single Source of Truth" by registering the new hook in
+  `packages/cli/src/schema.ts` and relying on generated setup output rather than
+  hand-editing installed configs.
+- Honors "Reconciliation Over Copy" by adding the hook through templates and
+  schema-owned files so setup/upgrade/reset can reconcile it.
+- Honors "IDE Parity" by using the same auto-upgrade core across Claude Code,
+  Codex, and Cursor while keeping each agent's hook output contract separate.
+
+## Known deviations
+
+- Cursor major-version and repeated-failure notices remain silent in this slice.
+  This is deliberate because Cursor `sessionStart` does not provide a reliable
+  user-visible message path; richer notification UX stays deferred.
+- Cursor runs context injection and auto-upgrade as two `sessionStart` hooks
+  instead of one dispatcher. This preserves the existing context path and accepts
+  the small chance that one session sees pre-upgrade context.
+
+## Assessment triggers
+
+- Revisit the separate-hook design if Cursor documents ordered `sessionStart`
+  execution or a reliable startup message channel.
+- Revisit silent outcomes if users miss major-version availability or repeated
+  failure-cap notices in practice.
+- Revisit wrapper error handling if Cursor begins enforcing `sessionStart`
+  responses or changes exit-code behavior.
+- Revisit the implementation if the shared auto-upgrade core moves to
+  `safeword hook <name>` CLI dispatch.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -8,7 +8,7 @@ epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
 created: 2026-06-20T12:54:31.933Z
-last_modified: 2026-06-25T23:45:00Z
+last_modified: 2026-06-26T02:20:00Z
 ---
 
 # Auto-upgrade under Cursor
@@ -57,6 +57,22 @@ Options considered:
 
 - Deferred: richer Cursor notification UX for major-available / repeated-failure outcomes after silent apply ships.
 
+## Root Cause
+
+Post-merge `/quality-review` found two risks in the silent Cursor path:
+
+- Cursor `sessionStart` is fire-and-forget, so the auto-upgrade hook can still be
+  running when the agent starts editing. The shared core stages safeword-managed
+  files after `safeword upgrade`, so Cursor writes need a repository lock while
+  the upgrade is active.
+- `.cursor/hooks.json` merged Cursor hook arrays by replacing entire safeword
+  event arrays. Silent upgrade turns that into a higher-risk path because a user
+  could lose custom Cursor hooks without seeing an interactive upgrade step.
+
+Confirmed by inspecting current Cursor docs and the merged code paths in
+`session-cursor-auto-upgrade.ts`, `hooks/lib/auto-upgrade.ts`, and
+`packages/cli/src/schema.ts`.
+
 ## Work Log
 
 - 2026-06-20T12:54:31.933Z Created (child of BJX7WR). Blocked on epic figure-it-out.
@@ -64,3 +80,4 @@ Options considered:
 - 2026-06-25T05:55:00Z Parent design updated: Cursor should use a silent `sessionStart` wrapper around the shared apply core, exit `0`, and rely on the git auto-upgrade commit as the durable record. Remaining blocker is implementation slice 0: extract the shared apply core before wiring Cursor.
 - 2026-06-25T06:00:00Z Checked PR #433. It does not conflict with this ticket file, and it likely supplies the shared core this ticket needs. If #433 lands first, Y6HZR7 should proceed directly to a Cursor wrapper around `hooks/lib/auto-upgrade.ts`.
 - 2026-06-25T23:45:00Z Implemented Cursor wrapper on `cursor/y6hzr7-cursor-auto-upgrade-wrapper`: added `session-cursor-auto-upgrade.ts`, wired it as a second Cursor `sessionStart` command, registered it in schema/package/hook coverage, and added setup + integration tests. Focused tests green: 127/127.
+- 2026-06-26T02:20:00Z Followed up on post-merge quality review: added the missing `impl-plan.md`, preserved user-authored Cursor hook entries during merge/unmerge, dogfooded the new Cursor sessionStart hook, and added a git-dir auto-upgrade lock that makes Cursor write gates wait while silent auto-upgrade runs.

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -14,11 +14,13 @@ import {
   parseRecordSkillInvocationCommand,
   rememberCursorRunIdentity,
 } from '../lib/cursor-run-identity.ts';
+import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-upgrade-lock.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
   decideFromGate,
   runClaudeHook,
+  toCursorDecision,
 } from './gate-adapter.ts';
 
 async function readInput(): Promise<CursorShellInput> {
@@ -41,6 +43,11 @@ if (workspace) process.chdir(workspace);
 const command = input.command ?? '';
 if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
+  process.stdout.write(JSON.stringify(toCursorDecision(AUTO_UPGRADE_LOCK_MESSAGE)) + '\n');
+  process.exit(0);
 }
 
 const translated: ClaudeGateInput = {

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -13,6 +13,7 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { evaluateDoneEvidence } from '../lib/done-gate.ts';
+import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-upgrade-lock.ts';
 import {
   type ClaudeGateInput,
   type CursorDecision,
@@ -52,6 +53,10 @@ if (workspace) process.chdir(workspace);
 const claudeTool = mapCursorToolName(input.tool_name);
 if (claudeTool !== 'Write' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
+  emitDecisionAndExit(toCursorDecision(AUTO_UPGRADE_LOCK_MESSAGE));
 }
 
 const filePath = extractFilePath(input.tool_input);

--- a/.safeword/hooks/lib/auto-upgrade-lock.ts
+++ b/.safeword/hooks/lib/auto-upgrade-lock.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+const LOCK_FILE_NAME = 'safeword-auto-upgrade.lock';
+const LOCK_MAX_AGE_MS = 10 * 60 * 1000;
+
+export const AUTO_UPGRADE_LOCK_MESSAGE =
+  'Safeword auto-upgrade is already updating this repository. Wait a moment, then retry this edit.';
+
+type LockFile = {
+  pid: number;
+  startedAt: number;
+};
+
+function resolveGitCommonDirectory({ projectDir }: { projectDir: string }): string | undefined {
+  try {
+    const output = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!output) return undefined;
+    return nodePath.resolve(projectDir, output);
+  } catch {
+    return undefined;
+  }
+}
+
+export function autoUpgradeLockPath({ projectDir }: { projectDir: string }): string | undefined {
+  const gitDirectory = resolveGitCommonDirectory({ projectDir });
+  return gitDirectory ? nodePath.join(gitDirectory, LOCK_FILE_NAME) : undefined;
+}
+
+function readLock({ lockPath }: { lockPath: string }): LockFile | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<LockFile>;
+    if (typeof parsed.pid !== 'number' || typeof parsed.startedAt !== 'number') return undefined;
+    return { pid: parsed.pid, startedAt: parsed.startedAt };
+  } catch {
+    return undefined;
+  }
+}
+
+export function releaseAutoUpgradeLock({ lockPath }: { lockPath: string | undefined }): void {
+  if (!lockPath) return;
+  rmSync(lockPath, { force: true });
+}
+
+export function isAutoUpgradeLockActive({
+  projectDir,
+  now = Date.now,
+}: {
+  projectDir: string;
+  now?: () => number;
+}): boolean {
+  const lockPath = autoUpgradeLockPath({ projectDir });
+  if (!lockPath) return false;
+
+  const lock = readLock({ lockPath });
+  if (lock && now() - lock.startedAt < LOCK_MAX_AGE_MS) return true;
+
+  releaseAutoUpgradeLock({ lockPath });
+  return false;
+}
+
+export function acquireAutoUpgradeLock({
+  projectDir,
+  now = Date.now,
+}: {
+  projectDir: string;
+  now?: () => number;
+}): string | undefined {
+  const lockPath = autoUpgradeLockPath({ projectDir });
+  if (!lockPath) return undefined;
+  if (isAutoUpgradeLockActive({ projectDir, now })) return undefined;
+
+  mkdirSync(nodePath.dirname(lockPath), { recursive: true });
+  try {
+    writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: now() }), {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    return lockPath;
+  } catch {
+    return undefined;
+  }
+}

--- a/.safeword/hooks/session-cursor-auto-upgrade.ts
+++ b/.safeword/hooks/session-cursor-auto-upgrade.ts
@@ -8,18 +8,23 @@
 import process from 'node:process';
 
 import { runAutoUpgrade } from './lib/auto-upgrade.ts';
+import { acquireAutoUpgradeLock, releaseAutoUpgradeLock } from './lib/auto-upgrade-lock.ts';
 import { filterSafewordFiles } from './lib/owned-paths.ts';
 import { readHookInput, resolveProjectDir } from './lib/safeword-context.ts';
 
 export async function runCursorAutoUpgrade(): Promise<number> {
   const hookInput = await readHookInput();
   const projectDir = resolveProjectDir(hookInput);
+  const lockPath = acquireAutoUpgradeLock({ projectDir });
+  if (!lockPath) return 0;
 
   try {
     await runAutoUpgrade({ projectDir, filterSafewordFiles });
   } catch {
     // Cursor has no reliable sessionStart notification channel. The next
     // session retries through the shared core's normal gates.
+  } finally {
+    releaseAutoUpgradeLock({ lockPath });
   }
 
   return 0;

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -590,6 +590,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/lib/scenario-format.ts': { template: 'hooks/lib/scenario-format.ts' },
     '.safeword/hooks/lib/test-runner.ts': { template: 'hooks/lib/test-runner.ts' },
     '.safeword/hooks/lib/auto-upgrade.ts': { template: 'hooks/lib/auto-upgrade.ts' },
+    '.safeword/hooks/lib/auto-upgrade-lock.ts': { template: 'hooks/lib/auto-upgrade-lock.ts' },
     '.safeword/hooks/lib/safeword-context.ts': { template: 'hooks/lib/safeword-context.ts' },
     '.safeword/hooks/lib/update-cache.ts': { template: 'hooks/lib/update-cache.ts' },
     '.safeword/hooks/lib/version.ts': { template: 'hooks/lib/version.ts' },
@@ -1055,27 +1056,30 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       ],
       removeFileIfEmpty: true,
       merge: existing => {
-        const hooks = (existing.hooks as Record<string, unknown[]>) ?? {};
+        const existingHooks = (existing.hooks as Record<string, unknown[]>) ?? {};
+        const hooks: Record<string, unknown[]> = { ...existingHooks };
+        for (const [event, newHooks] of Object.entries(CURSOR_HOOKS)) {
+          const eventHooks = hooks[event] ?? [];
+          const nonSafewordHooks = filterOutSafewordHooks(eventHooks);
+          hooks[event] = [...nonSafewordHooks, ...newHooks];
+        }
         return {
           ...existing,
           version: 1, // Required by Cursor
-          hooks: {
-            ...hooks,
-            ...CURSOR_HOOKS,
-          },
+          hooks,
         };
       },
       unmerge: existing => {
         const result = { ...existing };
         const existingHooks = (existing.hooks as Record<string, unknown[]>) ?? {};
 
-        // Keep only hooks safeword did NOT install. Derived from CURSOR_HOOKS so
-        // the unmerge can never drift from the merge as new hooks are added — the
-        // old hardcoded delete-list missed newly-wired events, leaving a
-        // non-empty hooks.json that kept .cursor/ alive after reset.
-        const safewordHookNames = new Set(Object.keys(CURSOR_HOOKS));
+        // Keep only hooks safeword did NOT install. Filtering entries instead of
+        // whole events preserves user-authored Cursor hooks that share an event
+        // with safeword, such as `sessionStart`.
         const hooks = Object.fromEntries(
-          Object.entries(existingHooks).filter(([name]) => !safewordHookNames.has(name)),
+          Object.entries(existingHooks)
+            .map(([name, eventHooks]) => [name, filterOutSafewordHooks(eventHooks)] as const)
+            .filter(([, eventHooks]) => eventHooks.length > 0),
         );
 
         // `version` is only meaningful while safeword's hooks remain; drop it

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -3,13 +3,17 @@
  */
 
 interface HookCommand {
-  type: string;
+  type?: string;
   command: string;
 }
 
 interface HookEntry {
   matcher?: string;
   hooks: HookCommand[];
+}
+
+interface CursorHookEntry {
+  command: string;
 }
 
 /**
@@ -22,15 +26,18 @@ function isHookEntry(h: unknown): h is HookEntry {
   );
 }
 
+function isCursorHookEntry(h: unknown): h is CursorHookEntry {
+  return typeof h === 'object' && h !== null && typeof (h as CursorHookEntry).command === 'string';
+}
+
 /**
  * Check if a hook entry contains a safeword hook (command contains '.safeword')
  * @param h
  */
 function isSafewordHook(h: unknown): boolean {
+  if (isCursorHookEntry(h)) return h.command.includes('.safeword');
   if (!isHookEntry(h)) return false;
-  return h.hooks.some(
-    command => typeof command.command === 'string' && command.command.includes('.safeword'),
-  );
+  return h.hooks.some(command => command.command.includes('.safeword'));
 }
 
 /**

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -14,11 +14,13 @@ import {
   parseRecordSkillInvocationCommand,
   rememberCursorRunIdentity,
 } from '../lib/cursor-run-identity.ts';
+import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-upgrade-lock.ts';
 import {
   type ClaudeGateInput,
   type CursorShellInput,
   decideFromGate,
   runClaudeHook,
+  toCursorDecision,
 } from './gate-adapter.ts';
 
 async function readInput(): Promise<CursorShellInput> {
@@ -41,6 +43,11 @@ if (workspace) process.chdir(workspace);
 const command = input.command ?? '';
 if (command === '' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
+  process.stdout.write(JSON.stringify(toCursorDecision(AUTO_UPGRADE_LOCK_MESSAGE)) + '\n');
+  process.exit(0);
 }
 
 const translated: ClaudeGateInput = {

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -13,6 +13,7 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { evaluateDoneEvidence } from '../lib/done-gate.ts';
+import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-upgrade-lock.ts';
 import {
   type ClaudeGateInput,
   type CursorDecision,
@@ -52,6 +53,10 @@ if (workspace) process.chdir(workspace);
 const claudeTool = mapCursorToolName(input.tool_name);
 if (claudeTool !== 'Write' || !existsSync('.safeword')) {
   emitAllowAndExit();
+}
+
+if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
+  emitDecisionAndExit(toCursorDecision(AUTO_UPGRADE_LOCK_MESSAGE));
 }
 
 const filePath = extractFilePath(input.tool_input);

--- a/packages/cli/templates/hooks/lib/auto-upgrade-lock.ts
+++ b/packages/cli/templates/hooks/lib/auto-upgrade-lock.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+const LOCK_FILE_NAME = 'safeword-auto-upgrade.lock';
+const LOCK_MAX_AGE_MS = 10 * 60 * 1000;
+
+export const AUTO_UPGRADE_LOCK_MESSAGE =
+  'Safeword auto-upgrade is already updating this repository. Wait a moment, then retry this edit.';
+
+type LockFile = {
+  pid: number;
+  startedAt: number;
+};
+
+function resolveGitCommonDirectory({ projectDir }: { projectDir: string }): string | undefined {
+  try {
+    const output = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!output) return undefined;
+    return nodePath.resolve(projectDir, output);
+  } catch {
+    return undefined;
+  }
+}
+
+export function autoUpgradeLockPath({ projectDir }: { projectDir: string }): string | undefined {
+  const gitDirectory = resolveGitCommonDirectory({ projectDir });
+  return gitDirectory ? nodePath.join(gitDirectory, LOCK_FILE_NAME) : undefined;
+}
+
+function readLock({ lockPath }: { lockPath: string }): LockFile | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<LockFile>;
+    if (typeof parsed.pid !== 'number' || typeof parsed.startedAt !== 'number') return undefined;
+    return { pid: parsed.pid, startedAt: parsed.startedAt };
+  } catch {
+    return undefined;
+  }
+}
+
+export function releaseAutoUpgradeLock({ lockPath }: { lockPath: string | undefined }): void {
+  if (!lockPath) return;
+  rmSync(lockPath, { force: true });
+}
+
+export function isAutoUpgradeLockActive({
+  projectDir,
+  now = Date.now,
+}: {
+  projectDir: string;
+  now?: () => number;
+}): boolean {
+  const lockPath = autoUpgradeLockPath({ projectDir });
+  if (!lockPath) return false;
+
+  const lock = readLock({ lockPath });
+  if (lock && now() - lock.startedAt < LOCK_MAX_AGE_MS) return true;
+
+  releaseAutoUpgradeLock({ lockPath });
+  return false;
+}
+
+export function acquireAutoUpgradeLock({
+  projectDir,
+  now = Date.now,
+}: {
+  projectDir: string;
+  now?: () => number;
+}): string | undefined {
+  const lockPath = autoUpgradeLockPath({ projectDir });
+  if (!lockPath) return undefined;
+  if (isAutoUpgradeLockActive({ projectDir, now })) return undefined;
+
+  mkdirSync(nodePath.dirname(lockPath), { recursive: true });
+  try {
+    writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: now() }), {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    return lockPath;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/templates/hooks/session-cursor-auto-upgrade.ts
+++ b/packages/cli/templates/hooks/session-cursor-auto-upgrade.ts
@@ -8,18 +8,23 @@
 import process from 'node:process';
 
 import { runAutoUpgrade } from './lib/auto-upgrade.ts';
+import { acquireAutoUpgradeLock, releaseAutoUpgradeLock } from './lib/auto-upgrade-lock.ts';
 import { filterSafewordFiles } from './lib/owned-paths.ts';
 import { readHookInput, resolveProjectDir } from './lib/safeword-context.ts';
 
 export async function runCursorAutoUpgrade(): Promise<number> {
   const hookInput = await readHookInput();
   const projectDir = resolveProjectDir(hookInput);
+  const lockPath = acquireAutoUpgradeLock({ projectDir });
+  if (!lockPath) return 0;
 
   try {
     await runAutoUpgrade({ projectDir, filterSafewordFiles });
   } catch {
     // Cursor has no reliable sessionStart notification channel. The next
     // session retries through the shared core's normal gates.
+  } finally {
+    releaseAutoUpgradeLock({ lockPath });
   }
 
   return 0;

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -14,6 +14,7 @@ import {
   readTestFile,
   removeTemporaryDirectory,
   runCli,
+  writeTestFile,
 } from '../helpers';
 
 describe('Test Suite: Setup - Cursor IDE Support', () => {
@@ -144,6 +145,76 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
         'bun ./.safeword/hooks/cursor/post-tool-quality.ts',
       );
       expect(hooksConfig.hooks.postToolUse[0].matcher).toBe('Write|Shell');
+    });
+
+    it('should preserve user-authored Cursor hooks on setup', async () => {
+      createTypeScriptPackageJson(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+      writeTestFile(
+        temporaryDirectory,
+        '.cursor/hooks.json',
+        `${JSON.stringify(
+          {
+            version: 1,
+            hooks: {
+              sessionStart: [{ command: 'node ./scripts/custom-session-start.js' }],
+              preToolUse: [{ command: 'node ./scripts/custom-pre-tool.js', matcher: 'Write' }],
+            },
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+
+      await runCli(['setup', '--yes'], { cwd: temporaryDirectory });
+
+      const hooksConfig = JSON.parse(readTestFile(temporaryDirectory, '.cursor/hooks.json'));
+      expect(
+        hooksConfig.hooks.sessionStart.map((hook: { command: string }) => hook.command),
+      ).toEqual([
+        'node ./scripts/custom-session-start.js',
+        'bun ./.safeword/hooks/session-safeword-context.ts --agent=cursor',
+        'bun ./.safeword/hooks/session-cursor-auto-upgrade.ts',
+      ]);
+      expect(hooksConfig.hooks.preToolUse).toEqual([
+        { command: 'node ./scripts/custom-pre-tool.js', matcher: 'Write' },
+        {
+          command: 'bun ./.safeword/hooks/cursor/pre-tool-quality.ts',
+          matcher: 'Write',
+          failClosed: true,
+          timeout: 90,
+        },
+      ]);
+    });
+
+    it('should preserve user-authored Cursor hooks on reset', async () => {
+      createTypeScriptPackageJson(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+      writeTestFile(
+        temporaryDirectory,
+        '.cursor/hooks.json',
+        `${JSON.stringify(
+          {
+            version: 1,
+            hooks: {
+              sessionStart: [{ command: 'node ./scripts/custom-session-start.js' }],
+            },
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+
+      await runCli(['setup', '--yes'], { cwd: temporaryDirectory });
+      await runCli(['reset', '--yes'], { cwd: temporaryDirectory });
+
+      const hooksConfig = JSON.parse(readTestFile(temporaryDirectory, '.cursor/hooks.json'));
+      expect(hooksConfig).toEqual({
+        version: 1,
+        hooks: {
+          sessionStart: [{ command: 'node ./scripts/custom-session-start.js' }],
+        },
+      });
     });
 
     it('should set failClosed only on the blocking gate hooks (ANAXG4)', async () => {

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -19,6 +19,11 @@ import process from 'node:process';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
+  acquireAutoUpgradeLock,
+  AUTO_UPGRADE_LOCK_MESSAGE,
+  releaseAutoUpgradeLock,
+} from '../../templates/hooks/lib/auto-upgrade-lock.js';
+import {
   createTemporaryDirectory,
   createTypeScriptPackageJson,
   fileExists,
@@ -1329,4 +1334,63 @@ describe('session-cursor-auto-upgrade.ts', () => {
     expect(result.stdout).toBe('');
     expect(result.stderr).toBe('');
   });
+});
+
+describe('Cursor auto-upgrade lock', () => {
+  it('blocks Cursor writes and shell commands while silent auto-upgrade is running', async () => {
+    const projectDirectory = createTemporaryDirectory();
+
+    try {
+      createTypeScriptPackageJson(projectDirectory);
+      initGitRepo(projectDirectory);
+      await setupOrThrow(projectDirectory);
+
+      const lockPath = acquireAutoUpgradeLock({ projectDir: projectDirectory });
+      expect(lockPath).toBeDefined();
+
+      try {
+        const result = spawnSync('bun', ['.safeword/hooks/cursor/pre-tool-quality.ts'], {
+          cwd: projectDirectory,
+          input: JSON.stringify({
+            workspace_roots: [projectDirectory],
+            conversation_id: 'conversation-1',
+            tool_name: 'Write',
+            tool_input: {
+              file_path: nodePath.join(projectDirectory, 'src/index.ts'),
+              content: 'export const value = 1;\n',
+            },
+          }),
+          encoding: 'utf8',
+        });
+
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual({
+          permission: 'deny',
+          user_message: AUTO_UPGRADE_LOCK_MESSAGE,
+          agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
+        });
+
+        const shellResult = spawnSync('bun', ['.safeword/hooks/cursor/before-shell-execution.ts'], {
+          cwd: projectDirectory,
+          input: JSON.stringify({
+            workspace_roots: [projectDirectory],
+            conversation_id: 'conversation-1',
+            command: 'printf "changed" > .project/tickets/example.md',
+          }),
+          encoding: 'utf8',
+        });
+
+        expect(shellResult.status, shellResult.stderr || shellResult.stdout).toBe(0);
+        expect(JSON.parse(shellResult.stdout)).toEqual({
+          permission: 'deny',
+          user_message: AUTO_UPGRADE_LOCK_MESSAGE,
+          agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
+        });
+      } finally {
+        releaseAutoUpgradeLock({ lockPath });
+      }
+    } finally {
+      removeTemporaryDirectory(projectDirectory);
+    }
+  }, 180_000);
 });

--- a/packages/cli/tests/npm-package.test.ts
+++ b/packages/cli/tests/npm-package.test.ts
@@ -75,6 +75,7 @@ describe('NPM Package Structure', () => {
 
     // Shared lib
     expect(files).toContain('lib');
+    expect(readdirSync(nodePath.join(hooksPath, 'lib'))).toContain('auto-upgrade-lock.ts');
   });
 
   it('should have templates/guides with methodology files', () => {


### PR DESCRIPTION
## Summary
- Add the missing Y6HZR7 `impl-plan.md` artifact and record the post-merge quality-review root cause.
- Preserve user-authored Cursor hook entries during setup/upgrade/reset instead of replacing whole hook arrays.
- Add a git-dir auto-upgrade lock so Cursor write and shell gates wait while silent auto-upgrade is running.

## Test plan
- `bun run test -- tests/commands/setup-cursor.test.ts tests/integration/hooks.test.ts tests/hooks/auto-upgrade-core.test.ts tests/npm-package.test.ts tests/schema.test.ts tests/smoke/hook-coverage.test.ts src/templates/config.test.ts`
- `bun run lint`
- `bun run format:check`


Made with [Cursor](https://cursor.com)