### PR TITLE
feat(sql): defer to host-owned SQL formatting; make sqlfluff fix opt-in

### DIFF
--- a/.safeword/hooks/lib/lint-config.ts
+++ b/.safeword/hooks/lib/lint-config.ts
@@ -105,13 +105,30 @@ export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
  * Whether the host repo formats SQL itself via prettier-plugin-sql (#638). The
  * SQL branch then runs the HOST's prettier — whose config declares the plugin
  * and whose .prettierignore carve-outs (e.g. frozen DDL migrations, #636) apply
- * — instead of sqlfluff. node_modules presence is the signal, mirroring the
- * prettier-plugin-sh check in lint.ts; the setup-side twin in packs/sql/files.ts
- * checks declared deps instead (kept in sync by hand — templates can't be
- * imported from src).
+ * — instead of sqlfluff. Signals: installed in node_modules (mirrors the
+ * prettier-plugin-sh check in lint.ts) OR declared in root package.json — the
+ * declared check keeps this in step with the setup-side twin in
+ * packs/sql/files.ts (kept in sync by hand — templates can't be imported from
+ * src), so a declared-but-not-installed repo whose sqlfluff configs setup
+ * suppressed doesn't fall through to the auto-upgrade path on every edit.
  */
 export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
-  return existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'));
+  if (existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'))) {
+    return true;
+  }
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, unknown>;
+      devDependencies?: Record<string, unknown>;
+    };
+    return Boolean(
+      parsed.dependencies?.['prettier-plugin-sql'] ??
+      parsed.devDependencies?.['prettier-plugin-sql'],
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/.safeword/hooks/lib/lint-config.ts
+++ b/.safeword/hooks/lib/lint-config.ts
@@ -8,7 +8,8 @@
 // a new extension is a one-line add — the drift this replaces was an
 // *incomplete* list (`.ts`/`.yaml` were missing), not enumeration itself.
 
-import { readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
 
 const ESLINT_FLAT_EXTENSIONS = ['js', 'mjs', 'cjs', 'ts', 'mts', 'cts'];
 const ESLINT_RC_EXTENSIONS = ['js', 'cjs', 'yaml', 'yml', 'json'];
@@ -98,4 +99,33 @@ export function projectOwnsAlternativeFormatter(projectDirectory: string): boole
  */
 export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
   return !detectAlternativeFormatter(entries) && !detectPrettierConfig(entries);
+}
+
+/**
+ * Whether the host repo formats SQL itself via prettier-plugin-sql (#638). The
+ * SQL branch then runs the HOST's prettier — whose config declares the plugin
+ * and whose .prettierignore carve-outs (e.g. frozen DDL migrations, #636) apply
+ * — instead of sqlfluff. node_modules presence is the signal, mirroring the
+ * prettier-plugin-sh check in lint.ts; the setup-side twin in packs/sql/files.ts
+ * checks declared deps instead (kept in sync by hand — templates can't be
+ * imported from src).
+ */
+export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
+  return existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'));
+}
+
+/**
+ * Whether edit-time `sqlfluff fix` is enabled (`.safeword/config.json` →
+ * `sql.fix`). Off by default (#638): the hook lints and reports like the other
+ * language branches; rewriting the file beyond the agent's intended edit is
+ * opt-in. Missing/malformed config reads as "off".
+ */
+export function sqlFixOptedIn(projectDirectory: string): boolean {
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { sql?: { fix?: unknown } };
+    return parsed.sql?.fix === true;
+  } catch {
+    return false;
+  }
 }

--- a/.safeword/hooks/lib/lint.ts
+++ b/.safeword/hooks/lib/lint.ts
@@ -393,13 +393,22 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     // prettier — no --config override, so the host config (which declares the
     // plugin) and its .prettierignore carve-outs (frozen DDL migrations) apply.
     // Prettier's ignore resolution is cwd-relative; hooks run with cwd =
-    // project root, which is what makes those carve-outs hold. On failure
-    // (e.g. plugin in node_modules but undeclared in config → "No parser could
-    // be inferred", exit 2) fall through to sqlfluff rather than leave SQL
-    // ungated.
+    // project root, which is what makes those carve-outs hold. This bypasses
+    // runPrettier's V7GGJZ guard deliberately: plugin presence means the host
+    // formats SQL with prettier even when Biome/dprint owns its JS/TS style.
     if (hostFormatsSqlWithPrettier(projectDir)) {
       const result = await $`bunx prettier --write ${file}`.nothrow().quiet();
       if (result.exitCode === 0) return { warnings };
+      // Non-zero: the plugin is undeclared in the host config, or the edit
+      // itself doesn't parse. Only fall through to sqlfluff when its config
+      // already exists — in a host-owned repo it's absent by design, and
+      // falling through would fire ensurePackInstalled's network upgrade on
+      // every failing edit. Surface prettier's stderr so the agent sees the
+      // parse error instead of silence.
+      if (!hasConfig(SAFEWORD_SQLFLUFF)) {
+        const stderr = result.stderr.toString().trim();
+        return { warnings, ...(stderr && { errors: stderr }) };
+      }
     }
     const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {

--- a/.safeword/hooks/lib/lint.ts
+++ b/.safeword/hooks/lib/lint.ts
@@ -11,7 +11,11 @@ import nodePath from 'node:path';
 
 import { $ } from 'bun';
 
-import { projectOwnsAlternativeFormatter } from './lint-config.js';
+import {
+  hostFormatsSqlWithPrettier,
+  projectOwnsAlternativeFormatter,
+  sqlFixOptedIn,
+} from './lint-config.js';
 
 // File extensions for different linting strategies
 const JS_EXTENSIONS = new Set([
@@ -380,23 +384,48 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     return { warnings };
   }
 
-  // SQL files - sqlfluff (only for SQL-focused projects)
+  // SQL files - host prettier when the host owns SQL formatting, else sqlfluff
+  // (only for SQL-focused projects).
   // Only warn about missing sqlfluff if the sql pack is installed,
   // since .sql files exist in many non-SQL-focused contexts.
   if (SQL_EXTENSIONS.has(extension)) {
+    // Host formats SQL via prettier-plugin-sql (#636/#638): run the HOST's
+    // prettier — no --config override, so the host config (which declares the
+    // plugin) and its .prettierignore carve-outs (frozen DDL migrations) apply.
+    // Prettier's ignore resolution is cwd-relative; hooks run with cwd =
+    // project root, which is what makes those carve-outs hold. On failure
+    // (e.g. plugin in node_modules but undeclared in config → "No parser could
+    // be inferred", exit 2) fall through to sqlfluff rather than leave SQL
+    // ungated.
+    if (hostFormatsSqlWithPrettier(projectDir)) {
+      const result = await $`bunx prettier --write ${file}`.nothrow().quiet();
+      if (result.exitCode === 0) return { warnings };
+    }
     const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {
       if (
         !(await checkToolAvailable(
           'sqlfluff',
           'SQL/dbt',
-          getPythonInstallHint(file, 'sqlfluff'),
+          getPythonInstallHint(file, "'sqlfluff>=4.2.0'"),
           warnings,
         ))
       ) {
         return { warnings };
       }
-      await $`sqlfluff fix --config ${SAFEWORD_SQLFLUFF} ${file}`.nothrow().quiet();
+      // Lint-and-report by default, like the ESLint/ruff branches; in-place
+      // rewriting (`sqlfluff fix`) mutates the file beyond the agent's
+      // intended edit, so it's opt-in via `sql.fix` (#638). Opted-in hosts
+      // carve out frozen files with .sqlfluffignore, which sqlfluff honors
+      // even for explicitly passed paths.
+      if (sqlFixOptedIn(projectDir)) {
+        await $`sqlfluff fix --config ${SAFEWORD_SQLFLUFF} ${file}`.nothrow().quiet();
+      }
+      const errors = await captureRemainingErrors(
+        ['sqlfluff', 'lint', '--config', SAFEWORD_SQLFLUFF, file],
+        warnings,
+      );
+      return { warnings, ...(errors && { errors }) };
     }
     return { warnings };
   }

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -16,6 +16,8 @@ import {
   installPythonDependencies,
 } from '../packs/python/setup.js';
 import { getMissingPacks } from '../packs/registry.js';
+import { hostOwnsSqlFormatting } from '../packs/sql/files.js';
+import type { ProjectContext } from '../packs/types.js';
 import { reconcile, type ReconcileResult } from '../reconcile.js';
 import { SAFEWORD_SCHEMA, SAFEWORD_TRANSIENT_PATHS } from '../schema.js';
 import { ensureLanguageSkills } from '../skills/languages.js';
@@ -199,11 +201,15 @@ function installPythonTools(cwd: string): void {
   installPythonBasedTools(pythonDirectory, ['ruff', 'mypy'], 'Python tools');
 }
 
-function installSqlTools(cwd: string): void {
+function installSqlTools(cwd: string, ctx: ProjectContext): void {
+  // Host owns SQL formatting via prettier-plugin-sql (#638): no sqlfluff
+  // configs are generated, so don't install a tool safeword won't run.
+  if (hostOwnsSqlFormatting(ctx)) return;
   // SQL projects use Python for SQLFluff — find pyproject.toml near dbt_project.yml
   const sqlDirectory = findInTree(cwd, 'dbt_project.yml') ?? cwd;
   const pythonDirectory = findInTree(sqlDirectory, 'pyproject.toml') ?? sqlDirectory;
-  installPythonBasedTools(pythonDirectory, ['sqlfluff'], 'SQL tools');
+  // >=4.2.0 floor matches the lint hook's install hint (2026 DoS CVEs).
+  installPythonBasedTools(pythonDirectory, ['sqlfluff>=4.2.0'], 'SQL tools');
 }
 
 /**
@@ -213,12 +219,12 @@ function installSqlTools(cwd: string): void {
  * before a language's skills existed; the on-disk presence check keeps repeat
  * upgrades network-free).
  */
-function installLanguageTools(cwd: string, missingPacks: string[]): void {
+function installLanguageTools(cwd: string, missingPacks: string[], ctx: ProjectContext): void {
   if (missingPacks.includes('python')) {
     installPythonTools(cwd);
   }
   if (missingPacks.includes('sql')) {
-    installSqlTools(cwd);
+    installSqlTools(cwd, ctx);
   }
   ensureLanguageSkills(cwd);
 }
@@ -435,7 +441,7 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
       installPack(packId, cwd);
       info(`Installed ${packId} pack`);
     }
-    installLanguageTools(cwd, missingPacks);
+    installLanguageTools(cwd, missingPacks, ctx);
 
     maybeRefreshDepcruiseConfig(cwd, safewordDirectory, result);
 

--- a/packages/cli/src/packs/config.ts
+++ b/packages/cli/src/packs/config.ts
@@ -14,6 +14,8 @@ const CONFIG_PATH = '.safeword/config.json';
 interface SafewordConfig {
   installedPacks: string[];
   autoUpgrade?: boolean;
+  /** SQL pack options — `fix: true` opts in to edit-time `sqlfluff fix` (#638). */
+  sql?: { fix?: boolean };
 }
 
 function readConfig(cwd: string): SafewordConfig | undefined {

--- a/packages/cli/src/packs/sql/files.ts
+++ b/packages/cli/src/packs/sql/files.ts
@@ -5,8 +5,23 @@
  * Imported by schema.ts and spread into SAFEWORD_SCHEMA.
  */
 
-import type { FileDefinition, ManagedFileDefinition } from '../types.js';
+import type { FileDefinition, ManagedFileDefinition, ProjectContext } from '../types.js';
 import { detectSqlDialect } from './dialect.js';
+
+/**
+ * Whether the host repo already owns SQL formatting via prettier-plugin-sql
+ * declared in its root package.json (#636/#638). Setup then generates no
+ * sqlfluff configs — safeword defers to the host's formatter, the same way it
+ * defers to Biome/dprint for JS/TS. Declared deps only: a transitive copy in
+ * node_modules is not ownership. Hook-side twin: hostFormatsSqlWithPrettier in
+ * templates/hooks/lib/lint-config.ts (kept in sync by hand — src can't import
+ * templates).
+ */
+function hostOwnsSqlFormatting(ctx: ProjectContext): boolean {
+  return (
+    'prettier-plugin-sql' in ctx.developmentDeps || 'prettier-plugin-sql' in ctx.productionDeps
+  );
+}
 
 // ============================================================================
 // SQLFluff Configuration
@@ -87,7 +102,7 @@ ${SQLFLUFF_STRICT_RULES}
 export const sqlOwnedFiles: Record<string, FileDefinition> = {
   '.safeword/sqlfluff.cfg': {
     generator: ctx =>
-      ctx.languages?.sql
+      ctx.languages?.sql && !hostOwnsSqlFormatting(ctx)
         ? generateSqlfluffBaseConfig(
             ctx.projectType.existingSqlfluffConfig,
             detectSqlDialect(ctx.cwd) ?? 'ansi',
@@ -122,7 +137,7 @@ apply_dbt_builtins = True
 export const sqlManagedFiles: Record<string, ManagedFileDefinition> = {
   '.sqlfluff': {
     generator: ctx =>
-      ctx.languages?.sql && !ctx.projectType.existingSqlfluffConfig
+      ctx.languages?.sql && !ctx.projectType.existingSqlfluffConfig && !hostOwnsSqlFormatting(ctx)
         ? generateProjectSqlfluffConfig(detectSqlDialect(ctx.cwd) ?? 'ansi')
         : undefined,
   },

--- a/packages/cli/src/packs/sql/files.ts
+++ b/packages/cli/src/packs/sql/files.ts
@@ -17,7 +17,7 @@ import { detectSqlDialect } from './dialect.js';
  * templates/hooks/lib/lint-config.ts (kept in sync by hand — src can't import
  * templates).
  */
-function hostOwnsSqlFormatting(ctx: ProjectContext): boolean {
+export function hostOwnsSqlFormatting(ctx: ProjectContext): boolean {
   return (
     'prettier-plugin-sql' in ctx.developmentDeps || 'prettier-plugin-sql' in ctx.productionDeps
   );

--- a/packages/cli/templates/hooks/lib/lint-config.ts
+++ b/packages/cli/templates/hooks/lib/lint-config.ts
@@ -105,13 +105,30 @@ export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
  * Whether the host repo formats SQL itself via prettier-plugin-sql (#638). The
  * SQL branch then runs the HOST's prettier — whose config declares the plugin
  * and whose .prettierignore carve-outs (e.g. frozen DDL migrations, #636) apply
- * — instead of sqlfluff. node_modules presence is the signal, mirroring the
- * prettier-plugin-sh check in lint.ts; the setup-side twin in packs/sql/files.ts
- * checks declared deps instead (kept in sync by hand — templates can't be
- * imported from src).
+ * — instead of sqlfluff. Signals: installed in node_modules (mirrors the
+ * prettier-plugin-sh check in lint.ts) OR declared in root package.json — the
+ * declared check keeps this in step with the setup-side twin in
+ * packs/sql/files.ts (kept in sync by hand — templates can't be imported from
+ * src), so a declared-but-not-installed repo whose sqlfluff configs setup
+ * suppressed doesn't fall through to the auto-upgrade path on every edit.
  */
 export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
-  return existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'));
+  if (existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'))) {
+    return true;
+  }
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, unknown>;
+      devDependencies?: Record<string, unknown>;
+    };
+    return Boolean(
+      parsed.dependencies?.['prettier-plugin-sql'] ??
+      parsed.devDependencies?.['prettier-plugin-sql'],
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/cli/templates/hooks/lib/lint-config.ts
+++ b/packages/cli/templates/hooks/lib/lint-config.ts
@@ -8,7 +8,8 @@
 // a new extension is a one-line add — the drift this replaces was an
 // *incomplete* list (`.ts`/`.yaml` were missing), not enumeration itself.
 
-import { readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
 
 const ESLINT_FLAT_EXTENSIONS = ['js', 'mjs', 'cjs', 'ts', 'mts', 'cts'];
 const ESLINT_RC_EXTENSIONS = ['js', 'cjs', 'yaml', 'yml', 'json'];
@@ -98,4 +99,33 @@ export function projectOwnsAlternativeFormatter(projectDirectory: string): boole
  */
 export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
   return !detectAlternativeFormatter(entries) && !detectPrettierConfig(entries);
+}
+
+/**
+ * Whether the host repo formats SQL itself via prettier-plugin-sql (#638). The
+ * SQL branch then runs the HOST's prettier — whose config declares the plugin
+ * and whose .prettierignore carve-outs (e.g. frozen DDL migrations, #636) apply
+ * — instead of sqlfluff. node_modules presence is the signal, mirroring the
+ * prettier-plugin-sh check in lint.ts; the setup-side twin in packs/sql/files.ts
+ * checks declared deps instead (kept in sync by hand — templates can't be
+ * imported from src).
+ */
+export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
+  return existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'));
+}
+
+/**
+ * Whether edit-time `sqlfluff fix` is enabled (`.safeword/config.json` →
+ * `sql.fix`). Off by default (#638): the hook lints and reports like the other
+ * language branches; rewriting the file beyond the agent's intended edit is
+ * opt-in. Missing/malformed config reads as "off".
+ */
+export function sqlFixOptedIn(projectDirectory: string): boolean {
+  try {
+    const raw = readFileSync(nodePath.join(projectDirectory, '.safeword', 'config.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { sql?: { fix?: unknown } };
+    return parsed.sql?.fix === true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/cli/templates/hooks/lib/lint.ts
+++ b/packages/cli/templates/hooks/lib/lint.ts
@@ -393,13 +393,22 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     // prettier — no --config override, so the host config (which declares the
     // plugin) and its .prettierignore carve-outs (frozen DDL migrations) apply.
     // Prettier's ignore resolution is cwd-relative; hooks run with cwd =
-    // project root, which is what makes those carve-outs hold. On failure
-    // (e.g. plugin in node_modules but undeclared in config → "No parser could
-    // be inferred", exit 2) fall through to sqlfluff rather than leave SQL
-    // ungated.
+    // project root, which is what makes those carve-outs hold. This bypasses
+    // runPrettier's V7GGJZ guard deliberately: plugin presence means the host
+    // formats SQL with prettier even when Biome/dprint owns its JS/TS style.
     if (hostFormatsSqlWithPrettier(projectDir)) {
       const result = await $`bunx prettier --write ${file}`.nothrow().quiet();
       if (result.exitCode === 0) return { warnings };
+      // Non-zero: the plugin is undeclared in the host config, or the edit
+      // itself doesn't parse. Only fall through to sqlfluff when its config
+      // already exists — in a host-owned repo it's absent by design, and
+      // falling through would fire ensurePackInstalled's network upgrade on
+      // every failing edit. Surface prettier's stderr so the agent sees the
+      // parse error instead of silence.
+      if (!hasConfig(SAFEWORD_SQLFLUFF)) {
+        const stderr = result.stderr.toString().trim();
+        return { warnings, ...(stderr && { errors: stderr }) };
+      }
     }
     const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {

--- a/packages/cli/templates/hooks/lib/lint.ts
+++ b/packages/cli/templates/hooks/lib/lint.ts
@@ -11,7 +11,11 @@ import nodePath from 'node:path';
 
 import { $ } from 'bun';
 
-import { projectOwnsAlternativeFormatter } from './lint-config.js';
+import {
+  hostFormatsSqlWithPrettier,
+  projectOwnsAlternativeFormatter,
+  sqlFixOptedIn,
+} from './lint-config.js';
 
 // File extensions for different linting strategies
 const JS_EXTENSIONS = new Set([
@@ -380,23 +384,48 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     return { warnings };
   }
 
-  // SQL files - sqlfluff (only for SQL-focused projects)
+  // SQL files - host prettier when the host owns SQL formatting, else sqlfluff
+  // (only for SQL-focused projects).
   // Only warn about missing sqlfluff if the sql pack is installed,
   // since .sql files exist in many non-SQL-focused contexts.
   if (SQL_EXTENSIONS.has(extension)) {
+    // Host formats SQL via prettier-plugin-sql (#636/#638): run the HOST's
+    // prettier — no --config override, so the host config (which declares the
+    // plugin) and its .prettierignore carve-outs (frozen DDL migrations) apply.
+    // Prettier's ignore resolution is cwd-relative; hooks run with cwd =
+    // project root, which is what makes those carve-outs hold. On failure
+    // (e.g. plugin in node_modules but undeclared in config → "No parser could
+    // be inferred", exit 2) fall through to sqlfluff rather than leave SQL
+    // ungated.
+    if (hostFormatsSqlWithPrettier(projectDir)) {
+      const result = await $`bunx prettier --write ${file}`.nothrow().quiet();
+      if (result.exitCode === 0) return { warnings };
+    }
     const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {
       if (
         !(await checkToolAvailable(
           'sqlfluff',
           'SQL/dbt',
-          getPythonInstallHint(file, 'sqlfluff'),
+          getPythonInstallHint(file, "'sqlfluff>=4.2.0'"),
           warnings,
         ))
       ) {
         return { warnings };
       }
-      await $`sqlfluff fix --config ${SAFEWORD_SQLFLUFF} ${file}`.nothrow().quiet();
+      // Lint-and-report by default, like the ESLint/ruff branches; in-place
+      // rewriting (`sqlfluff fix`) mutates the file beyond the agent's
+      // intended edit, so it's opt-in via `sql.fix` (#638). Opted-in hosts
+      // carve out frozen files with .sqlfluffignore, which sqlfluff honors
+      // even for explicitly passed paths.
+      if (sqlFixOptedIn(projectDir)) {
+        await $`sqlfluff fix --config ${SAFEWORD_SQLFLUFF} ${file}`.nothrow().quiet();
+      }
+      const errors = await captureRemainingErrors(
+        ['sqlfluff', 'lint', '--config', SAFEWORD_SQLFLUFF, file],
+        warnings,
+      );
+      return { warnings, ...(errors && { errors }) };
     }
     return { warnings };
   }

--- a/packages/cli/tests/hooks/lint-config.test.ts
+++ b/packages/cli/tests/hooks/lint-config.test.ts
@@ -209,6 +209,24 @@ describe('hostFormatsSqlWithPrettier', () => {
     expect(hostFormatsSqlWithPrettier(directory)).toBe(false);
   });
 
+  it.each(['dependencies', 'devDependencies'] as const)(
+    'is true when the plugin is declared in %s but not yet installed',
+    dependencyField => {
+      writeFileSync(
+        path.join(directory, 'package.json'),
+        JSON.stringify({ [dependencyField]: { 'prettier-plugin-sql': '^0.20.0' } }),
+      );
+
+      expect(hostFormatsSqlWithPrettier(directory)).toBe(true);
+    },
+  );
+
+  it('is false for a malformed package.json', () => {
+    writeFileSync(path.join(directory, 'package.json'), '{not json');
+
+    expect(hostFormatsSqlWithPrettier(directory)).toBe(false);
+  });
+
   it('is false (does not throw) for a nonexistent directory', () => {
     expect(hostFormatsSqlWithPrettier(path.join(directory, 'nope'))).toBe(false);
   });

--- a/packages/cli/tests/hooks/lint-config.test.ts
+++ b/packages/cli/tests/hooks/lint-config.test.ts
@@ -5,7 +5,7 @@
  * that caused this ticket: `eslint.config.ts` / `.prettierrc.yaml` were missed).
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -15,8 +15,10 @@ import {
   detectAlternativeFormatter,
   detectEslintConfig,
   detectPrettierConfig,
+  hostFormatsSqlWithPrettier,
   projectOwnsAlternativeFormatter,
   shouldWarnMissingPrettier,
+  sqlFixOptedIn,
 } from '../../templates/hooks/lib/lint-config.js';
 
 describe('detectEslintConfig', () => {
@@ -179,6 +181,80 @@ describe('projectOwnsAlternativeFormatter', () => {
 
   it('is false (does not throw) for a nonexistent directory', () => {
     expect(projectOwnsAlternativeFormatter(path.join(directory, 'nope'))).toBe(false);
+  });
+});
+
+describe('hostFormatsSqlWithPrettier', () => {
+  // The gate the SQL branch uses to defer to a host that formats SQL itself
+  // via prettier-plugin-sql (#636/#638): host prettier runs, sqlfluff doesn't.
+  let directory: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), 'sql-owns-'));
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('is true when prettier-plugin-sql is installed in node_modules', () => {
+    mkdirSync(path.join(directory, 'node_modules', 'prettier-plugin-sql'), { recursive: true });
+
+    expect(hostFormatsSqlWithPrettier(directory)).toBe(true);
+  });
+
+  it('is false without the plugin (other node_modules content does not count)', () => {
+    mkdirSync(path.join(directory, 'node_modules', 'prettier'), { recursive: true });
+
+    expect(hostFormatsSqlWithPrettier(directory)).toBe(false);
+  });
+
+  it('is false (does not throw) for a nonexistent directory', () => {
+    expect(hostFormatsSqlWithPrettier(path.join(directory, 'nope'))).toBe(false);
+  });
+});
+
+describe('sqlFixOptedIn', () => {
+  // Edit-time `sqlfluff fix` rewrites files beyond the agent's intended edit,
+  // so it's opt-in via `.safeword/config.json` → sql.fix (#638). Anything
+  // other than an explicit true reads as "off".
+  let directory: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), 'sql-fix-'));
+    mkdirSync(path.join(directory, '.safeword'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  const writeConfig = (content: string): void => {
+    writeFileSync(path.join(directory, '.safeword', 'config.json'), content);
+  };
+
+  it('is true only when sql.fix is explicitly true', () => {
+    writeConfig(JSON.stringify({ installedPacks: ['sql'], sql: { fix: true } }));
+
+    expect(sqlFixOptedIn(directory)).toBe(true);
+  });
+
+  it('is false when sql.fix is absent, false, or non-boolean', () => {
+    writeConfig(JSON.stringify({ installedPacks: ['sql'] }));
+    expect(sqlFixOptedIn(directory)).toBe(false);
+
+    writeConfig(JSON.stringify({ sql: { fix: false } }));
+    expect(sqlFixOptedIn(directory)).toBe(false);
+
+    writeConfig(JSON.stringify({ sql: { fix: 'yes' } }));
+    expect(sqlFixOptedIn(directory)).toBe(false);
+  });
+
+  it('is false when config.json is missing or malformed', () => {
+    expect(sqlFixOptedIn(path.join(directory, 'nope'))).toBe(false);
+
+    writeConfig('{not json');
+    expect(sqlFixOptedIn(directory)).toBe(false);
   });
 });
 

--- a/packages/cli/tests/hooks/lint-sql-branch.test.ts
+++ b/packages/cli/tests/hooks/lint-sql-branch.test.ts
@@ -13,12 +13,20 @@
  */
 
 import { execFile } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
 
@@ -62,5 +70,80 @@ describe('lintFile SQL branch — host-owned prettier formatting', () => {
     // No fall-through side effects: ensurePackInstalled would have created or
     // touched .safeword/ via `safeword upgrade` + git; the guard returns first.
     expect(existsSync(path.join(directory, '.safeword'))).toBe(false);
+  }, 90_000);
+});
+
+describe('lintFile SQL branch — sqlfluff dispatch', () => {
+  // The breaking dispatch under review: with sql.fix unset the hook must run
+  // `sqlfluff lint` (report-only) and must NOT run `sqlfluff fix`; with
+  // sql.fix true it runs fix then lint. sqlfluff is stubbed with a PATH shim
+  // that records its argv, so the assertion is on the real command dispatch,
+  // not a mock of the hook's internals.
+  let directory: string;
+  let stubBin: string;
+  let logFile: string;
+
+  beforeAll(() => {
+    directory = mkdtempSync(path.join(tmpdir(), 'lint-sql-dispatch-'));
+    // sqlfluff config present → ensurePackInstalled short-circuits, no upgrade.
+    mkdirSync(path.join(directory, '.safeword'), { recursive: true });
+    writeFileSync(path.join(directory, '.safeword', 'sqlfluff.cfg'), '[sqlfluff]\n');
+    writeFileSync(path.join(directory, 'query.sql'), 'select 1;\n');
+
+    stubBin = path.join(directory, 'stub-bin');
+    logFile = path.join(directory, 'sqlfluff-invocations.log');
+    mkdirSync(stubBin, { recursive: true });
+    const stub = path.join(stubBin, 'sqlfluff');
+    writeFileSync(stub, `#!/bin/sh\necho "$@" >> ${JSON.stringify(logFile)}\nexit 0\n`);
+    chmodSync(stub, 0o755);
+  });
+
+  afterAll(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(logFile, { force: true });
+    rmSync(path.join(directory, '.safeword', 'config.json'), { force: true });
+  });
+
+  async function runLintFile(): Promise<string[]> {
+    const sqlFile = path.join(directory, 'query.sql');
+    const script = `
+      const { lintFile } = await import(${JSON.stringify(LINT_MODULE)});
+      const result = await lintFile(${JSON.stringify(sqlFile)}, ${JSON.stringify(directory)});
+      console.log(JSON.stringify(result));
+    `;
+    await execFileAsync('bun', ['-e', script], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PATH: `${stubBin}${path.delimiter}${process.env.PATH ?? ''}`,
+        CLAUDE_PROJECT_DIR: directory,
+      },
+      timeout: 60_000,
+    });
+    return existsSync(logFile)
+      ? readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean)
+      : [];
+  }
+
+  it('runs sqlfluff lint and NOT fix when sql.fix is unset (the #638 default)', async () => {
+    const invocations = await runLintFile();
+
+    expect(invocations.some(line => line.startsWith('lint '))).toBe(true);
+    expect(invocations.some(line => line.startsWith('fix '))).toBe(false);
+  }, 90_000);
+
+  it('runs sqlfluff fix then lint when sql.fix is opted in', async () => {
+    writeFileSync(
+      path.join(directory, '.safeword', 'config.json'),
+      JSON.stringify({ installedPacks: ['sql'], sql: { fix: true } }),
+    );
+
+    const invocations = await runLintFile();
+
+    expect(invocations[0]).toMatch(/^fix /);
+    expect(invocations.some(line => line.startsWith('lint '))).toBe(true);
   }, 90_000);
 });

--- a/packages/cli/tests/hooks/lint-sql-branch.test.ts
+++ b/packages/cli/tests/hooks/lint-sql-branch.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Real-collaborator test for the lint hook's SQL branch in a host-owned repo
+ * (#636/#638): prettier-plugin-sql present, no .safeword/sqlfluff.cfg (setup
+ * suppresses it by design). When the host prettier run fails, the hook must
+ * surface prettier's error to the agent and return — NOT fall through to the
+ * sqlfluff/auto-upgrade path, which would fire a network upgrade attempt on
+ * every failing SQL edit.
+ *
+ * lint.ts imports Bun's `$`, so it can't be imported under the node-based
+ * vitest process — the hook runs in a `bun` subprocess instead, with cwd at
+ * the repo root so `bunx prettier` resolves the repo's local install
+ * (no network).
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const LINT_MODULE = path.resolve(__dirname, '../../templates/hooks/lib/lint.ts');
+
+describe('lintFile SQL branch — host-owned prettier formatting', () => {
+  let directory: string;
+
+  beforeAll(() => {
+    directory = mkdtempSync(path.join(tmpdir(), 'lint-sql-host-'));
+    // Host owns SQL formatting: plugin installed, sqlfluff config absent.
+    mkdirSync(path.join(directory, 'node_modules', 'prettier-plugin-sql'), { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('surfaces the prettier error and does not fall through to the upgrade path when prettier fails', async () => {
+    // Valid SQL, but the temp dir has no prettier config declaring the sql
+    // plugin — prettier exits non-zero ("No parser could be inferred"), the
+    // same failure shape as an unparseable agent edit.
+    const sqlFile = path.join(directory, 'query.sql');
+    writeFileSync(sqlFile, 'select 1;\n');
+
+    const script = `
+      const { lintFile } = await import(${JSON.stringify(LINT_MODULE)});
+      const result = await lintFile(${JSON.stringify(sqlFile)}, ${JSON.stringify(directory)});
+      console.log(JSON.stringify(result));
+    `;
+    const { stdout } = await execFileAsync('bun', ['-e', script], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: directory },
+      timeout: 60_000,
+    });
+
+    const result = JSON.parse(stdout.trim()) as { warnings: string[]; errors?: string };
+    // The agent gets prettier's parse error instead of silence.
+    expect(result.errors).toMatch(/parser/i);
+    // No fall-through side effects: ensurePackInstalled would have created or
+    // touched .safeword/ via `safeword upgrade` + git; the guard returns first.
+    expect(existsSync(path.join(directory, '.safeword'))).toBe(false);
+  }, 90_000);
+});

--- a/packages/cli/tests/integration/sql-golden-path.test.ts
+++ b/packages/cli/tests/integration/sql-golden-path.test.ts
@@ -194,35 +194,28 @@ describe('E2E: dbt Golden Path', () => {
   // =========================================================================
 
   describe('Suite 2b: Host-owned SQL formatting', () => {
-    it('2b.1: generates no sqlfluff configs when prettier-plugin-sql is a declared devDependency', async () => {
-      createDbtProject(temporaryDirectory);
-      createSafewordBasePackageJson(temporaryDirectory, {
-        name: 'test-dbt-project',
-        private: true,
-        devDependencies: { 'prettier-plugin-sql': '^0.20.0' },
-      });
-      initGitRepo(temporaryDirectory);
+    it.each(['devDependencies', 'dependencies'] as const)(
+      '2b.1: generates no sqlfluff configs when prettier-plugin-sql is declared in %s',
+      async dependencyField => {
+        createDbtProject(temporaryDirectory);
+        createSafewordBasePackageJson(temporaryDirectory, {
+          name: 'test-dbt-project',
+          private: true,
+          [dependencyField]: { 'prettier-plugin-sql': '^0.20.0' },
+        });
+        initGitRepo(temporaryDirectory);
 
-      await runCli(['setup'], { cwd: temporaryDirectory });
+        await runCli(['setup'], { cwd: temporaryDirectory });
 
-      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
-      expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
-    });
-
-    it('2b.2: generates no sqlfluff configs when prettier-plugin-sql is a declared dependency', async () => {
-      createDbtProject(temporaryDirectory);
-      createSafewordBasePackageJson(temporaryDirectory, {
-        name: 'test-dbt-project',
-        private: true,
-        dependencies: { 'prettier-plugin-sql': '^0.20.0' },
-      });
-      initGitRepo(temporaryDirectory);
-
-      await runCli(['setup'], { cwd: temporaryDirectory });
-
-      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
-      expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
-    });
+        // Anchor: the sql pack itself still installs (deference suppresses
+        // configs, not detection) — guards against a vacuous pass where SQL
+        // detection broke and configs are absent for the wrong reason.
+        const config = readTestFile(temporaryDirectory, '.safeword/config.json');
+        expect(JSON.parse(config).installedPacks).toContain('sql');
+        expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
+        expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
+      },
+    );
 
     it('2b.3: upgrade does not resurrect sqlfluff configs after the host adopts prettier-plugin-sql', async () => {
       createDbtProject(temporaryDirectory);

--- a/packages/cli/tests/integration/sql-golden-path.test.ts
+++ b/packages/cli/tests/integration/sql-golden-path.test.ts
@@ -8,7 +8,7 @@
  * - Projects without SQL markers don't get SQL pack
  */
 
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -186,6 +186,64 @@ describe('E2E: dbt Golden Path', () => {
 
       const config = readTestFile(temporaryDirectory, '.safeword/sqlfluff.cfg');
       expect(config).toContain('capitalisation_policy');
+    });
+  });
+
+  // =========================================================================
+  // Suite 2b: Host-owned SQL formatting deference (#636/#638)
+  // =========================================================================
+
+  describe('Suite 2b: Host-owned SQL formatting', () => {
+    it('2b.1: generates no sqlfluff configs when prettier-plugin-sql is a declared devDependency', async () => {
+      createDbtProject(temporaryDirectory);
+      createSafewordBasePackageJson(temporaryDirectory, {
+        name: 'test-dbt-project',
+        private: true,
+        devDependencies: { 'prettier-plugin-sql': '^0.20.0' },
+      });
+      initGitRepo(temporaryDirectory);
+
+      await runCli(['setup'], { cwd: temporaryDirectory });
+
+      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
+      expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
+    });
+
+    it('2b.2: generates no sqlfluff configs when prettier-plugin-sql is a declared dependency', async () => {
+      createDbtProject(temporaryDirectory);
+      createSafewordBasePackageJson(temporaryDirectory, {
+        name: 'test-dbt-project',
+        private: true,
+        dependencies: { 'prettier-plugin-sql': '^0.20.0' },
+      });
+      initGitRepo(temporaryDirectory);
+
+      await runCli(['setup'], { cwd: temporaryDirectory });
+
+      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
+      expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
+    });
+
+    it('2b.3: upgrade does not resurrect sqlfluff configs after the host adopts prettier-plugin-sql', async () => {
+      createDbtProject(temporaryDirectory);
+      initGitRepo(temporaryDirectory);
+
+      await runCli(['setup'], { cwd: temporaryDirectory });
+      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(true);
+
+      // Host adopts prettier-plugin-sql and removes the generated configs
+      createSafewordBasePackageJson(temporaryDirectory, {
+        name: 'test-dbt-project',
+        private: true,
+        devDependencies: { 'prettier-plugin-sql': '^0.20.0' },
+      });
+      rmSync(nodePath.join(temporaryDirectory, '.sqlfluff'));
+      rmSync(nodePath.join(temporaryDirectory, '.safeword', 'sqlfluff.cfg'));
+
+      await runCli(['upgrade'], { cwd: temporaryDirectory });
+
+      expect(fileExists(temporaryDirectory, '.sqlfluff')).toBe(false);
+      expect(fileExists(temporaryDirectory, '.safeword/sqlfluff.cfg')).toBe(false);
     });
   });
 

--- a/packages/website/src/content/docs/reference/cli.mdx
+++ b/packages/website/src/content/docs/reference/cli.mdx
@@ -38,7 +38,7 @@ bunx safeword@latest setup
 | `clippy.toml`           | Creates file                                       | Linting config (Rust)                              |
 | `rustfmt.toml`          | Creates file                                       | Formatting config (Rust)                           |
 | `Cargo.toml`            | Adds lints section                                 | clippy lints (Rust)                                |
-| `.sqlfluff`             | Creates file                                       | Linting config (SQL/dbt)                           |
+| `.sqlfluff`             | Creates file (unless Prettier formats your SQL)    | Linting config (SQL/dbt)                           |
 | `AGENTS.md`             | Creates or prepends                                | Links to SAFEWORD.md                               |
 | `.mcp.json`             | Creates or merges                                  | MCP server config                                  |
 | `.cursor/mcp.json`      | Creates or merges                                  | MCP server config (Cursor)                         |

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -109,6 +109,13 @@ Both tools coexist cleanly — ESLint handles code analysis (bugs, security, com
 | jiti (devDep)     | jiti (devDep)     |
 | _(no Prettier)_   | Prettier (devDep) |
 
+## SQL Formatting
+
+Safeword lints SQL with SQLFluff, but the host's chosen formatter formats:
+
+- **If your project formats SQL with Prettier** (`prettier-plugin-sql` in your dependencies), safeword defers: setup skips the SQLFluff configs (`.sqlfluff`, `.safeword/sqlfluff.cfg`), and the edit-time hook runs _your_ Prettier with _your_ config instead of SQLFluff — so `.prettierignore` carve-outs (like frozen DDL migrations) are honored.
+- **Otherwise**, the edit-time hook runs `sqlfluff lint` and reports violations to the agent. In-place rewriting is opt-in — set `"sql": { "fix": true }` in `.safeword/config.json` to have the hook run `sqlfluff fix` on edited files. SQLFluff honors `.sqlfluffignore`, so you can exclude files (e.g. applied migrations) from rewriting.
+
 ## Hook Configuration
 
 Hooks are configured in `.claude/settings.json` (Claude Code), `.cursor/hooks.json` (Cursor), and `.codex/config.toml` (Codex). See [Hooks & Skills](/reference/hooks-and-skills) for what runs automatically.

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -111,10 +111,10 @@ Both tools coexist cleanly — ESLint handles code analysis (bugs, security, com
 
 ## SQL Formatting
 
-Safeword lints SQL with SQLFluff, but the host's chosen formatter formats:
+Your project's chosen SQL formatter owns SQL formatting; safeword adapts to it:
 
-- **If your project formats SQL with Prettier** (`prettier-plugin-sql` in your dependencies), safeword defers: setup skips the SQLFluff configs (`.sqlfluff`, `.safeword/sqlfluff.cfg`), and the edit-time hook runs _your_ Prettier with _your_ config instead of SQLFluff — so `.prettierignore` carve-outs (like frozen DDL migrations) are honored.
-- **Otherwise**, the edit-time hook runs `sqlfluff lint` and reports violations to the agent. In-place rewriting is opt-in — set `"sql": { "fix": true }` in `.safeword/config.json` to have the hook run `sqlfluff fix` on edited files. SQLFluff honors `.sqlfluffignore`, so you can exclude files (e.g. applied migrations) from rewriting.
+- **If your project formats SQL with Prettier** (`prettier-plugin-sql` in your dependencies), safeword defers entirely: setup skips the SQLFluff configs (`.sqlfluff`, `.safeword/sqlfluff.cfg`), and the edit-time hook runs _your_ Prettier with _your_ config — so `.prettierignore` carve-outs (like frozen DDL migrations) are honored. Adopting `prettier-plugin-sql` in a repo that already has safeword-generated SQLFluff configs? Delete `.sqlfluff` and `.safeword/sqlfluff.cfg`; upgrades won't recreate them.
+- **Otherwise**, safeword lints SQL with SQLFluff: the edit-time hook runs `sqlfluff lint` and reports violations to the agent. In-place rewriting is opt-in — set `"sql": { "fix": true }` in `.safeword/config.json` to have the hook run `sqlfluff fix` on edited files. SQLFluff honors `.sqlfluffignore`, so you can exclude files (e.g. applied migrations) from rewriting.
 
 ## Hook Configuration
 


### PR DESCRIPTION
Resolves #636, closes #638, closes #639.

## What

Applies the deference principle safeword already enforces for JS/TS — *safeword lints; the host's chosen formatter formats* — to the SQL pack:

- **Hook (`templates/hooks/lib/lint.ts` + dogfood copy):** when the host formats SQL via `prettier-plugin-sql` (installed in `node_modules` or declared in root package.json), the SQL branch runs the **host's** prettier with the host's config — so its `.prettierignore` carve-outs (e.g. frozen DDL migrations, the #636 collision) are honored by prettier itself. If prettier fails, its error is surfaced to the agent; the hook falls through to sqlfluff only when a sqlfluff config exists (in a host-owned repo it's absent by design, and falling through would trigger a per-edit auto-upgrade attempt).
- **Hook:** sqlfluff now **lints-and-reports by default** like the ESLint/ruff branches, surfacing violations to the agent. In-place `sqlfluff fix` is opt-in via `.safeword/config.json` → `"sql": { "fix": true }`. Opted-in hosts can exclude files with `.sqlfluffignore`, which sqlfluff honors even for explicitly passed paths.
- **Hook + upgrade:** sqlfluff install hint and upgrade-path install pinned to `'sqlfluff>=4.2.0'` (CVE-2026-46373 / CVE-2026-46374, DoS fixes landed in 4.1.0/4.2.0); upgrade skips installing sqlfluff entirely when the host owns SQL formatting.
- **Setup (`packs/sql/files.ts`):** no `.sqlfluff` / `.safeword/sqlfluff.cfg` generated when `prettier-plugin-sql` is a declared root dependency — and upgrade no longer resurrects them after a host adopts its own SQL formatter.
- **Docs:** new "SQL Formatting" section in `configuration.mdx`; `.sqlfluff` row qualified in `cli.mdx`.

## Why not #639's full swap

Replacing sqlfluff with prettier + `prettier-plugin-sql` was evaluated and rejected: the plugin has no Jinja/dbt templating support, its default backend (sql-formatter) doesn't support stored procedures and throws on unparseable input, and sql-formatter is in maintenance mode. A full swap would break the pack's tier-1 dbt audience to serve tier-2 repos whose SQL is mostly deliberately-frozen migrations. Deference (this PR) gives those repos the right behavior without the tool swap.

## Behavior change note

Existing sql-pack installs move from silent `sqlfluff fix` on every edit to lint-and-report; restoring the old behavior is one config line (`"sql": { "fix": true }`). **Versioning resolution (owner call, see review thread):** safeword is 0.x beta, so this ships as built in a normal 0.x bump — give it a prominent changelog callout at release.

## Testing

- Unit tests for the detection helpers (`hostFormatsSqlWithPrettier` incl. declared-dep and malformed-package.json cases, `sqlFixOptedIn`)
- Integration tests via real CLI runs (setup suppression for both dep types; no resurrection on upgrade), anchored on `installedPacks` to prevent vacuous passes
- Real-collaborator subprocess tests for the hook's SQL branch: prettier failure → error surfaced, no upgrade fall-through; PATH-shim sqlfluff dispatch (default runs `lint`, never `fix`; opt-in runs `fix` then `lint`)
- Full suite green locally (307 files, 4,405 tests + 181 Gherkin scenarios) and CI green on head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMRSQMtX4dW6gUtQrEMPeF