### PR TITLE
Make no-bloat guidance explicit

### DIFF
--- a/.agents/skills/bdd/DISCOVERY.md
+++ b/.agents/skills/bdd/DISCOVERY.md
@@ -216,3 +216,5 @@ Define-behavior scenarios draw from the self-test: behavior that changes seeds h
 Technical breakdown — component identification and any design-doc/ADR triggers — belongs here in intake (you design the architecture in "Understanding" above). The per-scenario proof plan + build order step now happens at the scenario-gate exit; the standalone `decomposition` phase is retired (see the ADR in `ARCHITECTURE.md`).
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.agents/skills/bdd/DONE.md
+++ b/.agents/skills/bdd/DONE.md
@@ -11,3 +11,5 @@ Done means the ticket is closed. All verification happened in the verify phase.
 3. Final commit: `feat(scope): [summary]`
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
+
+**Avoid bloat.**

--- a/.agents/skills/bdd/SCENARIOS.md
+++ b/.agents/skills/bdd/SCENARIOS.md
@@ -208,3 +208,5 @@ After the gate, `safeword codify <ticket>` derives implementation stubs from the
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.
 
 Either way `.feature` is the scenario source of truth. test-definitions.md is the R/G/R ledger for checkboxes and hooks.
+
+**Avoid bloat.**

--- a/.agents/skills/bdd/SPLITTING.md
+++ b/.agents/skills/bdd/SPLITTING.md
@@ -54,3 +54,5 @@ User can decline: "Proceed anyway"
 - Log: "Split suggested but user declined"
 - Continue at current phase
 - Don't re-suggest at same checkpoint this session
+
+**Avoid bloat.**

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -144,3 +144,5 @@ bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-pla
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+
+**Avoid bloat.**

--- a/.agents/skills/bdd/VERIFY.md
+++ b/.agents/skills/bdd/VERIFY.md
@@ -23,3 +23,5 @@ Before proceeding to done:
    ```
 
 The stop hook hard-blocks `phase: done` if verify.md is missing or empty.
+
+**Avoid bloat.**

--- a/.agents/skills/figure-it-out/SKILL.md
+++ b/.agents/skills/figure-it-out/SKILL.md
@@ -92,3 +92,5 @@ If two options tie on correctness and elegance, the smaller one wins.
 **No hedging.** If you genuinely can't pick, you're missing one input — name it and ask one question. "Either could work" is not an answer.
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -150,3 +150,5 @@ stop condition; tests are the ground truth.
 4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -216,3 +216,5 @@ Define-behavior scenarios draw from the self-test: behavior that changes seeds h
 Technical breakdown — component identification and any design-doc/ADR triggers — belongs here in intake (you design the architecture in "Understanding" above). The per-scenario proof plan + build order step now happens at the scenario-gate exit; the standalone `decomposition` phase is retired (see the ADR in `ARCHITECTURE.md`).
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/DONE.md
+++ b/.claude/skills/bdd/DONE.md
@@ -11,3 +11,5 @@ Done means the ticket is closed. All verification happened in the verify phase.
 3. Final commit: `feat(scope): [summary]`
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/SCENARIOS.md
+++ b/.claude/skills/bdd/SCENARIOS.md
@@ -208,3 +208,5 @@ After the gate, `safeword codify <ticket>` derives implementation stubs from the
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.
 
 Either way `.feature` is the scenario source of truth. test-definitions.md is the R/G/R ledger for checkboxes and hooks.
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/SPLITTING.md
+++ b/.claude/skills/bdd/SPLITTING.md
@@ -54,3 +54,5 @@ User can decline: "Proceed anyway"
 - Log: "Split suggested but user declined"
 - Continue at current phase
 - Don't re-suggest at same checkpoint this session
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -144,3 +144,5 @@ bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-pla
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+
+**Avoid bloat.**

--- a/.claude/skills/bdd/VERIFY.md
+++ b/.claude/skills/bdd/VERIFY.md
@@ -23,3 +23,5 @@ Before proceeding to done:
    ```
 
 The stop hook hard-blocks `phase: done` if verify.md is missing or empty.
+
+**Avoid bloat.**

--- a/.claude/skills/figure-it-out/SKILL.md
+++ b/.claude/skills/figure-it-out/SKILL.md
@@ -92,3 +92,5 @@ If two options tie on correctness and elegance, the smaller one wins.
 **No hedging.** If you genuinely can't pick, you're missing one input — name it and ask one question. "Either could work" is not an answer.
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -150,3 +150,5 @@ stop condition; tests are the ground truth.
 4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -189,6 +189,7 @@ try {
   // Counter file missing or corrupted — skip escalation
 }
 
+lines.push('- Avoid bloat.');
 console.log(lines.join('\n'));
 
 function tddNextStep(step: string): string {

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -189,6 +189,7 @@ try {
   // Counter file missing or corrupted — skip escalation
 }
 
+lines.push('- Avoid bloat.');
 console.log(lines.join('\n'));
 
 function tddNextStep(step: string): string {

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -216,3 +216,5 @@ Define-behavior scenarios draw from the self-test: behavior that changes seeds h
 Technical breakdown — component identification and any design-doc/ADR triggers — belongs here in intake (you design the architecture in "Understanding" above). The per-scenario proof plan + build order step now happens at the scenario-gate exit; the standalone `decomposition` phase is retired (see the ADR in `ARCHITECTURE.md`).
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/DONE.md
+++ b/packages/cli/templates/skills/bdd/DONE.md
@@ -11,3 +11,5 @@ Done means the ticket is closed. All verification happened in the verify phase.
 3. Final commit: `feat(scope): [summary]`
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/SCENARIOS.md
+++ b/packages/cli/templates/skills/bdd/SCENARIOS.md
@@ -208,3 +208,5 @@ After the gate, `safeword codify <ticket>` derives implementation stubs from the
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.
 
 Either way `.feature` is the scenario source of truth. test-definitions.md is the R/G/R ledger for checkboxes and hooks.
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/SPLITTING.md
+++ b/packages/cli/templates/skills/bdd/SPLITTING.md
@@ -54,3 +54,5 @@ User can decline: "Proceed anyway"
 - Log: "Split suggested but user declined"
 - Continue at current phase
 - Don't re-suggest at same checkpoint this session
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -144,3 +144,5 @@ bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-pla
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/VERIFY.md
+++ b/packages/cli/templates/skills/bdd/VERIFY.md
@@ -23,3 +23,5 @@ Before proceeding to done:
    ```
 
 The stop hook hard-blocks `phase: done` if verify.md is missing or empty.
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/figure-it-out/SKILL.md
+++ b/packages/cli/templates/skills/figure-it-out/SKILL.md
@@ -92,3 +92,5 @@ If two options tie on correctness and elegance, the smaller one wins.
 **No hedging.** If you genuinely can't pick, you're missing one input — name it and ask one question. "Either could work" is not an answer.
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -150,3 +150,5 @@ stop condition; tests are the ground truth.
 4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
+
+**Avoid bloat.**

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -444,6 +444,7 @@ describe('E2E: UserPromptSubmit Hooks', () => {
       );
 
       expect(output).toContain('Contribute before asking');
+      expect(output.trim().split('\n').at(-1)).toBe('- Avoid bloat.');
     });
 
     it('exits silently for non-safeword project', () => {


### PR DESCRIPTION
## Summary
- Add explicit `Avoid bloat` guidance to figure-it-out, quality-review, and BDD phase docs in source templates and active Claude/Codex copies
- Append `- Avoid bloat.` as the final user prompt hook reminder
- Add an integration assertion that the prompt hook keeps the reminder as its final line

## Verification
- `bun run test -- tests/integration/hooks.test.ts` (55 passed)
- `git diff --check`