### PR TITLE
Wire architecture drift nudges for Cursor and Codex

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -355,12 +355,12 @@ Test Quality:
 - If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
   - **Dependency drift:**
     - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-    - **Gap (warn):** Major dependencies not documented
+    - **Gap (error):** Major dependencies not documented
   - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
     - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
     - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
-    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
-    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Missing (error):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (error):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
     - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
   - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
@@ -375,7 +375,7 @@ Test Quality:
 
 **Documentation impact check:**
 
-Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag any documentation that references changed code but hasn't been updated.
+Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
 ---
 
@@ -388,18 +388,19 @@ Report findings by severity with codes:
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
 - [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
+- [E004] Documentation drift: Codex Stop hook behavior changed, but `README.md` or docs still describe only PreToolUse coverage
+- [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
+- [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
+- [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Warnings (should review)
 
 - [W001] Size: `CLAUDE.md` has 245 instructions (recommended: 150-200)
 - [W002] Structure: `AGENTS.md` missing recommended WHAT/WHY/HOW sections
 - [W003] Staleness: `README.md` last modified 45 days ago (12 commits since)
-- [W004] Gap: `@tanstack/query` not documented in ARCHITECTURE.md
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
-- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
-- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -355,12 +355,12 @@ Test Quality:
 - If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
   - **Dependency drift:**
     - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-    - **Gap (warn):** Major dependencies not documented
+    - **Gap (error):** Major dependencies not documented
   - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
     - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
     - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
-    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
-    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Missing (error):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (error):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
     - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
   - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
@@ -375,7 +375,7 @@ Test Quality:
 
 **Documentation impact check:**
 
-Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag any documentation that references changed code but hasn't been updated.
+Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
 ---
 
@@ -388,18 +388,19 @@ Report findings by severity with codes:
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
 - [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
+- [E004] Documentation drift: Codex Stop hook behavior changed, but `README.md` or docs still describe only PreToolUse coverage
+- [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
+- [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
+- [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Warnings (should review)
 
 - [W001] Size: `CLAUDE.md` has 245 instructions (recommended: 150-200)
 - [W002] Structure: `AGENTS.md` missing recommended WHAT/WHY/HOW sections
 - [W003] Staleness: `README.md` last modified 45 days ago (12 commits since)
-- [W004] Gap: `@tanstack/query` not documented in ARCHITECTURE.md
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
-- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
-- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -41,6 +41,14 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool
 timeout = 30
 statusMessage = "Surfacing language-skill guidance"
 
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
+timeout = 30
+statusMessage = "Checking safeword Stop nudges"
+
 [mcp_servers.context7]
 url = "https://mcp.context7.com/mcp"
 

--- a/.cursor/commands/audit.md
+++ b/.cursor/commands/audit.md
@@ -320,7 +320,7 @@ Test Quality:
 - If missing → create from `.safeword/templates/architecture-template.md`
 - If exists → check for drift and gaps:
   - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-  - **Gap (warn):** Major dependencies not documented
+  - **Gap (error):** Major dependencies not documented
 
 **README.md:**
 
@@ -333,7 +333,7 @@ Test Quality:
 
 **Documentation impact check:**
 
-Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag any documentation that references changed code but hasn't been updated.
+Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
 ---
 
@@ -345,13 +345,14 @@ Report findings by severity with codes:
 
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
+- [E004] Documentation drift: Codex Stop hook behavior changed, but `README.md` or docs still describe only PreToolUse coverage
+- [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
 
 ### Warnings (should review)
 
 - [W001] Size: `CLAUDE.md` has 245 instructions (recommended: 150-200)
 - [W002] Structure: `AGENTS.md` missing recommended WHAT/WHY/HOW sections
 - [W003] Staleness: `README.md` last modified 45 days ago (12 commits since)
-- [W004] Gap: `@tanstack/query` not documented in ARCHITECTURE.md
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
 

--- a/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/test-definitions.md
+++ b/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/test-definitions.md
@@ -1,0 +1,69 @@
+# Test definitions (R/G/R ledger) - JN403D
+
+Test type: integration because the behavior is the real hook/config output observed by Cursor, Codex, and safeword install/upgrade.
+
+## Rule: Architecture drift advisories reach every local Stop-hook harness
+
+### Scenario: Cursor Stop emits the architecture drift advisory during done-phase work
+
+- [x] RED - `cursor-stop-review.test.ts` expected `ARCHITECTURE_DOCUMENT_NUDGE`; hook only emitted the generic quality follow-up.
+- [x] GREEN - Cursor Stop now includes the advisory; focused test file passes 5/5, then 6/6 after the explicit implement-phase drift regression was added.
+- [x] REFACTOR - Kept the delivery as a thin done-phase helper around the shared `architectureDocumentNudgeForProject` detector.
+
+### Scenario: Cursor Stop does not emit the architecture drift advisory outside done-phase drift
+
+- [x] RED - Covered by the Cursor delivery RED: without a done-phase guard, the new advisory path would have leaked into implement-phase Stop output.
+- [x] GREEN - Added explicit implement-phase architecture-drift regression; focused Cursor Stop test file passes 6/6.
+- [x] REFACTOR - Silence behavior remains tied to the existing active-ticket phase/session-state checks.
+
+### Scenario: Codex Stop emits the architecture drift advisory as a continuation nudge
+
+- [x] RED - `codex-stop-nudge.test.ts` failed with exit status 1 because `templates/hooks/codex/stop.ts` does not exist yet.
+- [x] GREEN - Codex Stop adapter emits `decision: "block"` with `ARCHITECTURE_DOCUMENT_NUDGE`; focused test passes 1/1, then 4/4 after silence/re-entry coverage.
+- [x] REFACTOR - Adapter delegates detection to the shared architecture nudge library and keeps Codex Stop as a continuation-only surface.
+
+### Scenario: Codex Stop stays silent when the advisory does not apply or a Stop continuation is already active
+
+- [x] RED - Covered by the Codex adapter RED: before the adapter existed, no silence/re-entry behavior existed to exercise.
+- [x] GREEN - Added non-done, no-drift, and `stop_hook_active` regressions; focused Codex Stop test file passes 4/4.
+- [x] REFACTOR - Early exits are ordered before any detector work to avoid loop/re-entry output.
+
+## Rule: Codex config delivery is installed, upgraded, and removable
+
+### Scenario: Fresh Codex config wires the safeword Stop nudge exactly once
+
+- [x] RED - `setup-reconcile.test.ts` failed because install omitted `.safeword/hooks/codex/stop.ts` and `[[hooks.Stop]]`.
+- [x] GREEN - Schema registers the hook file and fresh config template includes exactly one `[[hooks.Stop]]`; focused setup test passes 15/15.
+- [x] REFACTOR - Schema drift test now treats Codex `stop.ts` as a Codex-only adapter, not a Claude `SETTINGS_HOOKS` entry.
+
+### Scenario: Upgrade retrofits the safeword Stop nudge without duplicating user config
+
+- [x] RED - Covered by the same missing schema/config path as the fresh setup RED; old safeword configs lacked the Stop patch marker.
+- [x] GREEN - Upgrade retrofit appends `.safeword/hooks/codex/stop.ts` once and stays idempotent; focused upgrade test passes 18/18.
+- [x] REFACTOR - Retrofit uses the hook path as marker so user-authored Stop hooks are preserved.
+
+### Scenario: Uninstall strips the safeword Codex Stop nudge while preserving user config
+
+- [x] RED - Added uninstall assertion for the new Stop block alongside existing Codex hook unpatch coverage.
+- [x] GREEN - Uninstall strips safeword's Stop hook while preserving user config; focused reconcile test passes 77/77.
+- [x] REFACTOR - Each Codex config append patch removes its own block; the primary patch still owns safeword-only file removal.
+
+---
+
+## Feature-level cross-scenario refactor
+
+- [x] cross-scenario - Focused verification passes across Cursor/Codex Stop hooks, setup, upgrade, uninstall/reconcile, schema drift, typecheck, diff hygiene, and Bun hook parse checks.
+
+## Rule: Audit treats changed-code documentation drift as a hard finding
+
+### Scenario: Audit surfaces classify documentation drift and gaps as errors
+
+- [x] RED - Added assertions that would fail against the previous `Gap (warn)` / `[W004] Gap` wording and missing documentation-drift error codes.
+- [x] GREEN - All five audit surfaces now require `Gap (error)`, `[E004] Documentation drift`, and `[E005] Dependency gap`; focused audit documentation source test passes 29/29.
+- [x] REFACTOR - Kept template, `.agents`, `.claude`, and `.cursor` audit copies synchronized byte-for-byte.
+
+### Scenario: Project docs describe Codex Stop delivery separately from PreToolUse edit gates
+
+- [x] RED - PR review found docs still described Codex hook coverage as PreToolUse-only after `codex/stop.ts` was added.
+- [x] GREEN - README, quick-start, hook reference, and ARCHITECTURE.md now document Codex Stop continuation nudges and the non-hard-enforcement boundary.
+- [x] REFACTOR - Kept the wording scoped to Codex Stop delivery and avoided expanding the hard done-gate claim to Cursor/Codex.

--- a/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/ticket.md
+++ b/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/ticket.md
@@ -1,0 +1,64 @@
+---
+id: JN403D
+slug: architecture-drift-nudge-harness-parity
+type: task
+phase: done
+status: done
+created: 2026-07-02T00:03:33.109Z
+last_modified: 2026-07-02T15:33:30Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/598
+relates_to:
+  - AXRC4D
+  - HPP49X
+  - VAX3Z2
+scope:
+  - Route the existing `ARCHITECTURE.md` drift nudge through Cursor's local/project `stop` hook without changing Cursor's hard done-gate placement.
+  - Add Codex Stop-hook delivery for the same nudge using Codex continuation semantics (`decision: "block"` on `Stop`), not hard-block semantics.
+  - Ship the Codex Stop hook in fresh installs and retrofit it into existing safeword-owned Codex configs without duplicating user-authored hooks.
+  - Keep the existing fingerprint detector as the source of truth; add only delivery/wiring code and focused tests.
+  - Repair public/project documentation drift for Codex Stop delivery and make audit classify changed-code documentation drift as an error.
+out_of_scope:
+  - Building a new architecture drift detector or recomputing architecture shape from source.
+  - Porting Claude's full `stop-quality.ts` gate into Cursor or Codex.
+  - Claiming Cursor cloud-agent Stop support; current Cursor docs say cloud agents do not run `stop`.
+  - Changing done-gate hard enforcement policy for Cursor or Codex.
+done_when:
+  - Cursor Stop emits the architecture drift advisory as a `followup_message` when a done-phase ticket has moved the generated architecture fingerprint.
+  - Cursor Stop remains silent for the architecture advisory when the active ticket is not in done phase or the architecture fingerprint did not move.
+  - Codex Stop emits the same advisory as a continuation nudge (`decision: "block"`, `reason`) when a done-phase ticket has moved the generated architecture fingerprint.
+  - Codex Stop remains silent when the advisory does not apply, and it does not loop when `stop_hook_active` is true.
+  - Fresh and upgraded Codex configs include exactly one safeword Stop hook block, and uninstall strips safeword's Codex Stop hook while preserving user config.
+  - README, website docs, and ARCHITECTURE.md document Codex Stop continuation nudges separately from Codex PreToolUse edit gates.
+  - Audit guidance reports changed-code documentation drift and documentation gaps as errors, with tests covering all installed/template audit surfaces.
+  - Focused Cursor/Codex hook tests, Codex config reconciliation tests, typecheck, lint, and relevant parity checks pass.
+---
+
+# Nudge architecture drift in Cursor and Codex Stop hooks
+
+**Goal:** Make the existing `ARCHITECTURE.md` drift advisory reach Cursor and Codex Stop hooks with the same non-blocking nudge semantics as Claude.
+
+**Why:** Issue #598 found that the architecture-document nudge added by AXRC4D is Claude-only even though Cursor and Codex both have local Stop-hook surfaces that can deliver the advisory.
+
+## Decision
+
+Reuse `architectureDocumentNudgeForProject` as the only drift detector. Cursor and Codex should add thin Stop-hook delivery around it, scoped to done-phase work, because the completed lifecycle tickets already establish that Cursor/Codex Stop hooks nudge but do not hard-enforce done gates.
+
+## Work Log
+
+- 2026-07-02T15:33:30Z VERIFY: Repaired the Codex Stop documentation drift found during PR review and tightened `/audit` so documentation drift/gaps are errors, not warnings. Focused audit documentation surface test passes 29/29.
+- 2026-07-02T04:48:42Z DONE: Verified PR #605 after CI surfaced the ticket-status annotation. Rebasing removed unrelated `.project/surfaces.md` scope drift; GitHub CI lint/test pass, local lint/typecheck/Gherkin pass, scenarios are 22/22 complete, and `verify.md` records done-gate evidence.
+- 2026-07-02T02:33:03Z REFACTOR: Extracted `readSessionActiveTicket` into the shared quality-state library and used it from Cursor/Codex Stop adapters. Focused Stop/quality-state tests pass 15/15; typecheck, ESLint, and diff hygiene pass.
+- 2026-07-02T00:34:30Z VERIFY: Focused verification passes: Cursor/Codex Stop integration, setup/upgrade/reconcile/schema suites (150 tests), targeted Cursor rerun (6 tests), `tsc --noEmit`, `git diff --check`, and Bun `--check` on template/dogfood Stop hooks.
+- 2026-07-02T00:33:30Z GREEN: Added explicit Cursor implement-phase architecture-drift regression; focused Cursor Stop test file passes 6/6.
+- 2026-07-02T00:31:20Z GREEN: Schema drift check updated for Codex-only Stop adapter; focused verification set passes 6 files / 150 tests.
+- 2026-07-02T00:30:30Z REFACTOR: Synced dogfood `.codex/config.toml` and `.safeword/hooks/codex/stop.ts` narrowly, then removed unrelated language-pack churn from the interrupted upgrade.
+- 2026-07-02T00:25:30Z GREEN: Codex Stop silence/re-entry tests pass 4/4; upgrade retrofit test passes 18/18; uninstall/reconcile test passes 77/77.
+- 2026-07-02T00:17:47Z RED: Added fresh setup assertions for Codex Stop asset/config. Focused setup-reconcile test failed because `.safeword/hooks/codex/stop.ts` and `[[hooks.Stop]]` are not installed.
+- 2026-07-02T00:16:46Z GREEN: Added `packages/cli/templates/hooks/codex/stop.ts`; focused Codex Stop test passes 1/1 and emits the nudge as Codex continuation JSON.
+- 2026-07-02T00:15:21Z RED: Added Codex Stop integration coverage for done-phase architecture drift. Focused test failed with hook process status 1 because the Codex Stop adapter does not exist.
+- 2026-07-02T00:13:35Z GREEN: Cursor Stop delivery implemented in the template and synced to dogfood; focused `cursor-stop-review.test.ts` passes 5/5 with lock wait disabled because another worktree held the package-test lock.
+- 2026-07-02T00:10:45Z RED: Added Cursor Stop integration coverage for a done-phase ticket with a moved architecture fingerprint. Focused test failed because `followup_message` contained only the generic quality review prompt, not `ARCHITECTURE_DOCUMENT_NUDGE`.
+- 2026-07-02T00:03:39Z Phase: advanced to implement after creating `test-definitions.md`; scenario set is bounded to Cursor Stop output, Codex Stop output, and Codex config install/upgrade/uninstall behavior.
+- 2026-07-02T00:03:39Z Phase: advanced to define-behavior after frontmatter scope/out_of_scope/done_when were recorded.
+- 2026-07-02T00:03:39Z Scoped: Revalidated #598, existing AXRC4D/HPP49X/VAX3Z2/JENFZX context, and current Cursor/Codex Stop semantics. Implementation path is thin delivery adapters, not a full Stop-gate port.
+- 2026-07-02T00:03:33.109Z Started: Created ticket JN403D

--- a/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/verify.md
+++ b/.project/tickets/JN403D-architecture-drift-nudge-harness-parity/verify.md
@@ -1,0 +1,26 @@
+# Verify - JN403D architecture-drift-nudge-harness-parity
+
+## Verify Checklist
+
+**Test Suite:** ✓ 150/150 tests pass in the focused local issue suite; ✓ 15/15 tests pass in the post-refactor local suite; GitHub CI `test (node 24)` passed.
+**Gherkin:** ✅ Acceptance lane passes (181 scenarios, 3414 steps).
+**Build:** ✅ Success (GitHub CI build step passed; local test lanes rebuilt the CLI with tsup).
+**Lint:** ✅ Clean (`bun run lint` passed locally; GitHub CI `lint` passed).
+**Scenarios:** All 22 scenarios marked complete.
+**PR Scope:** ✅ Diff matches ticket scope after rebasing onto `origin/main`; unrelated `.project/surfaces.md` sibling commit was removed from the local branch.
+**Dep Drift:** ✅ Clean (no dependency manifest or lockfile changes).
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal Stop-hook/config plumbing, not persona-facing UI.
+**Evidence limits:** ✅ None
+**Audit:** Audit passed
+
+Additional evidence:
+
+- Focused audit docs surface test passed locally: `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run --cwd packages/cli test tests/skills/audit-documentation-sources.test.ts` (29/29).
+- Post-doc correction checks passed locally: `git diff --check`, `bun run --cwd packages/cli typecheck`, `bun run --cwd packages/cli lint:eslint`, `bun run lint:eslint`, `bun run lint:gherkin`, `bun run format:check`, and `bun run --cwd packages/website typecheck`.
+- GitHub PR #605 checks: `lint` passed, `test (node 24)` passed.
+- `bun run test:bdd` passed locally: 181 scenarios, 3414 steps.
+- `bun run typecheck` passed locally.
+- `bun run lint` passed locally.
+- `git diff --name-status origin/main...HEAD` matches the ticket scope.

--- a/.safeword/hooks/codex/stop.ts
+++ b/.safeword/hooks/codex/stop.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+// Safeword: Codex Stop adapter for one-shot continuation nudges.
+//
+// Codex Stop cannot hard-block completion. `decision: "block"` creates a new
+// continuation prompt, so this adapter only delivers non-blocking advisories
+// whose enforcement already lives elsewhere.
+
+import { existsSync } from 'node:fs';
+
+import { getActiveTicket } from '../lib/active-ticket.ts';
+import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
+import { readSessionActiveTicket } from '../lib/quality-state.ts';
+import { resolveRunIdentity } from '../lib/run-identity.ts';
+import { installCrashCapture } from '../lib/self-report.ts';
+
+installCrashCapture('codex-stop', undefined, 'codex');
+
+interface CodexStopInput {
+  session_id?: string;
+  turn_id?: string;
+  stop_hook_active?: boolean;
+  last_assistant_message?: string | null;
+}
+
+async function readInput(): Promise<CodexStopInput> {
+  try {
+    return JSON.parse(await Bun.stdin.text()) as CodexStopInput;
+  } catch {
+    return {};
+  }
+}
+
+function isDonePhaseWork(projectDirectory: string, input: CodexStopInput): boolean {
+  const runIdentity = resolveRunIdentity(input, { runtime: 'codex' });
+  const ticket = readSessionActiveTicket(projectDirectory, runIdentity);
+  if (ticket) {
+    return ticket.status === 'in_progress' && ticket.phase === 'done';
+  }
+
+  return getActiveTicket(projectDirectory).phase === 'done';
+}
+
+const input = await readInput();
+const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+if (input.stop_hook_active === true) process.exit(0);
+if (!existsSync(`${projectDirectory}/.safeword`)) process.exit(0);
+if (!isDonePhaseWork(projectDirectory, input)) process.exit(0);
+
+const architectureNudge = architectureDocumentNudgeForProject(projectDirectory);
+if (architectureNudge === null) process.exit(0);
+
+console.log(
+  JSON.stringify({
+    decision: 'block',
+    reason: architectureNudge,
+  }),
+);

--- a/.safeword/hooks/cursor/stop.ts
+++ b/.safeword/hooks/cursor/stop.ts
@@ -8,9 +8,9 @@
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 
-import { getTicketInfo } from '../lib/active-ticket.ts';
+import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
 import { QUALITY_REVIEW_MESSAGE } from '../lib/quality.ts';
-import { readSessionState } from '../lib/quality-state.ts';
+import { readSessionActiveTicket } from '../lib/quality-state.ts';
 import { getRunStorageKey, resolveRunIdentity } from '../lib/run-identity.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
 
@@ -31,11 +31,18 @@ function isAutomatedEvidenceRun(
   workspace: string,
   runIdentity: ReturnType<typeof resolveRunIdentity>,
 ): boolean {
-  const state = readSessionState(workspace, runIdentity);
-  const activeTicket = state?.activeTicket;
-  if (!activeTicket) return false;
-  const phase = getTicketInfo(workspace, activeTicket).phase;
+  const phase = readSessionActiveTicket(workspace, runIdentity)?.phase;
   return phase === 'implement' || phase === 'verify';
+}
+
+function architectureNudgeForDonePhase(
+  workspace: string,
+  runIdentity: ReturnType<typeof resolveRunIdentity>,
+): string | null {
+  const ticketInfo = readSessionActiveTicket(workspace, runIdentity);
+  if (!ticketInfo) return null;
+  if (ticketInfo.status !== 'in_progress' || ticketInfo.phase !== 'done') return null;
+  return architectureDocumentNudgeForProject(workspace);
 }
 
 // Read hook input from stdin
@@ -79,13 +86,15 @@ if (await Bun.file(markerFile).exists()) {
     if (process.env.DEBUG) console.error('[cursor/stop] marker cleanup failed:', error);
   });
 
-  if (isAutomatedEvidenceRun(process.cwd(), runIdentity)) {
+  const architectureNudge = architectureNudgeForDonePhase(process.cwd(), runIdentity);
+  if (isAutomatedEvidenceRun(process.cwd(), runIdentity) && architectureNudge === null) {
     console.log('{}');
     process.exit(0);
   }
 
+  const followupMessage = [architectureNudge, QUALITY_REVIEW_MESSAGE].filter(Boolean).join('\n\n');
   const output: StopOutput = {
-    followup_message: QUALITY_REVIEW_MESSAGE,
+    followup_message: followupMessage,
   };
   console.log(JSON.stringify(output));
 } else {

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -5,6 +5,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
+import { getTicketInfo, type TicketDetails } from './active-ticket.js';
 import { resolveNamespaceRoot } from './namespace-root.js';
 import { getRunStorageKey, resolveRunIdentity, type RunIdentity } from './run-identity.js';
 import { captureGateEscalation } from './self-report.js';
@@ -144,6 +145,15 @@ export function readSessionState(
     }
   }
   return null;
+}
+
+export function readSessionActiveTicket(
+  projectDirectory: string,
+  sessionId: string | RunIdentity | undefined,
+): TicketDetails | null {
+  const state = readSessionState(projectDirectory, sessionId);
+  const activeTicket = state?.activeTicket;
+  return activeTicket ? getTicketInfo(projectDirectory, activeTicket) : null;
 }
 
 /** Counter file for cross-session failure pattern tracking. */

--- a/.safeword/logs/ticket-JN403D-architecture-drift-nudge-harness-parity.md
+++ b/.safeword/logs/ticket-JN403D-architecture-drift-nudge-harness-parity.md
@@ -1,0 +1,19 @@
+# Work log - JN403D architecture-drift-nudge-harness-parity
+
+## 2026-07-02
+
+- 2026-07-02T15:33:30Z VERIFY docs/audit: Repaired Codex Stop documentation drift in README, website docs, and ARCHITECTURE.md. Tightened `/audit` documentation checks so changed-code documentation drift and documentation gaps report as errors; focused audit documentation source test passes 29/29.
+- 2026-07-02T04:48:42Z DONE: Verified PR #605 after CI surfaced the ticket-status annotation. Rebasing removed unrelated `.project/surfaces.md` scope drift; GitHub CI lint/test pass, local lint/typecheck/Gherkin pass, scenarios are 22/22 complete, and `verify.md` records done-gate evidence.
+- 2026-07-02T02:33:03Z REFACTOR: Extracted `readSessionActiveTicket` into shared quality-state helpers and updated Cursor/Codex Stop adapters to use it. Focused Stop/quality-state tests pass 15/15; `bun run --cwd packages/cli typecheck`, `bun run --cwd packages/cli lint:eslint`, and `git diff --check` pass. Commit deferred because the refactor is mixed into the existing feature diff.
+- 2026-07-02T00:34:30Z VERIFY: Focused verification passes: Cursor/Codex Stop integration, setup/upgrade/reconcile/schema suites (150 tests), targeted Cursor rerun (6 tests), `bun run --cwd packages/cli typecheck`, `git diff --check`, and Bun `--check` on template/dogfood Stop hooks.
+- 2026-07-02T00:33:30Z GREEN Cursor: Added explicit implement-phase architecture-drift silence regression. Focused Cursor Stop test file passes 6/6.
+- 2026-07-02T00:31:20Z GREEN schema: Added Codex-only `stop.ts` to schema drift-test exclusions. Focused verification set passes 6 files / 150 tests.
+- 2026-07-02T00:30:30Z REFACTOR cleanup: Synced dogfood Codex Stop config/hook manually and removed unrelated language-pack files and metadata created by the interrupted upgrade.
+- 2026-07-02T00:25:30Z GREEN config/removal: Codex Stop silence tests pass 4/4; upgrade retrofit passes 18/18; uninstall/reconcile passes 77/77.
+- 2026-07-02T00:17:47Z RED Codex config: Fresh setup test failed on missing `.safeword/hooks/codex/stop.ts` and missing `[[hooks.Stop]]` block.
+- 2026-07-02T00:16:46Z GREEN Codex: Added template `hooks/codex/stop.ts`; focused Codex Stop test passes 1/1 with `decision:"block"` continuation JSON.
+- 2026-07-02T00:15:21Z RED Codex: Added `codex-stop-nudge.test.ts` coverage for done-phase architecture drift. Failure was expected: no Codex Stop adapter exists.
+- 2026-07-02T00:13:35Z GREEN Cursor: Added done-phase architecture nudge delivery to Cursor Stop. Focused Cursor Stop test file passes 5/5. Used `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0` because another worktree held the global package-test lock.
+- 2026-07-02T00:10:45Z RED Cursor: Added `cursor-stop-review.test.ts` coverage for done-phase architecture drift. Failure was expected: Cursor Stop returned only `QUALITY_REVIEW_MESSAGE`, no architecture nudge.
+- 2026-07-02T00:03:39Z Started implementation from GitHub issue #598 after revalidation and figure-it-out. Key decision: keep `architectureDocumentNudgeForProject` as detector; add Cursor/Codex delivery only.
+- 2026-07-02T00:03:39Z Created ticket frontmatter with scope, out-of-scope, and done_when before adding test definitions, per the phase gate.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Safeword Architecture
 
 **Version:** 1.15
-**Last Updated:** 2026-06-02
+**Last Updated:** 2026-07-02
 **Status:** Production
 
 ---
@@ -23,7 +23,7 @@
 
 ## Overview
 
-Safeword is a CLI tool that configures linting, hooks, and development guides for AI coding agent projects (Claude Code and Cursor). It supports JavaScript/TypeScript projects (ESLint, Prettier), Python projects (Ruff, mypy), Go projects (golangci-lint), Rust projects (clippy, rustfmt), and dbt projects (SQLFluff).
+Safeword is a CLI tool that configures linting, hooks, and development guides for AI coding agent projects (Claude Code, Cursor, and Codex). It supports JavaScript/TypeScript projects (ESLint, Prettier), Python projects (Ruff, mypy), Go projects (golangci-lint), Rust projects (clippy, rustfmt), and dbt projects (SQLFluff).
 
 ### Tech Stack
 
@@ -82,13 +82,14 @@ packages/cli/
 │   ├── SAFEWORD.md     # Core instructions (installed to .safeword/)
 │   ├── AGENTS.md       # Project context template
 │   ├── commands/       # Slash commands (see templates/commands/ for full list)
+│   ├── codex/          # Codex hook config
 │   ├── cursor/         # Cursor IDE rules (.mdc files)
 │   ├── doc-templates/  # Feature specs, design docs, tickets
 │   ├── guides/         # Methodology guides (TDD, planning, etc.)
-│   ├── hooks/          # Claude Code hooks (lint, quality review)
+│   ├── hooks/          # Claude Code, Cursor, and Codex hook adapters
 │   ├── prompts/        # Prompt templates for commands
 │   ├── scripts/        # Shell scripts (cleanup, bisect)
-│   └── skills/         # Claude Code skills (see templates/skills/ for full list)
+│   └── skills/         # Claude Code and Codex skills (see templates/skills/ for full list)
 ```
 
 ---
@@ -514,6 +515,8 @@ Published files: `dist/` + `templates/` (bundled for setup/upgrade).
 **`additionalContext` field:** PreToolUse deny output uses `additionalContext` (Claude Code v2.1.9+) to guide Claude toward skills. `permissionDecisionReason` explains WHY blocked; `additionalContext` tells WHAT TO DO. This prevents content drift — hooks reference skills by name, skills own the review content.
 
 **Quality review cadence (SXSCJQ; implement-step reviews quieted by JENFZX):** The quality review fires at phase boundaries, not on a LOC throttle. PostToolUse surfaces a phase-appropriate review (`getQualityMessage`) as `additionalContext` on each `phase:` change in `ticket.md` — at the edit, so it works in long autonomous runs where the Stop hook never fires. Ordinary implement-step (RED/GREEN/REFACTOR) reviews no longer surface per step; they are folded into the whole-ticket review at the implement→verify exit (JENFZX). The Stop hook is a deduped backstop: it reviews per phase, but only for a boundary not already marked (`lastReviewedPhase` in session state), and still fires a generic review when there is no active ticket. The former implement-phase LOC review throttle (`LOC_REVIEW_THRESHOLD`) is removed. Shared decision logic lives in `lib/review-trigger.ts` (`shouldReviewPhase`); checkbox-flip detection in `lib/checkbox-transitions.ts`.
+
+**Cross-agent Stop delivery (JN403D):** Claude Code keeps the hard done-gate/review behavior in `stop-quality.ts`. Cursor and Codex use lighter local Stop adapters for continuation nudges, not hard done-gate enforcement: `cursor/stop.ts` appends `followup_message`, while `codex/stop.ts` emits Codex continuation output (`decision: "block"`, `reason`). Both reuse `architectureDocumentNudgeForProject` so the ARCHITECTURE.md drift advisory has one detector and agent-specific delivery wrappers.
 
 **Gate clearing:** All gates clear automatically when `git rev-parse --short HEAD` changes (i.e., a commit happened). No manual intervention needed. TDD gates have priority over LOC gate (LOC gate cannot overwrite an active TDD gate).
 

--- a/README.md
+++ b/README.md
@@ -251,12 +251,17 @@ Key directories created in your project:
 - `cursor/stop.ts` - Quality review prompt on Cursor stop
 - `cursor/post-tool-skill-nudge.ts` - Cursor adapter for the language coding-skill nudge (dormant pending Cursor bug #534)
 - `codex/pre-tool-quality.ts` - Adapts Codex PreToolUse events to safeword's quality gate
+- `codex/stop.ts` - Emits Codex Stop continuations for done-phase reminders, including ARCHITECTURE.md drift nudges
 - `codex/post-tool-skill-nudge.ts` - Codex adapter for the language coding-skill nudge
 
-Codex hook coverage is limited to the documented PreToolUse tool calls that
-Safeword configures (`Bash`, `apply_patch` edit payloads, and MCP tools). Live
-Codex runs can also report `file_change` execution items; those are recorded as
-a runtime boundary, not as edits Safeword claims to guard through PreToolUse.
+Codex edit-gate coverage is limited to the documented PreToolUse tool calls
+that Safeword configures (`Bash`, `apply_patch` edit payloads, and MCP tools).
+Live Codex runs can also report `file_change` execution items; those are
+recorded as a runtime boundary, not as edits Safeword claims to guard through
+PreToolUse. Codex Stop hooks are separate: Safeword uses Codex continuation
+semantics (`decision: "block"`, `reason`) to nudge the agent after a turn,
+including ARCHITECTURE.md drift reminders, without claiming hard done-gate
+enforcement.
 
 **Skills** (in `.claude/skills/` and `.agents/skills/`): Specialized agent capabilities
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -225,6 +225,16 @@ timeout = 30
 statusMessage = "Surfacing language-skill guidance"
 `;
 
+const CODEX_STOP_NUDGE_HOOK_PATCH = `
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
+timeout = 30
+statusMessage = "Checking safeword Stop nudges"
+`;
+
 // MCP servers for Codex parity with .mcp.json / .cursor/mcp.json (#269).
 // context7 uses the hosted streamable-HTTP transport (url); playwright uses
 // stdio (command/args) — matching MCP_SERVERS. Shipped via the codex/config.toml
@@ -732,6 +742,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/codex/post-tool-skill-nudge.ts': {
       template: 'hooks/codex/post-tool-skill-nudge.ts',
     },
+    '.safeword/hooks/codex/stop.ts': {
+      template: 'hooks/codex/stop.ts',
+    },
     '.safeword/hooks/write-review-stamp.ts': {
       template: 'hooks/write-review-stamp.ts',
     },
@@ -1215,6 +1228,18 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
         operation: 'append',
         content: CODEX_POST_TOOL_SKILL_NUDGE_HOOK_PATCH,
         marker: '.safeword/hooks/codex/post-tool-skill-nudge.ts',
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
+      },
+      // Stop architecture-nudge retrofit (#598): Codex Stop is a continuation
+      // surface, so this wires only the one-shot advisory adapter. Marker is the
+      // hook path to keep user-authored Stop hooks intact and avoid duplicates.
+      {
+        operation: 'append',
+        content: CODEX_STOP_NUDGE_HOOK_PATCH,
+        marker: '.safeword/hooks/codex/stop.ts',
         applyWhenContentIncludes: [
           '# Safeword Codex project configuration.',
           '.safeword/hooks/codex/pre-tool-quality.ts',

--- a/packages/cli/templates/codex/config.toml
+++ b/packages/cli/templates/codex/config.toml
@@ -41,6 +41,14 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool
 timeout = 30
 statusMessage = "Surfacing language-skill guidance"
 
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
+timeout = 30
+statusMessage = "Checking safeword Stop nudges"
+
 [mcp_servers.context7]
 url = "https://mcp.context7.com/mcp"
 

--- a/packages/cli/templates/commands/audit.md
+++ b/packages/cli/templates/commands/audit.md
@@ -320,7 +320,7 @@ Test Quality:
 - If missing → create from `.safeword/templates/architecture-template.md`
 - If exists → check for drift and gaps:
   - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-  - **Gap (warn):** Major dependencies not documented
+  - **Gap (error):** Major dependencies not documented
 
 **README.md:**
 
@@ -333,7 +333,7 @@ Test Quality:
 
 **Documentation impact check:**
 
-Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag any documentation that references changed code but hasn't been updated.
+Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
 ---
 
@@ -345,13 +345,14 @@ Report findings by severity with codes:
 
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
+- [E004] Documentation drift: Codex Stop hook behavior changed, but `README.md` or docs still describe only PreToolUse coverage
+- [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
 
 ### Warnings (should review)
 
 - [W001] Size: `CLAUDE.md` has 245 instructions (recommended: 150-200)
 - [W002] Structure: `AGENTS.md` missing recommended WHAT/WHY/HOW sections
 - [W003] Staleness: `README.md` last modified 45 days ago (12 commits since)
-- [W004] Gap: `@tanstack/query` not documented in ARCHITECTURE.md
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
 

--- a/packages/cli/templates/hooks/codex/stop.ts
+++ b/packages/cli/templates/hooks/codex/stop.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+// Safeword: Codex Stop adapter for one-shot continuation nudges.
+//
+// Codex Stop cannot hard-block completion. `decision: "block"` creates a new
+// continuation prompt, so this adapter only delivers non-blocking advisories
+// whose enforcement already lives elsewhere.
+
+import { existsSync } from 'node:fs';
+
+import { getActiveTicket } from '../lib/active-ticket.ts';
+import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
+import { readSessionActiveTicket } from '../lib/quality-state.ts';
+import { resolveRunIdentity } from '../lib/run-identity.ts';
+import { installCrashCapture } from '../lib/self-report.ts';
+
+installCrashCapture('codex-stop', undefined, 'codex');
+
+interface CodexStopInput {
+  session_id?: string;
+  turn_id?: string;
+  stop_hook_active?: boolean;
+  last_assistant_message?: string | null;
+}
+
+async function readInput(): Promise<CodexStopInput> {
+  try {
+    return JSON.parse(await Bun.stdin.text()) as CodexStopInput;
+  } catch {
+    return {};
+  }
+}
+
+function isDonePhaseWork(projectDirectory: string, input: CodexStopInput): boolean {
+  const runIdentity = resolveRunIdentity(input, { runtime: 'codex' });
+  const ticket = readSessionActiveTicket(projectDirectory, runIdentity);
+  if (ticket) {
+    return ticket.status === 'in_progress' && ticket.phase === 'done';
+  }
+
+  return getActiveTicket(projectDirectory).phase === 'done';
+}
+
+const input = await readInput();
+const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+if (input.stop_hook_active === true) process.exit(0);
+if (!existsSync(`${projectDirectory}/.safeword`)) process.exit(0);
+if (!isDonePhaseWork(projectDirectory, input)) process.exit(0);
+
+const architectureNudge = architectureDocumentNudgeForProject(projectDirectory);
+if (architectureNudge === null) process.exit(0);
+
+console.log(
+  JSON.stringify({
+    decision: 'block',
+    reason: architectureNudge,
+  }),
+);

--- a/packages/cli/templates/hooks/cursor/stop.ts
+++ b/packages/cli/templates/hooks/cursor/stop.ts
@@ -8,9 +8,9 @@
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 
-import { getTicketInfo } from '../lib/active-ticket.ts';
+import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
 import { QUALITY_REVIEW_MESSAGE } from '../lib/quality.ts';
-import { readSessionState } from '../lib/quality-state.ts';
+import { readSessionActiveTicket } from '../lib/quality-state.ts';
 import { getRunStorageKey, resolveRunIdentity } from '../lib/run-identity.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
 
@@ -31,11 +31,18 @@ function isAutomatedEvidenceRun(
   workspace: string,
   runIdentity: ReturnType<typeof resolveRunIdentity>,
 ): boolean {
-  const state = readSessionState(workspace, runIdentity);
-  const activeTicket = state?.activeTicket;
-  if (!activeTicket) return false;
-  const phase = getTicketInfo(workspace, activeTicket).phase;
+  const phase = readSessionActiveTicket(workspace, runIdentity)?.phase;
   return phase === 'implement' || phase === 'verify';
+}
+
+function architectureNudgeForDonePhase(
+  workspace: string,
+  runIdentity: ReturnType<typeof resolveRunIdentity>,
+): string | null {
+  const ticketInfo = readSessionActiveTicket(workspace, runIdentity);
+  if (!ticketInfo) return null;
+  if (ticketInfo.status !== 'in_progress' || ticketInfo.phase !== 'done') return null;
+  return architectureDocumentNudgeForProject(workspace);
 }
 
 // Read hook input from stdin
@@ -79,13 +86,15 @@ if (await Bun.file(markerFile).exists()) {
     if (process.env.DEBUG) console.error('[cursor/stop] marker cleanup failed:', error);
   });
 
-  if (isAutomatedEvidenceRun(process.cwd(), runIdentity)) {
+  const architectureNudge = architectureNudgeForDonePhase(process.cwd(), runIdentity);
+  if (isAutomatedEvidenceRun(process.cwd(), runIdentity) && architectureNudge === null) {
     console.log('{}');
     process.exit(0);
   }
 
+  const followupMessage = [architectureNudge, QUALITY_REVIEW_MESSAGE].filter(Boolean).join('\n\n');
   const output: StopOutput = {
-    followup_message: QUALITY_REVIEW_MESSAGE,
+    followup_message: followupMessage,
   };
   console.log(JSON.stringify(output));
 } else {

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -5,6 +5,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
+import { getTicketInfo, type TicketDetails } from './active-ticket.js';
 import { resolveNamespaceRoot } from './namespace-root.js';
 import { getRunStorageKey, resolveRunIdentity, type RunIdentity } from './run-identity.js';
 import { captureGateEscalation } from './self-report.js';
@@ -144,6 +145,15 @@ export function readSessionState(
     }
   }
   return null;
+}
+
+export function readSessionActiveTicket(
+  projectDirectory: string,
+  sessionId: string | RunIdentity | undefined,
+): TicketDetails | null {
+  const state = readSessionState(projectDirectory, sessionId);
+  const activeTicket = state?.activeTicket;
+  return activeTicket ? getTicketInfo(projectDirectory, activeTicket) : null;
 }
 
 /** Counter file for cross-session failure pattern tracking. */

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -355,12 +355,12 @@ Test Quality:
 - If exists → check for drift and gaps along TWO axes — dependency drift (what tech) and structural drift (what modules/layers):
   - **Dependency drift:**
     - **Drift (error):** Documented tech contradicts the code's actual dependencies (e.g., doc says "Redux" but `package.json` has "zustand"; doc says "Flask" but `pyproject.toml` has "fastapi")
-    - **Gap (warn):** Major dependencies not documented
+    - **Gap (error):** Major dependencies not documented
   - **Structural drift** — reconcile ARCHITECTURE.md's STRUCTURAL claims against `architecture.generated.md`, the deterministic, always-fresh module/package map (kept current by the architecture hooks). Read the generated doc as ground truth — NOT `package.json`:
     - Read the namespace-root `architecture.generated.md` (resolve the namespace root the same way as other audit checks; default `.project/`). Its `### <name>` headings under `## Modules` (single-repo) or `## Packages` (monorepo) ARE the project's real top-level units. This machine list is the source of structural truth, so the verdict is deterministic-by-reading, not guessed.
     - **Orphaned (error):** ARCHITECTURE.md documents a module/layer — including a layer→directory mapping in its "Layers & Boundaries" table — that no longer appears in the generated map (renamed or removed).
-    - **Missing (warn):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
-    - **Drifted layer→dir (warn):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
+    - **Missing (error):** A real top-level module/package in the generated map that ARCHITECTURE.md never mentions.
+    - **Drifted layer→dir (error):** A "Layers & Boundaries" `directory` entry that matches no module path in the generated map.
     - **Report only — never auto-overwrite prose.** Cite the generated-doc evidence and propose narrative edits for the user to review; the human "why" is human-owned, and only a person can judge whether a paragraph is still true. The deterministic structural facts come from reading the generated doc; the narrative judgment stays with the human/agent.
   - A monorepo `## Coverage gaps` advisory in the generated doc (a present-but-unparseable workspace manager, #558) is itself a coverage limitation — note it so the structural reconciliation isn't mistaken for complete.
 
@@ -375,7 +375,7 @@ Test Quality:
 
 **Documentation impact check:**
 
-Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag any documentation that references changed code but hasn't been updated.
+Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
 ---
 
@@ -388,18 +388,19 @@ Report findings by severity with codes:
 - [E001] Dead ref: `CLAUDE.md` references missing file `src/foo.ts`
 - [E002] Drift: `ARCHITECTURE.md` documents Redux, code uses Zustand
 - [E003] Structural drift: `ARCHITECTURE.md` documents module `legacy-sync` — absent from `architecture.generated.md` (orphaned; renamed or removed)
+- [E004] Documentation drift: Codex Stop hook behavior changed, but `README.md` or docs still describe only PreToolUse coverage
+- [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
+- [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
+- [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Warnings (should review)
 
 - [W001] Size: `CLAUDE.md` has 245 instructions (recommended: 150-200)
 - [W002] Structure: `AGENTS.md` missing recommended WHAT/WHY/HOW sections
 - [W003] Staleness: `README.md` last modified 45 days ago (12 commits since)
-- [W004] Gap: `@tanstack/query` not documented in ARCHITECTURE.md
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
-- [W008] Structural gap: module `billing` in `architecture.generated.md` not documented in `ARCHITECTURE.md` (missing)
-- [W009] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
 
 ### Code Quality
 

--- a/packages/cli/tests/commands/setup-reconcile.test.ts
+++ b/packages/cli/tests/commands/setup-reconcile.test.ts
@@ -210,6 +210,9 @@ describe('Setup Command - Reconcile Integration', () => {
           nodePath.join(temporaryDirectory, '.safeword/hooks/codex/pre-tool-quality-helpers.ts'),
         ),
       ).toBe(true);
+      expect(existsSync(nodePath.join(temporaryDirectory, '.safeword/hooks/codex/stop.ts'))).toBe(
+        true,
+      );
     });
 
     it('should wire Codex hooks through a single SessionStart dispatcher', async () => {
@@ -226,6 +229,9 @@ describe('Setup Command - Reconcile Integration', () => {
       expect(content).toContain('[[hooks.SessionStart]]');
       expect(content.match(/\[\[hooks\.SessionStart\]\]/g)).toHaveLength(1);
       expect(content).toContain('.safeword/hooks/session-codex-start.ts');
+      expect(content).toContain('[[hooks.Stop]]');
+      expect(content).toContain('.safeword/hooks/codex/stop.ts');
+      expect(content.match(/\[\[hooks\.Stop\]\]/g)).toHaveLength(1);
       expect(content).not.toContain('.safeword/hooks/session-safeword-context.ts" --agent=codex');
     });
 

--- a/packages/cli/tests/commands/upgrade-reconcile.test.ts
+++ b/packages/cli/tests/commands/upgrade-reconcile.test.ts
@@ -309,7 +309,7 @@ describe('Upgrade Command - Reconcile Integration', () => {
       ).toBe(true);
     });
 
-    it('should add prompt timestamp hook to existing safeword Codex config', async () => {
+    it('should add missing Codex hooks to existing safeword Codex config', async () => {
       const { reconcile } = await import('../../src/reconcile.js');
       const { SAFEWORD_SCHEMA } = await import('../../src/schema.js');
       const { createProjectContext } = await import('../../src/utils/context.js');
@@ -347,6 +347,8 @@ statusMessage = "Checking safeword PreToolUse gates"
       expect(upgraded).toContain('[[hooks.UserPromptSubmit]]');
       expect(upgraded).toContain('.safeword/hooks/prompt-timestamp.ts');
       expect(upgraded).toContain('.safeword/hooks/codex/pre-tool-quality.ts');
+      expect(upgraded).toContain('[[hooks.Stop]]');
+      expect(upgraded).toContain('.safeword/hooks/codex/stop.ts');
 
       await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
       const upgradedAgain = readFileSync(
@@ -356,6 +358,8 @@ statusMessage = "Checking safeword PreToolUse gates"
       const timestampHookCount =
         upgradedAgain.split('.safeword/hooks/prompt-timestamp.ts').length - 1;
       expect(timestampHookCount).toBe(1);
+      const stopHookCount = upgradedAgain.split('.safeword/hooks/codex/stop.ts').length - 1;
+      expect(stopHookCount).toBe(1);
     });
 
     it('migrates a customized legacy Codex config: swaps the context-only SessionStart hook for the auto-upgrade dispatcher', async () => {

--- a/packages/cli/tests/integration/codex-stop-nudge.test.ts
+++ b/packages/cli/tests/integration/codex-stop-nudge.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for Codex Stop-hook architecture drift nudges.
+ *
+ * Codex Stop is a continuation surface, not a hard done gate: `decision: "block"`
+ * creates a follow-up prompt. The architecture document nudge should use that
+ * continuation shape only when done-phase work moved the generated architecture
+ * fingerprint.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ARCHITECTURE_DOCUMENT_NUDGE } from '../../templates/hooks/lib/architecture-document-nudge.js';
+import {
+  createTemporaryDirectory,
+  initGitRepo,
+  removeTemporaryDirectory,
+  writeTestFile,
+} from '../helpers';
+
+const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+const CODEX_STOP = nodePath.join(SAFEWORD_ROOT, 'packages/cli/templates/hooks/codex/stop.ts');
+
+function generatedArchitectureDocument(fingerprint: string): string {
+  return `---\ngenerator: safeword-architecture\nfingerprint: ${fingerprint}\n---\n\n# Architecture\n`;
+}
+
+function buildProject(options: { phase: string; architectureDrift?: boolean }): string {
+  const cwd = createTemporaryDirectory();
+  initGitRepo(cwd);
+  writeTestFile(cwd, '.safeword/.gitkeep', '');
+  writeTestFile(cwd, 'ARCHITECTURE.md', '# Architecture\n\nHuman narrative.\n');
+  writeTestFile(
+    cwd,
+    '.project/architecture.generated.md',
+    generatedArchitectureDocument('base-fp'),
+  );
+  writeTestFile(
+    cwd,
+    '.project/tickets/C0DEX1-demo/ticket.md',
+    [
+      '---',
+      'id: C0DEX1',
+      'status: in_progress',
+      'type: task',
+      `phase: ${options.phase}`,
+      '---',
+    ].join('\n'),
+  );
+  execSync('git add . && git commit -qm base', { cwd, stdio: 'pipe' });
+
+  if (options.architectureDrift === true) {
+    const baseBranch = execSync('git branch --show-current', { cwd, encoding: 'utf8' }).trim();
+    execSync('git checkout -q -b feature-architecture-drift', { cwd, stdio: 'pipe' });
+    execSync(`git branch --set-upstream-to=${baseBranch} feature-architecture-drift`, {
+      cwd,
+      stdio: 'pipe',
+    });
+    writeTestFile(
+      cwd,
+      '.project/architecture.generated.md',
+      generatedArchitectureDocument('moved-fp'),
+    );
+  }
+
+  return cwd;
+}
+
+function runCodexStop(cwd: string, input: Record<string, unknown> = {}) {
+  return spawnSync('bun', [CODEX_STOP], {
+    cwd,
+    input: JSON.stringify({
+      session_id: 'codex-session',
+      stop_hook_active: false,
+      last_assistant_message: 'Done.',
+      ...input,
+    }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, SAFEWORD_AGENT_RUNTIME: 'codex' },
+    encoding: 'utf8',
+    timeout: 20_000,
+  });
+}
+
+describe('Codex Stop architecture drift nudge', () => {
+  let cwd = '';
+
+  afterEach(() => {
+    if (cwd) removeTemporaryDirectory(cwd);
+    cwd = '';
+  });
+
+  it('emits the architecture drift advisory as a continuation nudge for done-phase work', () => {
+    cwd = buildProject({ phase: 'done', architectureDrift: true });
+
+    const result = runCodexStop(cwd);
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse((result.stdout ?? '').trim()) as {
+      decision?: string;
+      reason?: string;
+    };
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).toContain(ARCHITECTURE_DOCUMENT_NUDGE);
+  });
+
+  it('stays silent outside done-phase work', () => {
+    cwd = buildProject({ phase: 'implement', architectureDrift: true });
+
+    const result = runCodexStop(cwd);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
+  it('stays silent when no architecture drift is detected', () => {
+    cwd = buildProject({ phase: 'done', architectureDrift: false });
+
+    const result = runCodexStop(cwd);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
+  it('does not re-enter when a Codex Stop continuation is already active', () => {
+    cwd = buildProject({ phase: 'done', architectureDrift: true });
+
+    const result = runCodexStop(cwd, { stop_hook_active: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/packages/cli/tests/integration/cursor-stop-review.test.ts
+++ b/packages/cli/tests/integration/cursor-stop-review.test.ts
@@ -12,6 +12,7 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { ARCHITECTURE_DOCUMENT_NUDGE } from '../../templates/hooks/lib/architecture-document-nudge.js';
 import {
   createTemporaryDirectory,
   initGitRepo,
@@ -32,16 +33,41 @@ const TEMPLATE_CURSOR_STOP = nodePath.join(
 const CONVERSATION_ID = 'conv-quiet-implement';
 const MARKER_FILE = `/tmp/safeword-cursor-edited-cursor-${CONVERSATION_ID}`;
 
-function buildProject(phase: string): string {
+function generatedArchitectureDocument(fingerprint: string): string {
+  return `---\ngenerator: safeword-architecture\nfingerprint: ${fingerprint}\n---\n\n# Architecture\n`;
+}
+
+function moveArchitectureFingerprint(cwd: string): void {
+  const baseBranch = execSync('git branch --show-current', { cwd, encoding: 'utf8' }).trim();
+  execSync('git checkout -q -b feature-architecture-drift', { cwd, stdio: 'pipe' });
+  execSync(`git branch --set-upstream-to=${baseBranch} feature-architecture-drift`, {
+    cwd,
+    stdio: 'pipe',
+  });
+  writeTestFile(
+    cwd,
+    '.safeword-project/architecture.generated.md',
+    generatedArchitectureDocument('moved-fp'),
+  );
+}
+
+function buildProject(phase: string, options: { architectureDrift?: boolean } = {}): string {
   const cwd = createTemporaryDirectory();
   initGitRepo(cwd);
   writeTestFile(cwd, '.safeword/.gitkeep', '');
+  writeTestFile(cwd, 'ARCHITECTURE.md', '# Architecture\n\nHuman narrative.\n');
+  writeTestFile(
+    cwd,
+    '.safeword-project/architecture.generated.md',
+    generatedArchitectureDocument('base-fp'),
+  );
   writeTestFile(
     cwd,
     '.safeword-project/tickets/JENFZX-demo/ticket.md',
     ['---', 'id: JENFZX', 'status: in_progress', 'type: task', `phase: ${phase}`, '---'].join('\n'),
   );
   execSync('git add . && git commit -qm base', { cwd, stdio: 'pipe' });
+  if (options.architectureDrift === true) moveArchitectureFingerprint(cwd);
   bindActiveTicketThroughCursorPostTool(cwd);
   return cwd;
 }
@@ -104,6 +130,15 @@ describe('Cursor stop review surface', () => {
     expect(JSON.parse(result.stdout)).toEqual({});
   });
 
+  it('does not emit the architecture drift nudge during implement-phase work', () => {
+    cwd = buildProject('implement', { architectureDrift: true });
+
+    const result = runCursorStop(cwd);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({});
+  });
+
   it('does not emit a generic follow-up before verify has run', () => {
     cwd = buildProject('verify');
 
@@ -121,6 +156,16 @@ describe('Cursor stop review surface', () => {
 
     expect(result.status).toBe(0);
     expect(parsed.followup_message).toContain('Phase: implement');
+  });
+
+  it('includes the architecture drift nudge for done-phase work when the fingerprint moved', () => {
+    cwd = buildProject('done', { architectureDrift: true });
+
+    const result = runCursorStop(cwd);
+    const parsed = JSON.parse(result.stdout) as { followup_message?: string };
+
+    expect(result.status).toBe(0);
+    expect(parsed.followup_message).toContain(ARCHITECTURE_DOCUMENT_NUDGE);
   });
 
   it('keeps crash capture wired in both Cursor stop hook copies', () => {

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1201,6 +1201,9 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).toContain('model = "gpt-5-codex"');
       expect(content).not.toContain('.safeword/hooks/prompt-timestamp.ts');
       expect(content).not.toContain('.safeword/hooks/codex/pre-tool-quality.ts');
+      expect(content).not.toContain('.safeword/hooks/codex/post-tool-skill-nudge.ts');
+      expect(content).not.toContain('.safeword/hooks/codex/stop.ts');
+      expect(content).not.toContain('[[hooks.Stop]]');
     });
 
     it('should clean legacy Codex config that only has the safeword PreToolUse hook', async () => {

--- a/packages/cli/tests/schema.test.ts
+++ b/packages/cli/tests/schema.test.ts
@@ -573,6 +573,8 @@ describe('Schema - Single Source of Truth', () => {
       const NON_LIFECYCLE_HOOK_MODULES = new Set([
         // Codex-only dispatcher wired through .codex/config.toml, not Claude SETTINGS_HOOKS.
         'session-codex-start.ts',
+        // Codex-only Stop adapter wired through .codex/config.toml, not Claude SETTINGS_HOOKS.
+        'stop.ts',
         // Cursor-only wrapper wired through .cursor/hooks.json, not Claude SETTINGS_HOOKS.
         'session-cursor-auto-upgrade.ts',
         'write-review-stamp.ts',

--- a/packages/cli/tests/skills/audit-documentation-sources.test.ts
+++ b/packages/cli/tests/skills/audit-documentation-sources.test.ts
@@ -15,6 +15,12 @@ const AUDIT_SURFACES = [
   '.cursor/commands/audit.md',
 ];
 
+const AUDIT_SKILL_SURFACES = [
+  'packages/cli/templates/skills/audit/SKILL.md',
+  '.agents/skills/audit/SKILL.md',
+  '.claude/skills/audit/SKILL.md',
+];
+
 function extractBashBlock(content: string, ordinal: number): string {
   const blocks = content
     .matchAll(/```bash\n[\s\S]*?\n```/g)
@@ -107,6 +113,33 @@ describe('audit documentation source guidance', () => {
     expect(content).toContain('If `docs.sources: []` is configured, do not prompt');
     expect(content).toContain('Always report docs coverage');
   });
+
+  it.each(AUDIT_SURFACES)('%s reports documentation drift as an error', relativePath => {
+    const content = readFileSync(nodePath.join(ROOT, relativePath), 'utf8');
+
+    expect(content).toContain('Gap (error)');
+    expect(content).toContain('Documentation drift is never a warning');
+    expect(content).toContain('[E004] Documentation drift');
+    expect(content).toContain('[E005] Dependency gap');
+    expect(content).not.toContain('Gap (warn)');
+    expect(content).not.toContain('[W004] Gap');
+  });
+
+  it.each(AUDIT_SKILL_SURFACES)(
+    '%s reports structural documentation gaps as errors',
+    relativePath => {
+      const content = readFileSync(nodePath.join(ROOT, relativePath), 'utf8');
+
+      expect(content).toContain('Missing (error)');
+      expect(content).toContain('Drifted layer→dir (error)');
+      expect(content).toContain('[E006] Structural gap');
+      expect(content).toContain('[E007] Drifted layer→dir');
+      expect(content).not.toContain('Missing (warn)');
+      expect(content).not.toContain('Drifted layer→dir (warn)');
+      expect(content).not.toContain('[W008] Structural gap');
+      expect(content).not.toContain('[W009] Drifted layer→dir');
+    },
+  );
 });
 
 describe('audit installed-project stack awareness', () => {

--- a/packages/website/src/content/docs/getting-started/quick-start.mdx
+++ b/packages/website/src/content/docs/getting-started/quick-start.mdx
@@ -39,6 +39,8 @@ You use Claude Code, Cursor, or Codex the same way you always have. Type a promp
 
     **PreToolUse gates run through Codex hooks.** Safeword writes `.codex/config.toml` and a Codex adapter at `.safeword/hooks/codex/pre-tool-quality.ts`. After setup or upgrade, review and trust the project hooks in Codex before relying on those gates. Safeword guards the documented Codex PreToolUse paths it configures: `Bash`, `apply_patch` edit payloads, and MCP tools.
 
+    **Stop nudges run through Codex continuations.** Safeword also installs `.safeword/hooks/codex/stop.ts`, which can continue the turn with advisory text after the agent stops. That is how done-phase reminders such as ARCHITECTURE.md drift nudges reach Codex; it is not hard done-gate enforcement.
+
   </TabItem>
 </Tabs>
 
@@ -75,6 +77,7 @@ Open your project and ask your agent to build something real:
     2. Your agent follows the safeword skills in `.agents/skills/`
     3. Before supported edits, Codex runs `.safeword/hooks/codex/pre-tool-quality.ts`
     4. If a safeword gate blocks the edit, your agent gets the denial before changing files
+    5. When the agent stops, Codex runs `.safeword/hooks/codex/stop.ts` for continuation nudges such as ARCHITECTURE.md drift reminders
 
   </TabItem>
 </Tabs>

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -90,8 +90,9 @@ Hooks run automatically at key moments. You don't invoke them—they work in the
     | ---------------------- | ------------------------------------------------- |
     | Before supported tools | Runs safeword's PreToolUse quality gate adapter |
     | Agent edits Go/Python/TS/Rust | Points it at that language's coding-skill |
+    | When the agent stops | Sends continuation nudges such as the ARCHITECTURE.md drift advisory |
 
-    Safeword's Codex adapter covers the documented PreToolUse paths it configures: `Bash`, `apply_patch` edit payloads, and MCP tools. Live Codex runs can also report `file_change` execution items; Safeword records that as a Codex runtime boundary, not as a PreToolUse path it claims to guard.
+    Safeword's Codex edit-gate adapter covers the documented PreToolUse paths it configures: `Bash`, `apply_patch` edit payloads, and MCP tools. Live Codex runs can also report `file_change` execution items; Safeword records that as a Codex runtime boundary, not as a PreToolUse path it claims to guard. The Codex Stop adapter is separate: it uses Codex continuation output to nudge the agent after a turn, including done-phase ARCHITECTURE.md drift reminders, without claiming hard done-gate enforcement.
 
     ### Skills
 
@@ -102,7 +103,7 @@ Hooks run automatically at key moments. You don't invoke them—they work in the
     Project-local Codex hooks only run after you review and trust them in Codex. Safeword writes the config, but Codex owns the trust decision.
 
     Hook config: `.codex/config.toml`
-    Hook adapter: `.safeword/hooks/codex/pre-tool-quality.ts`
+    Hook adapters: `.safeword/hooks/codex/pre-tool-quality.ts`, `.safeword/hooks/codex/stop.ts`
     Skill files: `.agents/skills/`
 
   </TabItem>


### PR DESCRIPTION
## Summary

- Wire architecture drift nudges into Cursor Stop output alongside the quality-review follow-up.
- Add a Codex Stop hook adapter and register it through config/schema reconciliation.
- Extend setup, upgrade, uninstall, Cursor, and Codex tests; extract shared session active-ticket lookup into quality-state.

## Verification

- `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run --cwd packages/cli test tests/integration/cursor-stop-review.test.ts tests/integration/codex-stop-nudge.test.ts tests/commands/setup-reconcile.test.ts tests/commands/upgrade-reconcile.test.ts tests/reconcile.test.ts tests/schema.test.ts`
- `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run --cwd packages/cli test tests/integration/cursor-stop-review.test.ts tests/integration/codex-stop-nudge.test.ts tests/hooks/quality-state-read.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli lint:eslint`
- `git diff --check`
- `bun packages/cli/src/cli.ts sync-config --check`
- Push hook schema-drift tests: 627/627

Closes #598
