### PR TITLE
chore(release): v0.58.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release.

## Changes since v0.58.0

- **fix(verify):** `/verify` no longer reports a false green when `safeword test-plan` generation fails (#487, PR #570). The guidance now captures the generated plan and checks the generator's exit code before running it, instead of `bash -c "$(...)"` which discarded the exit code and could run an empty `bash -c ""` (exit 0). A successful empty plan still stays a clean no-op.

## Version

- `packages/cli/package.json`, `.claude-plugin/marketplace.json`, and `bun.lock` workspace version → `0.58.1` (kept in lockstep).

Patch per semver: bug fix only, no added/removed behavior — safe to auto-upgrade. Tag `v0.58.1` after merge triggers the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyaYQyezg66g3JXjishd3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyaYQyezg66g3JXjishd3d)_