### PR TITLE
Support any monorepo: union workspace managers in architecture discovery (MGWZ4P)

### DIFF
--- a/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/dimensions.md
+++ b/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/dimensions.md
@@ -1,0 +1,27 @@
+# Behavioral dimensions — MGWZ4P (workspace-manager union in discovery)
+
+The behavior is `discoverLeafDirectories(projectDirectory) → leaf dirs`. The input
+space is "which workspace managers are present at the repo root, and how their
+declared dirs relate." Dimensions and the partitions that change the outcome:
+
+| # | Dimension | Partitions | Covered by |
+| - | --------- | ---------- | ---------- |
+| D1 | **Managers present** | (a) none; (b) single JS (package.json or pnpm); (c) single non-JS (go.work / Cargo / uv); (d) JS + one non-JS; (e) multiple non-JS; (f) JS + multiple non-JS | U5/AC (a,b,c no-regression); U1/AC1 (d); U2/AC2 (e); union-flat (f) |
+| D2 | **JS-vs-JS conflict** (package.json `workspaces` + pnpm-workspace.yaml) | (a) package.json only; (b) pnpm only; (c) BOTH, different dirs → package.json wins (precedence, NOT union) | U3/existing precedence test |
+| D3 | **Declared-dir overlap across managers** | (a) disjoint (different ecosystems, the common case); (b) one dir matched by two managers (maturin: pyproject + Cargo) → dedupe to one | U4 (dedupe); U1/U2 (disjoint) |
+| D4 | **Discovered dir has a recognized manifest** | (a) has manifest → kept; (b) glob matches a dir with no recognized manifest → skipped (unchanged existing guard) | existing `hasRecognizedManifest` tests (no change) |
+
+## Load-bearing partitions (where this change actually bites)
+
+- **D1(d), D1(e), D1(f)** — the bug: today only the FIRST manager's packages are
+  discovered; the rest are silently dropped. These are the new GREEN behavior.
+- **D2(c)** — the boundary that must NOT change: two JS managers are alternatives,
+  not additions, so package.json still wins and pnpm's dirs are not unioned in.
+  The union is *cross-ecosystem only*.
+- **D3(b)** — dedupe: a single dir legitimately matched by two managers is listed
+  once (the existing `Set` already guarantees this; assert it explicitly).
+
+## Out-of-partition (not exercised; noted)
+
+Nested/recursive workspaces (a member that is itself a workspace root) — out of
+scope per the ticket; current behavior (treat as one leaf) is unchanged.

--- a/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/spec.md
+++ b/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/spec.md
@@ -1,0 +1,82 @@
+# Spec: Support any monorepo — union workspace managers (MGWZ4P)
+
+## Jobs To Be Done
+
+### MGWZ4P.J1 — A complete map of a polyglot monorepo
+
+**Persona:** Technical Builder (TB)
+
+When I run safeword on a polyglot monorepo that declares packages with more than
+one workspace manager at once (e.g. `package.json` `workspaces` for the JS apps
+**and** `go.work` for the Go services), I want the generated root index to list
+**every** package regardless of which manager declares it, so I can trust the
+architecture doc as a complete map instead of a silent subset that hides whole
+languages. (The Non-Technical Builder feels this hardest — they can't audit the
+diff to notice the Go services are missing.)
+
+#### MGWZ4P.J1.AC1 — Cross-ecosystem managers are unioned
+
+A repo declaring packages with two or more different-ecosystem managers at the
+root (JS `workspaces` + `go.work`; or `go.work` + Cargo `[workspace]` + uv
+`[tool.uv.workspace]`) lists **every** manager's packages in the root index — none
+is silently dropped at the discovery layer.
+
+#### MGWZ4P.J1.AC2 — JS precedence is preserved (cross-ecosystem only)
+
+`package.json` `workspaces` still wins over `pnpm-workspace.yaml` when both are
+present — they are alternative managers for the *same* JS ecosystem, not additive.
+The union is cross-ecosystem only; pnpm's dirs are not unioned into an
+npm-authoritative repo.
+
+#### MGWZ4P.J1.AC3 — No double-counting
+
+A single directory legitimately matched by two managers (a maturin package under
+both a Cargo `[workspace]` and a uv workspace glob) is listed once.
+
+#### MGWZ4P.J1.AC4 — No regression
+
+Single-manager monorepos, single polyglot packages, and single-repo projects are
+unchanged; `architecture --check` still passes on this repo.
+
+## Problem
+
+`discoverLeafDirectories` is first-match-wins across the manager detectors:
+
+```text
+detectWorkspaces ?? detectPnpmWorkspaces ?? detectGoWork ?? detectCargoWorkspace ?? detectUvWorkspace
+```
+
+The first non-undefined result wins; the rest are never consulted. A repo
+declaring packages with two+ managers at once gets only the first manager's
+packages. The others vanish at the **discovery** layer — before the ZRW21K
+"not introspected" marker can fire — so the root index looks complete while
+silently omitting, say, every Go service. A coverage-honesty hole, not just a
+missing feature.
+
+## Design (refined from the intake "union all + dedupe")
+
+Reviewing the existing precedence test sharpened the intake's "union all":
+`package.json` `workspaces` and `pnpm-workspace.yaml` are **alternative JS
+managers** for the same ecosystem — a repo uses one, not both — and the ZRW21K
+rule (package.json wins) must stay. Dedupe alone does NOT preserve that when the
+two JS configs point at *different* dirs. So the rule is:
+
+- **Within JS**: keep precedence — `detectWorkspaces` (package.json) **else**
+  `detectPnpmWorkspaces`. Exactly one JS pattern set.
+- **Across ecosystems**: **union** that JS set with `go.work`, Cargo
+  `[workspace]`, and uv `[tool.uv.workspace]` — disjoint package sets (Go dirs
+  carry `go.mod`, Rust `Cargo.toml`, Python `pyproject.toml`), so they add.
+- **Dedupe** the final leaf-dir set (the existing `Set<string>`) — handles a single
+  dir matched by two managers.
+
+Concretely: `patterns = [ (detectWorkspaces ?? detectPnpmWorkspaces), detectGoWork,
+detectCargoWorkspace, detectUvWorkspace ].filter(present).flat()`. The existing
+glob-expand + `hasRecognizedManifest` + Set-dedupe loop is unchanged, so each leaf
+is still kept only when it carries a recognized manifest and is extracted by its
+own language branch. Union only **widens** the leaf set — contained blast radius.
+
+## Out of scope
+
+Per-leaf polyglot extraction (already works); new language packs / manifest
+formats; nested/recursive workspaces (note any limitation, don't expand); the
+ARCHITECTURE.md reconcile feature (AXRC4D).

--- a/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/test-definitions.md
+++ b/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/test-definitions.md
@@ -1,0 +1,36 @@
+# Test definitions (R/G/R ledger) — MGWZ4P
+
+Behavior: `discoverLeafDirectories` unions cross-ecosystem workspace managers
+(JS-precedence within JS, then union go.work + Cargo + uv), so a polyglot
+monorepo's every package is discovered. Black-box scenarios in
+`features/architecture-polyglot-monorepo.feature`; precision in
+`tests/utils/architecture-monorepo.test.ts`. Dimensions in dimensions.md.
+
+## Black-box scenarios (acceptance lane)
+
+- [x] **AC1 — JS + Go union** (`architecture-polyglot-monorepo.MGWZ4P.AC1`) [J1.AC1, D1(d)]
+  - RED: root index lists `web` but NOT `gosvc` ("root index does not list gosvc"). Confirmed RED.
+  - GREEN: union → root index lists both `web` and `gosvc`.
+- [x] **AC2 — Go + Rust + Python union, no JS** (`architecture-polyglot-monorepo.MGWZ4P.AC2`) [J1.AC1, D1(e)]
+  - RED: lists `gosvc` (first manager) but NOT `rscore`/`pytool`. Confirmed RED.
+  - GREEN: union → lists `gosvc`, `rscore`, `pytool`.
+
+## Unit tests (discovery precision — tests/utils/architecture-monorepo.test.ts)
+
+- [x] **U1 — JS + go.work union** [J1.AC1, D1(d)]: package.json workspaces (`packages/web`) + go.work (`./svc` with go.mod) → both dirs discovered.
+  - RED: only `packages/web` (first-match). GREEN: both.
+- [x] **U2 — Go + Cargo + uv union (no JS)** [J1.AC1, D1(e)]: go.work + Cargo `[workspace]` + uv `[tool.uv.workspace]` → all three member dirs discovered.
+  - RED: only the go.work members. GREEN: all three.
+- [x] **U3 — JS precedence preserved** [J1.AC2, D2(c)]: package.json workspaces (`packages/*`) + pnpm-workspace.yaml (`apps/*`), different dirs → only the package.json side; pnpm's `apps/*` NOT unioned in. Must stay GREEN.
+- [x] **U4 — same-dir dedupe** [J1.AC3, D3(b)]: a single member dir matched by two managers (a maturin dir under both a Cargo `[workspace]` and a uv workspace glob) appears once.
+  - GREEN: length 1, not 2.
+- [x] **U5 — no-regression** [J1.AC4, D1(b),(c)]: a single-manager monorepo (go.work only) and a single-repo project (no workspace config) return exactly today's result. Stays GREEN.
+- [x] **U6 — all managers compose** [J1.AC1, D1(f)] (scenario-gate finding #1): JS `workspaces` + go.work + Cargo `[workspace]` + uv `[tool.uv.workspace]` ALL at the root → all four ecosystems' leaves discovered. The partition where JS-precedence and cross-ecosystem union compose; pins the "any mix of the five" done_when.
+  - RED: only the JS side (first-match). GREEN: all four.
+- [x] **U7 — over-broad glob attributes once** [J1.AC3, D3(b)] (scenario-gate finding #2): a Cargo `members=["*"]` whose glob also sweeps a JS `packages/web` dir → `web` is listed exactly once (the `Set` + per-leaf `hasRecognizedManifest` keep the blast radius contained; a dir is a leaf if any manager's glob matches it and it has a recognized manifest — surfaced once regardless of which manager claimed it).
+
+## Reconcile note
+
+Coverage honesty (no silent drop) is the union of U1/U2 + AC1/AC2: every present
+cross-ecosystem manager's packages reach the root index — the property the above
+collectively prove.

--- a/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/ticket.md
+++ b/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/ticket.md
@@ -1,0 +1,69 @@
+---
+id: MGWZ4P
+slug: polyglot-monorepo-discovery
+type: feature
+phase: verify
+status: todo
+created: 2026-06-29T01:09:00.000Z
+last_modified: 2026-06-29T01:09:00.000Z
+scope:
+  - Make `discoverLeafDirectories` (architecture-monorepo.ts) UNION every workspace manager present at the repo root instead of first-match-wins. Today it is `detectWorkspaces ?? detectPnpmWorkspaces ?? detectGoWork ?? detectCargoWorkspace ?? detectUvWorkspace` — the first non-undefined result wins and the rest are never consulted. Change to: run all detectors, concatenate their glob-pattern lists, expand all, and dedupe leaf directories (the existing `Set<string>` already dedupes). A polyglot monorepo that declares packages with more than one manager at once (e.g. `package.json` workspaces for JS + `go.work` for Go + Cargo `[workspace]` for Rust) then discovers leaves from ALL of them.
+  - Preserve the one real precedence case via dedupe, not ordering: `package.json` `workspaces` and `pnpm-workspace.yaml` describe the SAME JS package set, so overlapping globs must not double-count (the `Set` of absolute leaf dirs handles this for free). Cross-language managers point at DIFFERENT dirs, so they add rather than collide.
+  - Coverage honesty (ZRW21K extended to the discovery layer): a package set declared by a present-but-unparsed or unmatched manager must never be SILENTLY omitted. With union, nothing is dropped — that is the core fix. Additionally, if a workspace glob resolves to a directory with no recognized manifest, keep today's behavior (skip / "not introspected"), never a false-complete root index.
+done_when:
+  - A monorepo with BOTH a `package.json` `workspaces` (JS) AND a `go.work` (Go) at the root lists JS and Go packages together in the root index — neither language is omitted.
+  - The same holds for any mix of the five managers (npm/yarn/bun `workspaces`, pnpm-workspace.yaml, go.work, Cargo `[workspace]`, uv `[tool.uv.workspace]`).
+  - Overlapping JS configs (`package.json` `workspaces` + `pnpm-workspace.yaml` pointing at the same dirs) do not double-count a package.
+  - Single-manager monorepos, single polyglot packages (maturin), and single-repo projects are unchanged — no regression; `architecture --check` still passes on this repo.
+  - No package set declared by a present manager is silently dropped from the root index (the coverage-honesty guarantee now holds at the discovery layer, not just the marker layer).
+out_of_scope:
+  - Per-leaf polyglot extraction (a single package mixing languages, e.g. maturin pyproject + Cargo) — already works via the manifest-keyed `extractSkeleton` dispatch and the union fingerprint.
+  - Adding new language packs / new manifest formats — this ticket only changes how the EXISTING managers are combined.
+  - The ARCHITECTURE.md reconcile feature (ticket AXRC4D) — but note the dependency below.
+  - Nested / recursive workspaces (a workspace whose members are themselves workspaces) unless it falls out for free — note any limitation rather than expanding scope.
+---
+
+# Support any monorepo shape — union all workspace managers in discovery
+
+**Goal:** A polyglot monorepo should be fully introspected no matter how many
+workspace managers it uses at once, with no language's packages silently missing
+from the generated architecture doc.
+
+## Why
+
+`discoverLeafDirectories` is first-match-wins across the workspace-manager
+detectors (`detectWorkspaces ?? detectPnpmWorkspaces ?? detectGoWork ??
+detectCargoWorkspace ?? detectUvWorkspace`). A repo that declares packages with
+more than one manager at once — e.g. a JS `package.json` `workspaces` alongside a
+`go.work` for Go services — gets ONLY the first manager's packages. The others
+are invisible.
+
+This is worse than a missing feature: it is a **coverage-honesty hole**. The
+dropped packages aren't shown with a "not introspected" marker (the ZRW21K
+guarantee) — they vanish at the *discovery* layer, before the marker logic runs,
+so the root index looks complete while silently omitting, say, every Go service.
+
+Per-package polyglot (maturin) and single-manager monorepos (one pnpm/npm
+workspace, Nx/Turborepo, a single go.work) already work. The gap is specifically
+**two or more managers active at the repo root simultaneously**.
+
+## Approach (small, low-risk)
+
+Union, don't short-circuit: collect glob patterns from every detector that fires,
+expand them all, dedupe leaf dirs via the existing `Set`. Unioning only WIDENS the
+leaf set, and each leaf is still kept only when `hasRecognizedManifest` is true and
+extracted by its own language branch — so the blast radius is contained. The
+former "package.json wins" precedence becomes a dedupe concern (same JS dirs from
+two JS configs collapse to one), not an ordering one.
+
+## Dependency
+
+Ticket **AXRC4D** (reconcile ARCHITECTURE.md against the generated doc) consumes
+the generated doc as ground truth. If discovery is incomplete (this gap), the
+generated doc is itself blind to the dropped packages and reconcile inherits the
+hole. Land this first, or sequence them together.
+
+## Next
+
+Run `/bdd` — multiple flows (JS+Go, JS+Rust, all-five mix, overlapping JS configs,
+single-manager no-regression, dir-without-manifest) want scenarios, not a patch.

--- a/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/verify.md
+++ b/.project/tickets/MGWZ4P-polyglot-monorepo-discovery/verify.md
@@ -1,0 +1,54 @@
+# Verify: polyglot monorepo discovery (MGWZ4P)
+
+## Verify checklist
+
+**Test suite:** ✅ 38 monorepo unit tests + 78 architecture unit tests
+(monorepo/skeleton/fingerprint) green. 6 new/reframed discovery tests (U1–U7;
+three prior "package.json wins over go.work/Cargo/uv" tests reframed as union —
+the bug they encoded — plus U2 compose, U4 dedupe, U6 all-managers, U7 over-broad
+glob).
+**Gherkin:** ✅ 2 new polyglot scenarios pass; 46 architecture scenarios green
+together (incl. the preserved "package.json wins over pnpm" precedence in
+monorepo-coverage-honesty).
+**Build:** ✅ CLI builds; dogfood `architecture --check` exits 0 (this repo is
+JS-only, so union == JS-only == unchanged — proves no regression on a single-manager
+repo).
+**Lint:** ✅ eslint clean (renamed `relativeDir`/`extDirectory` per unicorn).
+**Typecheck:** ✅ no new errors in the changed files (pre-existing TS6059 rootDir
+notes unchanged).
+**Scenarios:** All R/G/R confirmed — the .feature scenarios and U1/U2/U6 were RED
+against the first-match code for the right reason (only the first manager's
+packages listed), GREEN after the union.
+**Dep drift:** ✅ zero new dependencies (pure logic change in discoverLeafDirectories).
+**Reconcile:** the implementation matches the refined spec design — JS-precedence
+(`detectWorkspaces ?? detectPnpmWorkspaces`) **then** cross-ecosystem union
+(`go.work` + Cargo + uv) via `.filter(present).flat()`, with the existing leaf
+`Set` collapsing same-dir overlaps. No new module; the per-leaf
+`hasRecognizedManifest` keep-guard is untouched, so the ZRW21K "never
+false-complete" property is structurally preserved.
+
+## Evidence
+
+- **Independent scenario-gate review** (fresh context, `/review-spec`):
+  PASS-WITH-NITS. Confirmed both scenarios load-bearing RED, determinism clean,
+  design sound (JS-precedence-then-cross-ecosystem-union correctly supersedes the
+  intake's naive "union all + dedupe"). Its one load-bearing nit — D1(f) (JS +
+  multiple non-JS, where precedence and union compose) was claimed in the ledger
+  but untested — was addressed with **U6** (all-managers-compose); the
+  over-broad-glob pin became **U7**. Findings #3 (dedupe/precedence are unit-only)
+  accepted per the test pyramid. Stamp recorded.
+- **Behavior change, intentional & documented:** the prior three "package.json
+  wins over go.work/Cargo/uv" unit tests asserted the coverage-honesty bug as if
+  intended; they are reframed as union with MGWZ4P comments. The JS-vs-JS
+  precedence (package.json over pnpm) is preserved and still tested both unit and
+  black-box.
+- **Coverage honesty:** AC1/AC2 + U1/U2/U6 collectively prove no present
+  cross-ecosystem manager's packages are silently dropped — the guarantee now
+  holds at the discovery layer, not just the marker layer.
+
+## Scope honesty
+
+Per ticket out_of_scope: per-leaf polyglot extraction (already worked), new
+language packs, and nested/recursive workspaces are untouched. The AXRC4D
+reconcile feature (which consumes the generated doc) now has complete discovery
+to build on — the documented dependency is satisfied.

--- a/features/architecture-polyglot-monorepo.feature
+++ b/features/architecture-polyglot-monorepo.feature
@@ -1,0 +1,26 @@
+@architecture-polyglot-monorepo
+Feature: Polyglot monorepo coverage — union all workspace managers
+
+  When a monorepo declares packages with more than one workspace manager at once
+  (e.g. package.json workspaces for JS and go.work for Go), the generated root
+  index must list EVERY package, not just the first manager's. Workspace managers
+  for different language ecosystems are additive — dropping one silently omits a
+  whole language from the map. (Within JS, package.json still wins over pnpm —
+  those are alternatives, not additions; proven in monorepo-coverage-honesty.)
+
+  Rule: Cross-ecosystem workspace managers are unioned in discovery
+
+    @architecture-polyglot-monorepo.MGWZ4P.AC1
+    Scenario: A JS + Go monorepo lists both the JS package and the Go module
+      Given a monorepo whose package.json workspaces list a JS package "web" and whose go.work lists a Go module "gosvc"
+      When safeword generates the architecture doc
+      Then the root index lists the package "web"
+      And the root index lists the package "gosvc"
+
+    @architecture-polyglot-monorepo.MGWZ4P.AC2
+    Scenario: A Go + Rust + Python monorepo with no JS lists all three
+      Given a polyglot monorepo with a Go module "gosvc", a Rust crate "rscore", and a Python package "pytool"
+      When safeword generates the architecture doc
+      Then the root index lists the package "gosvc"
+      And the root index lists the package "rscore"
+      And the root index lists the package "pytool"

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -67,17 +67,24 @@ export interface MonorepoModel {
  * `package.json`. Returns `[]` for a non-workspace project.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  // package.json `workspaces` wins; pnpm-workspace.yaml is the next fallback (pnpm
-  // ignores the package.json field, so a repo with both is npm-authoritative); a
-  // go.work `use` list is the last fallback (ticket ZD70P1), so a Go-rooted
-  // monorepo is discovered when no JS workspace config is present.
-  const patterns =
-    detectWorkspaces(projectDirectory) ??
-    detectPnpmWorkspaces(projectDirectory) ??
-    detectGoWork(projectDirectory) ??
-    detectCargoWorkspace(projectDirectory) ??
-    detectUvWorkspace(projectDirectory);
-  if (patterns === undefined) return [];
+  // Within JS, package.json `workspaces` wins over pnpm-workspace.yaml (pnpm
+  // ignores the package.json field, so a repo with both is npm-authoritative) —
+  // they are alternative managers for the same ecosystem, not additive. Across
+  // ecosystems, managers are UNIONED: go.work, Cargo `[workspace]`, and uv
+  // `[tool.uv.workspace]` describe disjoint package sets (Go/Rust/Python dirs),
+  // so a polyglot monorepo declaring packages with more than one manager at once
+  // is fully discovered, never silently reduced to the first manager's packages
+  // (ticket MGWZ4P). Same-dir overlaps collapse in the leaf `Set` below.
+  const jsPatterns = detectWorkspaces(projectDirectory) ?? detectPnpmWorkspaces(projectDirectory);
+  const patterns = [
+    jsPatterns,
+    detectGoWork(projectDirectory),
+    detectCargoWorkspace(projectDirectory),
+    detectUvWorkspace(projectDirectory),
+  ]
+    .filter((group): group is string[] => group !== undefined)
+    .flat();
+  if (patterns.length === 0) return [];
 
   const matches = new Set<string>();
   for (const pattern of patterns) {

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -303,16 +303,18 @@ describe('discoverLeafDirectories — go.work discovery (ticket ZD70P1)', () => 
     expect(leaves).toContain(nodePath.join(context.directory, 'svc'));
   });
 
-  it('lets package.json workspaces win over go.work when both are present', () => {
+  it('unions package.json workspaces with go.work when both are present (MGWZ4P)', () => {
     // Root manifest (from beforeEach) declares workspaces: ['packages/*'].
+    // JS and Go are different ecosystems, so both packages are discovered —
+    // not just the first manager's (the coverage-honesty fix, MGWZ4P).
     writeGoWork(context.directory, 'go 1.22\n\nuse ./svc\n');
     makeGoPackage(context.directory, 'svc', { layout: true });
     makePackage(context.directory, 'web', { modules: ['ui'] });
 
-    const leaves = discoverLeafDirectories(context.directory);
-
-    expect(leaves).toEqual([nodePath.join(context.directory, 'packages', 'web')]);
-    expect(leaves).not.toContain(nodePath.join(context.directory, 'svc'));
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+      nodePath.join(context.directory, 'svc'),
+    ]);
   });
 });
 
@@ -369,8 +371,9 @@ describe('discoverLeafDirectories — Cargo workspace discovery (ticket YKFA5X)'
     );
   });
 
-  it('lets package.json workspaces win over a Cargo workspace when both are present', () => {
+  it('unions package.json workspaces with a Cargo workspace when both are present (MGWZ4P)', () => {
     // Root manifest (from beforeEach) declares workspaces: ['packages/*'].
+    // JS and Rust are different ecosystems → both discovered (MGWZ4P).
     writeFileSync(
       nodePath.join(context.directory, 'Cargo.toml'),
       '[workspace]\nmembers = ["crates/*"]\n',
@@ -378,10 +381,10 @@ describe('discoverLeafDirectories — Cargo workspace discovery (ticket YKFA5X)'
     makeCargoCrate(context.directory, 'svc', { module: 'config' });
     makePackage(context.directory, 'web', { modules: ['ui'] });
 
-    const leaves = discoverLeafDirectories(context.directory);
-
-    expect(leaves).toEqual([nodePath.join(context.directory, 'packages', 'web')]);
-    expect(leaves).not.toContain(nodePath.join(context.directory, 'crates', 'svc'));
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'crates', 'svc'),
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
   });
 
   it('returns no leaves when Cargo.toml has no [workspace] table', () => {
@@ -447,9 +450,10 @@ describe('discoverLeafDirectories — uv workspace discovery (ticket HWSEPV)', (
     );
   });
 
-  it('lets package.json workspaces win over a uv workspace when both are present', () => {
-    // Root manifest (from beforeEach) declares workspaces: ['packages/*']. The uv
-    // members point elsewhere (libs/*), so they are only reached if uv wins.
+  it('unions package.json workspaces with a uv workspace when both are present (MGWZ4P)', () => {
+    // Root manifest (from beforeEach) declares workspaces: ['packages/*']; the uv
+    // members point elsewhere (libs/*). JS and Python are different ecosystems →
+    // both discovered (MGWZ4P).
     writeFileSync(
       nodePath.join(context.directory, 'pyproject.toml'),
       '[tool.uv.workspace]\nmembers = ["libs/*"]\n',
@@ -460,10 +464,10 @@ describe('discoverLeafDirectories — uv workspace discovery (ticket HWSEPV)', (
     writeFileSync(nodePath.join(svcDirectory, 'src', 'api.py'), '');
     makePackage(context.directory, 'web', { modules: ['ui'] });
 
-    const leaves = discoverLeafDirectories(context.directory);
-
-    expect(leaves).toEqual([nodePath.join(context.directory, 'packages', 'web')]);
-    expect(leaves).not.toContain(svcDirectory);
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      svcDirectory,
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
   });
 
   it('returns no leaves when pyproject has no [tool.uv.workspace] table', () => {
@@ -471,6 +475,104 @@ describe('discoverLeafDirectories — uv workspace discovery (ticket HWSEPV)', (
     writeFileSync(nodePath.join(context.directory, 'pyproject.toml'), '[project]\nname = "solo"\n');
 
     expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+});
+
+describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
+  function writeGoModule(root: string, relativeDirectory: string, name: string): void {
+    const dir = nodePath.join(root, relativeDirectory);
+    mkdirSync(nodePath.join(dir, 'cmd', 'server'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'go.mod'), `module ${name}\n\ngo 1.22\n`);
+  }
+  function writeRustCrate(root: string, relativeDirectory: string, name: string): void {
+    const dir = nodePath.join(root, relativeDirectory);
+    mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+  }
+  function writePythonPackage(root: string, relativeDirectory: string, name: string): void {
+    const dir = nodePath.join(root, relativeDirectory);
+    mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(dir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
+  }
+
+  it('U2 — unions Go + Cargo + uv when no JS workspace is present', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./gosvc\n');
+    writeGoModule(context.directory, 'gosvc', 'gosvc');
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/rscore"]\n',
+    );
+    writeRustCrate(context.directory, nodePath.join('crates', 'rscore'), 'rscore');
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = ["pypkgs/pytool"]\n',
+    );
+    writePythonPackage(context.directory, nodePath.join('pypkgs', 'pytool'), 'pytool');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'crates', 'rscore'),
+      nodePath.join(context.directory, 'gosvc'),
+      nodePath.join(context.directory, 'pypkgs', 'pytool'),
+    ]);
+  });
+
+  it('U6 — unions a JS workspace with go.work + Cargo + uv all at the root', () => {
+    // Root package.json workspaces: ['packages/*'] comes from beforeEach.
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./gosvc\n');
+    writeGoModule(context.directory, 'gosvc', 'gosvc');
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/rscore"]\n',
+    );
+    writeRustCrate(context.directory, nodePath.join('crates', 'rscore'), 'rscore');
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = ["pypkgs/pytool"]\n',
+    );
+    writePythonPackage(context.directory, nodePath.join('pypkgs', 'pytool'), 'pytool');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'crates', 'rscore'),
+      nodePath.join(context.directory, 'gosvc'),
+      nodePath.join(context.directory, 'packages', 'web'),
+      nodePath.join(context.directory, 'pypkgs', 'pytool'),
+    ]);
+  });
+
+  it('U4 — lists a dir matched by two managers (maturin: Cargo + uv) exactly once', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["ext"]\n',
+    );
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = ["ext"]\n',
+    );
+    // The single member dir carries BOTH manifests (a maturin/pyo3 package).
+    const extensionDirectory = nodePath.join(context.directory, 'ext');
+    mkdirSync(nodePath.join(extensionDirectory, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(extensionDirectory, 'Cargo.toml'), '[package]\nname = "ext"\n');
+    writeFileSync(nodePath.join(extensionDirectory, 'pyproject.toml'), '[project]\nname = "ext"\n');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([extensionDirectory]);
+  });
+
+  it('U7 — an over-broad Cargo glob sweeping a JS dir lists that dir once', () => {
+    // Root JS workspaces: ['packages/*'] (beforeEach). The Cargo workspace uses an
+    // over-broad members glob that also matches the JS package dir; the leaf Set +
+    // per-dir manifest guard keep it listed exactly once.
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = ["packages/*"]\n',
+    );
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
   });
 });
 

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -495,20 +495,23 @@ describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
     writeFileSync(nodePath.join(dir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
   }
 
-  it('U2 — unions Go + Cargo + uv when no JS workspace is present', () => {
-    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
-    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./gosvc\n');
-    writeGoModule(context.directory, 'gosvc', 'gosvc');
+  /** Declares a go.work (gosvc), a Cargo [workspace] (crates/rscore), and a uv
+   * workspace (pypkgs/pytool) at the root, each with its member's manifest. */
+  function writeGoCargoUvManagers(root: string): void {
+    writeFileSync(nodePath.join(root, 'go.work'), 'go 1.22\n\nuse ./gosvc\n');
+    writeGoModule(root, 'gosvc', 'gosvc');
+    writeFileSync(nodePath.join(root, 'Cargo.toml'), '[workspace]\nmembers = ["crates/rscore"]\n');
+    writeRustCrate(root, nodePath.join('crates', 'rscore'), 'rscore');
     writeFileSync(
-      nodePath.join(context.directory, 'Cargo.toml'),
-      '[workspace]\nmembers = ["crates/rscore"]\n',
-    );
-    writeRustCrate(context.directory, nodePath.join('crates', 'rscore'), 'rscore');
-    writeFileSync(
-      nodePath.join(context.directory, 'pyproject.toml'),
+      nodePath.join(root, 'pyproject.toml'),
       '[tool.uv.workspace]\nmembers = ["pypkgs/pytool"]\n',
     );
-    writePythonPackage(context.directory, nodePath.join('pypkgs', 'pytool'), 'pytool');
+    writePythonPackage(root, nodePath.join('pypkgs', 'pytool'), 'pytool');
+  }
+
+  it('U2 — unions Go + Cargo + uv when no JS workspace is present', () => {
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeGoCargoUvManagers(context.directory);
 
     expect(discoverLeafDirectories(context.directory)).toEqual([
       nodePath.join(context.directory, 'crates', 'rscore'),
@@ -520,18 +523,7 @@ describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
   it('U6 — unions a JS workspace with go.work + Cargo + uv all at the root', () => {
     // Root package.json workspaces: ['packages/*'] comes from beforeEach.
     makePackage(context.directory, 'web', { modules: ['ui'] });
-    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./gosvc\n');
-    writeGoModule(context.directory, 'gosvc', 'gosvc');
-    writeFileSync(
-      nodePath.join(context.directory, 'Cargo.toml'),
-      '[workspace]\nmembers = ["crates/rscore"]\n',
-    );
-    writeRustCrate(context.directory, nodePath.join('crates', 'rscore'), 'rscore');
-    writeFileSync(
-      nodePath.join(context.directory, 'pyproject.toml'),
-      '[tool.uv.workspace]\nmembers = ["pypkgs/pytool"]\n',
-    );
-    writePythonPackage(context.directory, nodePath.join('pypkgs', 'pytool'), 'pytool');
+    writeGoCargoUvManagers(context.directory);
 
     expect(discoverLeafDirectories(context.directory)).toEqual([
       nodePath.join(context.directory, 'crates', 'rscore'),

--- a/steps/architecture-polyglot-monorepo.steps.ts
+++ b/steps/architecture-polyglot-monorepo.steps.ts
@@ -1,0 +1,77 @@
+/**
+ * Acceptance-lane Givens for polyglot monorepo discovery (ticket MGWZ4P).
+ * Black-box: builds fixtures that declare packages with MORE THAN ONE workspace
+ * manager at once (package.json workspaces + go.work + Cargo [workspace] + uv),
+ * then reuses the shared `safeword generates the architecture doc` When and the
+ * `root index lists the package` Thens from monorepo-coverage-honesty.steps.ts —
+ * cucumber registers step definitions globally, so only the new Givens live here.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { Given } from '@cucumber/cucumber';
+
+import {
+  type ArchitectureWorld,
+  worldDir as dir,
+  writeJson,
+} from './support/architecture-fixtures.ts';
+
+function writeFile(world: ArchitectureWorld, relativePath: string, content: string): void {
+  const absolute = nodePath.join(dir(world), relativePath);
+  mkdirSync(nodePath.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+}
+
+/** A JS workspace package under packages/<name> with a src tree. */
+function makeJsPackage(world: ArchitectureWorld, name: string): void {
+  writeJson(nodePath.join(dir(world), 'packages', name, 'package.json'), { name });
+  mkdirSync(nodePath.join(dir(world), 'packages', name, 'src', 'ui'), { recursive: true });
+}
+
+/** A Go module at <relativeDir> named <name>, declared by a go.work `use` line. */
+function makeGoModule(world: ArchitectureWorld, relativeDir: string, name: string): void {
+  writeFile(world, nodePath.join(relativeDir, 'go.mod'), `module ${name}\n\ngo 1.22\n`);
+  mkdirSync(nodePath.join(dir(world), relativeDir, 'cmd', name), { recursive: true });
+}
+
+/** A Rust crate at <relativeDir> named <name>, a Cargo [workspace] member. */
+function makeRustCrate(world: ArchitectureWorld, relativeDir: string, name: string): void {
+  writeFile(world, nodePath.join(relativeDir, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+  writeFile(world, nodePath.join(relativeDir, 'src', 'lib.rs'), '// rust\n');
+  mkdirSync(nodePath.join(dir(world), relativeDir, 'src', 'engine'), { recursive: true });
+}
+
+/** A Python package at <relativeDir> named <name>, a uv workspace member. */
+function makePythonPackage(world: ArchitectureWorld, relativeDir: string, name: string): void {
+  writeFile(world, nodePath.join(relativeDir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
+  mkdirSync(nodePath.join(dir(world), relativeDir, 'src', name), { recursive: true });
+}
+
+Given(
+  /^a monorepo whose package\.json workspaces list a JS package "([^"]+)" and whose go\.work lists a Go module "([^"]+)"$/,
+  function (this: ArchitectureWorld, jsName: string, goName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    makeJsPackage(this, jsName);
+    writeFile(this, 'go.work', `go 1.22\n\nuse ./services/${goName}\n`);
+    makeGoModule(this, nodePath.join('services', goName), goName);
+  },
+);
+
+Given(
+  /^a polyglot monorepo with a Go module "([^"]+)", a Rust crate "([^"]+)", and a Python package "([^"]+)"$/,
+  function (this: ArchitectureWorld, goName: string, rustName: string, pyName: string) {
+    writeFile(this, 'go.work', `go 1.22\n\nuse ./${goName}\n`);
+    makeGoModule(this, goName, goName);
+
+    writeFile(this, 'Cargo.toml', `[workspace]\nmembers = ["${rustName}"]\n`);
+    makeRustCrate(this, rustName, rustName);
+
+    writeFile(this, 'pyproject.toml', `[tool.uv.workspace]\nmembers = ["${pyName}"]\n`);
+    makePythonPackage(this, pyName, pyName);
+  },
+);


### PR DESCRIPTION
## Summary

The generated architecture doc now fully introspects a **polyglot monorepo that uses more than one workspace manager at once** — e.g. `package.json` `workspaces` for the JS apps **and** `go.work` for the Go services. Previously such a repo had whole languages silently missing from the root index.

## The bug

`discoverLeafDirectories` was first-match-wins across the workspace-manager detectors:

```
detectWorkspaces ?? detectPnpmWorkspaces ?? detectGoWork ?? detectCargoWorkspace ?? detectUvWorkspace
```

The first non-undefined result won; the rest were never consulted. A repo declaring packages with two+ managers got only the first manager's packages — the others vanished at the **discovery** layer, *before* the ZRW21K "not introspected" marker could fire. So the root index looked complete while silently omitting, say, every Go service. A coverage-honesty hole, not just a missing feature.

## The fix

- **Within JS**, `package.json` `workspaces` still wins over `pnpm-workspace.yaml` — they're alternative managers for the *same* ecosystem, not additive (the ZRW21K precedence rule is preserved and still tested).
- **Across ecosystems**, `go.work` / Cargo `[workspace]` / uv `[tool.uv.workspace]` are now **unioned** — they describe disjoint package sets — with the existing leaf `Set` collapsing any same-dir overlap (a maturin package matched by both Cargo and uv is listed once).

Concretely: `[ (detectWorkspaces ?? detectPnpmWorkspaces), detectGoWork, detectCargoWorkspace, detectUvWorkspace ].filter(present).flat()`. Union only **widens** the leaf set; the per-leaf `hasRecognizedManifest` keep-guard is unchanged, so a discovered dir is still kept only when it carries a recognized manifest and is extracted by its own language branch.

This is a refinement of the ticket's original "union all + dedupe": dedupe alone can't preserve JS precedence when two JS configs point at *different* dirs, so the rule is JS-precedence-then-cross-ecosystem-union.

## Behavior change

Three existing unit tests asserted "package.json wins over go.work/Cargo/uv" — that *was* the bug, encoded as if intended. They're reframed as union (with MGWZ4P comments). The `package.json`-wins-over-`pnpm` precedence test is unchanged.

## Verification

Full BDD cycle (spec → dimensions → scenario-gate → implement → verify):
- New black-box lane `features/architecture-polyglot-monorepo.feature` drives the real `safeword architecture` CLI (JS+Go, and Go+Rust+Python with no JS); 9 architecture scenarios green together, including the preserved precedence scenario.
- 38 monorepo + 78 architecture unit tests, covering every behavioral partition (JS+one, multi-non-JS, all-managers-compose, maturin dedupe, over-broad-glob attribution, JS precedence, no-regression).
- `architecture --check` dogfoot exits 0 (this repo is JS-only → union == unchanged, proving single-manager no-regression); depcruise 0 violations; lint + typecheck clean; **zero new dependencies**.
- An independent fresh-context scenario-gate review (PASS-WITH-NITS → nits addressed) and an independent quality-review (APPROVE, no critical issues).

## Known follow-up (out of scope)

A *present-but-unparseable* root manager (e.g. a malformed `go.work`) returns `undefined` and contributes nothing with no "not introspected" marker. This is pre-existing — each detector already degraded identically — and the union doesn't worsen it. A diagnostic for that case is worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMnbHUcWn2ykY1GLWpxa1S)_