### PR TITLE
chore(release): v0.60.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release. Bumps `packages/cli/package.json` + `.claude-plugin/marketplace.json` `0.59.0` → `0.60.0`. `bun install` produced no `bun.lock` change (bun 1.3.14; frozen-lockfile verified).

## What's in 0.60.0 (since v0.59.0)
- **feat(eslint):** generated config now declares Bun's `bun:test` globals for Bun-test projects, ending `no-undef` false-positives on `describe`/`test`/`expect` in `.js`/`.ts` test files (#584) — additive, gated on `hasBunTest` detection, scoped to test files.
- **fix(cli):** emit-free tsconfig unblocks a TypeScript 6 bump (#583, internal build config).
- **chore:** pre-approve Claude_Code_Remote scheduling tools (#579); local/cloud surface docs (#580); coverage nit + `TEST_FILE_GLOBS` dedup (#592).

Auto-upgrade-safe: strictly additive — passes the "auto-upgrade at SessionStart, does anything break?" test in the negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)