### PR TITLE
Surface present-but-unparseable workspace managers in architecture discovery (#558)

### DIFF
--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/dimensions.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/dimensions.md
@@ -1,0 +1,34 @@
+# Behavioral dimensions — UWP4XK (present-but-unparseable workspace managers)
+
+Behavior: `discoverWorkspaces(dir) → { patterns, unreadable[] }`, and how the
+`unreadable[]` set is surfaced (root-index advisory, `architecture`/`--check`
+warning) and folded into the root fingerprint. The input space is "for each
+manager at the root, is it absent, parseable, or present-but-unparseable, and do
+any OTHER managers still yield packages."
+
+| # | Dimension | Partitions | Covered by |
+| - | --------- | ---------- | ---------- |
+| D1 | **Per-manager detection outcome** | (a) absent; (b) parsed; (c) present-but-unparseable | U1–U5 (one per manager × each outcome) |
+| D2 | **Which manager is unparseable** | (a) go.work; (b) Cargo `[workspace]`; (c) uv `[tool.uv.workspace]`; (d) pnpm flow-style; (e) package.json malformed shape | U1/AC1, U2/AC2(Cargo), U3, U4, U5 |
+| D3 | **Co-present readable manager** | (a) none (only the unreadable one) → no root index, warning-only surface; (b) ≥1 other readable → root index lists readable packages + carries the advisory | AC1–AC3 + U6 (b); AC4 (a: warning-only) |
+| D4 | **Absent vs present-but-empty boundary** | (a) manifest absent → absent; (b) workspace table/field absent → absent; (c) table/field present but unparseable → unreadable; (d) explicitly-empty (e.g. `workspaces: []`) → absent | U7 (Cargo no-table absent), U8 (empty array absent) |
+| D5 | **Fingerprint freshness** | (a) unreadable set empty → fingerprint unchanged vs today (no churn); (b) unreadable appears/disappears → fingerprint moves | U9 |
+| D6 | **Surface non-blocking** | (a) `architecture` exit unchanged; (b) `--check` exit unchanged (advisory ≠ stale) | AC4 (command warns, exit 0) |
+
+## Load-bearing partitions (where this change actually bites)
+
+- **D1(c) for every manager (D2 a–e)** — the bug: a present-but-unparseable
+  manifest must become an `unreadable` signal, not `undefined`. New behavior.
+- **D3(b)** — the readable side is never blinded: a malformed go.work next to a
+  working manager still lists the working packages AND names go.work. This is the
+  coverage-honesty property (the union from #554 must survive one bad manager).
+- **D4(b) vs D4(c)** — the boundary that must NOT over-fire: a `Cargo.toml` with no
+  `[workspace]` (single crate) stays absent; only a present table with unparseable
+  members is unreadable. Guards against advisory false alarms.
+- **D5(a)** — no churn: a repo with zero unreadable configs keeps its fingerprint.
+
+## Out-of-partition (not exercised; noted)
+
+Nested/recursive workspaces (a member that is itself a workspace root) — out of
+scope; current behavior (treat as one leaf, or not discovered) is unchanged.
+Repairing the unparseable manifest — never attempted.

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/dimensions.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/dimensions.md
@@ -11,8 +11,8 @@ any OTHER managers still yield packages."
 | D1 | **Per-manager detection outcome** | (a) absent; (b) parsed; (c) present-but-unparseable | U1–U5 (one per manager × each outcome) |
 | D2 | **Which manager is unparseable** | (a) go.work; (b) Cargo `[workspace]`; (c) uv `[tool.uv.workspace]`; (d) pnpm flow-style; (e) package.json malformed shape | U1/AC1, U2/AC2(Cargo), U3, U4, U5 |
 | D3 | **Co-present readable manager** | (a) none (only the unreadable one) → no root index, warning-only surface; (b) ≥1 other readable → root index lists readable packages + carries the advisory | AC1–AC3 + U6 (b); AC4 (a: warning-only) |
-| D4 | **Absent vs present-but-empty boundary** | (a) manifest absent → absent; (b) workspace table/field absent → absent; (c) table/field present but unparseable → unreadable; (d) explicitly-empty (e.g. `workspaces: []`) → absent | U7 (Cargo no-table absent), U8 (empty array absent) |
-| D5 | **Fingerprint freshness** | (a) unreadable set empty → fingerprint unchanged vs today (no churn); (b) unreadable appears/disappears → fingerprint moves | U9 |
+| D4 | **Absent vs present-but-unparseable boundary** | (a) manifest absent → absent; (b) workspace table/field absent → absent; (c) **member-list key absent though a table exists** (Cargo `[workspace]` no `members` / pnpm no `packages:` / go.work no `use`) → absent, NOT a false alarm; (d) member-list key present but unparseable → unreadable; (e) explicitly-empty (e.g. `workspaces: []`) → absent | U7 (Cargo no-table), U8 (empty array), U9 (Cargo no-members), U10 (pnpm catalog-only), U11 (go.work no-use); U1–U5 (d) |
+| D5 | **Fingerprint freshness** | (a) unreadable set empty → fingerprint unchanged vs today (no churn); (b) unreadable appears/disappears → fingerprint moves | FP1/FP2 (fingerprint tests) |
 | D6 | **Surface non-blocking** | (a) `architecture` exit unchanged; (b) `--check` exit unchanged (advisory ≠ stale) | AC4 (command warns, exit 0) |
 
 ## Load-bearing partitions (where this change actually bites)

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/spec.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/spec.md
@@ -63,15 +63,23 @@ Replace each detector's `string[] | undefined` with a discriminated
 - `{ status: 'unreadable'; manager; config }` — a workspace is declared but its
   member list can't be parsed.
 
-What counts as *declared but unreadable* per manager:
+What counts as *declared but unreadable* per manager — the member-list declaration
+is PRESENT but can't be parsed (a *missing* declaration is absent, never a false
+alarm):
 
-- **go.work**: file present but zero member dirs parse (malformed/junk `use`).
-- **Cargo `[workspace]`**: `[workspace]` table present but `members` unparseable
-  (no `[workspace]` table ⇒ absent, a single crate).
-- **uv**: `[tool.uv.workspace]` table present but `members` unparseable (no table
-  ⇒ absent).
-- **pnpm**: `pnpm-workspace.yaml` present but no package glob parses (flow-style,
-  empty). The file existing *is* a workspace declaration.
+- **go.work**: a `use` directive present but zero member dirs parse (malformed/junk
+  `use`). No `use` directive at all ⇒ absent (a `go work init` file with no modules).
+- **Cargo `[workspace]`**: `[workspace]` + a `members` key present but unparseable.
+  No `[workspace]` ⇒ absent (single crate); `[workspace]` with no `members` key ⇒
+  absent (a valid root-package workspace that auto-discovers members from path deps /
+  `default-members` — out of scope like nested workspaces, verified against the Cargo
+  reference).
+- **uv**: `[tool.uv.workspace]` table present but `members` unparseable (no table ⇒
+  absent). uv *requires* `members`, so a table with no usable members is genuinely
+  malformed → unreadable.
+- **pnpm**: a `packages:` key present but no glob parses (flow-style, empty block).
+  No `packages:` key ⇒ absent (a catalog-only/settings-only file is valid and declares
+  no members — verified against the pnpm reference).
 - **package.json**: a `workspaces` field present but not a usable array /
   `{packages: [...]}` (malformed shape) ⇒ unreadable; an explicitly empty array
   ⇒ absent (deliberate). JS precedence (package.json wins over pnpm) is preserved:

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/spec.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/spec.md
@@ -1,0 +1,90 @@
+# Spec: Surface a present-but-unparseable workspace manager (UWP4XK)
+
+## Jobs To Be Done
+
+### UWP4XK.J1 — A polyglot map that admits what it could not read
+
+**Persona:** Technical Builder (TB)
+
+When safeword discovers my monorepo and one workspace manager's root manifest is
+present but unparseable (a malformed `go.work`, an unreadable Cargo `[workspace]
+members`, a flow-style `pnpm-workspace.yaml`), I want the generated map to **say
+so out loud** instead of silently listing zero packages for it, so I can trust
+"the map is complete" or see exactly which config to fix. (The NTB can't audit
+the diff to notice the Go services are missing — silence reads as "complete.")
+
+#### UWP4XK.J1.AC1 — Present-but-unparseable is surfaced, not dropped
+
+A root manifest that declares a workspace whose member list can't be parsed is
+named as unreadable (manager + config file) wherever the architecture surface is
+shown — it never contributes zero packages with no marker.
+
+#### UWP4XK.J1.AC2 — Absent stays silent
+
+A manager that is genuinely absent (no `go.work`; a `Cargo.toml`/`pyproject.toml`
+with no workspace table; a single-crate/single-package repo) produces no
+unreadable signal — only *present-but-unparseable* is surfaced, so the advisory
+is never a false alarm.
+
+#### UWP4XK.J1.AC3 — The readable side is never blinded
+
+When other managers are readable, their packages are still discovered and listed;
+the unreadable manager is surfaced *alongside* them (an advisory in the rendered
+root index), not in place of them. One unreadable config never drops a readable
+manager's packages.
+
+#### UWP4XK.J1.AC4 — Advisory, never blocking
+
+The surface is advisory: `safeword architecture` and `architecture --check` print
+a warning but their exit codes are unchanged; the root index renders the advisory
+but no command fails. The human doc / the build is never blocked on it.
+
+#### UWP4XK.J1.AC5 — The advisory stays fresh
+
+The root-index advisory re-renders when an unreadable config appears or is fixed
+(the unreadable set is part of the root fingerprint). A repo with no unreadable
+config keeps its existing fingerprint — no churn.
+
+## Problem
+
+`discoverLeafDirectories` unions managers (#554), but each detector returns
+`string[] | undefined` where `undefined` means BOTH "absent" and
+"present-but-unparseable." The unparseable case is filtered out at discovery,
+before the per-package "not introspected" marker (ZRW21K) can fire — a manager
+that discovered nothing has nothing to mark. So the set vanishes silently.
+
+## Design
+
+Replace each detector's `string[] | undefined` with a discriminated
+`WorkspaceDetection`:
+
+- `{ status: 'absent' }` — no workspace declared (no signal).
+- `{ status: 'parsed'; patterns: string[] }` — globs/dirs to expand (today's path).
+- `{ status: 'unreadable'; manager; config }` — a workspace is declared but its
+  member list can't be parsed.
+
+What counts as *declared but unreadable* per manager:
+
+- **go.work**: file present but zero member dirs parse (malformed/junk `use`).
+- **Cargo `[workspace]`**: `[workspace]` table present but `members` unparseable
+  (no `[workspace]` table ⇒ absent, a single crate).
+- **uv**: `[tool.uv.workspace]` table present but `members` unparseable (no table
+  ⇒ absent).
+- **pnpm**: `pnpm-workspace.yaml` present but no package glob parses (flow-style,
+  empty). The file existing *is* a workspace declaration.
+- **package.json**: a `workspaces` field present but not a usable array /
+  `{packages: [...]}` (malformed shape) ⇒ unreadable; an explicitly empty array
+  ⇒ absent (deliberate). JS precedence (package.json wins over pnpm) is preserved:
+  package.json present — parsed OR unreadable — wins; only an absent package.json
+  falls through to pnpm.
+
+`discoverWorkspaces(dir)` returns `{ patterns, unreadable[] }`. `discoverLeafDirectories`
+becomes a thin wrapper over `.patterns` (unchanged behavior + signature).
+`extractMonorepoModel` gains `unreadableWorkspaces[]`; `monorepoFingerprint`
+includes it only when non-empty. The root index renders a `## Coverage gaps`
+advisory; `architecture`/`--check` print a non-blocking warning.
+
+## Out of scope
+
+Nested/recursive workspaces; new manifest formats; per-leaf extraction; any
+blocking gate; repairing the unparseable manifest.

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/test-definitions.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/test-definitions.md
@@ -44,10 +44,18 @@ command's stdout/stderr) — no package internals.
   `web` + malformed go.work → patterns keep `packages/*`, leaves keep `web`, unreadable
   records `go.work`. The coverage-honesty property (#554 union survives one bad manager).
 - [x] **U7 — single-crate Cargo.toml (no [workspace]) raises no signal** [J1.AC2, D4(b)]
-- [x] **U8 — explicitly-empty `workspaces: []` is absent, not unreadable** [D4(d)]
+- [x] **U8 — explicitly-empty `workspaces: []` is absent, not unreadable** [D4(e)]
+- [x] **U9 — Cargo `[workspace]` with no `members` key (auto-discovery) is absent** [J1.AC2, D4(c)]:
+  a root-package workspace using `default-members`/path-dep auto-discovery is valid, not a
+  coverage gap — must not false-alarm. (quality-review finding; verified vs the Cargo reference.)
+- [x] **U10 — catalog-only `pnpm-workspace.yaml` (no `packages:` key) is absent** [J1.AC2, D4(c)]:
+  `packages:` is optional in pnpm; a catalog/settings-only file declares no members.
+  (quality-review finding; verified vs the pnpm reference.)
+- [x] **U11 — `go.work` with no `use` directive (fresh init) is absent** [J1.AC2, D4(c)]:
+  a member-less go.work declares nothing — only a present-but-junk `use` is unreadable.
 - [x] **model — `extractMonorepoModel` exposes `unreadableWorkspaces`** [feeds render + fingerprint]
-- [x] **U9 — fingerprint moves when an unreadable manager appears** [D5(b)]
-- [x] **U9b — fingerprint does NOT move for a clean repo (no churn)** [D5(a)]: the
+- [x] **FP1 — fingerprint moves when an unreadable manager appears** [D5(b)]
+- [x] **FP2 — fingerprint does NOT move for a clean repo (no churn)** [D5(a)]: the
   unreadable key is contributed only when non-empty, so a readable-only repo keeps its hash.
 
 ## Reconcile note

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/test-definitions.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/test-definitions.md
@@ -1,0 +1,58 @@
+# Test definitions (R/G/R ledger) — UWP4XK
+
+Behavior: a workspace manager PRESENT at the root but unparseable is surfaced
+(root-index `## Coverage gaps` advisory + `architecture`/`--check` warning),
+never silently dropped. Black-box scenarios in
+`features/architecture-unreadable-workspace.feature`; detector precision in
+`tests/utils/architecture-monorepo.test.ts`. Dimensions in dimensions.md.
+
+## Black-box scenarios (acceptance lane — `@architecture-unreadable-workspace`)
+
+- [x] **AC1 — malformed go.work + working JS** (`…UWP4XK.AC1`) [J1.AC1/AC3, D2(a), D3(b)]
+  - RED (pre-fix): go.work returns `undefined`, contributes nothing, no marker; root
+    index lists `web` only, NO advisory. Failure: "root index has no Coverage gaps".
+  - GREEN: root index lists `web` AND a `## Coverage gaps` advisory names `go.work`.
+- [x] **AC2 — unreadable Cargo [workspace] members + uv Python** (`…UWP4XK.AC2`) [J1.AC1/AC3, D2(b), D3(b)]
+  - RED: Cargo `undefined` (absent==unparseable), dropped silently; no advisory.
+  - GREEN: lists `pytool` AND advisory names `Cargo.toml`.
+- [x] **AC3 — flow-style pnpm + Go module** (`…UWP4XK.AC3`) [J1.AC1/AC3, D2(d), D3(b)]
+  - RED: pnpm flow-style → `undefined`, dropped; no advisory (today's silent
+    "degrades gracefully" path in monorepo-coverage-honesty).
+  - GREEN: lists `gosvc` AND advisory names `pnpm-workspace.yaml`.
+- [x] **AC4 — only-unparseable case is warned, not blocked** (`…UWP4XK.AC4`) [J1.AC4, D3(a), D6]
+  - RED: a lone malformed go.work → single-repo doc, zero signal, command silent.
+  - GREEN: command exits 0 AND its output warns that `go.work` is unreadable
+    (the warning channel covers the no-root-index path).
+- [x] **AC5 — absent is not a false alarm** (`…UWP4XK.AC5`) [J1.AC2, D4(b)]
+  - Negative case: a single-crate `Cargo.toml` (no `[workspace]`) must NOT raise an
+    advisory. GREEN: lists `gosvc`, no `## Coverage gaps` section.
+
+Each scenario is Arrange-Observe-Decide-Independent: the Given builds the repo, the
+When runs the real CLI, the Then reads only observable output (the rendered doc or the
+command's stdout/stderr) — no package internals.
+
+## Unit tests (detector precision — tests/utils/architecture-monorepo.test.ts)
+
+- [x] **U1 — malformed go.work is unreadable, not absent** [D1(c), D2(a)]
+  - RED: detector returned `undefined`; `discoverWorkspaces` had no `unreadable` field.
+    GREEN: `{ patterns: [], unreadable: [{go.work}] }`.
+- [x] **U2 — Cargo [workspace] present, members unparseable → unreadable** [D1(c), D2(b)]
+- [x] **U3 — uv [tool.uv.workspace] present, members unparseable → unreadable** [D1(c), D2(c)]
+- [x] **U4 — flow-style pnpm → unreadable** [D1(c), D2(d)]
+- [x] **U5 — package.json `workspaces` of wrong shape → unreadable** [D1(c), D2(e)]
+- [x] **U6 — a malformed manager never blinds the readable ones** [J1.AC3, D3(b)]: JS
+  `web` + malformed go.work → patterns keep `packages/*`, leaves keep `web`, unreadable
+  records `go.work`. The coverage-honesty property (#554 union survives one bad manager).
+- [x] **U7 — single-crate Cargo.toml (no [workspace]) raises no signal** [J1.AC2, D4(b)]
+- [x] **U8 — explicitly-empty `workspaces: []` is absent, not unreadable** [D4(d)]
+- [x] **model — `extractMonorepoModel` exposes `unreadableWorkspaces`** [feeds render + fingerprint]
+- [x] **U9 — fingerprint moves when an unreadable manager appears** [D5(b)]
+- [x] **U9b — fingerprint does NOT move for a clean repo (no churn)** [D5(a)]: the
+  unreadable key is contributed only when non-empty, so a readable-only repo keeps its hash.
+
+## Reconcile note
+
+Coverage honesty (no silent drop) is the union of U1–U6 + AC1–AC4: every present
+cross-ecosystem manager that can't be parsed reaches a surface (doc advisory and/or
+command warning). U7/U8 + AC5 pin the absent/empty boundary so the advisory is never a
+false alarm. U9/U9b keep the doc advisory fresh without churning clean repos.

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/ticket.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/ticket.md
@@ -2,10 +2,10 @@
 id: UWP4XK
 slug: unparseable-workspace-coverage
 type: feature
-phase: define-behavior
+phase: verify
 status: todo
 created: 2026-06-29T19:30:00.000Z
-last_modified: 2026-06-29T19:30:00.000Z
+last_modified: 2026-06-30T04:11:00.000Z
 scope:
   - Distinguish "workspace manager absent" from "workspace manager present-but-unparseable" at the detector boundary in `architecture-monorepo.ts` (`detectGoWork`, `detectCargoWorkspace`, `detectUvWorkspace`, the JS package.json/pnpm detectors). Today each returns `string[] | undefined` and `undefined` collapses both cases, so a present-but-unreadable root manifest contributes zero packages with no marker.
   - SURFACE a present-but-unparseable workspace config (advisory only, never blocking) in two places: a `## Coverage gaps` advisory line in the rendered monorepo root index naming the unreadable config, and a `safeword architecture` / `architecture --check` warning naming the unreadable config.

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/ticket.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/ticket.md
@@ -1,0 +1,69 @@
+---
+id: UWP4XK
+slug: unparseable-workspace-coverage
+type: feature
+phase: define-behavior
+status: todo
+created: 2026-06-29T19:30:00.000Z
+last_modified: 2026-06-29T19:30:00.000Z
+scope:
+  - Distinguish "workspace manager absent" from "workspace manager present-but-unparseable" at the detector boundary in `architecture-monorepo.ts` (`detectGoWork`, `detectCargoWorkspace`, `detectUvWorkspace`, the JS package.json/pnpm detectors). Today each returns `string[] | undefined` and `undefined` collapses both cases, so a present-but-unreadable root manifest contributes zero packages with no marker.
+  - SURFACE a present-but-unparseable workspace config (advisory only, never blocking) in two places: a `## Coverage gaps` advisory line in the rendered monorepo root index naming the unreadable config, and a `safeword architecture` / `architecture --check` warning naming the unreadable config.
+  - Fold the unreadable-workspace set into `monorepoFingerprint` (only when non-empty, to avoid churning repos that have none) so the root-index advisory stays fresh as an unreadable config appears or is fixed.
+out_of_scope:
+  - Nested/recursive workspaces (a member that is itself a workspace root).
+  - New language packs / manifest formats; per-leaf polyglot extraction (unchanged).
+  - Any blocking gate — the surface is advisory like the rest of the architecture honesty layer.
+  - Repairing or guessing the contents of an unparseable manifest; we only report it.
+done_when:
+  - A repo with a malformed `go.work` (a `use` directive that yields no member dir) alongside a working manager surfaces the `go.work` as unreadable — its presence is named, not silently dropped.
+  - A repo with a `Cargo.toml` `[workspace]` whose `members` array can't be parsed surfaces `Cargo.toml` as unreadable; a `Cargo.toml` with NO `[workspace]` table (a single crate) stays silent (absent, not unreadable).
+  - A repo with a flow-style `pnpm-workspace.yaml` surfaces `pnpm-workspace.yaml` as unreadable.
+  - When at least one OTHER manager still yields packages, the rendered root index carries a `## Coverage gaps` advisory naming each unreadable config AND lists the packages the readable managers discovered (the readable side is never blinded by the unreadable one).
+  - `safeword architecture` and `architecture --check` print a non-blocking warning naming each unreadable config; neither command's exit code changes because of it.
+  - `monorepoFingerprint` moves when an unreadable config appears or is fixed, but a repo with no unreadable config (this repo) keeps its existing fingerprint — no dogfood churn beyond the one-time regeneration this ticket lands.
+  - No regression: absent managers, single-manager monorepos, and single-repo projects are unchanged; `architecture --check` still passes on this repo.
+---
+
+# Surface a present-but-unparseable workspace manager (coverage honesty)
+
+**Goal:** A workspace manager that is *present* at the repo root but whose member
+list safeword cannot parse must be **surfaced**, not silently dropped. Today it
+contributes zero packages and no marker — the same class of silent omission #554
+fixed (a whole language vanishing from the map), one layer up.
+
+**Origin:** GitHub #558, surfaced by the independent quality-review of #554
+(MGWZ4P). Pre-existing: each detector degraded this way under the old first-match
+chain too; explicitly out of scope for #554, filed so it isn't lost.
+
+## Problem
+
+`discoverLeafDirectories` unions all workspace managers (#554), but each detector
+returns `string[] | undefined`, and `undefined` means **both "absent" and
+"present-but-unparseable."** A malformed `go.work`, an unreadable Cargo
+`[workspace] members`, or a flow-style `pnpm-workspace.yaml` returns `undefined`,
+is filtered out, and contributes zero packages with no marker. The package set
+vanishes at the **discovery** layer — *before* the ZRW21K "not introspected"
+marker can fire (that marker is per-discovered-package; a manager that discovered
+nothing has nothing to mark). The root index looks complete while silently
+omitting, say, every Go service.
+
+safeword's coverage-honesty principle is "incomplete is fine, silently wrong is
+not." A present manager that can't be parsed should be surfaced.
+
+## Decision
+
+Distinguish the two cases at the detector boundary with a small discriminated
+return (`absent` | `parsed` | `unreadable`), carrying the manager label and
+config filename on the `unreadable` case so discovery can surface it. Reuse the
+existing glob-expand + `hasRecognizedManifest` + `Set`-dedupe pipeline unchanged
+— the readable managers still union exactly as before; the only addition is a
+parallel `unreadable[]` channel. Surface it advisory-only (root-index line +
+`--check`/command warning) and fold it into the root fingerprint (non-empty only)
+so the advisory stays fresh. Never block.
+
+## Next
+
+`/bdd`: spec → dimensions → scenarios (malformed go.work, unreadable Cargo
+members, flow-style pnpm — each surfaced, not silently empty) → independent
+scenario review → TDD → verify → audit.

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/verify.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/verify.md
@@ -42,6 +42,30 @@ docs are byte-unchanged; `architecture --check` exits 0.
   docs, both still true; the repo now additionally renders a root index carrying the
   advisory (the honest surface), which that scenario does not contradict.
 
+## Quality review (post-merge-prep, /quality-review)
+
+Fresh-context independent review returned **REQUEST CHANGES** on one real
+false-alarm: the detector classified a *valid* workspace as "unreadable" whenever
+the manager's table/file was present with no parseable globs — but a missing
+member-list declaration is valid for several managers. Verified against primary
+sources and fixed: a workspace is now `unreadable` only when the **member-list
+declaration is present but unparseable**, never when it is simply absent:
+
+- **Cargo** `[workspace]` with no `members` key → `absent` (valid root-package
+  auto-discovery / `default-members`; [Cargo reference](https://doc.rust-lang.org/cargo/reference/workspaces.html)). New `hasTomlTableKey` guard.
+- **pnpm** with no `packages:` key → `absent` (catalog/settings-only is valid;
+  [pnpm reference](https://pnpm.io/pnpm-workspace_yaml)).
+- **go.work** with no `use` directive → `absent` (a fresh `go work init` file).
+- **uv** unchanged — `members` is *required* in `[tool.uv.workspace]`, so a table
+  with no usable members is genuinely malformed → correctly `unreadable`.
+
+Added U9 (Cargo auto-discovery), U10 (pnpm catalog-only), U11 (go.work no-use) —
+each asserts `absent`, not a false alarm. `node:fs` `globSync` confirmed stable
+since Node 22 ([release notes](https://nodejs.org/en/blog/release/v22.0.0)). No new dependencies. Lint + tests green
+after the fix (52 monorepo unit tests, 14 architecture scenarios). The `--check`/
+`--stage` warning is the same `warnUnreadableWorkspaces` call proven end-to-end by
+AC4 on the default command — identical delegation, not separately re-tested.
+
 ## Reconcile
 
 Implementation matches the spec design: each detector returns `absent | parsed |

--- a/.project/tickets/UWP4XK-unparseable-workspace-coverage/verify.md
+++ b/.project/tickets/UWP4XK-unparseable-workspace-coverage/verify.md
@@ -1,0 +1,53 @@
+# Verify: present-but-unparseable workspace coverage (UWP4XK)
+
+## Verify checklist
+
+**Test Suite:** ✅ Full CLI unit suite green — 277 files, 4029 passed, 5 skipped. The
+UWP4XK additions: 11 new monorepo unit tests (U1–U9 + model + no-churn) in
+`tests/utils/architecture-monorepo.test.ts` (49 in that file total).
+**Gherkin:** ✅ 5 new `@architecture-unreadable-workspace` scenarios pass; 52
+architecture scenarios green together (monorepo-coverage-honesty incl. the preserved
+flow-style "degrades gracefully" path, polyglot, hierarchy, state-docs).
+**Build:** ✅ CLI runs (`bun packages/cli/src/cli.ts architecture --check` exits 0).
+**Lint:** ✅ eslint clean on all changed files (fixed a nested-ternary → `workspaceList`
+helper and a conditional spread → logical spread).
+**Typecheck:** ✅ No new errors in the changed files (pre-existing TS6059 rootDir notes
+for `.safeword/hooks/**` unchanged, as on main).
+**Scenarios:** All 5 acceptance scenarios + U-series RED-for-the-right-reason confirmed:
+pre-fix a present-but-unparseable manager returned `undefined`, contributed no packages,
+and rendered no `## Coverage gaps` advisory and no warning; GREEN after the discriminated
+detector return surfaces it.
+**Dep Drift:** ✅ Zero new dependencies (pure logic + render + one toml helper).
+**PR Scope:** ✅ Diff matches ticket scope — `architecture-monorepo.ts` (detectors +
+discovery), `architecture-document.ts` (root-index advisory + target routing),
+`commands/architecture.ts` (non-blocking warning), `toml.ts` (`hasTomlTable`), the
+acceptance feature/steps, and the ticket artifacts. No piggybacked changes.
+**Dogfood no-churn:** ✅ This repo has no unreadable workspace config, so the unreadable
+key never enters the fingerprint — `.project/architecture.generated.md` and the two leaf
+docs are byte-unchanged; `architecture --check` exits 0.
+
+## Evidence
+
+- **Independent scenario-gate review** (fresh-context general-purpose agent, `/review-spec`
+  checks): **PASS-WITH-NITS**, no load-bearing findings. Confirmed: load-bearing assertions
+  genuinely RED-before-fix (the `## Coverage gaps` / `unreadable` warning did not exist),
+  AODI-clean (observes only the rendered doc + captured stdout/stderr), deterministic
+  (isolated `mkdtemp` dirs), and the absent-vs-unparseable false-alarm boundary explicitly
+  pinned (AC5 single-crate Cargo + U7/U8). Two nits: stale `SC#` labels in dimensions.md /
+  test-definitions.md (fixed → `AC1–AC5`), and uv-unreadable being unit-only (U3) with no
+  black-box scenario (accepted per the test pyramid — the discovery→render→surface pipeline
+  is already proven end-to-end by three sibling managers).
+- **Behavior change, intentional & documented:** the existing flow-style pnpm
+  "degrades gracefully" scenario still passes — it asserts only command-success + no leaf
+  docs, both still true; the repo now additionally renders a root index carrying the
+  advisory (the honest surface), which that scenario does not contradict.
+
+## Reconcile
+
+Implementation matches the spec design: each detector returns `absent | parsed |
+unreadable`; `discoverWorkspaces` unions the readable patterns and collects the unreadable
+set; `discoverLeafDirectories` is a thin wrapper (unchanged signature/behavior). The
+ZRW21K "never false-complete" property is preserved and extended one layer up — a manager
+that discovers nothing now leaves a discovery-layer marker instead of vanishing. No new
+detector module; reuses the existing glob-expand + `hasRecognizedManifest` + `Set`
+pipeline and the `toml.ts` table readers.

--- a/features/architecture-unreadable-workspace.feature
+++ b/features/architecture-unreadable-workspace.feature
@@ -1,0 +1,49 @@
+@architecture-unreadable-workspace
+Feature: A present-but-unparseable workspace manager is surfaced, not dropped
+
+  safeword unions every workspace manager when it builds the architecture map
+  (#554). But a manager whose root manifest is PRESENT yet unparseable — a
+  malformed go.work, an unreadable Cargo [workspace] members array, a flow-style
+  pnpm-workspace.yaml — used to contribute zero packages with no marker, so a
+  whole language could vanish silently. Coverage honesty: "incomplete is fine,
+  silently wrong is not." A present manager safeword cannot read must be named,
+  never dropped. Advisory only — it never blocks.
+
+  Rule: An unparseable manager is surfaced in the root index alongside the readable ones
+
+    @architecture-unreadable-workspace.UWP4XK.AC1
+    Scenario: A malformed go.work next to a working JS package is named, not dropped
+      Given a monorepo with a working JS package "web" and a malformed go.work
+      When safeword generates the architecture doc
+      Then the root index lists the package "web"
+      And the root index notes "go.work" as an unreadable workspace config
+
+    @architecture-unreadable-workspace.UWP4XK.AC2
+    Scenario: An unreadable Cargo [workspace] members array next to a Python package is named
+      Given a monorepo with a Python package "pytool" and a Cargo.toml whose [workspace] members are unreadable
+      When safeword generates the architecture doc
+      Then the root index lists the package "pytool"
+      And the root index notes "Cargo.toml" as an unreadable workspace config
+
+    @architecture-unreadable-workspace.UWP4XK.AC3
+    Scenario: A flow-style pnpm-workspace.yaml next to a Go module is named
+      Given a monorepo with a Go module "gosvc" and a flow-style pnpm-workspace.yaml
+      When safeword generates the architecture doc
+      Then the root index lists the package "gosvc"
+      And the root index notes "pnpm-workspace.yaml" as an unreadable workspace config
+
+  Rule: The surface is advisory and never a false alarm
+
+    @architecture-unreadable-workspace.UWP4XK.AC4
+    Scenario: The only-unparseable case is warned about without blocking the command
+      Given a project whose only workspace config is a malformed go.work
+      When safeword refreshes the architecture doc and captures its output
+      Then the command succeeds
+      And the output warns that "go.work" is an unreadable workspace config
+
+    @architecture-unreadable-workspace.UWP4XK.AC5
+    Scenario: A single crate with no [workspace] table raises no unreadable signal
+      Given a monorepo with a Go module "gosvc" and a single-crate Cargo.toml with no workspace table
+      When safeword generates the architecture doc
+      Then the root index lists the package "gosvc"
+      And the root index has no "Coverage gaps" advisory

--- a/packages/cli/src/commands/architecture.ts
+++ b/packages/cli/src/commands/architecture.ts
@@ -28,8 +28,9 @@ import {
   selfHealProject,
   type SelfHealResult,
 } from '../utils/architecture-document.js';
+import { discoverUnreadableWorkspaces } from '../utils/architecture-monorepo.js';
 import { isArchitectureDocumentEnforcementEnabled } from '../utils/configured-paths.js';
-import { error, success } from '../utils/output.js';
+import { error, success, warn } from '../utils/output.js';
 
 export function architecture(
   cwd: string = process.cwd(),
@@ -46,7 +47,24 @@ export function architecture(
   for (const result of results) {
     success(`Architecture state document ${result.action}: ${result.path}`);
   }
+  warnUnreadableWorkspaces(cwd);
   return Promise.resolve();
+}
+
+/**
+ * Print a non-blocking warning for each workspace manager that is present at the root but
+ * unparseable (ticket UWP4XK, GitHub #558) — a malformed `go.work`, an unreadable Cargo
+ * `[workspace] members`, a flow-style `pnpm-workspace.yaml`. Advisory only: it never
+ * changes a command's exit code. Surfaced in every mode (default/`--check`/`--stage`),
+ * independent of `architectureDocEnforcement`, because coverage honesty is not enforcement
+ * — the architecture map silently omitting a whole language is wrong regardless of opt-out.
+ */
+function warnUnreadableWorkspaces(cwd: string): void {
+  for (const workspace of discoverUnreadableWorkspaces(cwd)) {
+    warn(
+      `Workspace config present but unreadable: ${workspace.config} (${workspace.manager}). Its packages may be missing from the architecture doc — fix the config and re-run \`safeword architecture\`. (Advisory; nothing is blocked.)`,
+    );
+  }
 }
 
 /**
@@ -55,6 +73,7 @@ export function architecture(
  * — git failures are swallowed so the commit always proceeds.
  */
 function architectureStage(cwd: string): Promise<void> {
+  warnUnreadableWorkspaces(cwd);
   if (!isArchitectureDocumentEnforcementEnabled(cwd)) {
     success('Architecture doc enforcement is opted out (architectureDocEnforcement: false).');
     return Promise.resolve();
@@ -89,6 +108,7 @@ function stageDocument(cwd: string, result: SelfHealResult): void {
  * out. Writes nothing — the fix is the human running `safeword architecture`.
  */
 function architectureCheck(cwd: string): Promise<void> {
+  warnUnreadableWorkspaces(cwd);
   if (!isArchitectureDocumentEnforcementEnabled(cwd)) {
     success('Architecture doc enforcement is opted out (architectureDocEnforcement: false).');
     return Promise.resolve();

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -16,10 +16,12 @@ import nodePath from 'node:path';
 import { shapeFingerprint } from './architecture-fingerprint.js';
 import {
   discoverLeafDirectories,
+  discoverUnreadableWorkspaces,
   extractMonorepoModel,
   monorepoFingerprint,
   type MonorepoModel,
   type PackageNode,
+  type UnreadableWorkspace,
 } from './architecture-monorepo.js';
 import { reconcileSections, type SectionStatus } from './architecture-reconcile.js';
 import { extractSkeleton, type SkeletonNode } from './architecture-skeleton.js';
@@ -158,7 +160,10 @@ function rootIndexTarget(projectDirectory: string): HealTarget {
   return {
     path: resolveGeneratedArchitecturePath(projectDirectory),
     fingerprint,
-    hasContent: model.packages.length > 0,
+    // An unreadable workspace is content too: a root index that exists only to carry the
+    // "config unreadable" advisory is still worth writing — silence would read as "no
+    // monorepo here" when in fact one is present but unreadable (UWP4XK).
+    hasContent: model.packages.length > 0 || model.unreadableWorkspaces.length > 0,
     render: () => renderRootIndex(model, fingerprint),
   };
 }
@@ -166,7 +171,13 @@ function rootIndexTarget(projectDirectory: string): HealTarget {
 /** The targets a project heals: single-repo → one; monorepo → root index + per-leaf. */
 function projectTargets(projectDirectory: string): HealTarget[] {
   const leaves = discoverLeafDirectories(projectDirectory);
-  if (leaves.length === 0) return [singleRepoTarget(projectDirectory)];
+  // A repo whose ONLY workspace signal is an unparseable manager (zero discovered leaves)
+  // is still a monorepo we must not mistake for a single-repo: render the root index so the
+  // "config unreadable" advisory has a home, rather than silently emitting a single-repo doc
+  // that omits the whole declared-but-unreadable workspace (UWP4XK).
+  if (leaves.length === 0 && discoverUnreadableWorkspaces(projectDirectory).length === 0) {
+    return [singleRepoTarget(projectDirectory)];
+  }
   return [rootIndexTarget(projectDirectory), ...leaves.map(leaf => leafTarget(leaf))];
 }
 
@@ -367,7 +378,21 @@ function renderRootIndex(model: MonorepoModel, fingerprint: string): string {
   const dependencies =
     model.edges.length === 0 ? '_No inter-package dependencies._\n' : `${edgeLines}\n`;
 
-  return `---\n${GENERATOR_KEY}: ${GENERATOR_VALUE}\n${FINGERPRINT_KEY}: ${fingerprint}\n---\n\n# Architecture\n\n## Packages\n\n${sections}\n## Dependencies\n\n${dependencies}`;
+  return `---\n${GENERATOR_KEY}: ${GENERATOR_VALUE}\n${FINGERPRINT_KEY}: ${fingerprint}\n---\n\n# Architecture\n\n## Packages\n\n${sections}\n## Dependencies\n\n${dependencies}${renderCoverageGaps(model.unreadableWorkspaces)}`;
+}
+
+/**
+ * A `## Coverage gaps` advisory naming each workspace manager that is present at the root
+ * but unparseable (ticket UWP4XK, GitHub #558). Empty string when there are none, so the
+ * section appears only when it carries weight. This is the discovery-layer analogue of the
+ * per-package "not introspected" marker (ZRW21K): a manager that discovered nothing has no
+ * package line to mark, so the honesty signal lives here instead — the packages it would
+ * have contributed may be missing from the index above, and the index says so out loud.
+ */
+function renderCoverageGaps(unreadable: UnreadableWorkspace[]): string {
+  if (unreadable.length === 0) return '';
+  const items = unreadable.map(entry => `> - \`${entry.config}\` (${entry.manager})`).join('\n');
+  return `## Coverage gaps\n\n> ⚠ not introspected — workspace config unreadable. A present workspace manager's member list could not be parsed, so its packages may be missing above. Fix the config and re-run \`safeword architecture\`:\n${items}\n`;
 }
 
 function renderPackageSection(node: PackageNode, stamp: string): string {

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -16,11 +16,11 @@ import nodePath from 'node:path';
 
 import { extractSkeleton } from './architecture-skeleton.js';
 import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
-import { detectWorkspaces } from './depcruise-config.js';
 import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
+import { hasTomlTable } from './toml.js';
 
 /** Placeholder purpose for a freshly modelled package awaiting prose. */
 const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
@@ -56,34 +56,95 @@ interface PackageEdge {
   to: string;
 }
 
+/**
+ * A workspace manager that is PRESENT at the repo root but whose member list could
+ * not be parsed (a malformed `go.work`, an unreadable Cargo `[workspace] members`, a
+ * flow-style `pnpm-workspace.yaml`). Surfaced — never silently dropped (ticket UWP4XK,
+ * GitHub #558): a manager that discovered nothing has no per-package "not introspected"
+ * marker to carry (ZRW21K), so the honesty signal must live one layer up, at discovery.
+ */
+export interface UnreadableWorkspace {
+  /** Human-facing manager label, e.g. `go.work`, `Cargo [workspace]`, `pnpm workspaces`. */
+  manager: string;
+  /** The config file the unreadable declaration lives in, e.g. `go.work`, `Cargo.toml`. */
+  config: string;
+}
+
+/**
+ * One manager's detection outcome. The discriminator is what #558 adds: `undefined`
+ * used to mean BOTH "absent" and "present-but-unparseable", collapsing the honesty
+ * signal. Now `absent` carries no signal, `parsed` carries globs/dirs to expand, and
+ * `unreadable` carries the config to surface.
+ */
+type WorkspaceDetection =
+  | { status: 'absent' }
+  | { status: 'parsed'; patterns: string[] }
+  | { status: 'unreadable'; manager: string; config: string };
+
+const ABSENT: WorkspaceDetection = { status: 'absent' };
+
+/** Globs to expand plus the present-but-unparseable managers to surface. */
+export interface WorkspaceDiscovery {
+  patterns: string[];
+  unreadable: UnreadableWorkspace[];
+}
+
 export interface MonorepoModel {
   packages: PackageNode[];
   edges: PackageEdge[];
+  /** Managers present at the root but unparseable; surfaced in the root index + `--check`. */
+  unreadableWorkspaces: UnreadableWorkspace[];
+}
+
+/**
+ * Probe every workspace manager at the root, returning the globs to expand plus the
+ * managers that are PRESENT but unparseable (ticket UWP4XK, GitHub #558).
+ *
+ * Within JS, package.json `workspaces` wins over pnpm-workspace.yaml (pnpm ignores the
+ * package.json field, so a repo with both is npm-authoritative) — they are alternative
+ * managers for the same ecosystem, not additive. A package.json that is PRESENT (parsed
+ * or unparseable) still wins; only an absent one falls through to pnpm. Across ecosystems,
+ * managers are UNIONED: go.work, Cargo `[workspace]`, and uv `[tool.uv.workspace]` describe
+ * disjoint package sets (Go/Rust/Python dirs), so a polyglot monorepo declaring packages
+ * with more than one manager at once is fully discovered (ticket MGWZ4P). Crucially, one
+ * unparseable manager never blinds the readable ones: its globs simply don't contribute,
+ * and it is recorded in `unreadable` instead of vanishing.
+ */
+export function discoverWorkspaces(projectDirectory: string): WorkspaceDiscovery {
+  const detections = [
+    detectJsWorkspaces(projectDirectory),
+    detectGoWork(projectDirectory),
+    detectCargoWorkspace(projectDirectory),
+    detectUvWorkspace(projectDirectory),
+  ];
+  return {
+    patterns: detections.flatMap(detection =>
+      detection.status === 'parsed' ? detection.patterns : [],
+    ),
+    unreadable: detections.flatMap(detection =>
+      detection.status === 'unreadable'
+        ? [{ manager: detection.manager, config: detection.config }]
+        : [],
+    ),
+  };
 }
 
 /**
  * Absolute directories of the workspace leaf packages, sorted. Expands the
  * workspace globs from the manifest and keeps only directories that carry a
- * `package.json`. Returns `[]` for a non-workspace project.
+ * recognized manifest. Returns `[]` for a non-workspace project.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  // Within JS, package.json `workspaces` wins over pnpm-workspace.yaml (pnpm
-  // ignores the package.json field, so a repo with both is npm-authoritative) —
-  // they are alternative managers for the same ecosystem, not additive. Across
-  // ecosystems, managers are UNIONED: go.work, Cargo `[workspace]`, and uv
-  // `[tool.uv.workspace]` describe disjoint package sets (Go/Rust/Python dirs),
-  // so a polyglot monorepo declaring packages with more than one manager at once
-  // is fully discovered, never silently reduced to the first manager's packages
-  // (ticket MGWZ4P). Same-dir overlaps collapse in the leaf `Set` below.
-  const jsPatterns = detectWorkspaces(projectDirectory) ?? detectPnpmWorkspaces(projectDirectory);
-  const patterns = [
-    jsPatterns,
-    detectGoWork(projectDirectory),
-    detectCargoWorkspace(projectDirectory),
-    detectUvWorkspace(projectDirectory),
-  ]
-    .filter((group): group is string[] => group !== undefined)
-    .flat();
+  return resolveLeafDirectories(projectDirectory, discoverWorkspaces(projectDirectory).patterns);
+}
+
+/** The present-but-unparseable workspace managers at the root, if any (UWP4XK). */
+export function discoverUnreadableWorkspaces(projectDirectory: string): UnreadableWorkspace[] {
+  return discoverWorkspaces(projectDirectory).unreadable;
+}
+
+/** Expand the discovered patterns to leaf dirs (glob → keep recognized-manifest dirs, deduped). */
+function resolveLeafDirectories(projectDirectory: string, patterns: string[]): string[] {
   if (patterns.length === 0) return [];
 
   const matches = new Set<string>();
@@ -100,6 +161,45 @@ export function discoverLeafDirectories(projectDirectory: string): string[] {
   return [...matches].toSorted(byString);
 }
 
+/**
+ * JS workspace detection with precedence: package.json `workspaces` wins over
+ * pnpm-workspace.yaml when present (parsed OR unparseable), preserving ZRW21K's
+ * "package.json is authoritative" rule; only an absent package.json consults pnpm.
+ */
+function detectJsWorkspaces(projectDirectory: string): WorkspaceDetection {
+  const packageJson = detectPackageJsonWorkspaces(projectDirectory);
+  return packageJson.status === 'absent' ? detectPnpmWorkspaces(projectDirectory) : packageJson;
+}
+
+/**
+ * package.json `workspaces`: absent when the field is missing or an explicitly-empty list
+ * (a deliberate "no workspaces"); parsed when it is a non-empty `string[]` or
+ * `{ packages: string[] }`; unreadable when present in some other (malformed) shape.
+ */
+function detectPackageJsonWorkspaces(projectDirectory: string): WorkspaceDetection {
+  const workspaces = readManifest(projectDirectory)?.workspaces;
+  if (workspaces === undefined) return ABSENT;
+
+  const list = workspaceList(workspaces);
+  if (list === undefined) {
+    return { status: 'unreadable', manager: 'package.json workspaces', config: 'package.json' };
+  }
+  const patterns = list.filter((entry): entry is string => typeof entry === 'string');
+  // An explicitly-empty list is a deliberate "no workspaces", not an unparse — stay absent.
+  return patterns.length > 0 ? { status: 'parsed', patterns } : ABSENT;
+}
+
+/** The glob list of a package.json `workspaces` field — a bare array or `{ packages: [] }`. */
+function workspaceList(workspaces: unknown): unknown[] | undefined {
+  if (Array.isArray(workspaces)) return workspaces;
+  if (isObjectRecord(workspaces) && Array.isArray(workspaces.packages)) return workspaces.packages;
+  return undefined;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 /** A discovered directory is a leaf package if it carries a recognized manifest. */
 function hasRecognizedManifest(directory: string): boolean {
   return (
@@ -112,7 +212,8 @@ function hasRecognizedManifest(directory: string): boolean {
 
 /** The package/edge model the root index renders over. */
 export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
-  const packages: PackageNode[] = discoverLeafDirectories(projectDirectory)
+  const { patterns, unreadable } = discoverWorkspaces(projectDirectory);
+  const packages: PackageNode[] = resolveLeafDirectories(projectDirectory, patterns)
     .map(dir => ({
       name: packageName(dir),
       dir,
@@ -132,7 +233,7 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
   }
   edges.sort((a, b) => byString(a.from, b.from) || byString(a.to, b.to));
 
-  return { packages, edges };
+  return { packages, edges, unreadableWorkspaces: unreadable };
 }
 
 /**
@@ -148,6 +249,12 @@ export function monorepoFingerprint(projectDirectory: string): string {
     packages: model.packages.map(node => `${node.name}:${node.introspected}`),
     edges: model.edges.map(edge => `${edge.from}->${edge.to}`),
     boundaryConfig: readBoundaryConfig(projectDirectory),
+    // The unreadable-workspace advisory is root shape too: it must re-render when an
+    // unparseable config appears or is fixed. Contributed ONLY when non-empty, so a
+    // repo with no unreadable config keeps its existing fingerprint — no churn (UWP4XK).
+    ...(model.unreadableWorkspaces.length > 0 && {
+      unreadable: model.unreadableWorkspaces.map(entry => `${entry.manager}:${entry.config}`),
+    }),
   };
   return createHash('sha256').update(JSON.stringify(inputs)).digest('hex');
 }
@@ -194,13 +301,19 @@ function readPyprojectCrateName(packageDirectory: string): string | undefined {
 
 /**
  * Read workspace member globs from a `pyproject.toml` `[tool.uv.workspace] members`
- * array (ticket HWSEPV) — uv stores its workspace list here. Returns the path globs, or
- * `undefined` when the file is absent or has no uv-workspace table (so a single Python
- * package, or a non-uv pyproject, degrades to no-workspaces).
+ * array (ticket HWSEPV) — uv stores its workspace list here. `absent` when the file or the
+ * uv-workspace table is missing (a single Python package, or a non-uv pyproject); `parsed`
+ * with the globs when readable; `unreadable` when the table is PRESENT but `members` can't
+ * be parsed (UWP4XK) — surfaced, not silently empty.
  */
-function detectUvWorkspace(projectDirectory: string): string[] | undefined {
+function detectUvWorkspace(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'pyproject.toml'));
-  return content === undefined ? undefined : readUvWorkspaceMembers(content);
+  if (content === undefined) return ABSENT; // no pyproject.toml
+  if (!hasTomlTable(content, 'tool.uv.workspace')) return ABSENT; // a non-uv pyproject
+  const members = readUvWorkspaceMembers(content);
+  return members === undefined
+    ? { status: 'unreadable', manager: 'uv workspace', config: 'pyproject.toml' }
+    : { status: 'parsed', patterns: members };
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -226,21 +339,22 @@ function readBoundaryConfig(projectDirectory: string): string {
  *     - "packages/*"
  *     - "apps/*"
  *
- * Returns the include globs (quotes stripped, `!`-exclusions skipped), or
- * `undefined` when the file is absent or not in the block-list form (flow-style
- * `packages: [..]` and other shapes are out of scope and degrade to no-workspaces
- * — incomplete, never silently wrong).
+ * `absent` when the file is missing; `parsed` with the include globs (quotes stripped,
+ * `!`-exclusions skipped) for the block-list form; `unreadable` when the file is PRESENT
+ * but no package glob parses (flow-style `packages: [..]`, an empty list, or other shapes
+ * out of scope) — the file's existence IS a workspace declaration, so an unparseable one
+ * is surfaced, never silently empty (UWP4XK).
  */
-function detectPnpmWorkspaces(projectDirectory: string): string[] | undefined {
+function detectPnpmWorkspaces(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'));
-  if (content === undefined) return undefined;
+  if (content === undefined) return ABSENT;
 
   const lines = content.split(/\r?\n/);
   const start = lines.findIndex(line => /^packages:\s*$/.test(line));
-  if (start === -1) return undefined;
-
-  const globs = collectPnpmGlobs(lines.slice(start + 1));
-  return globs.length > 0 ? globs : undefined;
+  const globs = start === -1 ? [] : collectPnpmGlobs(lines.slice(start + 1));
+  return globs.length > 0
+    ? { status: 'parsed', patterns: globs }
+    : { status: 'unreadable', manager: 'pnpm workspaces', config: 'pnpm-workspace.yaml' };
 }
 
 /** Collect the include globs from a pnpm `packages:` block, stopping at the dedent. */
@@ -268,21 +382,24 @@ function collectPnpmGlobs(blockLines: string[]): string[] {
  *       ./gateway
  *   )
  *
- * Returns the member directories (leading `./` stripped, quotes removed), or
- * `undefined` when the file is absent or no `use` target parses. An entry that is
- * not a clean relative path (e.g. junk, or a multi-token line) is skipped, not
- * fatal — a single unreadable entry never blinds the rest (incomplete, never
- * silently wrong).
+ * Returns the member directories (leading `./` stripped, quotes removed) as `parsed`. An
+ * entry that is not a clean relative path (e.g. junk, or a multi-token line) is skipped,
+ * not fatal — a single unreadable entry never blinds the rest. `absent` when the file is
+ * missing; `unreadable` when the go.work is PRESENT but NO `use` target parses (a malformed
+ * file) — surfaced, not silently empty (UWP4XK). A go.work exists to declare a workspace,
+ * so one that yields zero members is worth naming.
  */
-function detectGoWork(projectDirectory: string): string[] | undefined {
+function detectGoWork(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'go.work'));
-  if (content === undefined) return undefined;
+  if (content === undefined) return ABSENT;
 
   const lines = content.split(/\r?\n/);
   const directories: string[] = [];
   collectGoWorkBlock(lines, directories);
   collectGoWorkSingleLines(lines, directories);
-  return directories.length > 0 ? directories : undefined;
+  return directories.length > 0
+    ? { status: 'parsed', patterns: directories }
+    : { status: 'unreadable', manager: 'go.work', config: 'go.work' };
 }
 
 /** Member directories from a `use (\n  ./x\n)` block, stopping at the closing paren. */
@@ -316,11 +433,17 @@ function normalizeUseTarget(raw: string): string | undefined {
 
 /**
  * Read workspace member globs from a `Cargo.toml` `[workspace] members` array (ticket
- * YKFA5X) — Cargo stores its workspace list here, not in package.json. Returns the
- * path globs, or `undefined` when the file is absent or has no parseable members
- * array (so a single crate, or an unparseable manifest, degrades to no-workspaces).
+ * YKFA5X) — Cargo stores its workspace list here, not in package.json. `absent` when the
+ * file or the `[workspace]` table is missing (a single crate); `parsed` with the globs when
+ * readable; `unreadable` when the `[workspace]` table is PRESENT but `members` can't be
+ * parsed (UWP4XK) — surfaced, not silently empty.
  */
-function detectCargoWorkspace(projectDirectory: string): string[] | undefined {
+function detectCargoWorkspace(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'Cargo.toml'));
-  return content === undefined ? undefined : readCargoWorkspaceMembers(content);
+  if (content === undefined) return ABSENT; // no Cargo.toml
+  if (!hasTomlTable(content, 'workspace')) return ABSENT; // a single crate, not a workspace
+  const members = readCargoWorkspaceMembers(content);
+  return members === undefined
+    ? { status: 'unreadable', manager: 'Cargo [workspace]', config: 'Cargo.toml' }
+    : { status: 'parsed', patterns: members };
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -20,7 +20,7 @@ import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
-import { hasTomlTable } from './toml.js';
+import { hasTomlTable, hasTomlTableKey } from './toml.js';
 
 /** Placeholder purpose for a freshly modelled package awaiting prose. */
 const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
@@ -339,17 +339,23 @@ function readBoundaryConfig(projectDirectory: string): string {
  *     - "packages/*"
  *     - "apps/*"
  *
- * `absent` when the file is missing; `parsed` with the include globs (quotes stripped,
- * `!`-exclusions skipped) for the block-list form; `unreadable` when the file is PRESENT
- * but no package glob parses (flow-style `packages: [..]`, an empty list, or other shapes
- * out of scope) — the file's existence IS a workspace declaration, so an unparseable one
- * is surfaced, never silently empty (UWP4XK).
+ * `absent` when the file is missing OR has no top-level `packages:` key at all (a
+ * catalog-only / settings-only `pnpm-workspace.yaml` is valid and declares no members —
+ * out of scope, not a coverage gap); `parsed` with the include globs (quotes stripped,
+ * `!`-exclusions skipped) for the block-list form; `unreadable` only when a `packages:` key
+ * IS present but no glob parses (flow-style `packages: [..]`, an empty block, or other
+ * shapes out of scope) — a present-but-unparseable member list, surfaced not silently empty
+ * (UWP4XK).
  */
 function detectPnpmWorkspaces(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'));
   if (content === undefined) return ABSENT;
 
   const lines = content.split(/\r?\n/);
+  // A top-level `packages:` key (block `packages:` or flow `packages: [..]`) is the member
+  // declaration; without it the file declares no members (catalog-only) → absent.
+  if (lines.every(line => !line.startsWith('packages:'))) return ABSENT;
+
   const start = lines.findIndex(line => /^packages:\s*$/.test(line));
   const globs = start === -1 ? [] : collectPnpmGlobs(lines.slice(start + 1));
   return globs.length > 0
@@ -385,9 +391,10 @@ function collectPnpmGlobs(blockLines: string[]): string[] {
  * Returns the member directories (leading `./` stripped, quotes removed) as `parsed`. An
  * entry that is not a clean relative path (e.g. junk, or a multi-token line) is skipped,
  * not fatal — a single unreadable entry never blinds the rest. `absent` when the file is
- * missing; `unreadable` when the go.work is PRESENT but NO `use` target parses (a malformed
- * file) — surfaced, not silently empty (UWP4XK). A go.work exists to declare a workspace,
- * so one that yields zero members is worth naming.
+ * missing OR has no `use` directive at all (a freshly `go work init`-ed file with no
+ * modules yet declares no members — out of scope, not a coverage gap); `unreadable` only
+ * when a `use` directive IS present but no target parses (a malformed file) — a
+ * present-but-unparseable member list, surfaced not silently empty (UWP4XK).
  */
 function detectGoWork(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'go.work'));
@@ -397,9 +404,12 @@ function detectGoWork(projectDirectory: string): WorkspaceDetection {
   const directories: string[] = [];
   collectGoWorkBlock(lines, directories);
   collectGoWorkSingleLines(lines, directories);
-  return directories.length > 0
-    ? { status: 'parsed', patterns: directories }
-    : { status: 'unreadable', manager: 'go.work', config: 'go.work' };
+  if (directories.length > 0) return { status: 'parsed', patterns: directories };
+  // No member dir parsed: a malformed `use` (present but junk) is unreadable; a go.work
+  // with no `use` directive at all declares no members and stays absent.
+  return lines.some(line => /^\s*use\b/.test(line))
+    ? { status: 'unreadable', manager: 'go.work', config: 'go.work' }
+    : ABSENT;
 }
 
 /** Member directories from a `use (\n  ./x\n)` block, stopping at the closing paren. */
@@ -434,14 +444,17 @@ function normalizeUseTarget(raw: string): string | undefined {
 /**
  * Read workspace member globs from a `Cargo.toml` `[workspace] members` array (ticket
  * YKFA5X) — Cargo stores its workspace list here, not in package.json. `absent` when the
- * file or the `[workspace]` table is missing (a single crate); `parsed` with the globs when
- * readable; `unreadable` when the `[workspace]` table is PRESENT but `members` can't be
- * parsed (UWP4XK) — surfaced, not silently empty.
+ * file, the `[workspace]` table, or the `members` key is missing; `parsed` with the globs
+ * when readable; `unreadable` only when `members` is PRESENT but can't be parsed (UWP4XK).
+ * A `[workspace]` with NO `members` key is a valid root-package workspace that
+ * auto-discovers members from path deps (or lists `default-members`) — out of scope like
+ * nested workspaces, NOT a coverage gap, so it stays `absent` rather than false-alarming.
  */
 function detectCargoWorkspace(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'Cargo.toml'));
   if (content === undefined) return ABSENT; // no Cargo.toml
   if (!hasTomlTable(content, 'workspace')) return ABSENT; // a single crate, not a workspace
+  if (!hasTomlTableKey(content, 'workspace', 'members')) return ABSENT; // auto-discovery, out of scope
   const members = readCargoWorkspaceMembers(content);
   return members === undefined
     ? { status: 'unreadable', manager: 'Cargo [workspace]', config: 'Cargo.toml' }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -83,6 +83,16 @@ type WorkspaceDetection =
 
 const ABSENT: WorkspaceDetection = { status: 'absent' };
 
+/** A workspace whose member globs/dirs were read. */
+const parsed = (patterns: string[]): WorkspaceDetection => ({ status: 'parsed', patterns });
+
+/** A workspace declared at `config` (by `manager`) whose member list could not be parsed. */
+const unreadable = (manager: string, config: string): WorkspaceDetection => ({
+  status: 'unreadable',
+  manager,
+  config,
+});
+
 /** Globs to expand plus the present-but-unparseable managers to surface. */
 export interface WorkspaceDiscovery {
   patterns: string[];
@@ -181,12 +191,10 @@ function detectPackageJsonWorkspaces(projectDirectory: string): WorkspaceDetecti
   if (workspaces === undefined) return ABSENT;
 
   const list = workspaceList(workspaces);
-  if (list === undefined) {
-    return { status: 'unreadable', manager: 'package.json workspaces', config: 'package.json' };
-  }
+  if (list === undefined) return unreadable('package.json workspaces', 'package.json');
   const patterns = list.filter((entry): entry is string => typeof entry === 'string');
   // An explicitly-empty list is a deliberate "no workspaces", not an unparse — stay absent.
-  return patterns.length > 0 ? { status: 'parsed', patterns } : ABSENT;
+  return patterns.length > 0 ? parsed(patterns) : ABSENT;
 }
 
 /** The glob list of a package.json `workspaces` field — a bare array or `{ packages: [] }`. */
@@ -212,7 +220,7 @@ function hasRecognizedManifest(directory: string): boolean {
 
 /** The package/edge model the root index renders over. */
 export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
-  const { patterns, unreadable } = discoverWorkspaces(projectDirectory);
+  const { patterns, unreadable: unreadableWorkspaces } = discoverWorkspaces(projectDirectory);
   const packages: PackageNode[] = resolveLeafDirectories(projectDirectory, patterns)
     .map(dir => ({
       name: packageName(dir),
@@ -233,7 +241,7 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
   }
   edges.sort((a, b) => byString(a.from, b.from) || byString(a.to, b.to));
 
-  return { packages, edges, unreadableWorkspaces: unreadable };
+  return { packages, edges, unreadableWorkspaces };
 }
 
 /**
@@ -311,9 +319,7 @@ function detectUvWorkspace(projectDirectory: string): WorkspaceDetection {
   if (content === undefined) return ABSENT; // no pyproject.toml
   if (!hasTomlTable(content, 'tool.uv.workspace')) return ABSENT; // a non-uv pyproject
   const members = readUvWorkspaceMembers(content);
-  return members === undefined
-    ? { status: 'unreadable', manager: 'uv workspace', config: 'pyproject.toml' }
-    : { status: 'parsed', patterns: members };
+  return members === undefined ? unreadable('uv workspace', 'pyproject.toml') : parsed(members);
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -358,9 +364,7 @@ function detectPnpmWorkspaces(projectDirectory: string): WorkspaceDetection {
 
   const start = lines.findIndex(line => /^packages:\s*$/.test(line));
   const globs = start === -1 ? [] : collectPnpmGlobs(lines.slice(start + 1));
-  return globs.length > 0
-    ? { status: 'parsed', patterns: globs }
-    : { status: 'unreadable', manager: 'pnpm workspaces', config: 'pnpm-workspace.yaml' };
+  return globs.length > 0 ? parsed(globs) : unreadable('pnpm workspaces', 'pnpm-workspace.yaml');
 }
 
 /** Collect the include globs from a pnpm `packages:` block, stopping at the dedent. */
@@ -404,12 +408,10 @@ function detectGoWork(projectDirectory: string): WorkspaceDetection {
   const directories: string[] = [];
   collectGoWorkBlock(lines, directories);
   collectGoWorkSingleLines(lines, directories);
-  if (directories.length > 0) return { status: 'parsed', patterns: directories };
+  if (directories.length > 0) return parsed(directories);
   // No member dir parsed: a malformed `use` (present but junk) is unreadable; a go.work
   // with no `use` directive at all declares no members and stays absent.
-  return lines.some(line => /^\s*use\b/.test(line))
-    ? { status: 'unreadable', manager: 'go.work', config: 'go.work' }
-    : ABSENT;
+  return lines.some(line => /^\s*use\b/.test(line)) ? unreadable('go.work', 'go.work') : ABSENT;
 }
 
 /** Member directories from a `use (\n  ./x\n)` block, stopping at the closing paren. */
@@ -456,7 +458,5 @@ function detectCargoWorkspace(projectDirectory: string): WorkspaceDetection {
   if (!hasTomlTable(content, 'workspace')) return ABSENT; // a single crate, not a workspace
   if (!hasTomlTableKey(content, 'workspace', 'members')) return ABSENT; // auto-discovery, out of scope
   const members = readCargoWorkspaceMembers(content);
-  return members === undefined
-    ? { status: 'unreadable', manager: 'Cargo [workspace]', config: 'Cargo.toml' }
-    : { status: 'parsed', patterns: members };
+  return members === undefined ? unreadable('Cargo [workspace]', 'Cargo.toml') : parsed(members);
 }

--- a/packages/cli/src/utils/toml.ts
+++ b/packages/cli/src/utils/toml.ts
@@ -28,6 +28,17 @@ export function readTomlTableArray(
   return values.length > 0 ? values : undefined;
 }
 
+/**
+ * Whether `content` declares a `[<table>]` (or `[[<table>]]`) header. Comment-aware
+ * (a header inside a `#` comment does not count) and table-scoped (exact name). Lets a
+ * caller tell "the table is absent" from "the table is present but its key is
+ * unparseable" — `readTomlTableArray` returns `undefined` for both, so this distinguishes
+ * a single crate (no `[workspace]`) from a workspace whose `members` could not be read.
+ */
+export function hasTomlTable(content: string, table: string): boolean {
+  return content.split(/\r?\n/).some(line => tableHeader(stripTomlComment(line).trim()) === table);
+}
+
 /** The string value of `[<table>] <key> = "…"`, or `undefined`. Table-scoped. */
 export function readTomlTableString(
   content: string,

--- a/packages/cli/src/utils/toml.ts
+++ b/packages/cli/src/utils/toml.ts
@@ -39,6 +39,29 @@ export function hasTomlTable(content: string, table: string): boolean {
   return content.split(/\r?\n/).some(line => tableHeader(stripTomlComment(line).trim()) === table);
 }
 
+/**
+ * Whether `[<table>]` declares `<key> = …` (any value, parseable or not). Comment-aware,
+ * table-scoped. Lets a caller tell "the key is absent" from "the key is present but its
+ * value is unparseable" — `readTomlTableArray` returns `undefined` for both, so this
+ * separates a workspace whose `members` list can't be read (surface it) from one with no
+ * `members` key at all (a Cargo root-package workspace that auto-discovers members from
+ * path deps — valid, out of scope, not a coverage gap).
+ */
+export function hasTomlTableKey(content: string, table: string, key: string): boolean {
+  let inTable = false;
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = stripTomlComment(rawLine).trim();
+    if (line === '') continue;
+    const header = tableHeader(line);
+    if (header !== undefined) {
+      inTable = header === table;
+      continue;
+    }
+    if (inTable && tableValue(line, key) !== undefined) return true;
+  }
+  return false;
+}
+
 /** The string value of `[<table>] <key> = "…"`, or `undefined`. Table-scoped. */
 export function readTomlTableString(
   content: string,

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -658,6 +658,37 @@ describe('discoverWorkspaces — present-but-unparseable managers are surfaced (
     expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
   });
 
+  it('U9 — a Cargo [workspace] with no members key (auto-discovery) is absent, not unreadable', () => {
+    // A root-package workspace using default-members / path-dep auto-discovery is VALID —
+    // `members` is optional. It must not false-alarm as "unreadable" (quality-review).
+    clearRootManifest(context.directory);
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[package]\nname = "root"\n\n[workspace]\ndefault-members = ["crates/a"]\n',
+    );
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
+  it('U10 — a catalog-only pnpm-workspace.yaml (no packages key) is absent, not unreadable', () => {
+    // `packages:` is optional in pnpm-workspace.yaml; a catalog-only file is valid and
+    // declares no members — must not false-alarm (quality-review).
+    writeManifest(context.directory, { name: 'root' }); // no package.json workspaces
+    writeFileSync(
+      nodePath.join(context.directory, 'pnpm-workspace.yaml'),
+      'catalog:\n  react: ^19.0.0\n',
+    );
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
+  it('U11 — a go.work with no use directive (fresh init) is absent, not unreadable', () => {
+    clearRootManifest(context.directory);
+    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n');
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
   it('exposes the unreadable set on the monorepo model', () => {
     makePackage(context.directory, 'web', { modules: ['ui'] });
     writeFileSync(

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   discoverLeafDirectories,
+  discoverUnreadableWorkspaces,
+  discoverWorkspaces,
   extractMonorepoModel,
   monorepoFingerprint,
 } from '../../src/utils/architecture-monorepo.js';
@@ -565,6 +567,133 @@ describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
     expect(discoverLeafDirectories(context.directory)).toEqual([
       nodePath.join(context.directory, 'packages', 'web'),
     ]);
+  });
+});
+
+describe('discoverWorkspaces — present-but-unparseable managers are surfaced (ticket UWP4XK)', () => {
+  function clearRootManifest(root: string): void {
+    rmSync(nodePath.join(root, 'package.json'), { force: true });
+  }
+  function configsOf(root: string): string[] {
+    return discoverUnreadableWorkspaces(root).map(entry => entry.config);
+  }
+
+  it('U1 — a malformed go.work (no parseable use target) is unreadable, not absent', () => {
+    clearRootManifest(context.directory);
+    writeFileSync(
+      nodePath.join(context.directory, 'go.work'),
+      'go 1.22\n\nuse (\n\t@@@ not a path @@@\n)\n',
+    );
+
+    const discovery = discoverWorkspaces(context.directory);
+
+    expect(discovery.patterns).toEqual([]);
+    expect(discovery.unreadable).toEqual([{ manager: 'go.work', config: 'go.work' }]);
+  });
+
+  it('U2 — a [workspace] table with an unparseable members value is unreadable', () => {
+    clearRootManifest(context.directory);
+    // `members` is a string, not an array — present table, unparseable member list.
+    writeFileSync(
+      nodePath.join(context.directory, 'Cargo.toml'),
+      '[workspace]\nmembers = "crates/*"\n',
+    );
+
+    expect(configsOf(context.directory)).toEqual(['Cargo.toml']);
+  });
+
+  it('U3 — a [tool.uv.workspace] table with an unparseable members value is unreadable', () => {
+    clearRootManifest(context.directory);
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = "packages/*"\n',
+    );
+
+    expect(configsOf(context.directory)).toEqual(['pyproject.toml']);
+  });
+
+  it('U4 — a flow-style pnpm-workspace.yaml is unreadable', () => {
+    writeManifest(context.directory, { name: 'root' }); // no package.json `workspaces`
+    writeFileSync(
+      nodePath.join(context.directory, 'pnpm-workspace.yaml'),
+      'packages: ["packages/*"]\n', // flow style — unparseable by the block-list reader
+    );
+
+    expect(configsOf(context.directory)).toEqual(['pnpm-workspace.yaml']);
+  });
+
+  it('U5 — a package.json workspaces field of the wrong shape is unreadable', () => {
+    writeManifest(context.directory, { name: 'root', workspaces: 'packages/*' }); // string, not array
+
+    expect(configsOf(context.directory)).toEqual(['package.json']);
+  });
+
+  it('U6 — a malformed manager never blinds the readable ones (readable side intact)', () => {
+    // package.json workspaces (packages/*) from beforeEach stays readable; go.work malformed.
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    writeFileSync(
+      nodePath.join(context.directory, 'go.work'),
+      'go 1.22\n\nuse @@@ not a path @@@\n',
+    );
+
+    const discovery = discoverWorkspaces(context.directory);
+
+    expect(discovery.patterns).toContain('packages/*');
+    expect(discovery.unreadable).toEqual([{ manager: 'go.work', config: 'go.work' }]);
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+    ]);
+  });
+
+  it('U7 — a single-crate Cargo.toml with no [workspace] table raises no signal (absent)', () => {
+    clearRootManifest(context.directory);
+    writeFileSync(nodePath.join(context.directory, 'Cargo.toml'), '[package]\nname = "solo"\n');
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
+  it('U8 — an explicitly-empty package.json workspaces array is absent, not unreadable', () => {
+    writeManifest(context.directory, { name: 'root', workspaces: [] });
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
+  it('exposes the unreadable set on the monorepo model', () => {
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    writeFileSync(
+      nodePath.join(context.directory, 'go.work'),
+      'go 1.22\n\nuse @@@ not a path @@@\n',
+    );
+
+    const model = extractMonorepoModel(context.directory);
+
+    expect(model.packages.map(node => node.name)).toEqual(['web']);
+    expect(model.unreadableWorkspaces).toEqual([{ manager: 'go.work', config: 'go.work' }]);
+  });
+});
+
+describe('monorepoFingerprint — the unreadable-workspace set is part of the root shape (UWP4XK)', () => {
+  it('moves when a present-but-unparseable manager appears, so the advisory re-renders', () => {
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    const before = monorepoFingerprint(context.directory);
+
+    writeFileSync(
+      nodePath.join(context.directory, 'go.work'),
+      'go 1.22\n\nuse @@@ not a path @@@\n',
+    );
+    const after = monorepoFingerprint(context.directory);
+
+    expect(after).not.toBe(before);
+  });
+
+  it('does NOT move for a repo with no unreadable config (no churn vs the prior hash inputs)', () => {
+    // Two readable-only repos with identical shape hash identically — the unreadable key is
+    // contributed only when non-empty, so a clean repo is never re-fingerprinted by UWP4XK.
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    const first = monorepoFingerprint(context.directory);
+    const second = monorepoFingerprint(context.directory);
+
+    expect(second).toBe(first);
   });
 });
 

--- a/steps/architecture-unreadable-workspace.steps.ts
+++ b/steps/architecture-unreadable-workspace.steps.ts
@@ -1,0 +1,146 @@
+/**
+ * Acceptance-lane steps for present-but-unparseable workspace managers (ticket
+ * UWP4XK, GitHub #558). Black-box: builds fixtures where one workspace manager's
+ * root manifest is PRESENT but unparseable (a malformed go.work, an unreadable
+ * Cargo [workspace] members, a flow-style pnpm-workspace.yaml), drives the real
+ * `safeword architecture` CLI, and asserts the unreadable config is SURFACED — in
+ * the rendered root index and in the command output — not silently dropped. Reuses
+ * the shared `root index lists the package` / `command succeeds` Thens from
+ * monorepo-coverage-honesty.steps.ts (cucumber registers steps globally).
+ */
+
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { Given, Then, When } from '@cucumber/cucumber';
+
+import {
+  type ArchitectureWorld,
+  CLI_PATH,
+  rootDoc,
+  worldDir as dir,
+  writeJson,
+} from './support/architecture-fixtures.ts';
+
+/** A malformed go.work: a `use` directive whose target is multi-token junk (no member dir). */
+const MALFORMED_GO_WORK = 'go 1.22\n\nuse @@@ not a path @@@\n';
+
+function writeFile(world: ArchitectureWorld, relativePath: string, content: string): void {
+  const absolute = nodePath.join(dir(world), relativePath);
+  mkdirSync(nodePath.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+}
+
+/** A JS workspace package under packages/<name> with a src tree (a working manager). */
+function makeJsPackage(world: ArchitectureWorld, name: string): void {
+  writeJson(nodePath.join(dir(world), 'packages', name, 'package.json'), { name });
+  mkdirSync(nodePath.join(dir(world), 'packages', name, 'src', 'ui'), { recursive: true });
+}
+
+/** A Go module at <relativeDir> named <name>, with a src layout. */
+function makeGoModule(world: ArchitectureWorld, relativeDir: string, name: string): void {
+  writeFile(world, nodePath.join(relativeDir, 'go.mod'), `module ${name}\n\ngo 1.22\n`);
+  mkdirSync(nodePath.join(dir(world), relativeDir, 'cmd', name), { recursive: true });
+}
+
+/** A Python package at <relativeDir> named <name> with a src tree (a uv workspace member). */
+function makePythonPackage(world: ArchitectureWorld, relativeDir: string, name: string): void {
+  writeFile(world, nodePath.join(relativeDir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
+  mkdirSync(nodePath.join(dir(world), relativeDir, 'src', name), { recursive: true });
+}
+
+// --- Givens ---
+
+Given(
+  /^a monorepo with a working JS package "([^"]+)" and a malformed go\.work$/,
+  function (this: ArchitectureWorld, jsName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    makeJsPackage(this, jsName);
+    writeFile(this, 'go.work', MALFORMED_GO_WORK);
+  },
+);
+
+Given(
+  /^a monorepo with a Python package "([^"]+)" and a Cargo\.toml whose \[workspace\] members are unreadable$/,
+  function (this: ArchitectureWorld, pyName: string) {
+    // uv is the working manager; Cargo declares a [workspace] but `members` is a string,
+    // not an array — present table, unparseable member list.
+    writeFile(this, 'pyproject.toml', `[tool.uv.workspace]\nmembers = ["pkgs/${pyName}"]\n`);
+    makePythonPackage(this, nodePath.join('pkgs', pyName), pyName);
+    writeFile(this, 'Cargo.toml', '[workspace]\nmembers = "crates/*"\n');
+  },
+);
+
+Given(
+  /^a monorepo with a Go module "([^"]+)" and a flow-style pnpm-workspace\.yaml$/,
+  function (this: ArchitectureWorld, goName: string) {
+    // go.work is the working manager; package.json has no `workspaces`, so the flow-style
+    // pnpm-workspace.yaml is consulted and surfaces as unreadable.
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writeFile(this, 'go.work', `go 1.22\n\nuse ./services/${goName}\n`);
+    makeGoModule(this, nodePath.join('services', goName), goName);
+    writeFile(this, 'pnpm-workspace.yaml', 'packages: ["packages/*"]\n');
+  },
+);
+
+Given(
+  'a project whose only workspace config is a malformed go.work',
+  function (this: ArchitectureWorld) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'solo' });
+    writeFile(this, 'go.work', MALFORMED_GO_WORK);
+  },
+);
+
+Given(
+  /^a monorepo with a Go module "([^"]+)" and a single-crate Cargo\.toml with no workspace table$/,
+  function (this: ArchitectureWorld, goName: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writeFile(this, 'go.work', `go 1.22\n\nuse ./services/${goName}\n`);
+    makeGoModule(this, nodePath.join('services', goName), goName);
+    writeFile(this, 'Cargo.toml', '[package]\nname = "solo"\n'); // no [workspace] → absent
+  },
+);
+
+// --- When (output-capturing variant; the silent one lives in monorepo-coverage-honesty) ---
+
+When(
+  'safeword refreshes the architecture doc and captures its output',
+  function (this: ArchitectureWorld) {
+    const result = spawnSync('bun', [CLI_PATH, 'architecture'], {
+      cwd: dir(this),
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    this.status = result.status ?? 1;
+    this.output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  },
+);
+
+// --- Thens ---
+
+Then(
+  /^the root index notes "([^"]+)" as an unreadable workspace config$/,
+  function (this: ArchitectureWorld, config: string) {
+    const doc = rootDoc(this);
+    assert.match(doc, /^## Coverage gaps/m, 'root index has no "Coverage gaps" advisory');
+    assert.ok(doc.includes(config), `Coverage gaps advisory does not name ${config}`);
+  },
+);
+
+Then(
+  /^the output warns that "([^"]+)" is an unreadable workspace config$/,
+  function (this: ArchitectureWorld, config: string) {
+    const output = this.output ?? '';
+    assert.match(output, /unreadable/i, 'output carries no unreadable-workspace warning');
+    assert.ok(output.includes(config), `warning does not name ${config}`);
+  },
+);
+
+Then('the root index has no "Coverage gaps" advisory', function (this: ArchitectureWorld) {
+  assert.doesNotMatch(rootDoc(this), /^## Coverage gaps/m, 'unexpected "Coverage gaps" advisory');
+});

--- a/steps/support/architecture-fixtures.ts
+++ b/steps/support/architecture-fixtures.ts
@@ -21,6 +21,8 @@ export const CLI_PATH = nodePath.join(PROJECT_ROOT, 'packages/cli/src/cli.ts');
 export interface ArchitectureWorld extends SafewordWorld {
   dir?: string;
   status?: number;
+  /** Combined stdout+stderr of the last CLI run, when a step captures it. */
+  output?: string;
 }
 
 /** The scenario's temp project directory, created on first use. */


### PR DESCRIPTION
Closes #558.

## Problem

`discoverLeafDirectories` unions all workspace managers (#554), but each detector returned `string[] | undefined`, where `undefined` meant **both "absent" and "present-but-unparseable."** A malformed `go.work`, an unreadable Cargo `[workspace] members`, or a flow-style `pnpm-workspace.yaml` returned `undefined`, was filtered out, and contributed **zero packages with no marker** — so a whole language could vanish from the map at the *discovery* layer, before the ZRW21K per-package "not introspected" marker could fire (a manager that discovered nothing has nothing to mark).

This is the same class of silent omission #554 fixed, one layer up. Coverage honesty: "incomplete is fine, silently wrong is not."

## Change

Each detector now returns a discriminated outcome instead of `string[] | undefined`:

- `absent` — no workspace declared (no signal)
- `parsed` — globs/dirs to expand (today's path)
- `unreadable` — a workspace is declared but its member list can't be parsed (carries the manager label + config file)

The unreadable set is surfaced **advisory-only**, never blocking:

- a `## Coverage gaps` section in the generated **root index** naming each unreadable config;
- a non-blocking warning from `safeword architecture` / `architecture --check` (covers the case where the *only* manager is unreadable, so no root index renders).

It is folded into `monorepoFingerprint` **only when non-empty**, so a repo with no unreadable config (including this one) keeps its existing fingerprint — zero dogfood churn.

### Absent vs present-but-unparseable, per manager

- **go.work** — present but zero `use` targets parse.
- **Cargo `[workspace]`** — `[workspace]` table present but `members` unparseable (no table ⇒ a single crate ⇒ absent).
- **uv** — `[tool.uv.workspace]` present but `members` unparseable (no table ⇒ absent).
- **pnpm** — `pnpm-workspace.yaml` present but no package glob parses (flow-style/empty).
- **package.json** — `workspaces` present in a malformed shape ⇒ unreadable; an explicitly-empty array ⇒ absent (deliberate). JS precedence (package.json over pnpm) preserved.

Reuses the existing union+dedupe discovery pipeline and the `toml.ts` table readers (new `hasTomlTable` helper). **No new detector module, no blocking gate.**

## Tests

- 11 new unit tests in `tests/utils/architecture-monorepo.test.ts` (U1–U9 + model + no-churn) pinning each manager's absent/parsed/unreadable outcomes, the "readable side never blinded" property, the absent-vs-unparseable boundary, and fingerprint freshness/no-churn.
- 5 new acceptance scenarios (`features/architecture-unreadable-workspace.feature`): malformed go.work, unreadable Cargo members, flow-style pnpm (each surfaced in a rendered root index), the only-unparseable warning path, and the single-crate no-false-alarm negative case.
- Full CLI suite green (277 files, 4029 passed, 5 skipped); 52 architecture BDD scenarios green; lint clean; `architecture --check` still exits 0 on this repo.

Followed safeword's BDD flow (ticket `UWP4XK`): spec → dimensions → scenarios with an independent scenario-gate review (PASS-WITH-NITS, nits addressed) → TDD → verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRGYnMkxo3yim7qdFs7s19)_