### PR TITLE
chore(release): v0.61.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release. Bumps `packages/cli/package.json` + `.claude-plugin/marketplace.json` `0.60.0` → `0.61.0`. `bun install` produced no `bun.lock` change (bun 1.3.14).

## What's in 0.61.0 (since v0.60.0)
- **feat:** the retro / self-observation epic (#601) — `safeword retro` mines a session transcript for friction and files/updates GitHub issues behind a code-owned egress guard (constrained schema → fail-closed surface → entropy/secret backstop → code-assembled body). **Default-on autonomous filing** (accepted product posture; opt out via `selfReport.file:false`).
- **feat:** ARCHITECTURE-drift Stop-hook nudge wired for Cursor + Codex, not just Claude (#605).
- **feat(dx):** `parity-check --fix` / `bun run parity:fix` — auto-sync drifted template↔dogfood pairs (#616).
- **fix:** heavy E2Es retry `safeword setup` on timeout (#604); review-stamp flag parsing (#607); readiness lineage tags (#608).
- refactor/docs: test-helper dedup (#594), surfaces branch-prefix (#596).

Auto-upgrade note: additive, so a minor — but 0.61.0 turns on retro's default-on autonomous issue filing for auto-upgraders (per the accepted posture); opt out with `selfReport.file:false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)