### PR TITLE
fix(test-plan): only emit a Python lane when tests are discoverable

### DIFF
--- a/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
+++ b/.project/tickets/BKTTZA-test-plan-resolver/test-definitions.md
@@ -6,14 +6,14 @@ R/G/R ledger. Executable Given/When/Then live in the `.feature`; lower-level
 runner-detection proof rides on Vitest unit tests (pure resolver, injected
 `isToolAvailable` + temp fixtures) under each scenario's GREEN step.
 
-> Scenario count is 18 (above the soft >15 define-behavior split hint). Split
+> Scenario count is 19 (above the soft >15 define-behavior split hint). Split
 > **declined**: this is one cohesive journey — a single pure resolver's contract —
 > so "split by user journey" doesn't apply. The runner-detection cluster is
 > table-like and may collapse to a `Scenario Outline` at implementation.
 
 ## Rule: Every detected language appears in the plan (no first-match)
 
-### Scenario: A JS+Python repo yields exactly a javascript and a python entry
+### Scenario: A JS+Python repo with Python tests yields exactly a javascript and a python entry
 
 - [x] RED
 - [x] GREEN
@@ -52,6 +52,12 @@ runner-detection proof rides on Vitest unit tests (pure resolver, injected
 - [x] REFACTOR
 
 ### Scenario: Python with no pytest falls back to unittest
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: Python manifest without tests contributes no python entry
 
 - [x] RED
 - [x] GREEN

--- a/features/migrate-consumers-to-test-plan.feature
+++ b/features/migrate-consumers-to-test-plan.feature
@@ -45,6 +45,7 @@ Feature: migrate consumers to test-plan
     @migrate-consumers.SM1.AC3
     Scenario: A polyglot repo renders every language's command
       Given a repo with a root "test" script and a "pyproject.toml"
+      And the repo has a discoverable Python test file
       And the "pytest" toolchain is installed
       When I render the test plan as a shell script
       Then the script contains "run test"

--- a/features/test-plan-resolver.feature
+++ b/features/test-plan-resolver.feature
@@ -8,8 +8,9 @@ Feature: test-plan resolver
   Rule: Every detected language appears in the plan (no first-match)
 
     @test-plan-resolver.DEV1.AC1
-    Scenario: A JS+Python repo yields exactly a javascript and a python entry
+    Scenario: A JS+Python repo with Python tests yields exactly a javascript and a python entry
       Given a repo with a root "test" script and a "pyproject.toml"
+      And the repo has a discoverable Python test file
       When I request the test plan
       Then the plan includes a "javascript" entry
       And the plan includes a "python" entry
@@ -53,9 +54,16 @@ Feature: test-plan resolver
     @test-plan-resolver.DEV1.AC2
     Scenario: Python with no pytest falls back to unittest
       Given a Python repo with no pytest configuration
+      And the repo has a discoverable Python test file
       And only the "python" toolchain is installed
       When I request the test plan
       Then the "python" entry command is "python -m unittest discover"
+
+    @test-plan-resolver.DEV1.AC2
+    Scenario: Python manifest without tests contributes no python entry
+      Given a Python repo with no pytest configuration
+      When I request the test plan
+      Then the plan has no "python" entry
 
     @test-plan-resolver.DEV1.AC2
     Scenario: A uv-locked Python repo runs pytest through uv
@@ -105,6 +113,7 @@ Feature: test-plan resolver
     @test-plan-resolver.DEV1.AC4
     Scenario: A manifest in a sub-directory is discovered
       Given a repo with a "services/api/pyproject.toml" and no root manifest
+      And the repo has a discoverable Python test file under "services/api"
       When I request the test plan
       Then the plan includes a "python" entry
 

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
@@ -48,6 +48,24 @@ type ToolProbe = (tool: string) => boolean;
 type ManifestIndex = ReadonlyMap<string, string>;
 
 const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'tox.ini'];
+const PYTHON_TEST_SCAN_EXCLUDES = new Set([
+  'node_modules',
+  '.git',
+  '.safeword',
+  'vendor',
+  'dist',
+  'build',
+  'target',
+  'coverage',
+  'dbt_packages',
+  'out',
+  '.next',
+  '.nuxt',
+  '.output',
+  '__pycache__',
+  '.venv',
+  'venv',
+]);
 
 /** Every manifest probed via the tree (root-only files like package.json/go.work are checked directly). */
 const TREE_MANIFESTS = new Set<string>([
@@ -214,6 +232,55 @@ function pytestConfigured(index: ManifestIndex): boolean {
   return configContains(index, 'setup.cfg', '[tool:pytest]');
 }
 
+function hasDiscoverablePythonTests(directory: string, maxDepth = 10): boolean {
+  return scanForPythonTests(directory, 0, maxDepth);
+}
+
+function scanForPythonTests(directory: string, depth: number, maxDepth: number): boolean {
+  if (depth > maxDepth) return false;
+
+  let directoryEntries;
+  try {
+    directoryEntries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  if (
+    directoryEntries.some(
+      directoryEntry => directoryEntry.isFile() && isPythonTestFile(directoryEntry.name),
+    )
+  ) {
+    return true;
+  }
+
+  return directoryEntries
+    .filter(directoryEntry => shouldScanForPythonTests(directoryEntry))
+    .some(directoryEntry =>
+      scanForPythonTests(nodePath.join(directory, directoryEntry.name), depth + 1, maxDepth),
+    );
+}
+
+function shouldScanForPythonTests(directoryEntry: {
+  isDirectory(): boolean;
+  name: string;
+}): boolean {
+  return (
+    directoryEntry.isDirectory() &&
+    !directoryEntry.name.startsWith('.') &&
+    !PYTHON_TEST_SCAN_EXCLUDES.has(directoryEntry.name)
+  );
+}
+
+function isPythonTestFile(filename: string): boolean {
+  return (
+    filename.endsWith('.py') &&
+    (filename.startsWith('test_') ||
+      filename.endsWith('_test.py') ||
+      filename.endsWith('_tests.py'))
+  );
+}
+
 /** Package-manager-aware pytest invocation; returns the command and the tool whose presence gates availability. */
 function pytestInvocation(
   index: ManifestIndex,
@@ -235,10 +302,12 @@ function resolvePython(
   if (PYTHON_MANIFESTS.every(manifest => !index.has(manifest))) return undefined;
   const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
   if (index.has('tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
-  if (pytestConfigured(index) || isAvailable('pytest')) {
+  const hasPythonTests = hasDiscoverablePythonTests(cwd);
+  if (pytestConfigured(index) || (hasPythonTests && isAvailable('pytest'))) {
     const { command, tool } = pytestInvocation(index, isAvailable);
     return entry('python', cwd, command, 'pytest', isAvailable(tool));
   }
+  if (!hasPythonTests) return undefined;
   // Prefer python3 (the only `python` on macOS/modern distros), fall back to python.
   const pythonBin = isAvailable('python3') ? 'python3' : 'python';
   return entry(

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -43,6 +43,7 @@ describe('resolveTestPlan — every detected language appears (no first-match)',
     const root = makeRepo({
       'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
       'pyproject.toml': '[project]\nname = "x"\n',
+      'tests/test_example.py': 'def test_example():\n    assert True\n',
     });
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
     expect(languages(plan).toSorted((a, b) => a.localeCompare(b))).toEqual([
@@ -102,15 +103,30 @@ describe('resolveTestPlan — the command reflects the detected runner', () => {
   });
 
   it('python with no pytest falls back to unittest', () => {
-    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'tests/test_example.py': 'import unittest\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python') });
     expect(entryFor(plan, 'python')?.command).toBe('python -m unittest discover');
   });
 
   it('prefers python3 for the unittest fallback when available', () => {
-    const root = makeRepo({ 'pyproject.toml': '[project]\nname="x"\n' });
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'example_test.py': 'import unittest\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: onlyTools('python3') });
     expect(entryFor(plan, 'python')?.command).toBe('python3 -m unittest discover');
+  });
+
+  it('does not emit a python lane for manifests without python tests', () => {
+    const root = makeRepo({
+      'requirements.txt': 'gepa==0.1.1\n',
+      'run.py': 'print("experiment")\n',
+    });
+    const plan = resolveTestPlan(root, { kind: 'verify', isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')).toBeUndefined();
   });
 
   it('detects pytest configured via setup.cfg [tool:pytest]', () => {
@@ -188,7 +204,10 @@ describe('resolveTestPlan — missing toolchains stay visible', () => {
 
 describe('resolveTestPlan — nested and vendored manifests', () => {
   it('a manifest in a sub-directory is discovered', () => {
-    const root = makeRepo({ 'services/api/pyproject.toml': '[project]\n' });
+    const root = makeRepo({
+      'services/api/pyproject.toml': '[project]\n',
+      'services/api/tests/test_example.py': 'def test_example():\n    assert True\n',
+    });
     const plan = resolveTestPlan(root, { isToolAvailable: allTools });
     expect(entryFor(plan, 'python')).toBeDefined();
   });

--- a/steps/test-plan-resolver.steps.ts
+++ b/steps/test-plan-resolver.steps.ts
@@ -54,6 +54,10 @@ function seed(world: TestPlanWorld, name: string): void {
   write(world, name, DEFAULT_CONTENT[name] ?? '');
 }
 
+function seedPythonTest(world: TestPlanWorld, directory = ''): void {
+  write(world, nodePath.join(directory, 'tests', 'test_example.py'), 'def test_example():\n');
+}
+
 /** Run the real CLI from source via bun, capturing its JSON plan deterministically. */
 function runPlan(world: TestPlanWorld, kind: 'test' | 'build'): void {
   const cliPath = nodePath.join(process.cwd(), 'packages/cli/src/cli.ts');
@@ -123,6 +127,17 @@ Given('a Python repo with a {string}', function (this: TestPlanWorld, file: stri
 Given('a Python repo with no pytest configuration', function (this: TestPlanWorld) {
   write(this, 'pyproject.toml', '[project]\nname = "x"\n');
 });
+
+Given('the repo has a discoverable Python test file', function (this: TestPlanWorld) {
+  seedPythonTest(this);
+});
+
+Given(
+  'the repo has a discoverable Python test file under {string}',
+  function (this: TestPlanWorld, directory: string) {
+    seedPythonTest(this, directory);
+  },
+);
 
 Given(
   'a Python repo with a {string} and pytest configured',


### PR DESCRIPTION
## Summary

A Python manifest alone (`requirements.txt` / `pyproject.toml` / `setup.py` / `setup.cfg`) was enough to emit a runnable `python -m unittest discover` lane. In mixed or experiment-style repos with Python sources but **no tests**, that produced a misleading test command that discovers nothing.

`resolvePython` now scans for discoverable test files (`test_*.py`, `*_test.py`, `*_tests.py`), skipping vendored/build directories, before emitting a lane:

- Configured `tox` / `pytest` paths are **unchanged**.
- The bare `unittest` fallback is now gated on actually having tests.
- A manifest with no discoverable tests emits **no** Python lane.

## Provenance

Carries forward the fix originally proposed in #525 (a first-time fork PR), re-authored on an internal branch so it lands as one reviewed commit. Closes #462; supersedes and replaces #525.

## Test plan

- `bun run --cwd packages/cli test tests/test-plan/resolve.test.ts` → 32 passed
- `bun run --cwd packages/cli typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015KNWMCj354kvD66fDZgdL4)_