### PR TITLE
Avoid duplicate Cucumber execution in Vitest

### DIFF
--- a/packages/cli/tests/integration/cucumber-bdd.test.ts
+++ b/packages/cli/tests/integration/cucumber-bdd.test.ts
@@ -16,12 +16,13 @@ import vitestConfig from '../../vitest.config.js';
 import { TIMEOUT_SETUP } from '../helpers.js';
 
 const CLI_DIRECTORY = nodePath.resolve(import.meta.dirname, '../..');
+const CUCUMBER_WIRING_CHECK_ARGS = ['cucumber-js', '--dry-run', '--format', 'summary'];
 
 describe('cucumber-js acceptance lane (SM1.AC1)', () => {
   it(
     'gherkin-typescript.SM1.AC1.dogfood_feature_wiring_loads_without_executing_steps',
     () => {
-      const result = spawnSync('bunx', ['cucumber-js', '--dry-run', '--format', 'summary'], {
+      const result = spawnSync('bunx', CUCUMBER_WIRING_CHECK_ARGS, {
         cwd: CLI_DIRECTORY,
         encoding: 'utf8',
       });

--- a/packages/cli/tests/integration/cucumber-bdd.test.ts
+++ b/packages/cli/tests/integration/cucumber-bdd.test.ts
@@ -1,10 +1,9 @@
 /**
  * Integration test for the cucumber-js acceptance lane (ticket 102a — SM1.AC1).
  *
- * Proves safeword's own repo runs `.feature` specs through cucumber-js — the same
- * setup it scaffolds for customers — separate from the vitest unit suite. The
- * dogfood feature drives the built CLI from the outside; dist is already built by
- * the `pretest` step.
+ * Proves safeword's package-level Cucumber wiring loads feature specs and step
+ * definitions. Full scenario execution belongs to the root `test:bdd`
+ * acceptance lane, which also discovers package features.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -20,16 +19,16 @@ const CLI_DIRECTORY = nodePath.resolve(import.meta.dirname, '../..');
 
 describe('cucumber-js acceptance lane (SM1.AC1)', () => {
   it(
-    'gherkin-typescript.SM1.AC1.dogfood_feature_runs_green',
+    'gherkin-typescript.SM1.AC1.dogfood_feature_wiring_loads_without_executing_steps',
     () => {
-      const result = spawnSync('bunx', ['cucumber-js'], {
+      const result = spawnSync('bunx', ['cucumber-js', '--dry-run', '--format', 'summary'], {
         cwd: CLI_DIRECTORY,
         encoding: 'utf8',
       });
       const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
       expect(result.status, output).toBe(0);
-      expect(output).toMatch(/\b[1-9]\d* scenarios? \([1-9]\d* passed\)/);
-      expect(output).not.toMatch(/undefined|pending/);
+      expect(output).toMatch(/\b[1-9]\d* scenarios? \([1-9]\d* skipped\)/);
+      expect(output).not.toMatch(/undefined|ambiguous|pending|passed/);
     },
     TIMEOUT_SETUP,
   );


### PR DESCRIPTION
## Summary

- change the nested Vitest Cucumber integration test from full scenario execution to Cucumber dry-run wiring smoke
- keep the root `test:bdd` lane as the single full Cucumber acceptance execution path
- assert dry-run output has skipped scenarios and no undefined, ambiguous, pending, or passed steps

## Root Cause

CI runs `bun run --cwd packages/cli test`, then root `bun run test:bdd`. The Vitest suite included `packages/cli/tests/integration/cucumber-bdd.test.ts`, which spawned `bunx cucumber-js` from `packages/cli` and fully executed 23 package scenarios. Root `cucumber.mjs` also discovers `packages/*/features/**/*.feature`, so those package scenarios were executed again in the root BDD lane.

Ruled out: `safeword test-plan` duplication. The resolver does not emit `test:bdd`; the hook runner intentionally appends the acceptance lane separately.

## Verification

- Red phase: targeted test failed against the old full-run command after executing `23 scenarios (23 passed)` in ~92s
- `bun run --cwd packages/cli test tests/integration/cucumber-bdd.test.ts`
- `bun run test:bdd` -> `159 scenarios (159 passed)`, `2837 steps (2837 passed)`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli lint:eslint -- tests/integration/cucumber-bdd.test.ts`
- `bunx prettier --check packages/cli/tests/integration/cucumber-bdd.test.ts`
- `git diff --check`
