### PR TITLE
Fix duplicate readiness lineage tags

### DIFF
--- a/features/feature-ticket-readiness.feature
+++ b/features/feature-ticket-readiness.feature
@@ -5,7 +5,7 @@
 # The feature is @wip because hook behavior is already exercised more directly
 # by spawning the Bun hook scripts against temp projects; cucumber step
 # definitions would duplicate that harness without adding confidence.
-@wip @feature-ticket-readiness.TB1.AC1
+@wip
 Feature: Feature ticket readiness before define-behavior
 
   Feature tickets require complete intake artifacts before scenario formulation
@@ -15,13 +15,13 @@ Feature: Feature ticket readiness before define-behavior
 
   Rule: New feature tickets must be ready before entering define-behavior
 
-    @feature-ticket-readiness.TB1.AC1 @feature-ticket-readiness.SM1.AC1
+    @feature-ticket-readiness.TB1.AC1
     Scenario: A feature missing scope frontmatter is denied when phase advances
       Given an in-progress feature ticket in intake without scope, out_of_scope, or done_when
       When the agent edits ticket.md to set phase: define-behavior
       Then the edit is denied with a readiness message naming the missing frontmatter fields
 
-    @feature-ticket-readiness.TB1.AC1 @feature-ticket-readiness.SM1.AC1
+    @feature-ticket-readiness.TB1.AC1
     Scenario: A feature missing spec and dimensions is denied before define-behavior
       Given an in-progress feature ticket in intake with complete scope frontmatter but no spec.md or dimensions.md
       When the agent edits ticket.md to set phase: define-behavior


### PR DESCRIPTION
## Summary

- remove the inherited Feature-level AC lineage tag from `features/feature-ticket-readiness.feature`
- keep exactly one effective `@<jtbd>.AC#` lineage tag per readiness scenario
- leave `@wip` and scenario coverage intact

Fixes #428

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test:bdd` — 181 scenarios / 3414 steps passed
- `bun run test:smoke:fast` — 59 files / 812 tests passed
- `bun run --cwd packages/cli test src/utils/gherkin-feature.test.ts src/utils/scenario-coverage.test.ts tests/commands/check.test.ts` — 3 files / 81 tests passed
- targeted schema drift test — 31 tests passed after removing ignored local `.safeword/self-reports/cli.jsonl` runtime state
- direct lineage/coverage check — no lineage issues; no uncovered/stale/orphan refs

## Audit

- `/verify` invocation proof logged
- `/audit` invocation proof logged
- `bun packages/cli/src/cli.ts sync-config --check` — clean
- `bunx depcruise --output-type err --config .dependency-cruiser.cjs .` — no dependency violations
- `bun packages/cli/src/cli.ts architecture --check` — current
- `bun audit --json` — no advisories
- Cursor rule `@...` references — clean
- learning files Covers-line check — clean
- sampled test anti-pattern scan — clean

Known audit baseline, not changed by this PR: `knip` and `jscpd` report existing repo-wide findings; `bun outdated` reports dev-package patch/minor updates only. Full `bun run test` was attempted, but the local run was stopped after a long-running tail; the branch-scope targeted tests and fast smoke suite passed.