### PR TITLE
refactor: dedupe "targets X files" test closures in plugins.test.ts

### DIFF
--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/plugins.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/plugins.test.ts
@@ -17,7 +17,7 @@ import { playwrightConfig } from '../playwright.js';
 import { storybookConfig } from '../storybook.js';
 import { turboConfig } from '../turbo.js';
 import { vitestConfig } from '../vitest.js';
-import { getAllRules, getRuleConfig, getSeverityNumber } from './test-utilities.js';
+import { getAllRules, getRuleConfig, getSeverityNumber, hasFilePattern } from './test-utilities.js';
 
 const ERROR = 2;
 const WARN = 1;
@@ -43,15 +43,7 @@ describe('vitestConfig', () => {
   });
 
   it('targets test files', () => {
-    const hasTestFilePattern = vitestConfig.some(
-      config =>
-        typeof config === 'object' &&
-        config !== null &&
-        'files' in config &&
-        Array.isArray(config.files) &&
-        config.files.some((f: string) => f.includes('.test.') || f.includes('.spec.')),
-    );
-    expect(hasTestFilePattern).toBe(true);
+    expect(hasFilePattern(vitestConfig, ['.test.', '.spec.'])).toBe(true);
   });
 
   it('also targets tests/ and e2e/ directories for test infrastructure', () => {
@@ -134,15 +126,7 @@ describe('bunTestConfig', () => {
   });
 
   it('targets test files', () => {
-    const hasTestFilePattern = bunTestConfig.some(
-      config =>
-        typeof config === 'object' &&
-        config !== null &&
-        'files' in config &&
-        Array.isArray(config.files) &&
-        config.files.some((f: string) => f.includes('.test.') || f.includes('.spec.')),
-    );
-    expect(hasTestFilePattern).toBe(true);
+    expect(hasFilePattern(bunTestConfig, ['.test.', '.spec.'])).toBe(true);
   });
 
   it.each([
@@ -233,17 +217,7 @@ describe('playwrightConfig', () => {
   });
 
   it('targets test files', () => {
-    const hasTestFilePattern = playwrightConfig.some(
-      config =>
-        typeof config === 'object' &&
-        config !== null &&
-        'files' in config &&
-        Array.isArray(config.files) &&
-        config.files.some(
-          (f: string) => f.includes('.test.') || f.includes('.spec.') || f.includes('.e2e.'),
-        ),
-    );
-    expect(hasTestFilePattern).toBe(true);
+    expect(hasFilePattern(playwrightConfig, ['.test.', '.spec.', '.e2e.'])).toBe(true);
   });
 });
 
@@ -319,15 +293,7 @@ describe('storybookConfig', () => {
   });
 
   it('targets story files', () => {
-    const hasStoryFilePattern = storybookConfig.some(
-      config =>
-        typeof config === 'object' &&
-        config !== null &&
-        'files' in config &&
-        Array.isArray(config.files) &&
-        config.files.some((f: string) => f.includes('.stories.') || f.includes('.story.')),
-    );
-    expect(hasStoryFilePattern).toBe(true);
+    expect(hasFilePattern(storybookConfig, ['.stories.', '.story.'])).toBe(true);
   });
 });
 

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-utilities.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-utilities.ts
@@ -52,6 +52,21 @@ export function getSeverityNumber(ruleConfig: unknown): number {
 }
 
 /**
+ * Check whether any config block's `files` glob includes an entry matching
+ * one of the given substrings (e.g. '.test.', '.spec.').
+ */
+export function hasFilePattern(config: any[], matchers: string[]): boolean {
+  return config.some(
+    configObject =>
+      typeof configObject === 'object' &&
+      configObject !== null &&
+      'files' in configObject &&
+      Array.isArray(configObject.files) &&
+      configObject.files.some((f: string) => matchers.some(matcher => f.includes(matcher))),
+  );
+}
+
+/**
  * Collect all rules from flat config array.
  * Merges rules from all config objects.
  */


### PR DESCRIPTION
## Summary

Follow-up to #584 (merged) — closes the optional loose end noted in that PR's review: `vitestConfig`, `bunTestConfig`, `playwrightConfig`, and `storybookConfig` each had a `'targets test/story files'` test with a near-identical closure checking a config array's `files` glob, differing only in the matcher substrings. `jscpd` flagged the vitest/bunTest pair as an exact clone.

- Extracted `hasFilePattern(config, matchers)` into `eslint-configs/__tests__/test-utilities.ts`.
- Replaced all four call sites; no assertion changed.

## Test plan

- [x] `plugins.test.ts` — 66/66 tests pass, same count as before the extraction
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on both changed files
- [x] `jscpd` re-run on `packages/cli/src/presets/typescript`: the `plugins.test.ts` clone is gone (3 clones → 2, remaining 2 are pre-existing and unrelated to this file)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1TLy1CYuw8viZFkv3fCXJ)_