### PR TITLE
lint-staged: format .mdx at commit time (prettier only)

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -25,6 +25,10 @@ export default {
   '*.{vue,svelte,astro}': ['eslint --fix', 'prettier --write'],
   '*.{json,css,scss,html,yaml,yml,graphql}': ['prettier --write'],
   '*.md': ['markdownlint-cli2 --fix', 'prettier --write'],
+  // prettier only — markdownlint false-positives on MDX's JSX/imports. Mirrors
+  // CI's `prettier --check .`, which does cover .mdx (the gap that let an
+  // unformatted .mdx commit pass the hook and fail CI on PR #692).
+  '*.mdx': ['prettier --write'],
   '*.sh': ['shellcheck'],
   '*.feature': ['bun packages/cli/src/cli.ts lint-gherkin'],
 };


### PR DESCRIPTION
One-line tooling fix for a pre-commit/CI asymmetry surfaced by #692.

**Gap:** CI's `format:check` runs `prettier --check .`, which covers `.mdx` (prettier has a built-in MDX parser) — but no lint-staged glob matched `*.mdx`, so a hand-edited website doc passed the pre-commit hook unformatted and failed CI later.

**Fix:** a dedicated `'*.mdx': ['prettier --write']` entry. Deliberately *not* merged into the `'*.md'` entry: that one also runs `markdownlint-cli2`, which false-positives on MDX's JSX components and `import` statements. Prettier-only mirrors exactly what CI enforces.

Verified by staging a deliberately misformatted `.mdx` and running `bunx lint-staged` — the new task fires and prettier rewrites the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsRxD44HSbzHsrhXLm3XEW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsRxD44HSbzHsrhXLm3XEW)_