### PR TITLE
refactor: post-0.59 cleanup (dedup architecture/test-plan utils + boundary config)

### DIFF
--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -395,6 +395,36 @@ function formatCoverageTicketLabel(ticketId: string): string {
     : formatTicketReference(ticketId.slice(0, dashIndex), ticketId.slice(dashIndex + 1));
 }
 
+function ticketReferenceOf(id: string, labelById: ReadonlyMap<string, string>): string {
+  const title = labelById.get(id);
+  return title === undefined ? id : formatTicketReference(id, title);
+}
+
+/**
+ * Warn-only checks (dangling + cycle) over one directed relation field —
+ * depends_on (soft, AKZJXC) and blocked_on (hard, MBGQ89). Generic over the edge
+ * set; only the field name and cycle wording differ.
+ */
+function relationAdvisoriesFor(
+  nodes: { id: string; dependsOn: string[] }[],
+  danglingField: string,
+  cycleLabel: string,
+  labelById: ReadonlyMap<string, string>,
+): string[] {
+  const dangling = findDanglingDependencies(nodes).map(
+    ({ from, missing }) =>
+      `${ticketReferenceOf(from, labelById)}: ${danglingField} ${missing} — no such ticket (dangling ref)`,
+  );
+  const cyclic = findTicketsInCycles(nodes);
+  const cycle =
+    cyclic.length > 0
+      ? [
+          `${cycleLabel} cycle among: ${cyclic.map(id => ticketReferenceOf(id, labelById)).join(', ')} (break the loop)`,
+        ]
+      : [];
+  return [...dangling, ...cycle];
+}
+
 /**
  * Surface structured-relation problems as non-blocking advisories (ticket
  * AKZJXC): a `depends_on` pointing at a ticket absent from the corpus (dangling
@@ -414,34 +444,10 @@ function findRelationAdvisories(cwd: string): string[] {
   }
 
   const labelById = new Map(entries.map(entry => [entry.id, entry.title]));
-  const refOf = (id: string): string => {
-    const title = labelById.get(id);
-    return title === undefined ? id : formatTicketReference(id, title);
-  };
-
-  // Same warn-only checks (dangling + cycle) over each directed relation field:
-  // depends_on (soft, AKZJXC) and blocked_on (hard, MBGQ89). The finders are
-  // generic over the edge set; only the field name and cycle wording differ.
-  const advisoriesFor = (
-    nodes: { id: string; dependsOn: string[] }[],
-    danglingField: string,
-    cycleLabel: string,
-  ): string[] => {
-    const dangling = findDanglingDependencies(nodes).map(
-      ({ from, missing }) =>
-        `${refOf(from)}: ${danglingField} ${missing} — no such ticket (dangling ref)`,
-    );
-    const cyclic = findTicketsInCycles(nodes);
-    const cycle =
-      cyclic.length > 0
-        ? [`${cycleLabel} cycle among: ${cyclic.map(id => refOf(id)).join(', ')} (break the loop)`]
-        : [];
-    return [...dangling, ...cycle];
-  };
+  const statusById = new Map(entries.map(entry => [entry.id, entry.status]));
 
   // MBGQ89: a blocked_on_override is stale once every listed blocker is `done`
   // (done auto-unblocks, so the override no longer does anything — clean it up).
-  const statusById = new Map(entries.map(entry => [entry.id, entry.status]));
   const staleOverrides = entries
     .filter(
       entry =>
@@ -451,19 +457,21 @@ function findRelationAdvisories(cwd: string): string[] {
     )
     .map(
       entry =>
-        `${refOf(entry.id)}: blocked_on_override is stale — every blocker is done; remove it`,
+        `${ticketReferenceOf(entry.id, labelById)}: blocked_on_override is stale — every blocker is done; remove it`,
     );
 
   return [
-    ...advisoriesFor(
+    ...relationAdvisoriesFor(
       entries.map(entry => ({ id: entry.id, dependsOn: entry.dependsOn })),
       'depends_on',
       'dependency',
+      labelById,
     ),
-    ...advisoriesFor(
+    ...relationAdvisoriesFor(
       entries.map(entry => ({ id: entry.id, dependsOn: entry.blockedOn })),
       'blocked_on',
       'blocked_on',
+      labelById,
     ),
     ...staleOverrides,
   ];

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -15,11 +15,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { indexFilesInTree } from '../utils/fs.js';
+import { findFileMatchingInTree, indexFilesInTree } from '../utils/fs.js';
 import { detectPackageManager } from '../utils/install.js';
 
 export type PlanKind = 'test' | 'build' | 'verify' | 'typecheck';
@@ -48,25 +48,6 @@ type ToolProbe = (tool: string) => boolean;
 type ManifestIndex = ReadonlyMap<string, string>;
 
 const PYTHON_MANIFESTS = ['pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'tox.ini'];
-const PYTHON_TEST_SCAN_EXCLUDES = new Set([
-  'node_modules',
-  '.git',
-  '.safeword',
-  'vendor',
-  'dist',
-  'build',
-  'target',
-  'coverage',
-  'dbt_packages',
-  'out',
-  '.next',
-  '.nuxt',
-  '.output',
-  '__pycache__',
-  '.venv',
-  'venv',
-]);
-
 /** Every manifest probed via the tree (root-only files like package.json/go.work are checked directly). */
 const TREE_MANIFESTS = new Set<string>([
   ...PYTHON_MANIFESTS,
@@ -232,46 +213,6 @@ function pytestConfigured(index: ManifestIndex): boolean {
   return configContains(index, 'setup.cfg', '[tool:pytest]');
 }
 
-function hasDiscoverablePythonTests(directory: string, maxDepth = 10): boolean {
-  return scanForPythonTests(directory, 0, maxDepth);
-}
-
-function scanForPythonTests(directory: string, depth: number, maxDepth: number): boolean {
-  if (depth > maxDepth) return false;
-
-  let directoryEntries;
-  try {
-    directoryEntries = readdirSync(directory, { withFileTypes: true });
-  } catch {
-    return false;
-  }
-
-  if (
-    directoryEntries.some(
-      directoryEntry => directoryEntry.isFile() && isPythonTestFile(directoryEntry.name),
-    )
-  ) {
-    return true;
-  }
-
-  return directoryEntries
-    .filter(directoryEntry => shouldScanForPythonTests(directoryEntry))
-    .some(directoryEntry =>
-      scanForPythonTests(nodePath.join(directory, directoryEntry.name), depth + 1, maxDepth),
-    );
-}
-
-function shouldScanForPythonTests(directoryEntry: {
-  isDirectory(): boolean;
-  name: string;
-}): boolean {
-  return (
-    directoryEntry.isDirectory() &&
-    !directoryEntry.name.startsWith('.') &&
-    !PYTHON_TEST_SCAN_EXCLUDES.has(directoryEntry.name)
-  );
-}
-
 function isPythonTestFile(filename: string): boolean {
   return (
     filename.endsWith('.py') &&
@@ -302,7 +243,7 @@ function resolvePython(
   if (PYTHON_MANIFESTS.every(manifest => !index.has(manifest))) return undefined;
   const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
   if (index.has('tox.ini')) return entry('python', cwd, 'tox', 'tox', isAvailable('tox'));
-  const hasPythonTests = hasDiscoverablePythonTests(cwd);
+  const hasPythonTests = findFileMatchingInTree(cwd, isPythonTestFile) !== undefined;
   if (pytestConfigured(index) || (hasPythonTests && isAvailable('pytest'))) {
     const { command, tool } = pytestInvocation(index, isAvailable);
     return entry('python', cwd, command, 'pytest', isAvailable(tool));

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -14,19 +14,12 @@ import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
+import { readBoundaryConfig } from './boundary-config.js';
 import { readCargoDependencyNames } from './cargo-manifest.js';
 import { readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectDependencies } from './pyproject-manifest.js';
-
-/** Candidate dependency-cruiser config filenames, in resolution order. */
-const DEPENDENCY_CRUISER_CONFIG_NAMES = [
-  '.dependency-cruiser.cjs',
-  '.dependency-cruiser.js',
-  '.dependency-cruiser.mjs',
-  '.dependency-cruiser.json',
-];
 
 /** File extensions treated as schema definitions. */
 const SCHEMA_EXTENSIONS = new Set(['.sql', '.prisma']);
@@ -152,17 +145,6 @@ function collectGoRequireLines(lines: string[], modules: Set<string>): void {
     const match = /^require\s+(\S+)\s+\S/.exec(line.trim());
     if (match?.[1] !== undefined) modules.add(match[1]);
   }
-}
-
-function readBoundaryConfig(projectDirectory: string): string {
-  for (const name of DEPENDENCY_CRUISER_CONFIG_NAMES) {
-    try {
-      return readFileSync(nodePath.join(projectDirectory, name), 'utf8');
-    } catch {
-      // Try the next candidate name.
-    }
-  }
-  return '';
 }
 
 function collectSchemaFiles(projectDirectory: string): string[] {

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -15,6 +15,7 @@ import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
 import { readCargoDependencyNames } from './cargo-manifest.js';
+import { readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectDependencies } from './pyproject-manifest.js';
@@ -88,7 +89,9 @@ function readDependencyNames(projectDirectory: string): string[] {
 }
 
 function readPackageJsonDependencyNames(projectDirectory: string): string[] {
-  const manifest = readJson(nodePath.join(projectDirectory, 'package.json'));
+  const manifest = readJson(nodePath.join(projectDirectory, 'package.json')) as
+    | Record<string, unknown>
+    | undefined;
   return manifest === undefined ? [] : dependencySectionNames(manifest);
 }
 
@@ -198,13 +201,5 @@ function scanDirectoryForSchema(
       const absolutePath = nodePath.join(directory, entry.name);
       schemaFiles.push(nodePath.relative(projectDirectory, absolutePath).replaceAll('\\', '/'));
     }
-  }
-}
-
-function readJson(filePath: string): Record<string, unknown> | undefined {
-  try {
-    return JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return undefined;
   }
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -14,16 +14,13 @@ import { createHash } from 'node:crypto';
 import { globSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { extractSkeleton } from './architecture-skeleton.js';
+import { extractSkeleton, PURPOSE_PLACEHOLDER } from './architecture-skeleton.js';
 import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
 import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
-
-/** Placeholder purpose for a freshly modelled package awaiting prose. */
-const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
 
 /** Candidate dependency-cruiser config filenames (the shared, root-owned boundary). */
 const DEPENDENCY_CRUISER_CONFIG_NAMES = [

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -15,20 +15,13 @@ import { globSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { extractSkeleton, PURPOSE_PLACEHOLDER } from './architecture-skeleton.js';
+import { readBoundaryConfig } from './boundary-config.js';
 import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
 import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
-
-/** Candidate dependency-cruiser config filenames (the shared, root-owned boundary). */
-const DEPENDENCY_CRUISER_CONFIG_NAMES = [
-  '.dependency-cruiser.cjs',
-  '.dependency-cruiser.js',
-  '.dependency-cruiser.mjs',
-  '.dependency-cruiser.json',
-];
 
 const byString = (a: string, b: string): number => a.localeCompare(b);
 
@@ -203,14 +196,6 @@ function detectUvWorkspace(projectDirectory: string): string[] | undefined {
 function manifestDependencyNames(packageDirectory: string): string[] {
   const manifest = readManifest(packageDirectory);
   return manifest === undefined ? [] : dependencySectionNames(manifest);
-}
-
-function readBoundaryConfig(projectDirectory: string): string {
-  for (const name of DEPENDENCY_CRUISER_CONFIG_NAMES) {
-    const content = readFileSafe(nodePath.join(projectDirectory, name));
-    if (content !== undefined) return content;
-  }
-  return '';
 }
 
 /**

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -14,7 +14,7 @@ import nodePath from 'node:path';
 import { exists, isDirectory } from './fs.js';
 
 /** Placeholder purpose for a freshly extracted node awaiting human prose. */
-const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
+export const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
 
 /**
  * Conventional top-level directories of a Go module (ticket ZD70P1). Used as the

--- a/packages/cli/src/utils/boundary-config.ts
+++ b/packages/cli/src/utils/boundary-config.ts
@@ -1,0 +1,29 @@
+/**
+ * The root-owned dependency-cruiser boundary config.
+ *
+ * Both the leaf shape-fingerprint (architecture-fingerprint) and the root-index
+ * fingerprint (architecture-monorepo) hash this config, so they must agree on
+ * which file is canonical and how it's read — sharing one reader removes the
+ * silent-desync hazard of two hand-kept copies.
+ */
+
+import nodePath from 'node:path';
+
+import { readFileSafe } from './fs.js';
+
+/** Candidate dependency-cruiser config filenames, in resolution order. */
+export const DEPENDENCY_CRUISER_CONFIG_NAMES = [
+  '.dependency-cruiser.cjs',
+  '.dependency-cruiser.js',
+  '.dependency-cruiser.mjs',
+  '.dependency-cruiser.json',
+];
+
+/** Content of the first present dependency-cruiser config, or '' when none exists. */
+export function readBoundaryConfig(projectDirectory: string): string {
+  for (const name of DEPENDENCY_CRUISER_CONFIG_NAMES) {
+    const content = readFileSafe(nodePath.join(projectDirectory, name));
+    if (content !== undefined) return content;
+  }
+  return '';
+}

--- a/packages/cli/src/utils/boundary-config.ts
+++ b/packages/cli/src/utils/boundary-config.ts
@@ -12,7 +12,7 @@ import nodePath from 'node:path';
 import { readFileSafe } from './fs.js';
 
 /** Candidate dependency-cruiser config filenames, in resolution order. */
-export const DEPENDENCY_CRUISER_CONFIG_NAMES = [
+const DEPENDENCY_CRUISER_CONFIG_NAMES = [
   '.dependency-cruiser.cjs',
   '.dependency-cruiser.js',
   '.dependency-cruiser.mjs',

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -162,6 +162,62 @@ function scanTreeForFile(
 }
 
 /**
+ * Find the first directory (root first, then descending) that contains a file
+ * whose name matches `predicate`. Skips hidden dirs + SUBDIRECTORY_EXCLUDE. The
+ * predicate analogue of {@link findInTree} — share this instead of re-walking
+ * the tree (and re-declaring the exclude set) in callers.
+ * @param cwd - Project root directory
+ * @param predicate - Matches a filename (e.g. a Python test-file name)
+ * @param maxDepth - Maximum directory depth to scan (default: 10)
+ * @returns Directory containing a match, or undefined
+ */
+export function findFileMatchingInTree(
+  cwd: string,
+  predicate: (filename: string) => boolean,
+  maxDepth = 10,
+): string | undefined {
+  return scanTreeForMatch(cwd, predicate, 0, maxDepth);
+}
+
+function scanTreeForMatch(
+  directory: string,
+  predicate: (filename: string) => boolean,
+  depth: number,
+  maxDepth: number,
+): string | undefined {
+  if (depth > maxDepth) return undefined;
+
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  if (entries.some(entry => entry.isFile() && predicate(entry.name))) {
+    return directory;
+  }
+
+  for (const entry of entries) {
+    if (
+      !(entry.isDirectory() && !entry.name.startsWith('.') && !SUBDIRECTORY_EXCLUDE.has(entry.name))
+    ) {
+      continue;
+    }
+
+    const result = scanTreeForMatch(
+      nodePath.join(directory, entry.name),
+      predicate,
+      depth + 1,
+      maxDepth,
+    );
+    if (result !== undefined) return result;
+  }
+
+  return undefined;
+}
+
+/**
  * Index multiple files in a single tree walk — the multi-file analogue of
  * `findInTree`. Returns a Map from each requested filename to the directory of
  * its **shallowest** occurrence (root-first, level-order — same ordering as

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -129,6 +129,15 @@ describe('resolveTestPlan — the command reflects the detected runner', () => {
     expect(entryFor(plan, 'python')).toBeUndefined();
   });
 
+  it('ignores python test files inside excluded dirs (node_modules)', () => {
+    const root = makeRepo({
+      'requirements.txt': 'gepa==0.1.1\n',
+      'node_modules/pkg/test_vendored.py': 'def test_x():\n    assert True\n',
+    });
+    const plan = resolveTestPlan(root, { kind: 'verify', isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')).toBeUndefined();
+  });
+
   it('detects pytest configured via setup.cfg [tool:pytest]', () => {
     const root = makeRepo({
       'pyproject.toml': '[project]\nname="x"\n',


### PR DESCRIPTION
A `/refactor` scout over the CLI-`src` code merged since #535 (the prior cleanup) — #486/#537/#544/#546/#541/#545/#554. Five behavior-preserving SAFE refactors, leaf-first; net **+141/−139** (consolidation).

## Changes
1. **`architecture-fingerprint`: drop private `readJson`** — duplicated `utils/fs.readJson` (which the sibling already imports); cast at the one call site to preserve exact behavior.
2. **Share `PURPOSE_PLACEHOLDER`** — export from `architecture-skeleton`, drop the monorepo copy (drift seam).
3. **`health.ts`: hoist `findRelationAdvisories` closures** — `refOf`/`advisoriesFor` → module-level `ticketReferenceOf`/`relationAdvisoriesFor`; 64-line fn → ~30.
4. **Extract `utils/boundary-config.ts`** — `DEPENDENCY_CRUISER_CONFIG_NAMES` + `readBoundaryConfig` were **byte-identical** in fingerprint + monorepo, both feeding their fingerprints — a real desync hazard. One shared reader; fingerprint output unchanged.
5. **`fs.findFileMatchingInTree`** — `resolve.ts` re-implemented `fs.ts`'s tree-walk (`scanForPythonTests`) and re-declared `SUBDIRECTORY_EXCLUDE` (as `PYTHON_TEST_SCAN_EXCLUDES`). Add a predicate-based finder to `fs.ts`, rewire Python discovery, delete the dup set + 3 walk fns. **+ a `node_modules`-excluded-dir test** to lock the exclude-set equivalence (a gap the scout flagged).

## Deferred / skipped (scout-confirmed *not* smells)
- The 4 per-language `packs/*/skills.ts` — structurally similar but genuinely-distinct data, already tabled in `languages.ts`; tabling would be over-abstraction.
- `surfaceSlug` vs `slug.normalizeSlug` — look dup but differ (accent-folding, throw-vs-empty); a DRY trap, left alone.
- ~6 nitpicks (char-class predicates, husk loops, EMPTY_REPORT spread).

Verified: `tsc` ✓, eslint ✓, affected suites green (fingerprint 17, skeleton+monorepo 61, check 48, resolve 33, fs-tree). 0 dangling refs to any deleted symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)