### PR TITLE
cleanup: #584 coverage nit + share TEST_FILE_GLOBS

### DIFF
--- a/packages/cli/src/presets/typescript/eslint-configs/bun-test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/bun-test.ts
@@ -16,6 +16,8 @@
  * reach imported helper files either.
  */
 
+import { TEST_FILE_GLOBS } from './test-file-globs.js';
+
 /**
  * `bun:test` global names, all read-only (Bun owns these bindings).
  * Mirrors `bun:test`'s actual exports (verified against
@@ -58,12 +60,7 @@ const BUN_TEST_GLOBALS = {
 export const bunTestConfig: any[] = [
   {
     name: 'safeword/bun-test',
-    files: [
-      '**/*.test.{ts,tsx,js,jsx}',
-      '**/*.spec.{ts,tsx,js,jsx}',
-      '**/tests/**/*.{ts,tsx,js,jsx}',
-      '**/e2e/**/*.{ts,tsx,js,jsx}',
-    ],
+    files: [...TEST_FILE_GLOBS],
     languageOptions: {
       globals: BUN_TEST_GLOBALS,
     },

--- a/packages/cli/src/presets/typescript/eslint-configs/test-file-globs.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/test-file-globs.ts
@@ -1,0 +1,12 @@
+/**
+ * The glob patterns safeword treats as test files for lint purposes: `*.test`/`*.spec`
+ * files plus everything under `tests/` and `e2e/`. Shared by the test-runner configs
+ * (the `bun:test` globals and the Vitest rules) so their file scope cannot drift apart —
+ * a file that one treats as a test and the other doesn't would lint inconsistently.
+ */
+export const TEST_FILE_GLOBS = [
+  '**/*.test.{ts,tsx,js,jsx}',
+  '**/*.spec.{ts,tsx,js,jsx}',
+  '**/tests/**/*.{ts,tsx,js,jsx}',
+  '**/e2e/**/*.{ts,tsx,js,jsx}',
+] as const;

--- a/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
@@ -19,6 +19,8 @@
 
 import vitestPlugin from '@vitest/eslint-plugin';
 
+import { TEST_FILE_GLOBS } from './test-file-globs.js';
+
 /**
  * Vitest test linting config
  *
@@ -28,12 +30,7 @@ import vitestPlugin from '@vitest/eslint-plugin';
 export const vitestConfig: any[] = [
   {
     name: 'safeword/vitest',
-    files: [
-      '**/*.test.{ts,tsx,js,jsx}',
-      '**/*.spec.{ts,tsx,js,jsx}',
-      '**/tests/**/*.{ts,tsx,js,jsx}',
-      '**/e2e/**/*.{ts,tsx,js,jsx}',
-    ],
+    files: [...TEST_FILE_GLOBS],
     plugins: {
       vitest: vitestPlugin,
     },

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -55,6 +55,7 @@ describe('getEslintConfig', () => {
 
     // All framework plugins are conditional (peer deps require the framework)
     expect(config).toContain('detect.hasVitest(deps)');
+    expect(config).toContain('detect.hasBunTest(deps, __dirname)');
     expect(config).toContain('detect.hasPlaywright(deps)');
     expect(config).toContain('detect.hasStorybook(deps)');
     expect(config).toContain('detect.hasTanstackQuery(deps)');


### PR DESCRIPTION
Follow-up cleanup on the just-merged #584 (bun:test eslint globals).

## Commits
- **test(config):** assert the generated config gates `bunTest` on `detect.hasBunTest(deps, __dirname)` — the #584 review flagged this template line was the one gate left uncovered.
- **refactor:** extract `TEST_FILE_GLOBS` — #584's new `bunTest` config duplicated vitest's 4-pattern test-file glob array verbatim; now both spread one shared const so the "what is a test file" definition can't drift. Generated `files` output is byte-identical (plugins/config tests unchanged); Playwright keeps its distinct e2e-only globs.

## Deliberately deferred (with reasons)
- **vitest↔playwright rule-relaxation overlap** — real but *partial* and scattered (each config has significant unique rules + interspersed comments); jscpd doesn't even flag it as a clone. Extracting a shared block would couple two deliberately-distinct configs — over-abstraction. Left alone.
- **3 pre-existing test-setup clones** (`errors-on-bugs`/`warns-on-suspicious`, `nextjs.test`, `plugins.test`) — pre-date #584, out of this cleanup's scope, and test-setup DRY is lower-value.

## Verification
- eslint + tsc clean; 112 preset tests pass (plugins/config/detect); `test-file-globs.ts` has 2 live consumers (not dead).
- Full suite deferred to CI (authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)