### PR TITLE
Preserve Cursor ticket revalidation notes

### DIFF
--- a/.project/tickets/1833FW-cursor-verify-template-drift/ticket.md
+++ b/.project/tickets/1833FW-cursor-verify-template-drift/ticket.md
@@ -46,8 +46,15 @@ last_modified: 2026-06-14T02:05:00Z
 - If intentional, record why safeword's own dogfood should skip the Gherkin evidence line.
 - Quality-review guardrail: treat this as a blocker for wrapper generation, not as generic cleanup.
 
+## Resolution
+
+The dogfood Cursor verify command now matches the shipped verify template for the Gherkin acceptance lane and `**Gherkin:**` evidence pattern. F1HTQ4 can treat the current verify content as the intended generator input.
+
+Final `status: done` is still blocked by GitHub issue #469: local verify evidence needs to be reliable across agents before this ticket can close cleanly.
+
 ## Work Log
 
+- 2026-06-27T14:20:00Z Revalidated on current `origin/main`: `.cursor/commands/verify.md` and `packages/cli/templates/commands/verify.md` both include the Gherkin acceptance lane and `**Gherkin:**` evidence. This resolves the ticket criteria except for the mechanical done flip, which is blocked by #469.
 - 2026-06-14T02:05:00Z Reviewed: Marked the chosen verify content as generator input for F1HTQ4.
 - 2026-06-14T01:46:00Z Scoped: Figure-it-out marked the drift as a high-priority concrete follow-up.
 - 2026-06-14T01:39:31.130Z Started: Created ticket 1833FW.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -43,10 +43,10 @@
   Codex users get safeword's seamless patch/minor auto-upgrade (today Claude-Code-only) without manual `safeword upgrade` and within Codex's synchronous hook contract.
   external issue: https://github.com/ArcadeAI/safeword/issues/393
   → `.project/tickets/7R1D3B-auto-upgrade-codex`
-- **Epic: Cross-agent auto-upgrade (Cursor + Codex) (BJX7WR)** (in_progress, epic: auto-upgrade-cross-agent)
+- **Epic: Cross-agent auto-upgrade (Cursor + Codex) (BJX7WR)** (done, epic: auto-upgrade-cross-agent)
   Extend safeword's seamless auto-upgrade — today Claude-Code-only — to the other two supported agents, Cursor and Codex, so customers on any agent stay current without manual `safeword upgrade`.
   → `.project/tickets/BJX7WR-auto-upgrade-cross-agent`
-- **Auto-upgrade under Cursor (Y6HZR7)** (blocked, epic: auto-upgrade-cross-agent)
+- **Auto-upgrade under Cursor (Y6HZR7)** (done, epic: auto-upgrade-cross-agent)
   Cursor users get safeword's seamless patch/minor auto-upgrade (today Claude-Code-only) without manual `safeword upgrade` and without breaking Cursor's session start.
   → `.project/tickets/Y6HZR7-auto-upgrade-cursor`
 

--- a/.project/tickets/S3T6JA-agent-surface-refactor-epic/ticket.md
+++ b/.project/tickets/S3T6JA-agent-surface-refactor-epic/ticket.md
@@ -36,7 +36,7 @@ last_modified: 2026-06-14T03:24:46Z
 | Y06KJS | Generate Claude and Codex skill registrations from one manifest; do not delete dogfood mirrors. | High     |
 | F1HTQ4 | Generate Cursor command/rule wrappers from metadata while preserving physical wrapper files.    | High     |
 | 88QCHJ | Replace repeated skill-log shell injections with one installed helper command.                  | High     |
-| 1833FW | Reconcile or explicitly document the dogfood `.cursor/commands/verify.md` drift.                | High     |
+| 1833FW | Reconcile or explicitly document the dogfood `.cursor/commands/verify.md` drift.                | Resolved; close blocked by #469 |
 | W0E292 | Extract pure Codex hook translation helpers behind the current executable adapter.              | Medium   |
 | 6SE3MR | Share only the fake Codex binary writer; keep Cucumber/Vitest harness setup separate.           | Low      |
 | 2YZDKQ | Keep `versioning` as a Claude-local maintainer-only skill; exclude it from shared manifests.    | Medium   |
@@ -44,7 +44,7 @@ last_modified: 2026-06-14T03:24:46Z
 ## Quality-review guardrails
 
 - Run 2YZDKQ before Y06KJS so manifest generation does not silently promote or drop the dogfood-only `versioning` skill.
-- Run 1833FW before F1HTQ4 so Cursor wrapper generation captures the intended `verify` command content.
+- 1833FW is resolved for F1HTQ4: Cursor verify content is aligned to the shipped template; final ticket close is blocked only by #469.
 - Run Y06KJS before F1HTQ4 if F1HTQ4 consumes the shared skill metadata.
 - Do not assume Claude, Cursor, and Codex all execute the same skill-body shell syntax. 88QCHJ must verify helper invocation behavior per surface before replacing any snippet.
 - Keep a platform-current-docs check at pickup. Cursor and Codex both now expose skills/plugin concepts, but safeword still needs physical command/rule/config files where setup/upgrade installs them today.
@@ -69,6 +69,7 @@ last_modified: 2026-06-14T03:24:46Z
 
 ## Work Log
 
+- 2026-06-27T14:20:00Z Revalidated 1833FW: dogfood Cursor verify content is aligned with the shipped verify template, including Gherkin evidence. F1HTQ4 can proceed from the current verify content; the child ticket's final done flip is blocked by GitHub issue #469.
 - 2026-06-14T03:24:46Z Decided: 2YZDKQ keeps `versioning` Claude-local maintainer-only (`audience: maintainer`), so Y06KJS must exclude maintainer-only dogfood skills from shared customer-facing manifests.
 - 2026-06-14T02:05:00Z Reviewed: Quality-review pass approved the epic direction and added sequencing/runtime guardrails.
 - 2026-06-14T01:46:00Z Updated: Added second-pass figure-it-out decisions and seven child tickets.

--- a/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
+++ b/.project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md
@@ -63,12 +63,12 @@ Core children (own the `cursor-optimization` epic key). Status revalidated 2026-
 | ---------- | ------------------------------------------------------------------ | ------------------- | ---------------- |
 | **RBZR3F** | Add `sessionStart` context injection                               | restore enforcement | ✅ done          |
 | **151**    | Migrate four Cursor rules to `@reference` pattern                  | drift/parity        | ✅ done (folded) |
-| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | ready to close (rejected; no hook ships) |
-| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | ready to close |
-| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | ready to close |
-| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | ready to close |
-| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | PR #424 open |
-| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | open (Shell-only) |
+| **F2TKR3** | Wire `beforeSubmitPrompt` turn-start blocking gate                 | restore enforcement | resolved; close blocked by #469 |
+| **T3DV1K** | Port phase/LOC gates to `preToolUse` + `beforeShellExecution` deny | restore enforcement | shipped; close blocked by #469 |
+| **ANAXG4** | `failClosed:true` on gating hooks (default fail-open)              | correctness         | shipped; close blocked by #469 |
+| **AKNWZK** | Re-architect done/stop gate (stop can't block)                     | correctness         | shipped; close blocked by #469 |
+| **P9K783** | Harden Cursor done-gate close-detection (verify payload fields)    | correctness         | shipped; close blocked by #469 |
+| **TDX8NT** | Verify deny wins over Auto-review Run Mode (3.6)                   | watch/verify        | verified; close blocked by #469 |
 | **JFBFEP** | Add an action-based MCP safety gate for Cursor                     | correctness         | open             |
 | **DXYKJX** | Package as Team-Marketplace plugin (Required mode)                 | distribution        | open             |
 
@@ -78,13 +78,13 @@ These are Cursor-specific deliverables whose natural home is a cross-agent epic.
 
 | ID         | Title                                           | Home epic                | Status      |
 | ---------- | ----------------------------------------------- | ------------------------ | ----------- |
-| **1833FW** | Keep Cursor verify evidence aligned             | agent-surface-refactor   | in_progress |
+| **1833FW** | Keep Cursor verify evidence aligned             | agent-surface-refactor   | resolved; close blocked by #469 |
 | **F1HTQ4** | Generate Cursor command/rule wrappers from meta | agent-surface-refactor   | in_progress |
-| **Y6HZR7** | Auto-upgrade under Cursor                       | auto-upgrade-cross-agent | blocked     |
+| **Y6HZR7** | Auto-upgrade under Cursor                       | auto-upgrade-cross-agent | done        |
 
 ## Sequencing
 
-Remaining sequencing: land P9K783 (#424), then empirically verify `TDX8NT` for Shell deny precedence under Auto-review. Design/build `JFBFEP` before letting `DXYKJX` bundle MCP defaults; plugin packaging can proceed in parallel for non-MCP surfaces.
+Remaining sequencing: fix #469 so shipped Cursor tickets can close cleanly, then design/build `JFBFEP` before letting `DXYKJX` bundle MCP defaults. `F1HTQ4` can proceed because 1833FW's verify content is now resolved.
 
 ## Related
 
@@ -98,3 +98,4 @@ Epic **8R54HV** (Claude Code) — reuse gate logic; note Cursor's `stop` can't b
 - 2026-06-16 Gap noted (from FJKM4X): guides loaded via `.safeword/guides/` tell agents to "call `/figure-it-out`" — a literal slash command in Claude Code. In Cursor, `safeword-figure-it-out.mdc` already uses the `@reference` pattern correctly, but it has `alwaysApply: false` and activates by description match, not by explicit invocation from guide text. There is no direct bridge from "guide says call figure-it-out" to "MDC rule loads the procedure." In practice the context conditions overlap so the rule likely activates correctly, but it is not mechanically guaranteed the way Claude Code's slash command invocation is. Consider: (a) `alwaysApply: true` for figure-it-out.mdc since it's always relevant when a design choice surfaces, or (b) a guide-aware rule activation mechanism if Cursor exposes one.
 - 2026-06-24 **Consolidated all Cursor work under this epic + revalidated; broadened title to "Cursor optimization."** Checked GitHub issues — no Cursor epic exists there (ticket-system-only); only tangential open issues are #292 (Claude Code plugin spike) and #19 (MCP-in-plugin), nothing to fold. Folded pure-Cursor **151** (rules → `@reference`) in as a core child. Soft-linked three cross-agent Cursor tickets via `relates_to` without re-parenting: **1833FW**, **F1HTQ4** (agent-surface-refactor), **Y6HZR7** (auto-upgrade-cross-agent). **Revalidation against live code closed two as done:** RBZR3F (`sessionStart` already wired in `.cursor/hooks.json` → `session-safeword-context.ts`, emits `additional_context` for cursor) and 151 (the four rules are already 6-line `@reference` pointers; structural `checkCursorRulesThin` guard live; status was just never flipped). Remaining open children re-verified as still needed: F2TKR3/T3DV1K (`beforeSubmitPrompt`/`preToolUse`/`beforeShellExecution` not wired in `.cursor/hooks.json`), ANAXG4 (no `failClosed` anywhere), AKNWZK (done-gate rearchitect still pending — note: the `followup_message` nudge mechanism already exists in `cursor/stop.ts` for quality-review, useful precedent), TDX8NT + DXYKJX (unstarted). No duplicate tickets found; 151↔G1A6BS cover disjoint rule sets.
 - 2026-06-24 `/quality-review` + `/figure-it-out` refresh after P9K783: current Cursor docs confirm the implemented hook shape (`preToolUse`, `beforeShellExecution`, `failClosed`, stop `loop_limit`) and current plugin shape (`.cursor-plugin/plugin.json`, hooks/MCP bundling, Team Marketplace Required/Optional). Marked F2TKR3/T3DV1K/ANAXG4/AKNWZK as ready to close in this index pending explicit close confirmation; P9K783 is PR #424. Split MCP out of TDX8NT into new ticket JFBFEP because safeword has no `beforeMCPExecution` gate today and Arcade should use an action-based MCP policy instead of blocking MCP wholesale.
+- 2026-06-27T14:20:00Z Fast-forward revalidation: PRs #400, #415, #424, #434, #447, #463, and #492 have landed. The implementation/verification work for F2TKR3, T3DV1K, ANAXG4, AKNWZK, P9K783, TDX8NT, and Y6HZR7 is complete; Y6HZR7 is closed, and remaining final close flips are blocked by #469. Remaining product work is F1HTQ4, JFBFEP, and DXYKJX.


### PR DESCRIPTION
## Summary
- Record that Cursor verify evidence is aligned for 1833FW while final close remains blocked by #469.
- Refresh the Cursor optimization epic with current shipped/blocked status and remaining product work.
- Correct the ticket index for the completed cross-agent auto-upgrade epic and Cursor auto-upgrade ticket.

## Test plan
- [x] `bunx markdownlint-cli2 .project/tickets/1833FW-cursor-verify-template-drift/ticket.md .project/tickets/S3T6JA-agent-surface-refactor-epic/ticket.md .project/tickets/VAX3Z2-cursor-changelog-alignment-epic/ticket.md .project/tickets/INDEX.md`


Made with [Cursor](https://cursor.com)