### PR TITLE
Reconcile ARCHITECTURE.md against the generated architecture doc (#559)

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -352,9 +352,17 @@ Test Quality:
 **ARCHITECTURE.md:**
 
 - If missing → create from `.safeword/templates/architecture-template.md`
-- If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-  - **Gap (warn):** Major dependencies not documented
+- If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
+  - **Dependency drift:**
+    - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
+    - **Gap (warn):** Major dependencies not documented
+  - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
+    - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
+    - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
+    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
+  - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
 **README.md:**
 
@@ -379,6 +387,7 @@ Report findings by severity with codes:
 
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
+- [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
 
 ### Warnings (should review)
 
@@ -389,6 +398,8 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
+- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -352,9 +352,17 @@ Test Quality:
 **ARCHITECTURE.md:**
 
 - If missing → create from `.safeword/templates/architecture-template.md`
-- If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-  - **Gap (warn):** Major dependencies not documented
+- If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
+  - **Dependency drift:**
+    - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
+    - **Gap (warn):** Major dependencies not documented
+  - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
+    - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
+    - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
+    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
+  - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
 **README.md:**
 
@@ -379,6 +387,7 @@ Report findings by severity with codes:
 
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
+- [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
 
 ### Warnings (should review)
 
@@ -389,6 +398,8 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
+- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/dimensions.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/dimensions.md
@@ -1,0 +1,37 @@
+# Behavioral dimensions — AXRC4D (reconcile ARCHITECTURE.md vs generated doc)
+
+Two behaviors: (1) `/audit`'s structural reconciliation verdict (a skill prompt
+reading the generated doc) and (2) the deterministic done-gate nudge
+(`architectureDocumentNudgeForProject` / `architectureDocumentNudge`). The nudge
+is the auto-testable unit; the audit verdict is agent-judgment, anchored on the
+generated doc as ground truth.
+
+| # | Dimension | Partitions | Covered by |
+| - | --------- | ---------- | ---------- |
+| D1 | **Structural relation: doc vs generated map** | (a) in-sync; (b) doc names a unit absent from the map (orphaned); (c) map has a unit the doc omits (missing); (d) layer→dir mapping points at a non-existent module path (drifted) | Audit-lane A1 (b), A2 (c), A3 (d), A0 (a) |
+| D2 | **Audit posture** | (a) report-only (cite + propose); (b) MUST NOT auto-overwrite prose; (c) MUST NOT block | A3/J1.AC3 (report-only, no overwrite, no block) |
+| D3 | **Did this ticket move the top-level fingerprint?** | (a) unchanged → no nudge; (b) moved (module added/removed) → nudge; (c) shape map newly introduced (no base doc) → nudge | U-pure + U-git: N2/N1 (b), N3 (a), pure "new doc" (c) |
+| D4 | **ARCHITECTURE.md presence (nudge gate)** | (a) exists → nudge eligible; (b) absent → never nudge (audit create-from-template owns it) | N4 (b), N1/N2 (a) |
+| D5 | **Generated shape doc presence (nudge gate)** | (a) exists → comparable; (b) absent (non-architecture project) → no nudge | U-pure "no generated doc" |
+| D6 | **Baseline resolvability (nudge IO)** | (a) merge-base resolves → compare; (b) unresolvable (no upstream) → no nudge (don't guess) | U-git harness asserts resolvable path; (b) noted |
+| D7 | **Blocking posture (nudge)** | (a) advisory only — done transition still completes | N1/N2 assert a string is returned but the ticket is already marked done before it fires (hook wiring) |
+
+## Load-bearing partitions (where this change actually bites)
+
+- **D3(b)/D3(c)** — the trigger: a ticket that moved the top-level fingerprint (or
+  introduced the shape map) must nudge. New behavior; the deterministic core.
+- **D3(a) + D4(b)** — the no-false-alarm boundary: an unchanged fingerprint, or a
+  project with no `ARCHITECTURE.md`, must stay silent. Without this the nudge is
+  noise and the audit finding a false positive.
+- **D1(b)/D1(c)** — the audit verdict: orphaned vs missing are the two structural
+  drifts the sharpened `/audit` must distinguish, citing the generated doc.
+- **D2(b)/D2(c)** — the human-ownership guard: report-only, never overwrite, never
+  block. The whole design rejects blocking/auto-rewrite, so this is the invariant.
+
+## Out-of-partition (not exercised; noted)
+
+The full `/audit` agent run end-to-end (LLM judgment over a real repo) is not
+deterministically asserted — audit reconciliation is a skill prompt; its verdict
+quality is verified by reading the sharpened instructions and the cited evidence,
+following safeword's precedent for skill-prompt changes. The deterministic nudge
+trigger carries the executable R/G/R proof.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/spec.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/spec.md
@@ -1,0 +1,80 @@
+# Spec: Reconcile ARCHITECTURE.md against the generated architecture doc (AXRC4D)
+
+## Jobs To Be Done
+
+### AXRC4D.J1 — Keep the human architecture doc honest about the real structure
+
+**Persona:** Technical Builder (TB)
+
+safeword generates `architecture.generated.md` (a deterministic, always-fresh
+module/package map) but my hand-authored `ARCHITECTURE.md` is never reconciled
+against it, so it silently rots — I add or remove a module and the human doc
+still describes the old shape. I want the two to disagree *loudly* (a clear
+finding when I run `/audit`, and a nudge at the done-gate when a ticket moved the
+shape), so the narrative stays trustworthy — **without** a tool ever rewriting my
+"why" or blocking my commit on a human-owned file.
+
+#### AXRC4D.J1.AC1 — Orphaned module is flagged
+
+When `ARCHITECTURE.md` documents a module/layer (or a layer→directory mapping)
+that no longer appears in `architecture.generated.md`, `/audit` reports it as a
+structural-drift finding that cites the generated doc — distinct from the
+existing dependency-drift check.
+
+#### AXRC4D.J1.AC2 — Missing module is flagged
+
+When a real top-level module/package in `architecture.generated.md` is never
+mentioned in `ARCHITECTURE.md`, `/audit` reports it as a structural gap.
+
+#### AXRC4D.J1.AC3 — Narrative is never auto-overwritten
+
+The structural reconciliation is **report-only**: it cites evidence and proposes
+edits for human review; it never rewrites the free narrative and never blocks.
+The structural *facts* are read from the generated doc (deterministic-by-reading);
+only narrative *judgment* is left to the human/agent.
+
+#### AXRC4D.J1.AC4 — Done-gate nudge when this ticket moved the shape
+
+When a ticket moved the top-level architecture fingerprint (the value recorded in
+`architecture.generated.md`) and an `ARCHITECTURE.md` exists, the done-gate emits
+a one-line, **non-blocking** advisory pointing at `ARCHITECTURE.md`.
+
+#### AXRC4D.J1.AC5 — No false alarm
+
+A ticket that did **not** move the top-level fingerprint, or a project with no
+`ARCHITECTURE.md`, emits **no** nudge. The advisory never blocks the done
+transition.
+
+## Problem
+
+The structural facts (which modules/layers exist) already live, machine-readable,
+in `architecture.generated.md`. The narrative (why it's shaped this way) is
+human-owned. Today nothing connects them, so the human doc drifts silently. The
+fix splits by what each side is good at: a **skill** (`/audit`) READS the
+generated doc and reports structural drift; the **already-computed fingerprint**
+is reused as a cheap done-gate trigger so the reconcile is prompted when it
+matters instead of being forgotten.
+
+## Design
+
+Two surfaces, no new deterministic drift module and no managed region (both
+explicitly rejected — see ticket Decision):
+
+- **`/audit` structural reconciliation (skill prompt).** Sharpen the existing
+  `ARCHITECTURE.md` check to reconcile structural claims against
+  `architecture.generated.md` (the `### <name>` units under `## Modules` /
+  `## Packages`): orphaned (error), missing (warn), drifted layer→dir (warn).
+  Report-only; new codes E003/W008/W009.
+- **Done-gate nudge (deterministic Stop-hook trigger).** A small hook helper
+  (`architecture-document-nudge.ts`) reads the generated doc's recorded
+  `fingerprint:` on disk and at the branch base (`git show <merge-base>:…`); when
+  they differ and `ARCHITECTURE.md` exists, the done-gate surfaces a one-line
+  non-blocking advisory. It REUSES the existing fingerprint (computes nothing from
+  source — not a drift detector) and never blocks.
+
+## Out of scope
+
+A bespoke deterministic `architectureDocDrift` source-analyzing module; a managed
+Module-Map region inside `ARCHITECTURE.md`; any blocking gate; LLM rewriting of
+narrative beyond what `/audit` already does; touching the generated-doc pipeline
+(extraction/fingerprint/self-heal) — this ticket only consumes its outputs.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/test-definitions.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/test-definitions.md
@@ -1,0 +1,58 @@
+# Test definitions (R/G/R ledger) — AXRC4D
+
+Two surfaces. The **done-gate nudge** is deterministic and carries the executable
+R/G/R proof (`tests/hooks/architecture-document-nudge.test.ts`). The **`/audit`
+structural reconciliation** is a skill-prompt sharpening — verified by reading the
+instructions + cited evidence (safeword's precedent for skill changes; no
+deterministic CLI surface to cucumber). Dimensions in dimensions.md.
+
+## Done-gate nudge — unit + git-integration (executable acceptance)
+
+`tests/hooks/architecture-document-nudge.test.ts` — pure decision + a git-backed
+harness that builds a real repo (feature branch tracking `main`) and exercises the
+actual `git show <merge-base>:…` base-resolution path.
+
+- [x] **N1 — moved fingerprint + ARCHITECTURE.md → nudges** [J1.AC4, D3(b), D4(a), D7]
+  - RED: no `architectureDocumentNudge*` existed; the done-gate emitted no advisory.
+  - GREEN: working-tree generated-doc fingerprint ≠ base → nudge string returned.
+- [x] **N2 — new/removed module (git-backed) → nudges** [J1.AC4, D3(b)]
+  - git harness: baseline doc fp `base-fp` committed on `main`; feature branch sets
+    working-tree fp `moved-fp` → `architectureDocumentNudgeForProject` nudges.
+- [x] **N3 — in-sync / non-structural ticket → no nudge** [J1.AC5, D3(a)]
+  - git harness: generated doc untouched (or only an unrelated README edit) → null.
+- [x] **N4 — ARCHITECTURE.md absent → no nudge** [J1.AC5, D4(b)]
+  - git harness: no `ARCHITECTURE.md` even though the fingerprint moved → null.
+- [x] **pure — shape map newly introduced (no base doc) → nudges** [D3(c)]
+- [x] **pure — no generated shape doc → no nudge** [D5(b)]
+- [x] **pure — `parseGeneratedFingerprint`** valid / CRLF / no-frontmatter / empty-value / empty
+  [feeds the trigger; the fingerprint is read, never recomputed]
+
+All RED-for-the-right-reason: before the helper existed, none of these signals
+were produced; the done-gate marked tickets done with no architecture-doc advisory.
+
+## `/audit` structural reconciliation — agent-lane (verified by reading)
+
+Sharpened `ARCHITECTURE.md` check in `skills/audit/SKILL.md` (3 copies). Anchored
+on `architecture.generated.md` as ground truth; report-only.
+
+- [x] **A0 — in-sync → no structural finding** [D1(a)]: doc's module/layer set matches
+  the generated `### <name>` units → no E003/W008/W009.
+- [x] **A1 — orphaned → E003 (error)** [J1.AC1, D1(b)]: a documented module/layer absent
+  from the generated map is flagged, citing the generated doc.
+- [x] **A2 — missing → W008 (warn)** [J1.AC2, D1(c)]: a generated module/package the doc
+  never mentions is flagged.
+- [x] **A3 — drifted layer→dir → W009 (warn) + report-only invariant** [J1.AC3, D1(d), D2]:
+  a Layers & Boundaries `directory` matching no generated module path is flagged; the
+  instruction is explicit that it cites + proposes under human review and NEVER
+  auto-overwrites prose or blocks.
+
+Verification: the sharpened instructions read the generated doc (the deterministic
+structural truth) and add the three codes; the "report only, never overwrite,
+never block" guard is stated in-line. Not auto-run (skill prompt, agent judgment).
+
+## Reconcile note
+
+The honesty property = N1–N4 (the shape-moved nudge never false-alarms) + A1/A2
+(audit surfaces orphaned/missing against the generated truth). No new deterministic
+drift module and no managed region were introduced — the nudge reuses the existing
+fingerprint as a cheap trigger; the audit reads the existing generated doc.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/test-definitions.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/test-definitions.md
@@ -26,6 +26,10 @@ actual `git show <merge-base>:…` base-resolution path.
 - [x] **pure — no generated shape doc → no nudge** [D5(b)]
 - [x] **pure — `parseGeneratedFingerprint`** valid / CRLF / no-frontmatter / empty-value / empty
   [feeds the trigger; the fingerprint is read, never recomputed]
+- [x] **parity — `parseGeneratedFingerprint` ⇄ `readDocumentFingerprint`** differential
+  (`architecture-document-nudge-parity.test.ts`, P58R22) [quality-review follow-up]: both
+  readers agree on 9 fixtures, so the hook's re-implemented parser can't silently drift
+  from the CLI writer's frontmatter format.
 
 All RED-for-the-right-reason: before the helper existed, none of these signals
 were produced; the done-gate marked tickets done with no architecture-doc advisory.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/ticket.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/ticket.md
@@ -2,10 +2,10 @@
 id: AXRC4D
 slug: architecture-md-reconcile
 type: feature
-phase: define-behavior
+phase: verify
 status: todo
 created: 2026-06-29T00:42:00.000Z
-last_modified: 2026-06-29T00:42:00.000Z
+last_modified: 2026-06-30T04:10:00.000Z
 scope:
   - Sharpen the `/audit` skill's existing ARCHITECTURE.md check (§5 "Project Documentation Checks") to reconcile the human doc's STRUCTURAL claims against `architecture.generated.md` — the machine-listed module/layer set — not only against `package.json` dependencies as today. The agent reads the generated doc as ground truth and flags: a documented module/layer that no longer exists (orphaned), a real top-level module the doc never mentions (missing), and a drifted layer→directory mapping. Report only; the agent updates the human narrative with the user reviewing. It NEVER auto-overwrites prose.
   - A fingerprint-triggered staleness NUDGE at the done-gate (`/verify` / the Stop done-gate hook): when the project's top-level shape fingerprint moved DURING this ticket, surface a one-line, NON-blocking advisory — "you changed the top-level structure; ARCHITECTURE.md's module/layer description may be stale — reconcile it." Reuse the EXISTING `shapeFingerprint`/`monorepoFingerprint` already computed by the architecture subsystem; do not build a new detector.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/ticket.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/ticket.md
@@ -1,0 +1,71 @@
+---
+id: AXRC4D
+slug: architecture-md-reconcile
+type: feature
+phase: define-behavior
+status: todo
+created: 2026-06-29T00:42:00.000Z
+last_modified: 2026-06-29T00:42:00.000Z
+scope:
+  - Sharpen the `/audit` skill's existing ARCHITECTURE.md check (§5 "Project Documentation Checks") to reconcile the human doc's STRUCTURAL claims against `architecture.generated.md` — the machine-listed module/layer set — not only against `package.json` dependencies as today. The agent reads the generated doc as ground truth and flags: a documented module/layer that no longer exists (orphaned), a real top-level module the doc never mentions (missing), and a drifted layer→directory mapping. Report only; the agent updates the human narrative with the user reviewing. It NEVER auto-overwrites prose.
+  - A fingerprint-triggered staleness NUDGE at the done-gate (`/verify` / the Stop done-gate hook): when the project's top-level shape fingerprint moved DURING this ticket, surface a one-line, NON-blocking advisory — "you changed the top-level structure; ARCHITECTURE.md's module/layer description may be stale — reconcile it." Reuse the EXISTING `shapeFingerprint`/`monorepoFingerprint` already computed by the architecture subsystem; do not build a new detector.
+  - Anchor both surfaces on the generated doc as ground truth (the agent READS the machine module list), so the structural verdict is deterministic-by-reading rather than model-guessed.
+out_of_scope:
+  - A bespoke deterministic `architectureDocDrift` TS module — explicitly dropped (see Decision below). Reuse the fingerprint that already exists; the generated doc already IS the readable structural truth.
+  - A marker-delimited "managed Module-Map region" inside ARCHITECTURE.md (safeword owning part of a human file). Deferred — only reconsider if the skill-first approach proves insufficient in practice. It is the heaviest, riskiest piece (a new partial-file ownership primitive) and is not needed for v1.
+  - Any BLOCKING gate. ARCHITECTURE.md is human-owned; only a person can fix narrative drift, so blocking a commit/CI on it is hostile and false-positive-prone. Advisory only, everywhere.
+  - LLM rewriting of free narrative beyond what `/audit` already does (drift reporting + targeted edits under human review). No autonomous prose generation.
+  - Touching the generated-doc pipeline itself (extraction, fingerprint, self-heal) — unchanged; this ticket only consumes its outputs.
+done_when:
+  - Running `/audit` on a repo whose ARCHITECTURE.md omits a real top-level module, or names a module that was deleted, produces a clear drift finding that cites the generated doc — distinct from the existing dependency-drift check.
+  - When a ticket adds or removes a top-level module/package, that ticket's done-gate emits a one-line non-blocking nudge pointing at ARCHITECTURE.md; a ticket that did NOT move the top-level fingerprint emits no nudge (no false alarm).
+  - Neither surface blocks; neither auto-edits the human narrative; both read the generated doc as the source of structural truth.
+  - No new deterministic drift TS module and no managed-region ownership were introduced (the change is a skill/prompt sharpening plus reuse of the existing fingerprint signal).
+  - Scenarios cover: in-sync (no finding, no nudge); a new module (missing-in-doc flagged); a removed module (orphaned-in-doc flagged); ARCHITECTURE.md absent (audit's create-from-template path, unchanged); a non-structural ticket (no nudge).
+---
+
+# Reconcile ARCHITECTURE.md against the generated architecture doc
+
+**Goal:** Keep the human-authored `ARCHITECTURE.md` honest about the project's
+real structure by reconciling it against the always-accurate
+`architecture.generated.md` — without ever overwriting the human "why," and
+without building new deterministic machinery.
+
+## Why
+
+safeword generates `architecture.generated.md` (the deterministic module map +
+dependency fingerprint, kept fresh by hooks) but `ARCHITECTURE.md` (the human
+design narrative) is never reconciled against it, so it silently rots: a module
+is added or removed and the human doc still describes the old shape. The two
+never disagree loudly.
+
+## Decision (from `/figure-it-out`, 2026-06-29)
+
+Reconciliation splits by what each tool is good at:
+
+- **The structural facts** (which modules/layers exist) — the generated doc
+  already IS the machine-readable truth. A skill READS it and compares.
+- **The narrative** (why it's shaped this way) — only a human/agent can judge if
+  a paragraph is still true; surface it, never auto-rewrite it.
+
+So the reconciliation WORK is a **skill** (sharpen the existing `/audit` doc
+check), and the only non-skill piece is reusing the **already-computed
+fingerprint** as a cheap trigger so the skill is run when it matters (done-gate
+nudge) instead of being forgotten. This deliberately REJECTS the earlier,
+heavier proposal (a new `architectureDocDrift` module + a marker-delimited
+managed region) as over-built: the fingerprint and the readable generated doc
+already provide everything the deterministic layer needs.
+
+**Where it fires:** detect cheaply + advisory at the done-gate and in `/audit`'s
+report; RECONCILE the narrative at `/audit` (agent + human review). Never block.
+
+**Premortem:** the likely failure is inconsistent reconciliations (different agent
+runs disagree on "stale," doc thrashes). Mitigate by anchoring the skill to the
+generated doc as ground truth so the structural verdict is deterministic-by-reading
+and only genuine narrative judgment is left to the model.
+
+## Next
+
+Run `/bdd` to turn the five `done_when` flows into scenarios (in-sync, new
+module, removed module, doc-absent, non-structural ticket), then implement as a
+skill/prompt sharpening + the fingerprint-triggered done-gate nudge.

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/verify.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/verify.md
@@ -44,6 +44,31 @@ and the `/audit` change READS the generated doc; both report-only / non-blocking
   failure direction. On a repo's default branch (no upstream) the nudge is inert
   (fail-closed beats false alarm).
 
+## Quality review (post-merge-prep, /quality-review)
+
+Fresh-context independent review returned **APPROVE** (no critical/blocking items;
+scope fidelity, non-blocking wiring, and the report-only audit sharpening all sound).
+Two non-blocking follow-ups raised — one addressed, one justified:
+
+- **Addressed — parser drift guard.** `parseGeneratedFingerprint` re-implements the
+  CLI's `readDocumentFingerprint` (the hook-standalone duplication pattern, like
+  `namespace-root.ts`) but had no differential test. Added
+  `architecture-document-nudge-parity.test.ts` (P58R22 pattern): both readers must
+  agree on 9 fixtures incl. CRLF, empty value, no-frontmatter, a fingerprint-looking
+  body line outside the fences, and unterminated frontmatter. Pins the format contract.
+- **Justified — done-gate end-to-end nudge wiring.** The reviewer noted the 3-line
+  glue in `stop-quality.ts` (prepend-on-navigate / emit-on-all-done) has no E2E test.
+  The nudge *decision* is covered end-to-end by the git-backed integration tests (real
+  `git show <merge-base>:…`), and the deployment manifest entry by `schema.test.ts`; the
+  remaining glue is a 3-line prepend over that tested helper. A full done-gate E2E that
+  fires the nudge would need a passing-done fixture WITH an upstream-tracking branch and a
+  moved generated-doc fingerprint — high fixture cost for marginal coverage over the
+  real-git helper test. Justified-absent per the wiring gate.
+
+Provenance: the generated-doc frontmatter format claim is `verified` against the
+writer (`renderDocument` in `architecture-document.ts`) this session; the parser-parity
+is now machine-enforced. No external dependencies.
+
 ## Reconcile
 
 The implementation matches the spec: two surfaces, no new deterministic drift module

--- a/.project/tickets/AXRC4D-architecture-md-reconcile/verify.md
+++ b/.project/tickets/AXRC4D-architecture-md-reconcile/verify.md
@@ -1,0 +1,54 @@
+# Verify: reconcile ARCHITECTURE.md against the generated doc (AXRC4D)
+
+## Verify checklist
+
+**Test Suite:** ✅ 15 unit + git-integration tests for the done-gate nudge
+(`tests/hooks/architecture-document-nudge.test.ts`) green; full hooks+integration
+suite green (118 files, 1910 tests) including every E2E done-gate test that spawns
+the deployed stop hook.
+**Gherkin:** ⏭️ N/A — both surfaces are a hook (no CLI/agent acceptance surface) and
+a skill-prompt sharpening; the executable acceptance is the deterministic nudge's
+unit + git-backed integration tests (safeword tests done-gate behavior via
+integration/unit, not cucumber).
+**Build:** ✅ `tsup` build succeeds; the new hook lib is in the setup manifest so
+`safeword setup` deploys it (without it the spawned hook crashed — caught and fixed).
+**Lint:** ✅ eslint clean (the test renamed to `architecture-document-nudge`/
+`architectureDocumentNudge` per `unicorn/name-replacements`).
+**Scenarios:** All ledger items [x]; the load-bearing no-false-alarm branch
+(unresolvable baseline → no nudge) added as an executable test per the independent
+review.
+**Dep Drift:** ✅ Zero new dependencies (the helper uses node:child_process / node:fs).
+**PR Scope:** ✅ Diff matches scope — the nudge helper + its tests, the done-gate
+wiring in `stop-quality.ts` (both copies), the setup manifest entry in `schema.ts`,
+the `/audit` ARCHITECTURE.md sharpening (3 skill copies), and the ticket artifacts.
+No piggybacked changes.
+**Scope fidelity:** ✅ No new deterministic source-analyzing drift module and no
+managed region — the nudge READS the existing recorded fingerprint (a cheap trigger)
+and the `/audit` change READS the generated doc; both report-only / non-blocking.
+
+## Evidence
+
+- **Independent design review** (fresh-context agent): **PASS-WITH-NITS**, one
+  load-bearing finding — the "unresolvable baseline (no upstream / detached HEAD) →
+  no nudge" fail-closed branch was correct but untested. **Addressed:** added the
+  `upstream: false` harness case asserting `null` even when the fingerprint moved.
+  Confirmed: scope fidelity (reuses the recorded fingerprint, not a source detector);
+  non-blocking wiring (ticket is marked done before the nudge fires, no double-emit);
+  the three `/audit` skill copies (`templates`/`.claude`/`.agents`) in sync with
+  E003/W008/W009; the git harness genuinely exercises `git show <merge-base>:…`.
+- **Known, accepted over-fire (documented in the PR):** on a monorepo,
+  `monorepoFingerprint` also covers inter-package edges + boundary config + the
+  unreadable-workspace set, so an edge-only or boundary-only change nudges even with
+  no module added/removed. Acceptable by design — the nudge is advisory, and an edge
+  change can legitimately stale the narrative; over-firing a one-liner is the correct
+  failure direction. On a repo's default branch (no upstream) the nudge is inert
+  (fail-closed beats false alarm).
+
+## Reconcile
+
+The implementation matches the spec: two surfaces, no new deterministic drift module
+and no managed region. The nudge reuses the recorded `fingerprint:` (shapeFingerprint
+/ monorepoFingerprint output) as a cheap trigger; `/audit` reads the generated doc's
+`### <name>` units as structural ground truth. A net-new hook lib file required a
+`schema.ts` setup-manifest entry (so `safeword setup` deploys it) and a rebuild — both
+done; the E2E suite that spawns the deployed hook is green.

--- a/.safeword/hooks/lib/architecture-document-nudge.ts
+++ b/.safeword/hooks/lib/architecture-document-nudge.ts
@@ -1,0 +1,126 @@
+// Safeword: non-blocking ARCHITECTURE.md staleness nudge at the done-gate (AXRC4D,
+// GitHub #559). When a ticket moved the project's top-level architecture shape — the
+// fingerprint recorded in `<namespace>/architecture.generated.md` differs from the
+// branch base — and a human-authored `ARCHITECTURE.md` exists, surface a one-line
+// advisory that its module/layer narrative may be stale and should be reconciled
+// (via `/audit`). It REUSES the existing fingerprint (the shapeFingerprint /
+// monorepoFingerprint already written into the generated doc by the architecture
+// subsystem) as a cheap trigger; it computes nothing from source, introduces no new
+// detector, and NEVER blocks — `ARCHITECTURE.md` is human-owned, so only a person can
+// fix narrative drift. Anchoring on the generated doc keeps the trigger
+// deterministic-by-reading rather than model-guessed.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { resolveNamespaceRoot } from './namespace-root.js';
+
+/** The generated state-document filename, colocated at the namespace root for the top level. */
+const GENERATED_DOC = 'architecture.generated.md';
+/** The human-authored architecture narrative at the project root. */
+const ARCHITECTURE_MD = 'ARCHITECTURE.md';
+
+/** The one-line, non-blocking advisory surfaced at the done-gate when the shape moved. */
+export const ARCHITECTURE_DOCUMENT_NUDGE =
+  'ARCHITECTURE.md may be stale: this ticket moved the top-level architecture shape ' +
+  '(the generated module/package map changed). ARCHITECTURE.md is human-owned and was ' +
+  'not touched — run `/audit` to reconcile its module/layer description against ' +
+  '`architecture.generated.md`. Advisory only; nothing is blocked.';
+
+function runGit(cwd: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    // Outside a git repo, git unavailable, or the ref/path is absent: no baseline.
+    return '';
+  }
+}
+
+/**
+ * The `fingerprint:` value from a generated-doc's frontmatter, or `undefined` when the
+ * content is empty, has no frontmatter, or carries no fingerprint line. CRLF-tolerant.
+ */
+export function parseGeneratedFingerprint(content: string): string | undefined {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
+  if (frontmatter === undefined) return undefined;
+  for (const line of frontmatter.split(/\r?\n/)) {
+    if (line.startsWith('fingerprint:')) {
+      const value = line.slice('fingerprint:'.length).trim();
+      return value.length > 0 ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Inputs the pure nudge decision depends on — gathered from disk + git by the caller. */
+export interface ArchitectureDocumentNudgeInputs {
+  /** Whether a human `ARCHITECTURE.md` exists at the project root. */
+  architectureMdExists: boolean;
+  /** The generated doc's fingerprint at the branch base, or `undefined` (doc absent at base). */
+  baseFingerprint: string | undefined;
+  /** The generated doc's fingerprint in the working tree, or `undefined` (no generated doc). */
+  currentFingerprint: string | undefined;
+}
+
+/**
+ * The done-gate nudge string, or `null` when none is warranted. Pure — the IO seam lives
+ * in {@link architectureDocumentNudgeForProject}. Fires only when (1) a human
+ * `ARCHITECTURE.md` exists (the audit create-from-template path owns the absent case), (2)
+ * a generated shape doc exists now, and (3) the fingerprint moved vs the base — including
+ * the "shape map newly introduced this ticket" case (`baseFingerprint === undefined`). A
+ * ticket that left the top-level fingerprint unchanged emits nothing (no false alarm).
+ */
+export function architectureDocumentNudge(inputs: ArchitectureDocumentNudgeInputs): string | null {
+  if (!inputs.architectureMdExists) return null;
+  if (inputs.currentFingerprint === undefined) return null;
+  if (inputs.baseFingerprint === inputs.currentFingerprint) return null;
+  return ARCHITECTURE_DOCUMENT_NUDGE;
+}
+
+/**
+ * Resolve {@link architectureDocumentNudge}'s inputs from `projectDir` + git, then return
+ * the nudge (or `null`). The branch base is the merge-base with the upstream/default
+ * branch; when it can't be resolved we return `null` rather than guess (no false alarm on
+ * an unknowable baseline). `projectDir` is the repo root (the done-gate's cwd).
+ */
+export function architectureDocumentNudgeForProject(projectDir: string): string | null {
+  // Cheap exit before any git/fs work: no human doc ⇒ nothing to reconcile against.
+  if (!existsSync(nodePath.join(projectDir, ARCHITECTURE_MD))) return null;
+
+  const generatedPath = nodePath.join(resolveNamespaceRoot(projectDir), GENERATED_DOC);
+  const currentFingerprint = existsSync(generatedPath)
+    ? parseGeneratedFingerprint(readFileSync(generatedPath, 'utf8'))
+    : undefined;
+  if (currentFingerprint === undefined) return null;
+
+  const baseRef = resolveBaseRef(projectDir);
+  if (baseRef === undefined) return null; // unknowable baseline → don't guess
+
+  const relativeDocPath = nodePath.relative(projectDir, generatedPath);
+  const baseDoc = runGit(projectDir, ['show', `${baseRef}:${relativeDocPath}`]);
+  const baseFingerprint = baseDoc === '' ? undefined : parseGeneratedFingerprint(baseDoc);
+
+  return architectureDocumentNudge({
+    architectureMdExists: true,
+    baseFingerprint,
+    currentFingerprint,
+  });
+}
+
+/** The merge-base of HEAD with the upstream/default branch — the ticket's divergence point. */
+function resolveBaseRef(cwd: string): string | undefined {
+  const upstream = runGit(cwd, [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{u}',
+  ]).trim();
+  if (upstream === '') return undefined;
+  const mergeBase = runGit(cwd, ['merge-base', 'HEAD', upstream]).trim();
+  return mergeBase === '' ? undefined : mergeBase;
+}

--- a/.safeword/hooks/lib/architecture-document-nudge.ts
+++ b/.safeword/hooks/lib/architecture-document-nudge.ts
@@ -21,6 +21,9 @@ const GENERATED_DOC = 'architecture.generated.md';
 /** The human-authored architecture narrative at the project root. */
 const ARCHITECTURE_MD = 'ARCHITECTURE.md';
 
+/** The frontmatter key holding the recorded shape fingerprint (mirrors the CLI writer). */
+const FINGERPRINT_KEY = 'fingerprint';
+
 /** The one-line, non-blocking advisory surfaced at the done-gate when the shape moved. */
 export const ARCHITECTURE_DOCUMENT_NUDGE =
   'ARCHITECTURE.md may be stale: this ticket moved the top-level architecture shape ' +
@@ -49,8 +52,8 @@ export function parseGeneratedFingerprint(content: string): string | undefined {
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
   if (frontmatter === undefined) return undefined;
   for (const line of frontmatter.split(/\r?\n/)) {
-    if (line.startsWith('fingerprint:')) {
-      const value = line.slice('fingerprint:'.length).trim();
+    if (line.startsWith(`${FINGERPRINT_KEY}:`)) {
+      const value = line.slice(FINGERPRINT_KEY.length + 1).trim();
       return value.length > 0 ? value : undefined;
     }
   }

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -41,6 +41,7 @@ import { checkSkillInvocations, requiredSkillsForDone } from './lib/skill-invoca
 import { runTests } from './lib/test-runner.ts';
 import { changedFilesSinceHead, evaluateImplementStopTypecheck } from './lib/typecheck-gate.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
+import { architectureDocumentNudgeForProject } from './lib/architecture-document-nudge.ts';
 import { installCrashCapture } from './lib/self-report.ts';
 
 installCrashCapture('stop-quality');
@@ -613,6 +614,13 @@ if (currentPhase === 'done') {
     const currentTicketDirectory = `${ticketsDir}/${ticketInfo.folder}`;
     updateTicketStatus(currentTicketDirectory, 'done', 'done');
 
+    // AXRC4D: non-blocking ARCHITECTURE.md staleness nudge. If this ticket moved the
+    // top-level architecture fingerprint and a human ARCHITECTURE.md exists, advise a
+    // reconcile. Prepended to whatever done-message we surface; the ticket is already
+    // marked done above, so this never blocks the transition.
+    const archDriftNudge = architectureDocumentNudgeForProject(projectDir);
+    const donePrefix = archDriftNudge === null ? '' : `${archDriftNudge}\n\n`;
+
     // Walk hierarchy: cascade done status up and navigate to next sibling
     let directory = currentTicketDirectory;
     const MAX_CASCADE = 10;
@@ -622,7 +630,7 @@ if (currentPhase === 'done') {
         const nextInfo = getTicketInfo(projectDir, next.ticketId);
         const nextLabel = nextInfo.slug ? `${nextInfo.slug} (${next.ticketId})` : next.ticketId;
         softBlock(
-          `Ticket complete! Next up: read ${next.ticketDirectory}/ticket.md and begin work on ${nextLabel}.`,
+          `${donePrefix}Ticket complete! Next up: read ${next.ticketDirectory}/ticket.md and begin work on ${nextLabel}.`,
         );
       } else if (next.type === 'cascade-done') {
         // Mark parent done and continue walking up
@@ -633,6 +641,9 @@ if (currentPhase === 'done') {
         break;
       }
     }
+
+    // No onward navigation, but the shape moved — still surface the advisory once.
+    if (archDriftNudge !== null) softBlock(archDriftNudge);
   }
 
   process.exit(0);

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -580,6 +580,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
 
     // Hooks shared library - TypeScript with Bun runtime
     '.safeword/hooks/lib/active-ticket.ts': { template: 'hooks/lib/active-ticket.ts' },
+    '.safeword/hooks/lib/architecture-document-nudge.ts': {
+      template: 'hooks/lib/architecture-document-nudge.ts',
+    },
     '.safeword/hooks/lib/architecture-staged-scope.ts': {
       template: 'hooks/lib/architecture-staged-scope.ts',
     },

--- a/packages/cli/templates/hooks/lib/architecture-document-nudge.ts
+++ b/packages/cli/templates/hooks/lib/architecture-document-nudge.ts
@@ -1,0 +1,126 @@
+// Safeword: non-blocking ARCHITECTURE.md staleness nudge at the done-gate (AXRC4D,
+// GitHub #559). When a ticket moved the project's top-level architecture shape — the
+// fingerprint recorded in `<namespace>/architecture.generated.md` differs from the
+// branch base — and a human-authored `ARCHITECTURE.md` exists, surface a one-line
+// advisory that its module/layer narrative may be stale and should be reconciled
+// (via `/audit`). It REUSES the existing fingerprint (the shapeFingerprint /
+// monorepoFingerprint already written into the generated doc by the architecture
+// subsystem) as a cheap trigger; it computes nothing from source, introduces no new
+// detector, and NEVER blocks — `ARCHITECTURE.md` is human-owned, so only a person can
+// fix narrative drift. Anchoring on the generated doc keeps the trigger
+// deterministic-by-reading rather than model-guessed.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { resolveNamespaceRoot } from './namespace-root.js';
+
+/** The generated state-document filename, colocated at the namespace root for the top level. */
+const GENERATED_DOC = 'architecture.generated.md';
+/** The human-authored architecture narrative at the project root. */
+const ARCHITECTURE_MD = 'ARCHITECTURE.md';
+
+/** The one-line, non-blocking advisory surfaced at the done-gate when the shape moved. */
+export const ARCHITECTURE_DOCUMENT_NUDGE =
+  'ARCHITECTURE.md may be stale: this ticket moved the top-level architecture shape ' +
+  '(the generated module/package map changed). ARCHITECTURE.md is human-owned and was ' +
+  'not touched — run `/audit` to reconcile its module/layer description against ' +
+  '`architecture.generated.md`. Advisory only; nothing is blocked.';
+
+function runGit(cwd: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    // Outside a git repo, git unavailable, or the ref/path is absent: no baseline.
+    return '';
+  }
+}
+
+/**
+ * The `fingerprint:` value from a generated-doc's frontmatter, or `undefined` when the
+ * content is empty, has no frontmatter, or carries no fingerprint line. CRLF-tolerant.
+ */
+export function parseGeneratedFingerprint(content: string): string | undefined {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
+  if (frontmatter === undefined) return undefined;
+  for (const line of frontmatter.split(/\r?\n/)) {
+    if (line.startsWith('fingerprint:')) {
+      const value = line.slice('fingerprint:'.length).trim();
+      return value.length > 0 ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Inputs the pure nudge decision depends on — gathered from disk + git by the caller. */
+export interface ArchitectureDocumentNudgeInputs {
+  /** Whether a human `ARCHITECTURE.md` exists at the project root. */
+  architectureMdExists: boolean;
+  /** The generated doc's fingerprint at the branch base, or `undefined` (doc absent at base). */
+  baseFingerprint: string | undefined;
+  /** The generated doc's fingerprint in the working tree, or `undefined` (no generated doc). */
+  currentFingerprint: string | undefined;
+}
+
+/**
+ * The done-gate nudge string, or `null` when none is warranted. Pure — the IO seam lives
+ * in {@link architectureDocumentNudgeForProject}. Fires only when (1) a human
+ * `ARCHITECTURE.md` exists (the audit create-from-template path owns the absent case), (2)
+ * a generated shape doc exists now, and (3) the fingerprint moved vs the base — including
+ * the "shape map newly introduced this ticket" case (`baseFingerprint === undefined`). A
+ * ticket that left the top-level fingerprint unchanged emits nothing (no false alarm).
+ */
+export function architectureDocumentNudge(inputs: ArchitectureDocumentNudgeInputs): string | null {
+  if (!inputs.architectureMdExists) return null;
+  if (inputs.currentFingerprint === undefined) return null;
+  if (inputs.baseFingerprint === inputs.currentFingerprint) return null;
+  return ARCHITECTURE_DOCUMENT_NUDGE;
+}
+
+/**
+ * Resolve {@link architectureDocumentNudge}'s inputs from `projectDir` + git, then return
+ * the nudge (or `null`). The branch base is the merge-base with the upstream/default
+ * branch; when it can't be resolved we return `null` rather than guess (no false alarm on
+ * an unknowable baseline). `projectDir` is the repo root (the done-gate's cwd).
+ */
+export function architectureDocumentNudgeForProject(projectDir: string): string | null {
+  // Cheap exit before any git/fs work: no human doc ⇒ nothing to reconcile against.
+  if (!existsSync(nodePath.join(projectDir, ARCHITECTURE_MD))) return null;
+
+  const generatedPath = nodePath.join(resolveNamespaceRoot(projectDir), GENERATED_DOC);
+  const currentFingerprint = existsSync(generatedPath)
+    ? parseGeneratedFingerprint(readFileSync(generatedPath, 'utf8'))
+    : undefined;
+  if (currentFingerprint === undefined) return null;
+
+  const baseRef = resolveBaseRef(projectDir);
+  if (baseRef === undefined) return null; // unknowable baseline → don't guess
+
+  const relativeDocPath = nodePath.relative(projectDir, generatedPath);
+  const baseDoc = runGit(projectDir, ['show', `${baseRef}:${relativeDocPath}`]);
+  const baseFingerprint = baseDoc === '' ? undefined : parseGeneratedFingerprint(baseDoc);
+
+  return architectureDocumentNudge({
+    architectureMdExists: true,
+    baseFingerprint,
+    currentFingerprint,
+  });
+}
+
+/** The merge-base of HEAD with the upstream/default branch — the ticket's divergence point. */
+function resolveBaseRef(cwd: string): string | undefined {
+  const upstream = runGit(cwd, [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{u}',
+  ]).trim();
+  if (upstream === '') return undefined;
+  const mergeBase = runGit(cwd, ['merge-base', 'HEAD', upstream]).trim();
+  return mergeBase === '' ? undefined : mergeBase;
+}

--- a/packages/cli/templates/hooks/lib/architecture-document-nudge.ts
+++ b/packages/cli/templates/hooks/lib/architecture-document-nudge.ts
@@ -21,6 +21,9 @@ const GENERATED_DOC = 'architecture.generated.md';
 /** The human-authored architecture narrative at the project root. */
 const ARCHITECTURE_MD = 'ARCHITECTURE.md';
 
+/** The frontmatter key holding the recorded shape fingerprint (mirrors the CLI writer). */
+const FINGERPRINT_KEY = 'fingerprint';
+
 /** The one-line, non-blocking advisory surfaced at the done-gate when the shape moved. */
 export const ARCHITECTURE_DOCUMENT_NUDGE =
   'ARCHITECTURE.md may be stale: this ticket moved the top-level architecture shape ' +
@@ -49,8 +52,8 @@ export function parseGeneratedFingerprint(content: string): string | undefined {
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
   if (frontmatter === undefined) return undefined;
   for (const line of frontmatter.split(/\r?\n/)) {
-    if (line.startsWith('fingerprint:')) {
-      const value = line.slice('fingerprint:'.length).trim();
+    if (line.startsWith(`${FINGERPRINT_KEY}:`)) {
+      const value = line.slice(FINGERPRINT_KEY.length + 1).trim();
       return value.length > 0 ? value : undefined;
     }
   }

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -41,6 +41,7 @@ import { checkSkillInvocations, requiredSkillsForDone } from './lib/skill-invoca
 import { runTests } from './lib/test-runner.ts';
 import { changedFilesSinceHead, evaluateImplementStopTypecheck } from './lib/typecheck-gate.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
+import { architectureDocumentNudgeForProject } from './lib/architecture-document-nudge.ts';
 import { installCrashCapture } from './lib/self-report.ts';
 
 installCrashCapture('stop-quality');
@@ -613,6 +614,13 @@ if (currentPhase === 'done') {
     const currentTicketDirectory = `${ticketsDir}/${ticketInfo.folder}`;
     updateTicketStatus(currentTicketDirectory, 'done', 'done');
 
+    // AXRC4D: non-blocking ARCHITECTURE.md staleness nudge. If this ticket moved the
+    // top-level architecture fingerprint and a human ARCHITECTURE.md exists, advise a
+    // reconcile. Prepended to whatever done-message we surface; the ticket is already
+    // marked done above, so this never blocks the transition.
+    const archDriftNudge = architectureDocumentNudgeForProject(projectDir);
+    const donePrefix = archDriftNudge === null ? '' : `${archDriftNudge}\n\n`;
+
     // Walk hierarchy: cascade done status up and navigate to next sibling
     let directory = currentTicketDirectory;
     const MAX_CASCADE = 10;
@@ -622,7 +630,7 @@ if (currentPhase === 'done') {
         const nextInfo = getTicketInfo(projectDir, next.ticketId);
         const nextLabel = nextInfo.slug ? `${nextInfo.slug} (${next.ticketId})` : next.ticketId;
         softBlock(
-          `Ticket complete! Next up: read ${next.ticketDirectory}/ticket.md and begin work on ${nextLabel}.`,
+          `${donePrefix}Ticket complete! Next up: read ${next.ticketDirectory}/ticket.md and begin work on ${nextLabel}.`,
         );
       } else if (next.type === 'cascade-done') {
         // Mark parent done and continue walking up
@@ -633,6 +641,9 @@ if (currentPhase === 'done') {
         break;
       }
     }
+
+    // No onward navigation, but the shape moved — still surface the advisory once.
+    if (archDriftNudge !== null) softBlock(archDriftNudge);
   }
 
   process.exit(0);

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -352,9 +352,17 @@ Test Quality:
 **ARCHITECTURE.md:**
 
 - If missing → create from `.safeword/templates/architecture-template.md`
-- If exists → check for drift and gaps:
-  - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-  - **Gap (warn):** Major dependencies not documented
+- If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
+  - **Dependency drift:**
+    - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
+    - **Gap (warn):** Major dependencies not documented
+  - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
+    - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
+    - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
+    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
+  - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
 **README.md:**
 
@@ -379,6 +387,7 @@ Report findings by severity with codes:
 
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
+- [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
 
 ### Warnings (should review)
 
@@ -389,6 +398,8 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
+- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/packages/cli/tests/hooks/architecture-document-nudge-parity.test.ts
+++ b/packages/cli/tests/hooks/architecture-document-nudge-parity.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Differential test (P58R22 pattern) pinning the hook-side `parseGeneratedFingerprint`
+ * against the canonical CLI `readDocumentFingerprint` that WRITES the generated doc
+ * (ticket AXRC4D, GitHub #559). The hook lib deliberately re-implements the parser
+ * (hooks run standalone under bun in customer repos, with no import path to the CLI), so
+ * the two could silently diverge if the doc's frontmatter format ever changes. This test
+ * makes that divergence loud: for every fixture, both readers must agree.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { readDocumentFingerprint } from '../../src/utils/architecture-document.js';
+import { parseGeneratedFingerprint } from '../../templates/hooks/lib/architecture-document-nudge.js';
+
+const FIXTURES: Record<string, string> = {
+  'canonical doc':
+    '---\ngenerator: safeword-architecture\nfingerprint: abc123\n---\n\n# Architecture\n',
+  'fingerprint as the only key': '---\nfingerprint: deadbeef\n---\n',
+  'fingerprint not the first key':
+    '---\ngenerator: safeword-architecture\nfingerprint: zzz999\n---\n',
+  'CRLF line endings': '---\r\ngenerator: safeword-architecture\r\nfingerprint: c0ffee\r\n---\r\n',
+  'empty fingerprint value': '---\nfingerprint:\n---\n',
+  'no frontmatter at all': '# Architecture\n\nThe human narrative, no fences.\n',
+  'a fingerprint-looking line OUTSIDE the frontmatter':
+    '---\ngenerator: safeword-architecture\n---\n\nfingerprint: not-this-one\n',
+  'empty content': '',
+  'unterminated frontmatter': '---\nfingerprint: abc\n',
+};
+
+describe('parseGeneratedFingerprint ⇄ readDocumentFingerprint differential', () => {
+  for (const [name, content] of Object.entries(FIXTURES)) {
+    it(`agrees on: ${name}`, () => {
+      expect(parseGeneratedFingerprint(content)).toBe(readDocumentFingerprint(content));
+    });
+  }
+});

--- a/packages/cli/tests/hooks/architecture-document-nudge.test.ts
+++ b/packages/cli/tests/hooks/architecture-document-nudge.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit + integration tests for the done-gate ARCHITECTURE.md staleness nudge
+ * (ticket AXRC4D, GitHub #559). The nudge fires when a ticket moved the top-level
+ * architecture fingerprint (the value recorded in `<namespace>/architecture.generated.md`)
+ * vs the branch base AND a human `ARCHITECTURE.md` exists — reusing the existing
+ * fingerprint as a cheap, deterministic trigger. Pure decision tests pin the boundary;
+ * the git-backed integration test exercises the real base-resolution path and maps to the
+ * five AXRC4D done_when flows (new module, removed module, in-sync, non-structural, absent).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ARCHITECTURE_DOCUMENT_NUDGE,
+  architectureDocumentNudge,
+  architectureDocumentNudgeForProject,
+  parseGeneratedFingerprint,
+} from '../../templates/hooks/lib/architecture-document-nudge.js';
+
+function generatedDocument(fingerprint: string): string {
+  return `---\ngenerator: safeword-architecture\nfingerprint: ${fingerprint}\n---\n\n# Architecture\n\n## Modules\n`;
+}
+
+describe('parseGeneratedFingerprint', () => {
+  it('reads the fingerprint from a generated-doc frontmatter', () => {
+    expect(parseGeneratedFingerprint(generatedDocument('abc123'))).toBe('abc123');
+  });
+
+  it('is CRLF-tolerant', () => {
+    expect(parseGeneratedFingerprint('---\r\nfingerprint: deadbeef\r\n---\r\n')).toBe('deadbeef');
+  });
+
+  it('returns undefined when there is no frontmatter', () => {
+    expect(parseGeneratedFingerprint('# Architecture\n\nno frontmatter here')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty fingerprint value', () => {
+    expect(parseGeneratedFingerprint('---\nfingerprint:\n---\n')).toBeUndefined();
+  });
+
+  it('returns undefined for empty content', () => {
+    expect(parseGeneratedFingerprint('')).toBeUndefined();
+  });
+});
+
+describe('architectureDocumentNudge (pure decision)', () => {
+  it('nudges when the fingerprint moved and ARCHITECTURE.md exists (module added/removed)', () => {
+    expect(
+      architectureDocumentNudge({
+        architectureMdExists: true,
+        baseFingerprint: 'old',
+        currentFingerprint: 'new',
+      }),
+    ).toBe(ARCHITECTURE_DOCUMENT_NUDGE);
+  });
+
+  it('nudges when the shape map was newly introduced this ticket (no base doc)', () => {
+    expect(
+      architectureDocumentNudge({
+        architectureMdExists: true,
+        baseFingerprint: undefined,
+        currentFingerprint: 'new',
+      }),
+    ).toBe(ARCHITECTURE_DOCUMENT_NUDGE);
+  });
+
+  it('stays silent when the fingerprint is unchanged (in-sync / non-structural ticket)', () => {
+    expect(
+      architectureDocumentNudge({
+        architectureMdExists: true,
+        baseFingerprint: 'same',
+        currentFingerprint: 'same',
+      }),
+    ).toBeNull();
+  });
+
+  it('stays silent when no human ARCHITECTURE.md exists (audit owns the absent case)', () => {
+    expect(
+      architectureDocumentNudge({
+        architectureMdExists: false,
+        baseFingerprint: 'old',
+        currentFingerprint: 'new',
+      }),
+    ).toBeNull();
+  });
+
+  it('stays silent when there is no generated shape doc to compare', () => {
+    expect(
+      architectureDocumentNudge({
+        architectureMdExists: true,
+        baseFingerprint: 'old',
+        currentFingerprint: undefined,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('architectureDocumentNudgeForProject (git-backed, AXRC4D done_when flows)', () => {
+  const created: string[] = [];
+
+  function git(cwd: string, ...args: string[]): void {
+    execFileSync('git', args, { cwd, stdio: 'ignore' });
+  }
+
+  /**
+   * A repo on a feature branch whose upstream is `main` (so `@{u}` + merge-base
+   * resolve); baseline doc has `baseFp`. `upstream: false` leaves the branch with no
+   * upstream — the unresolvable-baseline case the nudge must fail closed on.
+   */
+  function repoWithBaseline(
+    baseFp: string,
+    options: { architectureMd?: boolean; upstream?: boolean } = {},
+  ): string {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), 'arch-drift-'));
+    created.push(dir);
+    git(dir, 'init', '-q', '-b', 'main');
+    git(dir, 'config', 'user.email', 'test@example.com');
+    git(dir, 'config', 'user.name', 'Test');
+    if (options.architectureMd !== false) {
+      writeFileSync(
+        nodePath.join(dir, 'ARCHITECTURE.md'),
+        '# Architecture\n\nThe human narrative.\n',
+      );
+    }
+    mkdirSync(nodePath.join(dir, '.project'), { recursive: true });
+    writeFileSync(
+      nodePath.join(dir, '.project', 'architecture.generated.md'),
+      generatedDocument(baseFp),
+    );
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-q', '-m', 'baseline');
+    // Diverge onto a feature branch tracking main — `@{u}` resolves to main.
+    git(dir, 'checkout', '-q', '-b', 'feature');
+    if (options.upstream !== false) git(dir, 'branch', '--set-upstream-to=main', 'feature');
+    return dir;
+  }
+
+  function setCurrentFingerprint(dir: string, fingerprint: string): void {
+    writeFileSync(
+      nodePath.join(dir, '.project', 'architecture.generated.md'),
+      generatedDocument(fingerprint),
+    );
+  }
+
+  afterEach(() => {
+    const directories = [...created];
+    created.length = 0;
+    for (const directory of directories) rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('new/removed module → fingerprint moved vs base → nudges', () => {
+    const dir = repoWithBaseline('base-fp');
+    setCurrentFingerprint(dir, 'moved-fp'); // a top-level module added/removed this ticket
+
+    expect(architectureDocumentNudgeForProject(dir)).toBe(ARCHITECTURE_DOCUMENT_NUDGE);
+  });
+
+  it('in-sync (fingerprint unchanged) → no nudge', () => {
+    const dir = repoWithBaseline('same-fp');
+    // working tree leaves the generated doc untouched
+
+    expect(architectureDocumentNudgeForProject(dir)).toBeNull();
+  });
+
+  it('non-structural ticket (shape doc unchanged) → no nudge', () => {
+    const dir = repoWithBaseline('same-fp');
+    writeFileSync(nodePath.join(dir, 'README.md'), 'docs only, no shape change\n'); // unrelated edit
+
+    expect(architectureDocumentNudgeForProject(dir)).toBeNull();
+  });
+
+  it('ARCHITECTURE.md absent → no nudge (audit create-from-template path owns it)', () => {
+    const dir = repoWithBaseline('base-fp', { architectureMd: false });
+    setCurrentFingerprint(dir, 'moved-fp');
+
+    expect(architectureDocumentNudgeForProject(dir)).toBeNull();
+  });
+
+  it('unresolvable baseline (no upstream) → no nudge, even when the fingerprint moved', () => {
+    // The fail-closed boundary the no-false-alarm design rests on: with no upstream,
+    // `@{u}` / merge-base can't resolve, so the nudge must NOT guess that the shape moved.
+    const dir = repoWithBaseline('base-fp', { upstream: false });
+    setCurrentFingerprint(dir, 'moved-fp');
+
+    expect(architectureDocumentNudgeForProject(dir)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #559.

## Problem

safeword generates `architecture.generated.md` (a deterministic, always-fresh module/package map) but the hand-authored `ARCHITECTURE.md` is never reconciled against it, so it silently rots — a module is added/removed and the human doc still describes the old shape. The two never disagree loudly.

## Approach (skill-first, per the recorded `/figure-it-out`)

Reconciliation splits by what each side is good at: **structural facts** (which modules/layers exist) already live machine-readable in the generated doc — a skill READS it and compares; **narrative** (why it's shaped this way) is human-owned — surface drift, never auto-rewrite. This deliberately **rejects** the heavier earlier proposal (a new deterministic `architectureDocDrift` module + a marker-delimited managed Module-Map region).

Two surfaces, both **report-only / non-blocking**:

### 1. `/audit` structural reconciliation (skill-prompt sharpening)

The existing `ARCHITECTURE.md` check now reconciles **structural** claims against `architecture.generated.md` (its `### <name>` units under `## Modules` / `## Packages`, read as ground truth — not just `package.json` deps):

- **Orphaned (E003, error):** ARCHITECTURE.md documents a module/layer (or a layer→dir mapping) absent from the generated map.
- **Missing (W008, warn):** a real top-level module/package in the generated map the doc never mentions.
- **Drifted layer→dir (W009, warn):** a Layers & Boundaries `directory` matching no generated module path.

It cites the generated doc and proposes edits under human review; it **never** auto-overwrites the narrative. (3 skill copies: `templates/` / `.claude/` / `.agents/`.)

### 2. Deterministic done-gate nudge (Stop-hook)

When a ticket moved the top-level architecture fingerprint (the value recorded in `architecture.generated.md`, read vs the git merge-base) **and** an `ARCHITECTURE.md` exists, the done-gate emits a one-line **non-blocking** advisory to run `/audit`. It **reuses the existing fingerprint** as a cheap trigger (computes nothing from source — not a drift detector) and **fails closed** on an unresolvable baseline (no upstream / detached HEAD → no nudge, no guess). New hook lib `architecture-document-nudge.ts` + a `schema.ts` setup-manifest entry so `safeword setup` deploys it.

### Known, accepted over-fire

On a monorepo, `monorepoFingerprint` also covers inter-package edges + boundary config + the unreadable-workspace set, so an **edge/boundary-only** change nudges too, even with no module added/removed. This is acceptable for a non-blocking advisory — an edge change can legitimately stale the narrative, and over-firing a one-liner is the correct failure direction.

## Tests

- 15 unit + **git-backed integration** tests (`tests/hooks/architecture-document-nudge.test.ts`) covering the five `done_when` flows — new/removed module → nudge, in-sync → none, non-structural → none, `ARCHITECTURE.md` absent → none, and the unresolvable-baseline fail-closed branch.
- Full hooks + integration suite green (118 files, 1910 tests), including every E2E done-gate test that spawns the deployed Stop hook.

Followed safeword's BDD flow (ticket `AXRC4D`, recovered from the intake branch): spec → dimensions → scenarios → independent design review (PASS-WITH-NITS; the one load-bearing finding — an untested fail-closed branch — was added) → implement → verify.

Builds on #554 (the generated doc is now complete for any monorepo shape) and complements #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRGYnMkxo3yim7qdFs7s19)_