### PR TITLE
chore(release): v0.58.0

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.58.0** — minor (auto-upgradeable). Rolls up 11 changes merged since v0.57.0.

### Minor (additive / non-breaking)
- **#459** — three new guides shipped: `llm-evals-guide`, `testing-guide`, `verification-lanes-guide` (+ testing skill references)
- **#463** — Cursor silent auto-upgrade hardening: new `auto-upgrade-lock` preventing concurrent-write races; per-entry hook preservation so users keep custom Cursor hooks on upgrade
- **#471** — implementation reviews quiet until exit (per-step RGR review nudges suppressed and folded into the implement-exit whole-ticket review; gate integrity unchanged)

### Patch (fixes / internal)
- **#448** ticket-system CLI resolver guidance · **#449** feature-ticket frontmatter scaffold · **#451** diff upgrade target version · **#452** check version-mismatch repair hint (per-PM) · **#457** ledger validation survives rebase (patch-id fallback, fails closed) · **#460** CI guard for ticket done-flips (warn-mode) · **#461** README guides listing · **#475** dedupe npm-registry version fetch into `version.ts` (fixes `check.ts` timer leak + version validation)

Bump rationale: new shipped guides (#459) make this additive-minor. #471 changes review *timing* but breaks no gate or command, so it's safe to auto-apply silently. Whole batch passes the "auto-upgrade at SessionStart — does anything break?" test in the negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)