### PR TITLE
Fix write-review-stamp multi-ticket failures across Claude, Codex, and Cursor (#630)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -57,6 +57,15 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool
 timeout = 30
 statusMessage = "Surfacing language-skill guidance"
 
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool-quality.ts"'
+timeout = 30
+statusMessage = "Updating safeword quality state"
+
 [mcp_servers.context7]
 url = "https://mcp.context7.com/mcp"
 

--- a/.safeword/hooks/codex/post-tool-quality.ts
+++ b/.safeword/hooks/codex/post-tool-quality.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+// Safeword: Codex PostToolUse adapter — maintains quality state.
+//
+// The LOC blast-radius gate and the review-stamp/session-context plumbing read
+// per-session state (LOC since last commit, active ticket binding,
+// commit-clears-gate) that is written by the Claude post-tool-quality.ts
+// accumulator. Codex doesn't run that Claude hook, so this adapter translates
+// the Codex payload (notably apply_patch, whose target paths are embedded in
+// the patch text) and spawns it as the source of truth after each edit/shell.
+// Mirrors the Cursor postToolUse adapter; keyed on session_id to match the
+// PreToolUse adapter's `codex-<id>` state key.
+//
+// Every translated target runs (each updates state); any review nudge the
+// accumulator emits is forwarded verbatim — Codex PostToolUse shares Claude's
+// hookSpecificOutput.additionalContext output shape.
+
+import { spawnSync } from 'node:child_process';
+import nodePath from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type ClaudeHookInput,
+  type CodexHookInput,
+  translateCodexInputToClaudeInputs,
+} from './pre-tool-quality-helpers.ts';
+import { installCrashCapture } from '../lib/self-report.ts';
+
+installCrashCapture('codex-post-tool-quality', undefined, 'codex');
+
+async function readInput(): Promise<CodexHookInput | undefined> {
+  try {
+    return JSON.parse(await Bun.stdin.text()) as CodexHookInput;
+  } catch {
+    return undefined;
+  }
+}
+
+function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
+  return spawnSync('bun', [claudeHookPath], {
+    cwd: process.cwd(),
+    input: JSON.stringify(translated),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+      SAFEWORD_AGENT_RUNTIME: 'codex',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+const input = await readInput();
+if (!input) process.exit(0);
+
+const translatedInputs = translateCodexInputToClaudeInputs(input);
+if (translatedInputs.length === 0) process.exit(0);
+
+const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
+const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts');
+
+// Run ALL targets — each spawn accumulates state — then forward the first
+// non-empty additionalContext payload.
+const outputs = translatedInputs.map(
+  translated => runClaudeHook(claudeHookPath, translated).stdout ?? '',
+);
+const firstOutput = outputs.find(output => output.trim() !== '');
+if (firstOutput !== undefined) {
+  process.stdout.write(firstOutput);
+}
+
+process.exit(0);

--- a/.safeword/hooks/codex/post-tool-quality.ts
+++ b/.safeword/hooks/codex/post-tool-quality.ts
@@ -14,13 +14,12 @@
 // accumulator emits is forwarded verbatim — Codex PostToolUse shares Claude's
 // hookSpecificOutput.additionalContext output shape.
 
-import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
@@ -35,20 +34,6 @@ async function readInput(): Promise<CodexHookInput | undefined> {
   }
 }
 
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-}
-
 const input = await readInput();
 if (!input) process.exit(0);
 
@@ -61,7 +46,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts'
 // Run ALL targets — each spawn accumulates state — then forward the first
 // non-empty additionalContext payload.
 const outputs = translatedInputs.map(
-  translated => runClaudeHook(claudeHookPath, translated).stdout ?? '',
+  translated => runClaudeHookAsCodex(claudeHookPath, translated).stdout ?? '',
 );
 const firstOutput = outputs.find(output => output.trim() !== '');
 if (firstOutput !== undefined) {

--- a/.safeword/hooks/codex/post-tool-skill-nudge.ts
+++ b/.safeword/hooks/codex/post-tool-skill-nudge.ts
@@ -8,13 +8,12 @@
 // understands, runs it per target, and forwards the first non-empty nudge
 // verbatim. Fail-open: no target / no nudge → exit 0 with no output.
 
-import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 
@@ -24,20 +23,6 @@ async function readInput(): Promise<CodexHookInput | undefined> {
   } catch {
     return undefined;
   }
-}
-
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
 }
 
 const input = await readInput();
@@ -52,7 +37,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-skill-nudge
 // Run per target; the hook dedups per scenario, so at most one fires. Forward the
 // first non-empty additionalContext payload (Codex shares Claude's output shape).
 for (const translated of translatedInputs) {
-  const result = runClaudeHook(claudeHookPath, translated);
+  const result = runClaudeHookAsCodex(claudeHookPath, translated);
   if ((result.stdout ?? '').trim() !== '') {
     process.stdout.write(result.stdout ?? '');
     process.exit(0);

--- a/.safeword/hooks/codex/pre-tool-quality-helpers.ts
+++ b/.safeword/hooks/codex/pre-tool-quality-helpers.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
 export interface CodexHookInput {
   session_id?: string;
   tool_name?: string;
@@ -17,6 +20,27 @@ export interface ClaudeHookInput {
   hook_event_name: 'PreToolUse';
   tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
   tool_input: NonNullable<CodexHookInput['tool_input']>;
+}
+
+/**
+ * Spawn a Claude source-of-truth hook with a translated Codex input — shared by
+ * all three Codex adapters. `CLAUDE_PROJECT_DIR` is set for the hook's path
+ * resolution; `SAFEWORD_AGENT_RUNTIME` is the authoritative agent attribution
+ * for the spawned hook (it runs under Codex, not Claude — this same var is what
+ * self-report's detectAgent reads and what scopes the per-session state key).
+ */
+export function runClaudeHookAsCodex(claudeHookPath: string, translated: ClaudeHookInput) {
+  return spawnSync('bun', [claudeHookPath], {
+    cwd: process.cwd(),
+    input: JSON.stringify(translated),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+      SAFEWORD_AGENT_RUNTIME: 'codex',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
 }
 
 interface PatchTarget {

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -10,9 +10,9 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
   denialReasonFromHookOutput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import {
@@ -44,23 +44,6 @@ function writeHookOutput(result: { stdout?: string | null; stderr?: string | nul
 
 function formatCodexReason(reason: string): string {
   return reason.replaceAll(CLAUDE_EXPLAIN_HINT, CODEX_EXPLAIN_HINT);
-}
-
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      // Authoritative agent attribution for the spawned hook: it runs under Codex,
-      // not Claude, even though we set CLAUDE_PROJECT_DIR for its path resolution.
-      // This same var is what self-report's detectAgent reads.
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
 }
 
 // Resolve the project root the same way the record-skill-invocation.ts fallback
@@ -99,7 +82,9 @@ if (translatedInputs.length === 0) process.exit(0);
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
-const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath, translated));
+const results = translatedInputs.map(translated =>
+  runClaudeHookAsCodex(claudeHookPath, translated),
+);
 
 for (const result of results) {
   const reason = denialReasonFromHookOutput(result.stdout ?? '');

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -116,22 +116,24 @@ for (const result of results) {
   process.exit(result.status ?? 0);
 }
 
+for (const result of results) {
+  writeHookOutput(result);
+}
+
+const failedResult = results.find(result => (result.status ?? 0) !== 0);
+
 // Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
 // process env has no run identity on Codex, so stash the session id right
-// before its command runs. Armed only after the gate allowed the command
-// (mirroring the Cursor adapter) so a denied stamp never leaves a live cache
-// another session could adopt. Separate cache from the proof bridge, so a
-// chained `record-skill-invocation && write-review-stamp` feeds both consumers.
-if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+// before its command runs. Armed only after the gate allowed the command AND
+// ran cleanly (mirroring the Cursor adapter) so neither a denied stamp nor a
+// crashed gate leaves a live cache another session could adopt. Separate cache
+// from the proof bridge, so a chained `record-skill-invocation &&
+// write-review-stamp` feeds both consumers.
+if (failedResult === undefined && commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
   rememberCodexReviewStampIdentity({
     projectDirectory: resolveProjectRoot(),
     id: input.session_id,
   });
 }
 
-for (const result of results) {
-  writeHookOutput(result);
-}
-
-const failedResult = results.find(result => (result.status ?? 0) !== 0);
 process.exit(failedResult?.status ?? 0);

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -16,7 +16,9 @@ import {
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import {
+  commandInvokesWriteReviewStamp,
   parseRecordSkillInvocationCommand,
+  rememberCodexReviewStampIdentity,
   rememberCodexRunIdentity,
 } from '../lib/cursor-run-identity.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
@@ -88,6 +90,17 @@ if (proofCommand !== undefined) {
     projectDirectory: resolveProjectRoot(),
     sessionId: input.session_id,
     skillName: proofCommand.skillName,
+  });
+}
+
+// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
+// process env has no run identity on Codex, so stash the session id right
+// before its command runs. Separate cache from the proof bridge, so a chained
+// `record-skill-invocation && write-review-stamp` command feeds both consumers.
+if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+  rememberCodexReviewStampIdentity({
+    projectDirectory: resolveProjectRoot(),
+    id: input.session_id,
   });
 }
 

--- a/.safeword/hooks/codex/pre-tool-quality.ts
+++ b/.safeword/hooks/codex/pre-tool-quality.ts
@@ -93,17 +93,6 @@ if (proofCommand !== undefined) {
   });
 }
 
-// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
-// process env has no run identity on Codex, so stash the session id right
-// before its command runs. Separate cache from the proof bridge, so a chained
-// `record-skill-invocation && write-review-stamp` command feeds both consumers.
-if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
-  rememberCodexReviewStampIdentity({
-    projectDirectory: resolveProjectRoot(),
-    id: input.session_id,
-  });
-}
-
 const translatedInputs = translateCodexInputToClaudeInputs(input);
 if (translatedInputs.length === 0) process.exit(0);
 
@@ -125,6 +114,19 @@ for (const result of results) {
   process.stdout.write(formatCodexReason(result.stdout ?? ''));
   if (result.stderr !== '') process.stderr.write(formatCodexReason(result.stderr ?? ''));
   process.exit(result.status ?? 0);
+}
+
+// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
+// process env has no run identity on Codex, so stash the session id right
+// before its command runs. Armed only after the gate allowed the command
+// (mirroring the Cursor adapter) so a denied stamp never leaves a live cache
+// another session could adopt. Separate cache from the proof bridge, so a
+// chained `record-skill-invocation && write-review-stamp` feeds both consumers.
+if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+  rememberCodexReviewStampIdentity({
+    projectDirectory: resolveProjectRoot(),
+    id: input.session_id,
+  });
 }
 
 for (const result of results) {

--- a/.safeword/hooks/cursor/before-shell-execution.ts
+++ b/.safeword/hooks/cursor/before-shell-execution.ts
@@ -11,7 +11,9 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  commandInvokesWriteReviewStamp,
   parseRecordSkillInvocationCommand,
+  rememberCursorReviewStampIdentity,
   rememberCursorRunIdentity,
 } from '../lib/cursor-run-identity.ts';
 import { stashCursorTranscript } from '../lib/cursor-state.ts';
@@ -58,6 +60,17 @@ if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
   process.exit(0);
 }
 
+// The stamp helper's process env has no run identity on Cursor; stash the
+// conversation id right before the command runs (mirrors the proof bridge,
+// separate cache — #630).
+function stashReviewStampIdentity(): void {
+  if (!commandInvokesWriteReviewStamp(command)) return;
+  rememberCursorReviewStampIdentity({
+    projectDirectory: process.cwd(),
+    id: input.conversation_id,
+  });
+}
+
 const proofCommand = parseRecordSkillInvocationCommand(command);
 const needsFailClosedGate = requiresFailClosedShellGate({ command });
 if (!needsFailClosedGate) {
@@ -68,6 +81,7 @@ if (!needsFailClosedGate) {
       skillName: proofCommand.skillName,
     });
   }
+  stashReviewStampIdentity();
   emitAllowAndExit();
 }
 
@@ -90,12 +104,15 @@ const decision = decideFromGate(
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
 );
-if (decision.permission === 'allow' && proofCommand !== undefined) {
-  rememberCursorRunIdentity({
-    projectDirectory: process.cwd(),
-    conversationId: input.conversation_id,
-    skillName: proofCommand.skillName,
-  });
+if (decision.permission === 'allow') {
+  if (proofCommand !== undefined) {
+    rememberCursorRunIdentity({
+      projectDirectory: process.cwd(),
+      conversationId: input.conversation_id,
+      skillName: proofCommand.skillName,
+    });
+  }
+  stashReviewStampIdentity();
 }
 process.stdout.write(JSON.stringify(decision) + '\n');
 process.exit(0);

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -1,10 +1,20 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { resolveNamespaceRoot } from './namespace-root.ts';
+import { resolveNamespaceRoot } from './namespace-root.js';
 
 const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
 const CODEX_RUN_IDENTITY_CACHE = 'codex-run-identity.json';
+
+// write-review-stamp.ts bridges use their own cache files (#630): the record-
+// skill-invocation cache is single-slot and deleted on read, so a chained
+// `record-skill-invocation && write-review-stamp` command would starve one
+// consumer if they shared a file.
+const CURSOR_REVIEW_STAMP_IDENTITY_CACHE = 'cursor-review-stamp-identity.json';
+const CODEX_REVIEW_STAMP_IDENTITY_CACHE = 'codex-review-stamp-identity.json';
+
+/** Fixed cache key for the stamp-helper bridge — not a skill, so not skill-named. */
+const REVIEW_STAMP_CACHE_KEY = 'review-stamp';
 
 const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 
@@ -75,6 +85,20 @@ function isBunExecutable(token: string | undefined): boolean {
 function isInvocationHelperPath(token: string | undefined): boolean {
   if (token === undefined) return false;
   return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
+}
+
+// Unlike the invocation-helper matcher (slash-anchored suffix only), the stamp
+// helper is documented in BOTH forms: `$PROJECT_DIR`-absolute (the self-review
+// fallback) and bare-relative (`bun .safeword/hooks/write-review-stamp.ts …`,
+// the skip valve and the Tier-2 phase stamp). Accept the exact relative form or
+// the slash-anchored suffix; `foo.safeword/…` still never matches.
+function isReviewStampHelperPath(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  const normalized = token.replaceAll('\\', '/');
+  return (
+    normalized === '.safeword/hooks/write-review-stamp.ts' ||
+    normalized.endsWith('/.safeword/hooks/write-review-stamp.ts')
+  );
 }
 
 function tokenizeShellCommand(command: string): string[] {
@@ -151,24 +175,35 @@ function tokenizeShellCommand(command: string): string[] {
   return tokens;
 }
 
-export function parseRecordSkillInvocationCommand(
-  command: string,
-): { skillName: string } | undefined {
+function shellSegments(command: string): string[][] {
   const tokens = tokenizeShellCommand(command);
+  const segments: string[][] = [];
   let segmentStart = 0;
 
   for (let index = 0; index <= tokens.length; index += 1) {
     if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
       continue;
     }
-
-    const segment = tokens.slice(segmentStart, index);
+    segments.push(tokens.slice(segmentStart, index));
     segmentStart = index + 1;
+  }
 
-    let executableIndex = 0;
-    while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
-      executableIndex += 1;
-    }
+  return segments;
+}
+
+function executableIndexOf(segment: string[]): number {
+  let executableIndex = 0;
+  while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
+    executableIndex += 1;
+  }
+  return executableIndex;
+}
+
+export function parseRecordSkillInvocationCommand(
+  command: string,
+): { skillName: string } | undefined {
+  for (const segment of shellSegments(command)) {
+    const executableIndex = executableIndexOf(segment);
 
     if (!isBunExecutable(segment[executableIndex])) continue;
     if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
@@ -180,6 +215,17 @@ export function parseRecordSkillInvocationCommand(
   }
 
   return undefined;
+}
+
+/** True when any segment of `command` runs write-review-stamp.ts under bun. */
+export function commandInvokesWriteReviewStamp(command: string): boolean {
+  return shellSegments(command).some(segment => {
+    const executableIndex = executableIndexOf(segment);
+    return (
+      isBunExecutable(segment[executableIndex]) &&
+      isReviewStampHelperPath(segment[executableIndex + 1])
+    );
+  });
 }
 
 /**
@@ -275,6 +321,64 @@ export function readFreshCodexRunIdentity(input: ReadFreshRunIdentityInput): str
     projectDirectory: input.projectDirectory,
     cacheFile: CODEX_RUN_IDENTITY_CACHE,
     skillName: input.skillName,
+    now: input.now,
+    maxAgeMs: input.maxAgeMs,
+  });
+}
+
+interface RememberReviewStampIdentityInput {
+  projectDirectory: string;
+  id: string | undefined;
+  now?: Date;
+}
+
+interface ReadFreshReviewStampIdentityInput {
+  projectDirectory: string;
+  now?: Date;
+  maxAgeMs?: number;
+}
+
+export function rememberCursorReviewStampIdentity(
+  input: RememberReviewStampIdentityInput,
+): boolean {
+  return rememberShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CURSOR_REVIEW_STAMP_IDENTITY_CACHE,
+    id: input.id,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+  });
+}
+
+export function readFreshCursorReviewStampIdentity(
+  input: ReadFreshReviewStampIdentityInput,
+): string | undefined {
+  return readFreshShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CURSOR_REVIEW_STAMP_IDENTITY_CACHE,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+    maxAgeMs: input.maxAgeMs,
+  });
+}
+
+export function rememberCodexReviewStampIdentity(input: RememberReviewStampIdentityInput): boolean {
+  return rememberShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CODEX_REVIEW_STAMP_IDENTITY_CACHE,
+    id: input.id,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+  });
+}
+
+export function readFreshCodexReviewStampIdentity(
+  input: ReadFreshReviewStampIdentityInput,
+): string | undefined {
+  return readFreshShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CODEX_REVIEW_STAMP_IDENTITY_CACHE,
+    skillName: REVIEW_STAMP_CACHE_KEY,
     now: input.now,
     maxAgeMs: input.maxAgeMs,
   });

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -195,10 +195,13 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
   // without touching ticket.md, so artifact edits must also bind — otherwise
   // write-review-stamp.ts sees no session ticket and hard-fails whenever more
   // than one ticket is in_progress. The folder's ticket.md carries the id.
-  // Epics never bind here (the stamp helper's in_progress scan excludes them),
-  // and a done/backlog folder only clears a binding to that same ticket —
-  // annotating an archived ticket must not unbind the session from its real
-  // one. The per-phase review trigger deliberately stays ticket.md-scoped.
+  // Binding demands status: in_progress — the full vocabulary (done, cancelled,
+  // superseded, wontfix, blocked, …) must neither bind nor steal the binding;
+  // an explicit non-active status only clears a binding to that same ticket, so
+  // annotating an archived ticket cannot unbind the session from its real one.
+  // Epics never bind (the stamp helper's in_progress scan excludes them). The
+  // per-phase review trigger deliberately stays ticket.md-scoped, and a custom
+  // paths.projectRoot shares isNamespacePath's default/legacy-root-only limit.
   const ticketFile = boundTicketFileForArtifact(editedFile);
   if (ticketFile !== undefined && existsSync(ticketFile)) {
     const content = readFileSync(ticketFile, 'utf8');
@@ -206,10 +209,10 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     const status = content.match(/^status:\s*(\S+)/m)?.[1];
     const type = content.match(/^type:\s*(\S+)/m)?.[1];
     if (id !== undefined) {
-      if (status === 'done' || status === 'backlog') {
-        if (state.activeTicket === id) state.activeTicket = null;
-      } else if (type !== 'epic') {
-        state.activeTicket = id;
+      if (status === 'in_progress') {
+        if (type !== 'epic') state.activeTicket = id;
+      } else if (status !== undefined && state.activeTicket === id) {
+        state.activeTicket = null;
       }
     }
   }

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -16,7 +16,11 @@ import {
   type QualityState,
 } from './lib/quality-state.ts';
 import { shouldReviewPhase } from './lib/review-trigger.ts';
-import { isNamespacePath } from './lib/namespace-root.ts';
+import {
+  isNamespacePath,
+  NAMESPACE_ROOT_DEFAULT,
+  NAMESPACE_ROOT_LEGACY,
+} from './lib/namespace-root.ts';
 import { installCrashCapture } from './lib/self-report.ts';
 
 installCrashCapture('post-tool-quality');
@@ -139,6 +143,22 @@ if (state.locSinceCommit >= LOC_THRESHOLD && !isGitOperationInProgress(projectDi
 // implement mode keeps ordinary RED/GREEN/REFACTOR progress out of chat.
 let reviewMessage: string | null = null;
 
+// `<namespace root>/tickets/<folder>/…` → absolute path of that folder's
+// ticket.md. Anchored on the same roots isNamespacePath accepts; a file not
+// nested inside a ticket folder (e.g. `tickets/foo.md`) yields undefined, and
+// `tickets/completed/<f>/…` resolves to the absent `tickets/completed/ticket.md`.
+const escapedNamespaceRoots = [NAMESPACE_ROOT_DEFAULT, NAMESPACE_ROOT_LEGACY]
+  .map(root => root.replaceAll('.', String.raw`\.`))
+  .join('|');
+const TICKET_FOLDER_PATTERN = new RegExp(`(?:^|/)(?:${escapedNamespaceRoots})/tickets/[^/]+/`);
+
+function boundTicketFileForArtifact(filePath: string): string | undefined {
+  const match = TICKET_FOLDER_PATTERN.exec(filePath);
+  if (!match) return undefined;
+  const ticketFile = `${filePath.slice(0, match.index + match[0].length)}ticket.md`;
+  return ticketFile.startsWith('/') ? ticketFile : nodePath.join(projectDirectory, ticketFile);
+}
+
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
 if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
   const fullPath = editedFile.startsWith('/')
@@ -167,6 +187,30 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     if (shouldReviewPhase(phase, state.lastReviewedPhase)) {
       reviewMessage = getQualityMessage(phase);
       state.lastReviewedPhase = phase;
+    }
+  }
+} else if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('.md')) {
+  // Broadened binding write-site (#630): a session resuming an in_progress
+  // ticket usually edits its artifacts (spec.md, test-definitions.md, …)
+  // without touching ticket.md, so artifact edits must also bind — otherwise
+  // write-review-stamp.ts sees no session ticket and hard-fails whenever more
+  // than one ticket is in_progress. The folder's ticket.md carries the id.
+  // Epics never bind here (the stamp helper's in_progress scan excludes them),
+  // and a done/backlog folder only clears a binding to that same ticket —
+  // annotating an archived ticket must not unbind the session from its real
+  // one. The per-phase review trigger deliberately stays ticket.md-scoped.
+  const ticketFile = boundTicketFileForArtifact(editedFile);
+  if (ticketFile !== undefined && existsSync(ticketFile)) {
+    const content = readFileSync(ticketFile, 'utf8');
+    const id = content.match(/^id:\s*(\S+)/m)?.[1];
+    const status = content.match(/^status:\s*(\S+)/m)?.[1];
+    const type = content.match(/^type:\s*(\S+)/m)?.[1];
+    if (id !== undefined) {
+      if (status === 'done' || status === 'backlog') {
+        if (state.activeTicket === id) state.activeTicket = null;
+      } else if (type !== 'epic') {
+        state.activeTicket = id;
+      }
     }
   }
 }

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -159,6 +159,12 @@ function boundTicketFileForArtifact(filePath: string): string | undefined {
   return ticketFile.startsWith('/') ? ticketFile : nodePath.join(projectDirectory, ticketFile);
 }
 
+// One `field: value` line from ticket.md frontmatter (same shape getTicketInfo
+// parses in lib/active-ticket.ts).
+function frontmatterField(content: string, field: string): string | undefined {
+  return content.match(new RegExp(`^${field}:\\s*(\\S+)`, 'm'))?.[1];
+}
+
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
 if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
   const fullPath = editedFile.startsWith('/')
@@ -168,14 +174,13 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     const content = readFileSync(fullPath, 'utf8');
 
     // Track active ticket
-    const idMatch = content.match(/^id:\s*(\S+)/m);
-    if (idMatch) {
-      state.activeTicket = idMatch[1];
+    const ticketId = frontmatterField(content, 'id');
+    if (ticketId !== undefined) {
+      state.activeTicket = ticketId;
     }
 
     // Auto-clear binding when ticket reaches done or backlog
-    const statusMatch = content.match(/^status:\s*(\S+)/m);
-    const ticketStatus = statusMatch?.[1];
+    const ticketStatus = frontmatterField(content, 'status');
     if (ticketStatus === 'done' || ticketStatus === 'backlog') {
       state.activeTicket = null;
     }
@@ -183,7 +188,7 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     // Per-phase review (enter-semantics, deduped). Fires on the first edit that
     // brings the ticket into an un-reviewed phase — autonomous-safe, since it
     // does not wait for a Stop. The Stop backstop covers non-edit phase bumps.
-    const phase = content.match(/^phase:\s*(\S+)/m)?.[1];
+    const phase = frontmatterField(content, 'phase');
     if (shouldReviewPhase(phase, state.lastReviewedPhase)) {
       reviewMessage = getQualityMessage(phase);
       state.lastReviewedPhase = phase;
@@ -205,9 +210,9 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
   const ticketFile = boundTicketFileForArtifact(editedFile);
   if (ticketFile !== undefined && existsSync(ticketFile)) {
     const content = readFileSync(ticketFile, 'utf8');
-    const id = content.match(/^id:\s*(\S+)/m)?.[1];
-    const status = content.match(/^status:\s*(\S+)/m)?.[1];
-    const type = content.match(/^type:\s*(\S+)/m)?.[1];
+    const id = frontmatterField(content, 'id');
+    const status = frontmatterField(content, 'status');
+    const type = frontmatterField(content, 'type');
     if (id !== undefined) {
       if (status === 'in_progress') {
         if (type !== 'epic') state.activeTicket = id;

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -26,10 +26,14 @@ import nodePath from 'node:path';
 import process from 'node:process';
 
 import { getInProgressTicketFolders, getTicketInfo } from './lib/active-ticket.ts';
+import {
+  readFreshCodexReviewStampIdentity,
+  readFreshCursorReviewStampIdentity,
+} from './lib/cursor-run-identity.ts';
 import { readSessionState } from './lib/quality-state.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
-import { resolveRunIdentity } from './lib/run-identity.ts';
+import { resolveRunIdentity, type RunIdentity } from './lib/run-identity.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 const ticketsDirectory = nodePath.join(resolveNamespaceRoot(projectDirectory), 'tickets');
@@ -39,7 +43,34 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-const runIdentity = resolveRunIdentity({}, { env: process.env });
+// Codex and Cursor expose the session id only to their pre-shell hooks, not to
+// this helper's process env. Those hooks stash it in a short-lived cache right
+// before this command runs (mirroring record-skill-invocation.ts). Construct a
+// full RunIdentity — not a raw string — so the session-state key
+// (`codex-<id>` / `cursor-<id>`) matches the one the runtime's post-tool
+// adapter writes the active-ticket binding under.
+function readBridgedRunIdentity(): RunIdentity | undefined {
+  const codexId = readFreshCodexReviewStampIdentity({ projectDirectory });
+  if (codexId !== undefined) {
+    return { runtime: 'codex', sessionKey: codexId, turnKey: null, source: 'review-stamp-bridge' };
+  }
+  const cursorId = readFreshCursorReviewStampIdentity({ projectDirectory });
+  if (cursorId !== undefined) {
+    return {
+      runtime: 'cursor',
+      sessionKey: cursorId,
+      turnKey: null,
+      source: 'review-stamp-bridge',
+    };
+  }
+  return undefined;
+}
+
+const environmentIdentity = resolveRunIdentity({}, { env: process.env });
+const runIdentity =
+  environmentIdentity.sessionKey === null
+    ? (readBridgedRunIdentity() ?? environmentIdentity)
+    : environmentIdentity;
 const sessionId = runIdentity.sessionKey ?? fail('missing run identity for review stamp');
 
 // Collapse all whitespace (incl. newlines) to single spaces. The log is one

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Key directories created in your project:
 - `codex/pre-tool-quality.ts` - Adapts Codex PreToolUse events to safeword's quality gate
 - `codex/stop.ts` - Runs invisible retro extraction and emits Stop continuations for done-phase reminders such as ARCHITECTURE.md drift
 - `codex/post-tool-skill-nudge.ts` - Codex adapter for the language coding-skill nudge
+- `codex/post-tool-quality.ts` - Codex adapter that maintains per-session quality state (LOC, active-ticket binding)
 
 Codex edit-gate coverage is limited to the documented PreToolUse
 tool calls that Safeword configures (`Bash`, `apply_patch` edit payloads, and

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -236,6 +236,22 @@ timeout = 600
 statusMessage = "Running safeword retro if this session is substantial"
 `;
 
+// Includes Bash (unlike the skill nudge): the quality accumulator counts LOC and
+// clears the gate on commit, so shell runs matter. Writes the per-session state
+// (active ticket binding, LOC) the PreToolUse gates and write-review-stamp.ts
+// read back under the same codex-<session> key (#630). Exported so tests can
+// strip the exact block when simulating pre-#630 configs.
+export const CODEX_POST_TOOL_QUALITY_HOOK_PATCH = `
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool-quality.ts"'
+timeout = 30
+statusMessage = "Updating safeword quality state"
+`;
+
 // Edit-only (no Bash): the language-skill nudge fires on source-file edits. Codex
 // PostToolUse supports hookSpecificOutput.additionalContext (GA), so the adapter
 // forwards the Claude hook's nudge verbatim.
@@ -772,6 +788,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/codex/stop.ts': {
       template: 'hooks/codex/stop.ts',
     },
+    '.safeword/hooks/codex/post-tool-quality.ts': {
+      template: 'hooks/codex/post-tool-quality.ts',
+    },
     '.safeword/hooks/codex/post-tool-skill-nudge.ts': {
       template: 'hooks/codex/post-tool-skill-nudge.ts',
     },
@@ -1230,6 +1249,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
           CODEX_SESSION_START_HOOK_PATCH,
           CODEX_LEGACY_CONTEXT_SESSION_START_HOOK_PATCH,
           CODEX_PRE_TOOL_QUALITY_HOOK_PATCH,
+          CODEX_POST_TOOL_QUALITY_HOOK_PATCH,
           CODEX_STOP_HOOK_PATCH,
         ],
         removeFileIfContentEquals: [CODEX_CONFIG_SCAFFOLD_WITHOUT_HOOKS],
@@ -1288,6 +1308,20 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
         operation: 'append',
         content: CODEX_POST_TOOL_SKILL_NUDGE_HOOK_PATCH,
         marker: '.safeword/hooks/codex/post-tool-skill-nudge.ts',
+        applyWhenContentIncludes: [
+          '# Safeword Codex project configuration.',
+          '.safeword/hooks/codex/pre-tool-quality.ts',
+        ],
+      },
+      // PostToolUse quality-state retrofit (#630): add-if-missing onto existing
+      // configs, same shape as the skill-nudge retrofit above. Writes the
+      // per-session state (active ticket binding, LOC) that the PreToolUse gates
+      // and write-review-stamp.ts read back. Uninstall cleanup is owned by the
+      // primary patch's unpatchContent.
+      {
+        operation: 'append',
+        content: CODEX_POST_TOOL_QUALITY_HOOK_PATCH,
+        marker: '.safeword/hooks/codex/post-tool-quality.ts',
         applyWhenContentIncludes: [
           '# Safeword Codex project configuration.',
           '.safeword/hooks/codex/pre-tool-quality.ts',

--- a/packages/cli/templates/codex/config.toml
+++ b/packages/cli/templates/codex/config.toml
@@ -57,6 +57,15 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool
 timeout = 30
 statusMessage = "Surfacing language-skill guidance"
 
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Bash|Edit|Write|MultiEdit|NotebookEdit)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/post-tool-quality.ts"'
+timeout = 30
+statusMessage = "Updating safeword quality state"
+
 [mcp_servers.context7]
 url = "https://mcp.context7.com/mcp"
 

--- a/packages/cli/templates/hooks/codex/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/post-tool-quality.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+// Safeword: Codex PostToolUse adapter — maintains quality state.
+//
+// The LOC blast-radius gate and the review-stamp/session-context plumbing read
+// per-session state (LOC since last commit, active ticket binding,
+// commit-clears-gate) that is written by the Claude post-tool-quality.ts
+// accumulator. Codex doesn't run that Claude hook, so this adapter translates
+// the Codex payload (notably apply_patch, whose target paths are embedded in
+// the patch text) and spawns it as the source of truth after each edit/shell.
+// Mirrors the Cursor postToolUse adapter; keyed on session_id to match the
+// PreToolUse adapter's `codex-<id>` state key.
+//
+// Every translated target runs (each updates state); any review nudge the
+// accumulator emits is forwarded verbatim — Codex PostToolUse shares Claude's
+// hookSpecificOutput.additionalContext output shape.
+
+import { spawnSync } from 'node:child_process';
+import nodePath from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type ClaudeHookInput,
+  type CodexHookInput,
+  translateCodexInputToClaudeInputs,
+} from './pre-tool-quality-helpers.ts';
+import { installCrashCapture } from '../lib/self-report.ts';
+
+installCrashCapture('codex-post-tool-quality', undefined, 'codex');
+
+async function readInput(): Promise<CodexHookInput | undefined> {
+  try {
+    return JSON.parse(await Bun.stdin.text()) as CodexHookInput;
+  } catch {
+    return undefined;
+  }
+}
+
+function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
+  return spawnSync('bun', [claudeHookPath], {
+    cwd: process.cwd(),
+    input: JSON.stringify(translated),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+      SAFEWORD_AGENT_RUNTIME: 'codex',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+const input = await readInput();
+if (!input) process.exit(0);
+
+const translatedInputs = translateCodexInputToClaudeInputs(input);
+if (translatedInputs.length === 0) process.exit(0);
+
+const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
+const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts');
+
+// Run ALL targets — each spawn accumulates state — then forward the first
+// non-empty additionalContext payload.
+const outputs = translatedInputs.map(
+  translated => runClaudeHook(claudeHookPath, translated).stdout ?? '',
+);
+const firstOutput = outputs.find(output => output.trim() !== '');
+if (firstOutput !== undefined) {
+  process.stdout.write(firstOutput);
+}
+
+process.exit(0);

--- a/packages/cli/templates/hooks/codex/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/post-tool-quality.ts
@@ -14,13 +14,12 @@
 // accumulator emits is forwarded verbatim — Codex PostToolUse shares Claude's
 // hookSpecificOutput.additionalContext output shape.
 
-import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
@@ -35,20 +34,6 @@ async function readInput(): Promise<CodexHookInput | undefined> {
   }
 }
 
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-}
-
 const input = await readInput();
 if (!input) process.exit(0);
 
@@ -61,7 +46,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-quality.ts'
 // Run ALL targets — each spawn accumulates state — then forward the first
 // non-empty additionalContext payload.
 const outputs = translatedInputs.map(
-  translated => runClaudeHook(claudeHookPath, translated).stdout ?? '',
+  translated => runClaudeHookAsCodex(claudeHookPath, translated).stdout ?? '',
 );
 const firstOutput = outputs.find(output => output.trim() !== '');
 if (firstOutput !== undefined) {

--- a/packages/cli/templates/hooks/codex/post-tool-skill-nudge.ts
+++ b/packages/cli/templates/hooks/codex/post-tool-skill-nudge.ts
@@ -8,13 +8,12 @@
 // understands, runs it per target, and forwards the first non-empty nudge
 // verbatim. Fail-open: no target / no nudge → exit 0 with no output.
 
-import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 
@@ -24,20 +23,6 @@ async function readInput(): Promise<CodexHookInput | undefined> {
   } catch {
     return undefined;
   }
-}
-
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
 }
 
 const input = await readInput();
@@ -52,7 +37,7 @@ const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-skill-nudge
 // Run per target; the hook dedups per scenario, so at most one fires. Forward the
 // first non-empty additionalContext payload (Codex shares Claude's output shape).
 for (const translated of translatedInputs) {
-  const result = runClaudeHook(claudeHookPath, translated);
+  const result = runClaudeHookAsCodex(claudeHookPath, translated);
   if ((result.stdout ?? '').trim() !== '') {
     process.stdout.write(result.stdout ?? '');
     process.exit(0);

--- a/packages/cli/templates/hooks/codex/pre-tool-quality-helpers.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality-helpers.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
 export interface CodexHookInput {
   session_id?: string;
   tool_name?: string;
@@ -17,6 +20,27 @@ export interface ClaudeHookInput {
   hook_event_name: 'PreToolUse';
   tool_name: 'Bash' | 'Edit' | 'Write' | 'MultiEdit' | 'NotebookEdit';
   tool_input: NonNullable<CodexHookInput['tool_input']>;
+}
+
+/**
+ * Spawn a Claude source-of-truth hook with a translated Codex input — shared by
+ * all three Codex adapters. `CLAUDE_PROJECT_DIR` is set for the hook's path
+ * resolution; `SAFEWORD_AGENT_RUNTIME` is the authoritative agent attribution
+ * for the spawned hook (it runs under Codex, not Claude — this same var is what
+ * self-report's detectAgent reads and what scopes the per-session state key).
+ */
+export function runClaudeHookAsCodex(claudeHookPath: string, translated: ClaudeHookInput) {
+  return spawnSync('bun', [claudeHookPath], {
+    cwd: process.cwd(),
+    input: JSON.stringify(translated),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+      SAFEWORD_AGENT_RUNTIME: 'codex',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
 }
 
 interface PatchTarget {

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -10,9 +10,9 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type ClaudeHookInput,
   type CodexHookInput,
   denialReasonFromHookOutput,
+  runClaudeHookAsCodex,
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import {
@@ -44,23 +44,6 @@ function writeHookOutput(result: { stdout?: string | null; stderr?: string | nul
 
 function formatCodexReason(reason: string): string {
   return reason.replaceAll(CLAUDE_EXPLAIN_HINT, CODEX_EXPLAIN_HINT);
-}
-
-function runClaudeHook(claudeHookPath: string, translated: ClaudeHookInput) {
-  return spawnSync('bun', [claudeHookPath], {
-    cwd: process.cwd(),
-    input: JSON.stringify(translated),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
-      // Authoritative agent attribution for the spawned hook: it runs under Codex,
-      // not Claude, even though we set CLAUDE_PROJECT_DIR for its path resolution.
-      // This same var is what self-report's detectAgent reads.
-      SAFEWORD_AGENT_RUNTIME: 'codex',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
 }
 
 // Resolve the project root the same way the record-skill-invocation.ts fallback
@@ -99,7 +82,9 @@ if (translatedInputs.length === 0) process.exit(0);
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'pre-tool-quality.ts');
 
-const results = translatedInputs.map(translated => runClaudeHook(claudeHookPath, translated));
+const results = translatedInputs.map(translated =>
+  runClaudeHookAsCodex(claudeHookPath, translated),
+);
 
 for (const result of results) {
   const reason = denialReasonFromHookOutput(result.stdout ?? '');

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -116,22 +116,24 @@ for (const result of results) {
   process.exit(result.status ?? 0);
 }
 
+for (const result of results) {
+  writeHookOutput(result);
+}
+
+const failedResult = results.find(result => (result.status ?? 0) !== 0);
+
 // Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
 // process env has no run identity on Codex, so stash the session id right
-// before its command runs. Armed only after the gate allowed the command
-// (mirroring the Cursor adapter) so a denied stamp never leaves a live cache
-// another session could adopt. Separate cache from the proof bridge, so a
-// chained `record-skill-invocation && write-review-stamp` feeds both consumers.
-if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+// before its command runs. Armed only after the gate allowed the command AND
+// ran cleanly (mirroring the Cursor adapter) so neither a denied stamp nor a
+// crashed gate leaves a live cache another session could adopt. Separate cache
+// from the proof bridge, so a chained `record-skill-invocation &&
+// write-review-stamp` feeds both consumers.
+if (failedResult === undefined && commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
   rememberCodexReviewStampIdentity({
     projectDirectory: resolveProjectRoot(),
     id: input.session_id,
   });
 }
 
-for (const result of results) {
-  writeHookOutput(result);
-}
-
-const failedResult = results.find(result => (result.status ?? 0) !== 0);
 process.exit(failedResult?.status ?? 0);

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -16,7 +16,9 @@ import {
   translateCodexInputToClaudeInputs,
 } from './pre-tool-quality-helpers.ts';
 import {
+  commandInvokesWriteReviewStamp,
   parseRecordSkillInvocationCommand,
+  rememberCodexReviewStampIdentity,
   rememberCodexRunIdentity,
 } from '../lib/cursor-run-identity.ts';
 import { installCrashCapture } from '../lib/self-report.ts';
@@ -88,6 +90,17 @@ if (proofCommand !== undefined) {
     projectDirectory: resolveProjectRoot(),
     sessionId: input.session_id,
     skillName: proofCommand.skillName,
+  });
+}
+
+// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
+// process env has no run identity on Codex, so stash the session id right
+// before its command runs. Separate cache from the proof bridge, so a chained
+// `record-skill-invocation && write-review-stamp` command feeds both consumers.
+if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+  rememberCodexReviewStampIdentity({
+    projectDirectory: resolveProjectRoot(),
+    id: input.session_id,
   });
 }
 

--- a/packages/cli/templates/hooks/codex/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/codex/pre-tool-quality.ts
@@ -93,17 +93,6 @@ if (proofCommand !== undefined) {
   });
 }
 
-// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
-// process env has no run identity on Codex, so stash the session id right
-// before its command runs. Separate cache from the proof bridge, so a chained
-// `record-skill-invocation && write-review-stamp` command feeds both consumers.
-if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
-  rememberCodexReviewStampIdentity({
-    projectDirectory: resolveProjectRoot(),
-    id: input.session_id,
-  });
-}
-
 const translatedInputs = translateCodexInputToClaudeInputs(input);
 if (translatedInputs.length === 0) process.exit(0);
 
@@ -125,6 +114,19 @@ for (const result of results) {
   process.stdout.write(formatCodexReason(result.stdout ?? ''));
   if (result.stderr !== '') process.stderr.write(formatCodexReason(result.stderr ?? ''));
   process.exit(result.status ?? 0);
+}
+
+// Same one-step bridge for write-review-stamp.ts (#630): the stamp helper's
+// process env has no run identity on Codex, so stash the session id right
+// before its command runs. Armed only after the gate allowed the command
+// (mirroring the Cursor adapter) so a denied stamp never leaves a live cache
+// another session could adopt. Separate cache from the proof bridge, so a
+// chained `record-skill-invocation && write-review-stamp` feeds both consumers.
+if (commandInvokesWriteReviewStamp(input.tool_input?.command ?? '')) {
+  rememberCodexReviewStampIdentity({
+    projectDirectory: resolveProjectRoot(),
+    id: input.session_id,
+  });
 }
 
 for (const result of results) {

--- a/packages/cli/templates/hooks/cursor/before-shell-execution.ts
+++ b/packages/cli/templates/hooks/cursor/before-shell-execution.ts
@@ -11,7 +11,9 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  commandInvokesWriteReviewStamp,
   parseRecordSkillInvocationCommand,
+  rememberCursorReviewStampIdentity,
   rememberCursorRunIdentity,
 } from '../lib/cursor-run-identity.ts';
 import { stashCursorTranscript } from '../lib/cursor-state.ts';
@@ -58,6 +60,17 @@ if (isAutoUpgradeLockActive({ projectDir: process.cwd() })) {
   process.exit(0);
 }
 
+// The stamp helper's process env has no run identity on Cursor; stash the
+// conversation id right before the command runs (mirrors the proof bridge,
+// separate cache — #630).
+function stashReviewStampIdentity(): void {
+  if (!commandInvokesWriteReviewStamp(command)) return;
+  rememberCursorReviewStampIdentity({
+    projectDirectory: process.cwd(),
+    id: input.conversation_id,
+  });
+}
+
 const proofCommand = parseRecordSkillInvocationCommand(command);
 const needsFailClosedGate = requiresFailClosedShellGate({ command });
 if (!needsFailClosedGate) {
@@ -68,6 +81,7 @@ if (!needsFailClosedGate) {
       skillName: proofCommand.skillName,
     });
   }
+  stashReviewStampIdentity();
   emitAllowAndExit();
 }
 
@@ -90,12 +104,15 @@ const decision = decideFromGate(
     timeoutMs: SHELL_GATE_TIMEOUT_MS,
   }),
 );
-if (decision.permission === 'allow' && proofCommand !== undefined) {
-  rememberCursorRunIdentity({
-    projectDirectory: process.cwd(),
-    conversationId: input.conversation_id,
-    skillName: proofCommand.skillName,
-  });
+if (decision.permission === 'allow') {
+  if (proofCommand !== undefined) {
+    rememberCursorRunIdentity({
+      projectDirectory: process.cwd(),
+      conversationId: input.conversation_id,
+      skillName: proofCommand.skillName,
+    });
+  }
+  stashReviewStampIdentity();
 }
 process.stdout.write(JSON.stringify(decision) + '\n');
 process.exit(0);

--- a/packages/cli/templates/hooks/lib/cursor-run-identity.ts
+++ b/packages/cli/templates/hooks/lib/cursor-run-identity.ts
@@ -1,10 +1,20 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { resolveNamespaceRoot } from './namespace-root.ts';
+import { resolveNamespaceRoot } from './namespace-root.js';
 
 const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
 const CODEX_RUN_IDENTITY_CACHE = 'codex-run-identity.json';
+
+// write-review-stamp.ts bridges use their own cache files (#630): the record-
+// skill-invocation cache is single-slot and deleted on read, so a chained
+// `record-skill-invocation && write-review-stamp` command would starve one
+// consumer if they shared a file.
+const CURSOR_REVIEW_STAMP_IDENTITY_CACHE = 'cursor-review-stamp-identity.json';
+const CODEX_REVIEW_STAMP_IDENTITY_CACHE = 'codex-review-stamp-identity.json';
+
+/** Fixed cache key for the stamp-helper bridge — not a skill, so not skill-named. */
+const REVIEW_STAMP_CACHE_KEY = 'review-stamp';
 
 const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 
@@ -75,6 +85,20 @@ function isBunExecutable(token: string | undefined): boolean {
 function isInvocationHelperPath(token: string | undefined): boolean {
   if (token === undefined) return false;
   return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
+}
+
+// Unlike the invocation-helper matcher (slash-anchored suffix only), the stamp
+// helper is documented in BOTH forms: `$PROJECT_DIR`-absolute (the self-review
+// fallback) and bare-relative (`bun .safeword/hooks/write-review-stamp.ts …`,
+// the skip valve and the Tier-2 phase stamp). Accept the exact relative form or
+// the slash-anchored suffix; `foo.safeword/…` still never matches.
+function isReviewStampHelperPath(token: string | undefined): boolean {
+  if (token === undefined) return false;
+  const normalized = token.replaceAll('\\', '/');
+  return (
+    normalized === '.safeword/hooks/write-review-stamp.ts' ||
+    normalized.endsWith('/.safeword/hooks/write-review-stamp.ts')
+  );
 }
 
 function tokenizeShellCommand(command: string): string[] {
@@ -151,24 +175,35 @@ function tokenizeShellCommand(command: string): string[] {
   return tokens;
 }
 
-export function parseRecordSkillInvocationCommand(
-  command: string,
-): { skillName: string } | undefined {
+function shellSegments(command: string): string[][] {
   const tokens = tokenizeShellCommand(command);
+  const segments: string[][] = [];
   let segmentStart = 0;
 
   for (let index = 0; index <= tokens.length; index += 1) {
     if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
       continue;
     }
-
-    const segment = tokens.slice(segmentStart, index);
+    segments.push(tokens.slice(segmentStart, index));
     segmentStart = index + 1;
+  }
 
-    let executableIndex = 0;
-    while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
-      executableIndex += 1;
-    }
+  return segments;
+}
+
+function executableIndexOf(segment: string[]): number {
+  let executableIndex = 0;
+  while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
+    executableIndex += 1;
+  }
+  return executableIndex;
+}
+
+export function parseRecordSkillInvocationCommand(
+  command: string,
+): { skillName: string } | undefined {
+  for (const segment of shellSegments(command)) {
+    const executableIndex = executableIndexOf(segment);
 
     if (!isBunExecutable(segment[executableIndex])) continue;
     if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
@@ -180,6 +215,17 @@ export function parseRecordSkillInvocationCommand(
   }
 
   return undefined;
+}
+
+/** True when any segment of `command` runs write-review-stamp.ts under bun. */
+export function commandInvokesWriteReviewStamp(command: string): boolean {
+  return shellSegments(command).some(segment => {
+    const executableIndex = executableIndexOf(segment);
+    return (
+      isBunExecutable(segment[executableIndex]) &&
+      isReviewStampHelperPath(segment[executableIndex + 1])
+    );
+  });
 }
 
 /**
@@ -275,6 +321,64 @@ export function readFreshCodexRunIdentity(input: ReadFreshRunIdentityInput): str
     projectDirectory: input.projectDirectory,
     cacheFile: CODEX_RUN_IDENTITY_CACHE,
     skillName: input.skillName,
+    now: input.now,
+    maxAgeMs: input.maxAgeMs,
+  });
+}
+
+interface RememberReviewStampIdentityInput {
+  projectDirectory: string;
+  id: string | undefined;
+  now?: Date;
+}
+
+interface ReadFreshReviewStampIdentityInput {
+  projectDirectory: string;
+  now?: Date;
+  maxAgeMs?: number;
+}
+
+export function rememberCursorReviewStampIdentity(
+  input: RememberReviewStampIdentityInput,
+): boolean {
+  return rememberShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CURSOR_REVIEW_STAMP_IDENTITY_CACHE,
+    id: input.id,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+  });
+}
+
+export function readFreshCursorReviewStampIdentity(
+  input: ReadFreshReviewStampIdentityInput,
+): string | undefined {
+  return readFreshShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CURSOR_REVIEW_STAMP_IDENTITY_CACHE,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+    maxAgeMs: input.maxAgeMs,
+  });
+}
+
+export function rememberCodexReviewStampIdentity(input: RememberReviewStampIdentityInput): boolean {
+  return rememberShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CODEX_REVIEW_STAMP_IDENTITY_CACHE,
+    id: input.id,
+    skillName: REVIEW_STAMP_CACHE_KEY,
+    now: input.now,
+  });
+}
+
+export function readFreshCodexReviewStampIdentity(
+  input: ReadFreshReviewStampIdentityInput,
+): string | undefined {
+  return readFreshShellRunIdentity({
+    projectDirectory: input.projectDirectory,
+    cacheFile: CODEX_REVIEW_STAMP_IDENTITY_CACHE,
+    skillName: REVIEW_STAMP_CACHE_KEY,
     now: input.now,
     maxAgeMs: input.maxAgeMs,
   });

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -195,10 +195,13 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
   // without touching ticket.md, so artifact edits must also bind — otherwise
   // write-review-stamp.ts sees no session ticket and hard-fails whenever more
   // than one ticket is in_progress. The folder's ticket.md carries the id.
-  // Epics never bind here (the stamp helper's in_progress scan excludes them),
-  // and a done/backlog folder only clears a binding to that same ticket —
-  // annotating an archived ticket must not unbind the session from its real
-  // one. The per-phase review trigger deliberately stays ticket.md-scoped.
+  // Binding demands status: in_progress — the full vocabulary (done, cancelled,
+  // superseded, wontfix, blocked, …) must neither bind nor steal the binding;
+  // an explicit non-active status only clears a binding to that same ticket, so
+  // annotating an archived ticket cannot unbind the session from its real one.
+  // Epics never bind (the stamp helper's in_progress scan excludes them). The
+  // per-phase review trigger deliberately stays ticket.md-scoped, and a custom
+  // paths.projectRoot shares isNamespacePath's default/legacy-root-only limit.
   const ticketFile = boundTicketFileForArtifact(editedFile);
   if (ticketFile !== undefined && existsSync(ticketFile)) {
     const content = readFileSync(ticketFile, 'utf8');
@@ -206,10 +209,10 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     const status = content.match(/^status:\s*(\S+)/m)?.[1];
     const type = content.match(/^type:\s*(\S+)/m)?.[1];
     if (id !== undefined) {
-      if (status === 'done' || status === 'backlog') {
-        if (state.activeTicket === id) state.activeTicket = null;
-      } else if (type !== 'epic') {
-        state.activeTicket = id;
+      if (status === 'in_progress') {
+        if (type !== 'epic') state.activeTicket = id;
+      } else if (status !== undefined && state.activeTicket === id) {
+        state.activeTicket = null;
       }
     }
   }

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -16,7 +16,11 @@ import {
   type QualityState,
 } from './lib/quality-state.ts';
 import { shouldReviewPhase } from './lib/review-trigger.ts';
-import { isNamespacePath } from './lib/namespace-root.ts';
+import {
+  isNamespacePath,
+  NAMESPACE_ROOT_DEFAULT,
+  NAMESPACE_ROOT_LEGACY,
+} from './lib/namespace-root.ts';
 import { installCrashCapture } from './lib/self-report.ts';
 
 installCrashCapture('post-tool-quality');
@@ -139,6 +143,22 @@ if (state.locSinceCommit >= LOC_THRESHOLD && !isGitOperationInProgress(projectDi
 // implement mode keeps ordinary RED/GREEN/REFACTOR progress out of chat.
 let reviewMessage: string | null = null;
 
+// `<namespace root>/tickets/<folder>/…` → absolute path of that folder's
+// ticket.md. Anchored on the same roots isNamespacePath accepts; a file not
+// nested inside a ticket folder (e.g. `tickets/foo.md`) yields undefined, and
+// `tickets/completed/<f>/…` resolves to the absent `tickets/completed/ticket.md`.
+const escapedNamespaceRoots = [NAMESPACE_ROOT_DEFAULT, NAMESPACE_ROOT_LEGACY]
+  .map(root => root.replaceAll('.', String.raw`\.`))
+  .join('|');
+const TICKET_FOLDER_PATTERN = new RegExp(`(?:^|/)(?:${escapedNamespaceRoots})/tickets/[^/]+/`);
+
+function boundTicketFileForArtifact(filePath: string): string | undefined {
+  const match = TICKET_FOLDER_PATTERN.exec(filePath);
+  if (!match) return undefined;
+  const ticketFile = `${filePath.slice(0, match.index + match[0].length)}ticket.md`;
+  return ticketFile.startsWith('/') ? ticketFile : nodePath.join(projectDirectory, ticketFile);
+}
+
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
 if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
   const fullPath = editedFile.startsWith('/')
@@ -167,6 +187,30 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     if (shouldReviewPhase(phase, state.lastReviewedPhase)) {
       reviewMessage = getQualityMessage(phase);
       state.lastReviewedPhase = phase;
+    }
+  }
+} else if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('.md')) {
+  // Broadened binding write-site (#630): a session resuming an in_progress
+  // ticket usually edits its artifacts (spec.md, test-definitions.md, …)
+  // without touching ticket.md, so artifact edits must also bind — otherwise
+  // write-review-stamp.ts sees no session ticket and hard-fails whenever more
+  // than one ticket is in_progress. The folder's ticket.md carries the id.
+  // Epics never bind here (the stamp helper's in_progress scan excludes them),
+  // and a done/backlog folder only clears a binding to that same ticket —
+  // annotating an archived ticket must not unbind the session from its real
+  // one. The per-phase review trigger deliberately stays ticket.md-scoped.
+  const ticketFile = boundTicketFileForArtifact(editedFile);
+  if (ticketFile !== undefined && existsSync(ticketFile)) {
+    const content = readFileSync(ticketFile, 'utf8');
+    const id = content.match(/^id:\s*(\S+)/m)?.[1];
+    const status = content.match(/^status:\s*(\S+)/m)?.[1];
+    const type = content.match(/^type:\s*(\S+)/m)?.[1];
+    if (id !== undefined) {
+      if (status === 'done' || status === 'backlog') {
+        if (state.activeTicket === id) state.activeTicket = null;
+      } else if (type !== 'epic') {
+        state.activeTicket = id;
+      }
     }
   }
 }

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -159,6 +159,12 @@ function boundTicketFileForArtifact(filePath: string): string | undefined {
   return ticketFile.startsWith('/') ? ticketFile : nodePath.join(projectDirectory, ticketFile);
 }
 
+// One `field: value` line from ticket.md frontmatter (same shape getTicketInfo
+// parses in lib/active-ticket.ts).
+function frontmatterField(content: string, field: string): string | undefined {
+  return content.match(new RegExp(`^${field}:\\s*(\\S+)`, 'm'))?.[1];
+}
+
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
 if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
   const fullPath = editedFile.startsWith('/')
@@ -168,14 +174,13 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     const content = readFileSync(fullPath, 'utf8');
 
     // Track active ticket
-    const idMatch = content.match(/^id:\s*(\S+)/m);
-    if (idMatch) {
-      state.activeTicket = idMatch[1];
+    const ticketId = frontmatterField(content, 'id');
+    if (ticketId !== undefined) {
+      state.activeTicket = ticketId;
     }
 
     // Auto-clear binding when ticket reaches done or backlog
-    const statusMatch = content.match(/^status:\s*(\S+)/m);
-    const ticketStatus = statusMatch?.[1];
+    const ticketStatus = frontmatterField(content, 'status');
     if (ticketStatus === 'done' || ticketStatus === 'backlog') {
       state.activeTicket = null;
     }
@@ -183,7 +188,7 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
     // Per-phase review (enter-semantics, deduped). Fires on the first edit that
     // brings the ticket into an un-reviewed phase — autonomous-safe, since it
     // does not wait for a Stop. The Stop backstop covers non-edit phase bumps.
-    const phase = content.match(/^phase:\s*(\S+)/m)?.[1];
+    const phase = frontmatterField(content, 'phase');
     if (shouldReviewPhase(phase, state.lastReviewedPhase)) {
       reviewMessage = getQualityMessage(phase);
       state.lastReviewedPhase = phase;
@@ -205,9 +210,9 @@ if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md'))
   const ticketFile = boundTicketFileForArtifact(editedFile);
   if (ticketFile !== undefined && existsSync(ticketFile)) {
     const content = readFileSync(ticketFile, 'utf8');
-    const id = content.match(/^id:\s*(\S+)/m)?.[1];
-    const status = content.match(/^status:\s*(\S+)/m)?.[1];
-    const type = content.match(/^type:\s*(\S+)/m)?.[1];
+    const id = frontmatterField(content, 'id');
+    const status = frontmatterField(content, 'status');
+    const type = frontmatterField(content, 'type');
     if (id !== undefined) {
       if (status === 'in_progress') {
         if (type !== 'epic') state.activeTicket = id;

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -26,10 +26,14 @@ import nodePath from 'node:path';
 import process from 'node:process';
 
 import { getInProgressTicketFolders, getTicketInfo } from './lib/active-ticket.ts';
+import {
+  readFreshCodexReviewStampIdentity,
+  readFreshCursorReviewStampIdentity,
+} from './lib/cursor-run-identity.ts';
 import { readSessionState } from './lib/quality-state.ts';
 import { formatReviewStamp, hashArtifact, reviewScope } from './lib/review-ledger.ts';
 import { resolveNamespaceRoot } from './lib/namespace-root.ts';
-import { resolveRunIdentity } from './lib/run-identity.ts';
+import { resolveRunIdentity, type RunIdentity } from './lib/run-identity.ts';
 
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 const ticketsDirectory = nodePath.join(resolveNamespaceRoot(projectDirectory), 'tickets');
@@ -39,7 +43,34 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-const runIdentity = resolveRunIdentity({}, { env: process.env });
+// Codex and Cursor expose the session id only to their pre-shell hooks, not to
+// this helper's process env. Those hooks stash it in a short-lived cache right
+// before this command runs (mirroring record-skill-invocation.ts). Construct a
+// full RunIdentity — not a raw string — so the session-state key
+// (`codex-<id>` / `cursor-<id>`) matches the one the runtime's post-tool
+// adapter writes the active-ticket binding under.
+function readBridgedRunIdentity(): RunIdentity | undefined {
+  const codexId = readFreshCodexReviewStampIdentity({ projectDirectory });
+  if (codexId !== undefined) {
+    return { runtime: 'codex', sessionKey: codexId, turnKey: null, source: 'review-stamp-bridge' };
+  }
+  const cursorId = readFreshCursorReviewStampIdentity({ projectDirectory });
+  if (cursorId !== undefined) {
+    return {
+      runtime: 'cursor',
+      sessionKey: cursorId,
+      turnKey: null,
+      source: 'review-stamp-bridge',
+    };
+  }
+  return undefined;
+}
+
+const environmentIdentity = resolveRunIdentity({}, { env: process.env });
+const runIdentity =
+  environmentIdentity.sessionKey === null
+    ? (readBridgedRunIdentity() ?? environmentIdentity)
+    : environmentIdentity;
 const sessionId = runIdentity.sessionKey ?? fail('missing run identity for review stamp');
 
 // Collapse all whitespace (incl. newlines) to single spaces. The log is one

--- a/packages/cli/tests/hooks/review-stamp-bridge.test.ts
+++ b/packages/cli/tests/hooks/review-stamp-bridge.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the write-review-stamp run-identity bridge (#630) —
+ * command recognition and the per-runtime stash/read round-trip.
+ *
+ * The recognizer must accept BOTH documented command forms: the
+ * `$PROJECT_DIR`-absolute form (self-review's fallback) and the bare-relative
+ * form (`bun .safeword/hooks/write-review-stamp.ts …`, used by the skip valve
+ * and the Tier-2 phase stamp) — the record-skill-invocation matcher's
+ * slash-anchored suffix alone would miss the latter.
+ */
+
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  commandInvokesWriteReviewStamp,
+  readFreshCodexReviewStampIdentity,
+  readFreshCursorReviewStampIdentity,
+  rememberCodexReviewStampIdentity,
+  rememberCursorReviewStampIdentity,
+} from '../../templates/hooks/lib/cursor-run-identity.js';
+
+const SELF_REVIEW_FALLBACK = [
+  'PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"',
+  'CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "$PROJECT_DIR/.safeword/hooks/write-review-stamp.ts" spec',
+].join('\n');
+
+describe('commandInvokesWriteReviewStamp (#630)', () => {
+  it('recognizes the bare-relative skip-valve form', () => {
+    expect(
+      commandInvokesWriteReviewStamp(
+        'bun .safeword/hooks/write-review-stamp.ts spec "trivial boilerplate"',
+      ),
+    ).toBe(true);
+  });
+
+  it('recognizes the bare-relative Tier-2 phase form', () => {
+    expect(
+      commandInvokesWriteReviewStamp('bun .safeword/hooks/write-review-stamp.ts --phase implement'),
+    ).toBe(true);
+  });
+
+  it('recognizes the $PROJECT_DIR-absolute self-review fallback (env assignments, quotes, newline)', () => {
+    expect(commandInvokesWriteReviewStamp(SELF_REVIEW_FALLBACK)).toBe(true);
+  });
+
+  it('recognizes an expanded absolute path', () => {
+    expect(
+      commandInvokesWriteReviewStamp(
+        'bun "/repo/checkout/.safeword/hooks/write-review-stamp.ts" spec',
+      ),
+    ).toBe(true);
+  });
+
+  it('recognizes the helper in a chained command alongside the proof helper', () => {
+    const chained =
+      'bun ".safeword/hooks/record-skill-invocation.ts" "/repo" self-review && bun .safeword/hooks/write-review-stamp.ts spec';
+    expect(commandInvokesWriteReviewStamp(chained)).toBe(true);
+  });
+
+  it('does not match a command that only mentions the helper in a string', () => {
+    expect(
+      commandInvokesWriteReviewStamp('echo "bun .safeword/hooks/write-review-stamp.ts spec"'),
+    ).toBe(false);
+  });
+
+  it('does not match a helper-looking path that is not the helper', () => {
+    expect(
+      commandInvokesWriteReviewStamp('bun foo.safeword/hooks/write-review-stamp.ts spec'),
+    ).toBe(false);
+    expect(
+      commandInvokesWriteReviewStamp('bun .safeword/hooks/write-review-stamp.ts.bak spec'),
+    ).toBe(false);
+  });
+
+  it('does not match other executables', () => {
+    expect(commandInvokesWriteReviewStamp('node .safeword/hooks/write-review-stamp.ts spec')).toBe(
+      false,
+    );
+  });
+});
+
+describe('review-stamp identity caches (#630)', () => {
+  function project(): string {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), 'stamp-bridge-'));
+    mkdirSync(nodePath.join(dir, '.project'), { recursive: true });
+    return dir;
+  }
+
+  it('round-trips a Codex session id and consumes it on read', () => {
+    const projectDirectory = project();
+    expect(rememberCodexReviewStampIdentity({ projectDirectory, id: 'codex-sess' })).toBe(true);
+
+    expect(readFreshCodexReviewStampIdentity({ projectDirectory })).toBe('codex-sess');
+    // Single-use: consumed by the first read.
+    expect(readFreshCodexReviewStampIdentity({ projectDirectory })).toBeUndefined();
+  });
+
+  it('keeps Codex and Cursor caches separate', () => {
+    const projectDirectory = project();
+    rememberCodexReviewStampIdentity({ projectDirectory, id: 'codex-sess' });
+    rememberCursorReviewStampIdentity({ projectDirectory, id: 'conv-1' });
+
+    expect(readFreshCursorReviewStampIdentity({ projectDirectory })).toBe('conv-1');
+    expect(readFreshCodexReviewStampIdentity({ projectDirectory })).toBe('codex-sess');
+  });
+
+  it('expires a stale stash', () => {
+    const projectDirectory = project();
+    const stashedAt = new Date('2026-07-03T00:00:00.000Z');
+    rememberCodexReviewStampIdentity({ projectDirectory, id: 'codex-sess', now: stashedAt });
+
+    const sixMinutesLater = new Date('2026-07-03T00:06:00.000Z');
+    expect(
+      readFreshCodexReviewStampIdentity({ projectDirectory, now: sixMinutesLater }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/integration/codex-post-tool-quality.test.ts
+++ b/packages/cli/tests/integration/codex-post-tool-quality.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration tests for the Codex PostToolUse quality-state adapter (#630).
+ * Spawns the real codex/post-tool-quality.ts with Codex-shaped payloads and
+ * asserts it writes the codex-scoped per-session quality state (active ticket
+ * binding) via the Claude accumulator — the state the PreToolUse gates and
+ * write-review-stamp.ts read back.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createTemporaryDirectory, initGitRepo, writeTestFile } from '../helpers.js';
+
+const ADAPTER_PATH = nodePath.resolve(
+  __dirname,
+  '../../templates/hooks/codex/post-tool-quality.ts',
+);
+const TICKET_FOLDER = '.safeword-project/tickets/ABC123';
+
+interface CodexPayload {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: { command?: string; file_path?: string };
+}
+
+function project(): string {
+  const dir = createTemporaryDirectory();
+  initGitRepo(dir);
+  writeTestFile(
+    dir,
+    `${TICKET_FOLDER}/ticket.md`,
+    '---\nid: ABC123\ntype: feature\nphase: define-behavior\nstatus: in_progress\n---\n',
+  );
+  writeTestFile(dir, `${TICKET_FOLDER}/spec.md`, '# Spec\n');
+  execSync('git add . && git commit -qm fixture', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+function runAdapter(cwd: string, payload: CodexPayload): void {
+  const result = spawnSync('bun', [ADAPTER_PATH], {
+    input: JSON.stringify(payload),
+    cwd,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 20_000,
+  });
+  expect(result.status).toBe(0);
+}
+
+function readBinding(cwd: string, sessionId: string): string | undefined {
+  const stateFile = nodePath.join(
+    cwd,
+    '.safeword-project',
+    `quality-state-codex-${sessionId}.json`,
+  );
+  if (!existsSync(stateFile)) return undefined;
+  return (
+    (JSON.parse(readFileSync(stateFile, 'utf8')) as { activeTicket: string | null }).activeTicket ??
+    undefined
+  );
+}
+
+describe('Codex PostToolUse quality-state adapter (#630)', () => {
+  it('writes the codex-scoped session binding on a direct Edit of a ticket artifact', () => {
+    const cwd = project();
+
+    runAdapter(cwd, {
+      session_id: 'sess-9',
+      tool_name: 'Edit',
+      tool_input: { file_path: nodePath.join(cwd, TICKET_FOLDER, 'spec.md') },
+    });
+
+    expect(readBinding(cwd, 'sess-9')).toBe('ABC123');
+  });
+
+  it('binds from an apply_patch Update whose target is a ticket artifact', () => {
+    const cwd = project();
+    const patch = [
+      '*** Begin Patch',
+      `*** Update File: ${nodePath.join(cwd, TICKET_FOLDER, 'spec.md')}`,
+      '@@',
+      '-# Spec',
+      '+# Spec (edited)',
+      '*** End Patch',
+    ].join('\n');
+
+    runAdapter(cwd, {
+      session_id: 'sess-9',
+      tool_name: 'apply_patch',
+      tool_input: { command: patch },
+    });
+
+    expect(readBinding(cwd, 'sess-9')).toBe('ABC123');
+  });
+
+  it('ignores unknown tools without writing state', () => {
+    const cwd = project();
+
+    runAdapter(cwd, { session_id: 'sess-9', tool_name: 'Read', tool_input: {} });
+
+    expect(readBinding(cwd, 'sess-9')).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -22,6 +22,14 @@ import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
 const STAMP_PATH = nodePath.resolve(__dirname, '../../templates/hooks/write-review-stamp.ts');
 const GATE_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-quality.ts');
 const POST_TOOL_PATH = nodePath.resolve(__dirname, '../../templates/hooks/post-tool-quality.ts');
+const CURSOR_BEFORE_SHELL_PATH = nodePath.resolve(
+  __dirname,
+  '../../templates/hooks/cursor/before-shell-execution.ts',
+);
+const CODEX_PRE_TOOL_PATH = nodePath.resolve(
+  __dirname,
+  '../../templates/hooks/codex/pre-tool-quality.ts',
+);
 const TICKET_ID = 'ABC123';
 
 const TICKET_FRONTMATTER = [
@@ -347,6 +355,89 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
       runPostToolEdit(nodePath.join(completedDirectory, 'spec.md'));
 
       expect(readSessionBinding()).toBeUndefined();
+    });
+  });
+
+  // #630: on Codex/Cursor the stamp helper's process env has no run identity;
+  // the runtime's pre-shell hook stashes the session id right before the
+  // command runs. Exercises the real pre-shell hook → write-review-stamp.ts
+  // chain, including that the bridged identity reads the SAME session-state
+  // key the runtime's post-tool adapter writes the binding under.
+  describe('run-identity bridge on Codex/Cursor (#630)', () => {
+    const STAMP_COMMAND = 'bun .safeword/hooks/write-review-stamp.ts spec';
+
+    function runCodexPreShell(sessionId: string): void {
+      const result = spawnSync('bun', [CODEX_PRE_TOOL_PATH], {
+        cwd: projectRoot,
+        input: JSON.stringify({
+          session_id: sessionId,
+          tool_name: 'Bash',
+          tool_input: { command: STAMP_COMMAND },
+        }),
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+      });
+      expect(result.status).toBe(0);
+    }
+
+    function runCursorBeforeShell(conversationId: string): void {
+      const result = spawnSync('bun', [CURSOR_BEFORE_SHELL_PATH], {
+        cwd: projectRoot,
+        input: JSON.stringify({
+          conversation_id: conversationId,
+          command: STAMP_COMMAND,
+          workspace_roots: [projectRoot],
+        }),
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+      });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout) as { permission?: string }).toEqual({
+        permission: 'allow',
+      });
+    }
+
+    function bindRuntimeSessionTicket(storageKey: string): void {
+      writeFileSync(
+        nodePath.join(projectRoot, '.safeword-project', `quality-state-${storageKey}.json`),
+        JSON.stringify({ activeTicket: TICKET_ID }),
+      );
+    }
+
+    it('Codex: the pre-shell stash lets the stamp resolve the codex-bound session ticket', () => {
+      createSecondTicket();
+      bindRuntimeSessionTicket('codex-sess-9');
+
+      runCodexPreShell('sess-9');
+      const stamp = runStampWithoutRuntimeIdentity('spec');
+
+      expect(stamp.status).toBe(0);
+      expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+    });
+
+    it('Cursor: the pre-shell stash lets the stamp resolve the cursor-bound session ticket', () => {
+      createSecondTicket();
+      bindRuntimeSessionTicket('cursor-conv-1');
+
+      runCursorBeforeShell('conv-1');
+      const stamp = runStampWithoutRuntimeIdentity('spec');
+
+      expect(stamp.status).toBe(0);
+      expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+    });
+
+    it('the stash is single-use: a second stamp without a new pre-shell event fails loudly', () => {
+      createSecondTicket();
+      bindRuntimeSessionTicket('codex-sess-9');
+
+      runCodexPreShell('sess-9');
+      expect(runStampWithoutRuntimeIdentity('spec').status).toBe(0);
+
+      const secondStamp = runStampWithoutRuntimeIdentity('spec');
+      expect(secondStamp.status).toBe(1);
+      expect(secondStamp.stdout).toContain('missing run identity');
     });
   });
 });

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -5,7 +5,7 @@
  * allow, end to end. Also covers the skip valve and the Tier 2 phase stamp.
  */
 
-import { spawnSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -21,6 +21,7 @@ import { expectHookAllow, expectHookDeny, type HookResult } from '../helpers';
 
 const STAMP_PATH = nodePath.resolve(__dirname, '../../templates/hooks/write-review-stamp.ts');
 const GATE_PATH = nodePath.resolve(__dirname, '../../templates/hooks/pre-tool-quality.ts');
+const POST_TOOL_PATH = nodePath.resolve(__dirname, '../../templates/hooks/post-tool-quality.ts');
 const TICKET_ID = 'ABC123';
 
 const TICKET_FRONTMATTER = [
@@ -236,5 +237,116 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(stamp.status).toBe(1);
     expect(stamp.stdout).toContain('missing run identity');
     expect(readLog()).not.toContain('unknown-session');
+  });
+
+  // #630: the binding write-site broadened from ticket.md-only to any artifact
+  // under the ticket's folder, so a session that resumes an in_progress ticket
+  // (never editing ticket.md) still stamps without --ticket. Exercises the real
+  // post-tool-quality.ts → write-review-stamp.ts chain.
+  describe('artifact-edit session binding (#630)', () => {
+    function runPostToolEdit(filePath: string): void {
+      const result = spawnSync('bun', [POST_TOOL_PATH], {
+        input: JSON.stringify({
+          session_id: 'sess-1',
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Edit',
+          tool_input: { file_path: filePath },
+        }),
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+      });
+      expect(result.status).toBe(0);
+    }
+
+    function readSessionBinding(): string | undefined {
+      const stateFile = nodePath.join(
+        projectRoot,
+        '.safeword-project',
+        'quality-state-sess-1.json',
+      );
+      if (!existsSync(stateFile)) return undefined;
+      return (
+        (JSON.parse(readFileSync(stateFile, 'utf8')) as { activeTicket: string | null })
+          .activeTicket ?? undefined
+      );
+    }
+
+    beforeEach(() => {
+      // post-tool-quality.ts exits before the binding write when HEAD is absent.
+      execSync(
+        'git init -q && git add -A && git -c user.email=t@t.t -c user.name=t commit -qm fixture',
+        { cwd: projectRoot, stdio: 'pipe' },
+      );
+    });
+
+    it('resume flow: a spec.md edit binds the session, so the stamp resolves among multiple in_progress tickets', () => {
+      createSecondTicket();
+
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+      const stamp = runStamp('spec');
+
+      expect(stamp.status).toBe(0);
+      expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+    });
+
+    it('does not rebind to an epic when one of its artifacts is edited', () => {
+      const epicDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'EPIC01');
+      mkdirSync(epicDirectory, { recursive: true });
+      writeFileSync(
+        nodePath.join(epicDirectory, 'ticket.md'),
+        '---\nid: EPIC01\ntype: epic\nphase: intake\nstatus: in_progress\n---\n',
+      );
+      writeFileSync(nodePath.join(epicDirectory, 'spec.md'), '# Epic spec\n');
+
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+      runPostToolEdit(nodePath.join(epicDirectory, 'spec.md'));
+
+      expect(readSessionBinding()).toBe(TICKET_ID);
+    });
+
+    it("editing a done ticket's artifact does not unbind the session from its active ticket", () => {
+      const doneDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'DONE01');
+      mkdirSync(doneDirectory, { recursive: true });
+      writeFileSync(
+        nodePath.join(doneDirectory, 'ticket.md'),
+        '---\nid: DONE01\ntype: feature\nphase: done\nstatus: done\n---\n',
+      );
+      writeFileSync(nodePath.join(doneDirectory, 'spec.md'), '# Archived spec\n');
+
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+      runPostToolEdit(nodePath.join(doneDirectory, 'spec.md'));
+
+      expect(readSessionBinding()).toBe(TICKET_ID);
+    });
+
+    it("clears the binding when the bound ticket's own artifact is edited after it went done", () => {
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+      expect(readSessionBinding()).toBe(TICKET_ID);
+
+      writeFileSync(
+        nodePath.join(ticketDirectory, 'ticket.md'),
+        `---\n${TICKET_FRONTMATTER.replace('status: in_progress', 'status: done')}\n---\n`,
+      );
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+
+      expect(readSessionBinding()).toBeUndefined();
+    });
+
+    it('does not bind from artifacts under tickets/completed/', () => {
+      const completedDirectory = nodePath.join(
+        projectRoot,
+        '.safeword-project',
+        'tickets',
+        'completed',
+        'OLD001',
+      );
+      mkdirSync(completedDirectory, { recursive: true });
+      writeFileSync(nodePath.join(completedDirectory, 'spec.md'), '# Old spec\n');
+
+      runPostToolEdit(nodePath.join(completedDirectory, 'spec.md'));
+
+      expect(readSessionBinding()).toBeUndefined();
+    });
   });
 });

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -313,6 +313,28 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
       expect(readSessionBinding()).toBe(TICKET_ID);
     });
 
+    it("editing a cancelled ticket's artifact does not steal the session binding", () => {
+      // The status vocabulary is wider than done/backlog — any non-in_progress
+      // status must neither bind nor overwrite an existing binding.
+      const cancelledDirectory = nodePath.join(
+        projectRoot,
+        '.safeword-project',
+        'tickets',
+        'CAN001',
+      );
+      mkdirSync(cancelledDirectory, { recursive: true });
+      writeFileSync(
+        nodePath.join(cancelledDirectory, 'ticket.md'),
+        '---\nid: CAN001\ntype: feature\nphase: intake\nstatus: cancelled\n---\n',
+      );
+      writeFileSync(nodePath.join(cancelledDirectory, 'work-log.md'), '# Notes\n');
+
+      runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
+      runPostToolEdit(nodePath.join(cancelledDirectory, 'work-log.md'));
+
+      expect(readSessionBinding()).toBe(TICKET_ID);
+    });
+
     it("editing a done ticket's artifact does not unbind the session from its active ticket", () => {
       const doneDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'DONE01');
       mkdirSync(doneDirectory, { recursive: true });

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -120,13 +120,21 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     );
   }
 
-  function createSecondTicket(): void {
-    const second = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'XYZ789');
-    mkdirSync(second, { recursive: true });
+  function createTicketFolder(
+    folder: string,
+    { type = 'feature', phase = 'intake', status = 'in_progress' } = {},
+  ): string {
+    const directory = nodePath.join(projectRoot, '.safeword-project', 'tickets', folder);
+    mkdirSync(directory, { recursive: true });
     writeFileSync(
-      nodePath.join(second, 'ticket.md'),
-      '---\nid: XYZ789\ntype: feature\nphase: intake\nstatus: in_progress\n---\n',
+      nodePath.join(directory, 'ticket.md'),
+      `---\nid: ${folder}\ntype: ${type}\nphase: ${phase}\nstatus: ${status}\n---\n`,
     );
+    return directory;
+  }
+
+  function createSecondTicket(): void {
+    createTicketFolder('XYZ789');
   }
 
   beforeEach(() => {
@@ -299,12 +307,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     });
 
     it('does not rebind to an epic when one of its artifacts is edited', () => {
-      const epicDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'EPIC01');
-      mkdirSync(epicDirectory, { recursive: true });
-      writeFileSync(
-        nodePath.join(epicDirectory, 'ticket.md'),
-        '---\nid: EPIC01\ntype: epic\nphase: intake\nstatus: in_progress\n---\n',
-      );
+      const epicDirectory = createTicketFolder('EPIC01', { type: 'epic' });
       writeFileSync(nodePath.join(epicDirectory, 'spec.md'), '# Epic spec\n');
 
       runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
@@ -316,17 +319,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     it("editing a cancelled ticket's artifact does not steal the session binding", () => {
       // The status vocabulary is wider than done/backlog — any non-in_progress
       // status must neither bind nor overwrite an existing binding.
-      const cancelledDirectory = nodePath.join(
-        projectRoot,
-        '.safeword-project',
-        'tickets',
-        'CAN001',
-      );
-      mkdirSync(cancelledDirectory, { recursive: true });
-      writeFileSync(
-        nodePath.join(cancelledDirectory, 'ticket.md'),
-        '---\nid: CAN001\ntype: feature\nphase: intake\nstatus: cancelled\n---\n',
-      );
+      const cancelledDirectory = createTicketFolder('CAN001', { status: 'cancelled' });
       writeFileSync(nodePath.join(cancelledDirectory, 'work-log.md'), '# Notes\n');
 
       runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));
@@ -336,12 +329,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     });
 
     it("editing a done ticket's artifact does not unbind the session from its active ticket", () => {
-      const doneDirectory = nodePath.join(projectRoot, '.safeword-project', 'tickets', 'DONE01');
-      mkdirSync(doneDirectory, { recursive: true });
-      writeFileSync(
-        nodePath.join(doneDirectory, 'ticket.md'),
-        '---\nid: DONE01\ntype: feature\nphase: done\nstatus: done\n---\n',
-      );
+      const doneDirectory = createTicketFolder('DONE01', { phase: 'done', status: 'done' });
       writeFileSync(nodePath.join(doneDirectory, 'spec.md'), '# Archived spec\n');
 
       runPostToolEdit(nodePath.join(ticketDirectory, 'spec.md'));

--- a/packages/cli/tests/reconcile.test.ts
+++ b/packages/cli/tests/reconcile.test.ts
@@ -1203,6 +1203,7 @@ describe('Reconcile - Reconciliation Engine', () => {
       expect(content).not.toContain('.safeword/hooks/prompt-timestamp.ts');
       expect(content).not.toContain('.safeword/hooks/codex/pre-tool-quality.ts');
       expect(content).not.toContain('.safeword/hooks/codex/post-tool-skill-nudge.ts');
+      expect(content).not.toContain('.safeword/hooks/codex/post-tool-quality.ts');
       expect(content).not.toContain('.safeword/hooks/codex/stop.ts');
       expect(content).not.toContain('[[hooks.Stop]]');
     });
@@ -1556,6 +1557,40 @@ describe('Reconcile - Reconciliation Engine', () => {
       const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
       expect(content).toContain('.safeword/hooks/prompt-retro-nudge.ts');
       expect(content.match(/\.safeword\/hooks\/prompt-retro-nudge\.ts/g)).toHaveLength(1);
+    });
+  });
+
+  describe('reconcile() - Codex quality-state parity (#630)', () => {
+    it('configures the PostToolUse quality-state hook on install', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { SAFEWORD_SCHEMA } = await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      await reconcile(SAFEWORD_SCHEMA, 'install', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(content).toContain('.safeword/hooks/codex/post-tool-quality.ts');
+      expect(content).toContain('Updating safeword quality state');
+    });
+
+    it('retrofits the PostToolUse quality-state hook into an existing pre-#630 config', async () => {
+      const { reconcile } = await import('../src/reconcile.js');
+      const { CODEX_POST_TOOL_QUALITY_HOOK_PATCH, SAFEWORD_SCHEMA } =
+        await import('../src/schema.js');
+
+      createPackageJson();
+      const ctx = createContext();
+
+      const preQuality = readCodexConfigTemplate().replace(CODEX_POST_TOOL_QUALITY_HOOK_PATCH, '');
+      mkdirSync(nodePath.join(temporaryDirectory, '.codex'), { recursive: true });
+      writeFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), preQuality);
+
+      await reconcile(SAFEWORD_SCHEMA, 'upgrade', ctx);
+
+      const content = readFileSync(nodePath.join(temporaryDirectory, '.codex/config.toml'), 'utf8');
+      expect(content.match(/\.safeword\/hooks\/codex\/post-tool-quality\.ts/g)).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #630. `write-review-stamp.ts` hard-failed with `multiple in_progress tickets` whenever the session→ticket binding didn't exist — which was most resume flows, and *always* on Codex/Cursor. Three changes close it end to end:

1. **Broadened binding write-site** (`post-tool-quality.ts`): any edit to `tickets/<folder>/*.md` now binds the session to that folder's ticket (previously only `ticket.md` edits did, so resuming a ticket and editing `spec.md` never bound). Guardrails: only `status: in_progress` tickets bind, epics never bind, and a non-active status (done/cancelled/superseded/wontfix/blocked) only clears a binding pointing at that same ticket — annotating an archived ticket can't steal or drop the session's real binding. The per-phase review trigger stays `ticket.md`-scoped. Cursor inherits this through its existing postToolUse adapter.
2. **Codex PostToolUse quality-state adapter** (`hooks/codex/post-tool-quality.ts`): Codex previously never wrote per-session quality state at all. New adapter mirrors the Cursor one (translates payloads including `apply_patch` targets, spawns the Claude accumulator with `SAFEWORD_AGENT_RUNTIME=codex`). Wired in the config template plus an add-if-missing retrofit patch for existing installs. **Deliberate side effect:** this activates the LOC blast-radius and implement-phase gates on Codex for the first time — intended parity with Claude/Cursor.
3. **Run-identity bridge for the stamp helper**: on Codex/Cursor the helper's process env has no session id, so it died at `missing run identity` before ticket resolution. The runtimes' pre-shell hooks now stash the session id in single-use, TTL'd, per-helper caches when a command invokes `write-review-stamp.ts` (both documented command forms: `$PROJECT_DIR`-absolute and bare-relative), armed only after the gate allows and runs cleanly. The helper falls back to the cache, constructing a full `RunIdentity` so it reads the same `codex-<id>`/`cursor-<id>` state key the post-tool adapter writes. The loud failure remains when no identity exists.

Also includes review-driven hardening (in_progress-only binding, arm-on-allow), three behavior-preserving refactors of the touched code (`frontmatterField`, `createTicketFolder` test fixture, shared `runClaudeHookAsCodex`), and a README hooks-list entry for the new adapter.

## Verification

- Full suite: 4420 passed / 5 skipped (308 files); Gherkin acceptance lane 181/181; build, typecheck, lint clean; `sync-config --check` and depcruise clean; template ↔ `.safeword/` dogfood copies byte-identical.
- Two independent fresh-context review passes over the diff; both findings fixed and re-verified (binding-steal by non-active statuses; stale identity cache on denied/crashed gate runs).
- New coverage: resume-flow end-to-end (real post-tool hook → real stamp helper), epic/cancelled/done/completed-folder binding edges, Codex adapter with direct-Edit and `apply_patch` payloads, bridge end-to-end through the real Cursor/Codex pre-shell hooks, single-use and TTL cache semantics, retrofit patch idempotence.

## Follow-ups (filed, out of scope)

- #647 — `.feature` scenario edits still don't bind the session ticket.
- #648 — Codex `apply_patch` Update translations carry no content, so the Tier-2 phase-advance gate can't fire on Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnZ24733sT4wZPZBcv5GkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnZ24733sT4wZPZBcv5GkX)_