### PR TITLE
Track follow-up tickets for review surfacing

### DIFF
--- a/.project/tickets/CQ4CD3-commit-dogfood-hooks-without-package-link/ticket.md
+++ b/.project/tickets/CQ4CD3-commit-dogfood-hooks-without-package-link/ticket.md
@@ -1,0 +1,50 @@
+---
+id: CQ4CD3
+slug: commit-dogfood-hooks-without-package-link
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-26T06:41:31.737Z
+last_modified: 2026-06-26T06:42:47Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/470
+---
+
+# Let maintainers commit dogfood hook changes without package-link setup
+
+**Goal:** Make the normal protected commit path work in Safeword source worktrees when staged files trigger `.safeword` ESLint.
+
+**Why:** Maintainers should not have to bypass Husky or hand-create `node_modules/safeword` links to commit verified dogfood hook changes.
+
+**Type:** Bug
+
+**Scope:** Fix Safeword's dogfood/source-worktree ESLint resolution path so `.safeword/eslint.config.mjs` can load `safeword/eslint` during pre-commit lint-staged runs. Cover the source repo and linked worktree case where the root does not contain `node_modules/safeword`.
+
+**Out of Scope:** Changing Safeword's public ESLint preset API, weakening lint rules, or masking real ESLint config/plugin failures.
+
+**Done When:**
+
+- [ ] In a fresh Safeword source worktree after normal dependency/setup steps, staging `.safeword/hooks/*.ts` and running `git commit` does not fail with `ERR_MODULE_NOT_FOUND` for `safeword`.
+- [ ] `.safeword/eslint.config.mjs` still fails loudly for genuine syntax errors, missing third-party plugins, and malformed project ESLint config.
+- [ ] The fix does not require maintainers to set `HUSKY=0`, run a manual package link command, or edit generated `.safeword` config files.
+
+**Tests:**
+
+- [ ] Regression: source-worktree fixture or integration test proves the pre-commit/lint path can resolve `safeword/eslint` without a root `node_modules/safeword` link.
+- [ ] Unit or integration coverage confirms the generated `.safeword/eslint.config.mjs` import path remains valid for normal installed projects.
+- [ ] Existing ESLint config generation and lint hook tests continue to pass.
+
+## Root Cause
+
+The dogfood `.safeword/eslint.config.mjs` imports `safeword/eslint`. During a normal commit on branch `codex/464-quiet-implement-review-surface`, lint-staged invoked ESLint for staged `.safeword/hooks` files, but Node could not resolve the package from the worktree root because `node_modules/safeword` was absent. Manual verification passed, but the commit had to use `HUSKY=0` to bypass the broken protected path.
+
+Possible fix directions:
+
+- Make the dogfood/source repo config resolve the local workspace package path when running from a Safeword source checkout.
+- Ensure Safeword setup/dogfood bootstrap creates the package link that the generated config expects.
+- Route pre-commit lint for source repo `.safeword` files through a config that is guaranteed to resolve from the worktree root.
+
+## Work Log
+
+- 2026-06-26T06:42:47Z Filed: Created GitHub issue #470 and linked it from this ticket.
+- 2026-06-26T06:41:26Z Found: Normal `git commit` failed because `.safeword/eslint.config.mjs` imports `safeword/eslint`, but the worktree root has no resolvable `node_modules/safeword`; committed #464 only after manual verification and `HUSKY=0`.
+- 2026-06-26T06:41:31.737Z Started: Created ticket CQ4CD3

--- a/.project/tickets/V9MP7T-align-phase-review-surface/ticket.md
+++ b/.project/tickets/V9MP7T-align-phase-review-surface/ticket.md
@@ -1,0 +1,55 @@
+---
+id: V9MP7T
+slug: align-phase-review-surface
+type: task
+phase: intake
+status: in_progress
+created: 2026-06-26T05:38:46.034Z
+last_modified: 2026-06-26T05:44:00.000Z
+relates_to:
+  - SXSCJQ
+  - JENFZX
+external_issue: https://github.com/ArcadeAI/safeword/issues/465
+scope:
+  - Align generic phase review surfacing with phase-exit evidence instead of phase-entry timing. Today `post-tool-quality.ts` emits `getQualityMessage(phase)` when a `ticket.md` edit enters a phase, but several phase messages ask for evidence that only exists at phase exit.
+  - Keep lightweight per-turn phase reminders from `prompt-questions.ts`; they are state guidance, not review prompts.
+  - Keep real phase work and gates intact: intake user sub-phase gates, scenario-gate `/review-spec`, verify `/verify` + `/audit`, done gate, and any configured review-stamp gates.
+  - Change generic hook-injected phase reviews so they surface only when they are actionable: phase-exit summaries, real blockers, anomalies, or user/scope decisions.
+  - Audit each phase's current review prompt for timing correctness: `intake`, `define-behavior`, `scenario-gate`, `verify`, and `done`. Document which phases should have no generic hook review because their real gate already owns the review.
+out_of_scope:
+  - Quieting implement-phase TDD step prompts; owned by `JENFZX-quiet-implement-review-surface`.
+  - Removing `/review-spec`, `/verify`, `/audit`, done-gate checks, or review-stamp gates.
+  - Changing TDD step review content or implementation-exit `/quality-review` + `/refactor` workflow.
+  - Broad BDD phase redesign; this is surfacing/timing, not phase model changes.
+done_when:
+  - Entering `define-behavior`, `scenario-gate`, or `verify` no longer injects a user-facing review prompt that asks for end-of-phase evidence that does not exist yet.
+  - Exiting a phase can still surface a concise summary when the agent has evidence to report, or a blocker/anomaly when the user needs to act.
+  - Phase reminders still appear through `prompt-questions.ts` for active tickets.
+  - Scenario-gate independent review, verify `/verify` + `/audit`, done gate, and configured review-stamp gates still run and surface as before.
+  - Tests cover phase-entry suppression, phase-exit/actionable surfacing, and preservation of non-review reminders and hard gates.
+---
+
+# Align phase review prompts with phase exits
+
+**Goal:** Stop generic phase review prompts from firing at phase entry when their evidence only exists at phase exit.
+
+**Why:** Outside implementation, the interruption rate is lower, but the semantics are still off: the hook can ask for scenario quality, AODI pass, or `/verify` evidence immediately after entering the phase that is supposed to produce that evidence.
+
+## Decision
+
+Keep phase guidance and real gates; remove mistimed generic reviews.
+
+- **Keep:** one-line prompt reminders, intake confirmation gates, scenario-gate `/review-spec`, verify `/verify` + `/audit`, done evidence gates, configured review stamps.
+- **Change:** generic hook-injected `CONFIDENT/BLOCKED` phase review prompts that fire because `phase:` changed in `ticket.md`.
+- **Surface:** only phase-exit summaries, blockers, anomalies, and user/scope decisions.
+
+## Related history
+
+- `SXSCJQ-remove-loc-review-throttle` moved review surfacing to boundary detection. This ticket narrows when non-implement boundaries should surface to the user.
+- `JENFZX-quiet-implement-review-surface` owns the implementation-phase version of this problem; do not broaden it.
+
+## Work Log
+
+- 2026-06-26T05:44:00.000Z Mirrored: Created GitHub issue #465 and recorded it as `external_issue`.
+- 2026-06-26T05:42:00.000Z Scoped: Created as a sibling to JENFZX after confirming other phases have a lower-frequency but similar timing problem: generic hook reviews fire on phase entry while their evidence templates are mostly phase-exit shaped.
+- 2026-06-26T05:38:46.034Z Started: Created ticket V9MP7T


### PR DESCRIPTION
## Summary

Adds the local ticket artifacts for two follow-up issues that were already filed on GitHub:

- #465 / `align-phase-review-surface` — align non-implementation phase review prompts with phase-exit evidence
- #470 / `commit-dogfood-hooks-without-package-link` — make Safeword source-worktree pre-commit lint resolve `safeword/eslint` without manual package-link setup

## Testing

- Commit hook ran markdownlint/prettier on both ticket files
- `git diff --cached --check` passed before commit

No product/runtime code changed.