### PR TITLE
Fix Python test-plan without tests

### DIFF
--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
@@ -48,6 +48,24 @@ type ToolProbe = (tool: string) => boolean;
 type ManifestIndex = ReadonlyMap<string, string>;
 
 const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'tox.ini'];
+const PYTHON_TEST_SCAN_EXCLUDES = new Set([
+  'node_modules',
+  '.git',
+  '.safeword',
+  'vendor',
+  'dist',
+  'build',
+  'target',
+  'coverage',
+  'dbt_packages',
+  'out',
+  '.next',
+  '.nuxt',
+  '.output',
+  '__pycache__',
+  '.venv',
+  'venv',
+]);
 
 /** Every manifest probed via the tree (root-only files like package.json/go.work are checked directly). */
 const TREE_MANIFESTS = new Set<string>([
@@ -214,6 +232,55 @@ function pytestConfigured(index: ManifestIndex): boolean {
   return configContains(index, 'setup.cfg', '[tool:pytest]');
 }
 
+function hasDiscoverablePythonTests(directory: string, maxDepth = 10): boolean {
+  return scanForPythonTests(directory, 0, maxDepth);
+}
+
+function scanForPythonTests(directory: string, depth: number, maxDepth: number): boolean {
+  if (depth > maxDepth) return false;
+
+  let directoryEntries;
+  try {
+    directoryEntries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  if (
+    directoryEntries.some(
+      directoryEntry => directoryEntry.isFile() && isPythonTestFile(directoryEntry.name),
+    )
+  ) {
+    return true;
+  }
+
+  return directoryEntries
+    .filter(directoryEntry => shouldScanForPythonTests(directoryEntry))
+    .some(directoryEntry =>
+      scanForPythonTests(nodePath.join(directory, directoryEntry.name), depth + 1, maxDepth),
+    );
+}
+
+function shouldScanForPythonTests(directoryEntry: {
+  isDirectory(): boolean;
+  name: string;
+}): boolean {
+  return (
+    directoryEntry.isDirectory() &&
+    !directoryEntry.name.startsWith('.') &&
+    !PYTHON_TEST_SCAN_EXCLUDES.has(directoryEntry.name)
+  );
+}
+
+function isPythonTestFile(filename: string): boolean {
+  return (
+    filename.endsWith('.py') &&
+    (filename.startsWith('test_') ||
+      filename.endsWith('_test.py') ||
+      filename.endsWith('_tests.py'))
+  );
+}
+
 /** Package-manager-aware pytest invocation; returns the command and the tool whose presence gates availability. */
 function pytestInvocation(
   index: ManifestIndex,
@@ -235,10 +302,12 @@ function resolvePython(
   if (PYTHON_MANIFESTS.every(manifest => !index.has(manifest))) return undefined;
   const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
   if (index.has('tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
-  if (pytestConfigured(index) || isAvailable('pytest')) {
+  const hasPythonTests = hasDiscoverablePythonTests(cwd);
+  if (pytestConfigured(index) || (hasPythonTests && isAvailable('pytest'))) {
     const { command, tool } = pytestInvocation(index, isAvailable);
     return entry('python', cwd, command, 'pytest', isAvailable(tool));
   }
+  if (!hasPythonTests) return undefined;
   // Prefer python3 (the only `python` on macOS/modern distros), fall back to python.
   const pythonBin = isAvailable('python3') ? 'python3' : 'python';
   return entry(

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -43,6 +43,7 @@ describe('resolveTestPlan — every detected language appears (no first-match)',
     const root = makeRepo({
       'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
       'pyproject.toml': '[project]\nname = "x"\n',
+      'tests/test_example.py': 'def test_example():\n    assert True\n',
     });
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
     expect(languages(plan).toSorted((a, b) => a.localeCompare(b))).toEqual([
@@ -102,15 +103,30 @@ describe('resolveTestPlan — the command reflects the detected runner', () => {
   });
 
   it('python with no pytest falls back to unittest', () => {
-    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'tests/test_example.py': 'import unittest\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python') });
     expect(entryFor(plan, 'python')?.command).toBe('python -m unittest discover');
   });
 
   it('prefers python3 for the unittest fallback when available', () => {
-    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'example_test.py': 'import unittest\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python3') });
     expect(entryFor(plan, 'python')?.command).toBe('python3 -m unittest discover');
+  });
+
+  it('does not emit a python lane for manifests without python tests', () => {
+    const root = makeRepo({
+      'requirements.txt': 'gepa==0.1.1\n',
+      'run.py': 'print("experiment")\n',
+    });
+    const plan = resolveTestPlan(root, { kind: 'verify', isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')).toBeUndefined();
   });
 
   it('detects pytest configured via setup.cfg [tool:pytest]', () => {
@@ -188,7 +204,10 @@ describe('resolveTestPlan — missing toolchains stay visible', () => {
 
 describe('resolveTestPlan — nested and vendored manifests', () => {
   it('a manifest in a sub-directory is discovered', () => {
-    const root = makeRepo({ 'services/api/pyproject.toml': '[project]\n' });
+    const root = makeRepo({
+      'services/api/pyproject.toml': '[project]\n',
+      'services/api/tests/test_example.py': 'def test_example():\n    assert True\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
     expect(entryFor(plan, 'python')).toBeDefined();
   });


### PR DESCRIPTION
# PR draft for ArcadeAI/safeword#462

## Title

Fix Python test-plan without tests

## Body

Fixes #462.

## What changed

- Detect whether a Python project actually has discoverable test files before emitting the fallback `python -m unittest discover` lane.
- Keep existing behavior for configured `tox` / `pytest` projects.
- Keep Python lanes visible when a project has normal `test_*.py`, `*_test.py`, or `*_tests.py` files.
- Add a regression case for a repo with `requirements.txt` and Python source files but no tests.

## Why

Previously, a Python manifest alone was enough to emit a runnable Python test lane. In mixed or experiment-style repos this can produce a misleading `unittest discover` command even when there are no Python tests to run.

## Validation

```bash
bun run --cwd packages/cli test tests/test-plan/resolve.test.ts
bun run --cwd packages/cli typecheck
```

Local result:

- `resolve.test.ts`: 32 passed
- `typecheck`: passed

## Risk

Low. The change is scoped to Python test-plan resolution and preserves configured `tox` / `pytest` paths.
