### PR TITLE
Retro recall: delta re-arm + sonnet + async hook + signature dedupe (ZFGWS1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -140,7 +140,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.safeword/hooks/stop-retro.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.safeword/hooks/stop-retro.ts",
+            "async": true
           }
         ]
       }

--- a/.project/tickets/1M20EW-retro-fixed-vs-present-friction/ticket.md
+++ b/.project/tickets/1M20EW-retro-fixed-vs-present-friction/ticket.md
@@ -1,0 +1,54 @@
+---
+id: 1M20EW
+slug: retro-fixed-vs-present-friction
+type: task
+phase: intake
+status: todo
+created: 2026-06-30T20:43:24.401Z
+last_modified: 2026-06-30T20:43:24.401Z
+---
+
+# Retro extractor reports fixed/discussed bugs as current friction
+
+**Goal:** Stop the invisible retro from filing issues for bugs the session
+already FIXED (or merely discussed) — only surface friction that is still live.
+
+**Why:** Discovered during the ZFGWS1 live fire (2026-06-30). Sonnet mined the
+back half of the ZFGWS1 build session and returned 6 sanitized findings — 5 of
+which described the very bugs ZFGWS1 *fixed in that session* (haiku default,
+once-per-session sentinel, title dedupe, blocking hook, missing session id),
+phrased as present-tense friction. The extractor can't distinguish "we fixed X
+this session" from "X is broken." For a self-reporting feature this is high-impact:
+**any** session that fixes safeword bugs will file false issues for the bugs it
+just resolved — exactly the sessions most likely to be substantial and trigger
+retro. (The 6th finding — the GitHub-indexing risk — was genuine and was filed +
+then closed as #581 after the indexing assumption was empirically confirmed.)
+
+## Evidence
+
+- Live-fire transcript window: `--window-start 2000000` over the ZFGWS1 session;
+  `model=sonnet rawFindings=9 encounters=6`.
+- 5/6 encounters were fixed-this-session bugs framed as current friction.
+- Egress + signature + filing + dedupe all worked correctly — the gap is purely
+  the extractor's temporal framing of findings.
+
+## Sketch (not yet designed — intake)
+
+Candidate directions to weigh in spec/figure-it-out:
+
+- Tighten the extraction system prompt to require findings be friction that is
+  STILL present at the end of the window (ignore problems the session resolved).
+- Post-filter: drop findings whose surface/title was touched by a commit in the
+  same session (the transcript shows the fix landing).
+- Accept-and-dedupe: rely on the occurrence ledger + human triage (weakest —
+  still files the false issue once).
+
+## Out of scope
+
+- ZFGWS1's shipped mechanism (delta re-arm, sonnet, async hook, signature dedupe)
+  — all validated by the live fire; this is a follow-up refinement, not a regression.
+
+## Work Log
+
+- 2026-06-30T20:43Z Created from the ZFGWS1 live fire — extractor reported 5/6
+  already-fixed bugs as current friction. Backlog (todo); needs intake/spec.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (359)
+## Tickets (360)
 
 ### agent-surface-refactor
 
@@ -629,6 +629,9 @@
 - **Harden hook git calls against shell injection (1JMSH6)** (done, epic: —)
   Close the shell-injection class in safeword hooks — git invoked via `execSync` string interpolation runs through `/bin/sh -c`, so file-derived free-text values can inject commands. The hooks auto-fire on UserPromptSubmit/Stop; in a shared repo the file content can come from an untrusted PR.
   → `.project/tickets/1JMSH6-harden-hook-git-injection`
+- **Retro extractor reports fixed/discussed bugs as current friction (1M20EW)** (todo, epic: —)
+  Stop the invisible retro from filing issues for bugs the session
+  → `.project/tickets/1M20EW-retro-fixed-vs-present-friction`
 - **Custom paths.projectRoot: wire formatter ignores + auto-upgrade staging (1QNPCF)** (done, epic: —)
   Make the namespace-root contribution to formatter ignore-lists and the auto-upgrade owned-paths prefixes follow the _resolved_ `paths.projectRoot`, not just the static `.project/`/`.safeword-project/`.
   → `.project/tickets/1QNPCF-custom-projectroot-wiring`
@@ -1158,7 +1161,7 @@
 - **Go language pack — architecture discovery, extraction, fingerprint (ZD70P1)** (done, epic: —)
   Teach the generated architecture doc to introspect **Go** projects —
   → `.project/tickets/ZD70P1-architecture-go-language-pack`
-- **Retro recall: delta re-arm + sonnet + async hook + signature dedupe (ZFGWS1)** (in_progress, epic: —)
+- **Retro recall: delta re-arm + sonnet + async hook + signature dedupe (ZFGWS1)** (done, epic: —)
   Make the invisible retro actually surface the friction a session hits —
   → `.project/tickets/ZFGWS1-retro-recall-delta-rearm`
 - **Promote scenario-coverage to a blocking gate (split from NMSD94 SM1.AC1) (ZRMDKD)** (backlog, epic: —)

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/dimensions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/dimensions.md
@@ -1,0 +1,41 @@
+# Dimensions: Retro recall — delta re-arm + sonnet + async + signature dedupe (ZFGWS1)
+
+Derived from spec.md (SM1/SM2/TB1/NTB1 ACs, done_when) + domain knowledge (delta
+windowing over a byte offset, additive cadence + backstop, atomic offset state,
+the inherited egress guard, GitHub signature search, async hook registration).
+
+| Dimension                  | Partitions                                                                                                                              | AC        |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| Delta window slice         | fire 1 → window from offset 0 (whole transcript so far); fire N → window from offset_{N-1} − overlap to end; `buildDigest` caps window | SM1.AC1   |
+| Window tiling / back half  | finding only in the back-half delta → reaches `prepareEncounters` input on fire N (not lost to the head-cap)                            | SM1.AC1   |
+| Extraction model default   | no override → `sonnet` at `buildAutoExtractor` (runner) AND `runHeadlessExtraction` default; `retro.model` config override honored      | SM1.AC2   |
+| Signature dedupe           | existing issue with same `retro:<hash>` in body → matched, no new issue; new signature → new issue; title differs but signature equal → matched | SM2.AC1   |
+| Signature embedded+search  | `assembleBody` embeds the signature marker; `searchBySignature` queries `in:body` and exact-filters the marker                          | SM2.AC1   |
+| Stable session id forward  | child env carries the resolved session id → CLI uses it (not `'unknown'`) even when `CLAUDE_SESSION_ID` is unset                        | SM2.AC2   |
+| Atomic offset state        | write = temp-file then `rename`; a concurrent reader sees either old or new whole state, never torn; offset only advances               | SM2.AC3   |
+| Async hook registration    | generated Claude Stop settings entry for `stop-retro.ts` carries `async: true`; NOT `asyncRewake`; inner `spawnSync` unchanged          | TB1.AC1   |
+| Additive cadence + backstop| growth < `REARM_GROWTH` since last fire → hold; ≥ → re-fire; `fires ≥ MAX_FIRES` → hold (backstop); first fire gated by substance       | TB1.AC2   |
+| Fail-open / guards         | retro child env → no fire (guard first); state-write throw → still fires, no throw; #563 absent → always-fire (bounded)                 | TB1.AC2   |
+| Egress guard (inherited)   | secret in window-derived free text → redacted; customer path → redacted; unresolved surface → dropped; pipeline unbypassed by windowing | NTB1.AC1  |
+
+**Test layers:**
+
+- **Unit (pure functions):** offset-state read/record helpers (stored value + key,
+  atomic-write contract via injected writer), the additive-cadence decision
+  (`decideRetroRun` successor — re-fire/hold/backstop/guard-first/fail-open), the
+  window slicer (offset + overlap), `retroSignature`/`assembleBody` marker, the
+  model resolver. Injected-deps style matching `retro-trigger.ts`.
+- **Module (wiring):** `triage` against a mock `IssueTracker` — match by signature
+  not title; new signature creates; repeat signature does not. `searchBySignature`
+  exact-filter logic.
+- **Command-level (wiring):** `safeword retro --auto-extract --window-start N` in a
+  temp dir with the `claude -p` subprocess + GitHub transport mocked — assert the
+  back-half finding reaches the egress pipeline and the window (not head) is digested.
+- **Config/settings:** `SETTINGS_HOOKS.Stop` retro entry carries `async: true`;
+  schema-parity for the `.safeword` mirror.
+
+**Boundaries mocked:** only process boundaries — the `claude -p` subprocess (stub
+stdout findings JSON) and the GitHub transport (mock `IssueTracker` incl.
+`searchBySignature`). Window slice, digest, cadence decision, offset state, egress
+pipeline, and triage run real. The offset-state fs is driven through an injected
+`baseDirectory`/writer like the existing sentinel tests.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
@@ -1,6 +1,13 @@
 # Impl Plan: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
 
-**Status:** planned
+**Status:** implemented
+
+_Reconciled at implement exit (2026-06-30): every Decisions-table choice shipped as
+designed — no row changed, no alternative adopted mid-implementation. Build order ran
+1→9 as planned. The load-bearing back-half proof (slice 4) passed, confirming the
+riskiest assumption (windowing surfaces a finding the head-cap misses). Whole-ticket
+/quality-review returned SHIP (0 must-fix); its temp-file-uniqueness hardening landed
+as the cross-scenario refactor. One naming nuance added to Known deviations._
 
 ## Approach
 
@@ -92,6 +99,15 @@ measured eval, not a regression scorer, which is deferred).
 - **Async last-fire residual:** if the container is reclaimed the instant the user
   goes idle after the final Stop, the last delta may be lost (bounded — one delta).
   Documented; BNGK9W (#568 cloud transport) is the fallback if this proves material.
+- **`OVERLAP_BYTES`/offset are CHAR (UTF-16 code-unit) offsets, not bytes** —
+  `windowFor` slices and the recorded `offset = transcript.length` both use string
+  code units, so they are internally consistent (no bug); the `*_BYTES` name is a
+  documented misnomer kept for now (quality-review nice-to-have). Rename to
+  `_CHARS` if/when the constant is touched again.
+- **Dedupe depends on GitHub indexing HTML-comment body text** — the signature
+  marker is an HTML comment; if GitHub search ever stopped indexing comment text the
+  dedupe would false-miss → a duplicate issue (bounded by the per-session create cap).
+  Acceptable: this is the thin REST boundary layer, and a duplicate is self-correcting.
 
 ## Assessment triggers
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
@@ -1,0 +1,104 @@
+# Impl Plan: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
+
+**Status:** planned
+
+## Approach
+
+**Riskiest assumption:** that slicing the transcript by a stored byte offset and
+feeding only that **window** to `buildDigest` actually surfaces a back-half finding
+the current head-cap misses — i.e. the recall win is real, not defeated by some
+other cap in the pipeline. Cheapest proof: the SM1.AC1 *"back-half-only finding
+beyond the head cap is filed"* scenario, driven through the real `runRetro` entry
+with the `claude -p` subprocess + GitHub transport mocked, over a transcript larger
+than the digest cap. If the design is wrong, that one wiring test fails while the
+rest is still cheap — so it is sequenced as early as the window plumbing allows
+(slice 4). Everything else (sonnet, dedupe, session id, async registration) is
+independently valuable but not where the design risk lives.
+
+Proof plan + build order (each builds on what's already green):
+
+1. **Offset-state helpers** (`retro-trigger.ts` + `.safeword` mirror): read/record
+   `{ offset, toolUses, fires }` keyed by session id; persist via temp-write +
+   `rename`. **Unit** (injected `baseDirectory`/writer, like the existing
+   `sentinelPath` tests) — proves SM2.AC3 atomic-write + strict-advance. No deps;
+   foundation for cadence.
+2. **Additive-cadence decision** (the `decideRetroRun` successor): recursion-guard
+   first → resolve session id → first fire gated by `SUBSTANCE_THRESHOLD` →
+   re-fire when `toolUses − lastFire ≥ REARM_GROWTH` → hold at `fires ≥ MAX_FIRES`
+   → record state (fail-open on write throw) → return `{ transcriptPath,
+   windowStart }`. **Unit** (injected deps) — proves all TB1.AC2 scenarios +
+   SM2.AC2 no-resolve negative. Composes 1.
+3. **Window slicer + pre-sliced digest** (`retro-extract.ts`): `windowFor(transcript,
+   windowStart)` = `transcript.slice(max(0, windowStart − OVERLAP_BYTES))`;
+   `buildDigest` runs over the window. **Unit** — proves SM1.AC1 first-fire,
+   later-fire (offset − overlap), overlap-clamp. Composes 2's `windowStart`.
+4. **Window plumbing + back-half proof** (`stop-retro.ts` → `retro.ts`): thread
+   `--window-start N`; `runRetro` slices before extraction. **Integration/wiring**
+   through `runRetro` (subprocess + transport mocked) — the load-bearing SM1.AC1
+   back-half proof. Composes 1–3.
+5. **Sonnet at both sites** (`retro.ts` `buildAutoExtractor`, `retro-extract.ts`
+   default; `retro.model` config read): **Unit** on argv (default sonnet, not
+   haiku) + config-override partition — SM1.AC2.
+6. **Signature dedupe** (`finding.ts` `assembleBody` embeds the signature marker;
+   `triage.ts` matches via a new `searchBySignature`; `github-rest.ts` impl;
+   mock tracker): **Module** test vs a mock `IssueTracker` — repeat-no-issue /
+   new-creates / fuzzy-near-miss-rejected — SM2.AC1. The body-marker is a focused
+   unit on `assembleBody`/`retroSignature`.
+7. **Stable session id forward** (`stop-retro.ts` passes the resolved id to the
+   child; `retro.ts` uses it over `'unknown'`): **Wiring** unit — SM2.AC2 happy.
+8. **`async: true` registration** (`config.ts` `asyncHook` helper; register
+   `stop-retro`; update the settings/parity fixtures): **Config** test on
+   `SETTINGS_HOOKS.Stop` — TB1.AC1 (async true; not asyncRewake).
+9. **Egress non-bypass** (NTB1.AC1): no new code path — windowed findings flow
+   through the unchanged `prepareEncounters`. Dedicated secret-redaction +
+   unresolved-surface-drop tests over a window-derived finding confirm the
+   boundary still fails closed.
+
+Supporting proof: pure-logic edge cases (clamp-at-zero, inclusive `REARM_GROWTH`
+boundary, backstop boundary) get focused unit cases; no eval needed (no AI-output
+quality claim — the sonnet choice is config, the *quality* evidence is the ticket's
+measured eval, not a regression scorer, which is deferred).
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| -------- | ------ | ----------------------- | ---------------- |
+| Re-fire state | Per-session `{ offset, toolUses, fires }` file replacing the boolean sentinel | Keep sentinel + a 2nd offset file | Two files desync; one atomic state file is simpler |
+| Cadence | **Additive** re-fire each `REARM_GROWTH`=200 tool-uses, backstop `MAX_FIRES`=20 | Geometric backoff; fire-every-Stop; low fire cap | Sim (0XEMEE plan-check): geometric front-loads → last fire 38%, blind tail; low cap exhausts at 7%. Additive → 91–100% |
+| Window boundary | Byte offset; window = `slice(max(0, offset − OVERLAP_BYTES))`; `OVERLAP_BYTES`=2048 | Line offset; no overlap | Byte offset matches `transcript.length`/`rename` atomicity; a cut first line is skipped by `buildDigest`; overlap keeps a straddling finding whole |
+| Concurrency | temp-write + `rename` (atomic, last-writer-wins) | Advisory lock; CAS/max-wins | Ticket forbids locks; max-wins needs a lock. Last-writer-wins + signature dedupe absorbs the rare duplicate |
+| Dedupe key | Content `signature` (`retro:<hash>`) embedded in body, matched via `searchBySignature` (`in:body` + exact-filter) | Match by title (`searchByTitle`) | Titles vary across fires → duplicate issues; signature is stable |
+| Extraction model | `sonnet` default at both sites, `retro.model` config override | Keep haiku; sonnet hardcoded | haiku 1–3 weak vs sonnet 9 strong (measured); config keeps it tunable |
+| Hook execution | `async: true` registration (whole hook tree backgrounded); inner `spawnSync` unchanged | `asyncRewake`; make spawns async | asyncRewake surfaces stderr → breaks invisibility; spawns already non-blocking once the tree backgrounds |
+| Window plumbing | Decision computes `windowStart`; CLI slices via `--window-start` | CLI owns all state | Keeps state read/write in one place (the hook decision), CLI stays a thin boundary |
+
+## Arch alignment
+
+- **Reconciliation Engine / Schema (`src/schema.ts`)** — every `templates/hooks/**`
+  change is byte-mirrored to `.safeword/hooks/**` and registered in `schema.ts`
+  (the parity contract); the new `asyncHook` registration and any hook edits keep
+  the three contracts in sync.
+- **Retro egress boundary (secretlint)** — windowing changes the *input* slice only;
+  the `@secretlint`-backed `sanitizeTextDeep` → `resolveSurface` → `buildDraft`
+  pipeline is reused unchanged (NTB1.AC1 honors the deny-by-default egress guard).
+- **Phase-exit review gate (NMSD94)** — this ticket honored the scenario-gate Tier-2
+  independent fresh-context review before stamping.
+
+## Known deviations
+
+- **Last-writer-wins, not max-wins** offset under true concurrency (no lock per the
+  ticket). Accepted: the only effect is a rare re-covered window, absorbed by
+  signature dedupe; correctness (no torn read) holds.
+- **Async last-fire residual:** if the container is reclaimed the instant the user
+  goes idle after the final Stop, the last delta may be lost (bounded — one delta).
+  Documented; BNGK9W (#568 cloud transport) is the fallback if this proves material.
+
+## Assessment triggers
+
+- **#563 "new friction since last fire" gate lands** → re-fires gate on real new
+  friction instead of fail-open always-fire.
+- **Re-arm cost material in telemetry** → raise `REARM_GROWTH` (G=250 ≈ $2.80 vs
+  G=150 ≈ $4.55 on the worst-case 25 MB session) or gate harder.
+- **Debounce-to-quiet becomes viable** (cloud reclaim timing characterized) →
+  replace additive cadence with a single end-of-session fire.
+- **Cloud reclaim kills in-hook async work** → move filing to the BNGK9W transport.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/impl-plan.md
@@ -36,7 +36,7 @@ Proof plan + build order (each builds on what's already green):
    windowStart }`. **Unit** (injected deps) — proves all TB1.AC2 scenarios +
    SM2.AC2 no-resolve negative. Composes 1.
 3. **Window slicer + pre-sliced digest** (`retro-extract.ts`): `windowFor(transcript,
-   windowStart)` = `transcript.slice(max(0, windowStart − OVERLAP_BYTES))`;
+   windowStart)` = `transcript.slice(max(0, windowStart − OVERLAP_CHARS))`;
    `buildDigest` runs over the window. **Unit** — proves SM1.AC1 first-fire,
    later-fire (offset − overlap), overlap-clamp. Composes 2's `windowStart`.
 4. **Window plumbing + back-half proof** (`stop-retro.ts` → `retro.ts`): thread
@@ -72,7 +72,7 @@ measured eval, not a regression scorer, which is deferred).
 | -------- | ------ | ----------------------- | ---------------- |
 | Re-fire state | Per-session `{ offset, toolUses, fires }` file replacing the boolean sentinel | Keep sentinel + a 2nd offset file | Two files desync; one atomic state file is simpler |
 | Cadence | **Additive** re-fire each `REARM_GROWTH`=200 tool-uses, backstop `MAX_FIRES`=20 | Geometric backoff; fire-every-Stop; low fire cap | Sim (0XEMEE plan-check): geometric front-loads → last fire 38%, blind tail; low cap exhausts at 7%. Additive → 91–100% |
-| Window boundary | Byte offset; window = `slice(max(0, offset − OVERLAP_BYTES))`; `OVERLAP_BYTES`=2048 | Line offset; no overlap | Byte offset matches `transcript.length`/`rename` atomicity; a cut first line is skipped by `buildDigest`; overlap keeps a straddling finding whole |
+| Window boundary | Char offset; window = `slice(max(0, offset − OVERLAP_CHARS))`; `OVERLAP_CHARS`=2048 | Line offset; no overlap | Char offset matches `transcript.length`/`String.slice`; a cut first line is skipped by `buildDigest`; overlap keeps a straddling finding whole |
 | Concurrency | temp-write + `rename` (atomic, last-writer-wins) | Advisory lock; CAS/max-wins | Ticket forbids locks; max-wins needs a lock. Last-writer-wins + signature dedupe absorbs the rare duplicate |
 | Dedupe key | Content `signature` (`retro:<hash>`) embedded in body, matched via `searchBySignature` (`in:body` + exact-filter) | Match by title (`searchByTitle`) | Titles vary across fires → duplicate issues; signature is stable |
 | Extraction model | `sonnet` default at both sites, `retro.model` config override | Keep haiku; sonnet hardcoded | haiku 1–3 weak vs sonnet 9 strong (measured); config keeps it tunable |
@@ -99,11 +99,10 @@ measured eval, not a regression scorer, which is deferred).
 - **Async last-fire residual:** if the container is reclaimed the instant the user
   goes idle after the final Stop, the last delta may be lost (bounded — one delta).
   Documented; BNGK9W (#568 cloud transport) is the fallback if this proves material.
-- **`OVERLAP_BYTES`/offset are CHAR (UTF-16 code-unit) offsets, not bytes** —
+- **`OVERLAP_CHARS`/offset are CHAR (UTF-16 code-unit) offsets, not bytes** —
   `windowFor` slices and the recorded `offset = transcript.length` both use string
-  code units, so they are internally consistent (no bug); the `*_BYTES` name is a
-  documented misnomer kept for now (quality-review nice-to-have). Rename to
-  `_CHARS` if/when the constant is touched again.
+  code units, so they are internally consistent (no bug). The constant was renamed
+  `OVERLAP_BYTES` → `OVERLAP_CHARS` (post-ship /refactor) to retire the misnomer.
 - **Dedupe depends on GitHub indexing HTML-comment body text** — the signature
   marker is an HTML comment; if GitHub search ever stopped indexing comment text the
   dedupe would false-miss → a duplicate issue (bounded by the per-session create cap).

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
@@ -110,11 +110,14 @@ The resolved session id is forwarded to the child so ledger session-accounting i
 correct; the child no longer falls back to `'unknown'` when `CLAUDE_SESSION_ID` is
 unset (e.g. cloud, where only `CLAUDE_CODE_REMOTE_SESSION_ID` is set).
 
-#### retro-recall.SM2.AC3 — Near-simultaneous Stops don't double-fire or corrupt state
+#### retro-recall.SM2.AC3 — Near-simultaneous Stops don't corrupt state
 
 Offset state is written temp-file-then-`rename` (atomic on the same filesystem), so
-two near-simultaneous Stops never read a torn state file; the offset only advances.
-Signature dedupe is the filing-level backstop against any residual duplicate fire.
+a concurrent reader never sees a torn state file (it reads the complete old or
+complete new state). Across sequential fires the recorded offset strictly advances.
+The mechanism is last-writer-wins, not max-wins (a lock is out of scope), so a rare
+concurrent race can re-cover a window already read — signature dedupe is the
+filing-level backstop that absorbs that residual duplicate fire.
 
 ### retro-recall.TB1 — Repeated retro never intrudes or blocks, and stays cheap
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
@@ -60,7 +60,7 @@ untouched and stays the security boundary.
 - **Delta window** — the slice of transcript from the previous fire's recorded byte
   offset (minus a small overlap) to the current end. Fed to `buildDigest` instead
   of the whole transcript, so the digest cap applies to the *window*, not the head.
-- **Overlap** — the last `OVERLAP_BYTES` (~2 KB) re-included before a window's start,
+- **Overlap** — the last `OVERLAP_CHARS` (~2 KB) re-included before a window's start,
   so a finding straddling a window boundary appears whole in one fire. Duplicate
   findings from overlap are absorbed by signature dedupe.
 - **Offset state** — per-session `{ offset, toolUses, fires }` (replaces the boolean
@@ -168,7 +168,7 @@ the safe direction.
 - **First fire vs re-fire:** the **first** fire keeps the existing substance gate
   (≥`SUBSTANCE_THRESHOLD` tool-uses) and digests from offset 0 (whole transcript so
   far, head-capped — unchanged for fire 1). Re-fires are gated by `REARM_GROWTH`.
-- **Overlap size:** `OVERLAP_BYTES = 2048` (~2 KB, ≈ the "last ~50 lines" framing).
+- **Overlap size:** `OVERLAP_CHARS = 2048` (~2 KB, ≈ the "last ~50 lines" framing).
   A byte-slice may cut the first line; `buildDigest` already skips a malformed JSONL
   line, so the partial head line is harmlessly dropped — the overlap still carries
   whole boundary entries.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/spec.md
@@ -1,0 +1,205 @@
+# Spec: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
+
+## Intent
+
+Make the invisible retro surface the friction a session actually hits **across the
+whole session**, invisibly, at bounded cost. Today the retro fires once, early
+(first Stop with ≥3 tool-uses = ~0.2% in), and `buildDigest` head-caps to the
+first 180 KB — the chronological **opening**. So the maintainer's friction stream
+is blind to ~90% of every session. This fixes the five **coupled** levers as one
+slice (proven coupled by `/quality-review` on the superseded 0XEMEE phase plan):
+delta re-arm over a pre-sliced window, sonnet at both model sites, an `async:true`
+Stop hook, signature dedupe, and atomic offset state. The egress guard is
+untouched and stays the security boundary.
+
+## Intake Brief
+
+- **Requested by:** alex@arcade.dev (Safeword Maintainer): the invisible retro
+  (7D8PJP) ships but only reads the session opening — the recall is too low to be
+  worth the run.
+- **Cost of inaction:** the friction stream the self-observation epic (#344)
+  depends on is ~90% blind. Real late-session friction (the #567 example surfaces
+  at 29%, full coverage not until ~50% — measured this session) is never filed, so
+  the feature looks like it works while quietly missing most of what it exists to
+  catch.
+- **Reversibility:** two-way door. Changes the trigger's *cadence* (fire N times
+  over delta windows vs. once over the head), the extraction *model*, the hook
+  *registration* (`async:true`), and the dedupe *key* (signature vs. title). The
+  egress guard, schema, sanitizer, and filing pipeline are untouched. Revert =
+  restore the once-per-session sentinel + haiku + sync hook + title match.
+
+## References
+
+- Decision: `/figure-it-out` (ticket.md "Why") — delta re-arm beats whole-transcript
+  chunk-and-map (~M calls / ~$1.44 vs ~M×N / ~$15) and plain re-arm (inert: head-cap).
+- `/quality-review` (isolated subprocess, 2026-06-30): design VALIDATED, scope
+  sharpened — second model site (retro.ts:113), atomic offset = temp-write+rename,
+  `async:true` backgrounds the whole hook tree (inner `spawnSync` stays sync),
+  `buildDigest` takes a pre-sliced window, overlap/`#563`-absent/tail → refinements below.
+- Parent **RV9JT4** (retro pipeline); sibling **7D8PJP** (invisible retro, built);
+  **BNGK9W** (#568, cloud transport — the fallback if cloud reclaim kills in-hook async).
+- Supersedes **0XEMEE** (killed: its incremental phase plan was proven inert).
+- Reuses unchanged: `src/retro/` egress pipeline (`normalizeFinding`,
+  `resolveSurface`, `sanitizeTextDeep`, `buildDraft`, `prepareEncounters`).
+
+## Personas
+
+- **Safeword Maintainer (SM)** — receives the friction stream. Wants it to reflect
+  the **whole** session (not just the opening), at a model tier that surfaces real
+  bugs, with **one issue per distinct friction** across re-fires and sessions.
+- **Technical Builder (TB)** — runs safeword in their agent. The retro firing
+  repeatedly must stay **invisible and non-blocking**, and its cost must stay
+  bounded — no stolen turn, no Stop latency, no runaway spend.
+- **Non-Technical Builder (NTB)** — can't read the diff. Needs the **no-leak**
+  guarantee to hold for **every** delta window, not just the first.
+
+## Vocabulary
+
+- **Fire** — one invocation of the out-of-band extraction at a Stop. A session now
+  has *multiple* fires (was: one).
+- **Delta window** — the slice of transcript from the previous fire's recorded byte
+  offset (minus a small overlap) to the current end. Fed to `buildDigest` instead
+  of the whole transcript, so the digest cap applies to the *window*, not the head.
+- **Overlap** — the last `OVERLAP_BYTES` (~2 KB) re-included before a window's start,
+  so a finding straddling a window boundary appears whole in one fire. Duplicate
+  findings from overlap are absorbed by signature dedupe.
+- **Offset state** — per-session `{ offset, toolUses, fires }` (replaces the boolean
+  once-per-session sentinel). Read→decide→write atomically (temp-write + rename).
+- **Additive cadence** — re-fire each time tool-uses grow by `REARM_GROWTH` since
+  the last fire (constant spacing → even tiling), bounded by `MAX_FIRES`.
+- **Content signature** — `retro:<12-hex>` keyed on category + surface + normalized
+  title (`retroSignature`). Stable across fires (the model-generated *title* is not).
+
+## Jobs To Be Done
+
+### retro-recall.SM1 — Receive safeword friction from the WHOLE session
+
+**Persona:** Safeword Maintainer (SM)
+
+> When a session hits friction late, I want it filed just like early friction, so
+> my stream reflects the whole session instead of only its opening ~10%.
+
+#### retro-recall.SM1.AC1 — A back-half finding is filed (delta windows tile the session)
+
+Each fire digests the **delta window since the previous fire's offset** (plus a
+small overlap), not the head; the union of windows covers the session. A friction
+that appears only in the back half reaches the egress pipeline and is filed.
+
+#### retro-recall.SM1.AC2 — Extraction defaults to a tier strong enough to surface real friction
+
+The extraction model defaults to **sonnet** at **both** sites — `buildAutoExtractor`
+(the runner, `retro.ts`) and the `runHeadlessExtraction` default (`retro-extract.ts`)
+— and is config-overridable. (Measured: haiku 1–3 weak findings vs sonnet 9 strong.)
+
+### retro-recall.SM2 — One issue per distinct friction, across re-fires and sessions
+
+**Persona:** Safeword Maintainer (SM)
+
+> When the retro re-fires within a session (or recurs across sessions), I want the
+> same friction to land on one issue, not a pile of near-duplicates.
+
+#### retro-recall.SM2.AC1 — Dedupe is by content signature, not the model-generated title
+
+Triage matches an existing issue by the content **signature** (`retro:<hash>`,
+embedded in the issue body and searchable), not the title (titles vary across
+fires). A genuinely new signature opens a new issue; a repeat signature does not.
+
+#### retro-recall.SM2.AC2 — A stable session id reaches the extraction child
+
+The resolved session id is forwarded to the child so ledger session-accounting is
+correct; the child no longer falls back to `'unknown'` when `CLAUDE_SESSION_ID` is
+unset (e.g. cloud, where only `CLAUDE_CODE_REMOTE_SESSION_ID` is set).
+
+#### retro-recall.SM2.AC3 — Near-simultaneous Stops don't double-fire or corrupt state
+
+Offset state is written temp-file-then-`rename` (atomic on the same filesystem), so
+two near-simultaneous Stops never read a torn state file; the offset only advances.
+Signature dedupe is the filing-level backstop against any residual duplicate fire.
+
+### retro-recall.TB1 — Repeated retro never intrudes or blocks, and stays cheap
+
+**Persona:** Technical Builder (TB)
+
+> When retro fires several times in my session, I want it to stay completely out of
+> my way — no blocked Stop, no stolen turn — and not run up cost.
+
+#### retro-recall.TB1.AC1 — The retro Stop hook is non-blocking (`async: true`)
+
+The generated Claude settings register the retro Stop hook with `async: true`
+(documented mode: returns immediately, runs in background, 600 s) — NOT
+`asyncRewake` (which surfaces stderr into chat → breaks invisibility). The inner
+`spawnSync` calls stay synchronous: the whole hook tree is backgrounded, so they
+never block the user.
+
+#### retro-recall.TB1.AC2 — Re-fire cadence is bounded and fail-open
+
+Cadence is additive (`REARM_GROWTH` tool-uses of growth since last fire) with a
+high `MAX_FIRES` runaway backstop. The `#563` "new friction since last fire" gate
+is out-of-scope; when absent the cadence is **fail-open / always-fire** (bounded by
+growth + backstop), never silently suppressing. The decision is recursion-guarded
+(a retro child never re-fires) and fail-open on a state-write failure — it never
+breaks Stop.
+
+### retro-recall.NTB1 — No leak, on every delta window
+
+**Persona:** Non-Technical Builder (NTB)
+
+> I can't audit the diff, so the no-leak guarantee has to hold for every window the
+> retro reads — not just the first one.
+
+#### retro-recall.NTB1.AC1 — Every delta window passes the full egress pipeline unchanged
+
+Findings from any window flow through `normalizeFinding → resolveSurface →
+sanitizeTextDeep → buildDraft` before filing. Delta windowing slices the *input*
+transcript only; it never injects a finding past the pipeline. Over-redaction is
+the safe direction.
+
+## Spec refinements (quality-review — locked here)
+
+- **Cadence constants** (recovered from the 0XEMEE sim-rearm.ts plan-check, carried
+  forward): `REARM_GROWTH = 200` tool-uses (additive, constant spacing → sim last
+  fire 91–100%; ~10 fires on a 1,904-tool-use session; typical sessions fire 1–3
+  times). `MAX_FIRES = 20` (high runaway backstop, a crash-loop bound — NOT a low
+  cap; a low cap lands the last fire early and leaves a blind tail). Both exported
+  constants, injectable in tests (like `SUBSTANCE_THRESHOLD`).
+- **First fire vs re-fire:** the **first** fire keeps the existing substance gate
+  (≥`SUBSTANCE_THRESHOLD` tool-uses) and digests from offset 0 (whole transcript so
+  far, head-capped — unchanged for fire 1). Re-fires are gated by `REARM_GROWTH`.
+- **Overlap size:** `OVERLAP_BYTES = 2048` (~2 KB, ≈ the "last ~50 lines" framing).
+  A byte-slice may cut the first line; `buildDigest` already skips a malformed JSONL
+  line, so the partial head line is harmlessly dropped — the overlap still carries
+  whole boundary entries.
+- **`#563` absent → fail-open:** with no friction gate, every armed Stop fires
+  (bounded by growth + backstop). Never suppress silently.
+- **Tail residual:** with constant `REARM_GROWTH` spacing the last fire ends within
+  one `REARM_GROWTH` of the session end (≤ one increment). On a session exceeding
+  `MAX_FIRES × REARM_GROWTH` tool-uses the backstop bites and the residual tail is
+  larger — a documented, bounded cost/coverage trade (the runaway backstop).
+- **Model config:** read `retro.model` from `.safeword/config.json` (default
+  `sonnet`); both sites resolve through it.
+
+## Rave Moment
+
+Inherits 7D8PJP's "the feature with no felt presence." This slice adds: *"the bug I
+hit at the very end of a three-hour session was already filed — not just the one
+from the first five minutes."*
+
+## Outcomes
+
+- A finding present only in the back half of a session is filed (the recall win).
+- Re-fires open no duplicate for the same signature; a new signature files.
+- The retro Stop hook is registered `async: true` and does not block Stop.
+- Fire N over a grown transcript digests the window since fire N-1 (with overlap);
+  the union of deltas covers the session.
+- Two near-simultaneous Stops do not corrupt offset state.
+- Sonnet is the default at both model sites; cadence is bounded and fail-open.
+
+## Open Questions
+
+- defer (#563): the "new friction since last fire" gate is out-of-scope; cadence is
+  fail-open without it. When #563 lands, re-fires gate on real new friction.
+- defer (BNGK9W/#568): if cloud container reclaim kills in-hook `async` work, move
+  filing to the cloud transport. Residual today: the last fire may be lost if the
+  user goes idle the instant after the final Stop (bounded — loses one delta).
+- defer: a validity/coverage eval scorer (regression guard) is spun out separately
+  so this slice ships.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -6,7 +6,7 @@ test-definitions.md is the R/G/R ledger.
 
 ## Rule: Delta windows tile the whole session
 
-### Scenario: The first fire digests from the start of the transcript
+### Scenario: The first fire digests the whole transcript so far under the digest cap
 
 - [ ] RED
 - [ ] GREEN
@@ -18,13 +18,13 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
-### Scenario: A back-half-only finding reaches the egress pipeline
+### Scenario: A back-half-only finding beyond the head cap is filed by the delta fire
 
 - [ ] RED
 - [ ] GREEN
 - [ ] REFACTOR
 
-### Scenario: The overlap re-includes the boundary so a straddling finding appears whole
+### Scenario: The window re-includes the overlap region before the previous offset
 
 - [ ] RED
 - [ ] GREEN
@@ -70,9 +70,21 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: A fuzzy signature-search near-miss is rejected by the exact filter
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ## Rule: A stable session id reaches the extraction child
 
 ### Scenario: The resolved session id is forwarded to the child
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: No session id resolves, so nothing is filed under the unknown fallback
 
 - [ ] RED
 - [ ] GREEN
@@ -86,7 +98,13 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
-### Scenario: The recorded offset only advances across fires
+### Scenario: A later sequential fire strictly advances the recorded offset
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A concurrent reader never sees a torn state file
 
 - [ ] RED
 - [ ] GREEN
@@ -107,6 +125,12 @@ test-definitions.md is the R/G/R ledger.
 - [ ] REFACTOR
 
 ## Rule: Re-fire cadence is bounded and fail-open
+
+### Scenario: A first Stop below the substance threshold does not fire
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
 
 ### Scenario: Growth below the re-arm threshold holds the fire
 
@@ -132,7 +156,7 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
-### Scenario: A state-write failure still fires
+### Scenario: A state-write failure still fires and leaves the offset unchanged
 
 - [ ] RED
 - [ ] GREEN

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -114,15 +114,15 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: The generated Claude Stop settings register the retro hook async
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0d9780f
+- [x] GREEN 8153cb0
+- [x] REFACTOR skip: asyncHook mirrors the existing asyncRewakeHook helper
 
 ### Scenario: The retro Stop hook is not registered asyncRewake
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 0d9780f
+- [x] GREEN 8153cb0
+- [x] REFACTOR skip: same assertion (async, not asyncRewake) in one config test
 
 ## Rule: Re-fire cadence is bounded and fail-open
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -34,21 +34,21 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: The runner builds the extractor with sonnet by default
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: shares the default-model RED (50abfdb, haiku→sonnet); lint no-unused blocked a runner-export-only scaffold; verified by run
+- [x] GREEN 99f0e1f
+- [x] REFACTOR skip: model resolution extracted to resolveRetroModel
 
 ### Scenario: The headless extraction default is sonnet when no model is passed
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 50abfdb
+- [x] GREEN 99f0e1f
+- [x] REFACTOR skip: one-line default change
 
 ### Scenario: A configured model overrides the sonnet default
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: resolveRetroModel added as config infra; override path verified at GREEN
+- [x] GREEN 99f0e1f
+- [x] REFACTOR skip: fail-open config read mirrors readSelfReportConfig
 
 ## Rule: Re-fires dedupe by content signature, not the model-generated title
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -54,35 +54,35 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A repeat signature under a different title opens no second issue
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: searchByTitle→searchBySignature is an atomic interface rename (no partial compiles); bug is triage.ts:82 title match; new behavior verified at GREEN
+- [x] GREEN 645be80
+- [x] REFACTOR skip: signature already on RetroDraft; only the match key changed
 
 ### Scenario: A genuinely new signature opens a new issue
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: atomic interface rename; verified at GREEN
+- [x] GREEN 645be80
+- [x] REFACTOR skip: unchanged create path
 
 ### Scenario: The issue body embeds the searchable signature marker
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: assembleBody had no marker; embed added in buildDraft, asserted at GREEN
+- [x] GREEN 645be80
+- [x] REFACTOR skip: one-line marker append
 
 ### Scenario: A fuzzy signature-search near-miss is rejected by the exact filter
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: searchBySignature is new (exact-filter mirrors searchByTitle's); verified at GREEN
+- [x] GREEN 645be80
+- [x] REFACTOR skip: filter mirrors the prior exact-match
 
 ## Rule: A stable session id reaches the extraction child
 
 ### Scenario: The resolved session id is forwarded to the child
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: retroChildArgs is new plumbing; forward asserted at GREEN
+- [x] GREEN 645be80
+- [x] REFACTOR skip: pure args builder
 
 ### Scenario: No session id resolves, so nothing is filed under the unknown fallback
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -1,0 +1,153 @@
+# Test Definitions: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
+
+Feature source: `packages/cli/features/retro-recall-delta-rearm.feature`
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: Delta windows tile the whole session
+
+### Scenario: The first fire digests from the start of the transcript
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A later fire digests only the window since the previous fire's offset
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A back-half-only finding reaches the egress pipeline
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The overlap re-includes the boundary so a straddling finding appears whole
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Extraction defaults to sonnet at both model sites
+
+### Scenario: The runner builds the extractor with sonnet by default
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The headless extraction default is sonnet when no model is passed
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A configured model overrides the sonnet default
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Re-fires dedupe by content signature, not the model-generated title
+
+### Scenario: A repeat signature under a different title opens no second issue
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A genuinely new signature opens a new issue
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The issue body embeds the searchable signature marker
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: A stable session id reaches the extraction child
+
+### Scenario: The resolved session id is forwarded to the child
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Offset state survives concurrent Stops
+
+### Scenario: Offset state is written atomically via temp-file then rename
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The recorded offset only advances across fires
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: The retro Stop hook is non-blocking
+
+### Scenario: The generated Claude Stop settings register the retro hook async
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The retro Stop hook is not registered asyncRewake
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Re-fire cadence is bounded and fail-open
+
+### Scenario: Growth below the re-arm threshold holds the fire
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Growth at the re-arm threshold re-fires
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The backstop caps total fires per session
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A retro child never re-fires
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A state-write failure still fires
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Every delta window passes the full egress pipeline unchanged
+
+### Scenario: A secret in a back-half finding is redacted before filing
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A delta-window finding with an unresolved surface is dropped
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -8,27 +8,27 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: The first fire digests the whole transcript so far under the digest cap
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: pure windowFor slicer asserted directly; RED for applied behavior proven by the back-half run (delta filed 0 pre-impl); lint no-unused-properties blocked a type-only scaffold commit
+- [x] GREEN e50230d
+- [x] REFACTOR skip: windowFor is a one-line clamp+slice
 
 ### Scenario: A later fire digests only the window since the previous fire's offset
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: covered by windowFor later-fire unit + decision windowStart (60863c6); RED verified by run
+- [x] GREEN e50230d
+- [x] REFACTOR skip: no structural improvement
 
 ### Scenario: A back-half-only finding beyond the head cap is filed by the delta fire
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: end-to-end run filed 0 before windowFor applied (verified); lint blocked a type-only scaffold RED commit
+- [x] GREEN e50230d
+- [x] REFACTOR skip: composes existing runRetro pipeline
 
 ### Scenario: The window re-includes the overlap region before the previous offset
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: windowFor overlap-clamp unit asserted directly; RED verified by run
+- [x] GREEN e50230d
+- [x] REFACTOR skip: one-line clamp
 
 ## Rule: Extraction defaults to sonnet at both model sites
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -166,12 +166,16 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A secret in a back-half finding is redacted before filing
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: protect test for the inherited egress guard; invariant holds (windowing slices input only), so it passes — no RED state
+- [x] GREEN b434d3a
+- [x] REFACTOR skip: reuses the unchanged egress pipeline
 
 ### Scenario: A delta-window finding with an unresolved surface is dropped
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: protect test for the inherited egress guard; invariant holds, passes without new code
+- [x] GREEN b434d3a
+- [x] REFACTOR skip: reuses the unchanged egress pipeline
+
+## Feature-level cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -86,29 +86,29 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: No session id resolves, so nothing is filed under the unknown fallback
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: clean fail-open branch, no structural improvement
 
 ## Rule: Offset state survives concurrent Stops
 
 ### Scenario: Offset state is written atomically via temp-file then rename
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: helper is minimal (temp-write + rename)
 
 ### Scenario: A later sequential fire strictly advances the recorded offset
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: covered by the cadence decision, no cleanup
 
 ### Scenario: A concurrent reader never sees a torn state file
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: graceful-parse branch is minimal
 
 ## Rule: The retro Stop hook is non-blocking
 
@@ -128,39 +128,39 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A first Stop below the substance threshold does not fire
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: single guard branch, no cleanup
 
 ### Scenario: Growth below the re-arm threshold holds the fire
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: covered by the cadence branch
 
 ### Scenario: Growth at the re-arm threshold re-fires
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: covered by the cadence branch
 
 ### Scenario: The backstop caps total fires per session
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: single backstop guard
 
 ### Scenario: A retro child never re-fires
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: guard ordering unchanged from 7D8PJP
 
 ### Scenario: A state-write failure still fires and leaves the offset unchanged
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d05e17a
+- [x] GREEN 60863c6
+- [x] REFACTOR skip: fail-open try/catch mirrors markNudged
 
 ## Rule: Every delta window passes the full egress pipeline unchanged
 

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/test-definitions.md
@@ -178,4 +178,4 @@ test-definitions.md is the R/G/R ledger.
 
 ## Feature-level cross-scenario refactor
 
-- [ ] cross-scenario
+- [x] cross-scenario 8ded451 # /quality-review SHIP; applied temp-file uniqueness hardening

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
@@ -2,8 +2,8 @@
 id: ZFGWS1
 slug: retro-recall-delta-rearm
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 parent: RV9JT4-retro-transcript-mining
 scope: |
   Fix the invisible retro's RECALL as ONE coherent slice (the levers are coupled;
@@ -150,3 +150,8 @@ levers together (supersedes 0XEMEE's inert linear-phase plan).
   must-fix / 0 should-fix; cross-scenario refactor = temp-file uniqueness hardening
   (8ded451). impl-plan reconciled → implemented (no decision changed; 2 naming nuances
   → Known deviations). Phase → verify.
+- 2026-06-30T19:40Z Complete: verify + done — /verify green (suite 4197/4197 + 5
+  skipped, build ✅, Gherkin 23/23, lint+tsc clean, PR scope matches, dep-drift clean);
+  /audit passed (0 circular deps, config in sync, no ZFGWS1 dead code). verify.md
+  written. All 7 done-when criteria met. Ticket → done. Builds on #543 (still open);
+  do not rebase onto main until #543 merges.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
@@ -2,7 +2,7 @@
 id: ZFGWS1
 slug: retro-recall-delta-rearm
 type: feature
-phase: intake
+phase: scenario-gate
 status: in_progress
 parent: RV9JT4-retro-transcript-mining
 scope: |
@@ -129,3 +129,9 @@ levers together (supersedes 0XEMEE's inert linear-phase plan).
   spawnSync stays sync (reviewer's "two spawnSync defeats async" was a misread, but
   retro.ts is named as touched); (d) buildDigest takes a pre-sliced window; (e)
   overlap size / #563-absent fail-open / tail bound → spec refinements. Next: spec.md.
+- 2026-06-30T17:20Z Complete: intake — spec.md (4 JTBD / 8 AC across SM/TB/NTB) +
+  dimensions.md authored; /self-review stamped. Cadence constants recovered from the
+  0XEMEE sim plan-check (REARM_GROWTH=200 additive, MAX_FIRES=20 backstop, OVERLAP=2KB).
+- 2026-06-30T17:25Z Complete: define-behavior — 22 scenarios across 8 rules in
+  features/retro-recall-delta-rearm.feature (@manual: unit+wiring, mocked boundaries).
+  Next: scenario-gate independent review (/review-spec, fresh context).

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
@@ -2,7 +2,7 @@
 id: ZFGWS1
 slug: retro-recall-delta-rearm
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 parent: RV9JT4-retro-transcript-mining
 scope: |
@@ -145,3 +145,8 @@ levers together (supersedes 0XEMEE's inert linear-phase plan).
   Haiku weaker than author, crossModelReview off; independence via zero-history
   fork. impl-plan.md written (load-bearing slice = back-half window→pipeline proof;
   build order 1–9). Phase → implement.
+- 2026-06-30T19:17Z Complete: implement — all 26 scenarios green (173 tests / 14 files);
+  byte-parity mirrors in sync. Whole-ticket /quality-review (fresh context) → SHIP, 0
+  must-fix / 0 should-fix; cross-scenario refactor = temp-file uniqueness hardening
+  (8ded451). impl-plan reconciled → implemented (no decision changed; 2 naming nuances
+  → Known deviations). Phase → verify.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/ticket.md
@@ -2,7 +2,7 @@
 id: ZFGWS1
 slug: retro-recall-delta-rearm
 type: feature
-phase: scenario-gate
+phase: implement
 status: in_progress
 parent: RV9JT4-retro-transcript-mining
 scope: |
@@ -135,3 +135,13 @@ levers together (supersedes 0XEMEE's inert linear-phase plan).
 - 2026-06-30T17:25Z Complete: define-behavior — 22 scenarios across 8 rules in
   features/retro-recall-delta-rearm.feature (@manual: unit+wiring, mocked boundaries).
   Next: scenario-gate independent review (/review-spec, fresh context).
+- 2026-06-30T17:30Z Complete: scenario-gate — independent fresh-context review
+  (general-purpose subagent, /review-spec procedure) round 1: 3 must-fix / 6
+  should-strengthen, all applied (tautological offset advance → strict; back-half
+  → observable filed outcome over >cap transcript; +first-fire substance gate,
+  +no-session-id negative, +fuzzy signature near-miss, +state-write-fail offset
+  unchanged). Round 2: 0 must-fix (gate PASS); 2 optional polish folded in. 26
+  scenarios / 8 rules. Cross-model review SKIPPED — Fable 5 unavailable, Sonnet/
+  Haiku weaker than author, crossModelReview off; independence via zero-history
+  fork. impl-plan.md written (load-bearing slice = back-half window→pipeline proof;
+  build order 1–9). Phase → implement.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/verify.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/verify.md
@@ -1,0 +1,43 @@
+# Verify: Retro recall — delta re-arm + sonnet + async hook + signature dedupe (ZFGWS1)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4197/4197 tests pass (5 skipped, 0 failures; 294 files — full `bun run test`)
+**Gherkin:** ✅ Acceptance lane passes (23 scenarios / 155 steps; the ZFGWS1 feature is `@manual` — proven by the vitest unit + wiring lane)
+**Build:** ✅ Success
+**Lint:** ✅ Clean (ESLint + Prettier + `tsc --noEmit`)
+**Scenarios:** All 26 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope (retro recall: spec/dimensions/feature/test-defs/impl-plan + retro core/hooks/CLI/config + tests + dogfood settings; no unrelated changes)
+**Dep Drift:** ✅ Clean (no new runtime dependencies added)
+**Parent Epic:** RV9JT4 (parent ticket — retro-transcript-mining)
+**Reconcile:** ✅ No pattern deviation (offset state mirrors the sentinel pattern; `resolveRetroModel` mirrors `readSelfReportConfig`; `asyncHook` mirrors `asyncRewakeHook`)
+**Experience:** ⏭️ N/A — not persona-facing (the retro is invisible/out-of-band by design; zero conversation footprint)
+**Evidence limits:** ✅ None (full suite ran; git-init preflight succeeded)
+
+## Audit
+
+Audit passed (0 errors).
+
+- **Architecture:** no circular dependencies, no layer violations (depcruise: 211 modules, 610 deps, 0 violations). The retro-trigger↔retro-extract cycle was deliberately avoided by housing `OVERLAP_BYTES`/`windowFor`/`retroChildArgs` in retro-extract.
+- **Config drift:** ✅ `safeword sync-config --check` in sync.
+- **Dead code:** no ZFGWS1 export is unused. The 5 knip "unused exports" are all pre-existing (schema.ts, labels.ts, upstream-monitor, ticket-index-warnings); the `claude`/`gh` "unused binaries" are spawned subprocesses knip can't see (pre-existing). `searchByTitle` fully removed (no stragglers).
+- **Duplication:** 1.30% across retro/hooks (13 clones, in pre-existing hook files; none introduced by this ticket).
+- **Outdated deps / docs:** repo-wide warnings unchanged by this ticket; out of scope.
+
+## Done-when criteria (from ticket.md)
+
+- ✅ A back-half-only finding reaches the egress pipeline and is filed (SM1.AC1 end-to-end test: delta fire over a >cap transcript files it; a head-capped fire files nothing).
+- ✅ Re-fires open no duplicate for the same signature; a new signature files; dedupe by signature (not title); stable session id reaches the child (SM2.AC1/AC2).
+- ✅ The retro Stop hook is registered `async: true` and is non-blocking; not `asyncRewake` (TB1.AC1).
+- ✅ Fire N digests the window since fire N-1 (with overlap); the union tiles the session (SM1.AC1 + windowFor units).
+- ✅ Two near-simultaneous Stops don't corrupt state (atomic temp-write + rename; torn-read prevention; SM2.AC3).
+- ✅ Sonnet default at BOTH model sites, config-overridable; a test covers buildAutoExtractor's model (SM1.AC2).
+- ✅ Cadence bounded (additive REARM_GROWTH=200 + MAX_FIRES=20 backstop); fail-open; recursion-guarded; never breaks Stop (TB1.AC2). Scenarios green; /verify + /audit pass.
+
+## Summary
+
+Errors: 0 | Warnings: pre-existing repo-wide only | Passed: all gates
+
+Audit passed. Ready to mark done.
+
+**Next:** push the branch and flip the ticket to `done`.

--- a/.project/tickets/ZFGWS1-retro-recall-delta-rearm/verify.md
+++ b/.project/tickets/ZFGWS1-retro-recall-delta-rearm/verify.md
@@ -18,7 +18,7 @@
 
 Audit passed (0 errors).
 
-- **Architecture:** no circular dependencies, no layer violations (depcruise: 211 modules, 610 deps, 0 violations). The retro-trigger↔retro-extract cycle was deliberately avoided by housing `OVERLAP_BYTES`/`windowFor`/`retroChildArgs` in retro-extract.
+- **Architecture:** no circular dependencies, no layer violations (depcruise: 211 modules, 610 deps, 0 violations). The retro-trigger↔retro-extract cycle was deliberately avoided by housing `OVERLAP_CHARS`/`windowFor`/`retroChildArgs` in retro-extract.
 - **Config drift:** ✅ `safeword sync-config --check` in sync.
 - **Dead code:** no ZFGWS1 export is unused. The 5 knip "unused exports" are all pre-existing (schema.ts, labels.ts, upstream-monitor, ticket-index-warnings); the `claude`/`gh` "unused binaries" are spawned subprocesses knip can't see (pre-existing). `searchByTitle` fully removed (no stragglers).
 - **Duplication:** 1.30% across retro/hooks (13 clones, in pre-existing hook files; none introduced by this ticket).

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -66,6 +66,32 @@ export function windowFor(
   return transcript.slice(Math.max(0, windowStart - overlap));
 }
 
+/** A decision to run the retro child, carrying the delta window + stable session id. */
+export interface RetroChildInvocation {
+  transcriptPath: string;
+  windowStart: number;
+  sessionId: string;
+}
+
+/**
+ * Build the `safeword retro` argv the Stop hook spawns out-of-band. Forwards the
+ * delta window offset and the resolved session id (ZFGWS1) so the child digests
+ * only the new window and attributes findings to the real session — not the
+ * 'unknown' fallback its own env resolves to in cloud.
+ */
+export function retroChildArgs(invocation: RetroChildInvocation): string[] {
+  return [
+    'retro',
+    '--auto-extract',
+    '--transcript',
+    invocation.transcriptPath,
+    '--window-start',
+    String(invocation.windowStart),
+    '--session-id',
+    invocation.sessionId,
+  ];
+}
+
 /**
  * The headless extractor only ever READS the digest — never writes, edits, or
  * runs shell. A read-only allow-list keeps the out-of-band child from mutating

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -48,7 +48,7 @@ export function resolveRetroModel(projectDirectory: string): string {
  * line, so whole boundary entries still survive. Duplicate findings from the
  * overlap are absorbed by signature dedupe (triage).
  */
-export const OVERLAP_BYTES = 2048;
+export const OVERLAP_CHARS = 2048;
 
 /**
  * Slice the delta window a fire should digest: from `windowStart` (the previous
@@ -60,7 +60,7 @@ export const OVERLAP_BYTES = 2048;
 export function windowFor(
   transcript: string,
   windowStart: number,
-  overlap: number = OVERLAP_BYTES,
+  overlap: number = OVERLAP_CHARS,
 ): string {
   if (windowStart <= 0) return transcript;
   return transcript.slice(Math.max(0, windowStart - overlap));

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -8,11 +8,38 @@
 // synchronous runner. Agent-neutral where possible; Claude-specific bits are
 // named as such.
 
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
 /**
  * Default cap (chars) for a transcript digest. A real session transcript is tens
  * of MB; the extractor needs a bounded, signal-dense slice, not the raw JSONL.
  */
 export const DIGEST_CAP = 180_000;
+
+/**
+ * Default extraction model. Sonnet, not haiku: measured head-to-head on the same
+ * transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong ones (ZFGWS1).
+ * Overridable per install via `.safeword/config.json` → `retro.model`.
+ */
+export const DEFAULT_RETRO_MODEL = 'sonnet';
+
+/**
+ * Resolve the extraction model for an install: `retro.model` from
+ * `.safeword/config.json`, else the sonnet default. Fail-open to the default on
+ * any missing/unreadable/malformed config — model selection must never break the
+ * out-of-band retro run.
+ */
+export function resolveRetroModel(projectDirectory: string): string {
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { retro?: { model?: unknown } };
+    const model = parsed.retro?.model;
+    return typeof model === 'string' && model.length > 0 ? model : DEFAULT_RETRO_MODEL;
+  } catch {
+    return DEFAULT_RETRO_MODEL;
+  }
+}
 
 /**
  * Overlap (chars) re-included before a delta window's start, so a finding
@@ -177,7 +204,7 @@ export async function runHeadlessExtraction(
   try {
     const digestPath = dependencies.writeDigest(buildDigest(transcript));
     const argv = buildExtractArgv({
-      model: dependencies.model ?? 'haiku',
+      model: dependencies.model ?? DEFAULT_RETRO_MODEL,
       systemPrompt: EXTRACT_SYSTEM_PROMPT,
       prompt: buildExtractPrompt(digestPath),
     });

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -15,6 +15,31 @@
 export const DIGEST_CAP = 180_000;
 
 /**
+ * Overlap (chars) re-included before a delta window's start, so a finding
+ * straddling a window boundary appears whole in one fire (ticket ZFGWS1). A
+ * char-slice may cut the first JSONL line; `buildDigest` skips that malformed head
+ * line, so whole boundary entries still survive. Duplicate findings from the
+ * overlap are absorbed by signature dedupe (triage).
+ */
+export const OVERLAP_BYTES = 2048;
+
+/**
+ * Slice the delta window a fire should digest: from `windowStart` (the previous
+ * fire's recorded offset) minus a small overlap, to the end. The FIRST fire
+ * (`windowStart <= 0`) returns the whole transcript so far. So `buildDigest`'s cap
+ * applies to the WINDOW, not the chronological head — defeating the head-cap that
+ * made plain re-arm inert. The overlap is clamped at the start of the transcript.
+ */
+export function windowFor(
+  transcript: string,
+  windowStart: number,
+  overlap: number = OVERLAP_BYTES,
+): string {
+  if (windowStart <= 0) return transcript;
+  return transcript.slice(Math.max(0, windowStart - overlap));
+}
+
+/**
  * The headless extractor only ever READS the digest — never writes, edits, or
  * runs shell. A read-only allow-list keeps the out-of-band child from mutating
  * the working tree or exfiltrating via a tool.

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -155,14 +155,6 @@ export const REARM_GROWTH = 200;
  */
 export const MAX_FIRES = 20;
 
-/**
- * Overlap re-included before a window's start (chars), so a finding straddling a
- * window boundary appears whole in one fire. A byte-slice may cut the first JSONL
- * line; `buildDigest` skips that malformed head line, so whole boundary entries
- * still survive. Duplicate findings from the overlap are absorbed by signature dedupe.
- */
-export const OVERLAP_BYTES = 2048;
-
 /** Per-session delta state: where the last fire ended, and how many fires so far. */
 export interface OffsetState {
   /** Transcript length (chars) recorded at the last fire — the next window start. */

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -210,9 +210,12 @@ export function readOffsetState(
 /**
  * Persist the per-session offset state ATOMICALLY: write a temp file, then
  * `rename` it over the state file (atomic on the same filesystem on Linux), so a
- * concurrent reader never sees a torn write. The temp name carries the pid so two
- * near-simultaneous Stops don't clobber each other's temp file before the rename.
+ * concurrent reader never sees a torn write. The temp name carries the pid AND a
+ * per-process counter, so neither two near-simultaneous Stops (distinct pids) nor
+ * two writes within one process collide on the temp file before the rename.
  */
+let tempWriteCounter = 0;
+
 export function writeOffsetState(
   sessionId: string,
   state: OffsetState,
@@ -220,7 +223,7 @@ export function writeOffsetState(
   atomicFs: AtomicFs = defaultAtomicFs,
 ): void {
   const finalPath = offsetStatePath(sessionId, baseDirectory);
-  const tempPath = `${finalPath}.${process.pid}.tmp`;
+  const tempPath = `${finalPath}.${process.pid}.${tempWriteCounter++}.tmp`;
   atomicFs.writeFileSync(tempPath, JSON.stringify(state));
   atomicFs.renameSync(tempPath, finalPath);
 }

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -392,6 +392,11 @@ export interface RetroRunDecision {
    * digesting, so each fire reads only the NEW activity (plus a small overlap).
    */
   windowStart: number;
+  /**
+   * The resolved session id, forwarded to the child so ledger session-accounting
+   * is correct (the child's env fallback resolves to 'unknown' in cloud; ZFGWS1).
+   */
+  sessionId: string;
 }
 
 /**
@@ -469,5 +474,5 @@ export function decideRetroRun(
     // A state-write failure must not suppress the fire (mirrors markNudged); the
     // duplicate it risks next Stop is absorbed by signature dedupe (triage).
   }
-  return { transcriptPath, windowStart };
+  return { transcriptPath, windowStart, sessionId };
 }

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -13,8 +13,9 @@
 // makes re-fires idempotent across sessions; the once-per-session sentinel here
 // makes them idempotent within a session.
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
+import process from 'node:process';
 import { tmpdir } from 'node:os';
 
 import { isRetroChild } from './retro-extract.js';
@@ -132,6 +133,106 @@ export function markNudged(sessionId: string, baseDirectory: string = tmpdir()):
   writeFileSync(sentinelPath(sessionId, baseDirectory), `${sessionId}\n`);
 }
 
+// --- Delta re-arm offset state (ticket ZFGWS1) ---------------------------------
+//
+// The boolean once-per-session sentinel above made retro fire ONCE per session,
+// reading only the opening (the digest head-caps to the first 180 KB). Delta
+// re-arm replaces it: per-session offset state lets retro fire repeatedly, each
+// fire digesting only the NEW transcript since the last fire's offset, so the
+// deltas tile the whole session.
+
+/**
+ * Re-fire cadence: re-fire once the transcript grows by this many tool-uses since
+ * the last fire (ADDITIVE, constant spacing → even tiling; sim: last fire 91–100%
+ * of the session). Tunable; injected as `rearmGrowth` in tests.
+ */
+export const REARM_GROWTH = 200;
+
+/**
+ * Runaway backstop: at most this many fires per session, independent of cadence.
+ * A HIGH cap (a crash-loop bound), NOT a low cadence control — a low cap lands the
+ * last fire early and leaves a blind tail (the bug additive cadence fixes).
+ */
+export const MAX_FIRES = 20;
+
+/**
+ * Overlap re-included before a window's start (chars), so a finding straddling a
+ * window boundary appears whole in one fire. A byte-slice may cut the first JSONL
+ * line; `buildDigest` skips that malformed head line, so whole boundary entries
+ * still survive. Duplicate findings from the overlap are absorbed by signature dedupe.
+ */
+export const OVERLAP_BYTES = 2048;
+
+/** Per-session delta state: where the last fire ended, and how many fires so far. */
+export interface OffsetState {
+  /** Transcript length (chars) recorded at the last fire — the next window start. */
+  offset: number;
+  /** Tool-use count at the last fire — the additive-cadence baseline. */
+  toolUses: number;
+  /** Number of fires so far this session — the backstop counter. */
+  fires: number;
+}
+
+/** The fs primitives the atomic state write needs; injected so tests can assert them. */
+export interface AtomicFs {
+  writeFileSync: (path: string, data: string) => void;
+  renameSync: (from: string, to: string) => void;
+}
+
+const defaultAtomicFs: AtomicFs = { writeFileSync, renameSync };
+
+/** Absolute path of the per-session offset-state file for a session id. */
+export function offsetStatePath(sessionId: string, baseDirectory: string = tmpdir()): string {
+  return nodePath.join(
+    baseDirectory,
+    `safeword-retro-offset-${sessionId.replace(/[^\w.-]/g, '_')}.json`,
+  );
+}
+
+/**
+ * Read the per-session offset state, or undefined when absent, unreadable, or
+ * TORN (a partially-written file mid-rename). Fail-open by construction: a torn or
+ * missing state simply re-arms from offset 0 (a re-read the egress dedupe absorbs),
+ * never a throw — a Stop hook must not crash on a partial state file.
+ */
+export function readOffsetState(
+  sessionId: string,
+  baseDirectory: string = tmpdir(),
+): OffsetState | undefined {
+  try {
+    const raw = readFileSync(offsetStatePath(sessionId, baseDirectory), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<OffsetState>;
+    if (
+      typeof parsed.offset !== 'number' ||
+      typeof parsed.toolUses !== 'number' ||
+      typeof parsed.fires !== 'number'
+    ) {
+      return undefined;
+    }
+    return { offset: parsed.offset, toolUses: parsed.toolUses, fires: parsed.fires };
+  } catch {
+    return undefined; // missing / unreadable / torn → fail open (re-arm from 0)
+  }
+}
+
+/**
+ * Persist the per-session offset state ATOMICALLY: write a temp file, then
+ * `rename` it over the state file (atomic on the same filesystem on Linux), so a
+ * concurrent reader never sees a torn write. The temp name carries the pid so two
+ * near-simultaneous Stops don't clobber each other's temp file before the rename.
+ */
+export function writeOffsetState(
+  sessionId: string,
+  state: OffsetState,
+  baseDirectory: string = tmpdir(),
+  atomicFs: AtomicFs = defaultAtomicFs,
+): void {
+  const finalPath = offsetStatePath(sessionId, baseDirectory);
+  const tempPath = `${finalPath}.${process.pid}.tmp`;
+  atomicFs.writeFileSync(tempPath, JSON.stringify(state));
+  atomicFs.renameSync(tempPath, finalPath);
+}
+
 interface SessionIdEnv {
   CLAUDE_CODE_REMOTE_SESSION_ID?: string;
   CLAUDE_SESSION_ID?: string;
@@ -229,6 +330,14 @@ export interface RetroTriggerDeps {
     input: RetroTriggerInput,
     env: Record<string, string | undefined>,
   ) => string | undefined;
+  /** Additive re-fire growth in tool-uses (defaults to REARM_GROWTH). */
+  rearmGrowth?: number;
+  /** Runaway fire-count backstop (defaults to MAX_FIRES). */
+  maxFires?: number;
+  /** Offset-state reader (injected for tests; defaults to the fs helper). */
+  readOffsetState?: (sessionId: string, baseDirectory?: string) => OffsetState | undefined;
+  /** Offset-state writer (injected for tests; defaults to the atomic fs helper). */
+  writeOffsetState?: (sessionId: string, state: OffsetState, baseDirectory?: string) => void;
 }
 
 /**
@@ -285,19 +394,33 @@ export function decideRetroNudge(
 export interface RetroRunDecision {
   /** The transcript to mine, handed to the headless extractor. */
   transcriptPath: string;
+  /**
+   * Char offset where this fire's delta window starts (0 on the first fire). The
+   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_BYTES))` before
+   * digesting, so each fire reads only the NEW activity (plus a small overlap).
+   */
+  windowStart: number;
 }
 
 /**
- * Decide whether to RUN the invisible retro extraction this Stop (7D8PJP) — the
- * out-of-band replacement for `decideRetroNudge`. Same gates, but it returns the
- * transcript path to extract from instead of conversation text, and it adds the
- * recursion guard FIRST: a retro headless child (`SAFEWORD_RETRO_CHILD=1`) never
- * triggers another retro. Fail-open by construction — every "can't proceed"
- * branch returns undefined and leaves the once-per-session sentinel untouched:
+ * Decide whether to RUN the invisible retro extraction this Stop, and (when it
+ * does) compute the delta window and advance the per-session offset state
+ * (ZFGWS1 — supersedes the once-per-session sentinel of 7D8PJP). The retro now
+ * fires MORE than once per session: the FIRST fire keeps the substance gate and
+ * digests from offset 0 (the whole transcript so far); RE-fires are gated by
+ * ADDITIVE growth (`rearmGrowth` tool-uses since the last fire) under a high
+ * `maxFires` runaway backstop, and each returns `windowStart` = the previous
+ * fire's offset so the CLI digests only the new delta.
+ *
+ * The recursion guard runs FIRST (a retro headless child never re-fires). Fail-open
+ * by construction — every "can't proceed" branch returns undefined and leaves the
+ * offset state untouched, and a state-write failure still fires (the duplicate it
+ * risks is absorbed by signature dedupe), so the hook never blocks Stop:
  *   - this process is itself a retro child → undefined (before any gate)
  *   - no resolvable session id / no transcript_path → undefined
- *   - already ran this session → undefined
- *   - transcript unreadable / not substantial → undefined, sentinel unset
+ *   - transcript unreadable → undefined
+ *   - first fire below the substance threshold → undefined, state unset
+ *   - re-fire below the growth threshold, or backstop reached → undefined, state unchanged
  */
 export function decideRetroRun(
   input: RetroTriggerInput,
@@ -315,8 +438,6 @@ export function decideRetroRun(
   const transcriptPath = input.transcript_path;
   if (!transcriptPath || transcriptPath.length === 0) return undefined;
 
-  if (hasNudged(sessionId, dependencies.baseDirectory)) return undefined;
-
   const read = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
   let transcript: string;
   try {
@@ -326,15 +447,35 @@ export function decideRetroRun(
   }
 
   const counter = dependencies.countToolUses ?? countToolUses;
-  if (!isSubstantial(transcript, dependencies.threshold ?? SUBSTANCE_THRESHOLD, counter)) {
-    return undefined; // trivial session → silent, sentinel left unset
+  const toolUses = counter(transcript);
+  const threshold = dependencies.threshold ?? SUBSTANCE_THRESHOLD;
+  const rearmGrowth = dependencies.rearmGrowth ?? REARM_GROWTH;
+  const maxFires = dependencies.maxFires ?? MAX_FIRES;
+  const baseDirectory = dependencies.baseDirectory;
+  const readState = dependencies.readOffsetState ?? readOffsetState;
+  const writeState = dependencies.writeOffsetState ?? writeOffsetState;
+  const prior = readState(sessionId, baseDirectory);
+
+  let windowStart: number;
+  let fires: number;
+  if (!prior) {
+    // First fire: substance gate, digest from the start of the transcript.
+    if (toolUses < threshold) return undefined;
+    windowStart = 0;
+    fires = 1;
+  } else {
+    // Re-fire: bounded by the runaway backstop, then gated by additive growth.
+    if (prior.fires >= maxFires) return undefined;
+    if (toolUses - prior.toolUses < rearmGrowth) return undefined;
+    windowStart = prior.offset;
+    fires = prior.fires + 1;
   }
 
   try {
-    markNudged(sessionId, dependencies.baseDirectory);
+    writeState(sessionId, { offset: transcript.length, toolUses, fires }, baseDirectory);
   } catch {
-    // A sentinel-write failure must not suppress the run; worst case is a second
-    // extraction next Stop, which the occurrence ledger (RV9JT4) dedupes.
+    // A state-write failure must not suppress the fire (mirrors markNudged); the
+    // duplicate it risks next Stop is absorbed by signature dedupe (triage).
   }
-  return { transcriptPath };
+  return { transcriptPath, windowStart };
 }

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -391,7 +391,7 @@ export interface RetroRunDecision {
   transcriptPath: string;
   /**
    * Char offset where this fire's delta window starts (0 on the first fire). The
-   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_BYTES))` before
+   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_CHARS))` before
    * digesting, so each fire reads only the NEW activity (plus a small overlap).
    */
   windowStart: number;

--- a/.safeword/hooks/stop-retro.ts
+++ b/.safeword/hooks/stop-retro.ts
@@ -20,7 +20,7 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { RETRO_EXTRACT_CMD_ENV } from './lib/retro-extract.ts';
+import { retroChildArgs, RETRO_EXTRACT_CMD_ENV } from './lib/retro-extract.ts';
 import { decideRetroRun } from './lib/retro-trigger.ts';
 import { readSelfReportConfig } from './lib/self-report.ts';
 
@@ -36,11 +36,11 @@ interface HookInput {
  */
 function resolveExtractCommand(
   projectDirectory: string,
-  transcriptPath: string,
+  decision: { transcriptPath: string; windowStart: number; sessionId: string },
 ): [string, string[]] {
   const override = process.env[RETRO_EXTRACT_CMD_ENV];
   if (override && override.length > 0) return [override, []];
-  const retroArgs = ['retro', '--auto-extract', '--transcript', transcriptPath];
+  const retroArgs = retroChildArgs(decision);
   const localCli = nodePath.join(projectDirectory, 'packages/cli/src/cli.ts');
   return existsSync(localCli)
     ? ['bun', [localCli, ...retroArgs]]
@@ -65,7 +65,7 @@ async function main(): Promise<void> {
 
   // Run extraction + filing out of band, synchronously, with NO conversation
   // output. Failures are swallowed here (the CLI also fail-opens internally).
-  const [command, args] = resolveExtractCommand(projectDirectory, decision.transcriptPath);
+  const [command, args] = resolveExtractCommand(projectDirectory, decision);
   spawnSync(command, args, { cwd: projectDirectory, stdio: 'ignore', timeout: 300_000 });
 }
 

--- a/packages/cli/features/retro-recall-delta-rearm.feature
+++ b/packages/cli/features/retro-recall-delta-rearm.feature
@@ -21,7 +21,7 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
     Scenario: The first fire digests the whole transcript so far under the digest cap
       Given a substantial session at its first Stop with no prior offset state
       When the retro decides to fire
-      Then the delta window is the whole transcript so far and the digest cap applies to that whole, as on the pre-delta fire
+      Then the delta window is the whole transcript so far and the digest cap applies to that whole
 
     @retro-recall.SM1.AC1
     Scenario: A later fire digests only the window since the previous fire's offset
@@ -165,8 +165,9 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
     @retro-recall.TB1.AC2
     Scenario: A retro child never re-fires
       Given the environment marks this process as a retro child
+      And growth at or above the re-arm threshold since the last fire
       When a Stop is evaluated
-      Then the retro does not fire, the recursion guard taking precedence over every other gate
+      Then the retro does not fire, the recursion guard taking precedence over the armed re-fire
 
     @retro-recall.TB1.AC2
     Scenario: A state-write failure still fires and leaves the offset unchanged

--- a/packages/cli/features/retro-recall-delta-rearm.feature
+++ b/packages/cli/features/retro-recall-delta-rearm.feature
@@ -18,28 +18,28 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
   Rule: Delta windows tile the whole session
 
     @retro-recall.SM1.AC1
-    Scenario: The first fire digests from the start of the transcript
+    Scenario: The first fire digests the whole transcript so far under the digest cap
       Given a substantial session at its first Stop with no prior offset state
       When the retro decides to fire
-      Then the delta window starts at offset zero, covering the whole transcript so far
+      Then the delta window is the whole transcript so far and the digest cap applies to that whole, as on the pre-delta fire
 
     @retro-recall.SM1.AC1
     Scenario: A later fire digests only the window since the previous fire's offset
       Given offset state recording the previous fire's byte offset on a grown transcript
       When the retro fires again
-      Then the digested window begins at the previous offset, not the transcript head
+      Then the digested window begins at the previous offset minus the overlap, not at the transcript head
 
     @retro-recall.SM1.AC1
-    Scenario: A back-half-only finding reaches the egress pipeline
-      Given a grown transcript whose only friction appears after the previous fire's offset
-      When the delta fire runs auto-extraction
-      Then that finding reaches the egress pipeline instead of being lost to the head cap
+    Scenario: A back-half-only finding beyond the head cap is filed by the delta fire
+      Given a transcript larger than the digest cap whose only friction appears after the previous fire's offset
+      When safeword retro runs the delta fire over the window since that offset
+      Then an issue carrying that finding's signature is filed, which a head-capped fire would have missed
 
     @retro-recall.SM1.AC1
-    Scenario: The overlap re-includes the boundary so a straddling finding appears whole
-      Given a finding that straddles the previous window's end boundary
+    Scenario: The window re-includes the overlap region before the previous offset
+      Given offset state recording the previous fire's byte offset
       When the next delta fire builds its window
-      Then the window re-includes the prior overlap region so the finding appears whole in one fire
+      Then the window start index is the previous offset minus the overlap size, clamped at zero, so a boundary-straddling entry is contained in full
 
   Rule: Extraction defaults to sonnet at both model sites
 
@@ -82,6 +82,12 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
       When the issue body is built
       Then it contains the finding's retro signature in a form signature search can match
 
+    @retro-recall.SM2.AC1
+    Scenario: A fuzzy signature-search near-miss is rejected by the exact filter
+      Given signature search returns an issue whose body carries a different retro signature
+      When triage filters the search results
+      Then that issue is not treated as a match and a new issue is created
+
   Rule: A stable session id reaches the extraction child
 
     @retro-recall.SM2.AC2
@@ -89,6 +95,12 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
       Given a Stop with a resolvable session id but no CLAUDE_SESSION_ID in the environment
       When the hook spawns the extraction child
       Then the child receives the resolved session id rather than the unknown fallback
+
+    @retro-recall.SM2.AC2
+    Scenario: No session id resolves, so nothing is filed under the unknown fallback
+      Given a Stop where no session id resolves from the input or the environment
+      When the hook evaluates the retro
+      Then the retro does not fire and nothing is filed under an unknown session id
 
   Rule: Offset state survives concurrent Stops
 
@@ -99,10 +111,16 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
       Then it is written to a temp file and renamed over the state file, never written in place
 
     @retro-recall.SM2.AC3
-    Scenario: The recorded offset only advances across fires
-      Given offset state from a previous fire
+    Scenario: A later sequential fire strictly advances the recorded offset
+      Given a fire recorded an offset over a transcript that then grows
       When a later fire records its offset
-      Then the recorded offset is greater than or equal to the previous offset
+      Then the new recorded offset is strictly greater than the prior offset
+
+    @retro-recall.SM2.AC3
+    Scenario: A concurrent reader never sees a torn state file
+      Given an offset-state write whose temp file is written but not yet renamed
+      When another Stop reads the offset state
+      Then it reads either the complete prior state or the complete new state, never a partial one
 
   Rule: The retro Stop hook is non-blocking
 
@@ -119,6 +137,12 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
       Then it does not carry asyncRewake, which would surface stderr into the chat
 
   Rule: Re-fire cadence is bounded and fail-open
+
+    @retro-recall.TB1.AC2
+    Scenario: A first Stop below the substance threshold does not fire
+      Given a first Stop with no prior offset state and tool-uses below the substance threshold
+      When a Stop is evaluated
+      Then the retro does not fire and no offset state is written
 
     @retro-recall.TB1.AC2
     Scenario: Growth below the re-arm threshold holds the fire
@@ -145,10 +169,10 @@ Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
       Then the retro does not fire, the recursion guard taking precedence over every other gate
 
     @retro-recall.TB1.AC2
-    Scenario: A state-write failure still fires
+    Scenario: A state-write failure still fires and leaves the offset unchanged
       Given the offset-state writer throws on persist
       When a re-fire is decided
-      Then the retro still fires and does not throw
+      Then the retro still fires without throwing and the recorded offset is unchanged
 
   Rule: Every delta window passes the full egress pipeline unchanged
 

--- a/packages/cli/features/retro-recall-delta-rearm.feature
+++ b/packages/cli/features/retro-recall-delta-rearm.feature
@@ -1,0 +1,165 @@
+# BDD source for ZFGWS1 (retro recall — delta re-arm + sonnet + async hook +
+# signature dedupe). Proven by the vitest suite (tests named
+# `retro-recall-delta-rearm.*` / co-located `*.test.ts` under src/retro,
+# templates/hooks, and tests/hooks), whose unit + wiring scenarios mock only the
+# process boundaries (the `claude -p` subprocess, the GitHub transport, the
+# offset-state fs) — a shape the cucumber black-box lane can't drive. `@manual`
+# excludes it from the cucumber acceptance lane while keeping it readable by
+# codify / review-spec / safeword check.
+@retro-recall-delta-rearm @manual
+Feature: Retro recall — delta re-arm + sonnet + async hook + signature dedupe
+
+  The invisible retro fires more than once per session; each fire digests only the
+  NEW transcript since the last fire's offset (a pre-sliced window + small overlap),
+  so the deltas tile the whole session. Extraction defaults to sonnet, the Stop
+  hook is non-blocking (async), re-fires dedupe by content signature, and the
+  egress guard is preserved unchanged for every window.
+
+  Rule: Delta windows tile the whole session
+
+    @retro-recall.SM1.AC1
+    Scenario: The first fire digests from the start of the transcript
+      Given a substantial session at its first Stop with no prior offset state
+      When the retro decides to fire
+      Then the delta window starts at offset zero, covering the whole transcript so far
+
+    @retro-recall.SM1.AC1
+    Scenario: A later fire digests only the window since the previous fire's offset
+      Given offset state recording the previous fire's byte offset on a grown transcript
+      When the retro fires again
+      Then the digested window begins at the previous offset, not the transcript head
+
+    @retro-recall.SM1.AC1
+    Scenario: A back-half-only finding reaches the egress pipeline
+      Given a grown transcript whose only friction appears after the previous fire's offset
+      When the delta fire runs auto-extraction
+      Then that finding reaches the egress pipeline instead of being lost to the head cap
+
+    @retro-recall.SM1.AC1
+    Scenario: The overlap re-includes the boundary so a straddling finding appears whole
+      Given a finding that straddles the previous window's end boundary
+      When the next delta fire builds its window
+      Then the window re-includes the prior overlap region so the finding appears whole in one fire
+
+  Rule: Extraction defaults to sonnet at both model sites
+
+    @retro-recall.SM1.AC2
+    Scenario: The runner builds the extractor with sonnet by default
+      Given no retro model override in config
+      When the auto-extract runner constructs the headless extraction
+      Then the headless argv requests the sonnet model, not haiku
+
+    @retro-recall.SM1.AC2
+    Scenario: The headless extraction default is sonnet when no model is passed
+      Given the headless extraction is invoked without an explicit model
+      When it builds the argv
+      Then the requested model is sonnet
+
+    @retro-recall.SM1.AC2
+    Scenario: A configured model overrides the sonnet default
+      Given the retro model is configured as haiku
+      When the auto-extract runner constructs the headless extraction
+      Then the headless argv requests the configured haiku model
+
+  Rule: Re-fires dedupe by content signature, not the model-generated title
+
+    @retro-recall.SM2.AC1
+    Scenario: A repeat signature under a different title opens no second issue
+      Given an open issue already carries a finding's retro signature
+      And a re-fire produces the same signature under a different title
+      When triage processes the re-fire
+      Then no new issue is created and the existing issue is matched
+
+    @retro-recall.SM2.AC1
+    Scenario: A genuinely new signature opens a new issue
+      Given no open issue carries the finding's retro signature
+      When triage processes the finding
+      Then a new issue is created
+
+    @retro-recall.SM2.AC1
+    Scenario: The issue body embeds the searchable signature marker
+      Given a finding assembled into a draft
+      When the issue body is built
+      Then it contains the finding's retro signature in a form signature search can match
+
+  Rule: A stable session id reaches the extraction child
+
+    @retro-recall.SM2.AC2
+    Scenario: The resolved session id is forwarded to the child
+      Given a Stop with a resolvable session id but no CLAUDE_SESSION_ID in the environment
+      When the hook spawns the extraction child
+      Then the child receives the resolved session id rather than the unknown fallback
+
+  Rule: Offset state survives concurrent Stops
+
+    @retro-recall.SM2.AC3
+    Scenario: Offset state is written atomically via temp-file then rename
+      Given a fire records new offset state
+      When the state is persisted
+      Then it is written to a temp file and renamed over the state file, never written in place
+
+    @retro-recall.SM2.AC3
+    Scenario: The recorded offset only advances across fires
+      Given offset state from a previous fire
+      When a later fire records its offset
+      Then the recorded offset is greater than or equal to the previous offset
+
+  Rule: The retro Stop hook is non-blocking
+
+    @retro-recall.TB1.AC1
+    Scenario: The generated Claude Stop settings register the retro hook async
+      Given the generated Claude settings hooks
+      When the retro Stop hook entry is inspected
+      Then it is registered with async true
+
+    @retro-recall.TB1.AC1
+    Scenario: The retro Stop hook is not registered asyncRewake
+      Given the generated Claude settings hooks
+      When the retro Stop hook entry is inspected
+      Then it does not carry asyncRewake, which would surface stderr into the chat
+
+  Rule: Re-fire cadence is bounded and fail-open
+
+    @retro-recall.TB1.AC2
+    Scenario: Growth below the re-arm threshold holds the fire
+      Given offset state from a prior fire and growth below the re-arm threshold
+      When a Stop is evaluated
+      Then the retro does not fire and the offset state is unchanged
+
+    @retro-recall.TB1.AC2
+    Scenario: Growth at the re-arm threshold re-fires
+      Given growth at the re-arm threshold since the last fire
+      When a Stop is evaluated
+      Then the retro fires and records the new offset and count
+
+    @retro-recall.TB1.AC2
+    Scenario: The backstop caps total fires per session
+      Given the fire count has reached the runaway backstop
+      When a Stop is evaluated with further growth
+      Then the retro does not fire
+
+    @retro-recall.TB1.AC2
+    Scenario: A retro child never re-fires
+      Given the environment marks this process as a retro child
+      When a Stop is evaluated
+      Then the retro does not fire, the recursion guard taking precedence over every other gate
+
+    @retro-recall.TB1.AC2
+    Scenario: A state-write failure still fires
+      Given the offset-state writer throws on persist
+      When a re-fire is decided
+      Then the retro still fires and does not throw
+
+  Rule: Every delta window passes the full egress pipeline unchanged
+
+    @retro-recall.NTB1.AC1
+    Scenario: A secret in a back-half finding is redacted before filing
+      Given a delta-window finding whose free text contains a secret
+      When it flows through the egress pipeline
+      Then the secret is redacted in the filed issue body
+
+    @retro-recall.NTB1.AC1
+    Scenario: A delta-window finding with an unresolved surface is dropped
+      Given a delta-window finding naming a surface outside safeword
+      When it flows through the egress pipeline
+      Then it is dropped and nothing is filed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -198,14 +198,31 @@ program
     '--auto-extract',
     'Extract findings out-of-band via a headless `claude -p` session (no --findings needed)',
   )
-  .action(async (options: { transcript?: string; findings?: string; autoExtract?: boolean }) => {
-    const { retroCommand } = await import('./commands/retro.js');
-    await retroCommand({
-      transcript: options.transcript,
-      findings: options.findings,
-      autoExtract: options.autoExtract,
-    });
-  });
+  .option(
+    '--window-start <chars>',
+    'Delta re-arm: digest only the transcript from this char offset onward (ZFGWS1)',
+  )
+  .option('--session-id <id>', 'Stable session id to attribute findings to (ledger accounting)')
+  .action(
+    async (options: {
+      transcript?: string;
+      findings?: string;
+      autoExtract?: boolean;
+      windowStart?: string;
+      sessionId?: string;
+    }) => {
+      const { retroCommand } = await import('./commands/retro.js');
+      const windowStart =
+        options.windowStart === undefined ? undefined : Number(options.windowStart);
+      await retroCommand({
+        transcript: options.transcript,
+        findings: options.findings,
+        autoExtract: options.autoExtract,
+        windowStart: Number.isFinite(windowStart) ? windowStart : undefined,
+        sessionId: options.sessionId,
+      });
+    },
+  );
 
 program
   .command('lint-gherkin')

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import process from 'node:process';
 
+import { windowFor } from '../../templates/hooks/lib/retro-extract.js';
 import { prepareEncounters } from '../retro/pipeline.js';
 import { type IssueTracker, triage, type TriageResult } from '../retro/triage.js';
 
@@ -46,7 +47,7 @@ export interface RetroOutcome {
  * files nothing when it is missing or unreadable.
  */
 export async function runRetro(
-  options: { transcript?: string },
+  options: { transcript?: string; windowStart?: number },
   dependencies: RetroDependencies,
 ): Promise<RetroOutcome> {
   if (!options.transcript) {
@@ -65,7 +66,12 @@ export async function runRetro(
     return { ok: false, errorMessage: `cannot read transcript at ${options.transcript}` };
   }
 
-  const rawFindings = await dependencies.extract(transcript);
+  // Delta re-arm (ZFGWS1): digest only the window since the last fire's offset
+  // (plus a small overlap), so the cap applies to the new activity, not the head.
+  // windowStart 0 (or absent) means the whole transcript — the first-fire / legacy
+  // behavior. The window flows through the UNCHANGED egress pipeline below.
+  const window = windowFor(transcript, options.windowStart ?? 0);
+  const rawFindings = await dependencies.extract(window);
   const encounters = await prepareEncounters(rawFindings);
   const result = await triage(dependencies.transport, encounters, {
     sessionId: dependencies.sessionId,

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -87,28 +87,49 @@ export interface RetroCliOptions {
   autoExtract?: boolean;
 }
 
+/** Injectable seam for `buildAutoExtractor` (tests assert the resolved model/argv). */
+export interface AutoExtractDependencies {
+  /** Spawn the headless `claude` process; defaults to the real `spawnSync`. */
+  spawn?: (
+    argv: string[],
+    options: { cwd: string; env: Record<string, string | undefined> },
+  ) => Promise<{ code: number | null; stdout: string }>;
+  /** Extraction model; defaults to the install's `retro.model` (sonnet fallback). */
+  model?: string;
+}
+
 /**
  * Build the auto-extract `FindingExtractor`: run the retro extraction in a
  * separate, isolated headless `claude -p` session (read-only, no `--bare`) from a
- * neutral temp cwd, with `SAFEWORD_RETRO_CHILD=1` set by the runner. Fail-open:
- * the runner returns `[]` on any error.
+ * neutral temp cwd, with `SAFEWORD_RETRO_CHILD=1` set by the runner. The model
+ * defaults to the install's `retro.model` config (sonnet fallback — haiku proved
+ * too weak; ZFGWS1). Fail-open: the runner returns `[]` on any error.
  */
-async function buildAutoExtractor(): Promise<FindingExtractor> {
-  const { runHeadlessExtraction } = await import('../../templates/hooks/lib/retro-extract.js');
+export async function buildAutoExtractor(
+  projectDirectory: string,
+  dependencies: AutoExtractDependencies = {},
+): Promise<FindingExtractor> {
+  const { runHeadlessExtraction, resolveRetroModel } =
+    await import('../../templates/hooks/lib/retro-extract.js');
+
+  const model = dependencies.model ?? resolveRetroModel(projectDirectory);
+  const spawn =
+    dependencies.spawn ??
+    ((argv: string[], spawnOptions: { cwd: string; env: Record<string, string | undefined> }) => {
+      const result = spawnSync('claude', argv, {
+        cwd: spawnOptions.cwd,
+        env: spawnOptions.env,
+        encoding: 'utf8',
+        timeout: 240_000,
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      return Promise.resolve({ code: result.status, stdout: result.stdout ?? '' });
+    });
 
   const workDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-retro-'));
   return (transcript: string) =>
     runHeadlessExtraction(transcript, {
-      spawn: (argv, spawnOptions) => {
-        const result = spawnSync('claude', argv, {
-          cwd: spawnOptions.cwd,
-          env: spawnOptions.env,
-          encoding: 'utf8',
-          timeout: 240_000,
-          maxBuffer: 64 * 1024 * 1024,
-        });
-        return Promise.resolve({ code: result.status, stdout: result.stdout ?? '' });
-      },
+      spawn,
       writeDigest: (digest: string) => {
         const path = nodePath.join(workDirectory, 'digest.txt');
         writeFileSync(path, digest);
@@ -116,7 +137,7 @@ async function buildAutoExtractor(): Promise<FindingExtractor> {
       },
       env: process.env,
       cwd: workDirectory, // neutral cwd — not the user's project
-      model: 'haiku',
+      model,
     });
 }
 
@@ -131,9 +152,10 @@ export async function retroCommand(options: RetroCliOptions): Promise<void> {
   const { error, info, success } = await import('../utils/output.js');
   const { createRestTransport, resolveGitHubToken } = await import('../retro/github-rest.js');
 
+  const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
   const findingsPath = options.findings;
   const extract: FindingExtractor = options.autoExtract
-    ? await buildAutoExtractor()
+    ? await buildAutoExtractor(projectDirectory)
     : () => Promise.resolve(findingsPath ? readFindings(findingsPath) : []);
 
   // Use the environment's existing GitHub access (GITHUB_TOKEN or `gh auth token`);

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -85,6 +85,10 @@ export interface RetroCliOptions {
   findings?: string;
   /** Extract findings out-of-band via a headless `claude -p` session. */
   autoExtract?: boolean;
+  /** Delta re-arm: digest only the transcript from this char offset onward (ZFGWS1). */
+  windowStart?: number;
+  /** Stable session id forwarded from the hook, so the ledger isn't keyed to 'unknown'. */
+  sessionId?: string;
 }
 
 /** Injectable seam for `buildAutoExtractor` (tests assert the resolved model/argv). */
@@ -172,7 +176,10 @@ export async function retroCommand(options: RetroCliOptions): Promise<void> {
   const outcome = await runRetro(options, {
     extract,
     transport,
-    sessionId: process.env.CLAUDE_SESSION_ID ?? 'unknown',
+    // Prefer the session id the hook resolved and forwarded (cloud sets
+    // CLAUDE_CODE_REMOTE_SESSION_ID, not CLAUDE_SESSION_ID, so the env fallback
+    // alone resolved to 'unknown' and broke ledger session-accounting; ZFGWS1).
+    sessionId: options.sessionId ?? process.env.CLAUDE_SESSION_ID ?? 'unknown',
     harness: detectAgent(),
     readFile: (path: string) => readFileSync(path, 'utf8'),
   });

--- a/packages/cli/src/retro/draft.test.ts
+++ b/packages/cli/src/retro/draft.test.ts
@@ -23,6 +23,13 @@ describe('buildDraft', () => {
     expect(draft.title).toBe(finding.title);
     expect(Array.isArray(draft.labels)).toBe(true);
   });
+
+  it('retro-recall.SM2.AC1.body_embeds_the_searchable_signature_marker', () => {
+    const draft = buildDraft(finding);
+    // The signature must appear verbatim in the body so searchBySignature (in:body
+    // + exact-filter) can dedupe re-fires on it rather than the variable title.
+    expect(draft.body).toContain(draft.signature);
+  });
 });
 
 describe('retroSignature', () => {

--- a/packages/cli/src/retro/draft.ts
+++ b/packages/cli/src/retro/draft.ts
@@ -29,12 +29,26 @@ export function retroSignature(finding: Finding): string {
   return `retro:${shortHash(key)}`;
 }
 
+/**
+ * A hidden, searchable marker that carries the content signature into the issue
+ * body. Dedupe matches on THIS (via `searchBySignature` → `in:body`), not the
+ * model-generated title, because titles vary across delta re-fires (ZFGWS1). An
+ * HTML comment keeps it invisible in the rendered issue but present in the raw body
+ * GitHub search indexes.
+ */
+export function signatureMarker(signature: string): string {
+  return `<!-- safeword-retro-signature: ${signature} -->`;
+}
+
 /** Build the namespaced draft from a normalized finding. */
 export function buildDraft(finding: Finding): RetroDraft {
+  const signature = retroSignature(finding);
   return {
-    signature: retroSignature(finding),
+    signature,
     title: finding.title,
-    body: assembleBody(finding),
+    // Embed the signature marker so re-fires (and recurrences) dedupe on the
+    // stable signature, not the variable title.
+    body: `${assembleBody(finding)}\n${signatureMarker(signature)}`,
     labels: ['self-report', 'retro', finding.category],
   };
 }

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -59,18 +59,36 @@ describe('createRestTransport', () => {
     expect(createRestTransport('')).toBeUndefined();
   });
 
-  it('C2: strips quote/colon from the search query and requests per_page=100', async () => {
+  it('C2: searches the body for the signature hash token and requests per_page=100', async () => {
     const calls = mockFetch(() => ({ json: () => ({ items: [] }) }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
-    await transport.searchByTitle('Gate "fails" on: x');
+    await transport.searchBySignature('retro:abc123def456');
 
     const decoded = decodeURIComponent(calls[0] ?? '');
     expect(calls[0]).toContain('per_page=100');
-    expect(decoded).not.toContain('"');
-    expect(decoded).toContain('Gate');
-    expect(decoded).toContain('fails');
+    // searches the body, by the bare hash token (no `retro:` colon qualifier)
+    expect(decoded).toContain('in:body');
+    expect(decoded).toContain('abc123def456');
+    expect(decoded).not.toContain('retro:abc123def456');
+  });
+
+  it('C2: rejects a fuzzy near-miss whose body lacks the exact signature', async () => {
+    mockFetch(() => ({
+      json: () => ({
+        items: [
+          { number: 1, title: 'near miss', body: 'has retro:zzzzzzzzzzzz only' },
+          { number: 2, title: 'exact', body: 'carries retro:abc123def456 here' },
+        ],
+      }),
+    }));
+    const transport = createRestTransport('tok');
+    if (!transport) throw new Error('expected a transport');
+
+    const matches = await transport.searchBySignature('retro:abc123def456');
+
+    expect(matches).toEqual([{ number: 2, title: 'exact' }]);
   });
 
   it('C1: paginates listComments until a short page', async () => {

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -67,18 +67,18 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   }
 
   return {
-    async searchByTitle(title: string): Promise<IssueReference[]> {
-      // Strip characters GitHub's search grammar treats specially: a `"` would
-      // close the phrase early and `:` can read as a qualifier — both degrade
-      // recall and risk a dedup miss (→ duplicate issue). The exact-match filter
-      // below uses the ORIGINAL title, so stripping here only widens the search.
-      const searchable = title.replaceAll(/[":]/g, ' ');
-      const query = encodeURIComponent(`repo:${UPSTREAM_REPO} in:title state:open ${searchable}`);
+    async searchBySignature(signature: string): Promise<IssueReference[]> {
+      // Search the body for the signature's hash token (the `retro:` prefix carries
+      // a `:` that GitHub's grammar reads as a qualifier, degrading recall), then
+      // exact-filter on the FULL signature in the returned body — GitHub search is
+      // fuzzy, so a hash near-miss must be rejected to avoid matching the wrong issue.
+      const hashToken = signature.replace(/^retro:/, '');
+      const query = encodeURIComponent(`repo:${UPSTREAM_REPO} in:body state:open ${hashToken}`);
       const data = (await call('GET', `/search/issues?q=${query}&per_page=100`)) as {
-        items?: { number: number; title: string }[];
+        items?: { number: number; title: string; body?: string }[];
       };
       return (data.items ?? [])
-        .filter(item => item.title === title)
+        .filter(item => (item.body ?? '').includes(signature))
         .map(item => ({ number: item.number, title: item.title }));
     },
 

--- a/packages/cli/src/retro/triage.test.ts
+++ b/packages/cli/src/retro/triage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { RetroDraft } from './draft.js';
+import { type RetroDraft, signatureMarker } from './draft.js';
 import { LEDGER_MARKER, renderLedger } from './ledger.js';
 import {
   type CreateIssueInput,
@@ -28,8 +28,19 @@ class FakeGitHub implements IssueTracker {
   readonly commentsByIssue = new Map<number, IssueComment[]>();
   readonly calls = { createIssue: 0, createComment: 0, updateComment: 0 };
 
-  seedIssue(title: string, ledger?: { sessions: string[]; manifestations: string[] }): StoredIssue {
-    const issue: StoredIssue = { number: this.nextIssue++, title, body: '', labels: [] };
+  seedIssue(
+    title: string,
+    ledger?: { sessions: string[]; manifestations: string[] },
+    signature = `retro:${title}`,
+  ): StoredIssue {
+    // Embed the signature marker in the body so searchBySignature finds it, exactly
+    // as a real retro-filed issue carries it (buildDraft → signatureMarker).
+    const issue: StoredIssue = {
+      number: this.nextIssue++,
+      title,
+      body: signatureMarker(signature),
+      labels: [],
+    };
     this.issues.push(issue);
     const comments: IssueComment[] = [];
     if (ledger) {
@@ -47,9 +58,13 @@ class FakeGitHub implements IssueTracker {
     return issue;
   }
 
-  searchByTitle(title: string): Promise<IssueReference[]> {
+  searchBySignature(signature: string): Promise<IssueReference[]> {
+    // Match on the signature embedded in the body (as the real REST transport does
+    // via in:body + exact-filter), NOT the title.
     return Promise.resolve(
-      this.issues.filter(i => i.title === title).map(i => ({ number: i.number, title: i.title })),
+      this.issues
+        .filter(i => i.body.includes(signature))
+        .map(i => ({ number: i.number, title: i.title })),
     );
   }
 
@@ -87,15 +102,15 @@ class FakeGitHub implements IssueTracker {
   }
 }
 
-const draft = (title: string): RetroDraft => ({
-  signature: `retro:${title}`,
+const draft = (title: string, signature = `retro:${title}`): RetroDraft => ({
+  signature,
   title,
-  body: `body for ${title}`,
+  body: `body for ${title}\n${signatureMarker(signature)}`,
   labels: ['self-report', 'retro', 'rough-edge'],
 });
 
-const enc = (title: string, manifestation = 'm1'): Encounter => ({
-  draft: draft(title),
+const enc = (title: string, manifestation = 'm1', signature?: string): Encounter => ({
+  draft: draft(title, signature),
   manifestation,
 });
 const ctx = (over: Partial<{ sessionId: string; harness: string; maxNewIssues: number }> = {}) => ({
@@ -120,15 +135,6 @@ describe('triage — never a duplicate issue (SM1.AC2)', () => {
     expect(result.created).toEqual([]);
   });
 
-  it('retro-transcript-mining.SM1.AC2.matches_spool_filed_issue_without_duplicating', async () => {
-    const gh = new FakeGitHub();
-    // A spool-filed issue: same title, no retro ledger comment (non-retro origin).
-    gh.seedIssue('Coverage gate crash');
-    const result = await triage(gh, [enc('Coverage gate crash')], ctx());
-    expect(gh.calls.createIssue).toBe(0);
-    expect(result.created).toEqual([]);
-  });
-
   it('retro-transcript-mining.SM1.AC2.exactly_five_new_signatures_all_file', async () => {
     const gh = new FakeGitHub();
     const encounters = ['a', 'b', 'c', 'd', 'e'].map(t => enc(t));
@@ -145,6 +151,48 @@ describe('triage — never a duplicate issue (SM1.AC2)', () => {
     expect(gh.calls.createIssue).toBe(5);
     expect(result.created).toHaveLength(5);
     expect(result.deferred).toEqual(['f']);
+  });
+});
+
+describe('triage — dedupe by content signature, not title (ZFGWS1 SM2.AC1)', () => {
+  it('retro-recall.SM2.AC1.repeat_signature_under_a_different_title_opens_no_second_issue', async () => {
+    const gh = new FakeGitHub();
+    // An issue already filed for signature S under one (model-generated) title.
+    gh.seedIssue(
+      'Coverage gate omits the file',
+      { sessions: ['old'], manifestations: ['m1'] },
+      'retro:abc123def456',
+    );
+    // A re-fire surfaces the SAME signature under a DIFFERENT title.
+    const result = await triage(
+      gh,
+      [enc('Gate message is missing the filename', 'm1', 'retro:abc123def456')],
+      ctx({ sessionId: 'sess-new' }),
+    );
+    expect(gh.calls.createIssue).toBe(0);
+    expect(result.created).toEqual([]);
+  });
+
+  it('retro-recall.SM2.AC1.a_genuinely_new_signature_opens_a_new_issue', async () => {
+    const gh = new FakeGitHub();
+    gh.seedIssue(
+      'Some other friction',
+      { sessions: ['old'], manifestations: ['m1'] },
+      'retro:111111111111',
+    );
+    const result = await triage(gh, [enc('Brand new friction', 'm1', 'retro:222222222222')], ctx());
+    expect(gh.calls.createIssue).toBe(1);
+    expect(result.created).toEqual(['Brand new friction']);
+  });
+
+  it('retro-recall.SM2.AC1.a_fuzzy_search_near_miss_is_rejected_by_the_exact_filter', async () => {
+    const gh = new FakeGitHub();
+    // The body carries a DIFFERENT signature; the FakeGitHub (like the REST
+    // exact-filter) only matches the exact signature, so this is not a match.
+    gh.seedIssue('Near miss', { sessions: ['old'], manifestations: ['m1'] }, 'retro:aaaaaaaaaaaa');
+    const result = await triage(gh, [enc('New finding', 'm1', 'retro:bbbbbbbbbbbb')], ctx());
+    expect(gh.calls.createIssue).toBe(1);
+    expect(result.created).toEqual(['New finding']);
   });
 });
 

--- a/packages/cli/src/retro/triage.ts
+++ b/packages/cli/src/retro/triage.ts
@@ -2,8 +2,9 @@
 // issues but a record of every encounter. The IssueTracker is the only
 // boundary (mockable in tests); all dedup/cap/ledger logic is deterministic.
 //
-// - A signature already represented by an open issue (matched by title) never
-//   spawns a second issue (SM1.AC2); title-match also catches spool-filed issues.
+// - A signature already represented by an open issue (matched by the content
+//   signature embedded in the body, not the model-generated title — titles vary
+//   across delta re-fires; ZFGWS1) never spawns a second issue (SM1.AC2).
 // - New-issue creation is capped per session; the overflow is deferred.
 // - Every encounter with a known issue updates the occurrence ledger idempotently
 //   (one bump per session) and posts a shape comment only for a novel
@@ -36,7 +37,12 @@ export interface CreateIssueInput {
 }
 
 export interface IssueTracker {
-  searchByTitle(title: string): Promise<IssueReference[]>;
+  /**
+   * Find open issues carrying this content `signature` (matched in the body, not
+   * the title — titles vary across delta re-fires; ZFGWS1). Returns the matches so
+   * triage opens no duplicate for a signature already filed.
+   */
+  searchBySignature(signature: string): Promise<IssueReference[]>;
   createIssue(input: CreateIssueInput): Promise<IssueReference>;
   listComments(issueNumber: number): Promise<IssueComment[]>;
   createComment(issueNumber: number, body: string): Promise<IssueComment>;
@@ -79,7 +85,7 @@ export async function triage(
     // Isolate each encounter: a transport error (or a poisoned upstream ledger)
     // on one issue must not abort the rest of the session's findings (C3).
     try {
-      const matches = await transport.searchByTitle(encounter.draft.title);
+      const matches = await transport.searchBySignature(encounter.draft.signature);
       const [existing] = matches;
 
       if (existing) {

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -175,6 +175,20 @@ describe('SETTINGS_HOOKS', () => {
     expect(command.asyncRewake).toBe(true);
   });
 
+  it('retro-recall.TB1.AC1: registers the retro Stop hook async (non-blocking, not asyncRewake)', () => {
+    // ZFGWS1: async:true backgrounds the whole hook tree (returns immediately,
+    // 600s) so repeated delta fires never block Stop. NOT asyncRewake, which
+    // surfaces stderr into the chat on exit 2 and would break invisibility.
+    const command = SETTINGS_HOOKS.Stop.flatMap((entry: HookEntry) => entry.hooks).find(
+      (hook: HookCommand) => hook.type === 'command' && hook.command.includes('stop-retro'),
+    ) as { async?: boolean; asyncRewake?: boolean } | undefined;
+    if (!command) {
+      throw new Error('stop-retro hook not found');
+    }
+    expect(command.async).toBe(true);
+    expect(command.asyncRewake).toBeUndefined();
+  });
+
   it('should have PostToolUse quality observer matcher that includes Bash', () => {
     const qualityHook = SETTINGS_HOOKS.PostToolUse.find((h: HookEntry) =>
       h.hooks.some(

--- a/packages/cli/src/templates/config.ts
+++ b/packages/cli/src/templates/config.ts
@@ -389,6 +389,19 @@ function asyncRewakeHook(command: string) {
   return { hooks: [{ type: 'command', command, asyncRewake: true }] };
 }
 
+/**
+ * Create a fully backgrounded hook with `async: true` (documented Claude Code
+ * mode, https://code.claude.com/docs/en/hooks): the hook returns IMMEDIATELY and
+ * its whole process tree runs in the background (up to 600s), so it never blocks.
+ * Unlike `asyncRewake`, it surfaces NOTHING back into the conversation — used by
+ * the invisible retro (ZFGWS1) so repeated delta fires stay non-blocking AND
+ * invisible. Degrades safely: a build that doesn't know `async` treats it as an
+ * ordinary (synchronous) hook.
+ */
+function asyncHook(command: string) {
+  return { hooks: [{ type: 'command', command, async: true }] };
+}
+
 /** Create a hook entry with a tool matcher (PreToolUse, PostToolUse) */
 function matchedHook(matcher: string, command: string) {
   return { matcher, hooks: [{ type: 'command', command }] };
@@ -432,7 +445,9 @@ export const SETTINGS_HOOKS = {
     hook(`bun ${HOOKS_DIR}/stop-quality.ts`),
     hook(`bun ${HOOKS_DIR}/stop-reentry.ts`),
     hook(`bun ${HOOKS_DIR}/stop-self-report.ts`),
-    hook(`bun ${HOOKS_DIR}/stop-retro.ts`),
+    // Invisible retro (ZFGWS1): async so repeated delta fires never block Stop and
+    // run fully in the background; the inner spawnSync stays sync within that tree.
+    asyncHook(`bun ${HOOKS_DIR}/stop-retro.ts`),
   ],
   PreToolUse: [
     matchedHook('Bash', `bun ${HOOKS_DIR}/pre-tool-dependency-readiness.ts`),

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -66,6 +66,32 @@ export function windowFor(
   return transcript.slice(Math.max(0, windowStart - overlap));
 }
 
+/** A decision to run the retro child, carrying the delta window + stable session id. */
+export interface RetroChildInvocation {
+  transcriptPath: string;
+  windowStart: number;
+  sessionId: string;
+}
+
+/**
+ * Build the `safeword retro` argv the Stop hook spawns out-of-band. Forwards the
+ * delta window offset and the resolved session id (ZFGWS1) so the child digests
+ * only the new window and attributes findings to the real session — not the
+ * 'unknown' fallback its own env resolves to in cloud.
+ */
+export function retroChildArgs(invocation: RetroChildInvocation): string[] {
+  return [
+    'retro',
+    '--auto-extract',
+    '--transcript',
+    invocation.transcriptPath,
+    '--window-start',
+    String(invocation.windowStart),
+    '--session-id',
+    invocation.sessionId,
+  ];
+}
+
 /**
  * The headless extractor only ever READS the digest — never writes, edits, or
  * runs shell. A read-only allow-list keeps the out-of-band child from mutating

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -48,7 +48,7 @@ export function resolveRetroModel(projectDirectory: string): string {
  * line, so whole boundary entries still survive. Duplicate findings from the
  * overlap are absorbed by signature dedupe (triage).
  */
-export const OVERLAP_BYTES = 2048;
+export const OVERLAP_CHARS = 2048;
 
 /**
  * Slice the delta window a fire should digest: from `windowStart` (the previous
@@ -60,7 +60,7 @@ export const OVERLAP_BYTES = 2048;
 export function windowFor(
   transcript: string,
   windowStart: number,
-  overlap: number = OVERLAP_BYTES,
+  overlap: number = OVERLAP_CHARS,
 ): string {
   if (windowStart <= 0) return transcript;
   return transcript.slice(Math.max(0, windowStart - overlap));

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -8,11 +8,38 @@
 // synchronous runner. Agent-neutral where possible; Claude-specific bits are
 // named as such.
 
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
 /**
  * Default cap (chars) for a transcript digest. A real session transcript is tens
  * of MB; the extractor needs a bounded, signal-dense slice, not the raw JSONL.
  */
 export const DIGEST_CAP = 180_000;
+
+/**
+ * Default extraction model. Sonnet, not haiku: measured head-to-head on the same
+ * transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong ones (ZFGWS1).
+ * Overridable per install via `.safeword/config.json` → `retro.model`.
+ */
+export const DEFAULT_RETRO_MODEL = 'sonnet';
+
+/**
+ * Resolve the extraction model for an install: `retro.model` from
+ * `.safeword/config.json`, else the sonnet default. Fail-open to the default on
+ * any missing/unreadable/malformed config — model selection must never break the
+ * out-of-band retro run.
+ */
+export function resolveRetroModel(projectDirectory: string): string {
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { retro?: { model?: unknown } };
+    const model = parsed.retro?.model;
+    return typeof model === 'string' && model.length > 0 ? model : DEFAULT_RETRO_MODEL;
+  } catch {
+    return DEFAULT_RETRO_MODEL;
+  }
+}
 
 /**
  * Overlap (chars) re-included before a delta window's start, so a finding
@@ -177,7 +204,7 @@ export async function runHeadlessExtraction(
   try {
     const digestPath = dependencies.writeDigest(buildDigest(transcript));
     const argv = buildExtractArgv({
-      model: dependencies.model ?? 'haiku',
+      model: dependencies.model ?? DEFAULT_RETRO_MODEL,
       systemPrompt: EXTRACT_SYSTEM_PROMPT,
       prompt: buildExtractPrompt(digestPath),
     });

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -15,6 +15,31 @@
 export const DIGEST_CAP = 180_000;
 
 /**
+ * Overlap (chars) re-included before a delta window's start, so a finding
+ * straddling a window boundary appears whole in one fire (ticket ZFGWS1). A
+ * char-slice may cut the first JSONL line; `buildDigest` skips that malformed head
+ * line, so whole boundary entries still survive. Duplicate findings from the
+ * overlap are absorbed by signature dedupe (triage).
+ */
+export const OVERLAP_BYTES = 2048;
+
+/**
+ * Slice the delta window a fire should digest: from `windowStart` (the previous
+ * fire's recorded offset) minus a small overlap, to the end. The FIRST fire
+ * (`windowStart <= 0`) returns the whole transcript so far. So `buildDigest`'s cap
+ * applies to the WINDOW, not the chronological head — defeating the head-cap that
+ * made plain re-arm inert. The overlap is clamped at the start of the transcript.
+ */
+export function windowFor(
+  transcript: string,
+  windowStart: number,
+  overlap: number = OVERLAP_BYTES,
+): string {
+  if (windowStart <= 0) return transcript;
+  return transcript.slice(Math.max(0, windowStart - overlap));
+}
+
+/**
  * The headless extractor only ever READS the digest — never writes, edits, or
  * runs shell. A read-only allow-list keeps the out-of-band child from mutating
  * the working tree or exfiltrating via a tool.

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -155,14 +155,6 @@ export const REARM_GROWTH = 200;
  */
 export const MAX_FIRES = 20;
 
-/**
- * Overlap re-included before a window's start (chars), so a finding straddling a
- * window boundary appears whole in one fire. A byte-slice may cut the first JSONL
- * line; `buildDigest` skips that malformed head line, so whole boundary entries
- * still survive. Duplicate findings from the overlap are absorbed by signature dedupe.
- */
-export const OVERLAP_BYTES = 2048;
-
 /** Per-session delta state: where the last fire ended, and how many fires so far. */
 export interface OffsetState {
   /** Transcript length (chars) recorded at the last fire — the next window start. */

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -330,6 +330,14 @@ export interface RetroTriggerDeps {
     input: RetroTriggerInput,
     env: Record<string, string | undefined>,
   ) => string | undefined;
+  /** Additive re-fire growth in tool-uses (defaults to REARM_GROWTH). */
+  rearmGrowth?: number;
+  /** Runaway fire-count backstop (defaults to MAX_FIRES). */
+  maxFires?: number;
+  /** Offset-state reader (injected for tests; defaults to the fs helper). */
+  readOffsetState?: (sessionId: string, baseDirectory?: string) => OffsetState | undefined;
+  /** Offset-state writer (injected for tests; defaults to the atomic fs helper). */
+  writeOffsetState?: (sessionId: string, state: OffsetState, baseDirectory?: string) => void;
 }
 
 /**
@@ -386,19 +394,33 @@ export function decideRetroNudge(
 export interface RetroRunDecision {
   /** The transcript to mine, handed to the headless extractor. */
   transcriptPath: string;
+  /**
+   * Char offset where this fire's delta window starts (0 on the first fire). The
+   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_BYTES))` before
+   * digesting, so each fire reads only the NEW activity (plus a small overlap).
+   */
+  windowStart: number;
 }
 
 /**
- * Decide whether to RUN the invisible retro extraction this Stop (7D8PJP) — the
- * out-of-band replacement for `decideRetroNudge`. Same gates, but it returns the
- * transcript path to extract from instead of conversation text, and it adds the
- * recursion guard FIRST: a retro headless child (`SAFEWORD_RETRO_CHILD=1`) never
- * triggers another retro. Fail-open by construction — every "can't proceed"
- * branch returns undefined and leaves the once-per-session sentinel untouched:
+ * Decide whether to RUN the invisible retro extraction this Stop, and (when it
+ * does) compute the delta window and advance the per-session offset state
+ * (ZFGWS1 — supersedes the once-per-session sentinel of 7D8PJP). The retro now
+ * fires MORE than once per session: the FIRST fire keeps the substance gate and
+ * digests from offset 0 (the whole transcript so far); RE-fires are gated by
+ * ADDITIVE growth (`rearmGrowth` tool-uses since the last fire) under a high
+ * `maxFires` runaway backstop, and each returns `windowStart` = the previous
+ * fire's offset so the CLI digests only the new delta.
+ *
+ * The recursion guard runs FIRST (a retro headless child never re-fires). Fail-open
+ * by construction — every "can't proceed" branch returns undefined and leaves the
+ * offset state untouched, and a state-write failure still fires (the duplicate it
+ * risks is absorbed by signature dedupe), so the hook never blocks Stop:
  *   - this process is itself a retro child → undefined (before any gate)
  *   - no resolvable session id / no transcript_path → undefined
- *   - already ran this session → undefined
- *   - transcript unreadable / not substantial → undefined, sentinel unset
+ *   - transcript unreadable → undefined
+ *   - first fire below the substance threshold → undefined, state unset
+ *   - re-fire below the growth threshold, or backstop reached → undefined, state unchanged
  */
 export function decideRetroRun(
   input: RetroTriggerInput,
@@ -416,8 +438,6 @@ export function decideRetroRun(
   const transcriptPath = input.transcript_path;
   if (!transcriptPath || transcriptPath.length === 0) return undefined;
 
-  if (hasNudged(sessionId, dependencies.baseDirectory)) return undefined;
-
   const read = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
   let transcript: string;
   try {
@@ -427,15 +447,35 @@ export function decideRetroRun(
   }
 
   const counter = dependencies.countToolUses ?? countToolUses;
-  if (!isSubstantial(transcript, dependencies.threshold ?? SUBSTANCE_THRESHOLD, counter)) {
-    return undefined; // trivial session → silent, sentinel left unset
+  const toolUses = counter(transcript);
+  const threshold = dependencies.threshold ?? SUBSTANCE_THRESHOLD;
+  const rearmGrowth = dependencies.rearmGrowth ?? REARM_GROWTH;
+  const maxFires = dependencies.maxFires ?? MAX_FIRES;
+  const baseDirectory = dependencies.baseDirectory;
+  const readState = dependencies.readOffsetState ?? readOffsetState;
+  const writeState = dependencies.writeOffsetState ?? writeOffsetState;
+  const prior = readState(sessionId, baseDirectory);
+
+  let windowStart: number;
+  let fires: number;
+  if (!prior) {
+    // First fire: substance gate, digest from the start of the transcript.
+    if (toolUses < threshold) return undefined;
+    windowStart = 0;
+    fires = 1;
+  } else {
+    // Re-fire: bounded by the runaway backstop, then gated by additive growth.
+    if (prior.fires >= maxFires) return undefined;
+    if (toolUses - prior.toolUses < rearmGrowth) return undefined;
+    windowStart = prior.offset;
+    fires = prior.fires + 1;
   }
 
   try {
-    markNudged(sessionId, dependencies.baseDirectory);
+    writeState(sessionId, { offset: transcript.length, toolUses, fires }, baseDirectory);
   } catch {
-    // A sentinel-write failure must not suppress the run; worst case is a second
-    // extraction next Stop, which the occurrence ledger (RV9JT4) dedupes.
+    // A state-write failure must not suppress the fire (mirrors markNudged); the
+    // duplicate it risks next Stop is absorbed by signature dedupe (triage).
   }
-  return { transcriptPath };
+  return { transcriptPath, windowStart };
 }

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -210,9 +210,12 @@ export function readOffsetState(
 /**
  * Persist the per-session offset state ATOMICALLY: write a temp file, then
  * `rename` it over the state file (atomic on the same filesystem on Linux), so a
- * concurrent reader never sees a torn write. The temp name carries the pid so two
- * near-simultaneous Stops don't clobber each other's temp file before the rename.
+ * concurrent reader never sees a torn write. The temp name carries the pid AND a
+ * per-process counter, so neither two near-simultaneous Stops (distinct pids) nor
+ * two writes within one process collide on the temp file before the rename.
  */
+let tempWriteCounter = 0;
+
 export function writeOffsetState(
   sessionId: string,
   state: OffsetState,
@@ -220,7 +223,7 @@ export function writeOffsetState(
   atomicFs: AtomicFs = defaultAtomicFs,
 ): void {
   const finalPath = offsetStatePath(sessionId, baseDirectory);
-  const tempPath = `${finalPath}.${process.pid}.tmp`;
+  const tempPath = `${finalPath}.${process.pid}.${tempWriteCounter++}.tmp`;
   atomicFs.writeFileSync(tempPath, JSON.stringify(state));
   atomicFs.renameSync(tempPath, finalPath);
 }

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -392,6 +392,11 @@ export interface RetroRunDecision {
    * digesting, so each fire reads only the NEW activity (plus a small overlap).
    */
   windowStart: number;
+  /**
+   * The resolved session id, forwarded to the child so ledger session-accounting
+   * is correct (the child's env fallback resolves to 'unknown' in cloud; ZFGWS1).
+   */
+  sessionId: string;
 }
 
 /**
@@ -469,5 +474,5 @@ export function decideRetroRun(
     // A state-write failure must not suppress the fire (mirrors markNudged); the
     // duplicate it risks next Stop is absorbed by signature dedupe (triage).
   }
-  return { transcriptPath, windowStart };
+  return { transcriptPath, windowStart, sessionId };
 }

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -13,8 +13,9 @@
 // makes re-fires idempotent across sessions; the once-per-session sentinel here
 // makes them idempotent within a session.
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
+import process from 'node:process';
 import { tmpdir } from 'node:os';
 
 import { isRetroChild } from './retro-extract.js';
@@ -130,6 +131,106 @@ export function hasNudged(sessionId: string, baseDirectory: string = tmpdir()): 
  */
 export function markNudged(sessionId: string, baseDirectory: string = tmpdir()): void {
   writeFileSync(sentinelPath(sessionId, baseDirectory), `${sessionId}\n`);
+}
+
+// --- Delta re-arm offset state (ticket ZFGWS1) ---------------------------------
+//
+// The boolean once-per-session sentinel above made retro fire ONCE per session,
+// reading only the opening (the digest head-caps to the first 180 KB). Delta
+// re-arm replaces it: per-session offset state lets retro fire repeatedly, each
+// fire digesting only the NEW transcript since the last fire's offset, so the
+// deltas tile the whole session.
+
+/**
+ * Re-fire cadence: re-fire once the transcript grows by this many tool-uses since
+ * the last fire (ADDITIVE, constant spacing → even tiling; sim: last fire 91–100%
+ * of the session). Tunable; injected as `rearmGrowth` in tests.
+ */
+export const REARM_GROWTH = 200;
+
+/**
+ * Runaway backstop: at most this many fires per session, independent of cadence.
+ * A HIGH cap (a crash-loop bound), NOT a low cadence control — a low cap lands the
+ * last fire early and leaves a blind tail (the bug additive cadence fixes).
+ */
+export const MAX_FIRES = 20;
+
+/**
+ * Overlap re-included before a window's start (chars), so a finding straddling a
+ * window boundary appears whole in one fire. A byte-slice may cut the first JSONL
+ * line; `buildDigest` skips that malformed head line, so whole boundary entries
+ * still survive. Duplicate findings from the overlap are absorbed by signature dedupe.
+ */
+export const OVERLAP_BYTES = 2048;
+
+/** Per-session delta state: where the last fire ended, and how many fires so far. */
+export interface OffsetState {
+  /** Transcript length (chars) recorded at the last fire — the next window start. */
+  offset: number;
+  /** Tool-use count at the last fire — the additive-cadence baseline. */
+  toolUses: number;
+  /** Number of fires so far this session — the backstop counter. */
+  fires: number;
+}
+
+/** The fs primitives the atomic state write needs; injected so tests can assert them. */
+export interface AtomicFs {
+  writeFileSync: (path: string, data: string) => void;
+  renameSync: (from: string, to: string) => void;
+}
+
+const defaultAtomicFs: AtomicFs = { writeFileSync, renameSync };
+
+/** Absolute path of the per-session offset-state file for a session id. */
+export function offsetStatePath(sessionId: string, baseDirectory: string = tmpdir()): string {
+  return nodePath.join(
+    baseDirectory,
+    `safeword-retro-offset-${sessionId.replace(/[^\w.-]/g, '_')}.json`,
+  );
+}
+
+/**
+ * Read the per-session offset state, or undefined when absent, unreadable, or
+ * TORN (a partially-written file mid-rename). Fail-open by construction: a torn or
+ * missing state simply re-arms from offset 0 (a re-read the egress dedupe absorbs),
+ * never a throw — a Stop hook must not crash on a partial state file.
+ */
+export function readOffsetState(
+  sessionId: string,
+  baseDirectory: string = tmpdir(),
+): OffsetState | undefined {
+  try {
+    const raw = readFileSync(offsetStatePath(sessionId, baseDirectory), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<OffsetState>;
+    if (
+      typeof parsed.offset !== 'number' ||
+      typeof parsed.toolUses !== 'number' ||
+      typeof parsed.fires !== 'number'
+    ) {
+      return undefined;
+    }
+    return { offset: parsed.offset, toolUses: parsed.toolUses, fires: parsed.fires };
+  } catch {
+    return undefined; // missing / unreadable / torn → fail open (re-arm from 0)
+  }
+}
+
+/**
+ * Persist the per-session offset state ATOMICALLY: write a temp file, then
+ * `rename` it over the state file (atomic on the same filesystem on Linux), so a
+ * concurrent reader never sees a torn write. The temp name carries the pid so two
+ * near-simultaneous Stops don't clobber each other's temp file before the rename.
+ */
+export function writeOffsetState(
+  sessionId: string,
+  state: OffsetState,
+  baseDirectory: string = tmpdir(),
+  atomicFs: AtomicFs = defaultAtomicFs,
+): void {
+  const finalPath = offsetStatePath(sessionId, baseDirectory);
+  const tempPath = `${finalPath}.${process.pid}.tmp`;
+  atomicFs.writeFileSync(tempPath, JSON.stringify(state));
+  atomicFs.renameSync(tempPath, finalPath);
 }
 
 interface SessionIdEnv {

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -391,7 +391,7 @@ export interface RetroRunDecision {
   transcriptPath: string;
   /**
    * Char offset where this fire's delta window starts (0 on the first fire). The
-   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_BYTES))` before
+   * CLI slices `transcript.slice(max(0, windowStart - OVERLAP_CHARS))` before
    * digesting, so each fire reads only the NEW activity (plus a small overlap).
    */
   windowStart: number;

--- a/packages/cli/templates/hooks/stop-retro.ts
+++ b/packages/cli/templates/hooks/stop-retro.ts
@@ -20,7 +20,7 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { RETRO_EXTRACT_CMD_ENV } from './lib/retro-extract.ts';
+import { retroChildArgs, RETRO_EXTRACT_CMD_ENV } from './lib/retro-extract.ts';
 import { decideRetroRun } from './lib/retro-trigger.ts';
 import { readSelfReportConfig } from './lib/self-report.ts';
 
@@ -36,11 +36,11 @@ interface HookInput {
  */
 function resolveExtractCommand(
   projectDirectory: string,
-  transcriptPath: string,
+  decision: { transcriptPath: string; windowStart: number; sessionId: string },
 ): [string, string[]] {
   const override = process.env[RETRO_EXTRACT_CMD_ENV];
   if (override && override.length > 0) return [override, []];
-  const retroArgs = ['retro', '--auto-extract', '--transcript', transcriptPath];
+  const retroArgs = retroChildArgs(decision);
   const localCli = nodePath.join(projectDirectory, 'packages/cli/src/cli.ts');
   return existsSync(localCli)
     ? ['bun', [localCli, ...retroArgs]]
@@ -65,7 +65,7 @@ async function main(): Promise<void> {
 
   // Run extraction + filing out of band, synchronously, with NO conversation
   // output. Failures are swallowed here (the CLI also fail-opens internally).
-  const [command, args] = resolveExtractCommand(projectDirectory, decision.transcriptPath);
+  const [command, args] = resolveExtractCommand(projectDirectory, decision);
   spawnSync(command, args, { cwd: projectDirectory, stdio: 'ignore', timeout: 300_000 });
 }
 

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -7,7 +7,7 @@ import type {
   IssueReference,
   IssueTracker,
 } from '../../src/retro/triage.js';
-import { runHeadlessExtraction } from '../../templates/hooks/lib/retro-extract.js';
+import { DIGEST_CAP, runHeadlessExtraction } from '../../templates/hooks/lib/retro-extract.js';
 
 // Compact in-memory transport — only the network boundary is faked.
 class FakeGitHub implements IssueTracker {
@@ -193,5 +193,85 @@ describe('runRetro', () => {
     expect(filed).not.toContain('sk_live_TESTONLY1');
     expect(filed).not.toContain('src/billing.ts');
     expect(filed).toContain('[redacted]');
+  });
+
+  // ZFGWS1 — a friction only in the BACK HALF (beyond the digest head cap) is
+  // filed by a delta fire that windows from the prior offset, and a head-capped
+  // fire over the same transcript files nothing. Drives the real runRetro →
+  // windowFor → runHeadlessExtraction → buildDigest → triage path; the spawn is
+  // gated on whether the (windowed) digest actually contains the back-half marker.
+  it('retro-recall.SM1.AC1.back_half_finding_beyond_the_head_cap_is_filed', async () => {
+    const headText = 'x'.repeat(DIGEST_CAP + 1000); // alone exceeds the digest cap
+    const headEntry = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: headText }] },
+    });
+    const backEntry = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'BACKHALF friction in hooks/stop-quality.ts' }],
+      },
+    });
+    const transcript = `${headEntry}\n${backEntry}`;
+    const windowStart = headEntry.length + 1; // first char of the back-half line
+
+    const envelope = (text: string) =>
+      JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: text });
+    const findingJSON = JSON.stringify([
+      {
+        category: 'rough-edge',
+        title: 'Back-half friction',
+        safeword_surface: 'hooks/stop-quality.ts',
+        what_happened: 'surfaced only late in the session',
+        why_friction: 'a fire-once retro head-caps and never reads it',
+        repro: 'safeword check late in a long session',
+      },
+    ]);
+
+    // The spawn "sees" the back-half finding only when the digest it was built from
+    // actually contains the marker — i.e. only when the window read the back half.
+    let digest = '';
+    const autoExtractor = (window: string) =>
+      runHeadlessExtraction(window, {
+        writeDigest: (d: string) => {
+          digest = d;
+          return '/tmp/neutral/digest.txt';
+        },
+        spawn: () =>
+          Promise.resolve({
+            code: 0,
+            stdout: envelope(digest.includes('BACKHALF') ? findingJSON : '[]'),
+          }),
+        env: {},
+        cwd: '/tmp/neutral',
+        model: 'sonnet',
+      });
+
+    // Head fire (windowStart 0): the digest head-caps → no BACKHALF → files nothing.
+    const headTransport = new FakeGitHub();
+    await runRetro(
+      { transcript: '/t.jsonl', windowStart: 0 },
+      dependencies({
+        transport: headTransport,
+        extract: autoExtractor,
+        readFile: () => transcript,
+      }),
+    );
+    expect(headTransport.issues).toHaveLength(0);
+
+    // Delta fire (windowStart at the back half): the window digest carries BACKHALF
+    // → the finding is filed, which the head-capped fire above would have missed.
+    const deltaTransport = new FakeGitHub();
+    await runRetro(
+      { transcript: '/t.jsonl', windowStart },
+      dependencies({
+        transport: deltaTransport,
+        extract: autoExtractor,
+        readFile: () => transcript,
+      }),
+    );
+    expect(deltaTransport.issues).toHaveLength(1);
+    expect(deltaTransport.issues[0]?.body).toContain('hooks/stop-quality.ts');
   });
 });

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -278,6 +278,45 @@ describe('runRetro', () => {
     expect(deltaTransport.issues).toHaveLength(1);
     expect(deltaTransport.issues[0]?.body).toContain('hooks/stop-quality.ts');
   });
+
+  // ZFGWS1 NTB1.AC1 — the egress guard holds for EVERY delta window, not just the
+  // first: windowing slices the INPUT transcript only; findings from a re-fire
+  // (windowStart > 0) still flow through normalize → resolveSurface →
+  // sanitizeTextDeep → buildDraft, never bypassing it.
+  it('retro-recall.NTB1.AC1.a_secret_in_a_delta_window_finding_is_redacted', async () => {
+    const transport = new FakeGitHub();
+    await runRetro(
+      { transcript: '/t.jsonl', windowStart: 5000 },
+      dependencies({
+        transport,
+        extract: () =>
+          Promise.resolve([
+            rawFinding({
+              what_happened: 'leaked sk_live_TESTONLY1 editing /Users/jdoe/app/x.ts',
+            }),
+          ]),
+      }),
+    );
+    const filed = JSON.stringify(transport.issues);
+    expect(filed).not.toContain('sk_live_TESTONLY1');
+    expect(filed).not.toContain('/Users/jdoe/app/x.ts');
+    expect(filed).toContain('[redacted]');
+  });
+
+  it('retro-recall.NTB1.AC1.a_delta_window_finding_with_an_unresolved_surface_is_dropped', async () => {
+    const transport = new FakeGitHub();
+    await runRetro(
+      { transcript: '/t.jsonl', windowStart: 5000 },
+      dependencies({
+        transport,
+        extract: () =>
+          Promise.resolve([
+            rawFinding({ safeword_surface: 'src/billing.ts', title: 'Customer bug' }),
+          ]),
+      }),
+    );
+    expect(transport.issues).toHaveLength(0);
+  });
 });
 
 // ZFGWS1 SM1.AC2 — the RUNNER (buildAutoExtractor), not just the headless-default

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -20,7 +20,7 @@ class FakeGitHub implements IssueTracker {
   readonly issues: (CreateIssueInput & { number: number })[] = [];
   readonly calls = { createIssue: 0 };
 
-  searchByTitle(): Promise<IssueReference[]> {
+  searchBySignature(): Promise<IssueReference[]> {
     return Promise.resolve([]);
   }
 

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
 
-import { runRetro } from '../../src/commands/retro.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildAutoExtractor, runRetro } from '../../src/commands/retro.js';
 import type {
   CreateIssueInput,
   IssueComment,
@@ -273,5 +277,43 @@ describe('runRetro', () => {
     );
     expect(deltaTransport.issues).toHaveLength(1);
     expect(deltaTransport.issues[0]?.body).toContain('hooks/stop-quality.ts');
+  });
+});
+
+// ZFGWS1 SM1.AC2 — the RUNNER (buildAutoExtractor), not just the headless-default
+// concept, requests sonnet by default and honors the retro.model config override.
+// Covers the done_when "a test covers buildAutoExtractor's model".
+describe('buildAutoExtractor (SM1.AC2 — runner model: sonnet default, config-overridable)', () => {
+  let projectDirectory: string;
+  beforeEach(() => {
+    projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-runner-'));
+  });
+  afterEach(() => {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  });
+
+  async function modelFromRunner(directory: string): Promise<string | undefined> {
+    let argvSeen: string[] = [];
+    const extract = await buildAutoExtractor(directory, {
+      spawn: (argv: string[]) => {
+        argvSeen = argv;
+        return Promise.resolve({ code: 0, stdout: '' });
+      },
+    });
+    await extract('transcript');
+    return argvSeen[argvSeen.indexOf('--model') + 1];
+  }
+
+  it('builds the extractor with sonnet when no retro.model is configured', async () => {
+    expect(await modelFromRunner(projectDirectory)).toBe('sonnet');
+  });
+
+  it('uses the configured retro.model override', async () => {
+    mkdirSync(nodePath.join(projectDirectory, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(projectDirectory, '.safeword', 'config.json'),
+      JSON.stringify({ retro: { model: 'haiku' } }),
+    );
+    expect(await modelFromRunner(projectDirectory)).toBe('haiku');
   });
 });

--- a/packages/cli/tests/hooks/retro-delta-rearm.test.ts
+++ b/packages/cli/tests/hooks/retro-delta-rearm.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Retro recall — delta re-arm offset state + additive cadence (ticket ZFGWS1).
+ *
+ * The once-per-session boolean sentinel is replaced by per-session offset state
+ * `{ offset, toolUses, fires }`, and `decideRetroRun` becomes delta-aware: the
+ * first fire keeps the substance gate and digests from offset 0; re-fires are
+ * gated by additive growth (`REARM_GROWTH`) with a high `MAX_FIRES` backstop, and
+ * each returns the `windowStart` (the previous fire's offset) so the CLI digests
+ * only the new delta. State is persisted temp-write + rename (atomic), and every
+ * "can't proceed" branch fails open.
+ *
+ * Feature: packages/cli/features/retro-recall-delta-rearm.feature
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  decideRetroRun,
+  MAX_FIRES,
+  type OffsetState,
+  offsetStatePath,
+  readOffsetState,
+  REARM_GROWTH,
+  SUBSTANCE_THRESHOLD,
+  writeOffsetState,
+} from '../../templates/hooks/lib/retro-trigger.js';
+
+// A Claude JSONL transcript with `n` assistant tool_use content items.
+function transcriptWithToolUses(n: number): string {
+  const lines: string[] = [
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    }),
+  ];
+  for (let i = 0; i < n; i++) {
+    lines.push(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: `step ${i}` },
+            { type: 'tool_use', id: `tool_${i}`, name: 'Bash', input: {} },
+          ],
+        },
+      }),
+    );
+  }
+  return lines.join('\n');
+}
+
+describe('offset-state persistence (SM2.AC3)', () => {
+  let baseDirectory: string;
+  beforeEach(() => {
+    baseDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-offset-'));
+  });
+  afterEach(() => {
+    rmSync(baseDirectory, { recursive: true, force: true });
+  });
+
+  it('round-trips offset state keyed by session id', () => {
+    const state: OffsetState = { offset: 1234, toolUses: 7, fires: 2 };
+    writeOffsetState('sess-1', state, baseDirectory);
+    expect(readOffsetState('sess-1', baseDirectory)).toEqual(state);
+    // keyed by session id — a different id is independent
+    expect(readOffsetState('sess-2', baseDirectory)).toBeUndefined();
+  });
+
+  it('writes atomically: temp-file then rename, never in place', () => {
+    const writeFileSyncSpy = vi.fn();
+    const renameSyncSpy = vi.fn();
+    writeOffsetState('sess-1', { offset: 10, toolUses: 1, fires: 1 }, baseDirectory, {
+      writeFileSync: writeFileSyncSpy,
+      renameSync: renameSyncSpy,
+    });
+    const finalPath = offsetStatePath('sess-1', baseDirectory);
+    // the body is written to a temp path, NOT the final path
+    expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+    const [writtenPath] = writeFileSyncSpy.mock.calls[0];
+    expect(writtenPath).not.toBe(finalPath);
+    expect(String(writtenPath).startsWith(finalPath)).toBe(true);
+    // then renamed over the final path (atomic publish)
+    expect(renameSyncSpy).toHaveBeenCalledWith(writtenPath, finalPath);
+  });
+
+  it('a torn / partial state file reads as undefined, never throws (fail open)', () => {
+    writeFileSync(offsetStatePath('sess-1', baseDirectory), '{"offset":123,"toolUse'); // truncated
+    expect(readOffsetState('sess-1', baseDirectory)).toBeUndefined();
+  });
+});
+
+describe('decideRetroRun — delta re-arm cadence (ZFGWS1)', () => {
+  let baseDirectory: string;
+  beforeEach(() => {
+    baseDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-rearm-'));
+  });
+  afterEach(() => {
+    rmSync(baseDirectory, { recursive: true, force: true });
+  });
+
+  const dependencies = (over: Record<string, unknown> = {}) => ({
+    env: {} as Record<string, string | undefined>,
+    baseDirectory,
+    ...over,
+  });
+
+  it('TB1.AC2: a first Stop below the substance threshold does not fire and writes no state', () => {
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcriptWithToolUses(SUBSTANCE_THRESHOLD - 1) }),
+    );
+    expect(out).toBeUndefined();
+    expect(readOffsetState('sess-1', baseDirectory)).toBeUndefined();
+  });
+
+  it('SM1.AC1: the first fire digests from offset 0 and records state (fires=1)', () => {
+    const transcript = transcriptWithToolUses(SUBSTANCE_THRESHOLD + 1);
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcript }),
+    );
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 0 });
+    const state = readOffsetState('sess-1', baseDirectory);
+    expect(state).toMatchObject({ offset: transcript.length, fires: 1 });
+  });
+
+  it('TB1.AC2: growth below the re-arm threshold holds the fire and leaves state unchanged', () => {
+    const prior: OffsetState = { offset: 50, toolUses: 10, fires: 1 };
+    writeOffsetState('sess-1', prior, baseDirectory);
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcriptWithToolUses(10 + REARM_GROWTH - 1) }),
+    );
+    expect(out).toBeUndefined();
+    expect(readOffsetState('sess-1', baseDirectory)).toEqual(prior);
+  });
+
+  it('SM1.AC1 + TB1.AC2: growth at the re-arm threshold re-fires from the prior offset', () => {
+    const prior: OffsetState = { offset: 50, toolUses: 10, fires: 1 };
+    writeOffsetState('sess-1', prior, baseDirectory);
+    const transcript = transcriptWithToolUses(10 + REARM_GROWTH);
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcript }),
+    );
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50 });
+    expect(readOffsetState('sess-1', baseDirectory)).toMatchObject({
+      offset: transcript.length,
+      fires: 2,
+    });
+  });
+
+  it('SM2.AC3: a later fire strictly advances the recorded offset', () => {
+    const prior: OffsetState = { offset: 50, toolUses: 10, fires: 1 };
+    writeOffsetState('sess-1', prior, baseDirectory);
+    decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcriptWithToolUses(10 + REARM_GROWTH) }),
+    );
+    const after = readOffsetState('sess-1', baseDirectory);
+    expect(after?.offset).toBeGreaterThan(prior.offset);
+  });
+
+  it('TB1.AC2: the backstop holds further fires once MAX_FIRES is reached', () => {
+    writeOffsetState('sess-1', { offset: 50, toolUses: 10, fires: MAX_FIRES }, baseDirectory);
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({ readFile: () => transcriptWithToolUses(10 + REARM_GROWTH * 5) }),
+    );
+    expect(out).toBeUndefined();
+  });
+
+  it('TB1.AC2: a retro child never re-fires even with an armed re-fire (guard first)', () => {
+    writeOffsetState('sess-1', { offset: 50, toolUses: 10, fires: 1 }, baseDirectory);
+    const out = decideRetroRun(
+      { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+      dependencies({
+        env: { SAFEWORD_RETRO_CHILD: '1' },
+        readFile: () => transcriptWithToolUses(10 + REARM_GROWTH),
+      }),
+    );
+    expect(out).toBeUndefined();
+  });
+
+  it('TB1.AC2: a state-write failure still fires (fail open) and leaves the offset unchanged', () => {
+    const prior: OffsetState = { offset: 50, toolUses: 10, fires: 1 };
+    writeOffsetState('sess-1', prior, baseDirectory);
+    let out: unknown;
+    expect(() => {
+      out = decideRetroRun(
+        { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
+        dependencies({
+          readFile: () => transcriptWithToolUses(10 + REARM_GROWTH),
+          writeOffsetState: () => {
+            throw new Error('disk full');
+          },
+        }),
+      );
+    }).not.toThrow();
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50 });
+    // the write threw, so the persisted offset is left at its prior value
+    expect(readOffsetState('sess-1', baseDirectory)).toEqual(prior);
+  });
+
+  it('SM2.AC2: no resolvable session id → no fire (nothing filed under "unknown")', () => {
+    const out = decideRetroRun(
+      { transcript_path: '/t/s.jsonl' },
+      dependencies({ env: {}, readFile: () => transcriptWithToolUses(SUBSTANCE_THRESHOLD + 1) }),
+    );
+    expect(out).toBeUndefined();
+  });
+
+  it('fails open on a missing path or an unreadable transcript', () => {
+    expect(decideRetroRun({ session_id: 'sess-1' }, dependencies())).toBeUndefined();
+    expect(
+      decideRetroRun(
+        { session_id: 'sess-1', transcript_path: '/t/missing.jsonl' },
+        dependencies({
+          readFile: () => {
+            throw new Error('ENOENT');
+          },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/hooks/retro-delta-rearm.test.ts
+++ b/packages/cli/tests/hooks/retro-delta-rearm.test.ts
@@ -12,7 +12,7 @@
  * Feature: packages/cli/features/retro-recall-delta-rearm.feature
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -81,9 +81,9 @@ describe('offset-state persistence (SM2.AC3)', () => {
     const finalPath = offsetStatePath('sess-1', baseDirectory);
     // the body is written to a temp path, NOT the final path
     expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
-    const [writtenPath] = writeFileSyncSpy.mock.calls[0];
+    const writtenPath = writeFileSyncSpy.mock.calls[0]?.[0] as string;
     expect(writtenPath).not.toBe(finalPath);
-    expect(String(writtenPath).startsWith(finalPath)).toBe(true);
+    expect(writtenPath.startsWith(finalPath)).toBe(true);
     // then renamed over the final path (atomic publish)
     expect(renameSyncSpy).toHaveBeenCalledWith(writtenPath, finalPath);
   });

--- a/packages/cli/tests/hooks/retro-delta-rearm.test.ts
+++ b/packages/cli/tests/hooks/retro-delta-rearm.test.ts
@@ -124,7 +124,7 @@ describe('decideRetroRun — delta re-arm cadence (ZFGWS1)', () => {
       { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
       dependencies({ readFile: () => transcript }),
     );
-    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 0 });
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 0, sessionId: 'sess-1' });
     const state = readOffsetState('sess-1', baseDirectory);
     expect(state).toMatchObject({ offset: transcript.length, fires: 1 });
   });
@@ -148,7 +148,7 @@ describe('decideRetroRun — delta re-arm cadence (ZFGWS1)', () => {
       { session_id: 'sess-1', transcript_path: '/t/s.jsonl' },
       dependencies({ readFile: () => transcript }),
     );
-    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50 });
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50, sessionId: 'sess-1' });
     expect(readOffsetState('sess-1', baseDirectory)).toMatchObject({
       offset: transcript.length,
       fires: 2,
@@ -202,7 +202,7 @@ describe('decideRetroRun — delta re-arm cadence (ZFGWS1)', () => {
         }),
       );
     }).not.toThrow();
-    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50 });
+    expect(out).toEqual({ transcriptPath: '/t/s.jsonl', windowStart: 50, sessionId: 'sess-1' });
     // the write threw, so the persisted offset is left at its prior value
     expect(readOffsetState('sess-1', baseDirectory)).toEqual(prior);
   });

--- a/packages/cli/tests/hooks/retro-extract.test.ts
+++ b/packages/cli/tests/hooks/retro-extract.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   buildDigest,
   buildExtractArgv,
   isRetroChild,
+  resolveRetroModel,
   RETRO_CHILD_ENV,
   runHeadlessExtraction,
 } from '../../templates/hooks/lib/retro-extract.js';
@@ -158,6 +163,33 @@ describe('isRetroChild', () => {
 
   it('exposes the sentinel env name the spawn half sets', () => {
     expect(RETRO_CHILD_ENV).toBe('SAFEWORD_RETRO_CHILD');
+  });
+});
+
+describe('resolveRetroModel (SM1.AC2 — config-overridable, sonnet default)', () => {
+  let projectDirectory: string;
+  beforeEach(() => {
+    projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-model-'));
+  });
+  afterEach(() => {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  });
+
+  function writeRetroConfig(config: unknown): void {
+    const safewordDirectory = nodePath.join(projectDirectory, '.safeword');
+    mkdirSync(safewordDirectory, { recursive: true });
+    writeFileSync(nodePath.join(safewordDirectory, 'config.json'), JSON.stringify(config));
+  }
+
+  it('defaults to sonnet when no config / no retro.model is present', () => {
+    expect(resolveRetroModel(projectDirectory)).toBe('sonnet');
+    writeRetroConfig({ selfReport: { surface: true } }); // config present, no retro.model
+    expect(resolveRetroModel(projectDirectory)).toBe('sonnet');
+  });
+
+  it('honors a configured retro.model override', () => {
+    writeRetroConfig({ retro: { model: 'haiku' } });
+    expect(resolveRetroModel(projectDirectory)).toBe('haiku');
   });
 });
 

--- a/packages/cli/tests/hooks/retro-extract.test.ts
+++ b/packages/cli/tests/hooks/retro-extract.test.ts
@@ -10,6 +10,7 @@ import {
   isRetroChild,
   resolveRetroModel,
   RETRO_CHILD_ENV,
+  retroChildArgs as retroChildArguments,
   runHeadlessExtraction,
 } from '../../templates/hooks/lib/retro-extract.js';
 
@@ -190,6 +191,21 @@ describe('resolveRetroModel (SM1.AC2 — config-overridable, sonnet default)', (
   it('honors a configured retro.model override', () => {
     writeRetroConfig({ retro: { model: 'haiku' } });
     expect(resolveRetroModel(projectDirectory)).toBe('haiku');
+  });
+});
+
+describe('retroChildArgs (SM2.AC2 — forward session id + window to the child)', () => {
+  it('forwards the resolved session id and the delta window offset', () => {
+    const args = retroChildArguments({
+      transcriptPath: '/t/sess.jsonl',
+      windowStart: 4096,
+      sessionId: 'cloud-9',
+    });
+    expect(args).toContain('--auto-extract');
+    expect(args[args.indexOf('--transcript') + 1]).toBe('/t/sess.jsonl');
+    expect(args[args.indexOf('--window-start') + 1]).toBe('4096');
+    // the stable session id reaches the child rather than its 'unknown' env fallback
+    expect(args[args.indexOf('--session-id') + 1]).toBe('cloud-9');
   });
 });
 

--- a/packages/cli/tests/hooks/retro-extract.test.ts
+++ b/packages/cli/tests/hooks/retro-extract.test.ts
@@ -192,6 +192,16 @@ describe('runHeadlessExtraction', () => {
     expect((findings[0] as { title: string }).title).toBe('Gate message omits the file');
   });
 
+  // retro-recall.SM1.AC2 — when no model is passed, the extraction defaults to
+  // sonnet (haiku proved too weak: 1–3 weak findings vs sonnet's 9). ZFGWS1.
+  it('retro-recall.SM1.AC2.headless_extraction_defaults_to_sonnet', async () => {
+    const { calls, deps } = fakeDependencies({ model: undefined });
+    await runHeadlessExtraction('t', deps);
+    const argv = calls[0]?.argv ?? [];
+    const modelAt = argv.indexOf('--model');
+    expect(argv[modelAt + 1]).toBe('sonnet');
+  });
+
   // invisible-retro-claude.TB1.AC1 (fail-open) — extractor error or junk output
   // yields no findings and never throws.
   it('invisible-retro-claude.TB1.AC1.fail_open_stays_silent_when_extraction_errors', async () => {

--- a/packages/cli/tests/hooks/retro-trigger.test.ts
+++ b/packages/cli/tests/hooks/retro-trigger.test.ts
@@ -16,7 +16,6 @@ import {
   buildRetroNudge,
   countToolUses,
   decideRetroNudge,
-  decideRetroRun,
   hasNudged,
   isSubstantial,
   markNudged,
@@ -235,72 +234,9 @@ describe('decideRetroNudge (orchestration)', () => {
   });
 });
 
-describe('decideRetroRun (invisible trigger — run extraction, never a nudge)', () => {
-  let baseDirectory: string;
-  const substantial = transcriptWithToolUses(SUBSTANCE_THRESHOLD + 2);
-  const trivial = transcriptWithToolUses(SUBSTANCE_THRESHOLD - 1);
-
-  beforeEach(() => {
-    baseDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-run-'));
-  });
-  afterEach(() => {
-    rmSync(baseDirectory, { recursive: true, force: true });
-  });
-
-  const dependencies = dependenciesFactory(() => baseDirectory, substantial);
-
-  it('SM1.AC2: a substantial unset session returns the transcript path and arms the sentinel', () => {
-    const out = decideRetroRun(
-      { session_id: 'sess-1', transcript_path: '/t/sess-1.jsonl' },
-      dependencies(),
-    );
-    expect(out).toEqual({ transcriptPath: '/t/sess-1.jsonl' });
-    expect(hasNudged('sess-1', baseDirectory)).toBe(true);
-  });
-
-  it('SM1.AC2: an already-run session returns undefined (no second extraction)', () => {
-    markNudged('sess-1', baseDirectory);
-    const out = decideRetroRun(
-      { session_id: 'sess-1', transcript_path: '/t/sess-1.jsonl' },
-      dependencies(),
-    );
-    expect(out).toBeUndefined();
-  });
-
-  it('NTB1.AC2: a retro child (sentinel env set) returns undefined even when substantial', () => {
-    const out = decideRetroRun(
-      { session_id: 'sess-1', transcript_path: '/t/sess-1.jsonl' },
-      dependencies({ env: { SAFEWORD_RETRO_CHILD: '1' } }),
-    );
-    expect(out).toBeUndefined();
-    // guard fires before the sentinel is armed
-    expect(hasNudged('sess-1', baseDirectory)).toBe(false);
-  });
-
-  it('a trivial session returns undefined and leaves the sentinel unset', () => {
-    const out = decideRetroRun(
-      { session_id: 'sess-1', transcript_path: '/t/sess-1.jsonl' },
-      dependencies({ readFile: () => trivial }),
-    );
-    expect(out).toBeUndefined();
-    expect(hasNudged('sess-1', baseDirectory)).toBe(false);
-  });
-
-  it('fails open: no session id / no path / unreadable transcript → undefined', () => {
-    expect(decideRetroRun({ transcript_path: '/t/x.jsonl' }, dependencies())).toBeUndefined();
-    expect(decideRetroRun({ session_id: 'sess-1' }, dependencies())).toBeUndefined();
-    expect(
-      decideRetroRun(
-        { session_id: 'sess-1', transcript_path: '/t/missing.jsonl' },
-        dependencies({
-          readFile: () => {
-            throw new Error('ENOENT');
-          },
-        }),
-      ),
-    ).toBeUndefined();
-  });
-});
+// decideRetroRun's invisible-trigger behavior moved to delta re-arm (ZFGWS1) and
+// is covered in tests/hooks/retro-delta-rearm.test.ts (offset state + additive
+// cadence). The fire-once sentinel assertions that lived here are superseded.
 
 describe('buildRetroNudge', () => {
   it('contains the supplied transcript path and points at the retro guide', () => {

--- a/packages/cli/tests/hooks/retro-window.test.ts
+++ b/packages/cli/tests/hooks/retro-window.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Retro recall — pre-sliced delta window (ticket ZFGWS1).
+ *
+ * `windowFor` slices the transcript a fire should digest: the whole transcript on
+ * the first fire (windowStart 0), or the delta since the previous fire's offset
+ * (minus a small overlap) on a re-fire. `buildDigest`'s cap then applies to that
+ * WINDOW, not the chronological head — so a finding only in the back half is read.
+ *
+ * Feature: packages/cli/features/retro-recall-delta-rearm.feature
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { OVERLAP_BYTES, windowFor } from '../../templates/hooks/lib/retro-extract.js';
+
+describe('windowFor (SM1.AC1 — delta window slice)', () => {
+  const transcript = 'abcdefghijklmnopqrstuvwxyz'.repeat(500); // 13_000 chars
+
+  it('the first fire (windowStart 0) returns the whole transcript so far', () => {
+    expect(windowFor(transcript, 0)).toBe(transcript);
+  });
+
+  it('a later fire begins at the previous offset minus the overlap', () => {
+    const windowStart = 8000;
+    expect(windowFor(transcript, windowStart)).toBe(transcript.slice(windowStart - OVERLAP_BYTES));
+  });
+
+  it('the overlap is clamped at the start when it would underflow', () => {
+    const windowStart = Math.floor(OVERLAP_BYTES / 2); // smaller than the overlap
+    expect(windowFor(transcript, windowStart)).toBe(transcript);
+  });
+});

--- a/packages/cli/tests/hooks/retro-window.test.ts
+++ b/packages/cli/tests/hooks/retro-window.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { OVERLAP_BYTES, windowFor } from '../../templates/hooks/lib/retro-extract.js';
+import { OVERLAP_CHARS, windowFor } from '../../templates/hooks/lib/retro-extract.js';
 
 describe('windowFor (SM1.AC1 — delta window slice)', () => {
   const transcript = 'abcdefghijklmnopqrstuvwxyz'.repeat(500); // 13_000 chars
@@ -22,11 +22,11 @@ describe('windowFor (SM1.AC1 — delta window slice)', () => {
 
   it('a later fire begins at the previous offset minus the overlap', () => {
     const windowStart = 8000;
-    expect(windowFor(transcript, windowStart)).toBe(transcript.slice(windowStart - OVERLAP_BYTES));
+    expect(windowFor(transcript, windowStart)).toBe(transcript.slice(windowStart - OVERLAP_CHARS));
   });
 
   it('the overlap is clamped at the start when it would underflow', () => {
-    const windowStart = Math.floor(OVERLAP_BYTES / 2); // smaller than the overlap
+    const windowStart = Math.floor(OVERLAP_CHARS / 2); // smaller than the overlap
     expect(windowFor(transcript, windowStart)).toBe(transcript);
   });
 });

--- a/packages/cli/tests/integration/stop-retro.test.ts
+++ b/packages/cli/tests/integration/stop-retro.test.ts
@@ -17,7 +17,11 @@ import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { hasNudged, sentinelPath } from '../../templates/hooks/lib/retro-trigger.js';
+import {
+  offsetStatePath,
+  readOffsetState,
+  sentinelPath,
+} from '../../templates/hooks/lib/retro-trigger.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, TIMEOUT_QUICK } from '../helpers';
 
 const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
@@ -81,7 +85,10 @@ describe('stop-retro hook — invisible out-of-band run (7D8PJP)', () => {
   });
   afterEach(() => {
     removeTemporaryDirectory(dir);
-    for (const id of sessionIds) rmSync(sentinelPath(id), { force: true });
+    for (const id of sessionIds) {
+      rmSync(sentinelPath(id), { force: true });
+      rmSync(offsetStatePath(id), { force: true });
+    }
     sessionIds.length = 0;
   });
 
@@ -96,8 +103,9 @@ describe('stop-retro hook — invisible out-of-band run (7D8PJP)', () => {
     // The invisibility guarantee: nothing reaches the conversation.
     expect(result.stdout.trim()).toBe('');
     expect(result.stdout).not.toContain('additionalContext');
-    // It DID decide to run (sentinel armed), so silence is a real run, not a skip.
-    expect(hasNudged(id)).toBe(true);
+    // It DID decide to run (offset state armed for delta re-arm), so the silence is
+    // a real run, not a skip (ZFGWS1 — offset state replaced the boolean sentinel).
+    expect(readOffsetState(id)).toMatchObject({ fires: 1 });
   });
 
   it('stays silent on a trivial session', () => {
@@ -111,16 +119,18 @@ describe('stop-retro hook — invisible out-of-band run (7D8PJP)', () => {
     expect(result.stdout.trim()).toBe('');
   });
 
-  it('SM1.AC2: stays silent on the second Stop for the same session (sentinel set)', () => {
+  it('TB1.AC2: holds on the second Stop when the transcript has not grown (delta re-arm)', () => {
     writeConfig(dir, { surface: true });
     const transcript = writeTranscript(dir, 'big.jsonl', 8);
     const id = freshSession('twice');
 
     const first = runHook(dir, { session_id: id, transcript_path: transcript });
     expect(first.status).toBe(0);
+    // Same transcript → zero growth since the first fire → below REARM_GROWTH → holds.
     const second = runHook(dir, { session_id: id, transcript_path: transcript });
     expect(second.status).toBe(0);
     expect(second.stdout.trim()).toBe('');
+    expect(readOffsetState(id)).toMatchObject({ fires: 1 });
   });
 
   it('NTB1.AC2: stays silent for a retro headless child (SAFEWORD_RETRO_CHILD set)', () => {


### PR DESCRIPTION
## What & why

The invisible retro (7D8PJP) ships but only reads the **opening** of a session: it fires once, early, and `buildDigest` head-caps to the first 180 KB. So the maintainer's friction stream was blind to ~90% of every session. ZFGWS1 fixes recall as **one coherent slice** — the five levers are coupled, and no single one works alone (proven by `/quality-review` on the superseded 0XEMEE plan).

> **Base:** this PR targets `claude/safeword-self-reporting-2tdjta` (#543), **not** `main` — the retro feature it builds on lives only on that branch. Retarget to `main` once #543 merges.

## The five coupled levers

1. **Delta re-arm** — fires more than once per session. Per-session offset state (`{offset, toolUses, fires}`, written temp-file-then-`rename`, atomic) replaces the once-per-session boolean sentinel. Each fire digests only the **window since the last fire's offset** (+ a small overlap), so deltas tile the whole session. Additive cadence (`REARM_GROWTH=200` tool-uses) with a high `MAX_FIRES=20` runaway backstop; first fire keeps the substance gate; fail-open and recursion-guarded throughout.
2. **Sonnet** at **both** model sites (`buildAutoExtractor` runner + `runHeadlessExtraction` default), config-overridable via `retro.model` (haiku measured 1–3 weak findings vs sonnet's 9).
3. **Async Stop hook** — registered `async: true` (documented non-blocking/background/600s mode), **not** `asyncRewake` (which surfaces stderr → breaks invisibility). The whole hook tree backgrounds, so the inner `spawnSync` stays synchronous.
4. **Signature dedupe** — triage matches the content signature (`retro:<hash>`, embedded as a hidden marker in the issue body and found via `in:body` search + exact-filter), not the model-generated title (titles vary across fires). A stable session id is forwarded to the extraction child so ledger accounting isn't keyed to `'unknown'`.
5. **Pre-sliced window** — `buildDigest` receives the windowed string, so the cap applies to the new activity, not the chronological head.

The egress sanitizer (the security boundary, since retro files to the public repo) is **untouched** — windowing slices the input transcript only and never bypasses `normalizeFinding → resolveSurface → sanitizeTextDeep → buildDraft`.

## How it was built & verified

- Full BDD: spec → 26 scenarios → independent fresh-context scenario-gate review (3 must-fix applied, re-reviewed clean) → outside-in TDD across 7 slices → whole-ticket `/quality-review` (verdict SHIP, 0 blocking) → `/verify` + `/audit`.
- **Tests:** full suite 4197/4197 (5 skipped, 0 failures); Gherkin lane 23/23; build, ESLint, Prettier, `tsc --noEmit` all clean.
- **Audit:** 0 circular deps, config in sync, no new dead code, duplication 1.3% (pre-existing).
- Byte-parity mirrors (`templates/hooks/**` ↔ `.safeword/hooks/**`) maintained and registered in `schema.ts`.

## Live-fire validated (real boundaries, not mocks)

Ran the real pipeline over this build session's 4.3 MB transcript with a back-half delta window: real `claude -p --model sonnet` → egress → real GitHub filing. Sonnet surfaced 9 findings (→6 after egress, paths redacted, no leaks); a real issue was filed and its embedded signature marker was **immediately found** by GitHub `in:body` search — confirming dedupe works end-to-end (the riskiest unproven assumption).

One real limitation surfaced and tracked as **1M20EW**: the extractor frames bugs the session *already fixed* as current friction.

## Risk / reversibility

Two-way door. Changes the trigger's cadence, the extraction model, the hook registration, and the dedupe key; the egress guard, schema, sanitizer, and filing pipeline are unchanged. Revert = restore the sentinel + haiku + sync hook + title match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VsqfvrhacpctH7x4sfd6Q)_