### PR TITLE
Bind review stamps to the session ticket

### DIFF
--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -17,14 +17,16 @@
 // Usage:
 //   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
 //   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
-// With more than one in_progress ticket, pass --ticket to disambiguate; without
-// it the step fails rather than guess a ticket the gate may not be checking.
+// Without --ticket, the helper stamps the session-bound active ticket. If no
+// session binding exists and more than one ticket is in_progress, pass --ticket
+// to disambiguate rather than guessing a ticket the gate may not be checking.
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { getInProgressTicketFolders } from './lib/active-ticket.ts';
+import { getInProgressTicketFolders, getTicketInfo } from './lib/active-ticket.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 import { resolveRunIdentity } from './lib/run-identity.ts';
@@ -96,8 +98,31 @@ function parseArguments(argv: string[]): ParsedArguments {
 
 const { positional, explicitTicket, reviewerModel } = parseArguments(process.argv);
 
-// Resolve the ticket the same way the gate does conceptually (the one being worked),
-// failing loudly on ambiguity instead of stamping a ticket the gate isn't checking.
+function formatTicketList(folders: string[]): string {
+  const shown = folders.slice(0, 12).join(', ');
+  const remaining = folders.length - 12;
+  return remaining > 0 ? `${shown}, ... ${remaining} more` : shown;
+}
+
+function resolveSessionTicketFolder(): string | undefined {
+  const activeTicket = readSessionState(projectDirectory, runIdentity)?.activeTicket;
+  if (!activeTicket) return undefined;
+
+  const ticket = getTicketInfo(projectDirectory, activeTicket);
+  if (!ticket.folder) {
+    fail(`session-bound ticket "${activeTicket}" not found — pass --ticket <folder>`);
+  }
+  if (ticket.status !== undefined && ticket.status !== 'in_progress') {
+    fail(
+      `session-bound ticket "${activeTicket}" is ${ticket.status}, not in_progress — pass --ticket <folder>`,
+    );
+  }
+  return ticket.folder;
+}
+
+// Resolve the ticket the same way the gates do: current session binding first,
+// then the legacy single-ticket fallback. The fallback exists for tiny repos; a
+// mature backlog with many in-progress tickets must not become a guessing game.
 function resolveTicketFolder(): string {
   if (explicitTicket !== undefined) {
     if (!existsSync(nodePath.join(ticketsDirectory, explicitTicket, 'ticket.md'))) {
@@ -105,11 +130,15 @@ function resolveTicketFolder(): string {
     }
     return explicitTicket;
   }
+
+  const sessionTicketFolder = resolveSessionTicketFolder();
+  if (sessionTicketFolder !== undefined) return sessionTicketFolder;
+
   const inProgress = getInProgressTicketFolders(projectDirectory);
   if (inProgress.length === 0) fail('no in_progress ticket found — nothing to stamp');
   if (inProgress.length > 1) {
     fail(
-      `multiple in_progress tickets (${inProgress.join(', ')}) — pass --ticket <folder> to disambiguate`,
+      `no session-bound active ticket and multiple in_progress tickets (${formatTicketList(inProgress)}) — pass --ticket <folder> to disambiguate`,
     );
   }
   return inProgress[0] ?? fail('no in_progress ticket found — nothing to stamp');

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -17,14 +17,16 @@
 // Usage:
 //   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
 //   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
-// With more than one in_progress ticket, pass --ticket to disambiguate; without
-// it the step fails rather than guess a ticket the gate may not be checking.
+// Without --ticket, the helper stamps the session-bound active ticket. If no
+// session binding exists and more than one ticket is in_progress, pass --ticket
+// to disambiguate rather than guessing a ticket the gate may not be checking.
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { getInProgressTicketFolders } from './lib/active-ticket.ts';
+import { getInProgressTicketFolders, getTicketInfo } from './lib/active-ticket.ts';
+import { readSessionState } from './lib/quality-state.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
 import { resolveRunIdentity } from './lib/run-identity.ts';
@@ -96,8 +98,31 @@ function parseArguments(argv: string[]): ParsedArguments {
 
 const { positional, explicitTicket, reviewerModel } = parseArguments(process.argv);
 
-// Resolve the ticket the same way the gate does conceptually (the one being worked),
-// failing loudly on ambiguity instead of stamping a ticket the gate isn't checking.
+function formatTicketList(folders: string[]): string {
+  const shown = folders.slice(0, 12).join(', ');
+  const remaining = folders.length - 12;
+  return remaining > 0 ? `${shown}, ... ${remaining} more` : shown;
+}
+
+function resolveSessionTicketFolder(): string | undefined {
+  const activeTicket = readSessionState(projectDirectory, runIdentity)?.activeTicket;
+  if (!activeTicket) return undefined;
+
+  const ticket = getTicketInfo(projectDirectory, activeTicket);
+  if (!ticket.folder) {
+    fail(`session-bound ticket "${activeTicket}" not found — pass --ticket <folder>`);
+  }
+  if (ticket.status !== undefined && ticket.status !== 'in_progress') {
+    fail(
+      `session-bound ticket "${activeTicket}" is ${ticket.status}, not in_progress — pass --ticket <folder>`,
+    );
+  }
+  return ticket.folder;
+}
+
+// Resolve the ticket the same way the gates do: current session binding first,
+// then the legacy single-ticket fallback. The fallback exists for tiny repos; a
+// mature backlog with many in-progress tickets must not become a guessing game.
 function resolveTicketFolder(): string {
   if (explicitTicket !== undefined) {
     if (!existsSync(nodePath.join(ticketsDirectory, explicitTicket, 'ticket.md'))) {
@@ -105,11 +130,15 @@ function resolveTicketFolder(): string {
     }
     return explicitTicket;
   }
+
+  const sessionTicketFolder = resolveSessionTicketFolder();
+  if (sessionTicketFolder !== undefined) return sessionTicketFolder;
+
   const inProgress = getInProgressTicketFolders(projectDirectory);
   if (inProgress.length === 0) fail('no in_progress ticket found — nothing to stamp');
   if (inProgress.length > 1) {
     fail(
-      `multiple in_progress tickets (${inProgress.join(', ')}) — pass --ticket <folder> to disambiguate`,
+      `no session-bound active ticket and multiple in_progress tickets (${formatTicketList(inProgress)}) — pass --ticket <folder> to disambiguate`,
     );
   }
   return inProgress[0] ?? fail('no in_progress ticket found — nothing to stamp');

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -104,6 +104,22 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     return existsSync(logFile) ? readFileSync(logFile, 'utf8') : '';
   }
 
+  function bindSessionTicket(ticketId: string = TICKET_ID): void {
+    writeFileSync(
+      nodePath.join(projectRoot, '.safeword-project', 'quality-state-sess-1.json'),
+      JSON.stringify({ activeTicket: ticketId }),
+    );
+  }
+
+  function createSecondTicket(): void {
+    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
+    mkdirSync(second, { recursive: true });
+    writeFileSync(
+      nodePath.join(second, 'ticket.md'),
+      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
+    );
+  }
+
   beforeEach(() => {
     projectRoot = mkdtempSync(nodePath.join(tmpdir(), 'review-stamp-'));
     ticketDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', TICKET_ID);
@@ -170,16 +186,24 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(stamps.some(s => s.scope === 'HACKED:spec@deadbeefcafe')).toBe(false);
   });
 
-  it('fails loudly when more than one ticket is in_progress (no --ticket)', () => {
-    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
-    mkdirSync(second, { recursive: true });
-    writeFileSync(
-      nodePath.join(second, 'ticket.md'),
-      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
-    );
+  it('uses the session-bound active ticket when more than one ticket is in_progress (no --ticket)', () => {
+    createSecondTicket();
+    bindSessionTicket();
+
     const stamp = runStamp('spec');
+
+    expect(stamp.status).toBe(0);
+    expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+  });
+
+  it('fails loudly when multiple tickets are in_progress and no session ticket is bound', () => {
+    createSecondTicket();
+
+    const stamp = runStamp('spec');
+
     expect(stamp.status).toBe(1);
     expect(stamp.stdout).toContain('multiple in_progress tickets');
+    expect(stamp.stdout).toContain('pass --ticket <folder>');
   });
 
   it('rejects a path-separator in --ticket or the artifact (no escaping tickets/)', () => {
@@ -193,12 +217,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
   });
 
   it('--ticket disambiguates when more than one ticket is in_progress', () => {
-    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
-    mkdirSync(second, { recursive: true });
-    writeFileSync(
-      nodePath.join(second, 'ticket.md'),
-      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
-    );
+    createSecondTicket();
     const stamp = runStamp('--ticket', TICKET_ID, 'spec');
     expect(stamp.status).toBe(0);
     expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -224,12 +224,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
   });
 
   it('--ticket after --phase disambiguates when more than one ticket is in_progress', () => {
-    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
-    mkdirSync(second, { recursive: true });
-    writeFileSync(
-      nodePath.join(second, 'ticket.md'),
-      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
-    );
+    createSecondTicket();
     const stamp = runStamp('--phase', 'define-behavior', '--ticket', TICKET_ID);
     expect(stamp.status).toBe(0);
     expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'phase', 'define-behavior')}`);


### PR DESCRIPTION
## Summary

- Resolve `write-review-stamp.ts` against the session-bound active ticket before falling back to a global `in_progress` scan.
- Keep explicit `--ticket` behavior for manual disambiguation and stale/missing session bindings.
- Add integration coverage for multiple `in_progress` tickets with and without a session-bound ticket.
- Reuse the shared second-ticket fixture in the review-stamp tests.

Fixes #564.

## Notes

Issue #564 also mentioned `record-skill-invocation.ts`, but current code does not scan tickets there. The reproducible failing path is `write-review-stamp.ts`, which this PR fixes.

## Verification

- `SAFEWORD_TEST_LOCK_DIR=/tmp/safeword-8935-review-stamp-test.lock bun run test tests/integration/review-stamp.test.ts`
- `bun run typecheck`
- `bunx eslint packages/cli/tests/integration/review-stamp.test.ts`
- `git diff --check origin/main...HEAD`
- `cmp -s packages/cli/templates/hooks/write-review-stamp.ts .safeword/hooks/write-review-stamp.ts`
- `bun audit --json`
