### PR TITLE
Add "stakes set depth" framing to the four advice-framed analysis skills

### DIFF
--- a/.agents/skills/figure-it-out/SKILL.md
+++ b/.agents/skills/figure-it-out/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: '*'
 
 **Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
 
+**Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
+
 ## When to Use
 
 A real decision with two or more plausible directions: library or framework choice, architecture, API or schema design, algorithm selection, communication strategy, policy call. User invokes `/figure-it-out`.

--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Deep review with web research to verify against current ecosystem. Complements automatic hook.
 
+**Stakes set depth.** Review as if your verdict is the last gate before this ships — no one re-checks behind you. That standard, not "the hook already looked," sets how hard you research. Before searching, write your review plan: which angles (§2–3) this diff actually needs and the specific question each must answer, then work the list — don't stop at the first finding.
+
 ## Invocation log
 
 This skill is required at the done-gate for tickets with **two or more RGR loops** (W610WW) — the whole-ticket review half of the cross-scenario pass. The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /quality-review was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids and Codex thread ids from the runtime environment, so the fallback below can run without hand-picking an id. Hand-writing review notes cannot produce this gate proof.

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -14,6 +14,10 @@ step is unblocked. This is **Tier 1** — a cheap, inline floor. You review your
 own work; no sub-agent is spawned. The independent check is Tier 2 (the fork
 review at each phase exit), not this.
 
+**Stakes set depth.** Tier 2 may never run — review as if your stamp is the last
+word before code gets built on this spec, because often it is. Cheap floor means
+fast, not shallow.
+
 ## Earn the stamp
 
 The line below runs the stamp-earning step at render time. It binds a

--- a/.agents/skills/tdd-review/SKILL.md
+++ b/.agents/skills/tdd-review/SKILL.md
@@ -33,9 +33,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
-- **Fails for the right reason?** Missing behavior, not syntax errors.
+- **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
+
+**Vacuity guard (the external check).** A test that would pass without the feature proves nothing. The RED→GREEN transition is the proof it's wired to the behavior: it must be failing _now_, and the minimal implementation is what turns it green. If a test ever passes _before_ its implementation exists, it's vacuous — fix the test, not the code.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 

--- a/.agents/skills/tdd-review/SKILL.md
+++ b/.agents/skills/tdd-review/SKILL.md
@@ -10,6 +10,8 @@ Step-aware quality review at TDD phase boundaries. Run it as an internal self-ch
 
 These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
 
+**Stakes set depth.** Advisory means it won't block you — not that it can be shallow. The done-gate only runs tests, so a bug your eyes miss here ships. Review each step as if no later gate re-reads this code.
+
 **Visibility:** ordinary RED/GREEN/REFACTOR reviews stay quiet. Do not surface a chat-facing review after each checkbox flip unless you found a real blocker, a user/scope decision, or a risky external dependency/API finding. Report the review/refactor work in the implementation-exit summary.
 
 ## Detect Step

--- a/.claude/skills/figure-it-out/SKILL.md
+++ b/.claude/skills/figure-it-out/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: '*'
 
 **Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
 
+**Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
+
 ## When to Use
 
 A real decision with two or more plausible directions: library or framework choice, architecture, API or schema design, algorithm selection, communication strategy, policy call. User invokes `/figure-it-out`.

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Deep review with web research to verify against current ecosystem. Complements automatic hook.
 
+**Stakes set depth.** Review as if your verdict is the last gate before this ships — no one re-checks behind you. That standard, not "the hook already looked," sets how hard you research. Before searching, write your review plan: which angles (§2–3) this diff actually needs and the specific question each must answer, then work the list — don't stop at the first finding.
+
 ## Invocation log
 
 This skill is required at the done-gate for tickets with **two or more RGR loops** (W610WW) — the whole-ticket review half of the cross-scenario pass. The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /quality-review was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids and Codex thread ids from the runtime environment, so the fallback below can run without hand-picking an id. Hand-writing review notes cannot produce this gate proof.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -14,6 +14,10 @@ step is unblocked. This is **Tier 1** — a cheap, inline floor. You review your
 own work; no sub-agent is spawned. The independent check is Tier 2 (the fork
 review at each phase exit), not this.
 
+**Stakes set depth.** Tier 2 may never run — review as if your stamp is the last
+word before code gets built on this spec, because often it is. Cheap floor means
+fast, not shallow.
+
 ## Earn the stamp
 
 The line below runs the stamp-earning step at render time. It binds a

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -33,9 +33,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
-- **Fails for the right reason?** Missing behavior, not syntax errors.
+- **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
+
+**Vacuity guard (the external check).** A test that would pass without the feature proves nothing. The RED→GREEN transition is the proof it's wired to the behavior: it must be failing _now_, and the minimal implementation is what turns it green. If a test ever passes _before_ its implementation exists, it's vacuous — fix the test, not the code.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -10,6 +10,8 @@ Step-aware quality review at TDD phase boundaries. Run it as an internal self-ch
 
 These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
 
+**Stakes set depth.** Advisory means it won't block you — not that it can be shallow. The done-gate only runs tests, so a bug your eyes miss here ships. Review each step as if no later gate re-reads this code.
+
 **Visibility:** ordinary RED/GREEN/REFACTOR reviews stay quiet. Do not surface a chat-facing review after each checkbox flip unless you found a real blocker, a user/scope decision, or a risky external dependency/API finding. Report the review/refactor work in the implementation-exit summary.
 
 ## Detect Step

--- a/packages/cli/templates/skills/figure-it-out/SKILL.md
+++ b/packages/cli/templates/skills/figure-it-out/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: '*'
 
 **Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
 
+**Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
+
 ## When to Use
 
 A real decision with two or more plausible directions: library or framework choice, architecture, API or schema design, algorithm selection, communication strategy, policy call. User invokes `/figure-it-out`.

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools: '*'
 
 Deep review with web research to verify against current ecosystem. Complements automatic hook.
 
+**Stakes set depth.** Review as if your verdict is the last gate before this ships — no one re-checks behind you. That standard, not "the hook already looked," sets how hard you research. Before searching, write your review plan: which angles (§2–3) this diff actually needs and the specific question each must answer, then work the list — don't stop at the first finding.
+
 ## Invocation log
 
 This skill is required at the done-gate for tickets with **two or more RGR loops** (W610WW) — the whole-ticket review half of the cross-scenario pass. The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /quality-review was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids and Codex thread ids from the runtime environment, so the fallback below can run without hand-picking an id. Hand-writing review notes cannot produce this gate proof.

--- a/packages/cli/templates/skills/self-review/SKILL.md
+++ b/packages/cli/templates/skills/self-review/SKILL.md
@@ -14,6 +14,10 @@ step is unblocked. This is **Tier 1** — a cheap, inline floor. You review your
 own work; no sub-agent is spawned. The independent check is Tier 2 (the fork
 review at each phase exit), not this.
 
+**Stakes set depth.** Tier 2 may never run — review as if your stamp is the last
+word before code gets built on this spec, because often it is. Cheap floor means
+fast, not shallow.
+
 ## Earn the stamp
 
 The line below runs the stamp-earning step at render time. It binds a

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -33,9 +33,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
-- **Fails for the right reason?** Missing behavior, not syntax errors.
+- **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior and re-run the scenario-gate. Don't silently append scenarios to a signed-off `test-definitions.md`.
+
+**Vacuity guard (the external check).** A test that would pass without the feature proves nothing. The RED→GREEN transition is the proof it's wired to the behavior: it must be failing _now_, and the minimal implementation is what turns it green. If a test ever passes _before_ its implementation exists, it's vacuous — fix the test, not the code.
 
 If issues found: fix before implementing. If clean: commit and proceed to implementation.
 

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -10,6 +10,8 @@ Step-aware quality review at TDD phase boundaries. Run it as an internal self-ch
 
 These per-step reviews are **advisory self-checks** — the only hard gates in the implement phase are the commit ledger (`test-definitions.md` annotations) and the done-gate. Use these reviews to catch problems early; don't treat them as blocking walls.
 
+**Stakes set depth.** Advisory means it won't block you — not that it can be shallow. The done-gate only runs tests, so a bug your eyes miss here ships. Review each step as if no later gate re-reads this code.
+
 **Visibility:** ordinary RED/GREEN/REFACTOR reviews stay quiet. Do not surface a chat-facing review after each checkbox flip unless you found a real blocker, a user/scope decision, or a risky external dependency/API finding. Report the review/refactor work in the implementation-exit summary.
 
 ## Detect Step


### PR DESCRIPTION
## Why

Observation: hand-appending "make a plan and execute" to `/quality-review` and `/figure-it-out` produced sharper investigations. Investigating *why* (rather than cargo-culting the phrase) surfaced two mechanisms behind the effect:

1. **Consequential framing** — telling the model its output is load-bearing (ships unreviewed, nobody re-checks) raises rigor, vs. the default "it's just advice" framing that depresses it.
2. **Decomposition** — planning the *investigation* before diving in widens coverage.

This bakes those mechanisms into the skills so the gain no longer depends on remembering an incantation — and crucially **without** importing an "execute" scope that would break these as terminal analysis skills.

## Where it landed (and where it didn't)

A swept audit of all 17 skills + 5 workflow phases against a strict rubric (*qualifies only if load-bearing AND advice-framed AND missing both mechanisms*) found exactly four targets:

- **figure-it-out** — "investigate as if your recommendation ships unreviewed"; plan the *investigation*, not the answer (the anti-anchoring guard).
- **quality-review** — "review as if your verdict is the last gate before this ships."
- **tdd-review** — counterweight to its 4×-repeated "advisory self-check" framing: advisory means won't-block, not shallow.
- **self-review** — counterweight to "cheap Tier-1 floor, Tier 2 catches it": Tier 2 may never run.

Everything else correctly stayed untouched: `debug`, `elicit`, `review-spec`, `verify`, `bdd`, `testing` already carry the mechanism (debug via a *harder* iron-law enforcement); `audit`, `refactor`, `lint`, `cleanup-zombies`, `ticket-system`, `explain`, `brainstorm` are mechanical / read-only / intentionally divergent. Phases are covered transitively (Clarify→figure-it-out, Verify→/verify).

## Scoping discipline

Each addition is one tight sentence in the skill's own voice. The two review skills keep their advisory (non-blocking) cadence — the edits raise the *rigor* bar, not the *blocking* behavior. Every change is mirrored across all three parity copies (`packages/cli/templates/` + `.claude/` + `.agents/`).

## Verification

- `bun scripts/parity-check.ts --mode=all` → 185 pairs + 3 contracts in sync
- `parity.test.ts` + `verify-skill.test.ts` → 89 passed

## Caveat

These edits are an **unvalidated hypothesis**, not proven wins. The honest next step is a 3-arm A/B (bare skill / these edits / a generic "be rigorous" nudge of equal length) — if the generic nudge matches, the framing isn't pulling its weight. This branch is a clean, reversible place to run that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWfDo5ZDcjxAVxUH9BF5Mx)_