### PR TITLE
chore(release): v0.62.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.62.0 (minor — additive)

Rolls up 8 commits since `v0.61.0`. Minor per the versioning contract: strictly additive (new Codex retro capability + new `/retro` command skill), so it auto-upgrades safely at SessionStart.

### Additive (drives the minor)
- **feat(codex): run retro extraction invisibly** (#614) — Codex retro path, routes through the same hardened sanitizer/egress guard.
- **Retro epic follow-ups: `/retro` command skill + follow-up tickets** (#622) — manual on-demand retro path across all three harnesses.
- **Let dogfood hooks resolve `safeword/eslint` from source worktrees** (#615, closes #470) — generated eslint config loads TS project configs via `jiti`; jiti added to the TypeScript pack base so setup + upgrade install it.

### Fixes
- **Fix Cursor audit wrapper drift** (#606, closes #597) — generated wrapper + byte-equality guard.
- **Bind review stamps to the session ticket** (#613) — stops stamping the wrong ticket when several are in progress.

### Internal (no behavior change)
- **test(parity): cover `parity-check --fix` output/exit wiring** (#623)
- **refactor: extract codex stop no-continuation assertion** (#612)
- **refactor(retro): extract `ISSUES_BASE` in the github-rest transport** (#618)

### Version
- `packages/cli/package.json` + `.claude-plugin/marketplace.json`: 0.61.0 → 0.62.0
- `bun.lock` unchanged (bun 1.3.14 does not track the workspace self-version; not hand-forced)

Tag push after merge triggers OIDC trusted publish to npm.