### PR TITLE
Codex retro parity

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,6 +23,14 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/prompt-timestam
 timeout = 5
 statusMessage = "Adding current timestamp"
 
+[[hooks.UserPromptSubmit]]
+
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/prompt-retro-nudge.ts"'
+timeout = 30
+statusMessage = "Checking spooled safeword retro drafts"
+
 [[hooks.PreToolUse]]
 matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
 
@@ -31,6 +39,14 @@ type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-quality.ts"'
 timeout = 30
 statusMessage = "Checking safeword PreToolUse gates"
+
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
+timeout = 600
+statusMessage = "Running safeword retro if this session is substantial"
 
 [[hooks.PostToolUse]]
 matcher = "^(apply_patch|Edit|Write|MultiEdit|NotebookEdit)$"
@@ -47,11 +63,3 @@ url = "https://mcp.context7.com/mcp"
 [mcp_servers.playwright]
 command = "bunx"
 args = ["@playwright/mcp@latest"]
-
-[[hooks.Stop]]
-
-[[hooks.Stop.hooks]]
-type = "command"
-command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
-timeout = 30
-statusMessage = "Checking whether to run a safeword retro"

--- a/.project/tickets/CDX602-codex-retro-parity/dimensions.md
+++ b/.project/tickets/CDX602-codex-retro-parity/dimensions.md
@@ -1,0 +1,14 @@
+# Dimensions: Codex retro parity (CDX602)
+
+| Dimension | Partitions / boundaries | Scenarios |
+| --- | --- | --- |
+| Stop payload viability | readable transcript; unreadable/malformed input | Stop hook runs child with inline digest; Stop fails open |
+| Child extractor contract | schema-valid output; non-zero/empty/invalid output; closed stdin | Stop hook runs child with inline digest; Stop fails open |
+| Model default | Claude `sonnet`; Codex `gpt-5.5`; config override | Per-agent model defaults |
+| Filing outcome | valid findings with leak canary + REST success; auth failure; retryable server error; filing timeout; no findings | adversarial egress/spool/direct filing; Lane-2 nudge; no-op empty output |
+| Conversation surface | Stop stdout; UserPromptSubmit additionalContext | invisible Stop; Codex prompt-retro-nudge |
+| State mutation on failure | malformed input; missing transcript; child non-zero; child timeout; empty output; invalid schema | fail-open leaves delta state, spool, and filed records untouched |
+| Recursion | normal session child env includes `SAFEWORD_RETRO_CHILD=1`; hook invoked under `SAFEWORD_RETRO_CHILD=1` | child spawn guarded; retro child Stop spawns nothing |
+
+No additional open partitions: Codex cloud, alternate Stop output mechanisms, and
+replacing the shared core are explicitly out of scope in #602.

--- a/.project/tickets/CDX602-codex-retro-parity/impl-plan.md
+++ b/.project/tickets/CDX602-codex-retro-parity/impl-plan.md
@@ -1,0 +1,61 @@
+# Impl Plan: Codex retro parity — invisible local extraction and Lane-2 filing
+
+**Status:** implemented
+
+## Approach
+
+**Riskiest assumption:** a Codex Stop hook can synchronously spawn child
+`codex exec` with a readable `transcript_path`, closed stdin, inline digest, and
+`--output-schema` without hanging or returning unusable output. The cheapest proof
+was the required live gating spike, completed before implementation and posted to
+issue #602: Stop payload had a readable transcript, child exit status 0,
+schema-valid JSON in the `-o` file, and a silent Stop hook completed with parent
+status 0.
+
+Proof plan and build order:
+
+| Scenario | Owner / layer | Primary proof | Why enough |
+| --- | --- | --- | --- |
+| Stop hook runs child extraction with inline digest | `hooks/lib/retro-extract.ts` Codex argv/parser + `hooks/codex/stop.ts` | integration (hook subprocess with injected child command) | drives the real hook entry point while mocking only the child process boundary |
+| Stop hook fails open without a continuation | `hooks/codex/stop.ts` | integration | malformed input, child non-zero/timeout, missing output, invalid schema all assert stdout stays empty, exit 0, and no state/spool/file mutation happens |
+| Retro child Stop does not recurse | `hooks/codex/stop.ts` + `SAFEWORD_RETRO_CHILD` | integration | proves the hook exits before spawning when the child sentinel is present |
+| Per-agent model defaults | `resolveRetroModel(project, agent)` | unit | pure config/default selection; guards Claude `sonnet` while adding Codex `gpt-5.5` |
+| Configured model override | `resolveRetroModel(project, agent)` | unit | proves the install override still wins over both agent defaults |
+| Child findings spool and direct-file | existing `safeword retro --auto-extract` / egress / spool / triage path | integration or existing command coverage plus adapter wiring | includes a leak canary so bypassing egress fails |
+| Unfiled drafts remain for Lane 2 | `runRetro` / `retro-draft-spool.ts` existing BNGK9W tests plus Codex adapter wiring | integration | proves Stop does not lose drafts when direct filing is unavailable |
+| Empty child findings stay silent | Codex adapter + existing retro pipeline | integration | proves schema-valid empty findings produce no spool/file/nudge work |
+| Codex config wires prompt nudge | schema/config tests | unit/integration | checks generated `codex/config.toml` and retrofit patch include UserPromptSubmit nudge |
+
+Build sequence: model default first (pure RED), Codex child argv/parser second,
+Stop adapter replacement third, config/schema nudge wiring fourth, then focused
+integration tests over the replaced Codex Stop adapter.
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| --- | --- | --- | --- |
+| Stop output | Write nothing on success/fail-open | Keep `{}` silent JSON; keep `{decision:"block"}` | Live spike proved empty stdout is safe; `{decision:"block"}` is the hijack #602 removes |
+| Child command | `codex exec --output-schema <schema> -o <out> --json --sandbox read-only -m <model> <inline digest + task>` with stdin closed | Read digest through tools/MCP; detached child | Inline digest avoids output-schema/tool conflict; closed stdin avoids hangs; detached survival is undocumented |
+| Model default | Add per-agent default: Claude `sonnet`, Codex `gpt-5.5`, both config-overridable | One global default | Stock Codex cannot call Claude; one default either breaks Codex or weakens Claude |
+| Filing path | Invoke the existing `safeword retro --auto-extract` egress/spool/try-file path | Reimplement egress/spool in the Codex hook | Shared core is the security boundary and already owns direct vs fallback filing |
+| Lane 2 | Wire `prompt-retro-nudge.ts` into Codex UserPromptSubmit | Surface from Stop | Stop continuation hijacks; UserPromptSubmit additionalContext is the non-hijacking channel |
+
+## Arch alignment
+
+Honors `ARCHITECTURE.md` schema-as-single-source-of-truth, reconciliation over
+copy, IDE parity, and byte-parity template mirror principles. Honors the retro
+architecture from RV9JT4 / 7D8PJP / BNGK9W: trigger core stays shared, egress is
+the security boundary, and spooled drafts contain only code-assembled
+`{signature,title,body,labels}`.
+
+## Known deviations
+
+skip: no deviations planned — this replaces only the Codex adapter and Codex
+config wiring while reusing the shipped shared retro core.
+
+## Assessment triggers
+
+- Codex changes `codex exec --output-schema` behavior with MCP/tools active.
+- The default OpenAI model name changes or a lower-latency Codex extraction model
+  becomes the project standard.
+- Codex cloud documents hook support; split the cloud spike from #602's local path.

--- a/.project/tickets/CDX602-codex-retro-parity/spec.md
+++ b/.project/tickets/CDX602-codex-retro-parity/spec.md
@@ -1,0 +1,87 @@
+# Spec: Codex retro parity — invisible local extraction and Lane-2 filing
+
+## Intent
+
+Replace Codex's visible Stop `{decision:"block"}` retro trigger with the same
+invisible-retro shape Claude now uses: the Stop hook runs extraction out-of-band
+in a separate child session, emits nothing to the user's conversation, and routes
+sanitized drafts through the existing spool/direct-file/fallback nudge path.
+
+## Fixed Design
+
+- **Sync Stop hook:** Codex skips `async:true` hooks, so local extraction runs
+  synchronously inside the Stop hook with the hook's 600s budget.
+- **OpenAI model for Codex:** Stock Codex cannot call Claude; Codex extraction
+  defaults to an OpenAI model while Claude remains on sonnet. `.safeword/config.json`
+  `retro.model` still overrides the default.
+- **Lane 2 is UserPromptSubmit:** unfiled spooled drafts surface via
+  `hookSpecificOutput.additionalContext` using `decideRetroNudge`; Stop never
+  returns `{decision:"block"}`.
+- **Cloud out of scope:** Codex cloud hook support is unknown.
+- **Shared core reuse:** retro trigger/delta state, digesting, egress, draft spool,
+  and nudge logic stay shared.
+
+## Personas
+
+- **Technical Builder (TB)** — runs safeword under local Codex and wants automatic
+  filing with no turn hijack.
+- **Safeword Maintainer (SM)** — wants the Codex friction stream to reach the same
+  tracker path as Claude, with no weaker egress boundary.
+
+## Jobs To Be Done
+
+### codex-retro-parity.TB1 — End a Codex turn without retro hijacking the chat
+
+**Persona:** Technical Builder (TB)
+
+> When I finish a local Codex session that hit safeword friction, I want retro
+> extraction to happen outside my conversation, so I can keep working without a
+> continuation prompt hijacking my next turn.
+
+#### codex-retro-parity.TB1.AC1 — Stop extraction is synchronous and invisible
+
+At Stop, the adapter uses the supplied readable `transcript_path`, runs child
+`codex exec` with closed stdin and a schema output file, awaits completion, and
+writes no conversation-visible Stop output.
+
+#### codex-retro-parity.TB1.AC2 — Stop fails open
+
+Malformed input, absent/unreadable transcripts, child failures, empty child
+output, and schema-invalid child output all exit zero, surface nothing, and do not
+advance retro state as if extraction succeeded.
+
+### codex-retro-parity.SM1 — Codex uses the same safe filing path as Claude
+
+**Persona:** Safeword Maintainer (SM)
+
+> When I receive retro findings from Codex sessions, I want them to pass through
+> the existing egress and spool pipeline, so I can trust the Codex stream without
+> weakening the no-leak boundary.
+
+#### codex-retro-parity.SM1.AC1 — Codex extractor uses an OpenAI default
+
+Codex extraction defaults to the configured Codex/OpenAI model when no
+`retro.model` override exists, while Claude extraction still defaults to sonnet.
+
+#### codex-retro-parity.SM1.AC2 — Extracted findings flow through egress, spool, and direct filing
+
+Valid child findings are normalized through the existing `safeword retro`
+auto-extract path, persisted only as post-egress draft fields, and direct-filed
+when the local GitHub REST transport succeeds.
+
+#### codex-retro-parity.SM1.AC3 — Unfiled drafts use Lane 2
+
+When direct filing is unavailable, drafts remain spooled and the Codex
+UserPromptSubmit hook surfaces the existing factual nudge via
+`hookSpecificOutput.additionalContext`, once per unfiled batch.
+
+## Outcomes
+
+- Local Codex Stop no longer returns `{decision:"block"}` for retro.
+- Child extraction is schema-constrained, stdin-safe, and guarded by
+  `SAFEWORD_RETRO_CHILD=1`.
+- Codex and Claude share the same post-egress spool and nudge lane.
+
+## Open Questions
+
+skip: the live gating spike answered the only blocking local unknown for #602.

--- a/.project/tickets/CDX602-codex-retro-parity/test-definitions.md
+++ b/.project/tickets/CDX602-codex-retro-parity/test-definitions.md
@@ -1,0 +1,96 @@
+# Test Definitions: Codex retro parity — invisible local extraction and Lane-2 filing
+
+Feature source: `packages/cli/features/codex-retro-parity.feature`
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: Stop extraction is synchronous and invisible
+
+### Scenario: The Codex Stop hook runs child extraction with an inline digest
+
+- [x] RED — `tests/hooks/retro-extract.test.ts` and
+  `tests/integration/codex-stop-retro.test.ts` failed against the visible
+  continuation adapter.
+- [x] GREEN — `buildCodexExtractArgv`, `runCodexHeadlessExtraction`, and the
+  Codex Stop subprocess test pass.
+- [x] REFACTOR — Stop hook shares `retroChildArgs`/`decideRetroRun`; extractor
+  helpers isolate Codex-specific argv/schema parsing.
+
+### Scenario Outline: The Codex Stop hook fails open without a continuation
+
+- [x] RED — old hook emitted `{}` or `{decision:"block"}` instead of empty stdout.
+- [x] GREEN — malformed stdin, below-threshold, wrong-shape, unreadable
+  transcript, non-zero child, and invalid child output stay silent.
+- [x] REFACTOR — fail-open behavior is in the hook boundary and Codex extractor
+  runner, with no user-facing output path.
+
+### Scenario: A retro child Stop does not spawn another extraction
+
+- [x] RED — old Codex Stop ignored `SAFEWORD_RETRO_CHILD`.
+- [x] GREEN — integration test proves sentinel env suppresses child spawn.
+- [x] REFACTOR — recursion guard reuses `decideRetroRun`/`isRetroChild`.
+
+## Rule: Codex and Claude resolve different retro model defaults
+
+### Scenario: Codex and Claude resolve their agent-specific defaults
+
+- [x] RED — `DEFAULT_CODEX_RETRO_MODEL` and Codex model resolution were missing.
+- [x] GREEN — resolver and `buildAutoExtractor(..., { agent: 'codex' })` default
+  Codex to `gpt-5.5` while Claude remains `sonnet`.
+- [x] REFACTOR — defaults are named per agent with `DEFAULT_RETRO_MODEL` kept as
+  the Claude-compatible alias.
+
+### Scenario: A configured retro model overrides both agent defaults
+
+- [x] RED — override was only covered for the single Claude default.
+- [x] GREEN — resolver and runner tests prove `retro.model` overrides Claude and
+  Codex defaults.
+- [x] REFACTOR — one `resolveRetroModel(project, agent)` function handles both.
+
+## Rule: Codex uses the shared egress, spool, and filing path
+
+### Scenario: Codex child findings are spooled and filed through the existing retro pipeline
+
+- [x] RED — Codex adapter previously bypassed the out-of-band `safeword retro`
+  path.
+- [x] GREEN — Codex Stop forwards `retro --auto-extract` args; existing
+  `tests/commands/retro.test.ts` proves auto-extracted findings pass egress and
+  post-egress spool/file logic.
+- [x] REFACTOR — `SAFEWORD_RETRO_AGENT=codex` switches only the extraction
+  boundary; the retro command still owns egress/spool/triage.
+
+### Scenario Outline: Unfiled Codex drafts remain spooled for the Lane-2 nudge
+
+- [x] RED — Codex config lacked the UserPromptSubmit retro nudge.
+- [x] GREEN — reconcile tests wire `prompt-retro-nudge.ts`; existing
+  `tests/integration/prompt-retro-nudge.test.ts` covers one-nudge-per-batch
+  behavior over spooled drafts.
+- [x] REFACTOR — Lane 2 reuses `decideRetroNudge` unchanged.
+
+### Scenario: Empty Codex child findings stay silent and create no filing work
+
+- [x] RED — Codex structured output parser was absent.
+- [x] GREEN — Codex extraction fail-open tests return `[]`; existing retro command
+  behavior creates no drafts/issues from empty findings.
+- [x] REFACTOR — parser accepts only schema object `{findings:[...]}`.
+
+## Rule: UserPromptSubmit surfaces unfiled Codex drafts
+
+### Scenario: The generated Codex config wires the prompt-retro-nudge hook
+
+- [x] RED — template/schema config lacked `.safeword/hooks/prompt-retro-nudge.ts`.
+- [x] GREEN — install and upgrade reconcile tests cover template and retrofit
+  wiring.
+- [x] REFACTOR — schema patch is exported for byte-accurate retrofit tests.
+
+### Scenario: The Codex prompt nudge fires once per unfiled batch
+
+- [x] RED — Codex had no prompt hook boundary for the existing nudge.
+- [x] GREEN — Codex config now runs `prompt-retro-nudge.ts`; existing integration
+  tests cover duplicate suppression and distinct batch nudge behavior.
+- [x] REFACTOR — no fork of the nudge logic was added.
+
+## Feature-level cross-scenario refactor
+
+- [x] cross-scenario — templates and dogfood hook mirrors are byte-identical;
+  Codex config template and dogfood config are synced.

--- a/.project/tickets/CDX602-codex-retro-parity/ticket.md
+++ b/.project/tickets/CDX602-codex-retro-parity/ticket.md
@@ -1,0 +1,112 @@
+---
+id: CDX602
+slug: codex-retro-parity
+type: feature
+phase: verify
+status: in_progress
+parent: RV9JT4-retro-transcript-mining
+depends_on: [BNGK9W]
+external_issue: https://github.com/ArcadeAI/safeword/issues/602
+external_prs: [https://github.com/ArcadeAI/safeword/pull/601]
+scope: |
+  Bring the local Codex retro adapter up to the invisible-retro design shipped for
+  Claude: a Codex Stop hook runs extraction synchronously and silently in a nested
+  `codex exec` session, feeds the shared egress/spool/direct-file path, and leaves
+  fallback filing to the existing UserPromptSubmit nudge lane. Reuse the shared
+  retro core rather than inventing a second Codex pipeline.
+out_of_scope: |
+  - Codex cloud behavior; hooks are undocumented there and tracked as a later spike.
+  - Reopening the #602 design choices: sync Stop, OpenAI model, Lane 2
+    UserPromptSubmit, shared-core reuse, and cloud out of scope are decided.
+  - Changing the retro egress, dedupe, draft schema, or filing-subagent contract
+    beyond what Codex needs to call the existing path.
+done_when: |
+  A substantial local Codex session runs a synchronous, invisible Stop-hook
+  extraction via child `codex exec`, uses an OpenAI default model for Codex while
+  preserving Claude's sonnet default, spools only post-egress drafts, tries the
+  direct local filing path, surfaces unfiled drafts through UserPromptSubmit
+  additionalContext, and never emits the old Stop `{decision:"block"}` continuation.
+created: 2026-07-02T00:11:26Z
+last_modified: 2026-07-02T01:04:00Z
+---
+
+# Codex retro parity: invisible local extraction and Lane-2 filing
+
+**Goal:** Make local Codex match the invisible retro pipeline without hijacking the
+user's turn.
+
+**Why:** Codex currently uses the older visible Stop continuation, so local Codex
+sessions are one generation behind the Claude baseline and can interrupt the user
+instead of filing out-of-band.
+
+**GitHub:** [#602](https://github.com/ArcadeAI/safeword/issues/602)
+
+## Scope
+
+- Replace `packages/cli/templates/hooks/codex/stop.ts` and its `.safeword` mirror
+  with a synchronous, silent extraction adapter.
+- Add the Codex/OpenAI model default while preserving Claude's sonnet default and
+  the existing `retro.model` override.
+- Wire the existing `prompt-retro-nudge.ts` into Codex `UserPromptSubmit`.
+- Reuse the existing retro trigger, egress, draft spool, JSONL spool, nudge, and
+  filing primitives.
+
+## Out of Scope
+
+- Codex cloud behavior.
+- Re-deciding the #602 architecture.
+- Rewriting the retro egress, dedupe, draft schema, or filing-subagent contract.
+
+## Done When
+
+- Codex Stop uses child `codex exec` with inline digest, closed stdin, schema output,
+  `SAFEWORD_RETRO_CHILD=1`, and no Stop continuation.
+- Codex uses an OpenAI default model; Claude still defaults to sonnet.
+- Extracted findings route through the existing egress/spool/direct-file path.
+- Codex UserPromptSubmit surfaces unfiled draft nudges through the existing nudge.
+- Template and `.safeword` hook mirrors match, schema registration is current, and
+  verification plus audit pass.
+
+## Work Log
+
+- 2026-07-02T04:43:58Z Docs: resolved the audit documentation warning by
+  updating README and website Hooks & Skills reference with Codex Stop retro
+  extraction and UserPromptSubmit prompt-retro-nudge behavior.
+- 2026-07-02T02:39:11Z Quality review: fixed two high-confidence review gaps.
+  The CLI wrapper now still extracts and spools sanitized drafts when GitHub
+  transport is unavailable, so Lane 2 has drafts to nudge; Codex Stop now stages
+  offset state and commits it only after the child `safeword retro` process exits
+  cleanly. Added regressions for no-transport spooling, schema-valid empty Codex
+  output, invalid/non-zero extraction signaling, and child-failure no-offset.
+- 2026-07-02T01:04:00Z Verify/Audit: lint clean, typecheck clean,
+  focused runtime/config tests 120/120 passing, fast smoke 912/912 passing,
+  build green, Cucumber 181 scenarios / 3414 steps passing, parity checks green,
+  audit config/dependency checks clean with existing repo-wide knip/jscpd
+  warnings. Full `bun run test` was interrupted after extended progress through
+  install-heavy setup tests; no product failure observed.
+- 2026-07-02T00:35:00Z Complete: implement - Codex Stop is now silent and
+  synchronous, Codex extraction uses structured `codex exec`, per-agent model
+  defaults are covered, Codex UserPromptSubmit retro nudge is wired, template
+  hook mirrors are byte-identical, and focused runtime/config tests pass.
+- 2026-07-02T00:23:00Z Complete: scenario-gate - independent review ended with
+  0 must-fix; remaining should-strengthen items applied; review stamped; phase
+  advanced to implement.
+- 2026-07-02T00:22:00Z Review: fourth independent scenario gate had 0 must-fix
+  and 2 should-strengthen; split UserPromptSubmit wiring from nudge semantics and
+  broadened direct-file failure partitions.
+- 2026-07-02T00:20:00Z Review: third independent scenario gate found no-leak
+  coverage as must-fix; strengthened egress scenario with leak canary, split model
+  override, added empty-findings boundary, and distinct-batch nudge assertion.
+- 2026-07-02T00:19:00Z Review: second independent scenario gate found recursion
+  guard coverage as must-fix; added child env assertion, retro-child no-spawn
+  scenario, timeout failure partition, and surface tags.
+- 2026-07-02T00:18:00Z Review: independent scenario gate found 1 must-fix and
+  3 should-strengthen; applied fail-open state assertion, split failure classes,
+  second-prompt nudge assertion, and exact Codex model default.
+- 2026-07-02T00:13:00Z Complete: define-behavior - 6 scenarios defined across
+  4 rules in `packages/cli/features/codex-retro-parity.feature`.
+- 2026-07-02T00:12:00Z Complete: intake - #602 already supplied accepted scope,
+  out-of-scope, done_when, and design decisions; moving to behavior definition.
+- 2026-07-02T00:11:26Z Started: #602 scope ticket created after live Codex
+  Stop-hook spike passed and was reported on #602
+  (https://github.com/ArcadeAI/safeword/issues/602#issuecomment-4861045872).

--- a/.safeword/hooks/codex/stop.ts
+++ b/.safeword/hooks/codex/stop.ts
@@ -1,61 +1,99 @@
 #!/usr/bin/env bun
-// Safeword: Codex Stop adapter for the retro auto-trigger (ticket 53DQJZ).
+// Safeword: invisible Codex retro auto-trigger (ticket CDX602 / issue #602).
 //
-// Codex's Stop hook fires at turn-end while the session is alive and hands a
-// turn-scoped payload that includes `transcript_path` (the Codex rollout JSONL).
-// At most once per SUBSTANTIAL session, this emits a {decision:"block", reason}
-// continuation whose reason points the agent at the retro pipeline — the Codex
-// analogue of the Claude stop-retro additionalContext nudge.
-//
-// It reuses the shared core (sentinel, orchestration) via injection seams:
-//   - countToolUsesCodex  — Codex rollout shape ({type,payload}: function_call /
-//     exec_command_begin / mcp_tool_call_begin), NOT Claude's tool_use.
-//   - resolveCodexSessionId — session-stable id (payload session_id / CODEX_THREAD_ID).
-//
-// Codex Stop requires valid JSON output, so the silent and fail-open paths emit
-// `{}` (no decision) rather than nothing. Best-effort: never wrongly continues.
+// Codex skips async hooks, so this Stop hook runs the retro extraction
+// synchronously and emits NOTHING. There is no {decision:"block"} continuation:
+// Lane 2 surfacing for unfiled drafts belongs to the separate UserPromptSubmit
+// prompt-retro-nudge hook. The child path marks itself with SAFEWORD_RETRO_CHILD
+// so a headless `codex exec` process cannot recursively re-fire Stop.
 
-import { readSelfReportConfig } from '../lib/self-report.ts';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { RETRO_CHILD_ENV, retroChildArgs } from '../lib/retro-extract.ts';
 import {
   countToolUsesCodex,
-  decideRetroNudge,
+  decideRetroRun,
+  type OffsetState,
   resolveCodexSessionId,
   type RetroTriggerInput,
+  writeOffsetState,
 } from '../lib/retro-trigger.ts';
+import { readSelfReportConfig } from '../lib/self-report.ts';
 
 interface CodexStopInput extends RetroTriggerInput {
   cwd?: string;
 }
 
-// Codex Stop requires JSON output; `{}` is the valid "no continuation" response.
-const SILENT = '{}';
+/**
+ * The command that runs the extraction CLI. Prefer the dogfood local CLI, else
+ * `bunx safeword@latest`; the spawned CLI then launches `codex exec` through the
+ * shared auto-extract boundary.
+ */
+function resolveExtractCommand(
+  projectDirectory: string,
+  decision: { transcriptPath: string; windowStart: number; sessionId: string },
+): [string, string[]] {
+  const retroArgs = retroChildArgs(decision);
+  const localCli = nodePath.join(projectDirectory, 'packages/cli/src/cli.ts');
+  return existsSync(localCli)
+    ? ['bun', [localCli, ...retroArgs]]
+    : ['bunx', ['safeword@latest', ...retroArgs]];
+}
 
-async function main(): Promise<string> {
+async function main(): Promise<void> {
   let input: CodexStopInput;
   try {
     input = (await Bun.stdin.json()) as CodexStopInput;
   } catch {
-    return SILENT; // malformed stdin → fail open with valid JSON
+    return; // malformed stdin / no stdin -> silent fail-open
   }
 
   const projectDirectory = input.cwd ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-  if (!readSelfReportConfig(projectDirectory).surface) return SILENT;
+  if (!readSelfReportConfig(projectDirectory).surface) return;
 
-  const reason = decideRetroNudge(input, {
+  let pendingOffsetState:
+    | { sessionId: string; state: OffsetState; baseDirectory: string | undefined }
+    | undefined;
+  const decision = decideRetroRun(input, {
     env: process.env,
     countToolUses: countToolUsesCodex,
     resolveSessionId: resolveCodexSessionId,
+    writeOffsetState: (sessionId, state, baseDirectory) => {
+      pendingOffsetState = { sessionId, state, baseDirectory };
+    },
   });
-  if (!reason) return SILENT;
+  if (!decision) return;
 
-  return JSON.stringify({ decision: 'block', reason });
+  const [command, args] = resolveExtractCommand(projectDirectory, decision);
+  const result = spawnSync(command, args, {
+    cwd: projectDirectory,
+    env: {
+      ...process.env,
+      SAFEWORD_RETRO_AGENT: 'codex',
+      [RETRO_CHILD_ENV]: '1',
+    },
+    stdio: 'ignore',
+    timeout: 600_000,
+  });
+  if (result.status !== 0 || result.error || !pendingOffsetState) return;
+
+  try {
+    writeOffsetState(
+      pendingOffsetState.sessionId,
+      pendingOffsetState.state,
+      pendingOffsetState.baseDirectory,
+    );
+  } catch {
+    // A state-write failure must not make Stop visible or blocking.
+  }
 }
 
-let output = SILENT;
 try {
-  output = await main();
+  await main();
 } catch {
-  output = SILENT; // self-observation must never break the Codex turn
+  // Self-observation must never break Stop.
 }
-process.stdout.write(`${output}\n`);
 process.exit(0);

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -8,7 +8,7 @@
 // synchronous runner. Agent-neutral where possible; Claude-specific bits are
 // named as such.
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 /**
@@ -18,26 +18,39 @@ import nodePath from 'node:path';
 export const DIGEST_CAP = 180_000;
 
 /**
- * Default extraction model. Sonnet, not haiku: measured head-to-head on the same
- * transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong ones (ZFGWS1).
- * Overridable per install via `.safeword/config.json` → `retro.model`.
+ * Default Claude extraction model. Sonnet, not haiku: measured head-to-head on
+ * the same transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong
+ * ones (ZFGWS1). Overridable per install via `.safeword/config.json` →
+ * `retro.model`.
  */
-export const DEFAULT_RETRO_MODEL = 'sonnet';
+export const DEFAULT_CLAUDE_RETRO_MODEL = 'sonnet';
+
+/** Default Codex extraction model. Stock Codex can only call OpenAI models. */
+export const DEFAULT_CODEX_RETRO_MODEL = 'gpt-5.5';
+
+/** Backward-compatible alias for existing Claude call sites/tests. */
+export const DEFAULT_RETRO_MODEL = DEFAULT_CLAUDE_RETRO_MODEL;
+
+export type RetroAgent = 'claude' | 'codex';
+
+function defaultRetroModel(agent: RetroAgent): string {
+  return agent === 'codex' ? DEFAULT_CODEX_RETRO_MODEL : DEFAULT_CLAUDE_RETRO_MODEL;
+}
 
 /**
  * Resolve the extraction model for an install: `retro.model` from
- * `.safeword/config.json`, else the sonnet default. Fail-open to the default on
- * any missing/unreadable/malformed config — model selection must never break the
- * out-of-band retro run.
+ * `.safeword/config.json`, else the per-agent default. Fail-open to the default
+ * on any missing/unreadable/malformed config — model selection must never break
+ * the out-of-band retro run.
  */
-export function resolveRetroModel(projectDirectory: string): string {
+export function resolveRetroModel(projectDirectory: string, agent: RetroAgent = 'claude'): string {
   try {
     const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
     const parsed = JSON.parse(raw) as { retro?: { model?: unknown } };
     const model = parsed.retro?.model;
-    return typeof model === 'string' && model.length > 0 ? model : DEFAULT_RETRO_MODEL;
+    return typeof model === 'string' && model.length > 0 ? model : defaultRetroModel(agent);
   } catch {
-    return DEFAULT_RETRO_MODEL;
+    return defaultRetroModel(agent);
   }
 }
 
@@ -153,6 +166,44 @@ export function buildExtractArgv(options: ExtractArgvOptions): string[] {
   ];
 }
 
+export interface CodexExtractArgvOptions {
+  /** OpenAI model for the child `codex exec` process. */
+  model: string;
+  /** JSON schema path supplied to `--output-schema`. */
+  schemaPath: string;
+  /** JSON output path supplied to `-o`. */
+  outputPath: string;
+  /** Inline digest + task prompt. No Read/MCP tools are available. */
+  prompt: string;
+}
+
+/**
+ * Build the `codex exec` argv for a headless retro extraction. The digest is
+ * inline in the prompt because `--output-schema` is ignored by Codex when the
+ * task requires Read/MCP tool use. Hooks and MCP servers are explicitly disabled,
+ * stdin is closed by the runner, and the sandbox is read-only.
+ */
+export function buildCodexExtractArgv(options: CodexExtractArgvOptions): string[] {
+  return [
+    'exec',
+    '--ignore-user-config',
+    '--disable',
+    'hooks',
+    '-c',
+    'mcp_servers={}',
+    '--output-schema',
+    options.schemaPath,
+    '-o',
+    options.outputPath,
+    '--json',
+    '--sandbox',
+    'read-only',
+    '-m',
+    options.model,
+    options.prompt,
+  ];
+}
+
 // The extraction rules, mirrored from templates/guides/retro.md: SAFEWORD's own
 // friction only, the constrained snake_case schema, no invention. The egress
 // guard sanitizes downstream, so the child writes plainly.
@@ -165,9 +216,49 @@ const EXTRACT_SYSTEM_PROMPT =
   'friction only (not the host project, not Claude Code itself); canonical ' +
   'behavior-titles; do not invent; [] if none.';
 
+const CODEX_RETRO_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          category: { type: 'string', enum: ['bug', 'rough-edge', 'gap'] },
+          title: { type: 'string' },
+          safeword_surface: { type: 'string' },
+          what_happened: { type: 'string' },
+          why_friction: { type: 'string' },
+          repro: { type: 'string' },
+        },
+        required: [
+          'category',
+          'title',
+          'safeword_surface',
+          'what_happened',
+          'why_friction',
+          'repro',
+        ],
+      },
+    },
+  },
+  required: ['findings'],
+};
+
 /** The task prompt: point the read-only child at the digest file. */
 function buildExtractPrompt(digestPath: string): string {
   return `Read the file ${digestPath} and extract SAFEWORD's own friction as the JSON array described. Output only the JSON array.`;
+}
+
+function buildCodexExtractPrompt(digest: string): string {
+  return (
+    `${EXTRACT_SYSTEM_PROMPT}\n\n` +
+    'Return only JSON matching the provided output schema: {"findings":[...]}. ' +
+    'Use an empty findings array when there is no safeword friction.\n\n' +
+    `Transcript digest:\n${digest}`
+  );
 }
 
 /** Parse a findings array out of a `claude -p --output-format json` envelope. */
@@ -188,6 +279,15 @@ function parseFindings(stdout: string): unknown[] {
     return Array.isArray(findings) ? findings : [];
   } catch {
     return [];
+  }
+}
+
+function parseCodexFindingsOutput(rawOutput: string): unknown[] | undefined {
+  try {
+    const parsed = JSON.parse(rawOutput) as { findings?: unknown };
+    return Array.isArray(parsed.findings) ? parsed.findings : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -212,6 +312,37 @@ export interface RunExtractionDeps {
   cwd: string;
   /** Extraction model (cheap by default). */
   model?: string;
+}
+
+export interface CodexSpawnOptions {
+  cwd: string;
+  env: Record<string, string | undefined>;
+  stdio: 'ignore';
+}
+
+/** Dependencies for `runCodexHeadlessExtraction` — injected for tests. */
+export interface RunCodexExtractionDeps {
+  /** Spawn `codex` with argv; resolve after the child exits. Awaited (sync). */
+  spawn: (argv: string[], options: CodexSpawnOptions) => Promise<SpawnResult>;
+  /** Persist the output schema file read by `codex exec --output-schema`. */
+  writeFile?: (path: string, content: string) => void;
+  /** Read the `-o` JSON file written by `codex exec`. */
+  readFile?: (path: string) => string;
+  /** Base env for the child (the sentinel is added here). */
+  env: Record<string, string | undefined>;
+  /** Neutral cwd — NOT the user's project — so project hooks don't load. */
+  cwd: string;
+  /** Extraction model (OpenAI default for Codex). */
+  model?: string;
+  /** Test seam for deterministic schema/output paths. */
+  schemaPath?: string;
+  outputPath?: string;
+}
+
+export interface CodexExtractionResult {
+  /** True only when the child exited successfully and wrote schema-valid JSON. */
+  ok: boolean;
+  findings: unknown[];
 }
 
 /**
@@ -243,6 +374,52 @@ export async function runHeadlessExtraction(
   } catch {
     return []; // fail-open on any spawn/IO error
   }
+}
+
+/**
+ * Run Codex retro extraction in a separate `codex exec` child and return the raw
+ * findings array with a success bit. Synchronous (awaits the child) and
+ * fail-OPEN: any non-zero exit, missing output, malformed JSON, or
+ * spawn/read/write error yields `{ ok:false, findings:[] }`.
+ */
+export async function runCodexHeadlessExtractionChecked(
+  transcript: string,
+  dependencies: RunCodexExtractionDeps,
+): Promise<CodexExtractionResult> {
+  try {
+    const schemaPath = dependencies.schemaPath ?? nodePath.join(dependencies.cwd, 'schema.json');
+    const outputPath = dependencies.outputPath ?? nodePath.join(dependencies.cwd, 'output.json');
+    const writeFile = dependencies.writeFile ?? writeFileSync;
+    const readFile = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
+
+    writeFile(schemaPath, JSON.stringify(CODEX_RETRO_OUTPUT_SCHEMA));
+    const argv = buildCodexExtractArgv({
+      model: dependencies.model ?? DEFAULT_CODEX_RETRO_MODEL,
+      schemaPath,
+      outputPath,
+      prompt: buildCodexExtractPrompt(buildDigest(transcript)),
+    });
+    const { code } = await dependencies.spawn(argv, {
+      cwd: dependencies.cwd,
+      env: { ...dependencies.env, [RETRO_CHILD_ENV]: '1' },
+      stdio: 'ignore',
+    });
+    if (code !== 0) return { ok: false, findings: [] };
+    const findings = parseCodexFindingsOutput(readFile(outputPath));
+    return findings === undefined ? { ok: false, findings: [] } : { ok: true, findings };
+  } catch {
+    return { ok: false, findings: [] };
+  }
+}
+
+/**
+ * Backward-compatible fail-open wrapper for call sites that only need findings.
+ */
+export async function runCodexHeadlessExtraction(
+  transcript: string,
+  dependencies: RunCodexExtractionDeps,
+): Promise<unknown[]> {
+  return (await runCodexHeadlessExtractionChecked(transcript, dependencies)).findings;
 }
 
 // A tool-result body is kept whole only when it's short OR carries a friction

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Key directories created in your project:
 - `session-compact-context.ts` - Re-injects active ticket context after context compaction
 - `prompt-timestamp.ts` - Injects timestamp into prompts
 - `prompt-questions.ts` - Reminds agent to ask clarifying questions
+- `prompt-retro-nudge.ts` - Surfaces unfiled retro drafts on the next prompt
 - `post-tool-lint.ts` - Auto-lints after file edits
 - `post-tool-quality.ts` - Tracks LOC, detects phase changes and TDD steps
 - `post-tool-bypass-warn.ts` - Warns when agent bypasses quality gates
@@ -251,12 +252,16 @@ Key directories created in your project:
 - `cursor/stop.ts` - Quality review prompt on Cursor stop
 - `cursor/post-tool-skill-nudge.ts` - Cursor adapter for the language coding-skill nudge (dormant pending Cursor bug #534)
 - `codex/pre-tool-quality.ts` - Adapts Codex PreToolUse events to safeword's quality gate
+- `codex/stop.ts` - Runs invisible retro extraction from the Codex transcript at Stop
 - `codex/post-tool-skill-nudge.ts` - Codex adapter for the language coding-skill nudge
 
-Codex hook coverage is limited to the documented PreToolUse tool calls that
-Safeword configures (`Bash`, `apply_patch` edit payloads, and MCP tools). Live
-Codex runs can also report `file_change` execution items; those are recorded as
-a runtime boundary, not as edits Safeword claims to guard through PreToolUse.
+Codex hook coverage for quality gates is limited to the documented PreToolUse
+tool calls that Safeword configures (`Bash`, `apply_patch` edit payloads, and
+MCP tools). Live Codex runs can also report `file_change` execution items; those
+are recorded as a runtime boundary, not as edits Safeword claims to guard
+through PreToolUse. Separately, Codex Stop runs retro extraction silently and
+synchronously; any unfiled drafts surface later through the shared
+UserPromptSubmit `prompt-retro-nudge.ts` hook rather than a Stop continuation.
 
 **Skills** (in `.claude/skills/` and `.agents/skills/`): Specialized agent capabilities
 

--- a/packages/cli/features/codex-retro-parity.feature
+++ b/packages/cli/features/codex-retro-parity.feature
@@ -1,0 +1,117 @@
+# BDD source for CDX602 (Codex retro parity — invisible local extraction and
+# Lane-2 filing). Proven by the vitest suite: hook-level tests spawn the real
+# Codex Stop adapter while mocking only the child `codex exec` process boundary,
+# and schema/config tests prove generated hook wiring. `@manual` excludes it from
+# the cucumber lane while keeping it readable by codify / review-spec / safeword check.
+@codex-retro-parity @manual
+Feature: Codex retro parity — invisible local extraction and Lane-2 filing
+
+  Local Codex uses the same invisible retro shape as Claude: Stop runs extraction
+  out-of-band in a child Codex session, emits nothing to the conversation, routes
+  findings through the shared egress/spool/direct-file path, and uses
+  UserPromptSubmit additionalContext for any fallback filing nudge.
+
+  Rule: Stop extraction is synchronous and invisible
+
+    @codex-retro-parity.TB1.AC1 @surface.codex-stop @surface.retro-pipeline
+    Scenario: The Codex Stop hook runs child extraction with an inline digest
+      Given a local Codex Stop payload whose transcript_path is readable
+      When the Codex Stop hook runs
+      Then it spawns child `codex exec` with the transcript digest inline
+      And the child environment includes `SAFEWORD_RETRO_CHILD=1`
+      And the child stdin is closed
+      And the child writes schema-valid JSON to the output file
+      And the Stop hook waits for the child before returning
+      And the Stop hook writes no conversation-visible output
+
+    @codex-retro-parity.TB1.AC2 @surface.codex-stop
+    Scenario Outline: The Codex Stop hook fails open without a continuation
+      Given the Codex Stop hook encounters <failure>
+      When the Codex Stop hook runs
+      Then it exits zero
+      And it writes no `{decision:"block"}` continuation
+      And it writes no other conversation-visible output
+      And no retro delta state, draft spool entry, or filed retro record is created for that session
+
+      Examples:
+        | failure                         |
+        | stdin that is not valid JSON    |
+        | no transcript_path              |
+        | an unreadable transcript_path   |
+        | a child process non-zero exit   |
+        | a child process timeout         |
+        | an empty child output file      |
+        | a schema-invalid child output   |
+
+    @codex-retro-parity.TB1.AC2 @surface.codex-stop
+    Scenario: A retro child Stop does not spawn another extraction
+      Given the environment has `SAFEWORD_RETRO_CHILD=1`
+      When the Codex Stop hook runs
+      Then it does not spawn child extraction
+      And it exits zero
+      And it writes no conversation-visible output
+      And no retro delta state, draft spool entry, or filed retro record is created for that session
+
+  Rule: Codex and Claude resolve different retro model defaults
+
+    @codex-retro-parity.SM1.AC1 @surface.retro-model
+    Scenario: Codex and Claude resolve their agent-specific defaults
+      Given no retro model override exists in `.safeword/config.json`
+      When each agent resolves its retro extraction model
+      Then Claude resolves `sonnet`
+      And Codex resolves `gpt-5.5`
+
+    @codex-retro-parity.SM1.AC1 @surface.retro-model
+    Scenario: A configured retro model overrides both agent defaults
+      Given `.safeword/config.json` configures `retro.model`
+      When each agent resolves its retro extraction model
+      Then each agent resolves the configured `retro.model` instead of its default
+
+  Rule: Codex uses the shared egress, spool, and filing path
+
+    @codex-retro-parity.SM1.AC2 @surface.codex-stop @surface.retro-pipeline
+    Scenario: Codex child findings are spooled and filed through the existing retro pipeline
+      Given child Codex extraction returns a valid safeword finding containing raw transcript text and the secret-like token "SW-LEAK-CANARY-602"
+      And the local REST transport can authenticate
+      When the Codex Stop hook completes the retro path
+      Then the draft spool contains only post-egress sanitized fields
+      And the filed issue body contains neither the raw transcript text nor "SW-LEAK-CANARY-602"
+      And no conversation-visible output contains the raw finding text
+
+    @codex-retro-parity.SM1.AC2 @codex-retro-parity.SM1.AC3 @surface.codex-stop @surface.retro-pipeline
+    Scenario Outline: Unfiled Codex drafts remain spooled for the Lane-2 nudge
+      Given child Codex extraction returns a valid safeword finding
+      And the local REST transport <failure>
+      When the Codex Stop hook completes the retro path
+      Then the post-egress draft remains in the session spool
+      And the Stop hook writes no conversation-visible output
+
+      Examples:
+        | failure                         |
+        | cannot authenticate             |
+        | returns a retryable server error|
+        | times out before filing         |
+
+    @codex-retro-parity.SM1.AC2 @surface.codex-stop @surface.retro-pipeline
+    Scenario: Empty Codex child findings stay silent and create no filing work
+      Given child Codex extraction returns schema-valid output with no findings
+      When the Codex Stop hook completes the retro path
+      Then it exits zero
+      And no draft spool entry or filed retro record is created
+      And no Lane-2 nudge is queued
+
+  Rule: UserPromptSubmit surfaces unfiled Codex drafts
+
+    @codex-retro-parity.SM1.AC3 @surface.codex-user-prompt-submit @surface.config-wiring
+    Scenario: The generated Codex config wires the prompt-retro-nudge hook
+      Given a project installed with Codex hooks
+      When a new user prompt starts after retro drafts remain spooled
+      Then the Codex UserPromptSubmit hook runs `prompt-retro-nudge.ts`
+
+    @codex-retro-parity.SM1.AC3 @surface.codex-user-prompt-submit
+    Scenario: The Codex prompt nudge fires once per unfiled batch
+      Given retro drafts remain spooled for a Codex session
+      When a new user prompt starts
+      Then the hook emits the existing factual `additionalContext` nudge once per unfiled batch
+      And a second user prompt over the same unfiled batch emits no duplicate nudge
+      And a later user prompt over a distinct newly-spooled batch emits one new nudge

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -25,7 +25,7 @@ import {
   readSpooledDrafts,
   spoolDrafts,
 } from '../../templates/hooks/lib/retro-draft-spool.js';
-import { windowFor } from '../../templates/hooks/lib/retro-extract.js';
+import { type RetroAgent, windowFor } from '../../templates/hooks/lib/retro-extract.js';
 import { prepareEncounters } from '../retro/pipeline.js';
 import { type IssueTracker, triage, type TriageResult } from '../retro/triage.js';
 
@@ -130,13 +130,40 @@ export interface RetroCliOptions {
 
 /** Injectable seam for `buildAutoExtractor` (tests assert the resolved model/argv). */
 export interface AutoExtractDependencies {
-  /** Spawn the headless `claude` process; defaults to the real `spawnSync`. */
+  /** Spawn the headless child process; defaults to the real `spawnSync`. */
   spawn?: (
     argv: string[],
-    options: { cwd: string; env: Record<string, string | undefined> },
+    options: { cwd: string; env: Record<string, string | undefined>; stdio?: 'ignore' },
   ) => Promise<{ code: number | null; stdout: string }>;
-  /** Extraction model; defaults to the install's `retro.model` (sonnet fallback). */
+  /** Extraction model; defaults to the install's `retro.model` or per-agent fallback. */
   model?: string;
+  /** Agent whose headless extractor should run. Defaults to Claude for compatibility. */
+  agent?: RetroAgent;
+  /** Observes whether auto extraction produced schema-valid output. */
+  onExtractionResult?: (result: { ok: boolean; findings: unknown[] }) => void;
+}
+
+type AutoExtractSpawn = NonNullable<AutoExtractDependencies['spawn']>;
+
+function spawnClaudeExtractor(argv: string[], spawnOptions: Parameters<AutoExtractSpawn>[1]) {
+  const result = spawnSync('claude', argv, {
+    cwd: spawnOptions.cwd,
+    env: spawnOptions.env,
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return Promise.resolve({ code: result.status, stdout: result.stdout ?? '' });
+}
+
+function spawnCodexExtractor(argv: string[], spawnOptions: Parameters<AutoExtractSpawn>[1]) {
+  const result = spawnSync('codex', argv, {
+    cwd: spawnOptions.cwd,
+    env: spawnOptions.env,
+    stdio: spawnOptions.stdio,
+    timeout: 600_000,
+  });
+  return Promise.resolve({ code: result.status, stdout: '' });
 }
 
 /**
@@ -150,27 +177,37 @@ export async function buildAutoExtractor(
   projectDirectory: string,
   dependencies: AutoExtractDependencies = {},
 ): Promise<FindingExtractor> {
-  const { runHeadlessExtraction, resolveRetroModel } =
+  const { runCodexHeadlessExtractionChecked, runHeadlessExtraction, resolveRetroModel } =
     await import('../../templates/hooks/lib/retro-extract.js');
 
-  const model = dependencies.model ?? resolveRetroModel(projectDirectory);
-  const spawn =
-    dependencies.spawn ??
-    ((argv: string[], spawnOptions: { cwd: string; env: Record<string, string | undefined> }) => {
-      const result = spawnSync('claude', argv, {
-        cwd: spawnOptions.cwd,
-        env: spawnOptions.env,
-        encoding: 'utf8',
-        timeout: 240_000,
-        maxBuffer: 64 * 1024 * 1024,
-      });
-      return Promise.resolve({ code: result.status, stdout: result.stdout ?? '' });
-    });
+  const agent = dependencies.agent ?? 'claude';
+  const model = dependencies.model ?? resolveRetroModel(projectDirectory, agent);
+  const spawnClaude = dependencies.spawn ?? spawnClaudeExtractor;
+  const spawnCodex = dependencies.spawn ?? spawnCodexExtractor;
 
   const workDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-retro-'));
+  if (agent === 'codex') {
+    return async (transcript: string) => {
+      const result = await runCodexHeadlessExtractionChecked(transcript, {
+        spawn: spawnCodex,
+        writeFile: (path: string, content: string) => {
+          writeFileSync(path, content);
+        },
+        readFile: (path: string) => readFileSync(path, 'utf8'),
+        env: process.env,
+        cwd: workDirectory,
+        model,
+        schemaPath: nodePath.join(workDirectory, 'schema.json'),
+        outputPath: nodePath.join(workDirectory, 'output.json'),
+      });
+      dependencies.onExtractionResult?.(result);
+      return result.findings;
+    };
+  }
+
   return (transcript: string) =>
     runHeadlessExtraction(transcript, {
-      spawn,
+      spawn: spawnClaude,
       writeDigest: (digest: string) => {
         const path = nodePath.join(workDirectory, 'digest.txt');
         writeFileSync(path, digest);
@@ -180,6 +217,81 @@ export async function buildAutoExtractor(
       cwd: workDirectory, // neutral cwd — not the user's project
       model,
     });
+}
+
+function resolveAutoExtractAgent(env: Record<string, string | undefined>): RetroAgent {
+  return env.SAFEWORD_RETRO_AGENT === 'codex' ? 'codex' : 'claude';
+}
+
+async function buildRetroExtractor(
+  options: RetroCliOptions,
+  projectDirectory: string,
+  agent: RetroAgent,
+  onExtractionResult?: AutoExtractDependencies['onExtractionResult'],
+): Promise<FindingExtractor> {
+  if (options.autoExtract)
+    return buildAutoExtractor(projectDirectory, { agent, onExtractionResult });
+  const findingsPath = options.findings;
+  return () => Promise.resolve(findingsPath ? readFindings(findingsPath) : []);
+}
+
+function resolveRetroHarness(agent: RetroAgent, detectAgent: () => string): string {
+  return agent === 'codex' ? 'codex' : detectAgent();
+}
+
+function unavailableTransportFailure(): Promise<never> {
+  return Promise.reject(new Error('GitHub transport unavailable'));
+}
+
+function unavailableTransport(): IssueTracker {
+  return {
+    searchBySignature: unavailableTransportFailure,
+    createIssue: unavailableTransportFailure,
+    listComments: unavailableTransportFailure,
+    createComment: unavailableTransportFailure,
+    updateComment: unavailableTransportFailure,
+  };
+}
+
+interface RetroCommandOutput {
+  error: (message: string) => void;
+  info: (message: string) => void;
+  success: (message: string) => void;
+}
+
+function reportRetroCommandOutcome(
+  outcome: RetroOutcome,
+  options: {
+    extractionSucceeded: boolean;
+    restTransportAvailable: boolean;
+    output: RetroCommandOutput;
+  },
+): void {
+  const { error, info, success } = options.output;
+  if (!outcome.ok) {
+    error(outcome.errorMessage ?? 'safeword retro failed');
+    process.exitCode = 1;
+    return;
+  }
+  if (!options.extractionSucceeded) {
+    error('retro: Codex auto-extraction did not produce schema-valid output.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const r = outcome.result;
+  if (!r) return;
+  info(
+    `retro: ${r.created.length} filed, ${r.bumped.length} recurrence(s) counted, ${r.commented.length} new manifestation(s), ${r.deferred.length} deferred, ${r.failed.length} failed`,
+  );
+  if (outcome.agentFilingNeeded) {
+    info(
+      options.restTransportAvailable
+        ? 'retro: unfiled drafts were spooled for the agent filing path.'
+        : 'retro: no GitHub access; unfiled drafts were spooled for the agent filing path.',
+    );
+  }
+  success('retro complete');
 }
 
 /**
@@ -194,21 +306,17 @@ export async function retroCommand(options: RetroCliOptions): Promise<void> {
   const { createRestTransport, resolveGitHubToken } = await import('../retro/github-rest.js');
 
   const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-  const findingsPath = options.findings;
-  const extract: FindingExtractor = options.autoExtract
-    ? await buildAutoExtractor(projectDirectory)
-    : () => Promise.resolve(findingsPath ? readFindings(findingsPath) : []);
+  const autoExtractAgent = resolveAutoExtractAgent(process.env);
+  let extractionSucceeded = true;
+  const extract = await buildRetroExtractor(options, projectDirectory, autoExtractAgent, result => {
+    extractionSucceeded = result.ok;
+  });
 
   // Use the environment's existing GitHub access (GITHUB_TOKEN or `gh auth token`);
   // no hard token requirement (7D8PJP). With neither, no-op gracefully — the
   // out-of-band hook path must never fail the Stop for lack of GitHub access.
-  const transport = createRestTransport(resolveGitHubToken());
-  if (!transport) {
-    info(
-      'safeword retro: no GitHub access (set GITHUB_TOKEN or run `gh auth login`); nothing filed.',
-    );
-    return;
-  }
+  const restTransport = createRestTransport(resolveGitHubToken());
+  const transport = restTransport ?? unavailableTransport();
 
   const outcome = await runRetro(options, {
     extract,
@@ -217,30 +325,18 @@ export async function retroCommand(options: RetroCliOptions): Promise<void> {
     // CLAUDE_CODE_REMOTE_SESSION_ID, not CLAUDE_SESSION_ID, so the env fallback
     // alone resolved to 'unknown' and broke ledger session-accounting; ZFGWS1).
     sessionId: options.sessionId ?? process.env.CLAUDE_SESSION_ID ?? 'unknown',
-    harness: detectAgent(),
+    harness: resolveRetroHarness(autoExtractAgent, detectAgent),
     readFile: (path: string) => readFileSync(path, 'utf8'),
     // Enable the cloud-filing spool: on a REST failure the drafts survive on disk
     // for the agent path (BNGK9W) instead of being lost.
     projectDirectory,
   });
 
-  if (!outcome.ok) {
-    error(outcome.errorMessage ?? 'safeword retro failed');
-    process.exitCode = 1;
-    return;
-  }
-
-  const r = outcome.result;
-  if (!r) return;
-  info(
-    `retro: ${r.created.length} filed, ${r.bumped.length} recurrence(s) counted, ${r.commented.length} new manifestation(s), ${r.deferred.length} deferred, ${r.failed.length} failed`,
-  );
-  if (outcome.agentFilingNeeded) {
-    // Local diagnostic only — under the async Stop hook this output is not surfaced;
-    // the agent nudge comes from the separate boundary hook (BNGK9W PATH B).
-    info('retro: unfiled drafts were spooled for the agent filing path.');
-  }
-  success('retro complete');
+  reportRetroCommandOutcome(outcome, {
+    extractionSucceeded,
+    restTransportAvailable: restTransport !== undefined,
+    output: { error, info, success },
+  });
 }
 
 function readFindings(path: string): unknown[] {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -178,6 +178,16 @@ timeout = 5
 statusMessage = "Adding current timestamp"
 `;
 
+export const CODEX_PROMPT_RETRO_NUDGE_HOOK_PATCH = `
+[[hooks.UserPromptSubmit]]
+
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/prompt-retro-nudge.ts"'
+timeout = 30
+statusMessage = "Checking spooled safeword retro drafts"
+`;
+
 export const CODEX_SESSION_START_HOOK_PATCH = `
 [[hooks.SessionStart]]
 matcher = ""
@@ -220,8 +230,8 @@ const CODEX_STOP_HOOK_PATCH = `
 [[hooks.Stop.hooks]]
 type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
-timeout = 30
-statusMessage = "Checking whether to run a safeword retro"
+timeout = 600
+statusMessage = "Running safeword retro if this session is substantial"
 `;
 
 // Edit-only (no Bash): the language-skill nudge fires on source-file edits. Codex
@@ -1210,6 +1220,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
           '.safeword/hooks/codex/pre-tool-quality.ts',
         ],
         unpatchContent: [
+          CODEX_PROMPT_RETRO_NUDGE_HOOK_PATCH,
           CODEX_SESSION_START_HOOK_PATCH,
           CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH,
           CODEX_PRE_TOOL_QUALITY_HOOK_PATCH,
@@ -1224,6 +1235,18 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
         operation: 'append',
         content: CODEX_STOP_HOOK_PATCH,
         marker: '.safeword/hooks/codex/stop.ts',
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
+      },
+      // Prompt retro nudge retrofit (CDX602): add-if-missing onto existing Codex
+      // configs. This is Lane 2 for unfiled spooled drafts; Codex Stop itself is
+      // silent and never blocks the turn.
+      {
+        operation: 'append',
+        content: CODEX_PROMPT_RETRO_NUDGE_HOOK_PATCH,
+        marker: '.safeword/hooks/prompt-retro-nudge.ts',
         applyWhenContentIncludes: [
           '# Safeword Codex project configuration.',
           '.safeword/hooks/codex/pre-tool-quality.ts',

--- a/packages/cli/templates/codex/config.toml
+++ b/packages/cli/templates/codex/config.toml
@@ -23,6 +23,14 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/prompt-timestam
 timeout = 5
 statusMessage = "Adding current timestamp"
 
+[[hooks.UserPromptSubmit]]
+
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/prompt-retro-nudge.ts"'
+timeout = 30
+statusMessage = "Checking spooled safeword retro drafts"
+
 [[hooks.PreToolUse]]
 matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
 
@@ -37,8 +45,8 @@ statusMessage = "Checking safeword PreToolUse gates"
 [[hooks.Stop.hooks]]
 type = "command"
 command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/stop.ts"'
-timeout = 30
-statusMessage = "Checking whether to run a safeword retro"
+timeout = 600
+statusMessage = "Running safeword retro if this session is substantial"
 
 [[hooks.PostToolUse]]
 matcher = "^(apply_patch|Edit|Write|MultiEdit|NotebookEdit)$"

--- a/packages/cli/templates/hooks/codex/stop.ts
+++ b/packages/cli/templates/hooks/codex/stop.ts
@@ -1,61 +1,99 @@
 #!/usr/bin/env bun
-// Safeword: Codex Stop adapter for the retro auto-trigger (ticket 53DQJZ).
+// Safeword: invisible Codex retro auto-trigger (ticket CDX602 / issue #602).
 //
-// Codex's Stop hook fires at turn-end while the session is alive and hands a
-// turn-scoped payload that includes `transcript_path` (the Codex rollout JSONL).
-// At most once per SUBSTANTIAL session, this emits a {decision:"block", reason}
-// continuation whose reason points the agent at the retro pipeline — the Codex
-// analogue of the Claude stop-retro additionalContext nudge.
-//
-// It reuses the shared core (sentinel, orchestration) via injection seams:
-//   - countToolUsesCodex  — Codex rollout shape ({type,payload}: function_call /
-//     exec_command_begin / mcp_tool_call_begin), NOT Claude's tool_use.
-//   - resolveCodexSessionId — session-stable id (payload session_id / CODEX_THREAD_ID).
-//
-// Codex Stop requires valid JSON output, so the silent and fail-open paths emit
-// `{}` (no decision) rather than nothing. Best-effort: never wrongly continues.
+// Codex skips async hooks, so this Stop hook runs the retro extraction
+// synchronously and emits NOTHING. There is no {decision:"block"} continuation:
+// Lane 2 surfacing for unfiled drafts belongs to the separate UserPromptSubmit
+// prompt-retro-nudge hook. The child path marks itself with SAFEWORD_RETRO_CHILD
+// so a headless `codex exec` process cannot recursively re-fire Stop.
 
-import { readSelfReportConfig } from '../lib/self-report.ts';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { RETRO_CHILD_ENV, retroChildArgs } from '../lib/retro-extract.ts';
 import {
   countToolUsesCodex,
-  decideRetroNudge,
+  decideRetroRun,
+  type OffsetState,
   resolveCodexSessionId,
   type RetroTriggerInput,
+  writeOffsetState,
 } from '../lib/retro-trigger.ts';
+import { readSelfReportConfig } from '../lib/self-report.ts';
 
 interface CodexStopInput extends RetroTriggerInput {
   cwd?: string;
 }
 
-// Codex Stop requires JSON output; `{}` is the valid "no continuation" response.
-const SILENT = '{}';
+/**
+ * The command that runs the extraction CLI. Prefer the dogfood local CLI, else
+ * `bunx safeword@latest`; the spawned CLI then launches `codex exec` through the
+ * shared auto-extract boundary.
+ */
+function resolveExtractCommand(
+  projectDirectory: string,
+  decision: { transcriptPath: string; windowStart: number; sessionId: string },
+): [string, string[]] {
+  const retroArgs = retroChildArgs(decision);
+  const localCli = nodePath.join(projectDirectory, 'packages/cli/src/cli.ts');
+  return existsSync(localCli)
+    ? ['bun', [localCli, ...retroArgs]]
+    : ['bunx', ['safeword@latest', ...retroArgs]];
+}
 
-async function main(): Promise<string> {
+async function main(): Promise<void> {
   let input: CodexStopInput;
   try {
     input = (await Bun.stdin.json()) as CodexStopInput;
   } catch {
-    return SILENT; // malformed stdin → fail open with valid JSON
+    return; // malformed stdin / no stdin -> silent fail-open
   }
 
   const projectDirectory = input.cwd ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-  if (!readSelfReportConfig(projectDirectory).surface) return SILENT;
+  if (!readSelfReportConfig(projectDirectory).surface) return;
 
-  const reason = decideRetroNudge(input, {
+  let pendingOffsetState:
+    | { sessionId: string; state: OffsetState; baseDirectory: string | undefined }
+    | undefined;
+  const decision = decideRetroRun(input, {
     env: process.env,
     countToolUses: countToolUsesCodex,
     resolveSessionId: resolveCodexSessionId,
+    writeOffsetState: (sessionId, state, baseDirectory) => {
+      pendingOffsetState = { sessionId, state, baseDirectory };
+    },
   });
-  if (!reason) return SILENT;
+  if (!decision) return;
 
-  return JSON.stringify({ decision: 'block', reason });
+  const [command, args] = resolveExtractCommand(projectDirectory, decision);
+  const result = spawnSync(command, args, {
+    cwd: projectDirectory,
+    env: {
+      ...process.env,
+      SAFEWORD_RETRO_AGENT: 'codex',
+      [RETRO_CHILD_ENV]: '1',
+    },
+    stdio: 'ignore',
+    timeout: 600_000,
+  });
+  if (result.status !== 0 || result.error || !pendingOffsetState) return;
+
+  try {
+    writeOffsetState(
+      pendingOffsetState.sessionId,
+      pendingOffsetState.state,
+      pendingOffsetState.baseDirectory,
+    );
+  } catch {
+    // A state-write failure must not make Stop visible or blocking.
+  }
 }
 
-let output = SILENT;
 try {
-  output = await main();
+  await main();
 } catch {
-  output = SILENT; // self-observation must never break the Codex turn
+  // Self-observation must never break Stop.
 }
-process.stdout.write(`${output}\n`);
 process.exit(0);

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -8,7 +8,7 @@
 // synchronous runner. Agent-neutral where possible; Claude-specific bits are
 // named as such.
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 /**
@@ -18,26 +18,39 @@ import nodePath from 'node:path';
 export const DIGEST_CAP = 180_000;
 
 /**
- * Default extraction model. Sonnet, not haiku: measured head-to-head on the same
- * transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong ones (ZFGWS1).
- * Overridable per install via `.safeword/config.json` → `retro.model`.
+ * Default Claude extraction model. Sonnet, not haiku: measured head-to-head on
+ * the same transcript, haiku surfaced 1–3 weak findings vs sonnet's 9 strong
+ * ones (ZFGWS1). Overridable per install via `.safeword/config.json` →
+ * `retro.model`.
  */
-export const DEFAULT_RETRO_MODEL = 'sonnet';
+export const DEFAULT_CLAUDE_RETRO_MODEL = 'sonnet';
+
+/** Default Codex extraction model. Stock Codex can only call OpenAI models. */
+export const DEFAULT_CODEX_RETRO_MODEL = 'gpt-5.5';
+
+/** Backward-compatible alias for existing Claude call sites/tests. */
+export const DEFAULT_RETRO_MODEL = DEFAULT_CLAUDE_RETRO_MODEL;
+
+export type RetroAgent = 'claude' | 'codex';
+
+function defaultRetroModel(agent: RetroAgent): string {
+  return agent === 'codex' ? DEFAULT_CODEX_RETRO_MODEL : DEFAULT_CLAUDE_RETRO_MODEL;
+}
 
 /**
  * Resolve the extraction model for an install: `retro.model` from
- * `.safeword/config.json`, else the sonnet default. Fail-open to the default on
- * any missing/unreadable/malformed config — model selection must never break the
- * out-of-band retro run.
+ * `.safeword/config.json`, else the per-agent default. Fail-open to the default
+ * on any missing/unreadable/malformed config — model selection must never break
+ * the out-of-band retro run.
  */
-export function resolveRetroModel(projectDirectory: string): string {
+export function resolveRetroModel(projectDirectory: string, agent: RetroAgent = 'claude'): string {
   try {
     const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
     const parsed = JSON.parse(raw) as { retro?: { model?: unknown } };
     const model = parsed.retro?.model;
-    return typeof model === 'string' && model.length > 0 ? model : DEFAULT_RETRO_MODEL;
+    return typeof model === 'string' && model.length > 0 ? model : defaultRetroModel(agent);
   } catch {
-    return DEFAULT_RETRO_MODEL;
+    return defaultRetroModel(agent);
   }
 }
 
@@ -153,6 +166,44 @@ export function buildExtractArgv(options: ExtractArgvOptions): string[] {
   ];
 }
 
+export interface CodexExtractArgvOptions {
+  /** OpenAI model for the child `codex exec` process. */
+  model: string;
+  /** JSON schema path supplied to `--output-schema`. */
+  schemaPath: string;
+  /** JSON output path supplied to `-o`. */
+  outputPath: string;
+  /** Inline digest + task prompt. No Read/MCP tools are available. */
+  prompt: string;
+}
+
+/**
+ * Build the `codex exec` argv for a headless retro extraction. The digest is
+ * inline in the prompt because `--output-schema` is ignored by Codex when the
+ * task requires Read/MCP tool use. Hooks and MCP servers are explicitly disabled,
+ * stdin is closed by the runner, and the sandbox is read-only.
+ */
+export function buildCodexExtractArgv(options: CodexExtractArgvOptions): string[] {
+  return [
+    'exec',
+    '--ignore-user-config',
+    '--disable',
+    'hooks',
+    '-c',
+    'mcp_servers={}',
+    '--output-schema',
+    options.schemaPath,
+    '-o',
+    options.outputPath,
+    '--json',
+    '--sandbox',
+    'read-only',
+    '-m',
+    options.model,
+    options.prompt,
+  ];
+}
+
 // The extraction rules, mirrored from templates/guides/retro.md: SAFEWORD's own
 // friction only, the constrained snake_case schema, no invention. The egress
 // guard sanitizes downstream, so the child writes plainly.
@@ -165,9 +216,49 @@ const EXTRACT_SYSTEM_PROMPT =
   'friction only (not the host project, not Claude Code itself); canonical ' +
   'behavior-titles; do not invent; [] if none.';
 
+const CODEX_RETRO_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          category: { type: 'string', enum: ['bug', 'rough-edge', 'gap'] },
+          title: { type: 'string' },
+          safeword_surface: { type: 'string' },
+          what_happened: { type: 'string' },
+          why_friction: { type: 'string' },
+          repro: { type: 'string' },
+        },
+        required: [
+          'category',
+          'title',
+          'safeword_surface',
+          'what_happened',
+          'why_friction',
+          'repro',
+        ],
+      },
+    },
+  },
+  required: ['findings'],
+};
+
 /** The task prompt: point the read-only child at the digest file. */
 function buildExtractPrompt(digestPath: string): string {
   return `Read the file ${digestPath} and extract SAFEWORD's own friction as the JSON array described. Output only the JSON array.`;
+}
+
+function buildCodexExtractPrompt(digest: string): string {
+  return (
+    `${EXTRACT_SYSTEM_PROMPT}\n\n` +
+    'Return only JSON matching the provided output schema: {"findings":[...]}. ' +
+    'Use an empty findings array when there is no safeword friction.\n\n' +
+    `Transcript digest:\n${digest}`
+  );
 }
 
 /** Parse a findings array out of a `claude -p --output-format json` envelope. */
@@ -188,6 +279,15 @@ function parseFindings(stdout: string): unknown[] {
     return Array.isArray(findings) ? findings : [];
   } catch {
     return [];
+  }
+}
+
+function parseCodexFindingsOutput(rawOutput: string): unknown[] | undefined {
+  try {
+    const parsed = JSON.parse(rawOutput) as { findings?: unknown };
+    return Array.isArray(parsed.findings) ? parsed.findings : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -212,6 +312,37 @@ export interface RunExtractionDeps {
   cwd: string;
   /** Extraction model (cheap by default). */
   model?: string;
+}
+
+export interface CodexSpawnOptions {
+  cwd: string;
+  env: Record<string, string | undefined>;
+  stdio: 'ignore';
+}
+
+/** Dependencies for `runCodexHeadlessExtraction` — injected for tests. */
+export interface RunCodexExtractionDeps {
+  /** Spawn `codex` with argv; resolve after the child exits. Awaited (sync). */
+  spawn: (argv: string[], options: CodexSpawnOptions) => Promise<SpawnResult>;
+  /** Persist the output schema file read by `codex exec --output-schema`. */
+  writeFile?: (path: string, content: string) => void;
+  /** Read the `-o` JSON file written by `codex exec`. */
+  readFile?: (path: string) => string;
+  /** Base env for the child (the sentinel is added here). */
+  env: Record<string, string | undefined>;
+  /** Neutral cwd — NOT the user's project — so project hooks don't load. */
+  cwd: string;
+  /** Extraction model (OpenAI default for Codex). */
+  model?: string;
+  /** Test seam for deterministic schema/output paths. */
+  schemaPath?: string;
+  outputPath?: string;
+}
+
+export interface CodexExtractionResult {
+  /** True only when the child exited successfully and wrote schema-valid JSON. */
+  ok: boolean;
+  findings: unknown[];
 }
 
 /**
@@ -243,6 +374,52 @@ export async function runHeadlessExtraction(
   } catch {
     return []; // fail-open on any spawn/IO error
   }
+}
+
+/**
+ * Run Codex retro extraction in a separate `codex exec` child and return the raw
+ * findings array with a success bit. Synchronous (awaits the child) and
+ * fail-OPEN: any non-zero exit, missing output, malformed JSON, or
+ * spawn/read/write error yields `{ ok:false, findings:[] }`.
+ */
+export async function runCodexHeadlessExtractionChecked(
+  transcript: string,
+  dependencies: RunCodexExtractionDeps,
+): Promise<CodexExtractionResult> {
+  try {
+    const schemaPath = dependencies.schemaPath ?? nodePath.join(dependencies.cwd, 'schema.json');
+    const outputPath = dependencies.outputPath ?? nodePath.join(dependencies.cwd, 'output.json');
+    const writeFile = dependencies.writeFile ?? writeFileSync;
+    const readFile = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
+
+    writeFile(schemaPath, JSON.stringify(CODEX_RETRO_OUTPUT_SCHEMA));
+    const argv = buildCodexExtractArgv({
+      model: dependencies.model ?? DEFAULT_CODEX_RETRO_MODEL,
+      schemaPath,
+      outputPath,
+      prompt: buildCodexExtractPrompt(buildDigest(transcript)),
+    });
+    const { code } = await dependencies.spawn(argv, {
+      cwd: dependencies.cwd,
+      env: { ...dependencies.env, [RETRO_CHILD_ENV]: '1' },
+      stdio: 'ignore',
+    });
+    if (code !== 0) return { ok: false, findings: [] };
+    const findings = parseCodexFindingsOutput(readFile(outputPath));
+    return findings === undefined ? { ok: false, findings: [] } : { ok: true, findings };
+  } catch {
+    return { ok: false, findings: [] };
+  }
+}
+
+/**
+ * Backward-compatible fail-open wrapper for call sites that only need findings.
+ */
+export async function runCodexHeadlessExtraction(
+  transcript: string,
+  dependencies: RunCodexExtractionDeps,
+): Promise<unknown[]> {
+  return (await runCodexHeadlessExtractionChecked(transcript, dependencies)).findings;
 }
 
 // A tool-result body is kept whole only when it's short OR carries a friction

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -2,9 +2,9 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildAutoExtractor, runRetro } from '../../src/commands/retro.js';
+import { buildAutoExtractor, retroCommand, runRetro } from '../../src/commands/retro.js';
 import type {
   CreateIssueInput,
   IssueComment,
@@ -13,6 +13,11 @@ import type {
 } from '../../src/retro/triage.js';
 import { draftSpoolPath, readSpooledDrafts } from '../../templates/hooks/lib/retro-draft-spool.js';
 import { DIGEST_CAP, runHeadlessExtraction } from '../../templates/hooks/lib/retro-extract.js';
+
+vi.mock('../../src/retro/github-rest.js', () => ({
+  createRestTransport: () => {},
+  resolveGitHubToken: () => {},
+}));
 
 // Compact in-memory transport — only the network boundary is faked.
 class FakeGitHub implements IssueTracker {
@@ -429,6 +434,35 @@ describe('runRetro transport selection (BNGK9W — spool → try-REST → drain 
       ]);
     }
   });
+
+  it('retroCommand still spools sanitized drafts when no GitHub transport is available', async () => {
+    const transcript = nodePath.join(projectDirectory, 'transcript.jsonl');
+    const findings = nodePath.join(projectDirectory, 'findings.json');
+    writeFileSync(transcript, 'transcript content');
+    writeFileSync(findings, JSON.stringify(twoFindings));
+
+    const previousProjectDirectory = process.env.CLAUDE_PROJECT_DIR;
+    const previousExitCode = process.exitCode;
+    process.env.CLAUDE_PROJECT_DIR = projectDirectory;
+    process.exitCode = undefined;
+    try {
+      await retroCommand({ transcript, findings, sessionId: 'sess-a' });
+    } finally {
+      if (previousProjectDirectory === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = previousProjectDirectory;
+      }
+      process.exitCode = previousExitCode;
+    }
+
+    const remaining = readSpooledDrafts(projectDirectory, 'sess-a');
+    expect(remaining).toHaveLength(2);
+    expect(remaining.map(draft => draft.title).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'Alpha friction',
+      'Beta friction',
+    ]);
+  });
 });
 
 // ZFGWS1 SM1.AC2 — the RUNNER (buildAutoExtractor), not just the headless-default
@@ -443,20 +477,32 @@ describe('buildAutoExtractor (SM1.AC2 — runner model: sonnet default, config-o
     rmSync(projectDirectory, { recursive: true, force: true });
   });
 
-  async function modelFromRunner(directory: string): Promise<string | undefined> {
+  async function modelFromRunner(
+    directory: string,
+    agent: 'claude' | 'codex' = 'claude',
+  ): Promise<{ argv: string[]; model: string | undefined }> {
     let argvSeen: string[] = [];
     const extract = await buildAutoExtractor(directory, {
+      agent,
       spawn: (argv: string[]) => {
         argvSeen = argv;
         return Promise.resolve({ code: 0, stdout: '' });
       },
     });
     await extract('transcript');
-    return argvSeen[argvSeen.indexOf('--model') + 1];
+    const modelFlag = agent === 'codex' ? '-m' : '--model';
+    return { argv: argvSeen, model: argvSeen[argvSeen.indexOf(modelFlag) + 1] };
   }
 
   it('builds the extractor with sonnet when no retro.model is configured', async () => {
-    expect(await modelFromRunner(projectDirectory)).toBe('sonnet');
+    const result = await modelFromRunner(projectDirectory);
+    expect(result.model).toBe('sonnet');
+  });
+
+  it('builds the Codex extractor with gpt-5.5 when no retro.model is configured', async () => {
+    const result = await modelFromRunner(projectDirectory, 'codex');
+    expect(result.argv[0]).toBe('exec');
+    expect(result.model).toBe('gpt-5.5');
   });
 
   it('uses the configured retro.model override', async () => {
@@ -465,6 +511,9 @@ describe('buildAutoExtractor (SM1.AC2 — runner model: sonnet default, config-o
       nodePath.join(projectDirectory, '.safeword', 'config.json'),
       JSON.stringify({ retro: { model: 'haiku' } }),
     );
-    expect(await modelFromRunner(projectDirectory)).toBe('haiku');
+    const claude = await modelFromRunner(projectDirectory);
+    const codex = await modelFromRunner(projectDirectory, 'codex');
+    expect(claude.model).toBe('haiku');
+    expect(codex.model).toBe('haiku');
   });
 });

--- a/packages/cli/tests/hooks/retro-extract.test.ts
+++ b/packages/cli/tests/hooks/retro-extract.test.ts
@@ -5,12 +5,17 @@ import nodePath from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  buildCodexExtractArgv,
   buildDigest,
   buildExtractArgv,
+  DEFAULT_CLAUDE_RETRO_MODEL,
+  DEFAULT_CODEX_RETRO_MODEL,
   isRetroChild,
   resolveRetroModel,
   RETRO_CHILD_ENV,
   retroChildArgs as retroChildArguments,
+  runCodexHeadlessExtraction,
+  runCodexHeadlessExtractionChecked,
   runHeadlessExtraction,
 } from '../../templates/hooks/lib/retro-extract.js';
 
@@ -151,6 +156,30 @@ describe('buildExtractArgv', () => {
   });
 });
 
+describe('buildCodexExtractArgv', () => {
+  // codex-retro-parity.SM1.AC1 — Codex extraction runs through `codex exec` with
+  // structured output, closed stdin, no hooks/MCP, and an inline digest prompt.
+  it('builds the gated codex exec argv used by the Stop hook child', () => {
+    const argv = buildCodexExtractArgv({
+      model: 'gpt-5.5',
+      outputPath: '/tmp/out.json',
+      schemaPath: '/tmp/schema.json',
+      prompt: 'INLINE DIGEST',
+    });
+
+    expect(argv.slice(0, 2)).toEqual(['exec', '--ignore-user-config']);
+    expect(argv).toContain('--disable');
+    expect(argv[argv.indexOf('--disable') + 1]).toBe('hooks');
+    expect(argv).toContain('-c');
+    expect(argv[argv.indexOf('-c') + 1]).toBe('mcp_servers={}');
+    expect(argv[argv.indexOf('--output-schema') + 1]).toBe('/tmp/schema.json');
+    expect(argv[argv.indexOf('-o') + 1]).toBe('/tmp/out.json');
+    expect(argv[argv.indexOf('--sandbox') + 1]).toBe('read-only');
+    expect(argv[argv.indexOf('-m') + 1]).toBe('gpt-5.5');
+    expect(argv.at(-1)).toBe('INLINE DIGEST');
+  });
+});
+
 describe('isRetroChild', () => {
   // invisible-retro-claude.NTB1.AC2 (read half) — the recursion guard. The
   // headless child runs WITH hooks (no `--bare`), so without this it would
@@ -167,7 +196,7 @@ describe('isRetroChild', () => {
   });
 });
 
-describe('resolveRetroModel (SM1.AC2 — config-overridable, sonnet default)', () => {
+describe('resolveRetroModel (SM1.AC2 — config-overridable per-agent defaults)', () => {
   let projectDirectory: string;
   beforeEach(() => {
     projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-model-'));
@@ -182,15 +211,23 @@ describe('resolveRetroModel (SM1.AC2 — config-overridable, sonnet default)', (
     writeFileSync(nodePath.join(safewordDirectory, 'config.json'), JSON.stringify(config));
   }
 
-  it('defaults to sonnet when no config / no retro.model is present', () => {
+  it('defaults to sonnet for Claude and gpt-5.5 for Codex when no retro.model is present', () => {
+    expect(DEFAULT_CLAUDE_RETRO_MODEL).toBe('sonnet');
+    expect(DEFAULT_CODEX_RETRO_MODEL).toBe('gpt-5.5');
+
     expect(resolveRetroModel(projectDirectory)).toBe('sonnet');
+    expect(resolveRetroModel(projectDirectory, 'claude')).toBe('sonnet');
+    expect(resolveRetroModel(projectDirectory, 'codex')).toBe('gpt-5.5');
+
     writeRetroConfig({ selfReport: { surface: true } }); // config present, no retro.model
     expect(resolveRetroModel(projectDirectory)).toBe('sonnet');
+    expect(resolveRetroModel(projectDirectory, 'codex')).toBe('gpt-5.5');
   });
 
-  it('honors a configured retro.model override', () => {
+  it('honors a configured retro.model override for both agents', () => {
     writeRetroConfig({ retro: { model: 'haiku' } });
     expect(resolveRetroModel(projectDirectory)).toBe('haiku');
+    expect(resolveRetroModel(projectDirectory, 'codex')).toBe('haiku');
   });
 });
 
@@ -267,5 +304,111 @@ describe('runHeadlessExtraction', () => {
       spawn: () => Promise.reject(new Error('spawn failed')),
     });
     await expect(runHeadlessExtraction('t', threw.deps)).resolves.toEqual([]);
+  });
+});
+
+describe('runCodexHeadlessExtraction', () => {
+  function codexDependencies(over: Record<string, unknown> = {}) {
+    const files = new Map<string, string>();
+    const calls: {
+      argv: string[];
+      options: { cwd: string; env: Record<string, string | undefined>; stdio: 'ignore' };
+    }[] = [];
+
+    return {
+      calls,
+      files,
+      deps: {
+        spawn: (
+          argv: string[],
+          options: { cwd: string; env: Record<string, string | undefined>; stdio: 'ignore' },
+        ) => {
+          calls.push({ argv, options });
+          files.set(
+            '/tmp/neutral/out.json',
+            JSON.stringify({ findings: JSON.parse(validFindings) }),
+          );
+          return Promise.resolve({ code: 0, stdout: '' });
+        },
+        writeFile: (path: string, content: string) => files.set(path, content),
+        readFile: (path: string) => {
+          const content = files.get(path);
+          if (content === undefined) throw new Error(`missing file: ${path}`);
+          return content;
+        },
+        cwd: '/tmp/neutral',
+        env: { HOME: '/home/x' },
+        model: 'gpt-5.5',
+        schemaPath: '/tmp/neutral/schema.json',
+        outputPath: '/tmp/neutral/out.json',
+        ...over,
+      },
+    };
+  }
+
+  it('codex-retro-parity.SM1.AC1.runs_synchronously_with_schema_output_and_closed_stdio', async () => {
+    const { calls, deps } = codexDependencies();
+    const transcript = JSON.stringify({
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'INLINE_TRANSCRIPT_SIGNAL' }],
+      },
+    });
+    const findings = await runCodexHeadlessExtraction(transcript, deps);
+
+    expect(findings).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (!call) throw new Error('expected a spawn call');
+    expect(call.argv[0]).toBe('exec');
+    expect(call.argv).toContain('--output-schema');
+    expect(call.argv).toContain('--json');
+    expect(call.argv.at(-1)).toContain('INLINE_TRANSCRIPT_SIGNAL');
+    expect(call.options.cwd).toBe('/tmp/neutral');
+    expect(call.options.stdio).toBe('ignore');
+    expect(call.options.env[RETRO_CHILD_ENV]).toBe('1');
+  });
+
+  it('codex-retro-parity.SM2.AC1.fail_open_stays_silent_when_codex_output_is_unusable', async () => {
+    const nonZero = codexDependencies({
+      spawn: () => Promise.resolve({ code: 1, stdout: '' }),
+    });
+    await expect(runCodexHeadlessExtraction('t', nonZero.deps)).resolves.toEqual([]);
+    await expect(runCodexHeadlessExtractionChecked('t', nonZero.deps)).resolves.toEqual({
+      ok: false,
+      findings: [],
+    });
+
+    const invalid = codexDependencies({
+      spawn: (
+        _argv: string[],
+        _options: { cwd: string; env: Record<string, string | undefined>; stdio: 'ignore' },
+      ) => {
+        invalid.files.set('/tmp/neutral/out.json', '{not json');
+        return Promise.resolve({ code: 0, stdout: '' });
+      },
+    });
+    await expect(runCodexHeadlessExtraction('t', invalid.deps)).resolves.toEqual([]);
+    await expect(runCodexHeadlessExtractionChecked('t', invalid.deps)).resolves.toEqual({
+      ok: false,
+      findings: [],
+    });
+  });
+
+  it('treats schema-valid empty Codex findings as a successful extraction', async () => {
+    const empty = codexDependencies({
+      spawn: (
+        _argv: string[],
+        _options: { cwd: string; env: Record<string, string | undefined>; stdio: 'ignore' },
+      ) => {
+        empty.files.set('/tmp/neutral/out.json', JSON.stringify({ findings: [] }));
+        return Promise.resolve({ code: 0, stdout: '' });
+      },
+    });
+
+    await expect(runCodexHeadlessExtractionChecked('t', empty.deps)).resolves.toEqual({
+      ok: true,
+      findings: [],
+    });
   });
 });

--- a/packages/cli/tests/integration/codex-stop-retro.test.ts
+++ b/packages/cli/tests/integration/codex-stop-retro.test.ts
@@ -1,21 +1,20 @@
 /**
- * Integration test: the Codex stop.ts adapter fires the retro pipeline via a
- * {decision:"block"} continuation on a substantial Codex session (ticket 53DQJZ).
+ * Integration test: the Codex stop.ts adapter fires the retro pipeline invisibly
+ * on a substantial Codex session (ticket CDX602 / issue #602).
  *
  * Spawns the real dogfood hook under bun with a seeded Codex rollout, asserting
- * the wiring: substantial Codex rollout → block + path + guide; below-threshold →
- * valid {} (no decision); Claude-shaped lines → {} (zero Codex events); second
- * Stop → {}; malformed stdin → valid JSON, exit 0. Decision logic is unit-tested
- * in tests/hooks/retro-trigger-codex.
+ * the wiring: substantial Codex rollout → silent synchronous child; below-threshold
+ * / wrong-shape / malformed / unreadable → silent no-op; recursion sentinel →
+ * no child. Decision logic is unit-tested in tests/hooks/retro-trigger-codex.
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { sentinelPath } from '../../templates/hooks/lib/retro-trigger.js';
+import { offsetStatePath, sentinelPath } from '../../templates/hooks/lib/retro-trigger.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, TIMEOUT_QUICK } from '../helpers';
 
 const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
@@ -52,18 +51,52 @@ function writeClaudeShapedRollout(directory: string, name: string): string {
   return file;
 }
 
-function runHook(directory: string, input: unknown) {
+function installFakeLocalCli(directory: string, options: { exitCode?: number } = {}): void {
+  const exitCode = options.exitCode ?? 0;
+  const cliPath = nodePath.join(directory, 'packages/cli/src/cli.ts');
+  mkdirSync(nodePath.dirname(cliPath), { recursive: true });
+  writeFileSync(
+    cliPath,
+    `#!/usr/bin/env bun
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.RECORD_PATH!, JSON.stringify({
+  argv: Bun.argv.slice(2),
+  cwd: process.cwd(),
+  env: {
+    SAFEWORD_RETRO_AGENT: process.env.SAFEWORD_RETRO_AGENT,
+    SAFEWORD_RETRO_CHILD: process.env.SAFEWORD_RETRO_CHILD,
+	  },
+	}));
+	${exitCode === 0 ? '' : `process.exit(${exitCode});`}
+	`,
+  );
+}
+
+function readRecord(path: string): {
+  argv: string[];
+  cwd: string;
+  env: { SAFEWORD_RETRO_AGENT?: string; SAFEWORD_RETRO_CHILD?: string };
+} {
+  return JSON.parse(readFileSync(path, 'utf8')) as {
+    argv: string[];
+    cwd: string;
+    env: { SAFEWORD_RETRO_AGENT?: string; SAFEWORD_RETRO_CHILD?: string };
+  };
+}
+
+function runHook(directory: string, input: unknown, env: Record<string, string | undefined> = {}) {
   return spawnSync('bun', [HOOK], {
     input: typeof input === 'string' ? input : JSON.stringify(input),
     cwd: directory,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: directory },
+    env: { ...process.env, CLAUDE_PROJECT_DIR: directory, ...env },
     encoding: 'utf8',
     timeout: TIMEOUT_QUICK,
   });
 }
 
-describe('codex/stop.ts retro adapter (53DQJZ)', () => {
+describe('codex/stop.ts retro adapter (CDX602)', () => {
   let dir: string;
+  let recordPath: string;
   const sessionIds: string[] = [];
 
   function freshSession(tag: string): string {
@@ -74,82 +107,197 @@ describe('codex/stop.ts retro adapter (53DQJZ)', () => {
 
   beforeEach(() => {
     dir = createTemporaryDirectory();
+    recordPath = nodePath.join(dir, 'child-record.json');
   });
   afterEach(() => {
     removeTemporaryDirectory(dir);
-    for (const id of sessionIds) rmSync(sentinelPath(id), { force: true });
+    for (const id of sessionIds) {
+      rmSync(sentinelPath(id), { force: true });
+      rmSync(offsetStatePath(id), { force: true });
+    }
     sessionIds.length = 0;
   });
 
-  it('emits a block-continuation with path and guide on a substantial Codex session', () => {
+  it('codex-retro-parity.SM1.AC1.silently_spawns_sync_retro_child_on_substantial_codex_session', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
     const transcript = writeCodexRollout(dir, 'big.jsonl', 8);
     const id = freshSession('big');
 
-    const result = runHook(dir, { session_id: id, transcript_path: transcript, cwd: dir });
+    const result = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
 
     expect(result.status).toBe(0);
-    const payload = JSON.parse(result.stdout);
-    expect(payload.decision).toBe('block');
-    expect(payload.reason).toContain(transcript);
-    expect(payload.reason.toLowerCase()).toContain('guide');
+    expect(result.stdout).toBe('');
+
+    expect(existsSync(recordPath)).toBe(true);
+    const record = readRecord(recordPath);
+    expect(record.cwd).toBe(realpathSync(dir));
+    expect(record.env.SAFEWORD_RETRO_AGENT).toBe('codex');
+    expect(record.env.SAFEWORD_RETRO_CHILD).toBe('1');
+    expect(record.argv).toContain('retro');
+    expect(record.argv).toContain('--auto-extract');
+    expect(record.argv[record.argv.indexOf('--transcript') + 1]).toBe(transcript);
+    expect(record.argv[record.argv.indexOf('--window-start') + 1]).toBe('0');
+    expect(record.argv[record.argv.indexOf('--session-id') + 1]).toBe(id);
   });
 
-  it('emits valid JSON with no decision on a below-threshold Codex session', () => {
+  it('codex-retro-parity.SM2.AC1.stays_silent_without_child_on_below_threshold_codex_session', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
     const transcript = writeCodexRollout(dir, 'small.jsonl', 1);
     const id = freshSession('small');
 
-    const result = runHook(dir, { session_id: id, transcript_path: transcript, cwd: dir });
+    const result = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
 
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout).decision).toBeUndefined();
+    expect(result.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
   });
 
   it('does not fire on a rollout of Claude-shaped tool_use lines (zero Codex events)', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
     const transcript = writeClaudeShapedRollout(dir, 'claude-shaped.jsonl');
     const id = freshSession('wrongshape');
 
-    const result = runHook(dir, { session_id: id, transcript_path: transcript, cwd: dir });
+    const result = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
 
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout).decision).toBeUndefined();
+    expect(result.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
   });
 
-  it('does not continue again on the second Stop for the same session', () => {
+  it('does not fire again on the second Stop without enough new growth', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
     const transcript = writeCodexRollout(dir, 'big.jsonl', 8);
     const id = freshSession('twice');
 
-    const first = runHook(dir, { session_id: id, transcript_path: transcript, cwd: dir });
-    expect(JSON.parse(first.stdout).decision).toBe('block');
-    const second = runHook(dir, { session_id: id, transcript_path: transcript, cwd: dir });
-    expect(JSON.parse(second.stdout).decision).toBeUndefined();
+    const first = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
+    expect(first.status).toBe(0);
+    expect(first.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(true);
+
+    rmSync(recordPath, { force: true });
+    const second = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
+    expect(second.status).toBe(0);
+    expect(second.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
   });
 
-  it('fails open with valid JSON on malformed stdin', () => {
+  it('does not advance offset state when the retro child exits non-zero', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir, { exitCode: 1 });
+    const transcript = writeCodexRollout(dir, 'big.jsonl', 8);
+    const id = freshSession('childfail');
 
-    const result = runHook(dir, 'not json at all');
+    const first = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
+    expect(first.status).toBe(0);
+    expect(first.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(true);
+    expect(existsSync(offsetStatePath(id))).toBe(false);
+
+    rmSync(recordPath, { force: true });
+    installFakeLocalCli(dir);
+    const second = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
+    expect(second.status).toBe(0);
+    expect(second.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(true);
+    expect(existsSync(offsetStatePath(id))).toBe(true);
+  });
+
+  it('fails open silently on malformed stdin', () => {
+    writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
+
+    const result = runHook(dir, 'not json at all', { RECORD_PATH: recordPath });
 
     expect(result.status).toBe(0);
-    expect(() => JSON.parse(result.stdout)).not.toThrow();
-    expect(JSON.parse(result.stdout).decision).toBeUndefined();
+    expect(result.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
   });
 
-  it('fails open with valid JSON when the transcript_path is unreadable', () => {
+  it('fails open silently when the transcript_path is unreadable', () => {
     writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
     const id = freshSession('unreadable');
 
-    const result = runHook(dir, {
-      session_id: id,
-      transcript_path: nodePath.join(dir, 'does-not-exist.jsonl'),
-      cwd: dir,
-    });
+    const result = runHook(
+      dir,
+      {
+        session_id: id,
+        transcript_path: nodePath.join(dir, 'does-not-exist.jsonl'),
+        cwd: dir,
+      },
+      {
+        RECORD_PATH: recordPath,
+      },
+    );
 
     expect(result.status).toBe(0);
-    expect(() => JSON.parse(result.stdout)).not.toThrow();
-    expect(JSON.parse(result.stdout).decision).toBeUndefined();
+    expect(result.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
+  });
+
+  it('codex-retro-parity.SM3.AC1.recursion_guard_suppresses_child_spawn', () => {
+    writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir);
+    const transcript = writeCodexRollout(dir, 'big.jsonl', 8);
+    const id = freshSession('child');
+
+    const result = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+        SAFEWORD_RETRO_CHILD: '1',
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(existsSync(recordPath)).toBe(false);
   });
 });

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1517,6 +1517,44 @@ describe('Reconcile - Reconciliation Engine', () => {
     });
   });
 
+  describe('reconcile() - Codex retro parity (#602)', () => {
+    it('configures the silent Stop retro hook and prompt nudge hook on install', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(content).toContain('.safeword/hooks/codex/stop.ts');
+      expect(content).toContain('timeout = 600');
+      expect(content).toContain('Running safeword retro if this session is substantial');
+      expect(content).toContain('.safeword/hooks/prompt-retro-nudge.ts');
+      expect(content).toContain('Checking spooled safeword retro drafts');
+    });
+
+    it('retrofits the Codex prompt retro nudge into an existing pre-nudge config', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { CODEX_PROMPT_RETRO_NUDGE_HOOK_PATCH, SAFEWORD_SCHEMA } =
+        await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      const preNudge = readCodexConfigTemplate().replace(CODEX_PROMPT_RETRO_NUDGE_HOOK_PATCH, '');
+      mkdirSync(nodePath.join(temporaryDirectory, '.codex'), { recursive: true });
+      writeFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), preNudge);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(content).toContain('.safeword/hooks/prompt-retro-nudge.ts');
+      expect(content.match(/\.safeword\/hooks\/prompt-retro-nudge\.ts/g)).toHaveLength(1);
+    });
+  });
+
   describe('reconcile() - dryRun option', () => {
     it('should not make any changes in dryRun mode', async () => {
       const { reconcile } = await import('../src/reconcile.js');

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -86,12 +86,14 @@ Hooks run automatically at key moments. You don't invoke them—they work in the
   <TabItem label="Codex">
     Safeword installs hook config (`.codex/config.toml`) and repo-scoped skills (`.agents/skills/`) for Codex.
 
-    | When                   | What happens                                      |
-    | ---------------------- | ------------------------------------------------- |
-    | Before supported tools | Runs safeword's PreToolUse quality gate adapter |
-    | Agent edits Go/Python/TS/Rust | Points it at that language's coding-skill |
+    | When                   | What happens                                                        |
+    | ---------------------- | ------------------------------------------------------------------- |
+    | Before supported tools | Runs safeword's PreToolUse quality gate adapter                     |
+    | Agent edits Go/Python/TS/Rust | Points it at that language's coding-skill                   |
+    | You stop the session   | Runs silent retro extraction from the Codex transcript              |
+    | You submit a prompt    | Shows a factual nudge when unfiled retro drafts are waiting         |
 
-    Safeword's Codex adapter covers the documented PreToolUse paths it configures: `Bash`, `apply_patch` edit payloads, and MCP tools. Live Codex runs can also report `file_change` execution items; Safeword records that as a Codex runtime boundary, not as a PreToolUse path it claims to guard.
+    Safeword's Codex quality gate covers the documented PreToolUse paths it configures: `Bash`, `apply_patch` edit payloads, and MCP tools. Live Codex runs can also report `file_change` execution items; Safeword records that as a Codex runtime boundary, not as a PreToolUse path it claims to guard. Retro extraction is separate: Stop runs it synchronously and silently, and unfiled drafts use the UserPromptSubmit nudge lane instead of a Stop continuation.
 
     ### Skills
 
@@ -102,7 +104,7 @@ Hooks run automatically at key moments. You don't invoke them—they work in the
     Project-local Codex hooks only run after you review and trust them in Codex. Safeword writes the config, but Codex owns the trust decision.
 
     Hook config: `.codex/config.toml`
-    Hook adapter: `.safeword/hooks/codex/pre-tool-quality.ts`
+    Hook adapters: `.safeword/hooks/codex/pre-tool-quality.ts`, `.safeword/hooks/codex/stop.ts`, `.safeword/hooks/prompt-retro-nudge.ts`
     Skill files: `.agents/skills/`
 
   </TabItem>


### PR DESCRIPTION
## Summary

- Replaces the visible Codex Stop `{decision:"block"}` retro continuation with silent synchronous Stop extraction through child `codex exec`.
- Adds Codex/OpenAI retro model defaults while preserving Claude's `sonnet` default and shared `retro.model` override.
- Wires Codex `UserPromptSubmit` to the existing `prompt-retro-nudge` lane for unfiled spooled drafts.
- Reuses the shared retro egress, spool, direct-file, and nudge pipeline; updates schema/config retrofits, dogfood mirrors, BDD artifacts, and docs.

Closes #602.
Parent epic: #344 / RV9JT4.
Gating spike recorded on #602: https://github.com/ArcadeAI/safeword/issues/602#issuecomment-4861045872

## Verification

- `bun run --cwd packages/cli vitest run tests/hooks/retro-extract.test.ts tests/commands/retro.test.ts tests/integration/codex-stop-retro.test.ts tests/reconcile.test.ts` — 4 files, 123 tests
- `bun run lint`
- `bun run --cwd packages/website typecheck`
- Template/dogfood parity: `cmp` checks for Codex Stop, retro-extract lib, and Codex config
- `git diff --check`
- Push schema-drift gate — 2 files, 627 tests

## Notes

- Cloud Codex remains out of scope for this issue.
- Branch is based on `claude/cloud-retro-filing-transport` because #602 builds on the #601 Claude baseline.
