### PR TITLE
refactor: dedupe npm-registry version fetch (fixes check.ts timer leak)

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -13,36 +13,10 @@ import { syncTickets } from '../ticket-sync/index.js';
 import { detectPackageManager } from '../utils/install.js';
 import { header, info, keyValue, success, warn } from '../utils/output.js';
 import { buildIndexConflictListMessage } from '../utils/ticket-index-warnings.js';
-import { isNewerVersion } from '../utils/version.js';
+import { fetchRegistryLatestVersion, isNewerVersion } from '../utils/version.js';
 
 interface CheckOptions {
   offline?: boolean;
-}
-
-/**
- * Check for latest version from npm (with timeout)
- * @param timeout
- */
-async function checkLatestVersion(timeout = 3000): Promise<string | undefined> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-    }, timeout);
-
-    const response = await fetch('https://registry.npmjs.org/safeword/latest', {
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) return undefined;
-
-    const data = (await response.json()) as { version?: string };
-    return data.version ?? undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 /**
@@ -51,7 +25,7 @@ async function checkLatestVersion(timeout = 3000): Promise<string | undefined> {
  */
 async function reportUpdateStatus(health: HealthStatus): Promise<void> {
   info('\nChecking for updates...');
-  const latestVersion = await checkLatestVersion();
+  const latestVersion = await fetchRegistryLatestVersion();
 
   if (!latestVersion) {
     warn("Couldn't check for updates (offline?)");

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -11,7 +11,11 @@ import { SAFEWORD_SCHEMA } from '../schema.js';
 import { createProjectContext } from '../utils/context.js';
 import { exists, readFileSafe, readJson } from '../utils/fs.js';
 import { error, header, info, listItem, success, warn } from '../utils/output.js';
-import { compareVersions } from '../utils/version.js';
+import {
+  compareVersions,
+  fetchRegistryLatestVersion,
+  isComparableVersion,
+} from '../utils/version.js';
 import { VERSION } from '../version.js';
 
 interface DiffOptions {
@@ -25,15 +29,13 @@ interface FileDiff {
   newContent?: string;
 }
 
-interface UpdateCache {
+/**
+ * Local view of `.update-cache.json` (canonical shape: templates/hooks/lib/update-cache.ts).
+ * `latestVersion` is `unknown` — it is untrusted cache data; validate via
+ * `isComparableVersion` before use.
+ */
+interface UpdateCacheFile {
   latestVersion?: unknown;
-}
-
-const REGISTRY_TIMEOUT_MS = 3000;
-const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
-
-function isComparableVersion(value: unknown): value is string {
-  return typeof value === 'string' && VERSION_PATTERN.test(value);
 }
 
 function newerOfCliAnd(candidate: string): string {
@@ -42,31 +44,8 @@ function newerOfCliAnd(candidate: string): string {
 
 function readCachedTargetVersion(safewordDirectory: string): string | undefined {
   const cachePath = nodePath.join(safewordDirectory, '.update-cache.json');
-  const cache = readJson(cachePath) as UpdateCache | undefined;
+  const cache = readJson(cachePath) as UpdateCacheFile | undefined;
   return isComparableVersion(cache?.latestVersion) ? cache.latestVersion : undefined;
-}
-
-async function fetchRegistryLatestVersion(
-  timeout = REGISTRY_TIMEOUT_MS,
-): Promise<string | undefined> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => {
-    controller.abort();
-  }, timeout);
-
-  try {
-    const response = await fetch('https://registry.npmjs.org/safeword/latest', {
-      signal: controller.signal,
-    });
-    if (!response.ok) return undefined;
-
-    const data = (await response.json()) as { version?: unknown };
-    return isComparableVersion(data.version) ? data.version : undefined;
-  } catch {
-    return undefined;
-  } finally {
-    clearTimeout(timeoutId);
-  }
 }
 
 async function resolveDiffTargetVersion(safewordDirectory: string): Promise<string> {

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -30,3 +30,45 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
 export function isNewerVersion(current: string, latest: string): boolean {
   return compareVersions(current, latest) === -1;
 }
+
+const REGISTRY_TIMEOUT_MS = 3000;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Type guard for a comparable semver string (e.g. `"1.2.3"`). Use before
+ * passing a registry- or cache-sourced value into {@link compareVersions},
+ * which silently produces `NaN` comparisons on malformed input.
+ * @param value
+ */
+export function isComparableVersion(value: unknown): value is string {
+  return typeof value === 'string' && VERSION_PATTERN.test(value);
+}
+
+/**
+ * Fetch the latest published safeword version from the npm registry.
+ * Returns undefined on network error, timeout, non-OK response, or an
+ * unparseable/invalid version — callers treat undefined as "unknown".
+ * @param timeout milliseconds before the request is aborted
+ */
+export async function fetchRegistryLatestVersion(
+  timeout = REGISTRY_TIMEOUT_MS,
+): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeout);
+
+  try {
+    const response = await fetch('https://registry.npmjs.org/safeword/latest', {
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+
+    const data = (await response.json()) as { version?: unknown };
+    return isComparableVersion(data.version) ? data.version : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
## What

`diff.ts` and `check.ts` each grew a near-identical npm-registry latest-version fetch in the same session (#451, #452). This lifts `diff.ts`'s (correct) implementation into `version.ts` as shared `fetchRegistryLatestVersion` + `isComparableVersion`, and points both commands at it. Also renames `diff.ts`'s local `UpdateCache` interface to `UpdateCacheFile` with a comment-link to the canonical shape.

## Why — consolidating fixed two latent bugs in check.ts's copy

`check.ts`'s `checkLatestVersion` diverged from `diff.ts`'s correct version in two ways, both eliminated by sharing one copy:

1. **Timer leak on the offline path** — `clearTimeout` sat inside the `try` (after `await fetch`), so on a `fetch` reject (DNS failure / offline — the common path for this code) the 3s abort timer was never cleared, holding an event-loop handle and delaying process exit by up to 3s. `diff.ts` clears it in a `finally`.
2. **Unvalidated registry version** — `check.ts` returned `data.version` straight into `compareVersions` (which does `.split('.').map(Number)` → silent `NaN` compares on malformed input). `diff.ts` validates via `isComparableVersion` first.

## Verification

- `tsc --noEmit` ✓, eslint ✓
- `diff.test.ts` (8) ✓, `check.test.ts` (47) ✓ — user-facing behavior unchanged
- `fetchRegistryLatestVersion` now defined exactly once; zero dangling refs to the deleted `checkLatestVersion`; net −5 lines

Surfaced by a holistic `/quality-review` of this session's merged work. Pure CLI-`src` change — no hook/template parity surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)