### PR TITLE
chore(release): v0.59.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.58.1",
+      "version": "0.59.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release. Bumps `packages/cli/package.json` + `.claude-plugin/marketplace.json` `0.58.1` → `0.59.0`.

**Supersedes the untagged `0.58.1`** that #576 left on main: the window since `v0.58.0` is feature-level (strictly additive), so it warrants a **minor**, not a patch. `bun install` produced no `bun.lock` change under bun 1.3.14 (frozen-lockfile verified passing), so this is version files only — no hand-forced self-version.

## What's in 0.59.0 (additive since v0.58.0)
- **feat:** Python language pack — pyproject/uv discovery + dependency fingerprint (#544)
- **feat:** self-report — autonomous issue filing (#524/#528)
- **feat:** monorepo/workspace support — present-but-unparseable manager surfacing (#554/#561), `.gitattributes merge=union` for generated docs (#569), ARCHITECTURE.md reconcile nudge (#562)
- **feat:** coding-skills delivery + per-edit nudges (#537); BDD feature surfaces + auto-verify (#545/#526)
- **fix:** `/verify` fails loudly on test-plan generation failure (#570); empty-TOML-members → absent (#578)
- **chore:** Node 24 LTS + Bun 1.3.14 (#575); refactor cleanups (#535/#560/#590)

Auto-upgrade-safe: passes the "auto-upgrade at SessionStart — does anything break?" test in the negative (additive only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)