### PR TITLE
Verify Cursor root moves before edits

### DIFF
--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -170,6 +170,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Root moves (Cursor).** After `move_agent_to_root`, `move_agent_to_cloned_root`, or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
+
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -170,6 +170,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Root moves (Cursor).** After `move_agent_to_root`, `move_agent_to_cloned_root`, or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
+
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -41,6 +41,18 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       expect(content).toContain('alwaysApply: true');
       expect(content).toContain('@.safeword/SAFEWORD.md');
     });
+
+    it('installs Cursor root-move branch verification guidance', async () => {
+      createTypeScriptPackageJson(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+
+      await runCli(['setup', '--yes'], { cwd: temporaryDirectory });
+
+      const content = readTestFile(temporaryDirectory, '.safeword/SAFEWORD.md');
+      expect(content).toContain('move_agent_to_root');
+      expect(content).toContain('git branch --show-current');
+      expect(content).toContain('before evidence gathering or edits');
+    });
   });
 
   describe('Cursor Commands', () => {


### PR DESCRIPTION
## Summary
- Add a Cursor root-move standing rule that verifies path, git root, branch, and HEAD before evidence gathering or edits.
- Sync the dogfood SAFEWORD copy and cover the installed guidance through the Cursor setup flow.

## Test plan
- [x] `bun run --cwd packages/cli test tests/commands/setup-cursor.test.ts`

Fixes #439.

Made with [Cursor](https://cursor.com)