### PR TITLE
Auto-resolve merge conflicts on generated docs via .gitattributes merge=union (#566)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+
+# Safeword - managed merge strategy for generated artifacts
+**/architecture.generated.md merge=union linguist-generated=true
+.project/tickets/INDEX.md merge=union linguist-generated=true
+.project/tickets/INDEX-completed.md merge=union linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-
 # Safeword - managed merge strategy for generated artifacts
 **/architecture.generated.md merge=union linguist-generated=true
 .project/tickets/INDEX.md merge=union linguist-generated=true

--- a/.project/tickets/GA7T6M-generated-doc-merge-union/ticket.md
+++ b/.project/tickets/GA7T6M-generated-doc-merge-union/ticket.md
@@ -1,0 +1,60 @@
+---
+id: GA7T6M
+slug: generated-doc-merge-union
+type: task
+phase: verify
+status: todo
+created: 2026-06-30T14:55:00.000Z
+last_modified: 2026-06-30T14:55:00.000Z
+---
+
+# Auto-resolve merge conflicts on generated docs via `.gitattributes merge=union`
+
+**Goal (GitHub #566):** safeword's committed, deterministically-regenerated
+artifacts — the architecture docs (`architecture.generated.md`) and the ticket
+index (`tickets/INDEX.md`, `tickets/INDEX-completed.md`) — conflict on the
+`fingerprint:` line and reconcile/stale markers every time the default branch is
+merged into a branch that touched architecture or tickets. The conflicts add no
+value (the files are reproducible from source). Ship a safeword-managed
+`.gitattributes` marking these paths `merge=union` so a local `git merge`/`rebase`/
+`pull` auto-resolves them; safeword's existing heal + `architecture --check` then
+reconcile the union result to the correct content.
+
+**Decision (from `/figure-it-out`, 2026-06-30):** `merge=union` is a built-in git
+driver — **attribute-only, no `git config`** — so it deploys via a committed
+`.gitattributes` and works on any clone/CI. Rejected: gitignoring the artifacts
+(breaks `architecture --check`'s committed baseline and loses human prose in leaf
+docs); a custom merge driver (needs per-clone `git config`, fragile in consumer
+repos); dropping the fingerprint (doesn't fix body conflicts). GitHub does not
+honor `.gitattributes` merge drivers server-side, but the issue's repro is the
+**local** merge of the default branch into a feature branch — exactly what union
+fixes. `linguist-generated=true` is added as a bonus (collapses diffs, marks the
+files generated on GitHub).
+
+## Scope
+
+- A safeword-managed block in `.gitattributes` (append, marker-delimited, ctx-
+  resolved namespace root, `rerender` on upgrade) deployed by `safeword setup`,
+  mirroring the existing `.prettierignore` managed-block pattern:
+  - `**/architecture.generated.md merge=union linguist-generated=true`
+  - `<root>/tickets/INDEX.md merge=union linguist-generated=true`
+  - `<root>/tickets/INDEX-completed.md merge=union linguist-generated=true`
+- Dogfood: add the rendered block to this repo's `.gitattributes`.
+- Tests: setup writes/append-merges the block; idempotent on re-run; ctx-resolved
+  path for a custom `paths.projectRoot`; the #566 repro now auto-resolves.
+
+## Out of scope
+
+- GitHub server-side PR-merge conflicts (git limitation; not the reported repro).
+- Changing whether the docs are committed, or the `--check`/heal pipeline.
+- Carving leaf docs out of the glob — accepted trade-off below.
+
+## Accepted trade-off
+
+`**/architecture.generated.md` includes the prose-bearing leaf/single-repo docs,
+not just the fully-derived root index. A union that duplicates a leaf section where
+two branches edited the **same** human prose resolves last-write-wins (one
+paragraph kept; both retained in git history; heal keeps the survivor valid). This
+is rare, recoverable, and no worse than a human picking a side in a conflict — so
+the simpler one-glob form is preferred over per-package excludes. The frequent,
+zero-risk wins (root index + ticket index) are fully covered.

--- a/.project/tickets/GA7T6M-generated-doc-merge-union/verify.md
+++ b/.project/tickets/GA7T6M-generated-doc-merge-union/verify.md
@@ -1,0 +1,36 @@
+# Verify: generated-doc merge-union (GA7T6M / #566)
+
+## Checklist
+
+**Repro fixed:** ✅ The pre-fix repro (two branches each regenerating the doc) produced
+a 6-marker conflict; with `merge=union` active the same merge **auto-resolves with 0
+conflict markers** ("Merge made by the 'ort' strategy") — proven both ad-hoc and as a
+git-level test (`gitattributes-merge-union.test.ts`).
+**Setup deploys it:** ✅ `safeword setup` writes the managed `.gitattributes` block
+(3 `merge=union` lines + header); idempotent on re-run (no duplication); resolves the
+ticket-index paths against a custom `paths.projectRoot`; appends to (preserves) a
+consumer's existing `.gitattributes`.
+**Dogfood:** ✅ This repo's `.gitattributes` is **byte-identical** to setup output → no
+upgrade churn.
+**Tests:** ✅ 5 new tests pass; 173 reconcile/schema/owned-paths regression tests green.
+**Lint:** ✅ clean. **Typecheck:** ✅ no new errors.
+**`architecture --check`:** ✅ unaffected (the `.gitattributes` change does not touch the
+generated docs).
+**Dep drift:** ✅ zero new dependencies.
+
+## Constraints preserved (from the figure-it-out)
+
+- `architecture --check` still works — files stay committed; union only removes the
+  manual conflict step, and `--check` remains the gate that forces a correct regen.
+- Human prose preserved — union keeps both sides' lines; heal reconciles.
+- Browsability preserved (still committed); `linguist-generated=true` collapses diffs.
+- Deployable — `merge=union` is built-in/attribute-only, so the committed `.gitattributes`
+  works on any clone/CI with no per-clone `git config`.
+
+## Accepted trade-off (documented in ticket.md)
+
+`**/architecture.generated.md` includes prose-bearing leaf docs; a same-section prose
+collision resolves last-write-wins (rare, recoverable via history + heal). The frequent,
+zero-risk wins (root index + ticket index) are fully covered. GitHub server-side PR merges
+don't honor merge drivers (git limitation) — out of scope; the reported repro is the local
+merge, which is fixed.

--- a/packages/cli/src/owned-paths.ts
+++ b/packages/cli/src/owned-paths.ts
@@ -63,8 +63,7 @@ export function safewordIgnoreDirectories(namespaceRootLabel?: string): readonly
  * root resolved OUTSIDE the repo ('../…' would leak nonsensical entries).
  */
 export function resolvedNamespaceDirectory(ctx: ProjectContext): string | undefined {
-  const root = ctx.namespaceRoot ?? resolveNamespaceRoot(ctx.cwd);
-  const label = nodePath.relative(ctx.cwd, root) || '.';
+  const label = resolvedNamespaceRootLabel(ctx);
   // Skip the repo root ('.'), the well-known roots (already in the static lists),
   // and any root resolved OUTSIDE the repo ('../…') — a traversal label would leak
   // nonsensical ignore/prefix entries that match nothing under the repo.
@@ -72,6 +71,18 @@ export function resolvedNamespaceDirectory(ctx: ProjectContext): string | undefi
     return undefined;
   }
   return label;
+}
+
+/**
+ * The repo-relative resolved namespace-root label — always concrete (`.project` by
+ * default, the legacy or custom `paths.projectRoot` otherwise), unlike
+ * {@link resolvedNamespaceDirectory} which suppresses the well-known roots. Used where a
+ * managed file must name the actual root path (e.g. the `.gitattributes` ticket-index
+ * entries, #566). Repo-root namespace (`.`) yields `.`, so callers prefix-join cleanly.
+ */
+export function resolvedNamespaceRootLabel(ctx: ProjectContext): string {
+  const root = ctx.namespaceRoot ?? resolveNamespaceRoot(ctx.cwd);
+  return nodePath.relative(ctx.cwd, root) || '.';
 }
 
 /**

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1156,8 +1156,11 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       // paths.projectRoot resolves into the ticket-index paths, and the block re-renders
       // in place on upgrade. Default/legacy output is byte-identical, so those installs
       // no-op. Appended (marker-delimited) so a consumer's own .gitattributes is preserved.
+      // No leading newline (unlike .prettierignore): prettier-plugin-sh DOES format
+      // .gitattributes and rejects a leading blank line on a fresh install; existing
+      // content separates via its own trailing newline.
       operation: 'append',
-      content: ctx => `\n${managedGitattributes(ctx)}\n`,
+      content: ctx => `${managedGitattributes(ctx)}\n`,
       rerender: true,
       marker: GITATTRIBUTES_HEADER,
     },

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -30,6 +30,7 @@ import {
   generateOwnedPathsModule,
   resolvedIgnoreDirectories,
   resolvedNamespaceDirectory,
+  resolvedNamespaceRootLabel,
 } from './owned-paths.js';
 import type {
   FileDefinition,
@@ -385,6 +386,31 @@ function managedPrettierPaths(ctx: ProjectContext): string[] {
 // and re-rendered against this exact string). The "(owned dirs)" suffix marks the
 // post-EYRK34 format; the stable prefix is what stale-config-scan detects.
 const PRETTIER_EXCLUSIONS_HEADER = '# Safeword - managed prettier exclusions (owned dirs)';
+
+// Header line of the managed .gitattributes block — also its marker (re-applied and
+// re-rendered against this exact string). See GitHub #566 / ticket GA7T6M.
+const GITATTRIBUTES_HEADER = '# Safeword - managed merge strategy for generated artifacts';
+
+/**
+ * The managed `.gitattributes` block (issue #566): safeword's committed but
+ * deterministically-regenerated artifacts — the architecture docs and the ticket index —
+ * get `merge=union` so a local `git merge`/`rebase`/`pull` of the default branch
+ * auto-resolves them instead of conflicting on the `fingerprint:` line + reconcile/stale
+ * markers. `union` is a BUILT-IN driver (attribute-only, no `git config`), so it works on
+ * any clone/CI from the committed file; the heal + `architecture --check` pipeline then
+ * reconciles the union result to the correct content. `linguist-generated=true` collapses
+ * their diffs and marks them generated on GitHub. Resolved per-ctx so a custom
+ * `paths.projectRoot` ticket index is covered; the architecture-doc glob is root-agnostic.
+ */
+function managedGitattributes(ctx: ProjectContext): string {
+  const root = resolvedNamespaceRootLabel(ctx);
+  return [
+    GITATTRIBUTES_HEADER,
+    '**/architecture.generated.md merge=union linguist-generated=true',
+    `${root}/tickets/INDEX.md merge=union linguist-generated=true`,
+    `${root}/tickets/INDEX-completed.md merge=union linguist-generated=true`,
+  ].join('\n');
+}
 
 export const SAFEWORD_SCHEMA: SafewordSchema = {
   version: VERSION,
@@ -1124,6 +1150,16 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       content: ctx => `\n${PRETTIER_EXCLUSIONS_HEADER}\n${managedPrettierPaths(ctx).join('\n')}\n`,
       rerender: true,
       marker: PRETTIER_EXCLUSIONS_HEADER,
+    },
+    '.gitattributes': {
+      // ctx factory + rerender (issue #566), same shape as .prettierignore: a custom
+      // paths.projectRoot resolves into the ticket-index paths, and the block re-renders
+      // in place on upgrade. Default/legacy output is byte-identical, so those installs
+      // no-op. Appended (marker-delimited) so a consumer's own .gitattributes is preserved.
+      operation: 'append',
+      content: ctx => `\n${managedGitattributes(ctx)}\n`,
+      rerender: true,
+      marker: GITATTRIBUTES_HEADER,
     },
     '.codex/config.toml': [
       // Primary patch: retrofits the prompt-timestamp hook onto pre-existing

--- a/packages/cli/tests/gitattributes-merge-union.test.ts
+++ b/packages/cli/tests/gitattributes-merge-union.test.ts
@@ -1,0 +1,144 @@
+/**
+ * `.gitattributes merge=union` for generated artifacts (ticket GA7T6M, GitHub #566).
+ *
+ * safeword's committed-but-deterministically-regenerated artifacts (architecture docs +
+ * ticket index) conflicted on every default-branch merge. Setup now ships a managed
+ * `.gitattributes` block marking them `merge=union` (a built-in, attribute-only driver) so
+ * local merges auto-resolve. These tests pin: the block reconciles at the resolved
+ * namespace root, is idempotent, preserves a consumer's own `.gitattributes`, and that
+ * `merge=union` actually makes git auto-resolve the conflict the issue reported.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reconcile } from '../src/reconcile.js';
+import { SAFEWORD_SCHEMA } from '../src/schema.js';
+import { createProjectContext } from '../src/utils/context.js';
+import { createTemporaryDirectory, removeTemporaryDirectory } from './helpers.js';
+
+const HEADER = '# Safeword - managed merge strategy for generated artifacts';
+
+describe('.gitattributes merge=union for generated artifacts (GA7T6M / #566)', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = createTemporaryDirectory();
+    writeFileSync(nodePath.join(cwd, 'package.json'), JSON.stringify({ name: 'consumer' }));
+  });
+
+  afterEach(() => {
+    removeTemporaryDirectory(cwd);
+  });
+
+  function gitattributes(): string {
+    return readFileSync(nodePath.join(cwd, '.gitattributes'), 'utf8');
+  }
+
+  it('install writes the managed block marking the generated artifacts merge=union', async () => {
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+
+    const content = gitattributes();
+    expect(content).toContain(HEADER);
+    expect(content).toContain('**/architecture.generated.md merge=union linguist-generated=true');
+    expect(content).toContain('.project/tickets/INDEX.md merge=union linguist-generated=true');
+    expect(content).toContain(
+      '.project/tickets/INDEX-completed.md merge=union linguist-generated=true',
+    );
+  });
+
+  it('is idempotent — a second install does not duplicate the block', async () => {
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+
+    const unionLines = gitattributes()
+      .split('\n')
+      .filter(line => line.includes('merge=union'));
+    expect(unionLines).toHaveLength(3);
+  });
+
+  it('resolves the ticket-index paths against a custom paths.projectRoot', async () => {
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ paths: { projectRoot: 'team-ns' } }),
+    );
+
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+
+    const content = gitattributes();
+    expect(content).toContain('team-ns/tickets/INDEX.md merge=union linguist-generated=true');
+    // The architecture-doc glob is root-agnostic, so it stays the same.
+    expect(content).toContain('**/architecture.generated.md merge=union linguist-generated=true');
+  });
+
+  it("appends to (preserves) a consumer's existing .gitattributes", async () => {
+    writeFileSync(nodePath.join(cwd, '.gitattributes'), '*.png binary\n');
+
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+
+    const content = gitattributes();
+    expect(content).toContain('*.png binary'); // consumer's line survives
+    expect(content).toContain(HEADER); // safeword block appended
+  });
+});
+
+describe('merge=union actually auto-resolves the #566 conflict (git-level)', () => {
+  const created: string[] = [];
+
+  function git(dir: string, ...args: string[]): void {
+    execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  }
+  function write(dir: string, relativePath: string, body: string): void {
+    const abs = nodePath.join(dir, relativePath);
+    mkdirSync(nodePath.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+
+  afterEach(() => {
+    const directories = [...created];
+    created.length = 0;
+    for (const dir of directories) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a generated-doc divergence that conflicts WITHOUT the attribute auto-merges WITH it', () => {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), 'union-'));
+    created.push(dir);
+    git(dir, 'init', '-q', '-b', 'main');
+    git(dir, 'config', 'user.email', 't@t.co');
+    git(dir, 'config', 'user.name', 't');
+    write(dir, '.gitattributes', '.project/architecture.generated.md merge=union\n');
+    write(dir, '.project/architecture.generated.md', '---\nfingerprint: AAAA\n---\n### web\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'base');
+
+    git(dir, 'checkout', '-q', '-b', 'feature-1');
+    write(
+      dir,
+      '.project/architecture.generated.md',
+      '---\nfingerprint: BBBB\n---\n### web\n### billing\n',
+    );
+    git(dir, 'commit', '-qam', 'f1');
+
+    git(dir, 'checkout', '-q', 'main');
+    git(dir, 'checkout', '-q', '-b', 'feature-2');
+    write(
+      dir,
+      '.project/architecture.generated.md',
+      '---\nfingerprint: CCCC\n---\n### web\n### auth\n',
+    );
+    git(dir, 'commit', '-qam', 'f2');
+
+    // Merge feature-1 into feature-2 — the issue's "merge the default branch in" shape.
+    // Without `merge=union` this conflicts (verified separately); with it, git auto-resolves.
+    git(dir, 'merge', 'feature-1'); // throws if the merge fails (conflict → non-zero exit)
+
+    const merged = readFileSync(nodePath.join(dir, '.project/architecture.generated.md'), 'utf8');
+    expect(merged).not.toContain('<<<<<<<');
+    expect(merged).not.toContain('>>>>>>>');
+  });
+});


### PR DESCRIPTION
Closes #566.

## Problem

safeword's committed-but-deterministically-regenerated artifacts — the architecture docs (`architecture.generated.md`) and the ticket index (`tickets/INDEX.md`, `tickets/INDEX-completed.md`) — conflict on the frontmatter `fingerprint:` line + `<!-- reconciled: -->` / `> ⚠ stale` markers every time the default branch is merged into a branch that touched architecture or tickets. The conflicts add no value (the files are reproducible from source). Reproduced a clean 6-marker conflict locally.

## Fix

Ship a safeword-managed `.gitattributes` block marking these paths **`merge=union`** — a **built-in** git driver that's **attribute-only** (no `git config`), so the committed file works on any clone/CI:

```gitattributes
# Safeword - managed merge strategy for generated artifacts
**/architecture.generated.md merge=union linguist-generated=true
.project/tickets/INDEX.md merge=union linguist-generated=true
.project/tickets/INDEX-completed.md merge=union linguist-generated=true
```

A local `git merge`/`rebase`/`pull` of the default branch now **auto-resolves** these files; safeword's existing SessionStart heal + `architecture --check` then reconcile the union result to the correct content. `linguist-generated=true` collapses their diffs and marks them generated on GitHub.

**Verified:** the same divergence that produced 6 conflict markers now auto-merges with **0** ("Merge made by the 'ort' strategy") — both ad-hoc and as a git-level test.

## How it's shipped

Deployed via the setup schema as a marker-delimited **append-block** (mirrors the existing `.prettierignore` pattern: ctx-resolved namespace root + `rerender` on upgrade), so:
- a consumer's own `.gitattributes` is preserved (append, not overwrite);
- a custom `paths.projectRoot` resolves into the ticket-index paths;
- re-running setup is idempotent (no duplication).

Adds `resolvedNamespaceRootLabel` (the always-concrete root label, unlike `resolvedNamespaceDirectory` which suppresses the well-known roots). Dogfooded in this repo — the committed `.gitattributes` is byte-identical to setup output (no upgrade churn).

## Decision (`/figure-it-out`)

Chose `merge=union` over: **gitignoring** the artifacts (breaks `architecture --check`'s committed baseline and loses human prose in leaf docs); a **custom merge driver** (needs per-clone `git config`, fragile in consumer repos); **dropping the fingerprint** (doesn't fix body conflicts). GitHub does **not** honor `.gitattributes` merge drivers server-side, but the reported repro is the **local** merge, which this fixes.

**Accepted trade-off:** the `**/architecture.generated.md` glob includes prose-bearing leaf docs; a union that duplicates a leaf section where two branches edited the *same* prose resolves last-write-wins (rare, recoverable via history + heal). The frequent, zero-risk wins (the fully-derived root index + ticket index) are fully covered. Carving out per-package leaf excludes was rejected as more machinery than the residual risk warrants.

## Tests

- 5 new (`tests/gitattributes-merge-union.test.ts`): setup writes the block / idempotent / custom `paths.projectRoot` / preserves an existing `.gitattributes` / a git-level proof that `merge=union` auto-resolves the #566 conflict.
- 173 reconcile + schema + owned-paths regression tests green; lint + typecheck clean; `architecture --check` unaffected; zero new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRGYnMkxo3yim7qdFs7s19)_