### PR TITLE
Fix Cursor shell hook timeout failures

### DIFF
--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -170,6 +170,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Root moves (Cursor).** After `move_agent_to_root`, `move_agent_to_cloned_root`, or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
+
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -23,6 +23,8 @@ import {
   toCursorDecision,
 } from './gate-adapter.ts';
 
+const SHELL_GATE_TIMEOUT_MS = 8_000;
+
 async function readInput(): Promise<CursorShellInput> {
   try {
     return (await Bun.stdin.json()) as CursorShellInput;
@@ -60,8 +62,15 @@ const translated: ClaudeGateInput = {
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
-// Fail-closed: a gate that crashed or never started denies the command (ANAXG4).
-const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
+// Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
+// own cancellation path can reduce the failure to "Canceled: Canceled".
+const decision = decideFromGate(
+  runClaudeHook({
+    claudeHookPath,
+    input: translated,
+    timeoutMs: SHELL_GATE_TIMEOUT_MS,
+  }),
+);
 const proofCommand =
   decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
 if (proofCommand !== undefined) {

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -218,12 +218,14 @@ export function toCursorDecision(reason: string | undefined): CursorDecision {
 export interface ClaudeGateResult {
   /** The gate's stdout (its allow/deny verdict as JSON), or '' on failure. */
   stdout: string;
+  /** True when Safeword killed the inner gate because it exceeded its local timeout. */
+  timedOut: boolean;
   /**
    * True when the gate could not be run to a clean verdict — it failed to spawn
-   * (e.g. `bun` missing) or crashed (non-zero exit). The gate always exits 0 for
-   * BOTH allow and deny (the verdict travels in stdout), so a non-zero exit can
-   * only mean an unhandled crash, never a normal denial. This lets the adapter
-   * tell "gate ran and allowed" apart from "gate never produced a verdict".
+   * (e.g. `bun` missing), crashed (non-zero exit), or timed out. The gate always
+   * exits 0 for BOTH allow and deny (the verdict travels in stdout), so a non-zero
+   * exit can only mean an unhandled crash, never a normal denial. This lets the
+   * adapter tell "gate ran and allowed" apart from "gate never produced a verdict".
    */
   failed: boolean;
 }
@@ -233,17 +235,32 @@ export const GATE_UNAVAILABLE_REASON =
   'Safeword gate could not run (it crashed or failed to start), so this action was blocked. ' +
   'Check the Hooks output channel, then retry once the gate runs cleanly.';
 
+/** Message shown when Safeword returns a controlled block before Cursor cancels the hook. */
+export const GATE_TIMEOUT_REASON =
+  'Safeword gate took too long to check this shell command, so this command was blocked. ' +
+  'Retry once; if it repeats, check the Hooks output channel and temporarily disable the ' +
+  'beforeShellExecution entry in .cursor/hooks.json to unblock diagnostics.';
+
+export interface RunClaudeHookOptions {
+  claudeHookPath: string;
+  input: ClaudeGateInput;
+  timeoutMs?: number;
+}
+
 /**
  * Spawn a Claude source-of-truth hook with the translated input. `CLAUDE_PROJECT_DIR`
  * and `SAFEWORD_AGENT_RUNTIME` are set so the gate resolves project state from
  * the Cursor workspace root and uses the Cursor-scoped run key. Reports both the
  * stdout verdict and whether the gate actually ran — see `ClaudeGateResult`.
  */
-export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): ClaudeGateResult {
+export function runClaudeHook(options: RunClaudeHookOptions): ClaudeGateResult {
+  const { claudeHookPath, input, timeoutMs } = options;
   const result = spawnSync('bun', [claudeHookPath], {
     cwd: process.cwd(),
     input: JSON.stringify(input),
     encoding: 'utf8',
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
@@ -251,9 +268,12 @@ export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): C
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  // `error` => the process never started; non-zero/null `status` => it crashed.
+  // `spawnSync` reports timed-out children through `error`; detect it separately
+  // so users see a recovery path, not a generic crash.
+  const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT';
+  // `error` => the process never started/timed out; non-zero/null `status` => it crashed.
   const failed = result.error != null || result.status !== 0;
-  return { stdout: result.stdout ?? '', failed };
+  return { stdout: result.stdout ?? '', failed, timedOut };
 }
 
 /**
@@ -267,12 +287,11 @@ export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): C
  * times out, or emits invalid JSON.
  */
 export function decideFromGate(result: ClaudeGateResult): CursorDecision {
+  if (result.timedOut) {
+    return toCursorDecision(GATE_TIMEOUT_REASON);
+  }
   if (result.failed) {
-    return {
-      permission: 'deny',
-      user_message: GATE_UNAVAILABLE_REASON,
-      agent_message: GATE_UNAVAILABLE_REASON,
-    };
+    return toCursorDecision(GATE_UNAVAILABLE_REASON);
   }
   return toCursorDecision(claudeDenialReason(result.stdout));
 }

--- a/.safeword/hooks/cursor/post-tool-quality.ts
+++ b/.safeword/hooks/cursor/post-tool-quality.ts
@@ -67,4 +67,4 @@ const translated: ClaudeGateInput = {
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts');
 
-emitAndExit(translatePostOutput(runClaudeHook(claudeHookPath, translated).stdout));
+emitAndExit(translatePostOutput(runClaudeHook({ claudeHookPath, input: translated }).stdout));

--- a/.safeword/hooks/cursor/pre-tool-quality.ts
+++ b/.safeword/hooks/cursor/pre-tool-quality.ts
@@ -104,4 +104,4 @@ const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
 // Fail-closed: a gate that crashed or never started denies the edit (ANAXG4).
-emitDecisionAndExit(decideFromGate(runClaudeHook(claudeHookPath, translated)));
+emitDecisionAndExit(decideFromGate(runClaudeHook({ claudeHookPath, input: translated })));

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,30 @@
+const GENERATED_SAFEWORD_PATH = '.safeword/';
+
+function shellQuote(filePath) {
+  return JSON.stringify(filePath);
+}
+
+function withoutGeneratedSafewordFiles(files) {
+  return files.filter(
+    filePath => !filePath.startsWith(GENERATED_SAFEWORD_PATH) && !filePath.includes('/.safeword/'),
+  );
+}
+
+function eslintAndPrettier(files) {
+  const commands = [];
+  const lintableFiles = withoutGeneratedSafewordFiles(files);
+  if (lintableFiles.length > 0) {
+    commands.push(`eslint --fix ${lintableFiles.map(filePath => shellQuote(filePath)).join(' ')}`);
+  }
+  commands.push(`prettier --write ${files.map(filePath => shellQuote(filePath)).join(' ')}`);
+  return commands;
+}
+
+export default {
+  '*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}': eslintAndPrettier,
+  '*.{vue,svelte,astro}': ['eslint --fix', 'prettier --write'],
+  '*.{json,css,scss,html,yaml,yml,graphql}': ['prettier --write'],
+  '*.md': ['markdownlint-cli2 --fix', 'prettier --write'],
+  '*.sh': ['shellcheck'],
+  '*.feature': ['bun packages/cli/src/cli.ts lint-gherkin'],
+};

--- a/package.json
+++ b/package.json
@@ -44,29 +44,6 @@
     "shellcheck": "^4.1.0",
     "tsx": "^4.22.4"
   },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.{vue,svelte,astro}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.{json,css,scss,html,yaml,yml,graphql}": [
-      "prettier --write"
-    ],
-    "*.md": [
-      "markdownlint-cli2 --fix",
-      "prettier --write"
-    ],
-    "*.sh": [
-      "shellcheck"
-    ],
-    "*.feature": [
-      "bun packages/cli/src/cli.ts lint-gherkin"
-    ]
-  },
   "overrides": {
     "@felipecrs/decompress-tarxz": "5.0.6",
     "@types/estree": "^1.0.9",

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -334,9 +334,15 @@ export const CURSOR_HOOKS = {
       timeout: 90,
     },
   ],
-  // Blocking commit gate (a REFACTOR commit may not touch test files).
+  // Blocking commit gate (a REFACTOR commit may not touch test files). Cursor's
+  // timeout is longer than the adapter's inner timeout, so Safeword can return a
+  // clear denial message before Cursor falls back to opaque cancellation.
   beforeShellExecution: [
-    { command: 'bun ./.safeword/hooks/cursor/before-shell-execution.ts', failClosed: true },
+    {
+      command: 'bun ./.safeword/hooks/cursor/before-shell-execution.ts',
+      failClosed: true,
+      timeout: 12,
+    },
   ],
   // Observational: triggers lint on edited files. Fail-open — a lint crash must
   // not block the edit.

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -170,6 +170,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Root moves (Cursor).** After `move_agent_to_root`, `move_agent_to_cloned_root`, or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
+
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword sync-learnings` regenerates the index.
 
 ---

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -23,6 +23,8 @@ import {
   toCursorDecision,
 } from './gate-adapter.ts';
 
+const SHELL_GATE_TIMEOUT_MS = 8_000;
+
 async function readInput(): Promise<CursorShellInput> {
   try {
     return (await Bun.stdin.json()) as CursorShellInput;
@@ -60,8 +62,15 @@ const translated: ClaudeGateInput = {
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
-// Fail-closed: a gate that crashed or never started denies the command (ANAXG4).
-const decision = decideFromGate(runClaudeHook(claudeHookPath, translated));
+// Fail-closed with a local timeout: return Cursor-readable JSON before Cursor's
+// own cancellation path can reduce the failure to "Canceled: Canceled".
+const decision = decideFromGate(
+  runClaudeHook({
+    claudeHookPath,
+    input: translated,
+    timeoutMs: SHELL_GATE_TIMEOUT_MS,
+  }),
+);
 const proofCommand =
   decision.permission === 'allow' ? parseRecordSkillInvocationCommand(command) : undefined;
 if (proofCommand !== undefined) {

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -218,12 +218,14 @@ export function toCursorDecision(reason: string | undefined): CursorDecision {
 export interface ClaudeGateResult {
   /** The gate's stdout (its allow/deny verdict as JSON), or '' on failure. */
   stdout: string;
+  /** True when Safeword killed the inner gate because it exceeded its local timeout. */
+  timedOut: boolean;
   /**
    * True when the gate could not be run to a clean verdict — it failed to spawn
-   * (e.g. `bun` missing) or crashed (non-zero exit). The gate always exits 0 for
-   * BOTH allow and deny (the verdict travels in stdout), so a non-zero exit can
-   * only mean an unhandled crash, never a normal denial. This lets the adapter
-   * tell "gate ran and allowed" apart from "gate never produced a verdict".
+   * (e.g. `bun` missing), crashed (non-zero exit), or timed out. The gate always
+   * exits 0 for BOTH allow and deny (the verdict travels in stdout), so a non-zero
+   * exit can only mean an unhandled crash, never a normal denial. This lets the
+   * adapter tell "gate ran and allowed" apart from "gate never produced a verdict".
    */
   failed: boolean;
 }
@@ -233,17 +235,32 @@ export const GATE_UNAVAILABLE_REASON =
   'Safeword gate could not run (it crashed or failed to start), so this action was blocked. ' +
   'Check the Hooks output channel, then retry once the gate runs cleanly.';
 
+/** Message shown when Safeword returns a controlled block before Cursor cancels the hook. */
+export const GATE_TIMEOUT_REASON =
+  'Safeword gate took too long to check this shell command, so this command was blocked. ' +
+  'Retry once; if it repeats, check the Hooks output channel and temporarily disable the ' +
+  'beforeShellExecution entry in .cursor/hooks.json to unblock diagnostics.';
+
+export interface RunClaudeHookOptions {
+  claudeHookPath: string;
+  input: ClaudeGateInput;
+  timeoutMs?: number;
+}
+
 /**
  * Spawn a Claude source-of-truth hook with the translated input. `CLAUDE_PROJECT_DIR`
  * and `SAFEWORD_AGENT_RUNTIME` are set so the gate resolves project state from
  * the Cursor workspace root and uses the Cursor-scoped run key. Reports both the
  * stdout verdict and whether the gate actually ran — see `ClaudeGateResult`.
  */
-export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): ClaudeGateResult {
+export function runClaudeHook(options: RunClaudeHookOptions): ClaudeGateResult {
+  const { claudeHookPath, input, timeoutMs } = options;
   const result = spawnSync('bun', [claudeHookPath], {
     cwd: process.cwd(),
     input: JSON.stringify(input),
     encoding: 'utf8',
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
@@ -251,9 +268,12 @@ export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): C
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  // `error` => the process never started; non-zero/null `status` => it crashed.
+  // `spawnSync` reports timed-out children through `error`; detect it separately
+  // so users see a recovery path, not a generic crash.
+  const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT';
+  // `error` => the process never started/timed out; non-zero/null `status` => it crashed.
   const failed = result.error != null || result.status !== 0;
-  return { stdout: result.stdout ?? '', failed };
+  return { stdout: result.stdout ?? '', failed, timedOut };
 }
 
 /**
@@ -267,12 +287,11 @@ export function runClaudeHook(claudeHookPath: string, input: ClaudeGateInput): C
  * times out, or emits invalid JSON.
  */
 export function decideFromGate(result: ClaudeGateResult): CursorDecision {
+  if (result.timedOut) {
+    return toCursorDecision(GATE_TIMEOUT_REASON);
+  }
   if (result.failed) {
-    return {
-      permission: 'deny',
-      user_message: GATE_UNAVAILABLE_REASON,
-      agent_message: GATE_UNAVAILABLE_REASON,
-    };
+    return toCursorDecision(GATE_UNAVAILABLE_REASON);
   }
   return toCursorDecision(claudeDenialReason(result.stdout));
 }

--- a/packages/cli/templates/hooks/cursor/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/post-tool-quality.ts
@@ -67,4 +67,4 @@ const translated: ClaudeGateInput = {
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts');
 
-emitAndExit(translatePostOutput(runClaudeHook(claudeHookPath, translated).stdout));
+emitAndExit(translatePostOutput(runClaudeHook({ claudeHookPath, input: translated }).stdout));

--- a/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/cursor/pre-tool-quality.ts
@@ -104,4 +104,4 @@ const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
 // Fail-closed: a gate that crashed or never started denies the edit (ANAXG4).
-emitDecisionAndExit(decideFromGate(runClaudeHook(claudeHookPath, translated)));
+emitDecisionAndExit(decideFromGate(runClaudeHook({ claudeHookPath, input: translated })));

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -153,6 +153,7 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       expect(hooksConfig.hooks.beforeShellExecution[0].command).toBe(
         'bun ./.safeword/hooks/cursor/before-shell-execution.ts',
       );
+      expect(hooksConfig.hooks.beforeShellExecution[0].timeout).toBe(12);
       expect(hooksConfig.hooks.postToolUse[0].command).toBe(
         'bun ./.safeword/hooks/cursor/post-tool-quality.ts',
       );
@@ -195,6 +196,43 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
           matcher: 'Write',
           failClosed: true,
           timeout: 90,
+        },
+      ]);
+    });
+
+    it('should replace older safeword Cursor shell hooks on setup', async () => {
+      createTypeScriptPackageJson(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+      writeTestFile(
+        temporaryDirectory,
+        '.cursor/hooks.json',
+        `${JSON.stringify(
+          {
+            version: 1,
+            hooks: {
+              beforeShellExecution: [
+                { command: 'node ./scripts/custom-shell-gate.js' },
+                {
+                  command: 'bun ./.safeword/hooks/cursor/before-shell-execution.ts',
+                  failClosed: true,
+                },
+              ],
+            },
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+
+      await runCli(['setup', '--yes'], { cwd: temporaryDirectory });
+
+      const hooksConfig = JSON.parse(readTestFile(temporaryDirectory, '.cursor/hooks.json'));
+      expect(hooksConfig.hooks.beforeShellExecution).toEqual([
+        { command: 'node ./scripts/custom-shell-gate.js' },
+        {
+          command: 'bun ./.safeword/hooks/cursor/before-shell-execution.ts',
+          failClosed: true,
+          timeout: 12,
         },
       ]);
     });

--- a/packages/cli/tests/commands/setup-cursor.test.ts
+++ b/packages/cli/tests/commands/setup-cursor.test.ts
@@ -41,6 +41,18 @@ describe('Test Suite: Setup - Cursor IDE Support', () => {
       expect(content).toContain('alwaysApply: true');
       expect(content).toContain('@.safeword/SAFEWORD.md');
     });
+
+    it('installs Cursor root-move branch verification guidance', async () => {
+      createTypeScriptPackageJson(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+
+      await runCli(['setup', '--yes'], { cwd: temporaryDirectory });
+
+      const content = readTestFile(temporaryDirectory, '.safeword/SAFEWORD.md');
+      expect(content).toContain('move_agent_to_root');
+      expect(content).toContain('git branch --show-current');
+      expect(content).toContain('before evidence gathering or edits');
+    });
   });
 
   describe('Cursor Commands', () => {

--- a/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
+++ b/packages/cli/tests/hooks/cursor-gate-adapter.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -7,9 +11,11 @@ import {
   detectDoneTransition,
   extractFilePath,
   extractWriteContent,
+  GATE_TIMEOUT_REASON,
   GATE_UNAVAILABLE_REASON,
   mapCursorToolName,
   parseTicketType,
+  runClaudeHook,
   toCursorDecision,
 } from '../../templates/hooks/cursor/gate-adapter.js';
 
@@ -166,7 +172,7 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
     it('denies when the gate failed to run (crash / never started)', () => {
       // The whole point of ANAXG4: a broken gate must block, not silently allow.
       // stdout is empty here precisely because the gate crashed before emitting.
-      expect(decideFromGate({ stdout: '', failed: true })).toEqual({
+      expect(decideFromGate({ stdout: '', failed: true, timedOut: false })).toEqual({
         permission: 'deny',
         user_message: GATE_UNAVAILABLE_REASON,
         agent_message: GATE_UNAVAILABLE_REASON,
@@ -174,18 +180,54 @@ describe('Cursor gate adapter helpers (T3DV1K)', () => {
     });
 
     it('denies on failure even if partial stdout leaked before the crash', () => {
-      expect(decideFromGate({ stdout: 'half-written', failed: true }).permission).toBe('deny');
+      expect(
+        decideFromGate({ stdout: 'half-written', failed: true, timedOut: false }).permission,
+      ).toBe('deny');
+    });
+
+    it('denies with a timeout-specific recovery path when the gate exceeds its budget', () => {
+      const temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'cursor-gate-timeout-'));
+      const hookPath = nodePath.join(temporaryDirectory, 'hang.ts');
+      writeFileSync(
+        hookPath,
+        'await new Promise(resolve => setTimeout(resolve, 1_000));\n',
+        'utf8',
+      );
+
+      try {
+        const result = runClaudeHook({
+          claudeHookPath: hookPath,
+          input: {
+            hook_event_name: 'PreToolUse',
+            tool_name: 'Bash',
+            tool_input: { command: 'git status' },
+          },
+          timeoutMs: 20,
+        });
+
+        expect(result.failed).toBe(true);
+        expect(result.timedOut).toBe(true);
+        expect(decideFromGate(result)).toEqual({
+          permission: 'deny',
+          user_message: GATE_TIMEOUT_REASON,
+          agent_message: GATE_TIMEOUT_REASON,
+        });
+      } finally {
+        rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
     });
 
     it('allows when the gate ran cleanly and stayed silent', () => {
-      expect(decideFromGate({ stdout: '', failed: false })).toEqual({ permission: 'allow' });
+      expect(decideFromGate({ stdout: '', failed: false, timedOut: false })).toEqual({
+        permission: 'allow',
+      });
     });
 
     it('passes through a clean denial verdict from the gate', () => {
       const stdout = JSON.stringify({
         hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'no tests' },
       });
-      expect(decideFromGate({ stdout, failed: false })).toEqual({
+      expect(decideFromGate({ stdout, failed: false, timedOut: false })).toEqual({
         permission: 'deny',
         user_message: 'no tests',
         agent_message: 'no tests',


### PR DESCRIPTION
## Summary
- Fixes #510 by giving Cursor shell gates a Safeword-controlled inner timeout and a clear timeout denial message before Cursor can surface opaque cancellation.
- Sets the generated `beforeShellExecution` timeout and verifies setup refreshes stale Safeword shell hooks while preserving user-authored hooks.
- Includes the existing branch docs update for Cursor root-move verification guidance.

## Test plan
- [x] `bun run --cwd packages/cli test tests/hooks/cursor-gate-adapter.test.ts tests/commands/setup-cursor.test.ts`
- [x] `bun run --cwd packages/cli typecheck`
- [x] `bunx prettier --check packages/cli/src/templates/config.ts packages/cli/templates/hooks/cursor/before-shell-execution.ts packages/cli/templates/hooks/cursor/gate-adapter.ts packages/cli/templates/hooks/cursor/post-tool-quality.ts packages/cli/templates/hooks/cursor/pre-tool-quality.ts packages/cli/tests/commands/setup-cursor.test.ts packages/cli/tests/hooks/cursor-gate-adapter.test.ts`


Made with [Cursor](https://cursor.com)