### PR TITLE
fix(verify): fail loudly when test-plan generation fails (#487)

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -106,14 +106,17 @@ run_safeword() {
 # Capture the plan, then check the generator's exit status BEFORE running it.
 # `bash -c "$(...)"` discards the substitution's exit code, so a failed
 # generator that prints nothing would leave `bash -c ""` — a false green (#487).
-# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
-# without `set -e`, so the explicit check is load-bearing. An empty plan from a
-# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+# Reads $plan_kind from the caller, not a bash positional parameter: in a
+# command file Claude Code rewrites slash-command argument tokens before bash
+# runs, so a positional would be clobbered. Plain assignment (never
+# `local x=$(...)`, which masks `$?`); this block runs without `set -e`, so the
+# explicit check is load-bearing. A successful empty plan stays a clean no-op
+# (`bash -c ""` → exit 0).
 run_plan() {
-  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  plan="$(run_safeword test-plan --kind "$plan_kind" --format sh)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    echo "❌ Evidence generation failed: safeword test-plan --kind $plan_kind exited $rc (red, not a passed check)" >&2
     return "$rc"
   fi
   bash -c "$plan"
@@ -133,7 +136,8 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-run_plan verify
+plan_kind=verify
+run_plan
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -143,13 +147,15 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-run_plan build
+plan_kind=build
+run_plan
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-run_plan typecheck
+plan_kind=typecheck
+run_plan
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -102,6 +102,24 @@ run_safeword() {
   esac
 }
 
+# >>> run_plan (behavior covered by verify-skill.test.ts #487)
+# Capture the plan, then check the generator's exit status BEFORE running it.
+# `bash -c "$(...)"` discards the substitution's exit code, so a failed
+# generator that prints nothing would leave `bash -c ""` — a false green (#487).
+# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
+# without `set -e`, so the explicit check is load-bearing. An empty plan from a
+# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+run_plan() {
+  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    return "$rc"
+  fi
+  bash -c "$plan"
+}
+# <<< run_plan
+
 CANDIDATE="node_modules/.bin/safeword"
 if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
@@ -115,7 +133,7 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(run_safeword test-plan --kind verify --format sh)"
+run_plan verify
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -125,13 +143,13 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(run_safeword test-plan --kind build --format sh)"
+run_plan build
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
+run_plan typecheck
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -106,14 +106,17 @@ run_safeword() {
 # Capture the plan, then check the generator's exit status BEFORE running it.
 # `bash -c "$(...)"` discards the substitution's exit code, so a failed
 # generator that prints nothing would leave `bash -c ""` — a false green (#487).
-# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
-# without `set -e`, so the explicit check is load-bearing. An empty plan from a
-# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+# Reads $plan_kind from the caller, not a bash positional parameter: in a
+# command file Claude Code rewrites slash-command argument tokens before bash
+# runs, so a positional would be clobbered. Plain assignment (never
+# `local x=$(...)`, which masks `$?`); this block runs without `set -e`, so the
+# explicit check is load-bearing. A successful empty plan stays a clean no-op
+# (`bash -c ""` → exit 0).
 run_plan() {
-  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  plan="$(run_safeword test-plan --kind "$plan_kind" --format sh)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    echo "❌ Evidence generation failed: safeword test-plan --kind $plan_kind exited $rc (red, not a passed check)" >&2
     return "$rc"
   fi
   bash -c "$plan"
@@ -133,7 +136,8 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-run_plan verify
+plan_kind=verify
+run_plan
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -143,13 +147,15 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-run_plan build
+plan_kind=build
+run_plan
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-run_plan typecheck
+plan_kind=typecheck
+run_plan
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -102,6 +102,24 @@ run_safeword() {
   esac
 }
 
+# >>> run_plan (behavior covered by verify-skill.test.ts #487)
+# Capture the plan, then check the generator's exit status BEFORE running it.
+# `bash -c "$(...)"` discards the substitution's exit code, so a failed
+# generator that prints nothing would leave `bash -c ""` — a false green (#487).
+# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
+# without `set -e`, so the explicit check is load-bearing. An empty plan from a
+# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+run_plan() {
+  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    return "$rc"
+  fi
+  bash -c "$plan"
+}
+# <<< run_plan
+
 CANDIDATE="node_modules/.bin/safeword"
 if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
@@ -115,7 +133,7 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(run_safeword test-plan --kind verify --format sh)"
+run_plan verify
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -125,13 +143,13 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(run_safeword test-plan --kind build --format sh)"
+run_plan build
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
+run_plan typecheck
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -100,14 +100,17 @@ run_safeword() {
 # Capture the plan, then check the generator's exit status BEFORE running it.
 # `bash -c "$(...)"` discards the substitution's exit code, so a failed
 # generator that prints nothing would leave `bash -c ""` — a false green (#487).
-# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
-# without `set -e`, so the explicit check is load-bearing. An empty plan from a
-# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+# Reads $plan_kind from the caller, not a bash positional parameter: in a
+# command file Claude Code rewrites slash-command argument tokens before bash
+# runs, so a positional would be clobbered. Plain assignment (never
+# `local x=$(...)`, which masks `$?`); this block runs without `set -e`, so the
+# explicit check is load-bearing. A successful empty plan stays a clean no-op
+# (`bash -c ""` → exit 0).
 run_plan() {
-  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  plan="$(run_safeword test-plan --kind "$plan_kind" --format sh)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    echo "❌ Evidence generation failed: safeword test-plan --kind $plan_kind exited $rc (red, not a passed check)" >&2
     return "$rc"
   fi
   bash -c "$plan"
@@ -127,7 +130,8 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-run_plan verify
+plan_kind=verify
+run_plan
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -137,13 +141,15 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-run_plan build
+plan_kind=build
+run_plan
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-run_plan typecheck
+plan_kind=typecheck
+run_plan
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -96,6 +96,24 @@ run_safeword() {
   esac
 }
 
+# >>> run_plan (behavior covered by verify-skill.test.ts #487)
+# Capture the plan, then check the generator's exit status BEFORE running it.
+# `bash -c "$(...)"` discards the substitution's exit code, so a failed
+# generator that prints nothing would leave `bash -c ""` — a false green (#487).
+# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
+# without `set -e`, so the explicit check is load-bearing. An empty plan from a
+# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+run_plan() {
+  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    return "$rc"
+  fi
+  bash -c "$plan"
+}
+# <<< run_plan
+
 CANDIDATE="node_modules/.bin/safeword"
 if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
@@ -109,7 +127,7 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(run_safeword test-plan --kind verify --format sh)"
+run_plan verify
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -119,13 +137,13 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(run_safeword test-plan --kind build --format sh)"
+run_plan build
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
+run_plan typecheck
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -100,14 +100,17 @@ run_safeword() {
 # Capture the plan, then check the generator's exit status BEFORE running it.
 # `bash -c "$(...)"` discards the substitution's exit code, so a failed
 # generator that prints nothing would leave `bash -c ""` — a false green (#487).
-# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
-# without `set -e`, so the explicit check is load-bearing. An empty plan from a
-# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+# Reads $plan_kind from the caller, not a bash positional parameter: in a
+# command file Claude Code rewrites slash-command argument tokens before bash
+# runs, so a positional would be clobbered. Plain assignment (never
+# `local x=$(...)`, which masks `$?`); this block runs without `set -e`, so the
+# explicit check is load-bearing. A successful empty plan stays a clean no-op
+# (`bash -c ""` → exit 0).
 run_plan() {
-  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  plan="$(run_safeword test-plan --kind "$plan_kind" --format sh)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    echo "❌ Evidence generation failed: safeword test-plan --kind $plan_kind exited $rc (red, not a passed check)" >&2
     return "$rc"
   fi
   bash -c "$plan"
@@ -127,7 +130,8 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-run_plan verify
+plan_kind=verify
+run_plan
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -137,13 +141,15 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-run_plan build
+plan_kind=build
+run_plan
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-run_plan typecheck
+plan_kind=typecheck
+run_plan
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/packages/cli/templates/commands/verify.md
+++ b/packages/cli/templates/commands/verify.md
@@ -96,6 +96,24 @@ run_safeword() {
   esac
 }
 
+# >>> run_plan (behavior covered by verify-skill.test.ts #487)
+# Capture the plan, then check the generator's exit status BEFORE running it.
+# `bash -c "$(...)"` discards the substitution's exit code, so a failed
+# generator that prints nothing would leave `bash -c ""` — a false green (#487).
+# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
+# without `set -e`, so the explicit check is load-bearing. An empty plan from a
+# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+run_plan() {
+  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    return "$rc"
+  fi
+  bash -c "$plan"
+}
+# <<< run_plan
+
 CANDIDATE="node_modules/.bin/safeword"
 if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
@@ -109,7 +127,7 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(run_safeword test-plan --kind verify --format sh)"
+run_plan verify
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -119,13 +137,13 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(run_safeword test-plan --kind build --format sh)"
+run_plan build
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
+run_plan typecheck
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -106,14 +106,17 @@ run_safeword() {
 # Capture the plan, then check the generator's exit status BEFORE running it.
 # `bash -c "$(...)"` discards the substitution's exit code, so a failed
 # generator that prints nothing would leave `bash -c ""` — a false green (#487).
-# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
-# without `set -e`, so the explicit check is load-bearing. An empty plan from a
-# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+# Reads $plan_kind from the caller, not a bash positional parameter: in a
+# command file Claude Code rewrites slash-command argument tokens before bash
+# runs, so a positional would be clobbered. Plain assignment (never
+# `local x=$(...)`, which masks `$?`); this block runs without `set -e`, so the
+# explicit check is load-bearing. A successful empty plan stays a clean no-op
+# (`bash -c ""` → exit 0).
 run_plan() {
-  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  plan="$(run_safeword test-plan --kind "$plan_kind" --format sh)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    echo "❌ Evidence generation failed: safeword test-plan --kind $plan_kind exited $rc (red, not a passed check)" >&2
     return "$rc"
   fi
   bash -c "$plan"
@@ -133,7 +136,8 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-run_plan verify
+plan_kind=verify
+run_plan
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -143,13 +147,15 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-run_plan build
+plan_kind=build
+run_plan
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-run_plan typecheck
+plan_kind=typecheck
+run_plan
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -102,6 +102,24 @@ run_safeword() {
   esac
 }
 
+# >>> run_plan (behavior covered by verify-skill.test.ts #487)
+# Capture the plan, then check the generator's exit status BEFORE running it.
+# `bash -c "$(...)"` discards the substitution's exit code, so a failed
+# generator that prints nothing would leave `bash -c ""` — a false green (#487).
+# Plain assignment (never `local x=$(...)`, which masks `$?`); this block runs
+# without `set -e`, so the explicit check is load-bearing. An empty plan from a
+# successful generator stays a clean no-op (`bash -c ""` → exit 0).
+run_plan() {
+  plan="$(run_safeword test-plan --kind "$1" --format sh)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ Evidence generation failed: safeword test-plan --kind $1 exited $rc (red, not a passed check)" >&2
+    return "$rc"
+  fi
+  bash -c "$plan"
+}
+# <<< run_plan
+
 CANDIDATE="node_modules/.bin/safeword"
 if [ -x node_modules/.bin/safeword ] && supports_test_plan; then
   SW="node_modules/.bin/safeword"
@@ -115,7 +133,7 @@ else
 fi
 
 # --- Test suite (resolved by safeword test-plan — one source of truth) ---
-bash -c "$(run_safeword test-plan --kind verify --format sh)"
+run_plan verify
 
 # Gherkin acceptance lane (when available)
 if node -e 'const fs=require("fs");const pkg=JSON.parse(fs.readFileSync("package.json","utf8"));process.exit(pkg.scripts&&pkg.scripts["test:bdd"]?0:1)' 2> /dev/null; then
@@ -125,13 +143,13 @@ else
 fi
 
 # --- Build check (resolved by safeword test-plan) ---
-bash -c "$(run_safeword test-plan --kind build --format sh)"
+run_plan build
 
 # --- Typecheck: the same `tsc --noEmit` signal CI's lint job runs (#436). A
 #     green targeted-test run is NOT readiness if types are broken. An empty
 #     plan (no `typecheck` script / non-TS project) is a silent no-op — when the
 #     ticket touched TypeScript, run `/lint` (which runs tsc) so it isn't a gap. ---
-bash -c "$(run_safeword test-plan --kind typecheck --format sh)"
+run_plan typecheck
 ```
 
 The `/lint` command handles linting with auto-fix. Report any remaining unfixable errors. Aggregate every attempted stack test into the final `**Test Suite:**` status, and every attempted stack build into the final `**Build:**` status. **Typecheck is part of the gate, not optional:** when the ticket changed TypeScript, a passing targeted-test run is not "ready" until `test-plan --kind typecheck` (or `/lint`, which runs `tsc --noEmit`) is green — CI's lint job runs it and will go red otherwise. A skipped or empty test-plan is not a failure when the project lacks a matching automated check; it is an explicit evidence gap to mention when the ticket touched that stack.

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -170,13 +170,14 @@ describe('verify report structure (146)', () => {
 
   describe('Rule: section 2 consumes safeword test-plan (5FF0ZD)', () => {
     it.each(templateFiles)('%s evals the test and build plans from test-plan', (_name, content) => {
-      // Generation goes through run_plan <kind>; the single generator call lives
-      // in the helper (#487), so the kind is parameterized, not inlined.
-      expect(content).toContain('test-plan --kind "$1" --format sh');
-      expect(content).toContain('run_plan verify');
-      expect(content).toContain('run_plan build');
+      // Generation goes through run_plan; the single generator call lives in the
+      // helper (#487), keyed by $plan_kind set at each call site (not a `$1`
+      // positional, which Claude Code would substitute in a command file).
+      expect(content).toContain('test-plan --kind "$plan_kind" --format sh');
+      expect(content).toContain('plan_kind=verify');
+      expect(content).toContain('plan_kind=build');
       // Typecheck is part of the ready path — CI's lint job runs it (#436).
-      expect(content).toContain('run_plan typecheck');
+      expect(content).toContain('plan_kind=typecheck');
     });
 
     it.each(templateFiles)(
@@ -260,6 +261,10 @@ describe('verify report structure (146)', () => {
         expect(content).not.toContain('bash -c "$(run_safeword test-plan');
         // #375 word-splitting guard stays: never re-expand $SW via substitution.
         expect(content).not.toContain('$($SW test-plan');
+        // #487: no `$1`/`$2` positionals — Claude Code substitutes them with
+        // slash-command args in command files (the run_plan kind uses $plan_kind).
+        expect(content).not.toContain('$1');
+        expect(content).not.toContain('$2');
       },
     );
   });
@@ -298,7 +303,7 @@ describe('verify report structure (146)', () => {
     it.each(['verify', 'build'])('fails loudly when %s plan generation exits non-zero', kind => {
       const { code, stderr } = runHelper(
         'run_safeword() { echo boom >&2; return 3; }',
-        `run_plan ${kind}`,
+        `plan_kind=${kind}\nrun_plan`,
       );
       expect(code).not.toBe(0);
       expect(stderr).toContain('Evidence generation failed');
@@ -306,20 +311,20 @@ describe('verify report structure (146)', () => {
 
     // The original false-green: generator fails but prints no shell.
     it('reports an empty failed plan as a failure, not a green check', () => {
-      const { code } = runHelper('run_safeword() { return 4; }', 'run_plan verify');
+      const { code } = runHelper('run_safeword() { return 4; }', 'plan_kind=verify\nrun_plan');
       expect(code).not.toBe(0);
     });
 
     // AC2 (reconciled): a successful empty plan stays a clean no-op.
     it('stays a clean no-op (exit 0) for a successful empty plan', () => {
-      const { code } = runHelper('run_safeword() { return 0; }', 'run_plan verify');
+      const { code } = runHelper('run_safeword() { return 0; }', 'plan_kind=verify\nrun_plan');
       expect(code).toBe(0);
     });
 
     it('runs the generated plan when generation succeeds', () => {
       const { code, stdout } = runHelper(
         `run_safeword() { printf 'echo RAN_PLAN'; }`,
-        'run_plan build',
+        'plan_kind=build\nrun_plan',
       );
       expect(code).toBe(0);
       expect(stdout).toContain('RAN_PLAN');

--- a/packages/cli/tests/verify-skill.test.ts
+++ b/packages/cli/tests/verify-skill.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -169,10 +170,13 @@ describe('verify report structure (146)', () => {
 
   describe('Rule: section 2 consumes safeword test-plan (5FF0ZD)', () => {
     it.each(templateFiles)('%s evals the test and build plans from test-plan', (_name, content) => {
-      expect(content).toContain('test-plan --kind verify --format sh');
-      expect(content).toContain('test-plan --kind build --format sh');
+      // Generation goes through run_plan <kind>; the single generator call lives
+      // in the helper (#487), so the kind is parameterized, not inlined.
+      expect(content).toContain('test-plan --kind "$1" --format sh');
+      expect(content).toContain('run_plan verify');
+      expect(content).toContain('run_plan build');
       // Typecheck is part of the ready path — CI's lint job runs it (#436).
-      expect(content).toContain('test-plan --kind typecheck --format sh');
+      expect(content).toContain('run_plan typecheck');
     });
 
     it.each(templateFiles)(
@@ -248,11 +252,77 @@ describe('verify report structure (146)', () => {
       '%s executes test-plan through dispatch instead of shell word splitting',
       (_name, content) => {
         expect(content).toContain('run_safeword()');
-        expect(content).toContain('bash -c "$(run_safeword test-plan --kind verify --format sh)"');
-        expect(content).toContain('bash -c "$(run_safeword test-plan --kind build --format sh)"');
+        // #487: generation is captured + exit-checked via run_plan before its
+        // output runs, replacing the false-green `bash -c "$(...)"` pattern.
+        expect(content).toContain('run_plan()');
+        expect(content).toContain('rc=$?');
+        expect(content).toMatch(/Evidence generation failed/);
+        expect(content).not.toContain('bash -c "$(run_safeword test-plan');
+        // #375 word-splitting guard stays: never re-expand $SW via substitution.
         expect(content).not.toContain('$($SW test-plan');
-        expect(content).not.toContain('$1');
       },
     );
+  });
+
+  describe('Rule: verify fails loudly when plan generation fails (487)', () => {
+    // Extract the sentinel-delimited run_plan helper and run it under bash with a
+    // stubbed run_safeword — a behavioral check that the generator's exit code is
+    // gated before its output runs. String presence alone can't prove that: the
+    // bug was `bash -c "$(...)"` discarding the substitution's exit code.
+    const helperMatch = /# >>> run_plan[\s\S]*?# <<< run_plan/.exec(skillContent);
+    const runPlanHelper = helperMatch?.[0] ?? '';
+
+    function runHelper(
+      stub: string,
+      call: string,
+    ): { code: number; stderr: string; stdout: string } {
+      const script = `${stub}\n${runPlanHelper}\n${call}\n`;
+      try {
+        const stdout = execSync('bash', {
+          input: script,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return { code: 0, stderr: '', stdout };
+      } catch (error) {
+        const err = error as { status?: number; stderr?: string; stdout?: string };
+        return { code: err.status ?? 1, stderr: err.stderr ?? '', stdout: err.stdout ?? '' };
+      }
+    }
+
+    it('embeds an extractable run_plan helper', () => {
+      expect(runPlanHelper).toContain('run_plan()');
+    });
+
+    // AC1 + AC3: a non-zero generator exit must fail loudly for both kinds.
+    it.each(['verify', 'build'])('fails loudly when %s plan generation exits non-zero', kind => {
+      const { code, stderr } = runHelper(
+        'run_safeword() { echo boom >&2; return 3; }',
+        `run_plan ${kind}`,
+      );
+      expect(code).not.toBe(0);
+      expect(stderr).toContain('Evidence generation failed');
+    });
+
+    // The original false-green: generator fails but prints no shell.
+    it('reports an empty failed plan as a failure, not a green check', () => {
+      const { code } = runHelper('run_safeword() { return 4; }', 'run_plan verify');
+      expect(code).not.toBe(0);
+    });
+
+    // AC2 (reconciled): a successful empty plan stays a clean no-op.
+    it('stays a clean no-op (exit 0) for a successful empty plan', () => {
+      const { code } = runHelper('run_safeword() { return 0; }', 'run_plan verify');
+      expect(code).toBe(0);
+    });
+
+    it('runs the generated plan when generation succeeds', () => {
+      const { code, stdout } = runHelper(
+        `run_safeword() { printf 'echo RAN_PLAN'; }`,
+        'run_plan build',
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain('RAN_PLAN');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #487. `/verify` could report a false green when test-plan generation failed.

The guidance ran `bash -c "$(run_safeword test-plan --kind <k> --format sh)"`. Command substitution **discards the generator's exit code**, so a generator that failed while printing no shell left `bash -c ""` — which exits 0. Verify looked clean even though the evidence generator had broken.

## Fix

A `run_plan <kind>` helper that:
1. Captures the generated plan (plain assignment, so `$?` isn't masked by `local`).
2. Checks the generator's exit status **before** running anything — non-zero → `❌ Evidence generation failed` and propagates the failure (the block runs without `set -e`, so the explicit check is load-bearing).
3. Runs the captured shell only on success.

A **successful empty plan stays a clean no-op** (`bash -c ""` → exit 0), preserving the documented empty-plan contract for projects with no matching build/typecheck step. Emptiness is not treated as failure — the **exit code** is. (This is a deliberate, maintainer-approved reconciliation of the issue's literal AC2, which would otherwise false-RED legitimate empty plans.)

## Scope

- `packages/cli/templates/skills/verify/SKILL.md` and `templates/commands/verify.md` (canonical sources).
- Synced byte-identical to the `.claude` / `.agents` / `.cursor` dogfood copies.
- `packages/cli/tests/verify-skill.test.ts`: rewired the `#375` and `5FF0ZD` string assertions for the new helper (keeping the `$($SW test-plan` word-splitting guard), and a new behavioral block that extracts the sentinel-delimited helper and runs it under bash with a stubbed `run_safeword`.

## Acceptance criteria

- ✅ AC1 — fails when `test-plan --format sh` exits non-zero.
- ✅ AC2 — empty *failed* plan → failure; empty *successful* plan → green no-op.
- ✅ AC3 — covers both **verify** and **build** generation failures.

## Verification

- `verify-skill.test.ts`: 6 new #487 tests + rewired assertions, all green.
- typecheck clean, eslint clean, parity suite (35) green.
- Pre-commit dogfood-direction guard passed (canonical + dogfood staged together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyaYQyezg66g3JXjishd3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyaYQyezg66g3JXjishd3d)_