### PR TITLE
Run verification automatically after implementation

### DIFF
--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -122,7 +122,10 @@ All scenarios complete → reconcile `impl-plan.md` against what actually shippe
 
 _Worked example:_ the plan said "Decisions: parse with the shared markdown utility"; during implementation a local scan proved smaller, so the choice changed mid-implementation — the row now reads choice "local content-or-skip scan", with the shared utility recorded under Alternatives considered and the reason it lost. That update (not a rewrite of history — the alternatives column preserves it) is what reconciliation produces.
 
-Reconciled → set `phase: verify`.
+Reconciled → set `phase: verify` and continue directly into the verify phase:
+run `/verify`, then `/audit`. Do not ask the user whether to proceed; verification
+is agent-owned work. Ask the user only if `/verify`, `/audit`, or a review
+surfaces a real spec, scope, value, or risk decision.
 
 ## Implement exit: independent design review (architecture review gate)
 

--- a/.agents/skills/bdd/VERIFY.md
+++ b/.agents/skills/bdd/VERIFY.md
@@ -1,6 +1,9 @@
 # Verify: Evidence Gate
 
-**Entry:** All scenarios marked `[x]` in test-definitions.md.
+**Entry:** All scenarios marked `[x]` in test-definitions.md, implement-exit
+review/refactor is complete, and `impl-plan.md` is reconciled. Entry is
+automatic after implementation: run `/verify`, then `/audit`, without asking the
+user whether to proceed.
 
 ## Steps
 

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -122,7 +122,10 @@ All scenarios complete → reconcile `impl-plan.md` against what actually shippe
 
 _Worked example:_ the plan said "Decisions: parse with the shared markdown utility"; during implementation a local scan proved smaller, so the choice changed mid-implementation — the row now reads choice "local content-or-skip scan", with the shared utility recorded under Alternatives considered and the reason it lost. That update (not a rewrite of history — the alternatives column preserves it) is what reconciliation produces.
 
-Reconciled → set `phase: verify`.
+Reconciled → set `phase: verify` and continue directly into the verify phase:
+run `/verify`, then `/audit`. Do not ask the user whether to proceed; verification
+is agent-owned work. Ask the user only if `/verify`, `/audit`, or a review
+surfaces a real spec, scope, value, or risk decision.
 
 ## Implement exit: independent design review (architecture review gate)
 

--- a/.claude/skills/bdd/VERIFY.md
+++ b/.claude/skills/bdd/VERIFY.md
@@ -1,6 +1,9 @@
 # Verify: Evidence Gate
 
-**Entry:** All scenarios marked `[x]` in test-definitions.md.
+**Entry:** All scenarios marked `[x]` in test-definitions.md, implement-exit
+review/refactor is complete, and `impl-plan.md` is reconciled. Entry is
+automatic after implementation: run `/verify`, then `/audit`, without asking the
+user whether to proceed.
 
 ## Steps
 

--- a/.project/tickets/MZAHAW-run-verification-automatically-after-implementation/ticket.md
+++ b/.project/tickets/MZAHAW-run-verification-automatically-after-implementation/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: implement
 status: in_progress
 created: 2026-06-27T01:23:04.141Z
-last_modified: 2026-06-27T15:04:00Z
+last_modified: 2026-06-27T20:47:00Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/483
 scope:
   - stop treating entry to verify as a human-facing approval checkpoint
@@ -33,3 +33,4 @@ done_when:
 - 2026-06-27T01:33:11Z Complete: changed review-trigger and Cursor stop behavior so verify entry stays quiet; updated BDD verify guidance to run /verify + /audit automatically. Focused hook tests and package typecheck passed.
 - 2026-06-27T14:07:00Z Updated: rebased the patch onto current origin/main after #508 and related follow-up commits landed.
 - 2026-06-27T15:04:00Z Verified: direct Vitest hook sweep passed with 59/59 tests; package typecheck and git diff --check passed.
+- 2026-06-27T20:47:00Z Reviewed: PR feedback found the branch had dropped Cursor stop crash-capture wiring from current main; rebased again, confirmed the wiring was restored, and added a regression test to keep both Cursor stop hook copies wired.

--- a/.project/tickets/MZAHAW-run-verification-automatically-after-implementation/ticket.md
+++ b/.project/tickets/MZAHAW-run-verification-automatically-after-implementation/ticket.md
@@ -1,0 +1,35 @@
+---
+id: MZAHAW
+slug: run-verification-automatically-after-implementation
+type: task
+phase: implement
+status: in_progress
+created: 2026-06-27T01:23:04.141Z
+last_modified: 2026-06-27T15:04:00Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/483
+scope:
+  - stop treating entry to verify as a human-facing approval checkpoint
+  - make verify entry direct the agent to run /verify and /audit automatically
+  - keep real blockers and user decisions visible when verification finds them
+out_of_scope:
+  - redesigning all phase review behavior
+  - changing done-gate evidence requirements
+done_when:
+  - implement to verify transition does not inject a pre-verification human review prompt
+  - verify guidance tells the agent to run /verify and /audit without asking to proceed
+  - regression tests cover Claude and Cursor verify-entry behavior
+---
+
+# Run verification automatically after implementation
+
+**Goal:** Prevent SafeWord from pausing for human approval between implementation and verification.
+
+**Why:** Verification is agent-owned work; the human should only be interrupted for real blockers or decisions.
+
+## Work Log
+
+- 2026-06-27T01:23:04.141Z Started: Created ticket MZAHAW
+- 2026-06-27T01:25:00.000Z Found: GitHub issue #483 captures root cause: verify phase review fires before /verify evidence exists, creating a false approval stop.
+- 2026-06-27T01:33:11Z Complete: changed review-trigger and Cursor stop behavior so verify entry stays quiet; updated BDD verify guidance to run /verify + /audit automatically. Focused hook tests and package typecheck passed.
+- 2026-06-27T14:07:00Z Updated: rebased the patch onto current origin/main after #508 and related follow-up commits landed.
+- 2026-06-27T15:04:00Z Verified: direct Vitest hook sweep passed with 59/59 tests; package typecheck and git diff --check passed.

--- a/.safeword/hooks/cursor/stop.ts
+++ b/.safeword/hooks/cursor/stop.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 // Safeword: Cursor adapter for stop hook
 // Checks for marker file from afterFileEdit to determine if files were modified
-// Uses followup_message to inject quality review prompt into conversation
+// Uses followup_message to inject quality review prompt into conversation.
+// Suppresses phases where the next step is agent-owned execution, not a human
+// review stop: ordinary implement work and verify entry.
 
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
@@ -25,14 +27,15 @@ interface StopOutput {
   followup_message?: string;
 }
 
-function isQuietImplementRun(
+function isAutomatedEvidenceRun(
   workspace: string,
   runIdentity: ReturnType<typeof resolveRunIdentity>,
 ): boolean {
   const state = readSessionState(workspace, runIdentity);
   const activeTicket = state?.activeTicket;
   if (!activeTicket) return false;
-  return getTicketInfo(workspace, activeTicket).phase === 'implement';
+  const phase = getTicketInfo(workspace, activeTicket).phase;
+  return phase === 'implement' || phase === 'verify';
 }
 
 // Read hook input from stdin
@@ -76,7 +79,7 @@ if (await Bun.file(markerFile).exists()) {
     if (process.env.DEBUG) console.error('[cursor/stop] marker cleanup failed:', error);
   });
 
-  if (isQuietImplementRun(process.cwd(), runIdentity)) {
+  if (isAutomatedEvidenceRun(process.cwd(), runIdentity)) {
     console.log('{}');
     process.exit(0);
   }

--- a/.safeword/hooks/lib/review-trigger.ts
+++ b/.safeword/hooks/lib/review-trigger.ts
@@ -4,12 +4,14 @@
  *
  * Phase reviews use enter-semantics dedup. A phase boundary is reviewed once;
  * whichever trigger sees the un-reviewed boundary first fires it and records it,
- * the other skips.
+ * the other skips. `verify` is intentionally excluded: entering verify should
+ * run /verify + /audit, not ask for pre-verification review evidence.
  */
 
 export function shouldReviewPhase(
   currentPhase: string | undefined,
   lastReviewedPhase?: string,
 ): boolean {
+  if (currentPhase === 'verify') return false;
   return currentPhase !== undefined && currentPhase !== lastReviewedPhase;
 }

--- a/packages/cli/templates/hooks/cursor/stop.ts
+++ b/packages/cli/templates/hooks/cursor/stop.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 // Safeword: Cursor adapter for stop hook
 // Checks for marker file from afterFileEdit to determine if files were modified
-// Uses followup_message to inject quality review prompt into conversation
+// Uses followup_message to inject quality review prompt into conversation.
+// Suppresses phases where the next step is agent-owned execution, not a human
+// review stop: ordinary implement work and verify entry.
 
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
@@ -25,14 +27,15 @@ interface StopOutput {
   followup_message?: string;
 }
 
-function isQuietImplementRun(
+function isAutomatedEvidenceRun(
   workspace: string,
   runIdentity: ReturnType<typeof resolveRunIdentity>,
 ): boolean {
   const state = readSessionState(workspace, runIdentity);
   const activeTicket = state?.activeTicket;
   if (!activeTicket) return false;
-  return getTicketInfo(workspace, activeTicket).phase === 'implement';
+  const phase = getTicketInfo(workspace, activeTicket).phase;
+  return phase === 'implement' || phase === 'verify';
 }
 
 // Read hook input from stdin
@@ -76,7 +79,7 @@ if (await Bun.file(markerFile).exists()) {
     if (process.env.DEBUG) console.error('[cursor/stop] marker cleanup failed:', error);
   });
 
-  if (isQuietImplementRun(process.cwd(), runIdentity)) {
+  if (isAutomatedEvidenceRun(process.cwd(), runIdentity)) {
     console.log('{}');
     process.exit(0);
   }

--- a/packages/cli/templates/hooks/lib/review-trigger.ts
+++ b/packages/cli/templates/hooks/lib/review-trigger.ts
@@ -4,12 +4,14 @@
  *
  * Phase reviews use enter-semantics dedup. A phase boundary is reviewed once;
  * whichever trigger sees the un-reviewed boundary first fires it and records it,
- * the other skips.
+ * the other skips. `verify` is intentionally excluded: entering verify should
+ * run /verify + /audit, not ask for pre-verification review evidence.
  */
 
 export function shouldReviewPhase(
   currentPhase: string | undefined,
   lastReviewedPhase?: string,
 ): boolean {
+  if (currentPhase === 'verify') return false;
   return currentPhase !== undefined && currentPhase !== lastReviewedPhase;
 }

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -122,7 +122,10 @@ All scenarios complete → reconcile `impl-plan.md` against what actually shippe
 
 _Worked example:_ the plan said "Decisions: parse with the shared markdown utility"; during implementation a local scan proved smaller, so the choice changed mid-implementation — the row now reads choice "local content-or-skip scan", with the shared utility recorded under Alternatives considered and the reason it lost. That update (not a rewrite of history — the alternatives column preserves it) is what reconciliation produces.
 
-Reconciled → set `phase: verify`.
+Reconciled → set `phase: verify` and continue directly into the verify phase:
+run `/verify`, then `/audit`. Do not ask the user whether to proceed; verification
+is agent-owned work. Ask the user only if `/verify`, `/audit`, or a review
+surfaces a real spec, scope, value, or risk decision.
 
 ## Implement exit: independent design review (architecture review gate)
 

--- a/packages/cli/templates/skills/bdd/VERIFY.md
+++ b/packages/cli/templates/skills/bdd/VERIFY.md
@@ -1,6 +1,9 @@
 # Verify: Evidence Gate
 
-**Entry:** All scenarios marked `[x]` in test-definitions.md.
+**Entry:** All scenarios marked `[x]` in test-definitions.md, implement-exit
+review/refactor is complete, and `impl-plan.md` is reconciled. Entry is
+automatic after implementation: run `/verify`, then `/audit`, without asking the
+user whether to proceed.
 
 ## Steps
 

--- a/packages/cli/tests/hooks/review-trigger.test.ts
+++ b/packages/cli/tests/hooks/review-trigger.test.ts
@@ -23,6 +23,11 @@ describe('shouldReviewPhase — enter-semantics dedup (S2.1–2.2, S3.3)', () =>
     expect(shouldReviewPhase('implement')).toBe(true);
   });
 
+  it('does not fire on verify entry because verification should run automatically', () => {
+    expect(shouldReviewPhase('verify', 'implement')).toBe(false);
+    expect(shouldReviewPhase('verify')).toBe(false);
+  });
+
   it('does not fire when there is no current phase', () => {
     expect(shouldReviewPhase(undefined, 'implement')).toBe(false);
   });

--- a/packages/cli/tests/integration/cursor-stop-review.test.ts
+++ b/packages/cli/tests/integration/cursor-stop-review.test.ts
@@ -2,8 +2,8 @@
  * Integration tests for Cursor's stop-hook quality review surface.
  *
  * Cursor Stop cannot block, so the observable behavior is whether the hook emits
- * a `followup_message`. Quiet implement mode suppresses that generic follow-up
- * for ordinary implement-phase edits while preserving non-implement nudges.
+ * a `followup_message`. Automated evidence phases suppress that generic
+ * follow-up while preserving review nudges elsewhere.
  */
 
 import { execSync, spawnSync } from 'node:child_process';
@@ -100,8 +100,17 @@ describe('Cursor stop review surface', () => {
     expect(JSON.parse(result.stdout)).toEqual({});
   });
 
-  it('still emits the generic follow-up outside implement phase', () => {
+  it('does not emit a generic follow-up before verify has run', () => {
     cwd = buildProject('verify');
+
+    const result = runCursorStop(cwd);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({});
+  });
+
+  it('still emits the generic follow-up outside implement phase', () => {
+    cwd = buildProject('scenario-gate');
 
     const result = runCursorStop(cwd);
     const parsed = JSON.parse(result.stdout) as { followup_message?: string };

--- a/packages/cli/tests/integration/cursor-stop-review.test.ts
+++ b/packages/cli/tests/integration/cursor-stop-review.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -25,6 +25,10 @@ const CURSOR_POST_TOOL = nodePath.join(
   '.safeword/hooks/cursor/post-tool-quality.ts',
 );
 const CURSOR_STOP = nodePath.join(SAFEWORD_ROOT, '.safeword/hooks/cursor/stop.ts');
+const TEMPLATE_CURSOR_STOP = nodePath.join(
+  SAFEWORD_ROOT,
+  'packages/cli/templates/hooks/cursor/stop.ts',
+);
 const CONVERSATION_ID = 'conv-quiet-implement';
 const MARKER_FILE = `/tmp/safeword-cursor-edited-cursor-${CONVERSATION_ID}`;
 
@@ -117,5 +121,14 @@ describe('Cursor stop review surface', () => {
 
     expect(result.status).toBe(0);
     expect(parsed.followup_message).toContain('Phase: implement');
+  });
+
+  it('keeps crash capture wired in both Cursor stop hook copies', () => {
+    for (const hookPath of [CURSOR_STOP, TEMPLATE_CURSOR_STOP]) {
+      const content = readFileSync(hookPath, 'utf8');
+
+      expect(content).toContain("import { installCrashCapture } from '../lib/self-report.ts';");
+      expect(content).toContain("installCrashCapture('cursor-stop', undefined, 'cursor');");
+    }
   });
 });

--- a/packages/cli/tests/integration/post-tool-review.test.ts
+++ b/packages/cli/tests/integration/post-tool-review.test.ts
@@ -132,6 +132,17 @@ describe('PostToolUse per-phase review — autonomous-safe (S2.1, S2.2)', () => 
     expect(context).toContain('scenario-gate');
   });
 
+  it('does not surface a pre-verification review when implementation advances to verify', () => {
+    const cwd = project();
+    writeTicket(cwd, 'verify');
+    const { context } = run(cwd, 'Edit', {
+      file_path: ticketPath(cwd),
+      old_string: 'phase: implement',
+      new_string: 'phase: verify',
+    });
+    expect(context).toBeUndefined();
+  });
+
   it('surfaces nothing when the current phase was already reviewed (S2.2)', () => {
     const cwd = project();
     writeTicket(cwd, 'implement');


### PR DESCRIPTION
## Summary

- Stop treating entry to `phase: verify` as a human-facing review checkpoint.
- Keep verify entry quiet in Claude/PostToolUse and Cursor stop paths so the agent proceeds to `/verify`, then `/audit`.
- Update BDD TDD/VERIFY guidance to make verification agent-owned work after implementation.

Closes #483.

## Verification

- `bun ./node_modules/.bin/vitest run tests/hooks/review-trigger.test.ts --pool=forks --maxWorkers=1`
- `bun ./node_modules/.bin/vitest run tests/integration/post-tool-review.test.ts --pool=forks --maxWorkers=1`
- `bun ./node_modules/.bin/vitest run tests/integration/cursor-stop-review.test.ts --pool=forks --maxWorkers=1`
- `bun ./node_modules/.bin/vitest run tests/quality.test.ts tests/hooks/review-trigger.test.ts tests/integration/post-tool-review.test.ts tests/integration/cursor-stop-review.test.ts tests/integration/stop-review-backstop.test.ts --pool=forks --maxWorkers=1`
- `bun run --cwd packages/cli typecheck`
- `git diff --check`

Note: the normal `git commit` pre-commit path failed with the known dogfood package-link issue tracked in #470 / `CQ4CD3-commit-dogfood-hooks-without-package-link`, so this commit was made with `HUSKY=0` after the checks above passed.
