### PR TITLE
Capture Cursor closeout evidence

### DIFF
--- a/.project/tickets/1833FW-cursor-verify-template-drift/ticket.md
+++ b/.project/tickets/1833FW-cursor-verify-template-drift/ticket.md
@@ -46,8 +46,15 @@ last_modified: 2026-06-14T02:05:00Z
 - If intentional, record why safeword's own dogfood should skip the Gherkin evidence line.
 - Quality-review guardrail: treat this as a blocker for wrapper generation, not as generic cleanup.
 
+## Resolution
+
+The dogfood Cursor verify command now matches the shipped verify template for the Gherkin acceptance lane and `**Gherkin:**` evidence pattern. `F1HTQ4` can treat the current verify content as the intended generator input.
+
+Final `status: done` is blocked by the Cursor done gate timeout tracked in GitHub issue #469: the gate's internal `test:bdd` run is capped at 60s, while the same lane passes locally in about 91s.
+
 ## Work Log
 
+- 2026-06-26T06:55:00Z Revalidated on fast-forwarded `main`: `.cursor/commands/verify.md` and `packages/cli/templates/commands/verify.md` both include the Gherkin acceptance lane and `**Gherkin:**` evidence. This resolves the ticket criteria except for the mechanical done flip, which is blocked by #469.
 - 2026-06-14T02:05:00Z Reviewed: Marked the chosen verify content as generator input for F1HTQ4.
 - 2026-06-14T01:46:00Z Scoped: Figure-it-out marked the drift as a high-priority concrete follow-up.
 - 2026-06-14T01:39:31.130Z Started: Created ticket 1833FW.

--- a/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
+++ b/.project/tickets/BJX7WR-auto-upgrade-cross-agent/ticket.md
@@ -62,11 +62,11 @@ Slice 0 landed in PR #433: the agent-agnostic apply core is now in a reusable `l
 
 ## Acceptance (epic-level)
 
-- [ ] Cursor users on a clean tree get patch/minor auto-upgrades without manual action, without breaking session start.
+- [x] Cursor users on a clean tree get patch/minor auto-upgrades without manual action, without breaking session start.
 - [x] Codex users likewise.
-- [ ] All three agents share one apply implementation (no triplicated upgrade/commit logic).
-- [ ] Per-agent message behavior is explicit (surfaced where the agent supports it, silent-with-git-record where it doesn't).
-- [ ] Parity + the existing Claude Code behavior unchanged (no regression to XQ9CXA).
+- [x] All three agents share one apply implementation (no triplicated upgrade/commit logic).
+- [x] Per-agent message behavior is explicit (surfaced where the agent supports it, silent-with-git-record where it doesn't).
+- [x] Parity + the existing Claude Code behavior unchanged (no regression to XQ9CXA).
 
 ## Work Log
 
@@ -74,3 +74,4 @@ Slice 0 landed in PR #433: the agent-agnostic apply core is now in a reusable `l
 - 2026-06-25T05:55:00Z Resolved the Cursor side of the design after `/figure-it-out`: extract one shared apply core first; keep Claude's `asyncRewake` messaging; make Cursor a silent `sessionStart` wrapper that exits `0` and uses the git auto-upgrade commit as the durable record. Cursor notification UX for major-available / repeated-failure outcomes is deferred to a follow-up status strategy. Y6HZR7 remains blocked only on slice 0 extraction before implementation.
 - 2026-06-25T06:00:00Z Checked related PR #433 ("Bring auto-upgrade to Codex users"). It appears to implement slice 0 by adding `hooks/lib/auto-upgrade.ts` and turning Claude auto-upgrade into a wrapper, plus Codex wiring. No file conflict with Y6HZR7's ticket-only PR #440. If #433 lands first, Cursor work should reuse its shared core.
 - 2026-06-25T19:54:00Z Revalidated after PR #433 merged: 7R1D3B is done and GitHub issue #393 is closed. The parent epic remains in progress because Y6HZR7 is still the remaining Cursor implementation child.
+- 2026-06-26T06:55:00Z Revalidated after PRs #447 and #463: Cursor auto-upgrade is implemented and hardened on `main`; all epic acceptance criteria are met in code. Y6HZR7's final `status: done` flip is blocked by GitHub issue #469 because the Cursor done gate times out this repo's BDD lane.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -46,7 +46,7 @@
 - **Epic: Cross-agent auto-upgrade (Cursor + Codex) (BJX7WR)** (in_progress, epic: auto-upgrade-cross-agent)
   Extend safeword's seamless auto-upgrade — today Claude-Code-only — to the other two supported agents, Cursor and Codex, so customers on any agent stay current without manual `safeword upgrade`.
   → `.project/tickets/BJX7WR-auto-upgrade-cross-agent`
-- **Auto-upgrade under Cursor (Y6HZR7)** (blocked, epic: auto-upgrade-cross-agent)
+- **Auto-upgrade under Cursor (Y6HZR7)** (in_progress, epic: auto-upgrade-cross-agent)
   Cursor users get safeword's seamless patch/minor auto-upgrade (today Claude-Code-only) without manual `safeword upgrade` and without breaking Cursor's session start.
   → `.project/tickets/Y6HZR7-auto-upgrade-cursor`
 

--- a/.project/tickets/S3T6JA-agent-surface-refactor-epic/ticket.md
+++ b/.project/tickets/S3T6JA-agent-surface-refactor-epic/ticket.md
@@ -36,7 +36,7 @@ last_modified: 2026-06-14T03:24:46Z
 | Y06KJS | Generate Claude and Codex skill registrations from one manifest; do not delete dogfood mirrors. | High     |
 | F1HTQ4 | Generate Cursor command/rule wrappers from metadata while preserving physical wrapper files.    | High     |
 | 88QCHJ | Replace repeated skill-log shell injections with one installed helper command.                  | High     |
-| 1833FW | Reconcile or explicitly document the dogfood `.cursor/commands/verify.md` drift.                | High     |
+| 1833FW | Reconcile or explicitly document the dogfood `.cursor/commands/verify.md` drift.                | Resolved; close blocked by #469 |
 | W0E292 | Extract pure Codex hook translation helpers behind the current executable adapter.              | Medium   |
 | 6SE3MR | Share only the fake Codex binary writer; keep Cucumber/Vitest harness setup separate.           | Low      |
 | 2YZDKQ | Keep `versioning` as a Claude-local maintainer-only skill; exclude it from shared manifests.    | Medium   |
@@ -44,7 +44,7 @@ last_modified: 2026-06-14T03:24:46Z
 ## Quality-review guardrails
 
 - Run 2YZDKQ before Y06KJS so manifest generation does not silently promote or drop the dogfood-only `versioning` skill.
-- Run 1833FW before F1HTQ4 so Cursor wrapper generation captures the intended `verify` command content.
+- 1833FW is resolved for F1HTQ4: Cursor verify content is aligned to the shipped template; final ticket close is blocked only by #469.
 - Run Y06KJS before F1HTQ4 if F1HTQ4 consumes the shared skill metadata.
 - Do not assume Claude, Cursor, and Codex all execute the same skill-body shell syntax. 88QCHJ must verify helper invocation behavior per surface before replacing any snippet.
 - Keep a platform-current-docs check at pickup. Cursor and Codex both now expose skills/plugin concepts, but safeword still needs physical command/rule/config files where setup/upgrade installs them today.
@@ -70,6 +70,7 @@ last_modified: 2026-06-14T03:24:46Z
 ## Work Log
 
 - 2026-06-14T03:24:46Z Decided: 2YZDKQ keeps `versioning` Claude-local maintainer-only (`audience: maintainer`), so Y06KJS must exclude maintainer-only dogfood skills from shared customer-facing manifests.
+- 2026-06-26T06:55:00Z Revalidated 1833FW: dogfood Cursor verify content is aligned with the shipped verify template, including Gherkin evidence. F1HTQ4 can proceed from the current verify content; the child ticket's final done flip is blocked by GitHub issue #469.
 - 2026-06-14T02:05:00Z Reviewed: Quality-review pass approved the epic direction and added sequencing/runtime guardrails.
 - 2026-06-14T01:46:00Z Updated: Added second-pass figure-it-out decisions and seven child tickets.
 - 2026-06-14T01:39:00Z Created: Minted child tickets for the seven refactor candidates from the read-only pass.

--- a/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
+++ b/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
@@ -63,12 +63,12 @@ Core children (own the `cursor-optimization` epic key). Status revalidated 2026-
 | ---------- | ------------------------------------------------------------------ | ------------------- | ---------------- |
 | **RBZR3F** | Add `sessionStart` context injection                               | restore enforcement | ✅ done          |
 | **151**    | Migrate four Cursor rules to `@reference` pattern                  | drift/parity        | ✅ done (folded) |
-| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | ready to close (rejected; no hook ships) |
-| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | ready to close |
-| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | ready to close |
-| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | ready to close |
-| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | PR #424 open |
-| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | open (Shell-only) |
+| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | resolved; close blocked by #469 |
+| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | shipped; close blocked by #469 |
+| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | shipped; close blocked by #469 |
+| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | shipped; close blocked by #469 |
+| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | shipped; close blocked by #469 |
+| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | verified; close blocked by #469 |
 | **JFBFEP** | Add an action-based MCP safety gate for Cursor                     | correctness         | open             |
 | **DXYKJX** | Package as Team-Marketplace plugin (Required mode)                 | distribution        | open             |
 
@@ -78,13 +78,13 @@ These are Cursor-specific deliverables whose natural home is a cross-agent epic.
 
 | ID         | Title                                           | Home epic                | Status      |
 | ---------- | ----------------------------------------------- | ------------------------ | ----------- |
-| **1833FW** | Keep Cursor verify evidence aligned             | agent-surface-refactor   | in_progress |
+| **1833FW** | Keep Cursor verify evidence aligned             | agent-surface-refactor   | resolved; close blocked by #469 |
 | **F1HTQ4** | Generate Cursor command/rule wrappers from meta | agent-surface-refactor   | in_progress |
-| **Y6HZR7** | Auto-upgrade under Cursor                       | auto-upgrade-cross-agent | blocked     |
+| **Y6HZR7** | Auto-upgrade under Cursor                       | auto-upgrade-cross-agent | verified; close blocked by #469 |
 
 ## Sequencing
 
-Remaining sequencing: land P9K783 (#424), then empirically verify `TDX8NT` for Shell deny precedence under Auto-review. Design/build `JFBFEP` before letting `DXYKJX` bundle MCP defaults; plugin packaging can proceed in parallel for non-MCP surfaces.
+Remaining sequencing: fix #469 so shipped Cursor tickets can close cleanly, then design/build `JFBFEP` before letting `DXYKJX` bundle MCP defaults. `F1HTQ4` can proceed because 1833FW's verify content is now resolved.
 
 ## Related
 
@@ -98,3 +98,4 @@ Epic **8R54HV** (Claude Code) — reuse gate logic; note Cursor's `stop` can't b
 - 2026-06-16 Gap noted (from FJKM4X): guides loaded via `.safeword/guides/` tell agents to "call `/figure-it-out`" — a literal slash command in Claude Code. In Cursor, `safeword-figure-it-out.mdc` already uses the `@reference` pattern correctly, but it has `alwaysApply: false` and activates by description match, not by explicit invocation from guide text. There is no direct bridge from "guide says call figure-it-out" to "MDC rule loads the procedure." In practice the context conditions overlap so the rule likely activates correctly, but it is not mechanically guaranteed the way Claude Code's slash command invocation is. Consider: (a) `alwaysApply: true` for figure-it-out.mdc since it's always relevant when a design choice surfaces, or (b) a guide-aware rule activation mechanism if Cursor exposes one.
 - 2026-06-24 **Consolidated all Cursor work under this epic + revalidated; broadened title to "Cursor optimization."** Checked GitHub issues — no Cursor epic exists there (ticket-system-only); only tangential open issues are #292 (Claude Code plugin spike) and #19 (MCP-in-plugin), nothing to fold. Folded pure-Cursor **151** (rules → `@reference`) in as a core child. Soft-linked three cross-agent Cursor tickets via `relates_to` without re-parenting: **1833FW**, **F1HTQ4** (agent-surface-refactor), **Y6HZR7** (auto-upgrade-cross-agent). **Revalidation against live code closed two as done:** RBZR3F (`sessionStart` already wired in `.cursor/hooks.json` → `session-safeword-context.ts`, emits `additional_context` for cursor) and 151 (the four rules are already 6-line `@reference` pointers; structural `checkCursorRulesThin` guard live; status was just never flipped). Remaining open children re-verified as still needed: F2TKR3/T3DV1K (`beforeSubmitPrompt`/`preToolUse`/`beforeShellExecution` not wired in `.cursor/hooks.json`), ANAXG4 (no `failClosed` anywhere), AKNWZK (done-gate rearchitect still pending — note: the `followup_message` nudge mechanism already exists in `cursor/stop.ts` for quality-review, useful precedent), TDX8NT + DXYKJX (unstarted). No duplicate tickets found; 151↔G1A6BS cover disjoint rule sets.
 - 2026-06-24 `/quality-review` + `/figure-it-out` refresh after P9K783: current Cursor docs confirm the implemented hook shape (`preToolUse`, `beforeShellExecution`, `failClosed`, stop `loop_limit`) and current plugin shape (`.cursor-plugin/plugin.json`, hooks/MCP bundling, Team Marketplace Required/Optional). Marked F2TKR3/T3DV1K/ANAXG4/AKNWZK as ready to close in this index pending explicit close confirmation; P9K783 is PR #424. Split MCP out of TDX8NT into new ticket JFBFEP because safeword has no `beforeMCPExecution` gate today and Arcade should use an action-based MCP policy instead of blocking MCP wholesale.
+- 2026-06-26T06:55:00Z Fast-forward revalidation: PRs #400, #415, #424, #434, #447, and #463 have landed. The implementation/verification work for F2TKR3, T3DV1K, ANAXG4, AKNWZK, P9K783, TDX8NT, and Y6HZR7 is complete, but final `status: done` flips are blocked by #469 because the Cursor done gate kills this repo's 91s BDD lane at its 60s timeout. Remaining product work is F1HTQ4, JFBFEP, and DXYKJX.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/dimensions.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/dimensions.md
@@ -1,0 +1,8 @@
+# Dimensions: Auto-upgrade under Cursor
+
+| Dimension | Partitions | Notes |
+| --- | --- | --- |
+| Hook surface | `sessionStart` context, `sessionStart` auto-upgrade | Cursor keeps context injection first and runs auto-upgrade as a separate silent hook. |
+| Outcome channel | silent success, silent skip, git commit record | Cursor does not use exit 2, `continue:false`, or `user_message` for session-start notification. |
+| Shared core | Claude wrapper, Cursor wrapper, Codex dispatcher | Agent-specific wrappers share the auto-upgrade apply core. |
+| Repository safety | no upgrade running, upgrade lock active | Cursor write and shell gates wait while silent auto-upgrade owns repository state. |

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/spec.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/spec.md
@@ -1,74 +1,46 @@
 # Spec: Auto-upgrade under Cursor
 
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
-
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Cursor users should receive safeword patch/minor upgrades at session start without running `safeword upgrade` manually and without weakening Cursor startup.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- Parent epic: `BJX7WR-auto-upgrade-cross-agent`
+- Shared apply core: PR #433
+- Cursor wrapper: PR #447
+- Cursor safety hardening: PR #463
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-the configured personas file (e.g., Platform Operator (PO)). Add new
-personas to that file — don't invent them here. -->
+- Technical Builder (TB)
 
 ## Vocabulary
 
-<!-- Domain terms specific to this feature, consistent with
-the configured glossary file. Optional. -->
+- **Silent auto-upgrade:** A Cursor `sessionStart` hook that applies safe safeword upgrades without surfacing hook output.
+- **Durable record:** The git commit created by the shared auto-upgrade core when an upgrade applies.
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### auto-upgrade-cursor.TB1 — Stay current in Cursor without manual upgrade work
 
-Uncomment and customize:
+**Persona:** Technical Builder (TB)
 
-### oauth-flow.PO1 — Rotate credentials without a flag day
+> When I start a Cursor agent session in a safeword-managed project, I want safe safeword upgrades to apply automatically, so I can keep the guardrails current without remembering a manual command.
 
-**Persona:** Platform Operator (PO)
+#### auto-upgrade-cursor.TB1.AC1 — Cursor startup runs context injection and silent auto-upgrade
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
+#### auto-upgrade-cursor.TB1.AC2 — Cursor uses the same auto-upgrade implementation as the other agents
 
-Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
-in descriptive product language (a guarantee the user can observe), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario will prove a specific AC. If a JTBD has no user-observable capability
-to enumerate, write `skip: <reason>` under it instead of ACs.
-
-#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
-
-#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
--->
+#### auto-upgrade-cursor.TB1.AC3 — Cursor edits do not race an in-flight silent upgrade
 
 ## Outcomes
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+- Cursor setup installs the SAFEWORD context hook first and silent auto-upgrade hook second.
+- Cursor auto-upgrade exits `0` and stays silent when no upgrade applies.
+- Cursor, Claude Code, and Codex wrappers share the same apply core.
+- Cursor write and shell gates wait while silent auto-upgrade is running.
 
 ## Open Questions
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+- defer: Rich user-visible Cursor notifications for major-version or repeated-failure outcomes are a follow-up, not part of this slice.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/test-definitions.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/test-definitions.md
@@ -1,0 +1,29 @@
+# Test Definitions: Auto-upgrade under Cursor
+
+Feature source: retrofit from merged PRs #447 and #463; no separate `.feature` file exists for this cleanup.
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: Cursor sessionStart applies safe upgrades silently
+
+### Scenario: auto-upgrade-cursor.TB1.AC1.silent_cursor_session_upgrade
+
+- [x] RED: setup coverage expected only the SAFEWORD context hook, so the missing Cursor auto-upgrade hook was visible.
+- [x] GREEN: Cursor setup installs `session-safeword-context.ts --agent=cursor` first and `session-cursor-auto-upgrade.ts` second.
+- [x] REFACTOR: Cursor session-start hooks stay fail-open; the auto-upgrade wrapper exits `0` with no output when no upgrade applies.
+
+## Rule: Cursor shares the cross-agent auto-upgrade implementation
+
+### Scenario: auto-upgrade-cursor.TB1.AC2.shared_apply_core
+
+- [x] RED: before PR #433, the apply path lived inside Claude's `session-auto-upgrade.ts`.
+- [x] GREEN: Cursor's wrapper calls the shared `runAutoUpgrade()` core instead of copying upgrade logic.
+- [x] REFACTOR: schema/package/hook coverage guards keep the Cursor wrapper registered without changing Claude or Codex behavior.
+
+## Rule: Cursor gates wait during silent auto-upgrade
+
+### Scenario: auto-upgrade-cursor.TB1.AC3.cursor_upgrade_lock
+
+- [x] RED: post-merge review found Cursor `sessionStart` is fire-and-forget, so edits could race the silent upgrade.
+- [x] GREEN: `auto-upgrade-lock.ts` guards the silent upgrade, and Cursor write/shell gates wait before acting on repository state.
+- [x] REFACTOR: setup/reconcile preserves user-authored Cursor hook entries instead of replacing whole hook arrays.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/ticket.md
@@ -7,6 +7,19 @@ status: in_progress
 epic: auto-upgrade-cross-agent
 parent: BJX7WR
 relates_to: VAX3Z2
+scope:
+  - Wire Cursor sessionStart to run silent auto-upgrade after SAFEWORD context injection.
+  - Reuse the shared auto-upgrade apply core from PR #433 instead of copying upgrade logic.
+  - Keep Cursor startup fail-open and silent; rely on the git auto-upgrade commit as the durable record.
+  - Protect Cursor write and shell gates while silent auto-upgrade is running.
+out_of_scope:
+  - Rich Cursor notifications for major-version or repeated-failure outcomes.
+  - Replacing agent hook scripts with `safeword hook <name>` CLI dispatch.
+done_when:
+  - Cursor setup installs the context hook first and the silent auto-upgrade hook second.
+  - The Cursor auto-upgrade wrapper exits 0 without stdout or stderr when no upgrade applies.
+  - Cursor wrapper, Claude wrapper, and Codex dispatcher all use the shared auto-upgrade core.
+  - Cursor write and shell gates wait for the auto-upgrade lock.
 created: 2026-06-20T12:54:31.933Z
 last_modified: 2026-06-26T02:20:00Z
 ---
@@ -81,3 +94,4 @@ Confirmed by inspecting current Cursor docs and the merged code paths in
 - 2026-06-25T06:00:00Z Checked PR #433. It does not conflict with this ticket file, and it likely supplies the shared core this ticket needs. If #433 lands first, Y6HZR7 should proceed directly to a Cursor wrapper around `hooks/lib/auto-upgrade.ts`.
 - 2026-06-25T23:45:00Z Implemented Cursor wrapper on `cursor/y6hzr7-cursor-auto-upgrade-wrapper`: added `session-cursor-auto-upgrade.ts`, wired it as a second Cursor `sessionStart` command, registered it in schema/package/hook coverage, and added setup + integration tests. Focused tests green: 127/127.
 - 2026-06-26T02:20:00Z Followed up on post-merge quality review: added the missing `impl-plan.md`, preserved user-authored Cursor hook entries during merge/unmerge, dogfooded the new Cursor sessionStart hook, and added a git-dir auto-upgrade lock that makes Cursor write gates wait while silent auto-upgrade runs.
+- 2026-06-26T06:50:00Z Close evidence added on fast-forwarded `main`: focused Cursor auto-upgrade suite passed (131/131), Gherkin lane passed locally (159 scenarios, 2837 steps), lint passed, `verify.md` created, and all three feature scenarios are checked. Final `status: done` flip is blocked by the current Cursor done gate because its internal `test:bdd` run times out and sends SIGTERM even though the same lane passed outside the gate; tracked by GitHub issue #469.

--- a/.project/tickets/Y6HZR7-auto-upgrade-cursor/verify.md
+++ b/.project/tickets/Y6HZR7-auto-upgrade-cursor/verify.md
@@ -1,0 +1,20 @@
+# Verify: Auto-upgrade under Cursor
+
+## Verify Checklist
+
+**Test Suite:** ✓ 131/131 tests pass (`setup-cursor`, hook integration, auto-upgrade core, npm package, schema, hook coverage, config)
+**Gherkin:** ✅ Acceptance lane passes (159 scenarios, 2837 steps)
+**Build:** ✅ Success (tsup build completed during targeted test run)
+**Lint:** ✅ Clean (`bun run lint`)
+**Scenarios:** All 3 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope: PR #447 wired silent Cursor auto-upgrade, PR #463 added the Cursor safety hardening, and this cleanup only adds the missing close artifacts/status updates.
+**Dep Drift:** ✅ Clean (no new runtime dependency introduced for this slice)
+**Parent Epic:** BJX7WR (siblings: 2/2 done after this close)
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ✅ No new friction; Technical Builder keeps the same Cursor startup flow while safe upgrades happen silently.
+
+## Evidence
+
+- `bun run test -- tests/commands/setup-cursor.test.ts tests/integration/hooks.test.ts tests/hooks/auto-upgrade-core.test.ts tests/npm-package.test.ts tests/schema.test.ts tests/smoke/hook-coverage.test.ts src/templates/config.test.ts`
+- `bun run test:bdd`
+- `bun run lint`


### PR DESCRIPTION
## Summary
- Records the verified closeout state for Cursor auto-upgrade and Cursor verify-template drift tickets.
- Adds missing Y6HZR7 ticket artifacts: dimensions, test definitions, and verify evidence.
- Updates related epics/index notes to show the implementation is complete while final done flips remain blocked by #469.

## Test plan
- [x] Commit hooks passed: contract sync, schema/template guard, markdownlint, prettier.
- [ ] Not run: code tests. This PR changes ticket documentation only.


Made with [Cursor](https://cursor.com)