### PR TITLE
Refactor Codex Stop no-continuation assertions

### DIFF
--- a/packages/cli/tests/integration/codex-stop-nudge.test.ts
+++ b/packages/cli/tests/integration/codex-stop-nudge.test.ts
@@ -83,6 +83,11 @@ function runCodexStop(cwd: string, input: Record<string, unknown> = {}) {
   });
 }
 
+function expectNoContinuation(stdout: string): void {
+  const parsed = JSON.parse(stdout.trim()) as { decision?: string };
+  expect(parsed.decision).toBeUndefined();
+}
+
 describe('Codex Stop architecture drift nudge', () => {
   let cwd = '';
 
@@ -113,7 +118,7 @@ describe('Codex Stop architecture drift nudge', () => {
     expect(result.status).toBe(0);
     // Merged Stop adapter unifies the no-op output on valid JSON `{}` (no decision)
     // — the retro half requires parseable stdout — rather than empty output.
-    expect(JSON.parse(result.stdout.trim()).decision).toBeUndefined();
+    expectNoContinuation(result.stdout);
     expect(result.stderr).toBe('');
   });
 
@@ -125,7 +130,7 @@ describe('Codex Stop architecture drift nudge', () => {
     expect(result.status).toBe(0);
     // Merged Stop adapter unifies the no-op output on valid JSON `{}` (no decision)
     // — the retro half requires parseable stdout — rather than empty output.
-    expect(JSON.parse(result.stdout.trim()).decision).toBeUndefined();
+    expectNoContinuation(result.stdout);
     expect(result.stderr).toBe('');
   });
 
@@ -137,7 +142,7 @@ describe('Codex Stop architecture drift nudge', () => {
     expect(result.status).toBe(0);
     // Merged Stop adapter unifies the no-op output on valid JSON `{}` (no decision)
     // — the retro half requires parseable stdout — rather than empty output.
-    expect(JSON.parse(result.stdout.trim()).decision).toBeUndefined();
+    expectNoContinuation(result.stdout);
     expect(result.stderr).toBe('');
   });
 });


### PR DESCRIPTION
Follow-up to #598 / #605 after rebasing onto main.\n\nWhat changed:\n- Extracted the repeated Codex Stop no-continuation JSON assertion into a test helper.\n- No production behavior changes.\n\nVerification:\n- SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run --cwd packages/cli test tests/integration/codex-stop-nudge.test.ts\n- bun run --cwd packages/cli typecheck\n- bun run --cwd packages/cli lint:eslint\n- git diff --check\n