### PR TITLE
Plan outdated audit age filter

### DIFF
--- a/.project/tickets/NAATTE-age-filter-outdated-audit/spec.md
+++ b/.project/tickets/NAATTE-age-filter-outdated-audit/spec.md
@@ -1,0 +1,85 @@
+# Spec: Reduce outdated dependency noise in audit
+
+## Intent
+
+`/audit` should help builders notice dependency maintenance work that is old enough to deserve attention, not flood them with every release that landed yesterday. SafeWord should apply that noise filter consistently across JavaScript, Python, Go, and Rust while leaving the project owner's package-manager, Renovate, and Dependabot policies untouched.
+
+## Intake Brief
+
+- **Requested by:** Alex, during audit-skill tuning discussion.
+- **Cost of inaction:** Audit remains noisy enough that dependency findings become easy to ignore, especially in polyglot repos where native tools report different levels of detail.
+- **Reversibility:** Two-way door if implemented as SafeWord-owned reporting policy in `.safeword/config.json`; risk increases if it writes package-manager or updater-tool configuration, which is explicitly out of scope.
+
+## References
+
+- Prior discussion: filter audit output by candidate release age, not by the age of the installed package.
+- Prior decision: SafeWord should not mutate `.npmrc`, `.yarnrc.yml`, `pnpm-workspace.yaml`, `bunfig.toml`, Renovate, or Dependabot config to achieve this.
+
+## Personas
+
+- Technical Builder (TB)
+- Safeword Maintainer (SM)
+
+## Vocabulary
+
+- **Candidate update:** A newer package version reported by the ecosystem's normal outdated-dependency command.
+- **Release-age threshold:** The minimum age a candidate update must reach before `/audit` lists it as actionable. Default: 30 days.
+- **Direct dependency:** A package named by the project manifest. Transitive dependencies are pulled in by direct dependencies and are excluded from the main freshness report by default.
+- **Security finding:** A known vulnerability or advisory. Security findings bypass the release-age threshold.
+
+## Jobs To Be Done
+
+### age-filter-outdated-audit.TB1 — Act on stale dependency updates without release-feed noise
+
+**Persona:** Technical Builder (TB)
+
+> When I run `/audit` near the end of feature work, I want dependency freshness findings to show updates that have been available long enough to matter, so I can act on real maintenance debt instead of triaging every fresh release.
+
+#### age-filter-outdated-audit.TB1.AC1 — Fresh releases are suppressed until they pass the threshold
+
+#### age-filter-outdated-audit.TB1.AC2 — Suppressed update counts remain visible without filling the findings table
+
+#### age-filter-outdated-audit.TB1.AC3 — Security findings appear immediately, even when the fixed version is newer than the threshold
+
+### age-filter-outdated-audit.TB2 — Get consistent behavior across supported language stacks
+
+**Persona:** Technical Builder (TB)
+
+> When I audit a JavaScript, Python, Go, or Rust project outside the SafeWord repo itself, I want the same dependency-noise policy to apply, so the audit report feels like one SafeWord feature instead of four unrelated package-manager dumps.
+
+#### age-filter-outdated-audit.TB2.AC1 — JavaScript candidate updates use npm registry release times for age filtering
+
+#### age-filter-outdated-audit.TB2.AC2 — Python candidate updates use PyPI release upload times for age filtering
+
+#### age-filter-outdated-audit.TB2.AC3 — Go candidate updates use module version times for age filtering
+
+#### age-filter-outdated-audit.TB2.AC4 — Rust candidate updates use crate version publish times when available and report unknown-age candidates separately
+
+#### age-filter-outdated-audit.TB2.AC5 — Non-dogfood project fixtures prove behavior without relying on SafeWord's own package.json, .agents, or dogfood install layout
+
+### age-filter-outdated-audit.SM1 — Preserve repo-owned update policy
+
+**Persona:** Safeword Maintainer (SM)
+
+> When I ship the audit noise filter, I want it to live in SafeWord's report policy rather than package-manager config, so SafeWord does not collide with a repo's install behavior, Renovate schedule, Dependabot rules, or lockfile workflow.
+
+#### age-filter-outdated-audit.SM1.AC1 — Audit filtering does not write package-manager, updater, manifest, or lockfile configuration
+
+#### age-filter-outdated-audit.SM1.AC2 — The configured threshold belongs to SafeWord audit behavior, not package installation behavior
+
+## Rave Moment
+
+skip: table-stakes
+
+## Outcomes
+
+- `/audit` no longer prints a long table of very recent dependency releases by default.
+- Builders can still see that recent updates were suppressed and can lower the threshold if they want a raw freshness feed.
+- JavaScript, Python, Go, and Rust audit behavior share the same release-age concept even though their metadata sources differ.
+- Ordinary target projects get the behavior through generated SafeWord templates; this repo's dogfood copy is only a sync check.
+- Existing repo policy files remain untouched.
+
+## Open Questions
+
+- Should the v1 threshold config allow `0` to mean "show all outdated candidates" for teams that want raw package-manager behavior?
+- Should v1 read Renovate/Dependabot schedules as advisory context, or keep them entirely out until a later integration ticket?

--- a/.project/tickets/NAATTE-age-filter-outdated-audit/ticket.md
+++ b/.project/tickets/NAATTE-age-filter-outdated-audit/ticket.md
@@ -1,0 +1,46 @@
+---
+id: NAATTE
+slug: age-filter-outdated-audit
+type: feature
+phase: intake
+status: in_progress
+scope:
+  - Add an audit-owned outdated-dependency age filter, defaulting to 30 days, configurable from `.safeword/config.json` as audit behavior.
+  - Normalize outdated dependency candidates across JavaScript, Python, Go, and Rust before reporting them.
+  - Limit the main outdated-dependency report to direct dependencies by default; transitive package freshness stays out of the report unless it is a security finding.
+  - Enrich each candidate with its release timestamp from the ecosystem's package metadata when available, then hide candidates newer than the configured threshold.
+  - Report a short suppression summary for hidden recent updates and a separate note for candidates whose release age cannot be determined.
+  - Keep security findings outside the age filter so known vulnerabilities surface immediately.
+  - Update the shipped audit command/skill templates so Claude, Cursor, and Codex installs get the same behavior in ordinary target projects.
+  - Keep this repo's dogfood-installed audit surfaces in sync as verification only, not as the implementation target.
+out_of_scope:
+  - Writing or modifying package-manager policy files such as `.npmrc`, `.yarnrc.yml`, `pnpm-workspace.yaml`, `bunfig.toml`, Renovate config, or Dependabot config.
+  - Automatically upgrading packages, editing lockfiles, or choosing changelog migration actions.
+  - Full transitive dependency freshness reporting for Go/Rust/Python/JavaScript outside explicit security findings.
+  - Private registry authentication or organization-specific package metadata connectors.
+  - Replacing dedicated vulnerability scanners; this ticket only preserves the rule that security findings bypass the age filter.
+done_when:
+  - `/audit` shows outdated direct dependencies only when the candidate update is at least the configured age threshold, defaulting to 30 days.
+  - `/audit` summarizes hidden recent updates without listing every package in the main findings table.
+  - JavaScript, Python, Go, and Rust projects each have covered candidate parsing and release-age filtering behavior.
+  - Candidates with unknown release age are reported separately from the actionable aged table.
+  - No package-manager config, Renovate config, Dependabot config, lockfile, or manifest is changed by the audit check.
+  - Tests prove the age filter, direct-dependency default, unknown-age handling, and no-config-mutation guarantee.
+  - Tests or fixtures prove the behavior in non-dogfood target projects for JavaScript, Python, Go, and Rust.
+  - Audit templates, generated install surfaces, and this repo's dogfood-installed audit surfaces stay in sync.
+created: 2026-06-27T04:16:34.785Z
+last_modified: 2026-06-27T04:42:52Z
+---
+
+# Reduce outdated dependency noise in audit
+
+**Goal:** Make `/audit` report only dependency updates old enough to be worth action, across supported language ecosystems, without changing the target repo's package-management policy.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-06-27T04:42:52Z Scope check: Found dogfood-flavored wording in scope/done_when. Tightened the ticket so ordinary target projects are the implementation target, with this repo's dogfood-installed files only a sync verification surface.
+- 2026-06-27T04:24:09Z Quality-review: Approved intake scope with one non-blocking note — keep Renovate/Dependabot reading out of v1 unless it becomes an explicit later acceptance criterion. Primary-source check supports npm/PyPI/Go timestamp lookup; Rust is covered via publish-time-when-available plus unknown-age fallback.
+- 2026-06-27T04:19:41Z Intake: Scoped the feature as a SafeWord-owned audit report filter: default 30-day release-age threshold, direct dependencies by default, no package-manager config mutation, cross-ecosystem support for JavaScript/Python/Go/Rust, and security findings outside the filter.
+- 2026-06-27T04:16:34.785Z Started: Created ticket NAATTE


### PR DESCRIPTION
## Summary
- Adds local ticket `age-filter-outdated-audit (NAATTE)` for reducing noisy outdated dependency audit findings.
- Defines the spec for a 30-day candidate-release-age filter across JavaScript, Python, Go, and Rust.
- Captures guardrails: direct dependencies by default, security findings bypass the filter, unknown release ages are separated, and package-manager/updater config is not mutated.

## Verification
- `bunx prettier --check .project/tickets/NAATTE-age-filter-outdated-audit/ticket.md .project/tickets/NAATTE-age-filter-outdated-audit/spec.md`