### PR TITLE
fix(tests): retry safeword setup on timeout so heavy E2Es don't false-red under load

### DIFF
--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -24,8 +24,23 @@ const execFileAsync = promisify(execFile);
 export const TIMEOUT_QUICK = 10_000;
 /** Sync CLI operations without bun install (30s) */
 export const TIMEOUT_SYNC = 30_000;
-/** Setup commands that may run bun install with warm cache (60s) */
-export const TIMEOUT_SETUP = 60_000;
+/**
+ * Setup commands that spawn `safeword setup` (git init + scaffolding + tool
+ * detection + optional skills pull). 120s: setup under full-suite CPU saturation
+ * can far outrun its isolated single-digit-second runtime (issue #419). Paired
+ * with `setupOrThrow`'s bounded retry-on-timeout so a transient spike gets a
+ * second attempt rather than a false red.
+ */
+export const TIMEOUT_SETUP = 120_000;
+/**
+ * Budget that contains a full `setupOrThrow` run including its bounded retry:
+ * 2 attempts × TIMEOUT_SETUP + fixture slack. This is the value the base
+ * `hookTimeout` (vitest.base.ts) is set to, so every setup-in-`beforeAll`
+ * inherits enough headroom without a per-hook override. Test *bodies* that run
+ * `setupOrThrow` inline still set it explicitly — `testTimeout`/`hookTimeout`
+ * don't apply to an `it()`'s own timeout arg.
+ */
+export const TIMEOUT_SETUP_HOOK = TIMEOUT_SETUP * 2 + 60_000;
 /** Acceptance lanes can spawn their own runners and need headroom under full-suite load (120s) */
 export const TIMEOUT_ACCEPTANCE_LANE = 120_000;
 /** bun install operations under load or cold cache (120s) */
@@ -202,6 +217,13 @@ interface CliResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /**
+   * True when the subprocess was killed by its own timeout (wall-clock), as
+   * opposed to exiting with a non-zero code. A timeout is environmental (machine
+   * contention); a non-zero exit is a genuine failure. `setupOrThrow` retries the
+   * former and fails fast on the latter.
+   */
+  timedOut: boolean;
 }
 
 function normalizeCommandOutput(value?: string | Buffer): string {
@@ -257,6 +279,24 @@ export function runCommandSync(
 }
 
 /**
+ * True when a child-process error indicates the process was killed by its own
+ * timeout (wall-clock) rather than exiting with a code. Per Node's child_process
+ * docs, on timeout Node sets `killed: true` and a `signal` (the killSignal,
+ * default SIGTERM). A real non-zero exit has `killed: false`, `signal: null`, and
+ * a NUMERIC `code`; a spawn failure (e.g. ENOENT) also has `killed: false` but a
+ * STRING `code`. So the timeout signal is `killed`/`signal` — deliberately NOT a
+ * string `code`: keying on that would misread a spawn failure as a timeout and
+ * wrongly retry a real failure, which `setupOrThrow` must never do.
+ * @param execError
+ */
+export function wasKilledByTimeout(execError: {
+  killed?: boolean;
+  signal?: string | null;
+}): boolean {
+  return execError.killed === true || (execError.signal !== undefined && execError.signal !== null);
+}
+
+/**
  * Runs the CLI with the given arguments in the specified directory
  * Uses built CLI (dist/cli.js)
  * @param args
@@ -281,20 +321,23 @@ export async function runCli(
       env: { ...process.env, ...env },
       timeout,
     });
-    return { stdout, stderr, exitCode: 0 };
+    return { stdout, stderr, exitCode: 0, timedOut: false };
   } catch (error: unknown) {
     const execError = error as {
       stdout?: string;
       stderr?: string;
       code?: number | string;
       status?: number;
+      killed?: boolean;
+      signal?: string | null;
     };
-    // execFile sets code to signal name (e.g. 'SIGTERM') on timeout kill
+    const timedOut = wasKilledByTimeout(execError);
     const exitCode = typeof execError.code === 'number' ? execError.code : (execError.status ?? 1);
     return {
       stdout: execError.stdout ?? '',
       stderr: execError.stderr ?? '',
       exitCode,
+      timedOut,
     };
   }
 }
@@ -328,16 +371,19 @@ export function runCliSync(
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return { stdout, stderr: '', exitCode: 0 };
+    return { stdout, stderr: '', exitCode: 0, timedOut: false };
   } catch (error: unknown) {
     const execError = error as {
       stdout?: string | Buffer;
       stderr?: string | Buffer;
       status?: number;
+      killed?: boolean;
+      signal?: string | null;
     };
     const stdout = execError.stdout?.toString() ?? '';
     const stderr = execError.stderr?.toString() ?? '';
-    return { stdout, stderr, exitCode: execError.status ?? 1 };
+    const timedOut = wasKilledByTimeout(execError);
+    return { stdout, stderr, exitCode: execError.status ?? 1, timedOut };
   }
 }
 
@@ -400,6 +446,37 @@ export function initGitRepo(dir: string): void {
 }
 
 /**
+ * Build the error `setupOrThrow` throws once its attempts are exhausted. A
+ * timeout gets an environmental, retry-aware message distinct from the exit-code
+ * failure message, so a real hang stays diagnosable and is never confused with a
+ * "dist stale" failure.
+ * @param label
+ * @param projectDirectory
+ * @param result
+ * @param maxAttempts
+ */
+function buildSetupFailureError(
+  label: string,
+  projectDirectory: string,
+  result: CliResult,
+  maxAttempts: number,
+): Error {
+  if (result.timedOut) {
+    return new Error(
+      `${label} timed out after ${maxAttempts} attempts in ${projectDirectory}.\n` +
+        `A timeout is environmental (machine under load — see issue #419), not necessarily a setup bug.\n` +
+        `stderr: ${result.stderr || '(empty)'}`,
+    );
+  }
+  return new Error(
+    `${label} failed (exit ${result.exitCode}) in ${projectDirectory}.\n` +
+      `Likely cause: dist/cli.js missing or stale.\n` +
+      `Run: bun install && bun run --cwd packages/cli build\n` +
+      `stderr: ${result.stderr || '(empty)'}`,
+  );
+}
+
+/**
  * Run `safeword setup` (or variant) in a fixture and throw a loud, actionable
  * error if it fails. Use this in `beforeAll`/`beforeEach` blocks where a silent
  * setup failure would cascade into misleading test failures across the file.
@@ -407,6 +484,12 @@ export function initGitRepo(dir: string): void {
  * The most common silent-failure mode: `dist/cli.js` missing or stale in a fresh
  * worktree. Without this assertion, every subsequent test in the file fails with
  * "Module not found" or exit-code mismatches that look unrelated to setup.
+ *
+ * Retries ONCE, and ONLY on a wall-clock timeout. A timeout is environmental —
+ * `safeword setup` spawned in a `beforeAll` can outrun its timeout when the machine
+ * is saturated by parallel test/build processes (issue #419), succeeding cleanly in
+ * isolation and on uncontended CI. A non-zero *exit* is a genuine failure and fails
+ * fast/loud with no retry, so a real setup regression is never masked.
  * @param projectDirectory
  * @param setupArgs CLI args including the command (default: ['setup', '--yes'])
  */
@@ -414,17 +497,42 @@ export async function setupOrThrow(
   projectDirectory: string,
   setupArguments: string[] = ['setup', '--yes'],
   cliOptions: { env?: Record<string, string>; timeout?: number } = {},
+  // Injectable for tests: defaults to the real CLI runner. Lets unit tests drive
+  // the retry policy deterministically without spawning (or actually timing out)
+  // a subprocess. Production callers never pass this.
+  runner: typeof runCli = runCli,
 ): Promise<CliResult> {
-  const result = await runCli(setupArguments, { cwd: projectDirectory, ...cliOptions });
-  if (result.exitCode !== 0) {
-    throw new Error(
-      `safeword ${setupArguments.join(' ')} failed (exit ${result.exitCode}) in ${projectDirectory}.\n` +
-        `Likely cause: dist/cli.js missing or stale.\n` +
-        `Run: bun install && bun run --cwd packages/cli build\n` +
-        `stderr: ${result.stderr || '(empty)'}`,
-    );
+  const label = `safeword ${setupArguments.join(' ')}`;
+  // One retry (2 attempts). A transient contention spike usually clears by the
+  // second attempt; a persistent timeout across both attempts is a real hang and
+  // surfaces as a distinct, diagnosable error below.
+  const maxAttempts = 2;
+  let lastResult: CliResult | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await runner(setupArguments, { cwd: projectDirectory, ...cliOptions });
+    if (result.exitCode === 0) {
+      return result;
+    }
+    lastResult = result;
+    // Retry ONLY on timeout, never on a real non-zero exit.
+    if (result.timedOut && attempt < maxAttempts) {
+      // Loud breadcrumb (not silent) so a recovered timeout is visible in output.
+      // stderr, not console.*, to sidestep console spies in unrelated suites.
+      process.stderr.write(
+        `[setupOrThrow] ${label} timed out (attempt ${attempt}/${maxAttempts}) in ${projectDirectory} — ` +
+          `retrying once. This is environmental (machine contention, issue #419), not a setup regression.\n`,
+      );
+      continue;
+    }
+    break;
   }
-  return result;
+
+  // Defensive: the loop body always assigns lastResult before it can break/exhaust.
+  if (!lastResult) {
+    throw new Error(`${label} produced no result in ${projectDirectory}.`);
+  }
+  throw buildSetupFailureError(label, projectDirectory, lastResult, maxAttempts);
 }
 
 /**

--- a/packages/cli/tests/integration/add-language-golang.test.ts
+++ b/packages/cli/tests/integration/add-language-golang.test.ts
@@ -41,7 +41,9 @@ describe('E2E: Add Go to Existing TypeScript Project', () => {
     initGitRepo(projectDirectory);
     // Initial setup with TypeScript only
     await setupOrThrow(projectDirectory, ['setup']);
-  }, 180_000);
+    // No explicit budget: inherits the 300s base hookTimeout, which contains
+    // setupOrThrow's bounded retry (was 180_000, < 2× the per-attempt timeout).
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/add-language.test.ts
+++ b/packages/cli/tests/integration/add-language.test.ts
@@ -40,7 +40,7 @@ describe('E2E: Add Language to Existing Project', () => {
     initGitRepo(projectDirectory);
     // Initial setup with TypeScript only
     await setupOrThrow(projectDirectory, ['setup']);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/bdd-lane-golden-path.test.ts
+++ b/packages/cli/tests/integration/bdd-lane-golden-path.test.ts
@@ -86,7 +86,10 @@ describe('scaffolded lane runs green (AC3)', () => {
     goDirectory = createTemporaryDirectory();
     createGoProject(goDirectory);
     await setupOrThrow(goDirectory, ['setup', '--yes'], { env: SKIP_SKILLS_ENV });
-  }, TIMEOUT_BUN_INSTALL * 2);
+    // ×3 (was ×2): two sequential setups, each of which setupOrThrow may retry
+    // once on a contention timeout (issue #419). ×3 contains one retry plus the
+    // other setup running normally; a both-retry hang is real and fails here.
+  }, TIMEOUT_BUN_INSTALL * 3);
 
   afterAll(() => {
     removeTemporaryDirectory(tsDirectory);

--- a/packages/cli/tests/integration/claude-code-simulation.test.ts
+++ b/packages/cli/tests/integration/claude-code-simulation.test.ts
@@ -33,7 +33,7 @@ describe('E2E: Claude Code Hook Path Resolution', () => {
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup']);
     differentDirectory = createTemporaryDirectory();
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) removeTemporaryDirectory(projectDirectory);

--- a/packages/cli/tests/integration/golang-golden-path.test.ts
+++ b/packages/cli/tests/integration/golang-golden-path.test.ts
@@ -52,7 +52,8 @@ describe('E2E: Go Golden Path', () => {
     createGoProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup', '--yes'], { env: SKIP_SKILLS_ENV });
-  }, 180_000); // 3 min timeout for setup
+    // Inherits the 300s base hookTimeout, which contains setupOrThrow's retry.
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -178,7 +179,7 @@ describe('E2E: Go Setup Idempotency', () => {
     // Second call intentionally allowed to fail with "Already configured" exit 1 —
     // we verify file state survives an accidental re-run, not that setup is idempotent.
     await runCli(['setup', '--yes'], { cwd: projectDirectory, env: SKIP_SKILLS_ENV });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -228,7 +229,7 @@ describe('E2E: Go Lint Hook Fallback', () => {
     if (fileExists(projectDirectory, '.safeword/.golangci.yml')) {
       unlinkSync(golangciConfig);
     }
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/golden-path.test.ts
+++ b/packages/cli/tests/integration/golden-path.test.ts
@@ -49,7 +49,7 @@ describe('E2E: Golden Path', () => {
     createTypeScriptPackageJson(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000); // 3 min timeout for bun install
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -207,7 +207,7 @@ describe('E2E: TypeScript Setup Idempotency', () => {
     // Second call intentionally allowed to fail with "Already configured" exit 1 —
     // we verify file state survives an accidental re-run, not that setup is idempotent.
     await runCli(['setup', '--yes'], { cwd: projectDirectory });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -277,7 +277,7 @@ describe('E2E: TypeScript Lint Hook Fallback', () => {
     if (fileExists(projectDirectory, '.safeword/eslint.config.mjs')) {
       unlinkSync(eslintConfig);
     }
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -32,6 +32,7 @@ import {
   readTestFile,
   removeTemporaryDirectory,
   setupOrThrow,
+  TIMEOUT_SETUP_HOOK,
   writeTestFile,
 } from '../helpers';
 
@@ -48,7 +49,7 @@ beforeAll(async () => {
   createTypeScriptPackageJson(shared.projectDirectory);
   initGitRepo(shared.projectDirectory);
   await setupOrThrow(shared.projectDirectory);
-}, 180_000);
+});
 
 afterAll(() => {
   if (shared.projectDirectory) {
@@ -1338,60 +1339,68 @@ describe('session-cursor-auto-upgrade.ts', () => {
 });
 
 describe('Cursor auto-upgrade lock', () => {
-  it('blocks Cursor writes and shell commands while silent auto-upgrade is running', async () => {
-    const projectDirectory = createTemporaryDirectory();
-
-    try {
-      createTypeScriptPackageJson(projectDirectory);
-      initGitRepo(projectDirectory);
-      await setupOrThrow(projectDirectory);
-
-      const lockPath = acquireAutoUpgradeLock({ projectDir: projectDirectory });
-      expect(lockPath).toBeDefined();
+  it(
+    'blocks Cursor writes and shell commands while silent auto-upgrade is running',
+    async () => {
+      const projectDirectory = createTemporaryDirectory();
 
       try {
-        const result = spawnSync('bun', ['.safeword/hooks/cursor/pre-tool-quality.ts'], {
-          cwd: projectDirectory,
-          input: JSON.stringify({
-            workspace_roots: [projectDirectory],
-            conversation_id: 'conversation-1',
-            tool_name: 'Write',
-            tool_input: {
-              file_path: nodePath.join(projectDirectory, 'src/index.ts'),
-              content: 'export const value = 1;\n',
+        createTypeScriptPackageJson(projectDirectory);
+        initGitRepo(projectDirectory);
+        await setupOrThrow(projectDirectory);
+
+        const lockPath = acquireAutoUpgradeLock({ projectDir: projectDirectory });
+        expect(lockPath).toBeDefined();
+
+        try {
+          const result = spawnSync('bun', ['.safeword/hooks/cursor/pre-tool-quality.ts'], {
+            cwd: projectDirectory,
+            input: JSON.stringify({
+              workspace_roots: [projectDirectory],
+              conversation_id: 'conversation-1',
+              tool_name: 'Write',
+              tool_input: {
+                file_path: nodePath.join(projectDirectory, 'src/index.ts'),
+                content: 'export const value = 1;\n',
+              },
+            }),
+            encoding: 'utf8',
+          });
+
+          expect(result.status, result.stderr || result.stdout).toBe(0);
+          expect(JSON.parse(result.stdout)).toEqual({
+            permission: 'deny',
+            user_message: AUTO_UPGRADE_LOCK_MESSAGE,
+            agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
+          });
+
+          const shellResult = spawnSync(
+            'bun',
+            ['.safeword/hooks/cursor/before-shell-execution.ts'],
+            {
+              cwd: projectDirectory,
+              input: JSON.stringify({
+                workspace_roots: [projectDirectory],
+                conversation_id: 'conversation-1',
+                command: 'printf "changed" > .project/tickets/example.md',
+              }),
+              encoding: 'utf8',
             },
-          }),
-          encoding: 'utf8',
-        });
+          );
 
-        expect(result.status, result.stderr || result.stdout).toBe(0);
-        expect(JSON.parse(result.stdout)).toEqual({
-          permission: 'deny',
-          user_message: AUTO_UPGRADE_LOCK_MESSAGE,
-          agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
-        });
-
-        const shellResult = spawnSync('bun', ['.safeword/hooks/cursor/before-shell-execution.ts'], {
-          cwd: projectDirectory,
-          input: JSON.stringify({
-            workspace_roots: [projectDirectory],
-            conversation_id: 'conversation-1',
-            command: 'printf "changed" > .project/tickets/example.md',
-          }),
-          encoding: 'utf8',
-        });
-
-        expect(shellResult.status, shellResult.stderr || shellResult.stdout).toBe(0);
-        expect(JSON.parse(shellResult.stdout)).toEqual({
-          permission: 'deny',
-          user_message: AUTO_UPGRADE_LOCK_MESSAGE,
-          agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
-        });
+          expect(shellResult.status, shellResult.stderr || shellResult.stdout).toBe(0);
+          expect(JSON.parse(shellResult.stdout)).toEqual({
+            permission: 'deny',
+            user_message: AUTO_UPGRADE_LOCK_MESSAGE,
+            agent_message: AUTO_UPGRADE_LOCK_MESSAGE,
+          });
+        } finally {
+          releaseAutoUpgradeLock({ lockPath });
+        }
       } finally {
-        releaseAutoUpgradeLock({ lockPath });
+        removeTemporaryDirectory(projectDirectory);
       }
-    } finally {
-      removeTemporaryDirectory(projectDirectory);
-    }
-  }, 180_000);
+    },
+    TIMEOUT_SETUP_HOOK,
+  );
 });

--- a/packages/cli/tests/integration/mixed-project-golang.test.ts
+++ b/packages/cli/tests/integration/mixed-project-golang.test.ts
@@ -79,7 +79,7 @@ func main() {
 
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup', '--yes'], { env: SKIP_SKILLS_ENV });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/mixed-project.test.ts
+++ b/packages/cli/tests/integration/mixed-project.test.ts
@@ -62,7 +62,7 @@ version = "0.1.0"
 
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/override-survival.test.ts
+++ b/packages/cli/tests/integration/override-survival.test.ts
@@ -69,7 +69,7 @@ describe('Customer override survival (#137)', () => {
       initGitRepo(projectDirectory);
       await setupOrThrow(projectDirectory);
       originalConfig = readTestFile(projectDirectory, 'eslint.config.mjs');
-    }, TIMEOUT_BUN_INSTALL);
+    });
 
     afterAll(() => {
       if (projectDirectory) removeTemporaryDirectory(projectDirectory);
@@ -223,7 +223,7 @@ export default defineConfig([
       );
       initGitRepo(projectDirectory);
       await setupOrThrow(projectDirectory);
-    }, TIMEOUT_BUN_INSTALL);
+    });
 
     afterAll(() => {
       if (projectDirectory) removeTemporaryDirectory(projectDirectory);
@@ -268,7 +268,7 @@ select = ["E", "F"]
       initGitRepo(projectDirectory);
       await setupOrThrow(projectDirectory);
       originalRuffToml = readTestFile(projectDirectory, 'ruff.toml');
-    }, TIMEOUT_BUN_INSTALL);
+    });
 
     afterAll(() => {
       if (projectDirectory) removeTemporaryDirectory(projectDirectory);
@@ -363,7 +363,7 @@ extend-select = ["D"]
         initGitRepo(projectDirectory);
         await setupOrThrow(projectDirectory);
         bareRuffToml = readTestFile(projectDirectory, 'ruff.toml');
-      }, TIMEOUT_BUN_INSTALL);
+      });
 
       afterAll(() => {
         if (projectDirectory) removeTemporaryDirectory(projectDirectory);

--- a/packages/cli/tests/integration/python-golden-path.test.ts
+++ b/packages/cli/tests/integration/python-golden-path.test.ts
@@ -42,7 +42,7 @@ describe('E2E: Python Golden Path', () => {
     createPythonProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000); // 3 min timeout for setup
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -154,7 +154,7 @@ describe('E2E: Python Setup Idempotency', () => {
     // Second call intentionally allowed to fail with "Already configured" exit 1 —
     // we verify file state survives an accidental re-run, not that setup is idempotent.
     await runCli(['setup', '--yes'], { cwd: projectDirectory });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -206,7 +206,7 @@ describe('E2E: Python Lint Hook Fallback', () => {
     if (fileExists(projectDirectory, 'ruff.toml')) {
       unlinkSync(nodePath.join(projectDirectory, 'ruff.toml'));
     }
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/rust-golden-path.test.ts
+++ b/packages/cli/tests/integration/rust-golden-path.test.ts
@@ -45,7 +45,7 @@ describe('E2E: Rust Golden Path', () => {
     createRustProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000); // 3 min timeout for setup
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -180,7 +180,7 @@ cognitive-complexity-threshold = 25
     );
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -250,7 +250,7 @@ tab_spaces = 4
     );
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -295,7 +295,7 @@ unwrap_used = "allow"
     );
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -342,7 +342,7 @@ describe('E2E: TypeScript + Rust Mixed Project', () => {
     createRustProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -381,7 +381,7 @@ describe('E2E: Pure Rust Project', () => {
     // Ensure NO package.json exists
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -414,7 +414,7 @@ describe('E2E: Rust Workspace Setup', () => {
     createRustWorkspace(projectDirectory, { members: ['core', 'cli'] });
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -457,7 +457,7 @@ describe('E2E: Rust Virtual Workspace', () => {
     createRustWorkspace(projectDirectory, { members: ['lib-a', 'lib-b'] });
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -506,7 +506,7 @@ unwrap_used = "allow"
 
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -539,7 +539,7 @@ describe('E2E: Rust Workspace Glob Pattern', () => {
     createRustWorkspace(projectDirectory, { members: ['alpha', 'beta', 'gamma'], useGlob: true });
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -580,7 +580,7 @@ describe('E2E: Rust Lint Hook Fallback', () => {
     if (fileExists(projectDirectory, '.safeword/rustfmt.toml')) {
       unlinkSync(rustfmtConfig);
     }
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -610,7 +610,7 @@ describe('E2E: Rust Lint Hook Graceful Handling', () => {
     createRustProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -656,7 +656,7 @@ describe('E2E: Add Rust to Existing TypeScript Project', () => {
     initGitRepo(projectDirectory);
     // Initial setup with TypeScript only
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -723,7 +723,7 @@ describe('E2E: Rust Setup Idempotency', () => {
     // Second call intentionally allowed to fail with "Already configured" exit 1 —
     // we verify file state survives an accidental re-run, not that setup is idempotent.
     await runCli(['setup', '--yes'], { cwd: projectDirectory });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -763,7 +763,7 @@ describe('E2E: Rust Lint Hook Package Targeting', () => {
     createRustWorkspace(projectDirectory, { members: ['core', 'cli'] });
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory);
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/tooling-validation.test.ts
+++ b/packages/cli/tests/integration/tooling-validation.test.ts
@@ -51,7 +51,7 @@ requires-python = ">=3.10"
     writeTestFile(projectDirectory, 'src/main.py', 'print("hello")\n');
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup'], { timeout: TIMEOUT_SETUP });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -104,7 +104,7 @@ describe('E2E: mypy Type Error Detection', () => {
     createPythonProject(projectDirectory);
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup'], { timeout: TIMEOUT_SETUP });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -241,7 +241,7 @@ describe('E2E: React ESLint Violation Detection', () => {
 
     // Install dependencies so ESLint can run
     execSync('bun install', { cwd: projectDirectory, stdio: 'pipe' });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/integration/typescript-validation.test.ts
+++ b/packages/cli/tests/integration/typescript-validation.test.ts
@@ -40,7 +40,7 @@ describe('E2E: TypeScript Project Setup', () => {
     writeTestFile(projectDirectory, 'src/index.ts', 'export const hello = "world";\n');
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup'], { timeout: TIMEOUT_SETUP });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -86,7 +86,7 @@ describe('E2E: Type-Checked ESLint Rules', () => {
 
     // Install dependencies so ESLint can run with type checking
     execSync('bun install', { cwd: projectDirectory, stdio: 'pipe' });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {
@@ -193,7 +193,7 @@ describe('E2E: JavaScript-Only Project', () => {
     writeTestFile(projectDirectory, 'src/index.js', 'module.exports = { hello: "world" };\n');
     initGitRepo(projectDirectory);
     await setupOrThrow(projectDirectory, ['setup'], { timeout: TIMEOUT_SETUP });
-  }, 180_000);
+  });
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/cli/tests/setup-or-throw.test.ts
+++ b/packages/cli/tests/setup-or-throw.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for `setupOrThrow`'s bounded retry-on-timeout policy (issue #419
+ * test-harness companion).
+ *
+ * The heavy `safeword setup`-in-`beforeAll` E2Es false-red when the machine is
+ * saturated and setup outruns its wall-clock timeout. `setupOrThrow` now retries
+ * ONCE, and ONLY on a timeout — never on a real non-zero exit, so a genuine setup
+ * regression still fails fast and loud. These tests lock that invariant in place
+ * by injecting a scripted runner (no real subprocess, no real timeout).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { setupOrThrow, wasKilledByTimeout } from './helpers';
+
+interface FakeResult {
+  exitCode: number;
+  timedOut: boolean;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Build a fake `runCli` that returns the scripted results in order (clamping to
+ * the last entry if called more times), and records how many times it was called.
+ */
+type SetupRunner = Parameters<typeof setupOrThrow>[3];
+
+function scriptedRunner(results: FakeResult[]): {
+  runner: SetupRunner;
+  callCount: () => number;
+} {
+  let calls = 0;
+  const runner = (() => {
+    const result = results[Math.min(calls, results.length - 1)];
+    calls++;
+    if (!result) {
+      throw new Error('scriptedRunner requires a non-empty results array');
+    }
+    return Promise.resolve({
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+    });
+  }) as SetupRunner;
+  return { runner, callCount: () => calls };
+}
+
+const SUCCESS: FakeResult = { exitCode: 0, timedOut: false, stdout: 'setup complete' };
+const TIMEOUT: FakeResult = { exitCode: 1, timedOut: true, stderr: 'killed after timeout' };
+const REAL_FAILURE: FakeResult = { exitCode: 2, timedOut: false, stderr: 'dist/cli.js not found' };
+
+describe('setupOrThrow retry policy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns on first-attempt success without retrying', async () => {
+    const { runner, callCount } = scriptedRunner([SUCCESS]);
+
+    const result = await setupOrThrow('/fake/project', ['setup'], {}, runner);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('setup complete');
+    expect(callCount()).toBe(1);
+  });
+
+  it('retries once on a timeout, then returns the succeeding result', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const { runner, callCount } = scriptedRunner([TIMEOUT, SUCCESS]);
+
+    const result = await setupOrThrow('/fake/project', ['setup'], {}, runner);
+
+    expect(result.exitCode).toBe(0);
+    expect(callCount()).toBe(2);
+    // Recovered timeouts are visible, never silent.
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy.mock.calls[0]?.[0]).toContain('retrying once');
+  });
+
+  it('does NOT retry a real non-zero exit — fails fast and loud', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const { runner, callCount } = scriptedRunner([REAL_FAILURE, SUCCESS]);
+
+    await expect(setupOrThrow('/fake/project', ['setup'], {}, runner)).rejects.toThrow(
+      /failed \(exit 2\)/,
+    );
+    // A real failure is a genuine regression: exactly one attempt, no retry, no
+    // "retrying" breadcrumb — the second scripted SUCCESS is never reached.
+    expect(callCount()).toBe(1);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws a distinct timeout error (not the exit-code error) when both attempts time out', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const { runner, callCount } = scriptedRunner([TIMEOUT, TIMEOUT]);
+
+    await expect(setupOrThrow('/fake/project', ['setup'], {}, runner)).rejects.toThrow(
+      /timed out after 2 attempts/,
+    );
+    // Bounded: never more than 2 attempts even under a persistent timeout.
+    expect(callCount()).toBe(2);
+  });
+});
+
+// The timeout detector is what keeps the retry honest: it must fire on a real
+// wall-clock kill and NEVER on a genuine failure. These cases encode the three
+// child-process error shapes from Node's docs so the "retry only on timeout"
+// invariant can't be regressed by a change to the detector.
+describe('wasKilledByTimeout', () => {
+  it('is true for a timeout kill (killed + signal set)', () => {
+    // Node on timeout: killed:true, signal:'SIGTERM'.
+    const timeout = { killed: true, signal: 'SIGTERM' };
+    expect(wasKilledByTimeout(timeout)).toBe(true);
+  });
+
+  it('is false for a real non-zero exit (numeric code, not killed)', () => {
+    // Node on a real exit: killed:false, numeric code, absent signal.
+    const realExit = { killed: false, code: 1 };
+    expect(wasKilledByTimeout(realExit)).toBe(false);
+  });
+
+  it('is false for a spawn failure — a STRING code must not read as a timeout', () => {
+    // ENOENT-style spawn failure carries a string `code` but is NOT a timeout.
+    // The regression guard: keying on a string `code` would retry a real failure.
+    const spawnFailure = { killed: false, code: 'ENOENT' };
+    expect(wasKilledByTimeout(spawnFailure)).toBe(false);
+  });
+});

--- a/packages/cli/vitest.base.ts
+++ b/packages/cli/vitest.base.ts
@@ -22,9 +22,17 @@ export const baseConfig = defineConfig({
       GIT_CONFIG_KEY_0: 'commit.gpgsign',
       GIT_CONFIG_VALUE_0: 'false',
     },
-    // Increase hook timeout for afterEach cleanup (rmSync with retries)
-    // Default 10s isn't enough when bun has locked files
-    hookTimeout: 30_000,
+    // Hook timeout must contain the slowest *legitimate* hook: a `safeword setup`
+    // spawned in a `beforeAll` via setupOrThrow, which does real work (git init,
+    // scaffolding, tool detection, optional skills pull) and retries ONCE on a
+    // wall-clock timeout under machine contention (issue #419). Worst case is
+    // 2 × the 120s per-attempt setup timeout; 300s adds slack (= TIMEOUT_SETUP_HOOK).
+    // Raising the DEFAULT — rather than a budget per beforeAll — means every
+    // setup-in-beforeAll inherits the headroom with no per-hook override to forget
+    // or mis-size. Suites doing MULTIPLE setups in one hook (bdd-lane) still set a
+    // larger explicit budget. Was 30_000 — itself raised from 10s for afterEach
+    // rmSync-with-retries cleanup, which still fits comfortably.
+    hookTimeout: 300_000,
     // 3 workers (of the 4-vCPU ubuntu-latest runner). maxWorkers:1 timed the CI
     // `test` job out (20-min cap) — sequential is too slow for the full suite +
     // setup. The spawn-heavy integration tier can lose a timing race under CPU


### PR DESCRIPTION
## Problem

The heavy `safeword setup`-in-`beforeAll` E2Es false-fail the full local suite under machine contention. When parallel Claude/Codex worktrees are building+testing (see #419), `safeword setup` (spawned via `runCli` → `execFileAsync(process.execPath, [CLI_PATH, ...], {timeout})`) outruns its fixed wall-clock timeout and the whole file hard-fails with `safeword setup failed (exit 1)`.

This is a **false red**, verified three ways: it's non-deterministic (a *different* subtest fails each run); `safeword setup` succeeds cleanly in isolation; and CI (isolated, uncontended) passes green on the identical tree. It bit both the 0.59.0 and 0.60.0 release verifications. Root cause: a timeout was collapsed to `exit 1`, **indistinguishable from a real failure**.

## Fix (at the one shared helper)

- **Plumb a real `timedOut` signal** through `runCli`/`runCliSync`. Node marks a timeout kill with `killed:true` + `signal` (verified against the [child_process docs](https://nodejs.org/api/child_process.html) and empirically on Node v24.16.0) — distinct from a real non-zero exit's numeric `code` and a spawn failure's string `code`.
- **`setupOrThrow` retries ONCE, and ONLY on a timeout.** A real non-zero exit still fails fast and loud with **no retry** — a genuine setup regression is never masked. Exhausted timeouts throw a *distinct*, diagnosable error, and a retry emits a loud stderr breadcrumb (never silent).
- **`wasKilledByTimeout` keys on `killed`/`signal`, never a string `code`** — a spawn failure (ENOENT → string code) must not be misread as a timeout and retried. (This was a bug in the first commit, caught in review and fixed — see the 2nd commit.)
- **Bump per-attempt `TIMEOUT_SETUP` 60s→120s** and add **`TIMEOUT_SETUP_HOOK`** (=2×`TIMEOUT_SETUP`+slack) so `beforeAll` budgets contain the bounded retry.
- **Size the hook budget across *all* heavy setup-in-`beforeAll` E2Es** (3rd commit) — the 4 reported offenders plus 7 more (`add-language`, `claude-code-simulation`, `hooks`, `mixed-project`, `override-survival`, `python-golden-path`, `rust-golden-path`) whose budgets were `< 2×per-attempt`, where the retry would otherwise be silently defeated.

Approach chosen via `/figure-it-out` over (A) timeout-tuning-only — a fixed timeout always has a cliff — and (C) slow-lane isolation — CI runs only the default lane, so that would silently drop these from CI *and* flip on real installs. Native vitest `retry` is disqualified — it can't re-run `beforeAll` (vitest [#6726](https://github.com/vitest-dev/vitest/issues/6726)). Companion to #419: #419 lowers contention at the process-lock level; this makes each heavy E2E tolerant of whatever remains.

## Tests

New `packages/cli/tests/setup-or-throw.test.ts` locks the invariants via an injected runner (no real subprocess): retries once on timeout; does **not** retry a real non-zero exit; bounded to 2 attempts; distinct timeout error. Plus direct `wasKilledByTimeout` cases encoding all three documented Node error shapes (timeout / real-exit / spawn-failure).

## Verification (local)

- Full suite: **4116 passed** / 3 skipped (281 files) — ran clean, no contention false-red
- Gherkin lane: **181 scenarios, 3414 steps** pass
- Lint (`bun run lint`) + `tsc --noEmit`: clean
- Independent fresh-context review: **APPROVE, no criticals** (it caught the string-`code` bug, now fixed)
- Widened files, targeted: **139 pass**

CI adjudicates the isolated, uncontended run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)