### PR TITLE
Make local verification evidence reliable

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -69,6 +69,21 @@ not a `test-plan` suite).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
+# Local evidence preflight: many repo tests create throwaway git repos. Some
+# agent sandboxes cannot initialize repos in temp dirs, which makes those tests
+# fail for environment reasons instead of product reasons.
+LOCAL_EVIDENCE_LIMITS=""
+if GIT_PROBE_DIR="$(mktemp -d 2> /dev/null)" && git init "$GIT_PROBE_DIR" > /dev/null 2>&1; then
+  rm -rf "$GIT_PROBE_DIR"
+else
+  LOCAL_EVIDENCE_LIMITS="${LOCAL_EVIDENCE_LIMITS}
+- Temporary git repos: local environment cannot run git init in temp dirs. Treat git-backed test failures as local environment limitations until reproduced outside the sandbox or in CI."
+  [ -n "${GIT_PROBE_DIR:-}" ] && rm -rf "$GIT_PROBE_DIR"
+fi
+if [ -n "$LOCAL_EVIDENCE_LIMITS" ]; then
+  printf '%s\n' "Local evidence limits detected:${LOCAL_EVIDENCE_LIMITS}"
+fi
+
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
 # only if it actually supports test-plan.
 supports_test_plan() {
@@ -120,6 +135,10 @@ bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.
+
+If `LOCAL_EVIDENCE_LIMITS` is non-empty, keep running checks that can run, but classify affected failures as `⚠️ Local environment limitation: <reason>`. The common Cursor sandbox symptom is `.git/hooks/: Operation not permitted` during `git init`. A failure caused only by that preflight is not proof of product failure; confirm outside the sandbox or in CI before calling it real.
+
+If a full Vitest suite fails only because `packages/cli/tests/integration/cucumber-bdd.test.ts` times out while `bun run --cwd packages/cli test:bdd` passes directly, classify it as `⚠️ Local environment limitation: Cucumber wrapper timed out under full-suite load`. Report the isolated Cucumber lane as the Gherkin evidence and rerun that direct lane once. Treat it as a real product failure only when the direct Cucumber lane fails or CI reproduces it.
 
 Regression fixtures covered by `safeword test-plan` and its tests:
 
@@ -191,8 +210,8 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
-**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test suite)
+**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test:bdd script)
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
@@ -201,6 +220,7 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
+**Evidence limits:** ✅ None (or ⚠️ <local limitation>; affected failures are not product evidence until reproduced outside the limit)
 ```
 
 **PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
@@ -258,7 +278,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, Evidence limits is ✅ None, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -69,6 +69,21 @@ not a `test-plan` suite).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
+# Local evidence preflight: many repo tests create throwaway git repos. Some
+# agent sandboxes cannot initialize repos in temp dirs, which makes those tests
+# fail for environment reasons instead of product reasons.
+LOCAL_EVIDENCE_LIMITS=""
+if GIT_PROBE_DIR="$(mktemp -d 2> /dev/null)" && git init "$GIT_PROBE_DIR" > /dev/null 2>&1; then
+  rm -rf "$GIT_PROBE_DIR"
+else
+  LOCAL_EVIDENCE_LIMITS="${LOCAL_EVIDENCE_LIMITS}
+- Temporary git repos: local environment cannot run git init in temp dirs. Treat git-backed test failures as local environment limitations until reproduced outside the sandbox or in CI."
+  [ -n "${GIT_PROBE_DIR:-}" ] && rm -rf "$GIT_PROBE_DIR"
+fi
+if [ -n "$LOCAL_EVIDENCE_LIMITS" ]; then
+  printf '%s\n' "Local evidence limits detected:${LOCAL_EVIDENCE_LIMITS}"
+fi
+
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
 # only if it actually supports test-plan.
 supports_test_plan() {
@@ -120,6 +135,10 @@ bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.
+
+If `LOCAL_EVIDENCE_LIMITS` is non-empty, keep running checks that can run, but classify affected failures as `⚠️ Local environment limitation: <reason>`. The common Cursor sandbox symptom is `.git/hooks/: Operation not permitted` during `git init`. A failure caused only by that preflight is not proof of product failure; confirm outside the sandbox or in CI before calling it real.
+
+If a full Vitest suite fails only because `packages/cli/tests/integration/cucumber-bdd.test.ts` times out while `bun run --cwd packages/cli test:bdd` passes directly, classify it as `⚠️ Local environment limitation: Cucumber wrapper timed out under full-suite load`. Report the isolated Cucumber lane as the Gherkin evidence and rerun that direct lane once. Treat it as a real product failure only when the direct Cucumber lane fails or CI reproduces it.
 
 Regression fixtures covered by `safeword test-plan` and its tests:
 
@@ -191,8 +210,8 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
-**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test suite)
+**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test:bdd script)
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
@@ -201,6 +220,7 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
+**Evidence limits:** ✅ None (or ⚠️ <local limitation>; affected failures are not product evidence until reproduced outside the limit)
 ```
 
 **PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
@@ -258,7 +278,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, Evidence limits is ✅ None, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -63,6 +63,21 @@ not a `test-plan` suite).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
+# Local evidence preflight: many repo tests create throwaway git repos. Some
+# agent sandboxes cannot initialize repos in temp dirs, which makes those tests
+# fail for environment reasons instead of product reasons.
+LOCAL_EVIDENCE_LIMITS=""
+if GIT_PROBE_DIR="$(mktemp -d 2> /dev/null)" && git init "$GIT_PROBE_DIR" > /dev/null 2>&1; then
+  rm -rf "$GIT_PROBE_DIR"
+else
+  LOCAL_EVIDENCE_LIMITS="${LOCAL_EVIDENCE_LIMITS}
+- Temporary git repos: local environment cannot run git init in temp dirs. Treat git-backed test failures as local environment limitations until reproduced outside the sandbox or in CI."
+  [ -n "${GIT_PROBE_DIR:-}" ] && rm -rf "$GIT_PROBE_DIR"
+fi
+if [ -n "$LOCAL_EVIDENCE_LIMITS" ]; then
+  printf '%s\n' "Local evidence limits detected:${LOCAL_EVIDENCE_LIMITS}"
+fi
+
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
 # only if it actually supports test-plan.
 supports_test_plan() {
@@ -114,6 +129,10 @@ bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.
+
+If `LOCAL_EVIDENCE_LIMITS` is non-empty, keep running checks that can run, but classify affected failures as `⚠️ Local environment limitation: <reason>`. The common Cursor sandbox symptom is `.git/hooks/: Operation not permitted` during `git init`. A failure caused only by that preflight is not proof of product failure; confirm outside the sandbox or in CI before calling it real.
+
+If a full Vitest suite fails only because `packages/cli/tests/integration/cucumber-bdd.test.ts` times out while `bun run --cwd packages/cli test:bdd` passes directly, classify it as `⚠️ Local environment limitation: Cucumber wrapper timed out under full-suite load`. Report the isolated Cucumber lane as the Gherkin evidence and rerun that direct lane once. Treat it as a real product failure only when the direct Cucumber lane fails or CI reproduces it.
 
 Regression fixtures covered by `safeword test-plan` and its tests:
 
@@ -185,8 +204,8 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
-**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test suite)
+**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test:bdd script)
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
@@ -195,6 +214,7 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
+**Evidence limits:** ✅ None (or ⚠️ <local limitation>; affected failures are not product evidence until reproduced outside the limit)
 ```
 
 **PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
@@ -252,7 +272,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, Evidence limits is ✅ None, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -18,7 +18,7 @@ import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-
 import {
   type ClaudeGateInput,
   type CursorShellInput,
-  decideFromGate,
+  decideFromShellGate,
   runClaudeHook,
   toCursorDecision,
 } from './gate-adapter.ts';
@@ -64,13 +64,14 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
 // own cancellation path can reduce the failure to "Canceled: Canceled".
-const decision = decideFromGate(
-  runClaudeHook({
+const decision = decideFromShellGate({
+  command,
+  result: runClaudeHook({
     claudeHookPath,
     input: translated,
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
-);
+});
 const proofCommand =
   decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
 if (proofCommand !== undefined) {

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -18,7 +18,8 @@ import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-
 import {
   type ClaudeGateInput,
   type CursorShellInput,
-  decideFromShellGate,
+  decideFromGate,
+  requiresFailClosedShellGate,
   runClaudeHook,
   toCursorDecision,
 } from './gate-adapter.ts';
@@ -52,6 +53,19 @@ if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
   process.exit(0);
 }
 
+const proofCommand = parseRecordSkillInvocationCommand(command);
+const needsFailClosedGate = requiresFailClosedShellGate({ command });
+if (!needsFailClosedGate) {
+  if (proofCommand !== undefined) {
+    rememberCursorRunIdentity({
+      projectDirectory: process.cwd(),
+      conversationId: input.conversation_id,
+      skillName: proofCommand.skillName,
+    });
+  }
+  emitAllowAndExit();
+}
+
 const translated: ClaudeGateInput = {
   session_id: input.conversation_id,
   hook_event_name: 'PreToolUse',
@@ -64,17 +78,14 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
 // own cancellation path can reduce the failure to "Canceled: Canceled".
-const decision = decideFromShellGate({
-  command,
-  result: runClaudeHook({
+const decision = decideFromGate(
+  runClaudeHook({
     claudeHookPath,
     input: translated,
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
-});
-const proofCommand =
-  decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
-if (proofCommand !== undefined) {
+);
+if (decision.permission === 'allow' && proofCommand !== undefined) {
   rememberCursorRunIdentity({
     projectDirectory: process.cwd(),
     conversationId: input.conversation_id,

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -230,15 +230,126 @@ export interface ClaudeGateResult {
   failed: boolean;
 }
 
-/**
- * Matches the only Bash command that the shared pre-tool gate currently protects:
- * `git commit`. If that gate is unavailable, this command must stay fail-closed
- * because committing is the irreversible step the refactor gate exists to guard.
- */
-const FAIL_CLOSED_SHELL_COMMAND = /\bgit\s+commit\b(?!-)/;
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-C',
+  '-c',
+  '--config-env',
+  '--exec-path',
+  '--git-dir',
+  '--namespace',
+  '--work-tree',
+]);
 
-export function requiresFailClosedShellGate(command: string): boolean {
-  return FAIL_CLOSED_SHELL_COMMAND.test(command);
+export function requiresFailClosedShellGate(params: { command: string }): boolean {
+  const { command } = params;
+  return splitShellSegments(command).some(segment => isGitCommitSegment(parseShellWords(segment)));
+}
+
+function splitShellSegments(command: string): string[] {
+  const segments: string[] = [];
+  let segmentStart = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (quote !== undefined) continue;
+
+    const next = command[index + 1];
+    if (char === ';' || char === '\n' || char === '|' || (char === '&' && next === '&')) {
+      segments.push(command.slice(segmentStart, index));
+      segmentStart = char === '&' && next === '&' ? index + 2 : index + 1;
+      if (char === '&' && next === '&') index += 1;
+    }
+  }
+
+  segments.push(command.slice(segmentStart));
+  return segments;
+}
+
+function parseShellWords(segment: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const char of segment) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (quote === undefined && /\s/.test(char)) {
+      if (current !== '') {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current !== '') words.push(current);
+  return words;
+}
+
+function isGitCommitSegment(words: string[]): boolean {
+  let index = skipCommandPrefix(words);
+  if (words[index] !== 'git') return false;
+
+  index += 1;
+  while (index < words.length && words[index]?.startsWith('-')) {
+    const option = words[index];
+    if (option !== undefined && optionTakesSeparateValue(option)) index += 1;
+    index += 1;
+  }
+
+  return words[index] === 'commit';
+}
+
+function skipCommandPrefix(words: string[]): number {
+  let index = 0;
+  if (words[index] === 'command') index += 1;
+  if (words[index] !== 'env') return index;
+
+  index += 1;
+  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+}
+
+function optionTakesSeparateValue(option: string): boolean {
+  if (option.includes('=')) return false;
+  return GIT_GLOBAL_OPTIONS_WITH_VALUE.has(option);
 }
 
 /** Message shown when the gate itself could not run, so the action is fail-closed. */
@@ -321,7 +432,7 @@ export function decideFromShellGate(params: {
   result: ClaudeGateResult;
 }): CursorDecision {
   const { command, result } = params;
-  if (result.failed && !requiresFailClosedShellGate(command)) {
+  if (result.failed && !requiresFailClosedShellGate({ command })) {
     return { permission: 'allow' };
   }
   return decideFromGate(result);

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -336,15 +336,29 @@ function isGitCommitSegment(words: string[]): boolean {
 }
 
 function skipCommandPrefix(words: string[]): number {
-  let index = 0;
+  // A leading run of `VAR=val` assignments is a per-command environment, not the
+  // executable (`GIT_AUTHOR_NAME=bot git commit`). Skip it before resolving the
+  // command word — otherwise the assignment is read as the command name and a
+  // `git commit` slips the fail-closed gate.
+  let index = skipEnvironmentAssignments(words, 0);
   if (words[index] === 'command') index += 1;
   if (words[index] !== 'env') return index;
 
+  // `env [NAME=value ...] command` — skip past `env` and its own assignments.
   index += 1;
-  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? '')) {
+  return skipEnvironmentAssignments(words, index);
+}
+
+function skipEnvironmentAssignments(words: string[], start: number): number {
+  let index = start;
+  while (index < words.length && isEnvironmentAssignment(words[index] ?? '')) {
     index += 1;
   }
   return index;
+}
+
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
 function optionTakesSeparateValue(option: string): boolean {
@@ -418,22 +432,8 @@ export function decideFromGate(result: ClaudeGateResult): CursorDecision {
   return toCursorDecision(claudeDenialReason(result.stdout));
 }
 
-/**
- * Shell-specific gate decision.
- *
- * The delegated Bash gate only inspects `git commit`. When that gate is
- * unavailable, blocking every shell command creates a deadlock without adding
- * safety: the unavailable gate would not have denied `git status`, tests, or
- * audit commands anyway. Keep fail-closed behavior for `git commit`; fail open
- * for commands outside the delegated gate's scope.
- */
-export function decideFromShellGate(params: {
-  command: string;
-  result: ClaudeGateResult;
-}): CursorDecision {
-  const { command, result } = params;
-  if (result.failed && !requiresFailClosedShellGate({ command })) {
-    return { permission: 'allow' };
-  }
-  return decideFromGate(result);
-}
+// The shell-specific decision lives in before-shell-execution.ts: it calls
+// `requiresFailClosedShellGate` BEFORE spawning the delegated gate (so non-commit
+// commands are allowed without a spawn, avoiding the deadlock) and `decideFromGate`
+// AFTER. There is intentionally no combined helper here — keeping the two steps in
+// the hook is what lets it skip the spawn entirely for out-of-scope commands.

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -230,6 +230,17 @@ export interface ClaudeGateResult {
   failed: boolean;
 }
 
+/**
+ * Matches the only Bash command that the shared pre-tool gate currently protects:
+ * `git commit`. If that gate is unavailable, this command must stay fail-closed
+ * because committing is the irreversible step the refactor gate exists to guard.
+ */
+const FAIL_CLOSED_SHELL_COMMAND = /\bgit\s+commit\b(?!-)/;
+
+export function requiresFailClosedShellGate(command: string): boolean {
+  return FAIL_CLOSED_SHELL_COMMAND.test(command);
+}
+
 /** Message shown when the gate itself could not run, so the action is fail-closed. */
 export const GATE_UNAVAILABLE_REASON =
   'Safeword gate could not run (it crashed or failed to start), so this action was blocked. ' +
@@ -294,4 +305,24 @@ export function decideFromGate(result: ClaudeGateResult): CursorDecision {
     return toCursorDecision(GATE_UNAVAILABLE_REASON);
   }
   return toCursorDecision(claudeDenialReason(result.stdout));
+}
+
+/**
+ * Shell-specific gate decision.
+ *
+ * The delegated Bash gate only inspects `git commit`. When that gate is
+ * unavailable, blocking every shell command creates a deadlock without adding
+ * safety: the unavailable gate would not have denied `git status`, tests, or
+ * audit commands anyway. Keep fail-closed behavior for `git commit`; fail open
+ * for commands outside the delegated gate's scope.
+ */
+export function decideFromShellGate(params: {
+  command: string;
+  result: ClaudeGateResult;
+}): CursorDecision {
+  const { command, result } = params;
+  if (result.failed && !requiresFailClosedShellGate(command)) {
+    return { permission: 'allow' };
+  }
+  return decideFromGate(result);
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,29 @@
     "shellcheck": "^4.1.0",
     "tsx": "^4.22.4"
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}": [
+      "eslint --fix --config eslint.config.ts",
+      "prettier --write"
+    ],
+    "*.{vue,svelte,astro}": [
+      "eslint --fix --config eslint.config.ts",
+      "prettier --write"
+    ],
+    "*.{json,css,scss,html,yaml,yml,graphql}": [
+      "prettier --write"
+    ],
+    "*.md": [
+      "markdownlint-cli2 --fix",
+      "prettier --write"
+    ],
+    "*.sh": [
+      "shellcheck"
+    ],
+    "*.feature": [
+      "bun packages/cli/src/cli.ts lint-gherkin"
+    ]
+  },
   "overrides": {
     "@felipecrs/decompress-tarxz": "5.0.6",
     "@types/estree": "^1.0.9",

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -63,6 +63,21 @@ not a `test-plan` suite).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
+# Local evidence preflight: many repo tests create throwaway git repos. Some
+# agent sandboxes cannot initialize repos in temp dirs, which makes those tests
+# fail for environment reasons instead of product reasons.
+LOCAL_EVIDENCE_LIMITS=""
+if GIT_PROBE_DIR="$(mktemp -d 2> /dev/null)" && git init "$GIT_PROBE_DIR" > /dev/null 2>&1; then
+  rm -rf "$GIT_PROBE_DIR"
+else
+  LOCAL_EVIDENCE_LIMITS="${LOCAL_EVIDENCE_LIMITS}
+- Temporary git repos: local environment cannot run git init in temp dirs. Treat git-backed test failures as local environment limitations until reproduced outside the sandbox or in CI."
+  [ -n "${GIT_PROBE_DIR:-}" ] && rm -rf "$GIT_PROBE_DIR"
+fi
+if [ -n "$LOCAL_EVIDENCE_LIMITS" ]; then
+  printf '%s\n' "Local evidence limits detected:${LOCAL_EVIDENCE_LIMITS}"
+fi
+
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
 # only if it actually supports test-plan.
 supports_test_plan() {
@@ -114,6 +129,10 @@ bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.
+
+If `LOCAL_EVIDENCE_LIMITS` is non-empty, keep running checks that can run, but classify affected failures as `⚠️ Local environment limitation: <reason>`. The common Cursor sandbox symptom is `.git/hooks/: Operation not permitted` during `git init`. A failure caused only by that preflight is not proof of product failure; confirm outside the sandbox or in CI before calling it real.
+
+If a full Vitest suite fails only because `packages/cli/tests/integration/cucumber-bdd.test.ts` times out while `bun run --cwd packages/cli test:bdd` passes directly, classify it as `⚠️ Local environment limitation: Cucumber wrapper timed out under full-suite load`. Report the isolated Cucumber lane as the Gherkin evidence and rerun that direct lane once. Treat it as a real product failure only when the direct Cucumber lane fails or CI reproduces it.
 
 Regression fixtures covered by `safeword test-plan` and its tests:
 
@@ -185,8 +204,8 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
-**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test suite)
+**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test:bdd script)
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
@@ -195,6 +214,7 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
+**Evidence limits:** ✅ None (or ⚠️ <local limitation>; affected failures are not product evidence until reproduced outside the limit)
 ```
 
 **PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
@@ -252,7 +272,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, Evidence limits is ✅ None, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -18,7 +18,7 @@ import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-
 import {
   type ClaudeGateInput,
   type CursorShellInput,
-  decideFromGate,
+  decideFromShellGate,
   runClaudeHook,
   toCursorDecision,
 } from './gate-adapter.ts';
@@ -64,13 +64,14 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
 // own cancellation path can reduce the failure to "Canceled: Canceled".
-const decision = decideFromGate(
-  runClaudeHook({
+const decision = decideFromShellGate({
+  command,
+  result: runClaudeHook({
     claudeHookPath,
     input: translated,
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
-);
+});
 const proofCommand =
   decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
 if (proofCommand !== undefined) {

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -18,7 +18,8 @@ import { AUTO_UPGRADE_LOCK_MESSAGE, isAutoUpgradeLockActive } from '../lib/auto-
 import {
   type ClaudeGateInput,
   type CursorShellInput,
-  decideFromShellGate,
+  decideFromGate,
+  requiresFailClosedShellGate,
   runClaudeHook,
   toCursorDecision,
 } from './gate-adapter.ts';
@@ -52,6 +53,19 @@ if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
   process.exit(0);
 }
 
+const proofCommand = parseRecordSkillInvocationCommand(command);
+const needsFailClosedGate = requiresFailClosedShellGate({ command });
+if (!needsFailClosedGate) {
+  if (proofCommand !== undefined) {
+    rememberCursorRunIdentity({
+      projectDirectory: process.cwd(),
+      conversationId: input.conversation_id,
+      skillName: proofCommand.skillName,
+    });
+  }
+  emitAllowAndExit();
+}
+
 const translated: ClaudeGateInput = {
   session_id: input.conversation_id,
   hook_event_name: 'PreToolUse',
@@ -64,17 +78,14 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts')
 
 // Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
 // own cancellation path can reduce the failure to "Canceled: Canceled".
-const decision = decideFromShellGate({
-  command,
-  result: runClaudeHook({
+const decision = decideFromGate(
+  runClaudeHook({
     claudeHookPath,
     input: translated,
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
-});
-const proofCommand =
-  decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
-if (proofCommand !== undefined) {
+);
+if (decision.permission === 'allow' && proofCommand !== undefined) {
   rememberCursorRunIdentity({
     projectDirectory: process.cwd(),
     conversationId: input.conversation_id,

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -230,15 +230,126 @@ export interface ClaudeGateResult {
   failed: boolean;
 }
 
-/**
- * Matches the only Bash command that the shared pre-tool gate currently protects:
- * `git commit`. If that gate is unavailable, this command must stay fail-closed
- * because committing is the irreversible step the refactor gate exists to guard.
- */
-const FAIL_CLOSED_SHELL_COMMAND = /\bgit\s+commit\b(?!-)/;
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-C',
+  '-c',
+  '--config-env',
+  '--exec-path',
+  '--git-dir',
+  '--namespace',
+  '--work-tree',
+]);
 
-export function requiresFailClosedShellGate(command: string): boolean {
-  return FAIL_CLOSED_SHELL_COMMAND.test(command);
+export function requiresFailClosedShellGate(params: { command: string }): boolean {
+  const { command } = params;
+  return splitShellSegments(command).some(segment => isGitCommitSegment(parseShellWords(segment)));
+}
+
+function splitShellSegments(command: string): string[] {
+  const segments: string[] = [];
+  let segmentStart = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (quote !== undefined) continue;
+
+    const next = command[index + 1];
+    if (char === ';' || char === '\n' || char === '|' || (char === '&' && next === '&')) {
+      segments.push(command.slice(segmentStart, index));
+      segmentStart = char === '&' && next === '&' ? index + 2 : index + 1;
+      if (char === '&' && next === '&') index += 1;
+    }
+  }
+
+  segments.push(command.slice(segmentStart));
+  return segments;
+}
+
+function parseShellWords(segment: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const char of segment) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (quote === undefined && /\s/.test(char)) {
+      if (current !== '') {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current !== '') words.push(current);
+  return words;
+}
+
+function isGitCommitSegment(words: string[]): boolean {
+  let index = skipCommandPrefix(words);
+  if (words[index] !== 'git') return false;
+
+  index += 1;
+  while (index < words.length && words[index]?.startsWith('-')) {
+    const option = words[index];
+    if (option !== undefined && optionTakesSeparateValue(option)) index += 1;
+    index += 1;
+  }
+
+  return words[index] === 'commit';
+}
+
+function skipCommandPrefix(words: string[]): number {
+  let index = 0;
+  if (words[index] === 'command') index += 1;
+  if (words[index] !== 'env') return index;
+
+  index += 1;
+  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+}
+
+function optionTakesSeparateValue(option: string): boolean {
+  if (option.includes('=')) return false;
+  return GIT_GLOBAL_OPTIONS_WITH_VALUE.has(option);
 }
 
 /** Message shown when the gate itself could not run, so the action is fail-closed. */
@@ -321,7 +432,7 @@ export function decideFromShellGate(params: {
   result: ClaudeGateResult;
 }): CursorDecision {
   const { command, result } = params;
-  if (result.failed && !requiresFailClosedShellGate(command)) {
+  if (result.failed && !requiresFailClosedShellGate({ command })) {
     return { permission: 'allow' };
   }
   return decideFromGate(result);

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -336,15 +336,29 @@ function isGitCommitSegment(words: string[]): boolean {
 }
 
 function skipCommandPrefix(words: string[]): number {
-  let index = 0;
+  // A leading run of `VAR=val` assignments is a per-command environment, not the
+  // executable (`GIT_AUTHOR_NAME=bot git commit`). Skip it before resolving the
+  // command word — otherwise the assignment is read as the command name and a
+  // `git commit` slips the fail-closed gate.
+  let index = skipEnvironmentAssignments(words, 0);
   if (words[index] === 'command') index += 1;
   if (words[index] !== 'env') return index;
 
+  // `env [NAME=value ...] command` — skip past `env` and its own assignments.
   index += 1;
-  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? '')) {
+  return skipEnvironmentAssignments(words, index);
+}
+
+function skipEnvironmentAssignments(words: string[], start: number): number {
+  let index = start;
+  while (index < words.length && isEnvironmentAssignment(words[index] ?? '')) {
     index += 1;
   }
   return index;
+}
+
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
 function optionTakesSeparateValue(option: string): boolean {
@@ -418,22 +432,8 @@ export function decideFromGate(result: ClaudeGateResult): CursorDecision {
   return toCursorDecision(claudeDenialReason(result.stdout));
 }
 
-/**
- * Shell-specific gate decision.
- *
- * The delegated Bash gate only inspects `git commit`. When that gate is
- * unavailable, blocking every shell command creates a deadlock without adding
- * safety: the unavailable gate would not have denied `git status`, tests, or
- * audit commands anyway. Keep fail-closed behavior for `git commit`; fail open
- * for commands outside the delegated gate's scope.
- */
-export function decideFromShellGate(params: {
-  command: string;
-  result: ClaudeGateResult;
-}): CursorDecision {
-  const { command, result } = params;
-  if (result.failed && !requiresFailClosedShellGate({ command })) {
-    return { permission: 'allow' };
-  }
-  return decideFromGate(result);
-}
+// The shell-specific decision lives in before-shell-execution.ts: it calls
+// `requiresFailClosedShellGate` BEFORE spawning the delegated gate (so non-commit
+// commands are allowed without a spawn, avoiding the deadlock) and `decideFromGate`
+// AFTER. There is intentionally no combined helper here — keeping the two steps in
+// the hook is what lets it skip the spawn entirely for out-of-scope commands.

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -230,6 +230,17 @@ export interface ClaudeGateResult {
   failed: boolean;
 }
 
+/**
+ * Matches the only Bash command that the shared pre-tool gate currently protects:
+ * `git commit`. If that gate is unavailable, this command must stay fail-closed
+ * because committing is the irreversible step the refactor gate exists to guard.
+ */
+const FAIL_CLOSED_SHELL_COMMAND = /\bgit\s+commit\b(?!-)/;
+
+export function requiresFailClosedShellGate(command: string): boolean {
+  return FAIL_CLOSED_SHELL_COMMAND.test(command);
+}
+
 /** Message shown when the gate itself could not run, so the action is fail-closed. */
 export const GATE_UNAVAILABLE_REASON =
   'Safeword gate could not run (it crashed or failed to start), so this action was blocked. ' +
@@ -294,4 +305,24 @@ export function decideFromGate(result: ClaudeGateResult): CursorDecision {
     return toCursorDecision(GATE_UNAVAILABLE_REASON);
   }
   return toCursorDecision(claudeDenialReason(result.stdout));
+}
+
+/**
+ * Shell-specific gate decision.
+ *
+ * The delegated Bash gate only inspects `git commit`. When that gate is
+ * unavailable, blocking every shell command creates a deadlock without adding
+ * safety: the unavailable gate would not have denied `git status`, tests, or
+ * audit commands anyway. Keep fail-closed behavior for `git commit`; fail open
+ * for commands outside the delegated gate's scope.
+ */
+export function decideFromShellGate(params: {
+  command: string;
+  result: ClaudeGateResult;
+}): CursorDecision {
+  const { command, result } = params;
+  if (result.failed && !requiresFailClosedShellGate(command)) {
+    return { permission: 'allow' };
+  }
+  return decideFromGate(result);
 }

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -69,6 +69,21 @@ not a `test-plan` suite).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
+# Local evidence preflight: many repo tests create throwaway git repos. Some
+# agent sandboxes cannot initialize repos in temp dirs, which makes those tests
+# fail for environment reasons instead of product reasons.
+LOCAL_EVIDENCE_LIMITS=""
+if GIT_PROBE_DIR="$(mktemp -d 2> /dev/null)" && git init "$GIT_PROBE_DIR" > /dev/null 2>&1; then
+  rm -rf "$GIT_PROBE_DIR"
+else
+  LOCAL_EVIDENCE_LIMITS="${LOCAL_EVIDENCE_LIMITS}
+- Temporary git repos: local environment cannot run git init in temp dirs. Treat git-backed test failures as local environment limitations until reproduced outside the sandbox or in CI."
+  [ -n "${GIT_PROBE_DIR:-}" ] && rm -rf "$GIT_PROBE_DIR"
+fi
+if [ -n "$LOCAL_EVIDENCE_LIMITS" ]; then
+  printf '%s\n' "Local evidence limits detected:${LOCAL_EVIDENCE_LIMITS}"
+fi
+
 # Resolve a test-plan-capable safeword CLI — prefer the locally installed one
 # only if it actually supports test-plan.
 supports_test_plan() {
@@ -120,6 +135,10 @@ bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.
+
+If `LOCAL_EVIDENCE_LIMITS` is non-empty, keep running checks that can run, but classify affected failures as `⚠️ Local environment limitation: <reason>`. The common Cursor sandbox symptom is `.git/hooks/: Operation not permitted` during `git init`. A failure caused only by that preflight is not proof of product failure; confirm outside the sandbox or in CI before calling it real.
+
+If a full Vitest suite fails only because `packages/cli/tests/integration/cucumber-bdd.test.ts` times out while `bun run --cwd packages/cli test:bdd` passes directly, classify it as `⚠️ Local environment limitation: Cucumber wrapper timed out under full-suite load`. Report the isolated Cucumber lane as the Gherkin evidence and rerun that direct lane once. Treat it as a real product failure only when the direct Cucumber lane fails or CI reproduces it.
 
 Regression fixtures covered by `safeword test-plan` and its tests:
 
@@ -191,8 +210,8 @@ The Status section uses the existing Verify Checklist format. Format with these 
 ```
 ## Verify Checklist
 
-**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⏭️ Skipped — no test suite)
-**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⏭️ Skipped — no test:bdd script)
+**Test Suite:** ✓ X/X tests pass (or ❌ N failures, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test suite)
+**Gherkin:** ✅ Acceptance lane passes (or ❌ Failed, or ⚠️ Local environment limitation: <reason>, or ⏭️ Skipped — no test:bdd script)
 **Build:** ✅ Success (or ❌ Failed, or ⏭️ Skipped — no build step)
 **Lint:** ✅ Clean (or ❌ N errors)
 **Scenarios:** All N scenarios marked complete (or ❌ X/Y complete, or ⏭️ Skipped — no ticket)
@@ -201,6 +220,7 @@ The Status section uses the existing Verify Checklist format. Format with these 
 **Parent Epic:** {id} (siblings: X/Y done) or N/A
 **Reconcile:** ✅ No pattern deviation (or ⚠️ N deviations, M missing uplevel ticket — soft, never blocks)
 **Experience:** ✅ No new friction (or ⚠️ N friction points / dulled peak, or ⏭️ N/A — not persona-facing) — soft, never blocks
+**Evidence limits:** ✅ None (or ⚠️ <local limitation>; affected failures are not product evidence until reproduced outside the limit)
 ```
 
 **PR Scope** is the final "one purpose" guard. It blocks the all-green collapse: if it is ❌, the ticket is not ready to mark done until the unrelated work is reverted, split into another ticket/PR, or explicitly accepted as a scope change and reflected in the ticket artifacts.
@@ -258,7 +278,7 @@ Only include this section when there are concrete forward actions the agent will
 
 #### All-green collapse
 
-When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
+When **all Status checks pass, PR Scope is ✅/skipped for a valid reason, Evidence limits is ✅ None, AND zero decisions AND zero actions**, collapse the entire report to a single-line verdict:
 
 > Ready to mark done.
 

--- a/packages/cli/tests/cursor-shell-gate.test.ts
+++ b/packages/cli/tests/cursor-shell-gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ClaudeGateResult,
+  decideFromShellGate,
+  GATE_UNAVAILABLE_REASON,
+  requiresFailClosedShellGate,
+} from '../templates/hooks/cursor/gate-adapter';
+
+const unavailableGate: ClaudeGateResult = {
+  failed: true,
+  stdout: '',
+};
+
+function cleanGateWithOutput(stdout: string): ClaudeGateResult {
+  return {
+    failed: false,
+    stdout,
+  };
+}
+
+describe('Cursor beforeShellExecution gate', () => {
+  it.each(['git status --short', 'git diff --stat', 'git log -1 --oneline', 'bun run lint'])(
+    'allows %s when the delegated gate is unavailable',
+    command => {
+      expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
+        permission: 'allow',
+      });
+    },
+  );
+
+  it.each(['git commit -m "save"', 'git commit --amend'])(
+    'keeps %s fail-closed when the delegated gate is unavailable',
+    command => {
+      expect(requiresFailClosedShellGate(command)).toBe(true);
+      expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
+        permission: 'deny',
+        user_message: GATE_UNAVAILABLE_REASON,
+        agent_message: GATE_UNAVAILABLE_REASON,
+      });
+    },
+  );
+
+  it('does not mistake other git commit-prefixed commands for git commit', () => {
+    expect(requiresFailClosedShellGate('git commit-graph write')).toBe(false);
+    expect(requiresFailClosedShellGate('git commit-tree HEAD^{tree}')).toBe(false);
+  });
+
+  it('preserves a real denial from the delegated gate', () => {
+    const denialReason = 'Shell command denied by delegated gate.';
+    const deniedGate = cleanGateWithOutput(
+      JSON.stringify({
+        hookSpecificOutput: {
+          permissionDecision: 'deny',
+          permissionDecisionReason: denialReason,
+        },
+      }),
+    );
+
+    expect(decideFromShellGate({ command: 'git status --short', result: deniedGate })).toEqual({
+      permission: 'deny',
+      user_message: denialReason,
+      agent_message: denialReason,
+    });
+  });
+});

--- a/packages/cli/tests/cursor-shell-gate.test.ts
+++ b/packages/cli/tests/cursor-shell-gate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type ClaudeGateResult,
-  decideFromShellGate,
+  decideFromGate,
   GATE_UNAVAILABLE_REASON,
   requiresFailClosedShellGate,
 } from '../templates/hooks/cursor/gate-adapter';
@@ -21,13 +21,15 @@ function cleanGateWithOutput(stdout: string): ClaudeGateResult {
   };
 }
 
+// The shipped decision path lives in before-shell-execution.ts: it first asks
+// `requiresFailClosedShellGate` whether the command must be gated, and only spawns
+// the delegated gate (then maps its result via `decideFromGate`) when it must.
+// These tests pin both halves of that contract.
 describe('Cursor beforeShellExecution gate', () => {
   it.each(['git status --short', 'git diff --stat', 'git log -1 --oneline', 'bun run lint'])(
-    'allows %s when the delegated gate is unavailable',
+    'does not fail-close %s (allowed without spawning the delegated gate)',
     command => {
-      expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
-        permission: 'allow',
-      });
+      expect(requiresFailClosedShellGate({ command })).toBe(false);
     },
   );
 
@@ -38,9 +40,15 @@ describe('Cursor beforeShellExecution gate', () => {
     'git --no-pager commit -m "save"',
     'command git commit -m "save"',
     'env GIT_AUTHOR_NAME=bot git commit -m "save"',
-  ])('keeps %s fail-closed when the delegated gate is unavailable', command => {
+    // Bare leading env-assignments must not slip the gate (the env(1) wrapper is
+    // optional in real shells): `VAR=val git commit …` is still a commit.
+    'GIT_AUTHOR_NAME=bot git commit -m "save"',
+    'GIT_EDITOR=true git commit',
+    'GIT_AUTHOR_NAME=bot GIT_AUTHOR_EMAIL=bot@x command git commit -m "save"',
+  ])('keeps %s fail-closed, so the delegated gate runs', command => {
     expect(requiresFailClosedShellGate({ command })).toBe(true);
-    expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
+    // When that gate is then unavailable, the action is denied (fail-closed).
+    expect(decideFromGate(unavailableGate)).toEqual({
       permission: 'deny',
       user_message: GATE_UNAVAILABLE_REASON,
       agent_message: GATE_UNAVAILABLE_REASON,
@@ -51,6 +59,8 @@ describe('Cursor beforeShellExecution gate', () => {
     expect(requiresFailClosedShellGate({ command: 'git commit-graph write' })).toBe(false);
     expect(requiresFailClosedShellGate({ command: 'git commit-tree HEAD^{tree}' })).toBe(false);
     expect(requiresFailClosedShellGate({ command: 'echo "git commit -m save"' })).toBe(false);
+    // The env-assignment skip must not over-trigger on non-commit git subcommands.
+    expect(requiresFailClosedShellGate({ command: 'GIT_PAGER=cat git status' })).toBe(false);
   });
 
   it('preserves a real denial from the delegated gate', () => {
@@ -64,7 +74,7 @@ describe('Cursor beforeShellExecution gate', () => {
       }),
     );
 
-    expect(decideFromShellGate({ command: 'git status --short', result: deniedGate })).toEqual({
+    expect(decideFromGate(deniedGate)).toEqual({
       permission: 'deny',
       user_message: denialReason,
       agent_message: denialReason,

--- a/packages/cli/tests/cursor-shell-gate.test.ts
+++ b/packages/cli/tests/cursor-shell-gate.test.ts
@@ -10,12 +10,14 @@ import {
 const unavailableGate: ClaudeGateResult = {
   failed: true,
   stdout: '',
+  timedOut: false,
 };
 
 function cleanGateWithOutput(stdout: string): ClaudeGateResult {
   return {
     failed: false,
     stdout,
+    timedOut: false,
   };
 }
 
@@ -29,21 +31,26 @@ describe('Cursor beforeShellExecution gate', () => {
     },
   );
 
-  it.each(['git commit -m "save"', 'git commit --amend'])(
-    'keeps %s fail-closed when the delegated gate is unavailable',
-    command => {
-      expect(requiresFailClosedShellGate(command)).toBe(true);
-      expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
-        permission: 'deny',
-        user_message: GATE_UNAVAILABLE_REASON,
-        agent_message: GATE_UNAVAILABLE_REASON,
-      });
-    },
-  );
+  it.each([
+    'git commit -m "save"',
+    'git commit --amend',
+    'git -c user.name=bot commit -m "save"',
+    'git --no-pager commit -m "save"',
+    'command git commit -m "save"',
+    'env GIT_AUTHOR_NAME=bot git commit -m "save"',
+  ])('keeps %s fail-closed when the delegated gate is unavailable', command => {
+    expect(requiresFailClosedShellGate({ command })).toBe(true);
+    expect(decideFromShellGate({ command, result: unavailableGate })).toEqual({
+      permission: 'deny',
+      user_message: GATE_UNAVAILABLE_REASON,
+      agent_message: GATE_UNAVAILABLE_REASON,
+    });
+  });
 
   it('does not mistake other git commit-prefixed commands for git commit', () => {
-    expect(requiresFailClosedShellGate('git commit-graph write')).toBe(false);
-    expect(requiresFailClosedShellGate('git commit-tree HEAD^{tree}')).toBe(false);
+    expect(requiresFailClosedShellGate({ command: 'git commit-graph write' })).toBe(false);
+    expect(requiresFailClosedShellGate({ command: 'git commit-tree HEAD^{tree}' })).toBe(false);
+    expect(requiresFailClosedShellGate({ command: 'echo "git commit -m save"' })).toBe(false);
   });
 
   it('preserves a real denial from the delegated gate', () => {

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -26,6 +26,8 @@ export const TIMEOUT_QUICK = 10_000;
 export const TIMEOUT_SYNC = 30_000;
 /** Setup commands that may run bun install with warm cache (60s) */
 export const TIMEOUT_SETUP = 60_000;
+/** Acceptance lanes can spawn their own runners and need headroom under full-suite load (120s) */
+export const TIMEOUT_ACCEPTANCE_LANE = 120_000;
 /** bun install operations under load or cold cache (120s) */
 export const TIMEOUT_BUN_INSTALL = 120_000;
 

--- a/packages/cli/tests/integration/cucumber-bdd.test.ts
+++ b/packages/cli/tests/integration/cucumber-bdd.test.ts
@@ -13,7 +13,7 @@ import nodePath from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import vitestConfig from '../../vitest.config.js';
-import { TIMEOUT_SETUP } from '../helpers.js';
+import { TIMEOUT_ACCEPTANCE_LANE } from '../helpers.js';
 
 const CLI_DIRECTORY = nodePath.resolve(import.meta.dirname, '../..');
 const CUCUMBER_WIRING_CHECK_ARGS = ['cucumber-js', '--dry-run', '--format', 'summary'];
@@ -31,7 +31,7 @@ describe('cucumber-js acceptance lane (SM1.AC1)', () => {
       expect(output).toMatch(/\b[1-9]\d* scenarios? \([1-9]\d* skipped\)/);
       expect(output).not.toMatch(/undefined|ambiguous|pending|passed/);
     },
-    TIMEOUT_SETUP,
+    TIMEOUT_ACCEPTANCE_LANE,
   );
 
   it('gherkin-typescript.SM1.AC1.vitest_excludes_the_dogfood_feature', () => {

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -27,8 +27,8 @@ const dogfoodCursorCommandContent = readFileSync(
   'utf8',
 );
 
-// Both surfaces share the same instructions; tests run against both.
-const surfaces: [string, string][] = [
+// These template surfaces are the source files shipped to installed projects.
+const templateFiles: [string, string][] = [
   ['skill', skillContent],
   ['command', commandContent],
 ];
@@ -43,7 +43,7 @@ const allVerifySurfaces: [string, string][] = [
 
 describe('verify report structure (146)', () => {
   describe('Rule: Status section preserves existing checklist + done-gate evidence patterns', () => {
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s specifies Status section uses existing Verify Checklist',
       (_name, content) => {
         expect(content).toMatch(
@@ -52,7 +52,7 @@ describe('verify report structure (146)', () => {
       },
     );
 
-    it.each(surfaces)('%s lists the required evidence patterns', (_name, content) => {
+    it.each(templateFiles)('%s lists the required evidence patterns', (_name, content) => {
       expect(content).toContain('✓ X/X tests pass');
       expect(content).toContain('**Gherkin:**');
       expect(content).toContain('All N scenarios marked complete');
@@ -63,28 +63,28 @@ describe('verify report structure (146)', () => {
   });
 
   describe('Rule: Decisions section contains only spec/scope/value questions', () => {
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s names Decisions section "Decisions needed (spec / scope / value)"',
       (_name, content) => {
         expect(content).toMatch(/Decisions needed \(spec \/ scope \/ value\)/);
       },
     );
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s explicitly states implementation-path questions go in Actions, not Decisions',
       (_name, content) => {
         expect(content.toLowerCase()).toMatch(/implementation.*(go|belong).*actions/);
       },
     );
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s specifies Decisions section is hidden when empty (no None placeholder)',
       (_name, content) => {
         expect(content.toLowerCase()).toMatch(/decisions section is hidden when empty/);
       },
     );
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s includes at least one concrete spec-vs-impl borderline example',
       (_name, content) => {
         expect(content.toLowerCase()).toContain('borderline classification example');
@@ -95,28 +95,31 @@ describe('verify report structure (146)', () => {
   });
 
   describe('Rule: Actions section commits to concrete forward motion', () => {
-    it.each(surfaces)('%s names Actions section "Agent\'s next actions"', (_name, content) => {
+    it.each(templateFiles)('%s names Actions section "Agent\'s next actions"', (_name, content) => {
       expect(content).toMatch(/Agent's next actions/);
     });
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s specifies each action must be concrete and falsifiable',
       (_name, content) => {
         expect(content.toLowerCase()).toMatch(/concrete.*falsifiable|falsifiable.*concrete/);
       },
     );
 
-    it.each(surfaces)('%s specifies Actions section is hidden when empty', (_name, content) => {
-      expect(content.toLowerCase()).toMatch(/actions.*hidden when empty|hidden.*actions.*empty/);
-    });
+    it.each(templateFiles)(
+      '%s specifies Actions section is hidden when empty',
+      (_name, content) => {
+        expect(content.toLowerCase()).toMatch(/actions.*hidden when empty|hidden.*actions.*empty/);
+      },
+    );
   });
 
   describe('Rule: Hard cap N=5 per section; aggregate rest', () => {
-    it.each(surfaces)('%s specifies a hard cap of N=5 items per section', (_name, content) => {
+    it.each(templateFiles)('%s specifies a hard cap of N=5 items per section', (_name, content) => {
       expect(content).toMatch(/cap of \d+|N=5|max(?:imum)? of 5|hard cap.*5/i);
     });
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s specifies the aggregation format when items exceed cap',
       (_name, content) => {
         expect(content).toMatch(/N others, see test-definitions\.md/);
@@ -125,7 +128,7 @@ describe('verify report structure (146)', () => {
   });
 
   describe('Rule: All-green collapse to single-line verdict', () => {
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s specifies single-line "Ready to mark done" when all green and no decisions/actions',
       (_name, content) => {
         // The skill must specify that under all-pass + zero-items, the report
@@ -135,25 +138,25 @@ describe('verify report structure (146)', () => {
       },
     );
 
-    it.each(surfaces)('%s explicitly states empty sections are hidden', (_name, content) => {
+    it.each(templateFiles)('%s explicitly states empty sections are hidden', (_name, content) => {
       expect(content.toLowerCase()).toContain('empty sections are hidden');
     });
   });
 
   describe('Rule: PR scope prevents piggybacked changes', () => {
-    it.each(surfaces)('%s includes PR Scope in the Verify Checklist', (_name, content) => {
+    it.each(templateFiles)('%s includes PR Scope in the Verify Checklist', (_name, content) => {
       expect(content).toContain('**PR Scope:**');
       expect(content).toContain('Diff matches ticket scope');
       expect(content).toContain('Piggybacked changes');
     });
 
-    it.each(surfaces)('%s blocks all-green collapse when PR scope fails', (_name, content) => {
+    it.each(templateFiles)('%s blocks all-green collapse when PR scope fails', (_name, content) => {
       expect(content).toMatch(/PR Scope[\s\S]*one purpose/);
       expect(content).toMatch(/PR scope fails[\s\S]*do not collapse/);
       expect(content).toContain('Ready to mark done');
     });
 
-    it.each(surfaces)(
+    it.each(templateFiles)(
       '%s routes unrelated work to split, revert, or scope decision',
       (_name, content) => {
         expect(content).toContain('Nice-to-have refactors');
@@ -165,16 +168,49 @@ describe('verify report structure (146)', () => {
   });
 
   describe('Rule: section 2 consumes safeword test-plan (5FF0ZD)', () => {
-    it.each(surfaces)('%s evals the test and build plans from test-plan', (_name, content) => {
+    it.each(templateFiles)('%s evals the test and build plans from test-plan', (_name, content) => {
       expect(content).toContain('test-plan --kind verify --format sh');
       expect(content).toContain('test-plan --kind build --format sh');
       // Typecheck is part of the ready path — CI's lint job runs it (#436).
       expect(content).toContain('test-plan --kind typecheck --format sh');
     });
 
-    it.each(surfaces)('%s carries no inline per-language test/build branch', (_name, content) => {
-      expect(content).not.toMatch(/uv run pytest|go test|cargo test|go build|cargo build/);
+    it.each(templateFiles)(
+      '%s carries no inline per-language test/build branch',
+      (_name, content) => {
+        expect(content).not.toMatch(/uv run pytest|go test|cargo test|go build|cargo build/);
+      },
+    );
+  });
+
+  describe('Rule: local verify classifies environment limits (469)', () => {
+    it.each(allVerifySurfaces)('%s preflights temporary git repo creation', (_name, content) => {
+      expect(content).toContain('LOCAL_EVIDENCE_LIMITS');
+      expect(content).toContain('git init "$GIT_PROBE_DIR"');
+      expect(content).toContain('Local evidence limits detected:');
+      expect(content).toContain('Temporary git repos');
+      expect(content).toContain('.git/hooks/: Operation not permitted');
     });
+
+    it.each(allVerifySurfaces)(
+      '%s reports environment limits separately from product failures',
+      (_name, content) => {
+        expect(content).toContain('Local environment limitation');
+        expect(content).toContain('Evidence limits');
+        expect(content).toContain('not proof of product failure');
+        expect(content).toContain('affected failures are not product evidence');
+      },
+    );
+
+    it.each(allVerifySurfaces)(
+      '%s routes local Cucumber wrapper timeouts to isolated evidence',
+      (_name, content) => {
+        expect(content).toContain('packages/cli/tests/integration/cucumber-bdd.test.ts');
+        expect(content).toContain('bun run --cwd packages/cli test:bdd');
+        expect(content).toContain('Cucumber wrapper timed out under full-suite load');
+        expect(content).toContain('CI reproduces it');
+      },
+    );
   });
 
   describe('Rule: verify resolver selects only a test-plan-capable Safeword CLI (375)', () => {


### PR DESCRIPTION
## Summary
- Classifies known local sandbox limits separately from product failures in `/verify` output.
- Gives the Cucumber acceptance lane more explicit timeout headroom.
- Keeps Cursor `git commit` shell gates fail-closed while avoiding deadlocks for non-commit shell commands.

## Test plan
- `bun run --cwd packages/cli test -- tests/cursor-shell-gate.test.ts`
- `bun run --cwd packages/cli typecheck`
- Pre-commit hooks passed for both commits.


Made with [Cursor](https://cursor.com)