### PR TITLE
refactor: post-0.59 cleanup — dedup architecture/toml/fs utils merged in last 24h

### DIFF
--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -127,12 +127,12 @@ function planTarget(target: HealTarget): SelfHealAction {
   return decideAction(readExisting(target.path), target.fingerprint, target.hasContent);
 }
 
-/** The single-repo doc: the project's `src/` skeleton at the namespace-root path. */
-function singleRepoTarget(projectDirectory: string): HealTarget {
-  const fingerprint = shapeFingerprint(projectDirectory);
-  const nodes = extractSkeleton(projectDirectory).nodes;
+/** A `src/`-skeleton doc: the skeleton of `directory`, rendered to `path`. */
+function skeletonTarget(directory: string, path: string): HealTarget {
+  const fingerprint = shapeFingerprint(directory);
+  const nodes = extractSkeleton(directory).nodes;
   return {
-    path: resolveGeneratedArchitecturePath(projectDirectory),
+    path,
     fingerprint,
     hasContent: nodes.length > 0,
     render: (priorStamps, priorProse) =>
@@ -140,17 +140,17 @@ function singleRepoTarget(projectDirectory: string): HealTarget {
   };
 }
 
+/** The single-repo doc: the project's `src/` skeleton at the namespace-root path. */
+function singleRepoTarget(projectDirectory: string): HealTarget {
+  return skeletonTarget(projectDirectory, resolveGeneratedArchitecturePath(projectDirectory));
+}
+
 /** A colocated leaf: the package's own skeleton at `packages/<pkg>/architecture.generated.md`. */
 function leafTarget(packageDirectory: string): HealTarget {
-  const fingerprint = shapeFingerprint(packageDirectory);
-  const nodes = extractSkeleton(packageDirectory).nodes;
-  return {
-    path: nodePath.join(packageDirectory, GENERATED_ARCHITECTURE_FILENAME),
-    fingerprint,
-    hasContent: nodes.length > 0,
-    render: (priorStamps, priorProse) =>
-      renderDocument(nodes, fingerprint, priorStamps, priorProse),
-  };
+  return skeletonTarget(
+    packageDirectory,
+    nodePath.join(packageDirectory, GENERATED_ARCHITECTURE_FILENAME),
+  );
 }
 
 /** The derived root index: the package graph at the namespace-root path. */

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -309,6 +309,17 @@ function accumulateProseLine(line: string, inProse: boolean, buffer: string[]): 
   return true;
 }
 
+/**
+ * The shared frontmatter every generated doc opens with: the ownership marker, the
+ * fingerprint line, and the `# Architecture` heading. This is the serialization side of the
+ * contract that `readDocumentFingerprint` / `isSafewordOwned` (and the standalone hook
+ * parser) read back, so both renderers must emit it byte-identically — one writer guarantees
+ * that.
+ */
+function architectureFrontmatter(fingerprint: string): string {
+  return `---\n${GENERATOR_KEY}: ${GENERATOR_VALUE}\n${FINGERPRINT_KEY}: ${fingerprint}\n---\n\n# Architecture\n\n`;
+}
+
 function renderDocument(
   nodes: SkeletonNode[],
   fingerprint: string,
@@ -339,7 +350,7 @@ function renderDocument(
     })
     .join('\n');
 
-  return `---\n${GENERATOR_KEY}: ${GENERATOR_VALUE}\n${FINGERPRINT_KEY}: ${fingerprint}\n---\n\n# Architecture\n\n## Modules\n\n${sections}`;
+  return `${architectureFrontmatter(fingerprint)}## Modules\n\n${sections}`;
 }
 
 function renderSection(
@@ -378,7 +389,7 @@ function renderRootIndex(model: MonorepoModel, fingerprint: string): string {
   const dependencies =
     model.edges.length === 0 ? '_No inter-package dependencies._\n' : `${edgeLines}\n`;
 
-  return `---\n${GENERATOR_KEY}: ${GENERATOR_VALUE}\n${FINGERPRINT_KEY}: ${fingerprint}\n---\n\n# Architecture\n\n## Packages\n\n${sections}\n## Dependencies\n\n${dependencies}${renderCoverageGaps(model.unreadableWorkspaces)}`;
+  return `${architectureFrontmatter(fingerprint)}## Packages\n\n${sections}\n## Dependencies\n\n${dependencies}${renderCoverageGaps(model.unreadableWorkspaces)}`;
 }
 
 /**

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -298,6 +298,26 @@ function readPyprojectCrateName(packageDirectory: string): string | undefined {
 }
 
 /**
+ * The detection for a TOML workspace whose member list lives in `[<table>] members`:
+ * `parsed` with the globs when readable, `absent` for an explicitly-empty `members = []`
+ * (declares no members, like package.json `workspaces: []` — U8), otherwise `unreadable`
+ * (present but unparseable — UWP4XK). Shared by the Cargo and uv detectors, which differ
+ * only in their pre-checks and these arguments.
+ */
+function resolveTomlWorkspaceMembers(
+  content: string,
+  readMembers: (content: string) => string[] | undefined,
+  table: string,
+  label: string,
+  configFile: string,
+): WorkspaceDetection {
+  const members = readMembers(content);
+  if (members !== undefined) return parsed(members);
+  if (isTomlTableEmptyArray(content, table, 'members')) return ABSENT;
+  return unreadable(label, configFile);
+}
+
+/**
  * Read workspace member globs from a `pyproject.toml` `[tool.uv.workspace] members`
  * array (ticket HWSEPV) — uv stores its workspace list here. `absent` when the file or the
  * uv-workspace table is missing (a single Python package, or a non-uv pyproject); `parsed`
@@ -308,12 +328,13 @@ function detectUvWorkspace(projectDirectory: string): WorkspaceDetection {
   const content = readFileSafe(nodePath.join(projectDirectory, 'pyproject.toml'));
   if (content === undefined) return ABSENT; // no pyproject.toml
   if (!hasTomlTable(content, 'tool.uv.workspace')) return ABSENT; // a non-uv pyproject
-  const members = readUvWorkspaceMembers(content);
-  if (members !== undefined) return parsed(members);
-  // An explicitly-empty `members = []` declares no members — absent, like package.json
-  // `workspaces: []` (U8) — not a present-but-unparseable list (UWP4XK).
-  if (isTomlTableEmptyArray(content, 'tool.uv.workspace', 'members')) return ABSENT;
-  return unreadable('uv workspace', 'pyproject.toml');
+  return resolveTomlWorkspaceMembers(
+    content,
+    readUvWorkspaceMembers,
+    'tool.uv.workspace',
+    'uv workspace',
+    'pyproject.toml',
+  );
 }
 
 function manifestDependencyNames(packageDirectory: string): string[] {
@@ -443,10 +464,11 @@ function detectCargoWorkspace(projectDirectory: string): WorkspaceDetection {
   if (content === undefined) return ABSENT; // no Cargo.toml
   if (!hasTomlTable(content, 'workspace')) return ABSENT; // a single crate, not a workspace
   if (!hasTomlTableKey(content, 'workspace', 'members')) return ABSENT; // auto-discovery, out of scope
-  const members = readCargoWorkspaceMembers(content);
-  if (members !== undefined) return parsed(members);
-  // An explicitly-empty `members = []` declares no members — absent, like package.json
-  // `workspaces: []` (U8) — not a present-but-unparseable list (UWP4XK).
-  if (isTomlTableEmptyArray(content, 'workspace', 'members')) return ABSENT;
-  return unreadable('Cargo [workspace]', 'Cargo.toml');
+  return resolveTomlWorkspaceMembers(
+    content,
+    readCargoWorkspaceMembers,
+    'workspace',
+    'Cargo [workspace]',
+    'Cargo.toml',
+  );
 }

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -4,6 +4,7 @@
 
 import {
   chmodSync,
+  type Dirent,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -119,16 +120,18 @@ export function findInTree(cwd: string, filename: string, maxDepth = 10): string
   return scanTreeForFile(cwd, filename, 1, maxDepth);
 }
 
+/** Whether a dirent is a subdirectory safe to recurse into (not hidden, not excluded). */
+function isScannableSubdirectory(entry: Dirent): boolean {
+  return (
+    entry.isDirectory() && !entry.name.startsWith('.') && !SUBDIRECTORY_EXCLUDE.has(entry.name)
+  );
+}
+
 /** Return scannable subdirectory paths (excludes hidden dirs and SUBDIRECTORY_EXCLUDE). */
 function getScannableSubdirectories(directory: string): string[] {
   try {
     return readdirSync(directory, { withFileTypes: true })
-      .filter(
-        entry =>
-          entry.isDirectory() &&
-          !entry.name.startsWith('.') &&
-          !SUBDIRECTORY_EXCLUDE.has(entry.name),
-      )
+      .filter(entry => isScannableSubdirectory(entry))
       .map(entry => nodePath.join(directory, entry.name));
   } catch {
     return [];
@@ -199,11 +202,7 @@ function scanTreeForMatch(
   }
 
   for (const entry of entries) {
-    if (
-      !(entry.isDirectory() && !entry.name.startsWith('.') && !SUBDIRECTORY_EXCLUDE.has(entry.name))
-    ) {
-      continue;
-    }
+    if (!isScannableSubdirectory(entry)) continue;
 
     const result = scanTreeForMatch(
       nodePath.join(directory, entry.name),

--- a/packages/cli/src/utils/toml.ts
+++ b/packages/cli/src/utils/toml.ts
@@ -52,14 +52,11 @@ export function hasTomlTable(content: string, table: string): boolean {
 }
 
 /**
- * Whether `[<table>]` declares `<key> = …` (any value, parseable or not). Comment-aware,
- * table-scoped. Lets a caller tell "the key is absent" from "the key is present but its
- * value is unparseable" — `readTomlTableArray` returns `undefined` for both, so this
- * separates a workspace whose `members` list can't be read (surface it) from one with no
- * `members` key at all (a Cargo root-package workspace that auto-discovers members from
- * path deps — valid, out of scope, not a coverage gap).
+ * Yield the meaningful lines (comment-stripped, trimmed, non-empty) that fall inside
+ * `[<table>]`, in document order — the shared table-scoped traversal behind the key/value
+ * readers below. Table membership is tracked via the `[header]` lines a line follows.
  */
-export function hasTomlTableKey(content: string, table: string, key: string): boolean {
+function* linesInTable(content: string, table: string): Generator<string> {
   let inTable = false;
   for (const rawLine of content.split(/\r?\n/)) {
     const line = stripTomlComment(rawLine).trim();
@@ -69,7 +66,21 @@ export function hasTomlTableKey(content: string, table: string, key: string): bo
       inTable = header === table;
       continue;
     }
-    if (inTable && tableValue(line, key) !== undefined) return true;
+    if (inTable) yield line;
+  }
+}
+
+/**
+ * Whether `[<table>]` declares `<key> = …` (any value, parseable or not). Comment-aware,
+ * table-scoped. Lets a caller tell "the key is absent" from "the key is present but its
+ * value is unparseable" — `readTomlTableArray` returns `undefined` for both, so this
+ * separates a workspace whose `members` list can't be read (surface it) from one with no
+ * `members` key at all (a Cargo root-package workspace that auto-discovers members from
+ * path deps — valid, out of scope, not a coverage gap).
+ */
+export function hasTomlTableKey(content: string, table: string, key: string): boolean {
+  for (const line of linesInTable(content, table)) {
+    if (tableValue(line, key) !== undefined) return true;
   }
   return false;
 }
@@ -80,19 +91,7 @@ export function readTomlTableString(
   table: string,
   key: string,
 ): string | undefined {
-  let inTable = false;
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = stripTomlComment(rawLine).trim();
-    if (line === '') continue;
-
-    const header = tableHeader(line);
-    if (header !== undefined) {
-      inTable = header === table;
-      continue;
-    }
-    if (!inTable) continue;
-
+  for (const line of linesInTable(content, table)) {
     const value = tableValue(line, key);
     if (value?.startsWith('"')) {
       const end = value.indexOf('"', 1);

--- a/packages/cli/tests/utils/shallow-detection.test.ts
+++ b/packages/cli/tests/utils/shallow-detection.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { sqlPack } from '../../src/packs/sql/index.js';
-import { existsInTree, findInTree } from '../../src/utils/fs.js';
+import { existsInTree, findFileMatchingInTree, findInTree } from '../../src/utils/fs.js';
 import { detectLanguages } from '../../src/utils/project-detector.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, writeTestFile } from '../helpers';
 
@@ -142,6 +142,41 @@ describe('findInTree', () => {
     expect(findInTree(shared.projectDirectory, 'pyproject.toml', 2)).toBeUndefined();
     // depth 3 should reach it
     expect(findInTree(shared.projectDirectory, 'pyproject.toml', 3)).toContain('/a/b/c');
+  });
+});
+
+// =============================================================================
+// findFileMatchingInTree
+// =============================================================================
+
+describe('findFileMatchingInTree', () => {
+  const isMarker = (name: string): boolean => name.endsWith('.marker');
+
+  it('returns the directory of a matching file at root', () => {
+    writeTestFile(shared.projectDirectory, 'a.marker', 'x');
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker)).toBe(shared.projectDirectory);
+  });
+
+  it('returns the subdirectory that contains a match', () => {
+    writeTestFile(shared.projectDirectory, 'pkg/a.marker', 'x');
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker)).toContain('/pkg');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    writeTestFile(shared.projectDirectory, 'a.txt', 'x');
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker)).toBeUndefined();
+  });
+
+  it('skips excluded and hidden directories (no match inside node_modules or .git)', () => {
+    writeTestFile(shared.projectDirectory, 'node_modules/pkg/a.marker', 'x');
+    writeTestFile(shared.projectDirectory, '.git/a.marker', 'x');
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker)).toBeUndefined();
+  });
+
+  it('respects maxDepth', () => {
+    writeTestFile(shared.projectDirectory, 'a/b/c/deep.marker', 'x');
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker, 2)).toBeUndefined();
+    expect(findFileMatchingInTree(shared.projectDirectory, isMarker, 3)).toContain('/a/b/c');
   });
 });
 


### PR DESCRIPTION
Behavior-preserving cleanup of the CLI-src code merged over the last 24h (the architecture / test-plan / toml cluster from #560–#578). Six commits, each one-change → test → commit, scouted by three parallel read-only passes + an /audit catch-net.

## Refactors (all Tier-1/2 Extract Function, no behavior change)
| Commit | What |
|--------|------|
| `1549ee29` | `resolveTomlWorkspaceMembers` — fold the byte-identical Cargo + uv detector tails |
| `adbe8995` | `skeletonTarget` — fold near-identical `singleRepoTarget` / `leafTarget` |
| `fc156423` | `architectureFrontmatter` — one writer for the doc preamble (the serialization side of a parsed contract) |
| `4506f025` | test: direct `findFileMatchingInTree` coverage (safety net for the next commit) |
| `f135b140` | `isScannableSubdirectory` — share the dir-exclude predicate across the fs tree-walkers |
| `e20db8ad` | `linesInTable` generator — dedup the TOML table traversal (surfaced by /audit jscpd) |

## Deliberately NOT done (over-abstraction / already-mitigated)
- Merging the 6 workspace detectors into one template — their file-format bodies are irreducible; a callback-heavy frame would be worse.
- Unifying the CLI/hook fingerprint parsers — the hook can't import CLI src; already pinned by a differential parity test.
- Section-parser overlap, dep-cruiser filename lists — non-substitutable / different purposes.

## Verification
- Per-refactor: eslint + tsc clean, targeted suites green (toml/architecture-monorepo/architecture-document/fs/cargo/pyproject).
- /audit: architecture ✔ (no cycles/violations, 196 modules), dead-code ✔ (knip: nothing in touched files), duplication **1 → 0** (jscpd).
- Full local suite: 4051/4052 passed; the handful of integration-test timeouts are local machine contention (issue #419), not regressions — deferring to CI's isolated full suite as the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)