### PR TITLE
refactor: post-0.58.0 cleanup (parseToolList prefix + wrapper description dedup)

### DIFF
--- a/packages/cli/src/cursor-wrappers.ts
+++ b/packages/cli/src/cursor-wrappers.ts
@@ -34,6 +34,13 @@ const CURSOR_ACTION_SKILLS = [
   'review-spec',
 ] as const;
 
+// Shared verbatim by a skill's command wrapper and its rule wrapper.
+const DEBUG_DESCRIPTION =
+  "Four-phase debugging framework that ensures root cause identification before fixes. Use when encountering bugs, test failures, unexpected behavior, or when previous fix attempts failed. Enforces investigate-first discipline ('debug this', 'fix this error', 'test is failing', 'not working').";
+
+const REFACTOR_DESCRIPTION =
+  "Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.";
+
 export const CURSOR_COMMAND_WRAPPERS: readonly CursorCommandWrapper[] = [
   {
     name: 'bdd',
@@ -43,8 +50,7 @@ export const CURSOR_COMMAND_WRAPPERS: readonly CursorCommandWrapper[] = [
   },
   {
     name: 'debug',
-    description:
-      "Four-phase debugging framework that ensures root cause identification before fixes. Use when encountering bugs, test failures, unexpected behavior, or when previous fix attempts failed. Enforces investigate-first discipline ('debug this', 'fix this error', 'test is failing', 'not working').",
+    description: DEBUG_DESCRIPTION,
     skillPath: 'debug/SKILL.md',
   },
   {
@@ -55,8 +61,7 @@ export const CURSOR_COMMAND_WRAPPERS: readonly CursorCommandWrapper[] = [
   },
   {
     name: 'refactor',
-    description:
-      "Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.",
+    description: REFACTOR_DESCRIPTION,
     skillPath: 'refactor/SKILL.md',
   },
   {
@@ -83,8 +88,7 @@ export const CURSOR_RULE_WRAPPERS: readonly CursorRuleWrapper[] = [
   {
     name: 'safeword-debugging',
     alwaysApply: false,
-    description:
-      "Four-phase debugging framework that ensures root cause identification before fixes. Use when encountering bugs, test failures, unexpected behavior, or when previous fix attempts failed. Enforces investigate-first discipline ('debug this', 'fix this error', 'test is failing', 'not working').",
+    description: DEBUG_DESCRIPTION,
     referencePath: '.claude/skills/debug/SKILL.md',
     skill: 'debug',
   },
@@ -115,8 +119,7 @@ export const CURSOR_RULE_WRAPPERS: readonly CursorRuleWrapper[] = [
   {
     name: 'safeword-refactoring',
     alwaysApply: false,
-    description:
-      "Systematic refactoring with small-step discipline. Use when user says 'refactor', 'clean up', 'restructure', 'extract', 'rename', 'simplify', or mentions code smells. Enforces one change → test → commit when the commit can stay scoped. For structural improvements, NOT style/formatting (use /lint). NOT for adding features or fixing bugs.",
+    description: REFACTOR_DESCRIPTION,
     referencePath: '.claude/skills/refactor/SKILL.md',
     skill: 'refactor',
   },

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -68,19 +68,19 @@ const TREE_MANIFESTS = new Set<string>([
  */
 function fakeToolProbe(spec: string): (tool: string) => boolean {
   if (spec.startsWith('only:')) {
-    const set = parseToolList(spec);
+    const set = parseToolList(spec, 'only:');
     return tool => set.has(tool);
   }
   if (spec.startsWith('none:')) {
-    const set = parseToolList(spec);
+    const set = parseToolList(spec, 'none:');
     return tool => !set.has(tool);
   }
   return allToolsAvailable; // 'all' or empty
 }
 
 /** Parse the comma-separated tool list after a `only:` / `none:` prefix. */
-function parseToolList(spec: string): Set<string> {
-  return new Set(spec.slice('only:'.length).split(',').filter(Boolean));
+function parseToolList(spec: string, prefix: string): Set<string> {
+  return new Set(spec.slice(prefix.length).split(',').filter(Boolean));
 }
 
 function allToolsAvailable(): boolean {


### PR DESCRIPTION
A `/refactor` scout over the code merged since v0.58.0 (#492/#519/#524/#526/#528/#485…). Two behavior-preserving SAFE wins; everything else deferred or skipped (see below).

## Changes
1. **`test-plan/resolve.ts` — `parseToolList` prefix.** It hard-coded `slice('only:'.length)` but runs for both `only:` and `none:` specs — correct only because both prefixes are 5 chars. Now takes the prefix explicitly. (Fixes a latent coincidence-dependency; no behavior change.)
2. **`cursor-wrappers.ts` — hoist duplicated descriptions.** The `debug` and `refactor` skills had byte-identical description strings in both `CURSOR_COMMAND_WRAPPERS` and `CURSOR_RULE_WRAPPERS`; extracted `DEBUG_DESCRIPTION` / `REFACTOR_DESCRIPTION` so they can't drift. (`quality-review`/`testing` descriptions genuinely differ between command/rule and stay inline.) Generated `.mdc` output is byte-identical — schema drift detection green.

## Deferred / skipped (intentional, per the scout)
- **self-report hook lib** dups (`countSpoolRecords`/`parseSpoolFile`, `readSelfReportConfig`) — parity-paired (`templates/hooks` ↔ `.safeword/hooks`), doubles every edit, low value.
- **self-report sanitizer** (`sanitizeStackFrames`, the allowlists) — security-critical leak filter; refactor only under a security review.
- **self-report command** async conversion — would trip `require-await`; the `return Promise.resolve()` is intentional.
- **`isLanguageEnabled` lookup table** — inline alias branches are already clear; a table is a lateral move.

Verified: typecheck ✓, eslint ✓, `resolve.test.ts` (31) ✓, `schema.test.ts` (31) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)