### PR TITLE
feat(parity): parity-check --fix — auto-sync drifted template↔dogfood pairs (#585)

### DIFF
--- a/.claude/commands/parity-check.md
+++ b/.claude/commands/parity-check.md
@@ -9,13 +9,16 @@ Run the safeword parity check against `SAFEWORD_SCHEMA`. Reports drift on both p
 This command exists only in the safeword repo. It is NOT a customer-facing command and is NOT installed by `safeword install`.
 
 ```bash
-bun scripts/parity-check.ts --mode=all
+bun scripts/parity-check.ts --mode=all   # report drift
+bun scripts/parity-check.ts --fix        # auto-sync: copy drifted templates → dogfood mirrors (#585)
 ```
+
+`--fix` (or `bun run parity:fix`) resolves pair drift by copying each canonical template over its dogfood mirror, so a hook edit no longer has to be hand-`cp`'d between `templates/` and `.safeword/`. Templates are canonical; `.safeword/` is the mirror.
 
 ## What gets checked
 
-- **Pairs** (from `SAFEWORD_SCHEMA.ownedFiles`): every entry with a `template` field is compared byte-for-byte against its dogfood counterpart. Currently 88 pairs.
-- **Contracts** (from `SAFEWORD_SCHEMA.contracts`): every entry asserts its target file contains all required strings. Currently 1 contract.
+- **Pairs** (from `SAFEWORD_SCHEMA.ownedFiles`): every entry with a `template` field is compared byte-for-byte against its dogfood counterpart.
+- **Contracts** (from `SAFEWORD_SCHEMA.contracts`): every entry asserts its target file contains all required strings.
 
 ## When to use
 
@@ -25,7 +28,7 @@ bun scripts/parity-check.ts --mode=all
 
 ## When NOT to use
 
-- Mid-template-iteration: pair drift is expected while editing templates without syncing to dogfood. The release test catches pair drift pre-release; the slash command will surface it as informational here.
+- Mid-template-iteration: pair drift is expected while editing templates without syncing to dogfood — run `--fix` to sync instead of hand-`cp`-ing (#585). The release test catches any residual pair drift pre-release; the slash command surfaces it as informational here.
 
 ## Adding a new parity rule
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "bun run --cwd packages/cli typecheck",
     "lint": "eslint . && bun run lint:gherkin && bun run --cwd packages/cli typecheck",
     "format": "prettier --write .",
+    "parity:fix": "bun scripts/parity-check.ts --fix",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#examples\" \"#dist\"",
     "lint:sh": "shellcheck **/*.sh .safeword/hooks/* packages/cli/templates/hooks/* packages/cli/templates/scripts/* 2>/dev/null || true",
     "lint:gherkin": "bun packages/cli/src/cli.ts lint-gherkin",

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import type { ContractDefinition, FileDefinition } from './schema.js';
@@ -169,4 +169,51 @@ export function runParity(input: ParityInput): ParityResult {
   );
 
   return { failures, passedCount };
+}
+
+export interface ParitySyncResult {
+  /** Destination (dogfood) paths that were (re)written from their template. */
+  synced: string[];
+  /** Pairs that cannot be auto-copied — a missing *template* has nothing to copy from. */
+  unfixable: ParityFailure[];
+}
+
+/**
+ * Resolve byte-pair drift by copying each canonical template over its dogfood
+ * mirror — the auto-sync behind `parity-check --fix` (issue #585), so a hook edit
+ * no longer has to be hand-`cp`'d between `templates/` and `.safeword/`. Templates
+ * are canonical (they ship and are linted; `.safeword/` is the prettier-ignored
+ * mirror that falls behind), so the copy is always template → dogfood. Only `pair`
+ * drift is fixable this way; a missing template is reported unfixable. Contracts,
+ * orphan-templates, and cursor-rule fatness are not byte-copy-fixable and are left
+ * for the check to report. `input.mode` is ignored — sync is always pair-based.
+ */
+export function syncParityPairs(input: ParityInput): ParitySyncResult {
+  const synced: string[] = [];
+  const unfixable: ParityFailure[] = [];
+
+  for (const [destinationPath, definition] of Object.entries(input.schema.ownedFiles)) {
+    if (!definition.template) continue;
+    const templateFile = nodePath.join(input.templatesDirectory, definition.template);
+
+    if (!existsSync(templateFile)) {
+      unfixable.push({
+        kind: 'pair',
+        message: `[PAIR] Cannot fix — template missing: ${definition.template}`,
+      });
+      continue;
+    }
+
+    const dogfoodFile = nodePath.join(input.rootDirectory, destinationPath);
+    const templateContent = readFileSync(templateFile, 'utf8');
+    if (existsSync(dogfoodFile) && readFileSync(dogfoodFile, 'utf8') === templateContent) {
+      continue; // already byte-identical
+    }
+
+    mkdirSync(nodePath.dirname(dogfoodFile), { recursive: true });
+    writeFileSync(dogfoodFile, templateContent);
+    synced.push(destinationPath);
+  }
+
+  return { synced, unfixable };
 }

--- a/packages/cli/tests/parity.test.ts
+++ b/packages/cli/tests/parity.test.ts
@@ -1,10 +1,10 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { runParity } from '../src/parity.js';
+import { runParity, syncParityPairs } from '../src/parity.js';
 
 function makeFixture(): { rootDirectory: string; templatesDirectory: string } {
   const base = mkdtempSync(nodePath.join(tmpdir(), 'parity-'));
@@ -376,5 +376,82 @@ describe('runParity', () => {
 
       expect(result.failures.filter(f => f.kind === 'cursor-rule')).toHaveLength(0);
     });
+  });
+});
+
+describe('syncParityPairs (--fix, issue #585)', () => {
+  it('copies the canonical template over a drifted dogfood mirror', () => {
+    const { rootDirectory, templatesDirectory } = makeFixture();
+    mkdirSync(nodePath.join(rootDirectory, '.safeword'), { recursive: true });
+    writeFileSync(nodePath.join(templatesDirectory, 'sample.ts'), 'CANONICAL\n');
+    writeFileSync(nodePath.join(rootDirectory, '.safeword/sample.ts'), 'DRIFTED\n');
+
+    const result = syncParityPairs({
+      schema: { ownedFiles: { '.safeword/sample.ts': { template: 'sample.ts' } }, contracts: {} },
+      mode: 'all',
+      rootDirectory,
+      templatesDirectory,
+    });
+
+    expect(result.synced).toEqual(['.safeword/sample.ts']);
+    expect(result.unfixable).toHaveLength(0);
+    expect(readFileSync(nodePath.join(rootDirectory, '.safeword/sample.ts'), 'utf8')).toBe(
+      'CANONICAL\n',
+    );
+  });
+
+  it('creates a missing dogfood mirror and its parent directories from the template', () => {
+    const { rootDirectory, templatesDirectory } = makeFixture();
+    mkdirSync(nodePath.join(templatesDirectory, 'hooks/lib'), { recursive: true });
+    writeFileSync(nodePath.join(templatesDirectory, 'hooks/lib/retro.ts'), 'export const x = 1;\n');
+    const dest = '.safeword/hooks/lib/retro.ts';
+
+    const result = syncParityPairs({
+      schema: { ownedFiles: { [dest]: { template: 'hooks/lib/retro.ts' } }, contracts: {} },
+      mode: 'all',
+      rootDirectory,
+      templatesDirectory,
+    });
+
+    expect(result.synced).toEqual([dest]);
+    expect(existsSync(nodePath.join(rootDirectory, dest))).toBe(true);
+    expect(readFileSync(nodePath.join(rootDirectory, dest), 'utf8')).toBe('export const x = 1;\n');
+  });
+
+  it('leaves a byte-identical pair untouched', () => {
+    const { rootDirectory, templatesDirectory } = makeFixture();
+    mkdirSync(nodePath.join(rootDirectory, '.safeword'), { recursive: true });
+    writeFileSync(nodePath.join(templatesDirectory, 'sample.ts'), 'same\n');
+    writeFileSync(nodePath.join(rootDirectory, '.safeword/sample.ts'), 'same\n');
+
+    const result = syncParityPairs({
+      schema: { ownedFiles: { '.safeword/sample.ts': { template: 'sample.ts' } }, contracts: {} },
+      mode: 'all',
+      rootDirectory,
+      templatesDirectory,
+    });
+
+    expect(result.synced).toHaveLength(0);
+    expect(result.unfixable).toHaveLength(0);
+  });
+
+  it('reports a pair as unfixable when the template is missing (nothing to copy from)', () => {
+    const { rootDirectory, templatesDirectory } = makeFixture();
+    mkdirSync(nodePath.join(rootDirectory, '.safeword'), { recursive: true });
+    writeFileSync(nodePath.join(rootDirectory, '.safeword/orphan.ts'), 'dogfood only\n');
+
+    const result = syncParityPairs({
+      schema: { ownedFiles: { '.safeword/orphan.ts': { template: 'orphan.ts' } }, contracts: {} },
+      mode: 'all',
+      rootDirectory,
+      templatesDirectory,
+    });
+
+    expect(result.synced).toHaveLength(0);
+    expect(result.unfixable).toHaveLength(1);
+    expect(result.unfixable[0]?.message).toContain('template missing');
+    expect(readFileSync(nodePath.join(rootDirectory, '.safeword/orphan.ts'), 'utf8')).toBe(
+      'dogfood only\n',
+    );
   });
 });

--- a/scripts/parity-check.ts
+++ b/scripts/parity-check.ts
@@ -8,6 +8,7 @@
  *   bun scripts/parity-check.ts                  # mode=all
  *   bun scripts/parity-check.ts --mode=all
  *   bun scripts/parity-check.ts --mode=contracts-only
+ *   bun scripts/parity-check.ts --fix            # copy drifted templates → dogfood mirrors (#585)
  *
  * Exit codes:
  *   0 — no failures
@@ -22,7 +23,7 @@ import nodePath from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { runParity, type ParityInput } from '../packages/cli/src/parity.js';
+import { runParity, syncParityPairs, type ParityInput } from '../packages/cli/src/parity.js';
 import { SAFEWORD_SCHEMA } from '../packages/cli/src/schema.js';
 
 const scriptDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
@@ -32,6 +33,27 @@ const templatesDirectory = nodePath.resolve(repoRoot, 'packages/cli/templates');
 const arguments_ = process.argv.slice(2);
 const modeFlag = arguments_.find(a => a.startsWith('--mode='))?.split('=')[1];
 const mode: ParityInput['mode'] = modeFlag === 'contracts-only' ? 'contracts-only' : 'all';
+
+if (arguments_.includes('--fix')) {
+  const { synced, unfixable } = syncParityPairs({
+    schema: SAFEWORD_SCHEMA,
+    mode: 'all',
+    rootDirectory: repoRoot,
+    templatesDirectory,
+  });
+  if (synced.length === 0) {
+    console.log('All pairs already in sync — nothing to fix.');
+  } else {
+    console.log(`Synced ${synced.length} drifted pair(s) from templates → dogfood:`);
+    for (const path of synced) console.log(`  - ${path}`);
+  }
+  if (unfixable.length > 0) {
+    console.error(`\n${unfixable.length} pair(s) could not be auto-fixed:`);
+    for (const failure of unfixable) console.error(`  - ${failure.message}`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
 
 const pairCount = Object.values(SAFEWORD_SCHEMA.ownedFiles).filter(d => d.template).length;
 const contractCount = Object.keys(SAFEWORD_SCHEMA.contracts).length;


### PR DESCRIPTION
Closes #585.

## Rescope finding
#585's premise ("no automated byte-parity check") was **incorrect** — the check already runs per-PR: CI's "Release-gate tests" step runs `test:release` → `dogfood-parity.release.test.ts` → `runParity(mode:'all')` over all `ownedFiles` pairs (incl. the retro hooks registered in `schema.ts`), unconditionally on `pull_request`. A drifted pair fails CI today. The #601 reviewer's "not PR-gated" was a misread of the `*.release.test.ts` exclusion from the *local* `bun run test`.

So the real gap is **developer toil**: no one-command *sync*, so hook edits were hand-`cp`'d + diff-checked before each commit.

## Fix (option 1: auto-sync)
- `syncParityPairs(input)` in `parity.ts` — copies each canonical template over its drifted/missing dogfood mirror; returns `{synced, unfixable}`.
- `parity-check --fix` + `bun run parity:fix`.
- Direction is always template → dogfood (templates ship + are linted; `.safeword/` is the prettier-ignored mirror that falls behind).

## Verification
- eslint + tsc clean; 22/22 `parity.test.ts` pass (4 new).
- `--fix` on clean main → no-op; `--mode=all` regression intact (199 pairs, 3 contracts); no `.safeword/` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)