### PR TITLE
Make review-stamp skip an explicit --skip flag (#629)

### DIFF
--- a/.agents/skills/bdd/SKILL.md
+++ b/.agents/skills/bdd/SKILL.md
@@ -55,8 +55,8 @@ applying the `/review-spec` procedure; **its** verdict decides. When
 `crossModelReview` is on, that reviewer must be a **different model than the
 author** — a same-model reviewer shares the author's blind spots. Prefer one of
 comparable-or-better capability; never weaker. If you can't run a different
-model, log a deliberate `skip: <reason>` rather than stamping a same-model
-review. On a pass, record the stamp:
+model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a
+same-model review. On a pass, record the stamp:
 
 ```bash
 bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>
@@ -69,7 +69,7 @@ own guards (intake's user sub-phase gates, implement's tests, the done-gate's
 evidence checks). When the **review gate** is enabled (`reviewGate` in
 `.safeword/config.json` — e.g. autonomous runs where user gates auto-confirm,
 ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
-(`… --phase <phase> "<why no independent review is needed>"`).
+(`… --phase <phase> --skip "<why no independent review is needed>"`).
 
 ---
 

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -146,6 +146,6 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
 ```
 
-The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)
 
 **Avoid bloat.**

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -143,7 +143,7 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 **Cross-model (`crossModelReview: true`).** The reviewer must run on a **different model than the author** — a same-model reviewer shares the author's blind spots (correlated errors). Prefer one of comparable-or-better capability; never weaker. This means an explicit different-model subagent — **not** a `context: fork`, which inherits the author's model. Record the model you assigned:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
+bun .safeword/hooks/write-review-stamp.ts --model "<reviewer-model-id>" impl-plan
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -69,7 +69,8 @@ change), log a skip with a reason instead of a review — it clears the same gat
 and records why:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+bun .safeword/hooks/write-review-stamp.ts spec --skip "<why this spec needs no review>"
 ```
 
-An empty reason does not clear the gate.
+Skip is the explicit `--skip` flag, quoted as one argument — free text after the
+artifact is rejected, and an empty reason does not clear the gate.

--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -55,8 +55,8 @@ applying the `/review-spec` procedure; **its** verdict decides. When
 `crossModelReview` is on, that reviewer must be a **different model than the
 author** — a same-model reviewer shares the author's blind spots. Prefer one of
 comparable-or-better capability; never weaker. If you can't run a different
-model, log a deliberate `skip: <reason>` rather than stamping a same-model
-review. On a pass, record the stamp:
+model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a
+same-model review. On a pass, record the stamp:
 
 ```bash
 bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>
@@ -69,7 +69,7 @@ own guards (intake's user sub-phase gates, implement's tests, the done-gate's
 evidence checks). When the **review gate** is enabled (`reviewGate` in
 `.safeword/config.json` — e.g. autonomous runs where user gates auto-confirm,
 ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
-(`… --phase <phase> "<why no independent review is needed>"`).
+(`… --phase <phase> --skip "<why no independent review is needed>"`).
 
 ---
 

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -146,6 +146,6 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
 ```
 
-The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)
 
 **Avoid bloat.**

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -143,7 +143,7 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 **Cross-model (`crossModelReview: true`).** The reviewer must run on a **different model than the author** — a same-model reviewer shares the author's blind spots (correlated errors). Prefer one of comparable-or-better capability; never weaker. This means an explicit different-model subagent — **not** a `context: fork`, which inherits the author's model. Record the model you assigned:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
+bun .safeword/hooks/write-review-stamp.ts --model "<reviewer-model-id>" impl-plan
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -69,7 +69,8 @@ change), log a skip with a reason instead of a review — it clears the same gat
 and records why:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+bun .safeword/hooks/write-review-stamp.ts spec --skip "<why this spec needs no review>"
 ```
 
-An empty reason does not clear the gate.
+Skip is the explicit `--skip` flag, quoted as one argument — free text after the
+artifact is rejected, and an empty reason does not clear the gate.

--- a/.cursor/commands/self-review.md
+++ b/.cursor/commands/self-review.md
@@ -42,8 +42,10 @@ re-blocks until the corrected spec is re-reviewed.
 ## Skip valve
 
 Trivial or docs-only? Log a skip with a reason instead — it clears the same gate
-and records why (an empty reason does not clear it):
+and records why. Skip is the explicit `--skip` flag, quoted as one argument —
+free text after the artifact is rejected, and an empty reason does not clear
+the gate:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+bun .safeword/hooks/write-review-stamp.ts spec --skip "<why this spec needs no review>"
 ```

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -480,7 +480,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
       if (!gatePhaseAdvance(phaseScope, stamps).ok) {
         deny(
           `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
-          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
+          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or add \`--skip "<reason>"\` to log a deliberate skip).`,
         );
       }
       // Ceiling-raiser (7A0B2K): under cross-model, a real-review stamp must record a

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -290,7 +290,7 @@ function checkArchitectureReviewGate(ticketInfo: TicketInfo): void {
   const scope = reviewScope(ticketInfo.folder, 'impl-plan', hashArtifact(planContent));
   if (!reviewGateForNextAsset(scope, stamps).ok) {
     hardBlockDone(
-      'Architecture review gate: the impl-plan design has no independent design review at its current content. Spawn a fresh-context reviewer, then run `bun .safeword/hooks/write-review-stamp.ts impl-plan` on pass (or log a skip with a reason).',
+      'Architecture review gate: the impl-plan design has no independent design review at its current content. Spawn a fresh-context reviewer, then run `bun .safeword/hooks/write-review-stamp.ts impl-plan` on pass (or add `--skip "<reason>"` to log a deliberate skip).',
     );
   }
 

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -15,8 +15,12 @@
 // fork reviewer, not this script.
 //
 // Usage:
-//   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
-//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
+//   bun write-review-stamp.ts [--ticket <folder>] <artifact>       # stamp <artifact>.md as reviewed
+//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase>  # stamp a phase exit as reviewed
+// Add `--skip "<reason>"` to either form to log a deliberate skip instead of a
+// review. Skip is an explicit flag (issue #629): free text after the artifact or
+// phase is rejected, never silently reclassified as a skip — a pass carries no
+// annotation here; narrative context belongs in the ticket work log.
 // Without --ticket, the helper stamps the session-bound active ticket. If no
 // session binding exists and more than one ticket is in_progress, pass --ticket
 // to disambiguate rather than guessing a ticket the gate may not be checking.
@@ -62,21 +66,25 @@ interface ParsedArguments {
   positional: string[];
   explicitTicket: string | undefined;
   reviewerModel: string | undefined;
+  skipReason: string | undefined;
 }
 
-// Optional global flags `--ticket <folder>` and `--model <id>` may appear before
-// or after the positional command. `--model` is the reviewing model, supplied by
-// the orchestrator that assigned it (NOT self-reported by the reviewer — Claude
-// Code withholds model identity from subagents, ticket MR5M3A).
+// Optional global flags `--ticket <folder>`, `--model <id>`, and
+// `--skip <reason>` may appear before or after the positional command.
+// `--model` is the reviewing model, supplied by the orchestrator that assigned
+// it (NOT self-reported by the reviewer — Claude Code withholds model identity
+// from subagents, ticket MR5M3A). `--skip` is the ONLY way to record a skip:
+// pass vs skip is declared intent, never inferred from stray text (issue #629).
 function parseArguments(argv: string[]): ParsedArguments {
   const positional: string[] = [];
   let explicitTicket: string | undefined;
   let reviewerModel: string | undefined;
+  let skipReason: string | undefined;
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === undefined) fail('missing argument');
-    if (arg !== '--ticket' && arg !== '--model') {
+    if (arg !== '--ticket' && arg !== '--model' && arg !== '--skip') {
       positional.push(arg);
       continue;
     }
@@ -86,6 +94,10 @@ function parseArguments(argv: string[]): ParsedArguments {
     if (value === undefined || value === '') fail(`${flag} requires a value`);
     if (flag === '--ticket') {
       explicitTicket = bareName(value, '--ticket');
+    } else if (flag === '--skip') {
+      const reason = singleLine(value);
+      if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
+      skipReason = reason;
     } else {
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
@@ -93,10 +105,10 @@ function parseArguments(argv: string[]): ParsedArguments {
     index += 1;
   }
 
-  return { positional, explicitTicket, reviewerModel };
+  return { positional, explicitTicket, reviewerModel, skipReason };
 }
 
-const { positional, explicitTicket, reviewerModel } = parseArguments(process.argv);
+const { positional, explicitTicket, reviewerModel, skipReason } = parseArguments(process.argv);
 
 function formatTicketList(folders: string[]): string {
   const shown = folders.slice(0, 12).join(', ');
@@ -145,7 +157,16 @@ function resolveTicketFolder(): string {
 }
 
 const isPhase = positional[0] === '--phase';
-const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || undefined;
+
+// Fail closed on free text: before --skip existed, trailing words were slurped
+// into a skip reason, so a pass annotated with commentary was silently
+// misrecorded as a skip (and hidden from the cross-model gate) — issue #629.
+const trailing = positional.slice(isPhase ? 2 : 1);
+if (trailing.length > 0) {
+  fail(
+    `unexpected trailing arguments: "${trailing.join(' ')}" — a pass takes no free text (notes belong in the ticket work log); to log a deliberate skip, pass --skip "<reason>" (quote a multi-word reason as one argument)`,
+  );
+}
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -83,6 +83,7 @@ function parseArguments(argv: string[]): ParsedArguments {
   let explicitTicket: string | undefined;
   let reviewerModel: string | undefined;
   let skipReason: string | undefined;
+  const seen = new Set<string>();
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -93,6 +94,8 @@ function parseArguments(argv: string[]): ParsedArguments {
     }
 
     const flag = arg;
+    if (seen.has(flag)) fail(`${flag} given more than once`);
+    seen.add(flag);
     const value = argv[index + 1];
     if (value === undefined || value === '') fail(`${flag} requires a value`);
     // A flag-shaped value means the real value was omitted and the NEXT flag got
@@ -102,15 +105,12 @@ function parseArguments(argv: string[]): ParsedArguments {
       fail(`${flag} requires a value, got flag-like "${value}"`);
     }
     if (flag === '--ticket') {
-      if (explicitTicket !== undefined) fail('--ticket given more than once');
       explicitTicket = bareName(value, '--ticket');
     } else if (flag === '--skip') {
-      if (skipReason !== undefined) fail('--skip given more than once');
       const reason = singleLine(value);
       if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
       skipReason = reason;
     } else {
-      if (reviewerModel !== undefined) fail('--model given more than once');
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
     }

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -92,13 +92,22 @@ function parseArguments(argv: string[]): ParsedArguments {
     const flag = arg;
     const value = argv[index + 1];
     if (value === undefined || value === '') fail(`${flag} requires a value`);
+    // A flag-shaped value means the real value was omitted and the NEXT flag got
+    // swallowed — e.g. `--model --skip` would otherwise mint a PASS stamp with
+    // model "--skip" (clearing the cross-model gate) from a declared skip.
+    if (value.startsWith('--')) {
+      fail(`${flag} requires a value, got flag-like "${value}"`);
+    }
     if (flag === '--ticket') {
+      if (explicitTicket !== undefined) fail('--ticket given more than once');
       explicitTicket = bareName(value, '--ticket');
     } else if (flag === '--skip') {
+      if (skipReason !== undefined) fail('--skip given more than once');
       const reason = singleLine(value);
       if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
       skipReason = reason;
     } else {
+      if (reviewerModel !== undefined) fail('--model given more than once');
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
     }

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -75,6 +75,9 @@ interface ParsedArguments {
 // it (NOT self-reported by the reviewer — Claude Code withholds model identity
 // from subagents, ticket MR5M3A). `--skip` is the ONLY way to record a skip:
 // pass vs skip is declared intent, never inferred from stray text (issue #629).
+// Flags that consume the next argv token as their value.
+const VALUE_FLAGS = new Set(['--ticket', '--model', '--skip']);
+
 function parseArguments(argv: string[]): ParsedArguments {
   const positional: string[] = [];
   let explicitTicket: string | undefined;
@@ -84,7 +87,7 @@ function parseArguments(argv: string[]): ParsedArguments {
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === undefined) fail('missing argument');
-    if (arg !== '--ticket' && arg !== '--model' && arg !== '--skip') {
+    if (!VALUE_FLAGS.has(arg)) {
       positional.push(arg);
       continue;
     }

--- a/packages/cli/templates/commands/self-review.md
+++ b/packages/cli/templates/commands/self-review.md
@@ -42,8 +42,10 @@ re-blocks until the corrected spec is re-reviewed.
 ## Skip valve
 
 Trivial or docs-only? Log a skip with a reason instead — it clears the same gate
-and records why (an empty reason does not clear it):
+and records why. Skip is the explicit `--skip` flag, quoted as one argument —
+free text after the artifact is rejected, and an empty reason does not clear
+the gate:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+bun .safeword/hooks/write-review-stamp.ts spec --skip "<why this spec needs no review>"
 ```

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -480,7 +480,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
       if (!gatePhaseAdvance(phaseScope, stamps).ok) {
         deny(
           `Phase "${exitedPhase}" has no independent review stamp — advancing is blocked until a fork review of the phase is logged.`,
-          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or append a skip reason to log a deliberate skip).`,
+          `Spawn a fresh (context:fork) reviewer for the ${exitedPhase} phase, then run \`bun .safeword/hooks/write-review-stamp.ts --phase ${exitedPhase}\` on pass (or add \`--skip "<reason>"\` to log a deliberate skip).`,
         );
       }
       // Ceiling-raiser (7A0B2K): under cross-model, a real-review stamp must record a

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -290,7 +290,7 @@ function checkArchitectureReviewGate(ticketInfo: TicketInfo): void {
   const scope = reviewScope(ticketInfo.folder, 'impl-plan', hashArtifact(planContent));
   if (!reviewGateForNextAsset(scope, stamps).ok) {
     hardBlockDone(
-      'Architecture review gate: the impl-plan design has no independent design review at its current content. Spawn a fresh-context reviewer, then run `bun .safeword/hooks/write-review-stamp.ts impl-plan` on pass (or log a skip with a reason).',
+      'Architecture review gate: the impl-plan design has no independent design review at its current content. Spawn a fresh-context reviewer, then run `bun .safeword/hooks/write-review-stamp.ts impl-plan` on pass (or add `--skip "<reason>"` to log a deliberate skip).',
     );
   }
 

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -15,8 +15,12 @@
 // fork reviewer, not this script.
 //
 // Usage:
-//   bun write-review-stamp.ts [--ticket <folder>] <artifact> [skip reason…]      # stamp <artifact>.md
-//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase> [skip reason…] # stamp a phase exit
+//   bun write-review-stamp.ts [--ticket <folder>] <artifact>       # stamp <artifact>.md as reviewed
+//   bun write-review-stamp.ts [--ticket <folder>] --phase <phase>  # stamp a phase exit as reviewed
+// Add `--skip "<reason>"` to either form to log a deliberate skip instead of a
+// review. Skip is an explicit flag (issue #629): free text after the artifact or
+// phase is rejected, never silently reclassified as a skip — a pass carries no
+// annotation here; narrative context belongs in the ticket work log.
 // Without --ticket, the helper stamps the session-bound active ticket. If no
 // session binding exists and more than one ticket is in_progress, pass --ticket
 // to disambiguate rather than guessing a ticket the gate may not be checking.
@@ -62,21 +66,25 @@ interface ParsedArguments {
   positional: string[];
   explicitTicket: string | undefined;
   reviewerModel: string | undefined;
+  skipReason: string | undefined;
 }
 
-// Optional global flags `--ticket <folder>` and `--model <id>` may appear before
-// or after the positional command. `--model` is the reviewing model, supplied by
-// the orchestrator that assigned it (NOT self-reported by the reviewer — Claude
-// Code withholds model identity from subagents, ticket MR5M3A).
+// Optional global flags `--ticket <folder>`, `--model <id>`, and
+// `--skip <reason>` may appear before or after the positional command.
+// `--model` is the reviewing model, supplied by the orchestrator that assigned
+// it (NOT self-reported by the reviewer — Claude Code withholds model identity
+// from subagents, ticket MR5M3A). `--skip` is the ONLY way to record a skip:
+// pass vs skip is declared intent, never inferred from stray text (issue #629).
 function parseArguments(argv: string[]): ParsedArguments {
   const positional: string[] = [];
   let explicitTicket: string | undefined;
   let reviewerModel: string | undefined;
+  let skipReason: string | undefined;
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === undefined) fail('missing argument');
-    if (arg !== '--ticket' && arg !== '--model') {
+    if (arg !== '--ticket' && arg !== '--model' && arg !== '--skip') {
       positional.push(arg);
       continue;
     }
@@ -86,6 +94,10 @@ function parseArguments(argv: string[]): ParsedArguments {
     if (value === undefined || value === '') fail(`${flag} requires a value`);
     if (flag === '--ticket') {
       explicitTicket = bareName(value, '--ticket');
+    } else if (flag === '--skip') {
+      const reason = singleLine(value);
+      if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
+      skipReason = reason;
     } else {
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
@@ -93,10 +105,10 @@ function parseArguments(argv: string[]): ParsedArguments {
     index += 1;
   }
 
-  return { positional, explicitTicket, reviewerModel };
+  return { positional, explicitTicket, reviewerModel, skipReason };
 }
 
-const { positional, explicitTicket, reviewerModel } = parseArguments(process.argv);
+const { positional, explicitTicket, reviewerModel, skipReason } = parseArguments(process.argv);
 
 function formatTicketList(folders: string[]): string {
   const shown = folders.slice(0, 12).join(', ');
@@ -145,7 +157,16 @@ function resolveTicketFolder(): string {
 }
 
 const isPhase = positional[0] === '--phase';
-const skipReason = singleLine(positional.slice(isPhase ? 2 : 1).join(' ')) || undefined;
+
+// Fail closed on free text: before --skip existed, trailing words were slurped
+// into a skip reason, so a pass annotated with commentary was silently
+// misrecorded as a skip (and hidden from the cross-model gate) — issue #629.
+const trailing = positional.slice(isPhase ? 2 : 1);
+if (trailing.length > 0) {
+  fail(
+    `unexpected trailing arguments: "${trailing.join(' ')}" — a pass takes no free text (notes belong in the ticket work log); to log a deliberate skip, pass --skip "<reason>" (quote a multi-word reason as one argument)`,
+  );
+}
 
 function resolveScope(ticketFolder: string): { scope: string; label: string } {
   if (isPhase) {

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -83,6 +83,7 @@ function parseArguments(argv: string[]): ParsedArguments {
   let explicitTicket: string | undefined;
   let reviewerModel: string | undefined;
   let skipReason: string | undefined;
+  const seen = new Set<string>();
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -93,6 +94,8 @@ function parseArguments(argv: string[]): ParsedArguments {
     }
 
     const flag = arg;
+    if (seen.has(flag)) fail(`${flag} given more than once`);
+    seen.add(flag);
     const value = argv[index + 1];
     if (value === undefined || value === '') fail(`${flag} requires a value`);
     // A flag-shaped value means the real value was omitted and the NEXT flag got
@@ -102,15 +105,12 @@ function parseArguments(argv: string[]): ParsedArguments {
       fail(`${flag} requires a value, got flag-like "${value}"`);
     }
     if (flag === '--ticket') {
-      if (explicitTicket !== undefined) fail('--ticket given more than once');
       explicitTicket = bareName(value, '--ticket');
     } else if (flag === '--skip') {
-      if (skipReason !== undefined) fail('--skip given more than once');
       const reason = singleLine(value);
       if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
       skipReason = reason;
     } else {
-      if (reviewerModel !== undefined) fail('--model given more than once');
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
     }

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -92,13 +92,22 @@ function parseArguments(argv: string[]): ParsedArguments {
     const flag = arg;
     const value = argv[index + 1];
     if (value === undefined || value === '') fail(`${flag} requires a value`);
+    // A flag-shaped value means the real value was omitted and the NEXT flag got
+    // swallowed — e.g. `--model --skip` would otherwise mint a PASS stamp with
+    // model "--skip" (clearing the cross-model gate) from a declared skip.
+    if (value.startsWith('--')) {
+      fail(`${flag} requires a value, got flag-like "${value}"`);
+    }
     if (flag === '--ticket') {
+      if (explicitTicket !== undefined) fail('--ticket given more than once');
       explicitTicket = bareName(value, '--ticket');
     } else if (flag === '--skip') {
+      if (skipReason !== undefined) fail('--skip given more than once');
       const reason = singleLine(value);
       if (reason === '') fail('--skip reason must not be blank — a real reason is the audit trail');
       skipReason = reason;
     } else {
+      if (reviewerModel !== undefined) fail('--model given more than once');
       if (/\s/.test(value)) fail('--model id must not contain whitespace');
       reviewerModel = value;
     }

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -75,6 +75,9 @@ interface ParsedArguments {
 // it (NOT self-reported by the reviewer — Claude Code withholds model identity
 // from subagents, ticket MR5M3A). `--skip` is the ONLY way to record a skip:
 // pass vs skip is declared intent, never inferred from stray text (issue #629).
+// Flags that consume the next argv token as their value.
+const VALUE_FLAGS = new Set(['--ticket', '--model', '--skip']);
+
 function parseArguments(argv: string[]): ParsedArguments {
   const positional: string[] = [];
   let explicitTicket: string | undefined;
@@ -84,7 +87,7 @@ function parseArguments(argv: string[]): ParsedArguments {
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === undefined) fail('missing argument');
-    if (arg !== '--ticket' && arg !== '--model' && arg !== '--skip') {
+    if (!VALUE_FLAGS.has(arg)) {
       positional.push(arg);
       continue;
     }

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -55,8 +55,8 @@ applying the `/review-spec` procedure; **its** verdict decides. When
 `crossModelReview` is on, that reviewer must be a **different model than the
 author** — a same-model reviewer shares the author's blind spots. Prefer one of
 comparable-or-better capability; never weaker. If you can't run a different
-model, log a deliberate `skip: <reason>` rather than stamping a same-model
-review. On a pass, record the stamp:
+model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a
+same-model review. On a pass, record the stamp:
 
 ```bash
 bun .safeword/hooks/write-review-stamp.ts --phase <phase you are leaving>
@@ -69,7 +69,7 @@ own guards (intake's user sub-phase gates, implement's tests, the done-gate's
 evidence checks). When the **review gate** is enabled (`reviewGate` in
 `.safeword/config.json` — e.g. autonomous runs where user gates auto-confirm,
 ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
-(`… --phase <phase> "<why no independent review is needed>"`).
+(`… --phase <phase> --skip "<why no independent review is needed>"`).
 
 ---
 

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -146,6 +146,6 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
 ```
 
-The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate `skip: <reason>` rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `skip:`, is required.)
+The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)
 
 **Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -143,7 +143,7 @@ Off by default. When `.safeword/config.json` sets `architectureReviewGate: true`
 **Cross-model (`crossModelReview: true`).** The reviewer must run on a **different model than the author** — a same-model reviewer shares the author's blind spots (correlated errors). Prefer one of comparable-or-better capability; never weaker. This means an explicit different-model subagent — **not** a `context: fork`, which inherits the author's model. Record the model you assigned:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts --model < reviewer-model-id > impl-plan
+bun .safeword/hooks/write-review-stamp.ts --model "<reviewer-model-id>" impl-plan
 ```
 
 The gate compares that tag against the author model (captured at SessionStart) and enforces **different only** — "comparable-or-better" is your judgment, not gate-checked. An absent tag fails closed. If you can't run a different model, log a deliberate skip (`--skip "<reason>"`) rather than stamping a same-model review. (This gate is stricter than quality-review's advisory loop, which accepts a fresh-context pass on your own model — here a genuinely different model, or an explicit `--skip`, is required.)

--- a/packages/cli/templates/skills/self-review/SKILL.md
+++ b/packages/cli/templates/skills/self-review/SKILL.md
@@ -69,7 +69,8 @@ change), log a skip with a reason instead of a review — it clears the same gat
 and records why:
 
 ```bash
-bun .safeword/hooks/write-review-stamp.ts spec "<why this spec needs no review>"
+bun .safeword/hooks/write-review-stamp.ts spec --skip "<why this spec needs no review>"
 ```
 
-An empty reason does not clear the gate.
+Skip is the explicit `--skip` flag, quoted as one argument — free text after the
+artifact is rejected, and an empty reason does not clear the gate.

--- a/packages/cli/tests/integration/phase-review-gate.test.ts
+++ b/packages/cli/tests/integration/phase-review-gate.test.ts
@@ -97,7 +97,8 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
     return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
   }
 
-  function stampPhase(phase: string, ...skip: string[]): void {
+  function stampPhase(phase: string, skipReason?: string): void {
+    const skip = skipReason === undefined ? [] : ['--skip', skipReason];
     spawnSync('bun', [STAMP_PATH, '--phase', phase, ...skip], {
       encoding: 'utf8',
       env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot, CLAUDE_SESSION_ID: 'sess-1' },
@@ -160,7 +161,7 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
   });
 
   it('a skip stamp clears the phase gate', () => {
-    stampPhase('define-behavior', 'docs-only', 'phase');
+    stampPhase('define-behavior', 'docs-only phase');
     expectHookAllow(runGateWrite('implement'));
   });
 
@@ -206,7 +207,7 @@ describe('NMSD94 Tier 2 phase-advance gate (wired)', () => {
 
     it('a logged skip bypasses the cross-model requirement', () => {
       writeConfig(true, true);
-      stampPhase('define-behavior', 'docs-only', 'phase');
+      stampPhase('define-behavior', 'docs-only phase');
       expectHookAllow(runGateWrite('implement', { SAFEWORD_AUTHOR_MODEL: 'claude-opus-4-8' }));
     });
 

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -184,6 +184,34 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(readLog()).toBe('');
   });
 
+  it('rejects a flag-like flag value instead of minting a pass stamp from a declared skip', () => {
+    // Without this guard, `--model --skip` swallows --skip as the model id and
+    // writes a PASS stamp whose bogus model tag clears the cross-model gate.
+    const passFromSkip = runStamp('spec', '--model', '--skip');
+    expect(passFromSkip.status).toBe(1);
+    expect(passFromSkip.stdout).toContain('flag-like');
+
+    const skipEatsTicket = runStamp('--skip', '--ticket', TICKET_ID);
+    expect(skipEatsTicket.status).toBe(1);
+    expect(skipEatsTicket.stdout).toContain('flag-like');
+
+    expect(readLog()).toBe('');
+  });
+
+  it('rejects --skip with no value at end of argv', () => {
+    const stamp = runStamp('spec', '--skip');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('--skip requires a value');
+    expect(readLog()).toBe('');
+  });
+
+  it('rejects a repeated flag instead of silently last-winning', () => {
+    const stamp = runStamp('spec', '--skip', 'reason a', '--skip', 'reason b');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('--skip given more than once');
+    expect(readLog()).toBe('');
+  });
+
   it('--phase writes a ticket-qualified phase scope', () => {
     const stamp = runStamp('--phase', 'define-behavior');
     expect(stamp.status).toBe(0);

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -184,17 +184,19 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(readLog()).toBe('');
   });
 
-  it('rejects a flag-like flag value instead of minting a pass stamp from a declared skip', () => {
+  it('rejects --model swallowing --skip instead of minting a pass stamp from a declared skip', () => {
     // Without this guard, `--model --skip` swallows --skip as the model id and
     // writes a PASS stamp whose bogus model tag clears the cross-model gate.
-    const passFromSkip = runStamp('spec', '--model', '--skip');
-    expect(passFromSkip.status).toBe(1);
-    expect(passFromSkip.stdout).toContain('flag-like');
+    const stamp = runStamp('spec', '--model', '--skip');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('flag-like');
+    expect(readLog()).toBe('');
+  });
 
-    const skipEatsTicket = runStamp('--skip', '--ticket', TICKET_ID);
-    expect(skipEatsTicket.status).toBe(1);
-    expect(skipEatsTicket.stdout).toContain('flag-like');
-
+  it('rejects --skip swallowing --ticket instead of stamping the wrong ticket', () => {
+    const stamp = runStamp('--skip', '--ticket', TICKET_ID);
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('flag-like');
     expect(readLog()).toBe('');
   });
 

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -155,11 +155,33 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
   });
 
-  it('a skip stamp clears the gate and records its reason', () => {
-    const stamp = runStamp('spec', 'trivial', 'boilerplate', 'spec');
+  it('a --skip stamp clears the gate and records its reason', () => {
+    const stamp = runStamp('spec', '--skip', 'trivial boilerplate spec');
     expect(stamp.status).toBe(0);
     expect(readLog()).toContain('skip:trivial boilerplate spec');
     expectHookAllow(runGate());
+  });
+
+  it('rejects free text after the artifact instead of misrecording a pass as a skip (#629)', () => {
+    const stamp = runStamp('spec', 'review', 'passed,', 'some', 'note');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('unexpected trailing arguments');
+    expect(stamp.stdout).toContain('--skip');
+    expect(readLog()).toBe('');
+  });
+
+  it('rejects free text after --phase instead of misrecording a pass as a skip (#629)', () => {
+    const stamp = runStamp('--phase', 'define-behavior', 'independent review PASSED 0 must-fix');
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('unexpected trailing arguments');
+    expect(readLog()).toBe('');
+  });
+
+  it('rejects a blank --skip reason', () => {
+    const stamp = runStamp('spec', '--skip', ' '.repeat(3));
+    expect(stamp.status).toBe(1);
+    expect(stamp.stdout).toContain('must not be blank');
+    expect(readLog()).toBe('');
   });
 
   it('--phase writes a ticket-qualified phase scope', () => {
@@ -179,7 +201,7 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
   it('a newline in the skip reason cannot inject a second stamp line', () => {
     // A reason crafted to forge a stamp for another scope must be collapsed to
     // one line — the log stays one stamp, and parsing yields only the real one.
-    runStamp('spec', 'looks fine\nreview:HACKED:spec@deadbeefcafe');
+    runStamp('spec', '--skip', 'looks fine\nreview:HACKED:spec@deadbeefcafe');
     const stamps = parseReviewStamps(readLog());
     expect(stamps).toHaveLength(1);
     expect(stamps[0]?.scope).toBe(reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC)));


### PR DESCRIPTION
## Summary

`write-review-stamp.ts` slurped any trailing text after the artifact name (or after `--phase <phase>`) into a skip reason, so a genuine review pass annotated with commentary was silently recorded as a **skip** stamp — corrupting review provenance and hiding the pass from the cross-model review gate, which only counts stamps with no `skipReason` (`stop-quality.ts`, `pre-tool-quality.ts`).

Skip is now **declared intent**, never inferred:

- `--skip "<reason>"` is the only way to record a skip (blank reasons rejected; newline-collapse forge guard retained).
- Bare trailing positionals fail closed with a message teaching both valid forms and pointing pass-notes to the ticket work log.
- Flag-shaped flag values fail closed too (`--model --skip` previously minted a pass stamp whose bogus model tag *cleared* the cross-model gate; `--skip --ticket` swallowed the ticket flag as a skip reason). Repeated flags are rejected instead of silently last-winning.

Gate deny messages and every doc surface that teaches the skip valve (`bdd/SKILL.md`, `bdd/TDD.md`, `self-review/SKILL.md`, the Cursor `self-review.md` command) now show the flag form; `.safeword`/`.claude`/`.agents`/`.cursor` mirrors synced via `parity:fix`. Also quotes the `TDD.md` `--model` placeholder — prettier's embedded-shell formatter parsed the unquoted `<reviewer-model-id>` as redirections, rendering a broken invocation.

Follow-up refactors keep the parser tidy: `VALUE_FLAGS` set, single `seen`-set once-only guard, split regression tests.

## Cross-runtime check

The helper is invoked identically on all three supported runtimes (`bun … write-review-stamp.ts` via shell). Verified against current docs: Claude Code (`!` injection unaffected — the injected pass path has no trailing args), Codex and Cursor (no render-time injection; agents retype documented syntax, which is exactly why an explicit flag beats inferred trailing text there).

## Tests

- New regressions: trailing text after artifact / after `--phase` errors (the exact #629 repro), blank `--skip`, flag-like flag values in both swallow directions, `--skip` with no value, repeated flags — each asserting no stamp is written.
- Full suite green: 306 files, 4402 passed / 5 skipped. Gherkin lane: 181 scenarios passed. Typecheck + lint clean.
- Two independent fresh-context review passes; pass 1 found the flag-swallowing hole (fixed in 98dd6f8), pass 2 confirmed no criticals remain.

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ca26uUBYciQM2kxPp9Kpy

---
_Generated by [Claude Code](https://claude.ai/code/session_018ca26uUBYciQM2kxPp9Kpy)_