### PR TITLE
fix(architecture): empty-TOML-members → absent + gitattributes union negative-scope test

### DIFF
--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -21,7 +21,7 @@ import { isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
-import { hasTomlTable, hasTomlTableKey } from './toml.js';
+import { hasTomlTable, hasTomlTableKey, isTomlTableEmptyArray } from './toml.js';
 
 const byString = (a: string, b: string): number => a.localeCompare(b);
 
@@ -309,7 +309,11 @@ function detectUvWorkspace(projectDirectory: string): WorkspaceDetection {
   if (content === undefined) return ABSENT; // no pyproject.toml
   if (!hasTomlTable(content, 'tool.uv.workspace')) return ABSENT; // a non-uv pyproject
   const members = readUvWorkspaceMembers(content);
-  return members === undefined ? unreadable('uv workspace', 'pyproject.toml') : parsed(members);
+  if (members !== undefined) return parsed(members);
+  // An explicitly-empty `members = []` declares no members — absent, like package.json
+  // `workspaces: []` (U8) — not a present-but-unparseable list (UWP4XK).
+  if (isTomlTableEmptyArray(content, 'tool.uv.workspace', 'members')) return ABSENT;
+  return unreadable('uv workspace', 'pyproject.toml');
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -440,5 +444,9 @@ function detectCargoWorkspace(projectDirectory: string): WorkspaceDetection {
   if (!hasTomlTable(content, 'workspace')) return ABSENT; // a single crate, not a workspace
   if (!hasTomlTableKey(content, 'workspace', 'members')) return ABSENT; // auto-discovery, out of scope
   const members = readCargoWorkspaceMembers(content);
-  return members === undefined ? unreadable('Cargo [workspace]', 'Cargo.toml') : parsed(members);
+  if (members !== undefined) return parsed(members);
+  // An explicitly-empty `members = []` declares no members — absent, like package.json
+  // `workspaces: []` (U8) — not a present-but-unparseable list (UWP4XK).
+  if (isTomlTableEmptyArray(content, 'workspace', 'members')) return ABSENT;
+  return unreadable('Cargo [workspace]', 'Cargo.toml');
 }

--- a/packages/cli/src/utils/toml.ts
+++ b/packages/cli/src/utils/toml.ts
@@ -17,15 +17,27 @@ export function readTomlTableArray(
   table: string,
   key: string,
 ): string[] | undefined {
-  const body = tableArrayBody(content.split(/\r?\n/), table, key);
-  if (body === undefined) return undefined;
+  const found = tableArrayBody(content.split(/\r?\n/), table, key);
+  if (found === undefined) return undefined;
 
-  const values = body
+  const values = found.body
     .matchAll(/"([^"]*)"|'([^']*)'/g)
     .map(match => match[1] ?? match[2] ?? '')
     .filter(value => value.length > 0)
     .toArray();
   return values.length > 0 ? values : undefined;
+}
+
+/**
+ * Whether `[<table>] <key>` holds a well-formed but EMPTY array (`[]`, possibly across
+ * lines / with comments) — as opposed to a malformed value (`= "x"`, an unclosed `[`),
+ * which `readTomlTableArray` also collapses to `undefined`. Lets a caller treat an
+ * explicitly-empty member list as "declared no members" (absent, like package.json
+ * `workspaces: []`) rather than present-but-unparseable.
+ */
+export function isTomlTableEmptyArray(content: string, table: string, key: string): boolean {
+  const found = tableArrayBody(content.split(/\r?\n/), table, key);
+  return found !== undefined && found.closed && found.body.replaceAll(/[\s,]/g, '') === '';
 }
 
 /**
@@ -90,33 +102,52 @@ export function readTomlTableString(
   return undefined;
 }
 
-/** The comment-stripped text inside `[<table>] <key> = [ … ]`, or `undefined`. */
-function tableArrayBody(lines: string[], table: string, key: string): string | undefined {
-  let inTable = false;
-  let body: string | undefined;
+/**
+ * The comment-stripped text inside `[<table>] <key> = [ … ]` plus whether the array
+ * actually closed (a `]` was seen), or `undefined` when no array value is found. The
+ * `closed` flag distinguishes a well-formed array from one left unterminated at EOF —
+ * callers that only need the entries (`readTomlTableArray`) can ignore it.
+ */
+function tableArrayBody(
+  lines: string[],
+  table: string,
+  key: string,
+): { body: string; closed: boolean } | undefined {
+  const opened = findTableArrayOpen(lines, table, key);
+  if (opened === undefined) return undefined;
 
-  for (const rawLine of lines) {
-    const line = stripTomlComment(rawLine);
-    const trimmed = line.trim();
-
-    if (body === undefined) {
-      const header = tableHeader(trimmed);
-      if (header !== undefined) {
-        inTable = header === table;
-        continue;
-      }
-      const value = inTable ? tableValue(trimmed, key) : undefined;
-      if (!value?.startsWith('[')) continue;
-      body = value.slice(1);
-    } else {
-      body += `\n${line}`;
-    }
-
+  let body = opened.initial;
+  for (let index = opened.line; index < lines.length; index += 1) {
+    if (index > opened.line) body += `\n${stripTomlComment(lines[index] ?? '')}`;
     const close = indexOfOutsideQuotes(body, ']');
-    if (close !== -1) return body.slice(0, close);
+    if (close !== -1) return { body: body.slice(0, close), closed: true };
   }
+  return { body, closed: false };
+}
 
-  return body;
+/**
+ * The text after the opening `[` of `[<table>] <key> = [`, with the line it sits on, or
+ * `undefined` when the table, the key, or an array value is absent. Table-scoped and
+ * comment-aware — the seek half of {@link tableArrayBody}.
+ */
+function findTableArrayOpen(
+  lines: string[],
+  table: string,
+  key: string,
+): { line: number; initial: string } | undefined {
+  let inTable = false;
+  for (const [index, rawLine] of lines.entries()) {
+    const trimmed = stripTomlComment(rawLine).trim();
+    const header = tableHeader(trimmed);
+    if (header !== undefined) {
+      inTable = header === table;
+      continue;
+    }
+    if (!inTable) continue;
+    const value = tableValue(trimmed, key);
+    if (value?.startsWith('[') === true) return { line: index, initial: value.slice(1) };
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cli/tests/gitattributes-merge-union.test.ts
+++ b/packages/cli/tests/gitattributes-merge-union.test.ts
@@ -85,6 +85,24 @@ describe('.gitattributes merge=union for generated artifacts (GA7T6M / #566)', (
     expect(content).toContain('*.png binary'); // consumer's line survives
     expect(content).toContain(HEADER); // safeword block appended
   });
+
+  it('marks only generated artifacts — never a hand-authored doc, a broad *.md, or a lockfile', async () => {
+    // The danger of merge=union is an over-broad pattern silently both-sides-merging a
+    // hand-maintained file with no conflict signal. Pin that every union line targets a
+    // generated/derived artifact, and that the obvious leak targets are never marked.
+    await reconcile(SAFEWORD_SCHEMA, 'install', createProjectContext(cwd));
+
+    const content = gitattributes();
+    const unionLines = content.split('\n').filter(line => line.includes('merge=union'));
+    for (const line of unionLines) {
+      expect(line).toMatch(/architecture\.generated\.md|tickets\/INDEX(-completed)?\.md/);
+    }
+    // The hand-authored ARCHITECTURE.md (what #562 reconciles), a blanket markdown glob, and
+    // lockfiles must never be union-merged.
+    expect(content).not.toMatch(/ARCHITECTURE\.md\s+merge=union/);
+    expect(content).not.toMatch(/\*\.md\s+merge=union/);
+    expect(content).not.toMatch(/lock[\w.]*\s+merge=union/i);
+  });
 });
 
 describe('merge=union actually auto-resolves the #566 conflict (git-level)', () => {

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -689,6 +689,25 @@ describe('discoverWorkspaces — present-but-unparseable managers are surfaced (
     expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
   });
 
+  it('U12 — an explicitly-empty Cargo [workspace] members array is absent, not unreadable', () => {
+    // `members = []` declares no workspace members — like package.json `workspaces: []` (U8),
+    // a deliberate empty list, not a present-but-unparseable one (UWP4XK).
+    clearRootManifest(context.directory);
+    writeFileSync(nodePath.join(context.directory, 'Cargo.toml'), '[workspace]\nmembers = []\n');
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
+  it('U13 — an explicitly-empty uv [tool.uv.workspace] members array is absent, not unreadable', () => {
+    clearRootManifest(context.directory);
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = []\n',
+    );
+
+    expect(discoverUnreadableWorkspaces(context.directory)).toEqual([]);
+  });
+
   it('exposes the unreadable set on the monorepo model', () => {
     makePackage(context.directory, 'web', { modules: ['ui'] });
     writeFileSync(

--- a/packages/cli/tests/utils/toml.test.ts
+++ b/packages/cli/tests/utils/toml.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { readTomlTableArray, readTomlTableString } from '../../src/utils/toml.js';
+import {
+  isTomlTableEmptyArray,
+  readTomlTableArray,
+  readTomlTableString,
+} from '../../src/utils/toml.js';
 
 describe('readTomlTableArray', () => {
   it('reads a multi-line array scoped to its table', () => {
@@ -98,5 +102,42 @@ describe('readTomlTableArray / readTomlTableString — # inside a quoted value (
     expect(readTomlTableString('[project]\nname = "real" # the name\n', 'project', 'name')).toBe(
       'real',
     );
+  });
+});
+
+describe('isTomlTableEmptyArray (UWP4XK review nit — empty vs unparseable)', () => {
+  it('is true for a well-formed empty array (inline, spaced, and multi-line)', () => {
+    expect(isTomlTableEmptyArray('[workspace]\nmembers = []\n', 'workspace', 'members')).toBe(true);
+    expect(isTomlTableEmptyArray('[workspace]\nmembers = [ ]\n', 'workspace', 'members')).toBe(
+      true,
+    );
+    expect(isTomlTableEmptyArray('[workspace]\nmembers = [\n]\n', 'workspace', 'members')).toBe(
+      true,
+    );
+  });
+
+  it('is false for a non-empty array (read normally, never "empty")', () => {
+    expect(
+      isTomlTableEmptyArray('[workspace]\nmembers = ["crates/*"]\n', 'workspace', 'members'),
+    ).toBe(false);
+  });
+
+  it('is false for a malformed value — a string, or an array left unclosed (still unreadable)', () => {
+    expect(
+      isTomlTableEmptyArray('[workspace]\nmembers = "crates/*"\n', 'workspace', 'members'),
+    ).toBe(false);
+    expect(isTomlTableEmptyArray('[workspace]\nmembers = [\n', 'workspace', 'members')).toBe(false);
+  });
+
+  it('is false when the table or the key is absent', () => {
+    expect(isTomlTableEmptyArray('[project]\nname = "x"\n', 'workspace', 'members')).toBe(false);
+    expect(isTomlTableEmptyArray('[workspace]\nexclude = []\n', 'workspace', 'members')).toBe(
+      false,
+    );
+  });
+
+  it('is table-scoped — an empty array in the target table, not a same-named key elsewhere', () => {
+    const toml = '[other]\nmembers = ["x"]\n\n[workspace]\nmembers = []\n';
+    expect(isTomlTableEmptyArray(toml, 'workspace', 'members')).toBe(true);
   });
 });


### PR DESCRIPTION
Two small follow-ups from the post-merge eng-reviews of #561 and #569 (both non-blocking nits the reviewers flagged).

## Nit 1 — empty TOML `members = []` is absent, not unreadable (#561 review)
`detectPackageJsonWorkspaces` treats `workspaces: []` as **absent** (an explicitly-empty member list declares no members — test U8), but the Cargo/uv detectors routed `members = []` through `readTomlTableArray` → `undefined` → **unreadable**, a spurious "present-but-unparseable" advisory.

- New `isTomlTableEmptyArray` in the shared TOML reader distinguishes a well-formed empty `[]` from a genuinely malformed value (a string, or an array left unclosed) — both of which `readTomlTableArray` also collapses to `undefined`. Zero ripple to the reader's three existing consumers (the array-entry contract is unchanged).
- `detectCargoWorkspace` / `detectUvWorkspace` downgrade **only a confirmed-empty array** to absent; malformed/unclosed member lists stay `unreadable` (U2/U3 unchanged).
- Scoped to the TOML detectors the review named; pnpm/go.work keep their existing semantics.
- Tests: U12 (Cargo) + U13 (uv) integration cases, plus direct `isTomlTableEmptyArray` unit tests (empty / non-empty / malformed-string / unclosed / absent / table-scoped).

## Nit 2 — gitattributes `merge=union` negative-scope test (#569 review)
The suite proved union *applies* to the generated docs but had no assertion it does **not** leak. Added one: every managed union line must target a generated/derived artifact, and `ARCHITECTURE.md`, a blanket `*.md` glob, and lockfiles are explicitly never union-merged — regression insurance against a future over-broad pattern.

## Verification
- `tsc --noEmit` clean (0 errors), eslint clean.
- 99 tests green across toml / architecture-monorepo / cargo-manifest / pyproject-manifest / gitattributes-merge-union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)