### PR TITLE
Add a numbered Rule tier between JTBD and scenarios (invariant catalog with stable IDs)

### DIFF
--- a/.agents/skills/bdd/DISCOVERY.md
+++ b/.agents/skills/bdd/DISCOVERY.md
@@ -95,6 +95,7 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 - A `#### <jtbd-id>.AC<n> — <capability>` heading (e.g., `### oauth-flow.PO1` → `#### oauth-flow.PO1.AC1 — old key keeps working for a bounded grace window`).
 - Each JTBD needs **≥1 AC**, or a `skip: <reason>` under it for a job with no user-observable capability to enumerate. The intake-exit gate enforces this (denies `test-definitions.md` until every JTBD has an AC or a skip).
+- Alternative tier: a JTBD whose behavior is best stated as invariants may declare **numbered Rules** (`#### <jtbd-id>.R<n> — <invariant>`) instead of ACs — one criteria kind per job, never both. The gate accepts either; the full rule grammar lives in the bdd skill's SCENARIOS.md.
 
 **Coaching — keep ACs at the capability level, not implementation:**
 

--- a/.agents/skills/bdd/SCENARIOS.md
+++ b/.agents/skills/bdd/SCENARIOS.md
@@ -154,6 +154,36 @@ as advisories (never a gate):
   or an AC that was renumbered).
 - **orphan** — a scenario whose JTBD is absent from `spec.md` entirely.
 
+### Numbered Rules (optional third tier)
+
+A JTBD may declare **numbered Rules** instead of ACs — testable business
+invariants with stable per-JTBD IDs, stated generally and illustrated by the
+scenarios nested under them. Declaring them is the opt-in; there is no config
+flag, and a JTBD carries one criteria kind, never both (`safeword check` flags a
+mixed job as an issue).
+
+- **Spec catalog:** `#### <jtbd-id>.R<n> — <invariant>` headings under the JTBD,
+  exactly where AC headings sit (e.g. `#### webhook-retry.PO1.R1 — a failed
+delivery retries on exponential backoff`). IDs are 1-indexed per job and
+  numbering-locked after review — renumbering breaks references on purpose.
+- **Feature file:** the `Rule:` block carries the literal `@<jtbd-id>.R<n>` tag
+  (authoritative — scenarios inherit it as their single lineage ref) and repeats
+  the ID as its name's first token for readability; a mismatch is a lint issue.
+  An AC-shaped tag always wins the ref parse, so persona code `R` stays safe
+  (`@feat.R1.AC1` is an AC of JTBD `feat.R1`).
+- **Rejection paths:** tag at least one scenario per rule `@rejection` (the
+  example proving the system refuses when the invariant is violated); a numbered
+  rule without one draws a check advisory. Unnumbered `Rule:` grouping headers
+  are exempt from all of this.
+- **Selection:** `cucumber-js --tags @<jtbd-id>.R<n>` runs exactly that rule's
+  examples.
+- **Coverage:** the uncovered / stale ref / orphan advisories work for rule refs
+  exactly as for AC refs.
+- **Migrating a rule-numbered corpus** (e.g. Arcade-style split tags): the Rule
+  blocks, IDs, and nesting survive as-is; respell tags mechanically —
+  `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
+  block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
+
 ### Define Behavior Exit (REQUIRED)
 
 1. **Save scenarios** to `features/<slug>.feature`

--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -95,6 +95,7 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 - A `#### <jtbd-id>.AC<n> — <capability>` heading (e.g., `### oauth-flow.PO1` → `#### oauth-flow.PO1.AC1 — old key keeps working for a bounded grace window`).
 - Each JTBD needs **≥1 AC**, or a `skip: <reason>` under it for a job with no user-observable capability to enumerate. The intake-exit gate enforces this (denies `test-definitions.md` until every JTBD has an AC or a skip).
+- Alternative tier: a JTBD whose behavior is best stated as invariants may declare **numbered Rules** (`#### <jtbd-id>.R<n> — <invariant>`) instead of ACs — one criteria kind per job, never both. The gate accepts either; the full rule grammar lives in the bdd skill's SCENARIOS.md.
 
 **Coaching — keep ACs at the capability level, not implementation:**
 

--- a/.claude/skills/bdd/SCENARIOS.md
+++ b/.claude/skills/bdd/SCENARIOS.md
@@ -154,6 +154,36 @@ as advisories (never a gate):
   or an AC that was renumbered).
 - **orphan** — a scenario whose JTBD is absent from `spec.md` entirely.
 
+### Numbered Rules (optional third tier)
+
+A JTBD may declare **numbered Rules** instead of ACs — testable business
+invariants with stable per-JTBD IDs, stated generally and illustrated by the
+scenarios nested under them. Declaring them is the opt-in; there is no config
+flag, and a JTBD carries one criteria kind, never both (`safeword check` flags a
+mixed job as an issue).
+
+- **Spec catalog:** `#### <jtbd-id>.R<n> — <invariant>` headings under the JTBD,
+  exactly where AC headings sit (e.g. `#### webhook-retry.PO1.R1 — a failed
+delivery retries on exponential backoff`). IDs are 1-indexed per job and
+  numbering-locked after review — renumbering breaks references on purpose.
+- **Feature file:** the `Rule:` block carries the literal `@<jtbd-id>.R<n>` tag
+  (authoritative — scenarios inherit it as their single lineage ref) and repeats
+  the ID as its name's first token for readability; a mismatch is a lint issue.
+  An AC-shaped tag always wins the ref parse, so persona code `R` stays safe
+  (`@feat.R1.AC1` is an AC of JTBD `feat.R1`).
+- **Rejection paths:** tag at least one scenario per rule `@rejection` (the
+  example proving the system refuses when the invariant is violated); a numbered
+  rule without one draws a check advisory. Unnumbered `Rule:` grouping headers
+  are exempt from all of this.
+- **Selection:** `cucumber-js --tags @<jtbd-id>.R<n>` runs exactly that rule's
+  examples.
+- **Coverage:** the uncovered / stale ref / orphan advisories work for rule refs
+  exactly as for AC refs.
+- **Migrating a rule-numbered corpus** (e.g. Arcade-style split tags): the Rule
+  blocks, IDs, and nesting survive as-is; respell tags mechanically —
+  `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
+  block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
+
 ### Define Behavior Exit (REQUIRED)
 
 1. **Save scenarios** to `features/<slug>.feature`

--- a/.project/tickets/V0NHT6-rule-tier/dimensions.md
+++ b/.project/tickets/V0NHT6-rule-tier/dimensions.md
@@ -13,6 +13,7 @@ lineage machinery (`gherkin-feature.ts`, `scenario-coverage.ts`, `jtbd.ts`).
 | Name-token ↔ tag correspondence        | name first-token matches block tag · mismatch · unnumbered name with no R tag (legacy, exempt)                                                                          |
 | Intake-exit gate outcome               | R-only JTBD passes · neither-kind JTBD denied with message naming Rules                                                                                                  |
 | Backward compatibility                 | repo with zero R headings/tags — check output byte-identical, existing fixtures untouched                                                                                |
+| Message contract (NTB)                 | each new issue/advisory: names the id · plain-language problem · concrete next action                                                                                    |
 
 Boundary notes: 1-indexed `R<n>` per JTBD (R1 boundary); AC-wins precedence is the
 grammar-overlap boundary; unnumbered `Rule:` blocks are the exempt class throughout.

--- a/.project/tickets/V0NHT6-rule-tier/dimensions.md
+++ b/.project/tickets/V0NHT6-rule-tier/dimensions.md
@@ -1,0 +1,18 @@
+# Dimensions: Numbered Rule tier (V0NHT6)
+
+Derived from scope / done_when / decisions plus domain knowledge of the existing
+lineage machinery (`gherkin-feature.ts`, `scenario-coverage.ts`, `jtbd.ts`).
+
+| Dimension                              | Partitions                                                                                                                                                             |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Spec JTBD criterion kind               | AC-only · R-only · mixed AC+R · neither (no criteria, no skip) · `skip:` line                                                                                           |
+| Feature-file lineage tag kind/placement | R tag on `Rule:` block (inherited) · R tag directly on scenario · AC tag (flat lineage) · no lineage tag · multiple lineage refs after inheritance                       |
+| Ref-grammar overlap                    | tag ending `.AC<n>` after an `R<n>`-shaped segment (`@feat.R1.AC1`) — AC-match wins · plain R ref (terminal)                                                            |
+| Rule ID ↔ spec-catalog drift           | matching spec rule · stale (JTBD exists, R# doesn't) · orphan (JTBD absent) · uncovered (spec rule with zero referencing scenarios)                                     |
+| Rejection-path coverage                | numbered Rule with ≥1 `@rejection` scenario · numbered Rule with zero · unnumbered `Rule:` block (exempt)                                                               |
+| Name-token ↔ tag correspondence        | name first-token matches block tag · mismatch · unnumbered name with no R tag (legacy, exempt)                                                                          |
+| Intake-exit gate outcome               | R-only JTBD passes · neither-kind JTBD denied with message naming Rules                                                                                                  |
+| Backward compatibility                 | repo with zero R headings/tags — check output byte-identical, existing fixtures untouched                                                                                |
+
+Boundary notes: 1-indexed `R<n>` per JTBD (R1 boundary); AC-wins precedence is the
+grammar-overlap boundary; unnumbered `Rule:` blocks are the exempt class throughout.

--- a/.project/tickets/V0NHT6-rule-tier/impl-plan.md
+++ b/.project/tickets/V0NHT6-rule-tier/impl-plan.md
@@ -1,6 +1,13 @@
 # Impl Plan: Numbered Rule tier between JTBD and scenarios
 
-**Status:** planned
+**Status:** implemented
+
+Reconciliation (implement-phase exit, 2026-07-03): shipped as planned across all
+8 slices. Two notes, neither a design change: integration tests run the built
+dist (`runCli`), so slices touching `src/` require a rebuild before check-level
+proofs run; cucumber dry-run reports filtered scenarios as `undefined` (no step
+definitions in the fixture), not `skipped` — the selection-count assertion is
+unaffected.
 
 ## Approach
 

--- a/.project/tickets/V0NHT6-rule-tier/impl-plan.md
+++ b/.project/tickets/V0NHT6-rule-tier/impl-plan.md
@@ -1,0 +1,85 @@
+# Impl Plan: Numbered Rule tier between JTBD and scenarios
+
+**Status:** planned
+
+## Approach
+
+**Riskiest assumption:** the whole tier can ride the existing single-lineage-ref pipeline —
+extending the ref grammar to (AC | R) at the two parse points (`parseAcReferenceFromTag` /
+`uniqueAcReferences` in `gherkin-feature.ts`; the `parseAcIdsByJtbd` heading walk in
+`scenario-coverage.ts`) buckets coverage correctly without restructuring the report
+builders. **Cheapest proof:** the AC-precedence scenario (`@feat.R1.AC1` attributes to the
+AC, no false R ref) plus the R-tag inheritance scenario — both pure-parser unit tests,
+sequenced as slice 1 so a wrong grammar design fails before anything is built on it.
+
+Proof plan + build order (primary proof per `testing/SKILL.md` highest-practical-scope —
+parsers and report builders are pure functions, so unit is the highest scope that runs
+them fully; CLI/hook/cucumber surfaces get integration wiring proofs):
+
+1. **Ref grammar (load-bearing):** R-ref parse + AC-wins precedence + direct-vs-inherited
+   R tags — `gherkin-feature.ts` unit. Proves: AC-precedence, direct-tag, inheritance
+   scenarios.
+2. **Spec catalog walk:** classify AC vs R headings per JTBD + mixed-kind detection —
+   `scenario-coverage.ts` unit. Proves: mixed-JTBD issue scenario (report side).
+3. **Coverage buckets + advisories:** rule uncovered/stale/orphan, zero-rejection with
+   unnumbered-block exemption, message contract strings (id + plain-language problem +
+   next action) — unit on the report builders. Proves: drift trio, rejection trio, the
+   NTB message outline rows for check-owned messages.
+4. **Lint additions:** name-token/tag mismatch; lineage lint accepting exactly one AC-or-R
+   ref — unit. Proves: mismatch and multiple-lineage scenarios + their message rows.
+5. **`safeword check` wiring:** health.ts over real fixture ticket dirs (real fs, no
+   internal mocks) — integration. Proves: end-to-end check scenarios, AC-only snapshot
+   compat (path-normalized golden), corpus coverage scenario.
+6. **Intake-exit gate:** hook-side `jtbd.ts` classifies criteria kind; accepts R-only,
+   skip, and mixed (fail-open); denial message names Rules — unit in tests/hooks +
+   existing hook-parity/differential pattern. Proves: all four gate scenarios + denial
+   message row.
+7. **Cucumber selection:** tag expression on an R id over a fixture feature through the
+   repo's cucumber lane — integration. Proves: tag-expression scenario (pins the upstream
+   rule-tag-inheritance contract).
+8. **Templates + docs:** spec-template, bdd DISCOVERY/SCENARIOS, review-spec, migration
+   mapping; hook mirrors byte-identical — covered by parity check + full suite.
+
+Each slice lands as its own RED→GREEN→REFACTOR loop(s) against the ledger; nothing in a
+later slice is needed to prove an earlier one.
+
+## Decisions
+
+| Decision                     | Choice                                                                          | Alternatives considered              | Rejected because                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------ |
+| R-ref recognition            | Extend the ref-parsing helpers in `gherkin-feature.ts` beside the AC regex       | Standalone rule-parser module        | Duplicates the tag walk; doubles the hook-mirror surface                        |
+| Mixed-kind detection site    | The spec-catalog heading walk (`scenario-coverage.ts`), surfaced via health.ts   | A separate check pass                | Second walk over the same headings for one classification bit                  |
+| Zero-rejection data source   | Effective tags on `ParsedFeatureScenario` grouped by rule ref                    | Structural parse of Rule blocks      | Effective-tag inheritance already exists; structure adds no information         |
+| Gate classification          | Minimal heading-kind classifier added to hook-side `jtbd.ts`                     | Porting the CLI parser into the hook | Hooks can't import the CLI dist; the mirror stays deliberately minimal          |
+| Compat proof                 | Path-normalized golden snapshot of check/lint output on an AC-only fixture       | Byte-exact raw output comparison     | Absolute paths in output flake across machines/CI                               |
+
+## Arch alignment
+
+Honors (from `ARCHITECTURE.md` → Key Decisions):
+
+- **Product-Framing Layer in BDD Phase 0 (JTBD / Personas / Acceptance Criteria)** — the
+  tier extends this layer's grammar downward without replacing its artifacts.
+- **Unified BDD+TDD Workflow** — scenarios stay the single behavior source; the ledger and
+  hooks are untouched in shape.
+- **Continuous Quality Gates (LOC + Phase + TDD)** — new signals follow the established
+  advisory-first posture (issues for grammar violations, advisories for coverage; the
+  intake gate stays fail-open on mixed JTBDs).
+- **Frozen Transcript Fixture Testing** (pattern precedent) — compat proven against
+  recorded fixtures rather than live regeneration.
+- Cross-runtime hook-mirror pattern with differential/parity pinning (the `jtbd.ts` /
+  `markdown-sections.ts` precedent, P58R22).
+
+## Known deviations
+
+skip: no deviations planned
+
+## Assessment triggers
+
+- ZRMDKD (blocking coverage gate) starts — its hook-side port must adopt the tier-aware
+  coverage from slice 3, not re-derive it.
+- NMSD94 review stamps land — revisit the deferred hard numbering-lock (deny renumbering a
+  stamped rule ID).
+- Arcade corpus migration in practice — if mechanical tag respelling proves too costly,
+  revisit the deferred split-axis (`@job:`/`@rule:`) compat flag.
+- `@rejection` tag collisions with existing user tag conventions — revisit the tag name or
+  make it configurable.

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -43,6 +43,10 @@ Upstream tracker issue: ArcadeAI/safeword#649.
 **Technical Builder (TB)** — authors specs and scenarios through `/bdd` in their own repo,
 reviews the invariant catalog, and selects tests by rule when an invariant changes.
 
+**Non-Technical Builder (NTB)** — can't audit diffs; reviews behavior through the
+plain-language invariant catalog the agent presents, and acts on safeword's rule warnings
+only when they say what's wrong and what to do next without internal jargon.
+
 ## Surfaces
 
 Affected:
@@ -100,6 +104,17 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 > on a stable anchor instead of rotting across scattered, renumbered scenarios.
 
 #### rule-tier.TB3.AC1 — `safeword check` reports rule-tier drift as advisories: an uncovered spec Rule, a stale rule reference, and an orphan rule reference
+
+### rule-tier.NTB1 — Act on a rule warning without reading code
+
+**Persona:** Non-Technical Builder (NTB)
+
+> When safeword flags a rule problem (a missing rejection example, a job mixing criteria
+> kinds, a drifted reference), I want the message to name the rule and state the problem
+> and the next action in plain business language, so I can direct my agent to fix it
+> without decoding internal jargon.
+
+#### rule-tier.NTB1.AC1 — Every new rule-tier issue and advisory names the offending id, states the problem in plain language, and carries a concrete next action
 
 ### rule-tier.TB4 — Migrate an existing rule-numbered corpus onto /bdd
 

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -19,7 +19,8 @@ Upstream tracker issue: ArcadeAI/safeword#649.
   checks (a rule with zero rejection-path scenarios is invisible in flat scenario lists) and
   rule-level test selection.
 - **Reversibility:** One-way once adopted — rule IDs land in customer feature corpora, CI tag
-  expressions, and review references, and IDs are numbering-locked after review by design.
+  expressions, and review references, and are intended to be numbering-locked after review
+  (enforcement mechanism open — see Open Questions).
   The tier itself is opt-in; repos that don't adopt keep today's flat AC lineage unchanged.
 
 ## References
@@ -110,8 +111,8 @@ selection working quietly, not a peak moment that travels.
 - A reader of a `.feature` file can map any scenario to the invariant it illustrates, and
   any rule back to its JTBD/persona, from IDs alone.
 - `safeword check` / `lint-gherkin` surface rule-tier gaps (a spec rule no scenario
-  references; a `@rule` reference matching no spec rule; a rule with zero rejection-path
-  scenarios) without eyeball cross-referencing.
+  references; a rule reference in a scenario tag matching no spec rule; a rule with zero
+  rejection-path scenarios) without eyeball cross-referencing.
 - Repos that don't opt in see zero change to today's flat AC lineage.
 
 ## Open Questions

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -79,6 +79,8 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 
 #### rule-tier.TB1.AC3 — JTBDs and repos that declare no Rules keep today's flat AC lineage unchanged
 
+#### rule-tier.TB1.AC4 — A JTBD declaring both ACs and numbered Rules is flagged as a check issue naming the JTBD
+
 ### rule-tier.TB2 — Run every example of one invariant
 
 **Persona:** Technical Builder (TB)
@@ -131,15 +133,28 @@ selection working quietly, not a peak moment that travels.
 
 - **Coexistence — substitute-per-JTBD** (user-confirmed): a JTBD carries either ACs or
   numbered Rules, never both; every scenario keeps exactly one lineage tag (an AC ref or an
-  R ref). Rejected: parallel axis (two overlapping coverage models per scenario), nesting
-  under AC (breaks Arcade corpus fidelity, TB4).
+  R ref). A JTBD declaring both kinds is a `safeword check` **issue** (not advisory) naming
+  the JTBD — the gate still counts its criteria (fail-open), the issue drives the fix.
+  Rejected: parallel axis (two overlapping coverage models per scenario), nesting under AC
+  (breaks Arcade corpus fidelity, TB4).
 - **Tag scheme — combined tag** `@<jtbd-id>.R<#>`, mirroring the AC tag grammar. Preserves
   the exactly-one-lineage-tag lint and dots-only IDs; rule-level selection works under
   cucumber tag expressions either way. Split axes deferred (see Open Questions).
 - **Rule catalog — spec.md is the source of truth:** `#### <jtbd-id>.R<#> — <invariant>`
-  headings under the JTBD (exactly where AC headings sit); the `.feature` `Rule:` block
-  carries the ID as the first token of its name. This powers the drift checks (every rule
-  reference maps back to a spec Rule) with the same walk `parseAcIdsByJtbd` does today.
+  headings under the JTBD (exactly where AC headings sit). This powers the drift checks
+  (every rule reference maps back to a spec Rule) with the same walk `parseAcIdsByJtbd`
+  does today.
+- **Where the ID lives in `.feature`:** the `Rule:` block carries a literal
+  `@<jtbd-id>.R<#>` **tag** (scenarios inherit it via existing rule-tag inheritance — tags
+  are what selection and coverage read, so the tag is authoritative) and repeats the ID as
+  the first token of its name for human readability (Arcade style). Name-token ≠ tag is a
+  lint issue.
+- **Ref-parse precedence — AC wins:** a tag matching `.AC<n>` is an AC ref, never an R ref
+  (guards persona codes like `R`: `@feat.R1.AC1` is AC1 of JTBD `feat.R1`, not rule
+  `feat.R1`). The R-ref parser only matches when no AC segment follows.
+- **R refs are `.feature`-only:** the legacy test-definitions.md markdown-title path
+  (`parseAcReferenceFromTitle`) stays AC-only — the rule tier requires the `.feature`
+  source, which is already the canonical scenario source.
 - **Opt-in — the grammar is the opt-in:** declaring `R<#>` headings under a JTBD opts that
   JTBD into rule lineage; no config flag. Per-JTBD granularity falls out of the substitute
   decision; repos that never write an R heading are untouched.

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -1,0 +1,124 @@
+# Spec: Numbered Rule tier between JTBD and scenarios
+
+## Intent
+
+Safeword's scenario lineage is two-rung — JTBD → AC (`<jtbd-id>.AC<#>`) → scenarios — with
+Gherkin `Rule:` used only as an unnumbered grouping header. This feature adds an optional
+third rung: the **numbered Rule** (`<jtbd-id>.R<#>`), a testable business invariant with a
+stable ID that scenarios nest under and reference, so the spec states general behavior
+explicitly (an invariant catalog) instead of leaving it implied by a pile of examples.
+Upstream tracker issue: ArcadeAI/safeword#649.
+
+## Intake Brief
+
+- **Requested by:** TheMostlyGreat via GitHub issue #649, surfaced by a corpus-migration
+  audit of ArcadeAI/monorepo's pre-safeword spec system.
+- **Cost of inaction:** Arcade's CI-wired feature corpus in `tests/behaviors/` already
+  carries numbered-rule grammar that safeword's AC-only lineage cannot express — that repo's
+  spec-authoring flow stays blocked off `/bdd`. All repos keep missing invariant-level review
+  checks (a rule with zero rejection-path scenarios is invisible in flat scenario lists) and
+  rule-level test selection.
+- **Reversibility:** One-way once adopted — rule IDs land in customer feature corpora, CI tag
+  expressions, and review references, and IDs are numbering-locked after review by design.
+  The tier itself is opt-in; repos that don't adopt keep today's flat AC lineage unchanged.
+
+## References
+
+- Upstream issue: [ArcadeAI/safeword#649](https://github.com/ArcadeAI/safeword/issues/649).
+- XT1FFM — scenario lineage (`<jtbd-id>.AC<#>` tags + `safeword check` coverage report); this
+  feature extends that scheme one tier. Its arcade pair QEGKBK named Arcade's scheme the
+  fidelity target ("kept snake-exact").
+- 31W8M3 — AC layer in spec.md (`#### <jtbd-id>.AC<n>` headings).
+- Companion gap noted in #649 (post-done `measured` state) is a separate filing — out of scope.
+
+## Personas
+
+**Technical Builder (TB)** — authors specs and scenarios through `/bdd` in their own repo,
+reviews the invariant catalog, and selects tests by rule when an invariant changes.
+
+## Surfaces
+
+Affected:
+
+- skip: runtime-agnostic — the tier lives in CLI parsing/checks (`safeword check`,
+  `lint-gherkin`, `codify`) and shared skill templates deployed identically to every agent
+  runtime; no per-runtime behavior differs.
+
+## Vocabulary
+
+**Numbered Rule** — a testable business invariant with a stable per-JTBD ID
+(`<jtbd-id>.R<#>`, 1-indexed within its job), stated generally in the spec and illustrated
+by the scenarios nested under its Gherkin `Rule:` block. Feature-local term; distinct from
+today's unnumbered `Rule:` grouping header.
+
+**Rejection path** — a scenario proving the system refuses or fails safely when a rule's
+invariant is violated; a numbered rule with no rejection-path scenario is a review smell.
+
+## Jobs To Be Done
+
+### rule-tier.TB1 — State invariants once, see missing rejection paths
+
+**Persona:** Technical Builder (TB)
+
+> When I define behavior for a feature, I want each business invariant stated once as a
+> numbered rule with its examples nested under it, so the spec reads as an explicit
+> invariant catalog and a rule with no rejection-path scenario surfaces at review instead
+> of hiding in a flat scenario list.
+
+### rule-tier.TB2 — Run every example of one invariant
+
+**Persona:** Technical Builder (TB)
+
+> When one invariant changes or regresses, I want to select every scenario of that rule by
+> its stable ID (e.g. a cucumber tag expression), so I can verify the invariant directly
+> without running or eyeballing the whole feature suite.
+
+### rule-tier.TB3 — Anchor behavior changes to the rule that changed
+
+**Persona:** Technical Builder (TB)
+
+> When reviewed behavior changes, I want the change anchored to the one numbered rule that
+> changed — IDs numbering-locked after review — so status resets and cross-references land
+> on a stable anchor instead of rotting across scattered, renumbered scenarios.
+
+### rule-tier.TB4 — Migrate an existing rule-numbered corpus onto /bdd
+
+**Persona:** Technical Builder (TB)
+
+> When I bring a repo whose feature files already carry numbered-rule grammar (Arcade's
+> `tests/behaviors/`) onto safeword, I want the lineage grammar to express that corpus
+> as-is, so adopting `/bdd` doesn't force a corpus rewrite or drop the rule tier.
+
+## Rave Moment
+
+skip: table-stakes — spec-grammar infrastructure; the payoff is review checks and test
+selection working quietly, not a peak moment that travels.
+
+## Outcomes
+
+- A reader of a `.feature` file can map any scenario to the invariant it illustrates, and
+  any rule back to its JTBD/persona, from IDs alone.
+- `safeword check` / `lint-gherkin` surface rule-tier gaps (a spec rule no scenario
+  references; a `@rule` reference matching no spec rule; a rule with zero rejection-path
+  scenarios) without eyeball cross-referencing.
+- Repos that don't opt in see zero change to today's flat AC lineage.
+
+## Open Questions
+
+- **AC ↔ Rule coexistence (load-bearing):** parallel axis (scenario carries AC tag +
+  optional rule tag), nested under AC (`.AC1.R1`), or per-JTBD substitute (a JTBD carries
+  either ACs or Rules)? Lean: substitute-per-JTBD — preserves "exactly one lineage
+  reference per scenario" and matches Arcade's job → rule → scenario corpus, which has no
+  AC tier. Nested breaks corpus fidelity (motivation #4).
+- **Tag scheme:** safeword-style combined tag (`@<jtbd-id>.R<#>`) vs Arcade's split axes
+  (`@job:PO1 @rule:PO1.R1 @scenario:<name>`) with slug-less short IDs. Rule-level test
+  selection works under both; corpus-literal fidelity vs grammar minimalism.
+- **Rule catalog declaration:** `#### <jtbd-id>.R<#> — <invariant>` headings in spec.md
+  (mirrors ACs; enables the drift gate "every @rule tag maps to a spec rule") vs the
+  `.feature` `Rule:` blocks as the sole source of truth.
+- **Rejection-path signal:** how lint identifies a rejection-path scenario — a tag
+  convention (e.g. `@negative`) seems necessary; Then-text heuristics are unreliable.
+- **Opt-in mechanism:** `.safeword/config.json` flag vs auto-detection per feature file
+  (presence of `R<#>` IDs in Rule names).
+- **Intake-exit gate:** does the gate accept Rules in place of ACs for opted-in JTBDs
+  (it currently denies `test-definitions.md` until every JTBD has ≥1 AC or a skip)?

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -73,6 +73,12 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 > invariant catalog and a rule with no rejection-path scenario surfaces at review instead
 > of hiding in a flat scenario list.
 
+#### rule-tier.TB1.AC1 — A JTBD can declare numbered Rules in place of ACs and still satisfy every gate that requires criteria
+
+#### rule-tier.TB1.AC2 — A numbered Rule with no rejection-path scenario surfaces as an advisory
+
+#### rule-tier.TB1.AC3 — JTBDs and repos that declare no Rules keep today's flat AC lineage unchanged
+
 ### rule-tier.TB2 — Run every example of one invariant
 
 **Persona:** Technical Builder (TB)
@@ -81,6 +87,8 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 > its stable ID (e.g. a cucumber tag expression), so I can verify the invariant directly
 > without running or eyeballing the whole feature suite.
 
+#### rule-tier.TB2.AC1 — Scenarios under a numbered Rule inherit its ID as their single lineage reference, and a tag expression on that ID runs exactly that rule's examples
+
 ### rule-tier.TB3 — Anchor behavior changes to the rule that changed
 
 **Persona:** Technical Builder (TB)
@@ -88,6 +96,8 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 > When reviewed behavior changes, I want the change anchored to the one numbered rule that
 > changed — IDs numbering-locked after review — so status resets and cross-references land
 > on a stable anchor instead of rotting across scattered, renumbered scenarios.
+
+#### rule-tier.TB3.AC1 — `safeword check` reports rule-tier drift as advisories: an uncovered spec Rule, a stale rule reference, and an orphan rule reference
 
 ### rule-tier.TB4 — Migrate an existing rule-numbered corpus onto /bdd
 
@@ -100,6 +110,8 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 (Persona note: migration is done by the developer running the agent in their own repo —
 that is TB by definition; personas.md has no separate adopter archetype, so TB is a
 deliberate choice, not a default.)
+
+#### rule-tier.TB4.AC1 — A corpus of per-JTBD numbered Rule blocks parses, lints, and reports coverage without structural rewriting, with a documented migration mapping for tag spelling
 
 ## Rave Moment
 
@@ -115,37 +127,38 @@ selection working quietly, not a peak moment that travels.
   rejection-path scenarios) without eyeball cross-referencing.
 - Repos that don't opt in see zero change to today's flat AC lineage.
 
+## Decisions (intake, converged 2026-07-03)
+
+- **Coexistence — substitute-per-JTBD** (user-confirmed): a JTBD carries either ACs or
+  numbered Rules, never both; every scenario keeps exactly one lineage tag (an AC ref or an
+  R ref). Rejected: parallel axis (two overlapping coverage models per scenario), nesting
+  under AC (breaks Arcade corpus fidelity, TB4).
+- **Tag scheme — combined tag** `@<jtbd-id>.R<#>`, mirroring the AC tag grammar. Preserves
+  the exactly-one-lineage-tag lint and dots-only IDs; rule-level selection works under
+  cucumber tag expressions either way. Split axes deferred (see Open Questions).
+- **Rule catalog — spec.md is the source of truth:** `#### <jtbd-id>.R<#> — <invariant>`
+  headings under the JTBD (exactly where AC headings sit); the `.feature` `Rule:` block
+  carries the ID as the first token of its name. This powers the drift checks (every rule
+  reference maps back to a spec Rule) with the same walk `parseAcIdsByJtbd` does today.
+- **Opt-in — the grammar is the opt-in:** declaring `R<#>` headings under a JTBD opts that
+  JTBD into rule lineage; no config flag. Per-JTBD granularity falls out of the substitute
+  decision; repos that never write an R heading are untouched.
+- **Rejection-path signal — `@rejection` tag convention:** lint counts a rule's scenarios
+  tagged `@rejection`; zero on a numbered Rule → advisory (never a gate). Then-text
+  heuristics rejected as unreliable.
+- **Intake-exit gate accepts Rules:** ≥1 AC *or* ≥1 numbered Rule (or `skip:`) satisfies a
+  JTBD; lands in the hook-side `jtbd.ts` mirror alongside the CLI.
+- **Enforcement stack:** tier-awareness lands in `gherkin-feature.ts` (lineage lint + ref
+  parser), `scenario-coverage.ts`, and the hook-side mirror together; ZRMDKD's ticket gains
+  a tier-awareness requirement so the future blocking gate cannot deny opted-in features.
+- **Numbering lock (TB3) — v1 ships stable IDs + drift advisories:** a renumbered or
+  deleted rule ID surfaces as stale/orphan advisories on every scenario still referencing
+  it. Hard lock enforcement deferred (see Open Questions).
+
 ## Open Questions
 
-- **AC ↔ Rule coexistence (load-bearing):** parallel axis (scenario carries AC tag +
-  optional rule tag), nested under AC (`.AC1.R1`), or per-JTBD substitute (a JTBD carries
-  either ACs or Rules)? Lean: substitute-per-JTBD — preserves "exactly one lineage
-  reference per scenario" and matches Arcade's job → rule → scenario corpus, which has no
-  AC tier. Nested breaks corpus fidelity (motivation #4).
-- **Tag scheme:** safeword-style combined tag (`@<jtbd-id>.R<#>`) vs Arcade's split axes
-  (`@job:PO1 @rule:PO1.R1 @scenario:<name>`) with slug-less short IDs. Rule-level test
-  selection works under both (tag-expressions reserve only `( ) \` and whitespace, so `:`
-  is legal). The split scheme hides two conflicts: multiple lineage tags per scenario
-  collides with the exactly-one-lineage-tag lint, and a `@scenario:<name>` axis contradicts
-  "names plain English; lineage in tags, not names" — corpus-literal fidelity (TB4's
-  "as-is") therefore means *relaxing* existing lint rules, not just adding a tier.
-- **Enforcement-stack interaction:** under the substitute-per-JTBD lean, a scenario carries
-  no AC tag — which today's `findFeatureLineageIssues` hard-flags ("missing lineage") and
-  `parseAcReferenceFromTag` (AC-only regex) can't read. Tier-awareness must land in the CLI
-  *and* the hook-side mirror (`templates/hooks/lib/`, deployed `.safeword/hooks/`), and
-  ZRMDKD's planned blocking coverage gate must be sequenced with or made aware of the tier,
-  or opted-in features get denied at test-definitions creation.
-- **Numbering-lock mechanism (TB3):** what enforces "numbering-locked after review", and
-  what does "after review" map to in the phase flow — the scenario-gate review stamp
-  (NMSD94), a lint on renumbering an existing rule ID, or convention only? If convention
-  only, TB3's stable-anchor promise and the one-way reversibility claim rest on it —
-  resolve before ACs are written.
-- **Rule catalog declaration:** `#### <jtbd-id>.R<#> — <invariant>` headings in spec.md
-  (mirrors ACs; enables the drift gate "every @rule tag maps to a spec rule") vs the
-  `.feature` `Rule:` blocks as the sole source of truth.
-- **Rejection-path signal:** how lint identifies a rejection-path scenario — a tag
-  convention (e.g. `@negative`) seems necessary; Then-text heuristics are unreliable.
-- **Opt-in mechanism:** `.safeword/config.json` flag vs auto-detection per feature file
-  (presence of `R<#>` IDs in Rule names).
-- **Intake-exit gate:** does the gate accept Rules in place of ACs for opted-in JTBDs
-  (it currently denies `test-definitions.md` until every JTBD has ≥1 AC or a skip)?
+- Split-axis tag compat (`@job:` / `@rule:` / `@scenario:`) — defer: combined tag decided
+  for v1; revisit as a compat flag only if the Arcade corpus migration proves the mechanical
+  tag respelling too costly in practice.
+- Hard numbering-lock enforcement — defer: follow-up anchored to NMSD94's review stamps
+  (deny renumbering a stamped rule ID); v1's stale/orphan advisories cover detection.

--- a/.project/tickets/V0NHT6-rule-tier/spec.md
+++ b/.project/tickets/V0NHT6-rule-tier/spec.md
@@ -26,10 +26,16 @@ Upstream tracker issue: ArcadeAI/safeword#649.
 
 - Upstream issue: [ArcadeAI/safeword#649](https://github.com/ArcadeAI/safeword/issues/649).
 - XT1FFM — scenario lineage (`<jtbd-id>.AC<#>` tags + `safeword check` coverage report); this
-  feature extends that scheme one tier. Its arcade pair QEGKBK named Arcade's scheme the
+  feature extends that scheme one tier. Its arcade pair QEKGBK named Arcade's scheme the
   fidelity target ("kept snake-exact").
 - 31W8M3 — AC layer in spec.md (`#### <jtbd-id>.AC<n>` headings).
-- Companion gap noted in #649 (post-done `measured` state) is a separate filing — out of scope.
+- ZRMDKD (backlog) — plans to promote the AC↔scenario coverage check to a *blocking*
+  hook-side gate via a differential-tested port of `scenario-coverage.ts`; must become
+  tier-aware or sequence after this feature, else it denies opted-in rule-tier features.
+- NMSD94 — owns the two-tier review-stamp mechanism (candidate anchor for "numbering-locked
+  after review").
+- Companion gap noted in #649 (post-done `measured` state) is to be filed separately — out
+  of scope here.
 
 ## Personas
 
@@ -41,7 +47,8 @@ reviews the invariant catalog, and selects tests by rule when an invariant chang
 Affected:
 
 - skip: runtime-agnostic — the tier lives in CLI parsing/checks (`safeword check`,
-  `lint-gherkin`, `codify`) and shared skill templates deployed identically to every agent
+  `lint-gherkin`, `codify`), the hook-side mirror codepath (`templates/hooks/lib/` deployed
+  to `.safeword/hooks/`), and shared skill templates deployed identically to every agent
   runtime; no per-runtime behavior differs.
 
 ## Vocabulary
@@ -89,6 +96,10 @@ invariant is violated; a numbered rule with no rejection-path scenario is a revi
 > `tests/behaviors/`) onto safeword, I want the lineage grammar to express that corpus
 > as-is, so adopting `/bdd` doesn't force a corpus rewrite or drop the rule tier.
 
+(Persona note: migration is done by the developer running the agent in their own repo —
+that is TB by definition; personas.md has no separate adopter archetype, so TB is a
+deliberate choice, not a default.)
+
 ## Rave Moment
 
 skip: table-stakes — spec-grammar infrastructure; the payoff is review checks and test
@@ -112,7 +123,22 @@ selection working quietly, not a peak moment that travels.
   AC tier. Nested breaks corpus fidelity (motivation #4).
 - **Tag scheme:** safeword-style combined tag (`@<jtbd-id>.R<#>`) vs Arcade's split axes
   (`@job:PO1 @rule:PO1.R1 @scenario:<name>`) with slug-less short IDs. Rule-level test
-  selection works under both; corpus-literal fidelity vs grammar minimalism.
+  selection works under both (tag-expressions reserve only `( ) \` and whitespace, so `:`
+  is legal). The split scheme hides two conflicts: multiple lineage tags per scenario
+  collides with the exactly-one-lineage-tag lint, and a `@scenario:<name>` axis contradicts
+  "names plain English; lineage in tags, not names" — corpus-literal fidelity (TB4's
+  "as-is") therefore means *relaxing* existing lint rules, not just adding a tier.
+- **Enforcement-stack interaction:** under the substitute-per-JTBD lean, a scenario carries
+  no AC tag — which today's `findFeatureLineageIssues` hard-flags ("missing lineage") and
+  `parseAcReferenceFromTag` (AC-only regex) can't read. Tier-awareness must land in the CLI
+  *and* the hook-side mirror (`templates/hooks/lib/`, deployed `.safeword/hooks/`), and
+  ZRMDKD's planned blocking coverage gate must be sequenced with or made aware of the tier,
+  or opted-in features get denied at test-definitions creation.
+- **Numbering-lock mechanism (TB3):** what enforces "numbering-locked after review", and
+  what does "after review" map to in the phase flow — the scenario-gate review stamp
+  (NMSD94), a lint on renumbering an existing rule ID, or convention only? If convention
+  only, TB3's stable-anchor promise and the one-way reversibility claim rest on it —
+  resolve before ACs are written.
 - **Rule catalog declaration:** `#### <jtbd-id>.R<#> — <invariant>` headings in spec.md
   (mirrors ACs; enables the drift gate "every @rule tag maps to a spec rule") vs the
   `.feature` `Rule:` blocks as the sole source of truth.

--- a/.project/tickets/V0NHT6-rule-tier/test-definitions.md
+++ b/.project/tickets/V0NHT6-rule-tier/test-definitions.md
@@ -28,9 +28,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Mixed AC and Rule JTBD is flagged as a check issue
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Mixed JTBD still passes the intake-exit gate
 
@@ -60,15 +60,15 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 205f30e
+- [x] GREEN d567582
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Rule block whose name token disagrees with its tag is rejected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 31defdf
+- [x] GREEN 6dfe1fb
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: A tag expression on a rule ID runs exactly that rule's scenarios
 
@@ -80,41 +80,41 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Spec rule with no referencing scenario is reported uncovered
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Rule reference with a missing rule number is reported stale
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Rule reference whose JTBD is absent is reported orphan
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ## Rule: A rule with no rejection path is visible
 
 ### Scenario: Numbered rule with no rejection scenario draws an advisory
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED ca0b68f
+- [x] GREEN 8a69816
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Numbered rule with a rejection scenario is silent
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Unnumbered Rule block draws no zero-rejection advisory
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED ca0b68f
+- [x] GREEN 8a69816
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ## Rule: Non-adopters see zero change
 
@@ -128,15 +128,15 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Per-JTBD numbered Rule corpus passes lint without restructuring
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 4cce165
+- [x] GREEN 74238fe
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ### Scenario: Per-JTBD numbered Rule corpus resolves every reference in coverage
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 205f30e
+- [x] GREEN d567582
+- [x] REFACTOR skip: pure parser/report extension; structure stayed clean at GREEN
 
 ## Rule: Rule warnings are plain-language and actionable
 

--- a/.project/tickets/V0NHT6-rule-tier/test-definitions.md
+++ b/.project/tickets/V0NHT6-rule-tier/test-definitions.md
@@ -8,21 +8,21 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: R-only JTBD satisfies the intake-exit gate
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 45db62e
+- [x] GREEN 8001c3b
+- [x] REFACTOR skip: message/gate-predicate change; no structural refactor needed
 
 ### Scenario: JTBD with neither criteria kind is denied naming Rules as an option
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 45db62e
+- [x] GREEN 8001c3b
+- [x] REFACTOR skip: message/gate-predicate change; no structural refactor needed
 
 ### Scenario: JTBD with a skip line still satisfies the gate
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 45db62e
+- [x] GREEN 8001c3b
+- [x] REFACTOR skip: message/gate-predicate change; no structural refactor needed
 
 ## Rule: A JTBD declares one criteria kind, never both
 
@@ -34,9 +34,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Mixed JTBD still passes the intake-exit gate
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 45db62e
+- [x] GREEN 8001c3b
+- [x] REFACTOR skip: message/gate-predicate change; no structural refactor needed
 
 ## Rule: Rule blocks carry authoritative tags and scenarios inherit exactly one lineage reference
 
@@ -72,9 +72,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A tag expression on a rule ID runs exactly that rule's scenarios
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: pins upstream cucumber rule-tag inheritance — cannot fail before implementation
+- [x] GREEN 4f3aa9b
+- [x] REFACTOR skip: fixture-only integration test
 
 ## Rule: Check reports rule drift against the spec catalog
 
@@ -120,9 +120,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: AC-only project output is unchanged
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: regression guard — proven by the pre-existing check/lint suites passing unchanged
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: no code specific to this scenario
 
 ## Rule: An existing rule-numbered corpus is expressible
 
@@ -142,6 +142,6 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Rule-tier message names the id, the problem, and the next action
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 5c4e0d9
+- [x] GREEN de2fe00
+- [x] REFACTOR skip: message strings asserted across check, lint, and gate suites (de2fe00, 6dfe1fb, 8001c3b)

--- a/.project/tickets/V0NHT6-rule-tier/test-definitions.md
+++ b/.project/tickets/V0NHT6-rule-tier/test-definitions.md
@@ -1,0 +1,129 @@
+# Test Definitions: Numbered Rule tier between JTBD and scenarios
+
+Feature source: `features/rule-tier.feature`
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: A JTBD can carry Rules in place of ACs
+
+### Scenario: R-only JTBD satisfies the intake-exit gate
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: JTBD with neither criteria kind is denied naming Rules as an option
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: JTBD with a skip line still satisfies the gate
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: A JTBD declares one criteria kind, never both
+
+### Scenario: Mixed AC and Rule JTBD is flagged as a check issue
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Rule blocks carry authoritative tags and scenarios inherit exactly one lineage reference
+
+### Scenario: Scenarios under an ID-tagged Rule block pass lineage lint by inheritance
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A second lineage reference under an ID-tagged Rule block is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Rule block whose name token disagrees with its tag is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A tag expression on a rule ID runs exactly that rule's scenarios
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Check reports rule drift against the spec catalog
+
+### Scenario: Spec rule with no referencing scenario is reported uncovered
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Rule reference with a missing rule number is reported stale
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Rule reference whose JTBD is absent is reported orphan
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: A rule with no rejection path is visible
+
+### Scenario: Numbered rule with no rejection scenario draws an advisory
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Numbered rule with a rejection scenario is silent
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Non-adopters see zero change
+
+### Scenario: AC-only project output is unchanged
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: An existing rule-numbered corpus is expressible
+
+### Scenario: Per-JTBD numbered Rule corpus parses and lints without restructuring
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Rule warnings are plain-language and actionable
+
+### Scenario: Zero-rejection advisory states the problem and next action without jargon
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Mixed-criteria issue states the problem and next action without jargon
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/V0NHT6-rule-tier/test-definitions.md
+++ b/.project/tickets/V0NHT6-rule-tier/test-definitions.md
@@ -42,21 +42,21 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Scenarios under an ID-tagged Rule block pass lineage lint by inheritance
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 4cce165
+- [x] GREEN 74238fe
+- [x] REFACTOR skip: pure parser extension; structure stayed clean at GREEN, no per-scenario refactor
 
 ### Scenario: A scenario carrying a rule lineage tag directly passes lineage lint
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 4cce165
+- [x] GREEN 74238fe
+- [x] REFACTOR skip: pure parser extension; structure stayed clean at GREEN, no per-scenario refactor
 
 ### Scenario: A second lineage reference under an ID-tagged Rule block is rejected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 4cce165
+- [x] GREEN 74238fe
+- [x] REFACTOR skip: pure parser extension; structure stayed clean at GREEN, no per-scenario refactor
 
 ### Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
 

--- a/.project/tickets/V0NHT6-rule-tier/test-definitions.md
+++ b/.project/tickets/V0NHT6-rule-tier/test-definitions.md
@@ -32,9 +32,21 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Mixed JTBD still passes the intake-exit gate
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ## Rule: Rule blocks carry authoritative tags and scenarios inherit exactly one lineage reference
 
 ### Scenario: Scenarios under an ID-tagged Rule block pass lineage lint by inheritance
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A scenario carrying a rule lineage tag directly passes lineage lint
 
 - [ ] RED
 - [ ] GREEN
@@ -98,6 +110,12 @@ test-definitions.md is the R/G/R ledger.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Unnumbered Rule block draws no zero-rejection advisory
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ## Rule: Non-adopters see zero change
 
 ### Scenario: AC-only project output is unchanged
@@ -108,7 +126,13 @@ test-definitions.md is the R/G/R ledger.
 
 ## Rule: An existing rule-numbered corpus is expressible
 
-### Scenario: Per-JTBD numbered Rule corpus parses and lints without restructuring
+### Scenario: Per-JTBD numbered Rule corpus passes lint without restructuring
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Per-JTBD numbered Rule corpus resolves every reference in coverage
 
 - [ ] RED
 - [ ] GREEN
@@ -116,13 +140,7 @@ test-definitions.md is the R/G/R ledger.
 
 ## Rule: Rule warnings are plain-language and actionable
 
-### Scenario: Zero-rejection advisory states the problem and next action without jargon
-
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
-
-### Scenario: Mixed-criteria issue states the problem and next action without jargon
+### Scenario: Rule-tier message names the id, the problem, and the next action
 
 - [ ] RED
 - [ ] GREEN

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -5,10 +5,24 @@ type: feature
 phase: intake
 status: in_progress
 scope:
+  - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
+  - 'lineage: `@<jtbd-id>.R<n>` combined tag recognized by the ref parser and the exactly-one-lineage-tag lint (AC ref or R ref both satisfy it); `.feature` `Rule:` block names carry the ID as their first token'
+  - 'coverage: rule buckets (uncovered / stale / orphan) in `safeword check` advisories, plus a zero-rejection-path advisory per numbered Rule via the `@rejection` tag convention'
+  - 'intake-exit gate: hook-side `jtbd.ts` mirror accepts ≥1 AC or ≥1 numbered Rule (or `skip:`) per JTBD'
+  - 'templates: spec-template, bdd DISCOVERY/SCENARIOS, review-spec updated with the tier; hook-side mirrors kept byte-identical to templates'
 out_of_scope:
+  - 'split-axis tags (`@job:` / `@rule:` / `@scenario:`) — deferred compat follow-up; combined tag only in v1'
+  - 'hard numbering-lock enforcement — follow-up anchored to NMSD94 review stamps; v1 ships stale/orphan drift advisories'
+  - 'automated migration codemod for the Arcade corpus — documented tag-spelling mapping only'
+  - 'ZRMDKD blocking-gate port — its ticket gains a tier-awareness requirement, not implemented here'
+  - 'post-done `measured` state — separate filing per issue #649'
 done_when:
+  - 'a spec whose JTBD declares R headings and no ACs passes the intake-exit gate and test-definitions creation'
+  - 'a feature file with ID-carrying Rule blocks passes lineage lint via inherited R tags; repos with no R headings produce unchanged check output (existing suite green, untouched fixtures byte-identical)'
+  - '`safeword check` reports rule uncovered/stale/orphan and zero-rejection-path advisories on fixtures'
+  - 'templates ship the grammar; hook/template parity and full suite green'
 created: 2026-07-03T16:49:49.260Z
-last_modified: 2026-07-03T16:49:49.260Z
+last_modified: 2026-07-03T17:15:00.000Z
 ---
 
 # Numbered Rule tier between JTBD and scenarios
@@ -20,3 +34,6 @@ last_modified: 2026-07-03T16:49:49.260Z
 ## Work Log
 
 - 2026-07-03T16:49:49.260Z Started: Created ticket V0NHT6
+- 2026-07-03T16:55:00.000Z /quality-review pass 1 (fresh-context reviewer): 2 criticals (enforcement-stack interaction incl. ZRMDKD; numbering-lock mechanism) folded into spec; pass 2 APPROVE, nits applied.
+- 2026-07-03T17:11:00.000Z JTBD gate passed: user confirmed 4 jobs + substitute-per-JTBD coexistence ("go").
+- 2026-07-03T17:15:00.000Z Intake decisions recorded in spec.md (tag scheme, catalog source, opt-in, @rejection convention, gate acceptance, enforcement-stack landing, numbering-lock v1); 2 deliberate defers kept in Open Questions; ACs authored; engineering scope drafted — AC + scope gates pending user signoff.

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -7,9 +7,10 @@ status: in_progress
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
   - 'lineage: `@<jtbd-id>.R<n>` combined tag recognized by the ref parser and the exactly-one-lineage-tag lint (AC ref or R ref both satisfy it); `.feature` `Rule:` block names carry the ID as their first token'
-  - 'coverage: rule buckets (uncovered / stale / orphan) in `safeword check` advisories, plus a zero-rejection-path advisory per numbered Rule via the `@rejection` tag convention'
-  - 'intake-exit gate: hook-side `jtbd.ts` mirror accepts ≥1 AC or ≥1 numbered Rule (or `skip:`) per JTBD'
-  - 'templates: spec-template, bdd DISCOVERY/SCENARIOS, review-spec updated with the tier; hook-side mirrors kept byte-identical to templates'
+  - 'coverage: rule buckets (uncovered / stale / orphan) in `safeword check` advisories, plus a zero-rejection-path advisory per numbered Rule via the `@rejection` tag convention; R refs are `.feature`-only (legacy test-definitions title path stays AC-only)'
+  - 'mixed-JTBD guard: a JTBD declaring both ACs and Rules is a `safeword check` issue naming the JTBD (gate stays fail-open)'
+  - 'intake-exit gate: hook-side `jtbd.ts` mirror accepts ≥1 AC or ≥1 numbered Rule (or `skip:`) per JTBD, with the denial message naming Rules as an option'
+  - 'templates + docs: spec-template, bdd DISCOVERY/SCENARIOS, review-spec updated with the tier, including the documented migration mapping (Arcade split-tag spelling → combined tag); hook-side mirrors kept byte-identical to templates'
 out_of_scope:
   - 'split-axis tags (`@job:` / `@rule:` / `@scenario:`) — deferred compat follow-up; combined tag only in v1'
   - 'hard numbering-lock enforcement — follow-up anchored to NMSD94 review stamps; v1 ships stale/orphan drift advisories'
@@ -17,8 +18,8 @@ out_of_scope:
   - 'ZRMDKD blocking-gate port — its ticket gains a tier-awareness requirement, not implemented here'
   - 'post-done `measured` state — separate filing per issue #649'
 done_when:
-  - 'a spec whose JTBD declares R headings and no ACs passes the intake-exit gate and test-definitions creation'
-  - 'a feature file with ID-carrying Rule blocks passes lineage lint via inherited R tags; repos with no R headings produce unchanged check output (existing suite green, untouched fixtures byte-identical)'
+  - 'a spec whose JTBD declares R headings and no ACs passes the intake-exit gate with a denial message that names Rules when neither kind is present; a JTBD declaring both kinds surfaces the check issue naming it'
+  - 'a feature file whose `Rule:` blocks carry the `@<jtbd-id>.R<n>` tag passes lineage lint via inherited R tags (tag authoritative; name-token mismatch is a lint issue; a tag ending `.AC<n>` never parses as an R ref); repos with no R headings produce unchanged check output (existing suite green, untouched fixtures byte-identical)'
   - '`safeword check` reports rule uncovered/stale/orphan and zero-rejection-path advisories on fixtures'
   - 'templates ship the grammar; hook/template parity and full suite green'
 created: 2026-07-03T16:49:49.260Z

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -2,7 +2,7 @@
 id: V0NHT6
 slug: rule-tier
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
@@ -43,3 +43,4 @@ last_modified: 2026-07-03T17:15:00.000Z
 - 2026-07-03T20:36:00.000Z Amendment at decider gate: NTB persona + rule-tier.NTB1.AC1 (plain-language actionable messages) + message-contract dimension added on user prompt; scenario set re-presented and accepted ("go").
 - 2026-07-03T20:41:00.000Z Complete: define-behavior - 18 scenarios defined across 8 rules; features/rule-tier.feature saved (lint clean), R/G/R ledger saved.
 - 2026-07-03T20:55:00.000Z Complete: scenario-gate - Independent /review-spec (Tier 2, fresh subagent): PASS WITH FIXES → 1 blocking (unnumbered-Rule exempt class) + 6 strengtheners applied (fail-open gate scenario, direct R tag, observable AC-precedence Then, NTB message Scenario Outline ×8, TB4 atomicity split, snapshot determinism) → final verdict PASS; stamp written. impl-plan.md written (proof plan + build order, 8 slices, load-bearing ref-grammar slice first). Ledger now 21 entries.
+- 2026-07-03T21:35:00.000Z Complete: implement - All 8 slices RGR'd (ref grammar → catalog/mixed → rule coverage buckets → rejection report → name-tag lint → check wiring/messages → gate denial + mirrors → cucumber selection → templates/docs). Ledger 21/21 marked with commit SHAs. Full suite: 311 files, 4482 passed, 5 pre-existing skips. impl-plan reconciled → implemented.

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -2,8 +2,8 @@
 id: V0NHT6
 slug: rule-tier
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
   - 'lineage: `@<jtbd-id>.R<n>` combined tag recognized by the ref parser and the exactly-one-lineage-tag lint (AC ref or R ref both satisfy it; AC-match wins precedence); the `.feature` `Rule:` block carries the tag (authoritative — scenarios inherit it) and repeats the ID as its name''s first token, mismatch is a lint issue'
@@ -44,3 +44,5 @@ last_modified: 2026-07-03T17:15:00.000Z
 - 2026-07-03T20:41:00.000Z Complete: define-behavior - 18 scenarios defined across 8 rules; features/rule-tier.feature saved (lint clean), R/G/R ledger saved.
 - 2026-07-03T20:55:00.000Z Complete: scenario-gate - Independent /review-spec (Tier 2, fresh subagent): PASS WITH FIXES → 1 blocking (unnumbered-Rule exempt class) + 6 strengtheners applied (fail-open gate scenario, direct R tag, observable AC-precedence Then, NTB message Scenario Outline ×8, TB4 atomicity split, snapshot determinism) → final verdict PASS; stamp written. impl-plan.md written (proof plan + build order, 8 slices, load-bearing ref-grammar slice first). Ledger now 21 entries.
 - 2026-07-03T21:35:00.000Z Complete: implement - All 8 slices RGR'd (ref grammar → catalog/mixed → rule coverage buckets → rejection report → name-tag lint → check wiring/messages → gate denial + mirrors → cucumber selection → templates/docs). Ledger 21/21 marked with commit SHAs. Full suite: 311 files, 4482 passed, 5 pre-existing skips. impl-plan reconciled → implemented.
+- 2026-07-03T22:20:00.000Z Complete: verify - /verify + /audit run and logged; verify.md written (full suite 4482 pass, Gherkin lane 209/209 incl. 28 rule-tier instances via new steps/rule-tier.steps.ts, build/typecheck/lint green, PR scope clean, audit passed with pre-existing warnings only).
+- 2026-07-03T22:21:00.000Z Complete: done - Ticket closed (status: done).

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -2,7 +2,7 @@
 id: V0NHT6
 slug: rule-tier
 type: feature
-phase: scenario-gate
+phase: implement
 status: in_progress
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
@@ -42,3 +42,4 @@ last_modified: 2026-07-03T17:15:00.000Z
 - 2026-07-03T20:22:00.000Z Complete: intake - Understanding converged, scope established. AC + scope gates signed off (user "go"); cold-start check offered (one-way door) and declined.
 - 2026-07-03T20:36:00.000Z Amendment at decider gate: NTB persona + rule-tier.NTB1.AC1 (plain-language actionable messages) + message-contract dimension added on user prompt; scenario set re-presented and accepted ("go").
 - 2026-07-03T20:41:00.000Z Complete: define-behavior - 18 scenarios defined across 8 rules; features/rule-tier.feature saved (lint clean), R/G/R ledger saved.
+- 2026-07-03T20:55:00.000Z Complete: scenario-gate - Independent /review-spec (Tier 2, fresh subagent): PASS WITH FIXES → 1 blocking (unnumbered-Rule exempt class) + 6 strengtheners applied (fail-open gate scenario, direct R tag, observable AC-precedence Then, NTB message Scenario Outline ×8, TB4 atomicity split, snapshot determinism) → final verdict PASS; stamp written. impl-plan.md written (proof plan + build order, 8 slices, load-bearing ref-grammar slice first). Ledger now 21 entries.

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -2,7 +2,7 @@
 id: V0NHT6
 slug: rule-tier
 type: feature
-phase: define-behavior
+phase: scenario-gate
 status: in_progress
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
@@ -40,3 +40,5 @@ last_modified: 2026-07-03T17:15:00.000Z
 - 2026-07-03T17:15:00.000Z Intake decisions recorded in spec.md (tag scheme, catalog source, opt-in, @rejection convention, gate acceptance, enforcement-stack landing, numbering-lock v1); 2 deliberate defers kept in Open Questions; ACs authored; engineering scope drafted — AC + scope gates pending user signoff.
 - 2026-07-03T20:20:00.000Z /quality-review (2nd invocation, fresh-context reviewer): pass 1 → 1 critical (mixed AC+R JTBD undefined) + 5 improvements; all applied (TB1.AC4, tag-authoritative decision, AC-wins ref precedence, .feature-only R refs, migration-mapping scope owner, de-vacuoused done_when). Pass 2 → APPROVE, no criticals.
 - 2026-07-03T20:22:00.000Z Complete: intake - Understanding converged, scope established. AC + scope gates signed off (user "go"); cold-start check offered (one-way door) and declined.
+- 2026-07-03T20:36:00.000Z Amendment at decider gate: NTB persona + rule-tier.NTB1.AC1 (plain-language actionable messages) + message-contract dimension added on user prompt; scenario set re-presented and accepted ("go").
+- 2026-07-03T20:41:00.000Z Complete: define-behavior - 18 scenarios defined across 8 rules; features/rule-tier.feature saved (lint clean), R/G/R ledger saved.

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -1,0 +1,22 @@
+---
+id: V0NHT6
+slug: rule-tier
+type: feature
+phase: intake
+status: in_progress
+scope:
+out_of_scope:
+done_when:
+created: 2026-07-03T16:49:49.260Z
+last_modified: 2026-07-03T16:49:49.260Z
+---
+
+# Numbered Rule tier between JTBD and scenarios
+
+**Goal:** Add an optional numbered-Rule tier (`<jtbd-id>.R<#>`) to the scenario lineage so specs carry an invariant catalog with stable IDs, tier-aware checks, and expressiveness for Arcade's existing rule-numbered corpus (issue #649).
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-07-03T16:49:49.260Z Started: Created ticket V0NHT6

--- a/.project/tickets/V0NHT6-rule-tier/ticket.md
+++ b/.project/tickets/V0NHT6-rule-tier/ticket.md
@@ -2,11 +2,11 @@
 id: V0NHT6
 slug: rule-tier
 type: feature
-phase: intake
+phase: define-behavior
 status: in_progress
 scope:
   - 'spec.md grammar: `#### <jtbd-id>.R<n> — <invariant>` Rule headings parsed alongside AC headings (per-JTBD substitute — a JTBD carries ACs or Rules, never both); declaring Rules is the opt-in, no config flag'
-  - 'lineage: `@<jtbd-id>.R<n>` combined tag recognized by the ref parser and the exactly-one-lineage-tag lint (AC ref or R ref both satisfy it); `.feature` `Rule:` block names carry the ID as their first token'
+  - 'lineage: `@<jtbd-id>.R<n>` combined tag recognized by the ref parser and the exactly-one-lineage-tag lint (AC ref or R ref both satisfy it; AC-match wins precedence); the `.feature` `Rule:` block carries the tag (authoritative — scenarios inherit it) and repeats the ID as its name''s first token, mismatch is a lint issue'
   - 'coverage: rule buckets (uncovered / stale / orphan) in `safeword check` advisories, plus a zero-rejection-path advisory per numbered Rule via the `@rejection` tag convention; R refs are `.feature`-only (legacy test-definitions title path stays AC-only)'
   - 'mixed-JTBD guard: a JTBD declaring both ACs and Rules is a `safeword check` issue naming the JTBD (gate stays fail-open)'
   - 'intake-exit gate: hook-side `jtbd.ts` mirror accepts ≥1 AC or ≥1 numbered Rule (or `skip:`) per JTBD, with the denial message naming Rules as an option'
@@ -38,3 +38,5 @@ last_modified: 2026-07-03T17:15:00.000Z
 - 2026-07-03T16:55:00.000Z /quality-review pass 1 (fresh-context reviewer): 2 criticals (enforcement-stack interaction incl. ZRMDKD; numbering-lock mechanism) folded into spec; pass 2 APPROVE, nits applied.
 - 2026-07-03T17:11:00.000Z JTBD gate passed: user confirmed 4 jobs + substitute-per-JTBD coexistence ("go").
 - 2026-07-03T17:15:00.000Z Intake decisions recorded in spec.md (tag scheme, catalog source, opt-in, @rejection convention, gate acceptance, enforcement-stack landing, numbering-lock v1); 2 deliberate defers kept in Open Questions; ACs authored; engineering scope drafted — AC + scope gates pending user signoff.
+- 2026-07-03T20:20:00.000Z /quality-review (2nd invocation, fresh-context reviewer): pass 1 → 1 critical (mixed AC+R JTBD undefined) + 5 improvements; all applied (TB1.AC4, tag-authoritative decision, AC-wins ref precedence, .feature-only R refs, migration-mapping scope owner, de-vacuoused done_when). Pass 2 → APPROVE, no criticals.
+- 2026-07-03T20:22:00.000Z Complete: intake - Understanding converged, scope established. AC + scope gates signed off (user "go"); cold-start check offered (one-way door) and declined.

--- a/.project/tickets/V0NHT6-rule-tier/verify.md
+++ b/.project/tickets/V0NHT6-rule-tier/verify.md
@@ -1,0 +1,32 @@
+# Verify: Numbered Rule tier between JTBD and scenarios (V0NHT6)
+
+Verified 2026-07-03 on branch `claude/safeword-issue-649-1fmvwz`.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4482/4482 tests pass (311 files, 5 pre-existing skips; full vitest run after final code change — docs/ticket-artifact edits only since)
+**Gherkin:** ✅ Acceptance lane passes (209 scenarios / 4129 steps, including all 28 rule-tier scenario instances via steps/rule-tier.steps.ts)
+**Build:** ✅ Success (`test-plan --kind build`, exit 0)
+**Typecheck:** ✅ Clean (`test-plan --kind typecheck` → `tsc --noEmit`, exit 0)
+**Lint:** ✅ Clean (eslint per-file green on all changed sources; `lint-gherkin features/rule-tier.feature` exit 0; steps/ is eslint-ignored by repo config, consistent with existing step files)
+**Scenarios:** All 21 scenarios marked complete (RED/GREEN SHAs or reasoned skips in test-definitions.md)
+**PR Scope:** ✅ Diff matches ticket scope (23→25 files: parser/coverage/health + hook mirror + templates/deployed copies + tests/steps + ticket artifacts; ZRMDKD ticket note is the decided sequencing cleanup; no manifest changes)
+**Dep Drift:** ✅ Clean (no dependency changes; ARCHITECTURE.md untouched by deps)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation (extends the existing lineage/mirror/differential patterns; impl-plan Arch alignment names the honored decisions)
+**Experience:** ⚠️ 1 observation — Walked NTB through "check flags a rule problem": worst step = the `@rejection` next-action assumes the NTB relays tag syntax to their agent verbatim (message is copy-pasteable, so acceptable); new steps vs before = 0. Walked TB through R-only spec authoring: gate passes without ACs, denial message names both options. No rave moment declared (spec: skip table-stakes).
+**Evidence limits:** ✅ None
+
+Audit passed (with pre-existing warnings only):
+
+- Config drift: ✅ `sync-config --check` in sync
+- Architecture: ✅ depcruise 0 violations (548 modules)
+- Dead code: ✅ knip exit 0; the steps-file "unlisted binary" entries match the pre-existing pattern for every steps file; no new unused exports from this ticket
+- Duplication: 395 repo-wide clones (pre-existing baseline; none flagged in this ticket's files)
+- Outdated: 4 dev-only bumps (knip minor, prettier minor, tsx patch — low; markdownlint-cli2 0.x minor — medium, review changelog); no prod deps outdated
+- Learnings: ✅ all carry `Covers:`
+- Docs impact: ✅ bdd skill + spec template updated in-ticket; website docs contain no lineage-scheme content to drift
+
+## Agent's next actions
+
+- Follow-ups already recorded as spec defers: split-axis tag compat flag; hard numbering-lock on NMSD94 stamps. ZRMDKD carries its tier-awareness dependency note.

--- a/.project/tickets/ZRMDKD-coverage-gate-blocking/ticket.md
+++ b/.project/tickets/ZRMDKD-coverage-gate-blocking/ticket.md
@@ -22,6 +22,8 @@ last_modified: 2026-06-03T04:42:30.504Z
 
 **Out of scope:** the two-tier review stamp mechanism (NMSD94 owns it).
 
+**Dependency (added 2026-07-03):** V0NHT6 (rule-tier) adds a numbered-Rule lineage tier where a JTBD carries `R<n>` rules instead of ACs and scenarios reference `@<jtbd-id>.R<n>`. This gate's hook-side port must treat a rule reference as covering lineage (not an uncovered-AC denial) — sequence after V0NHT6 or port tier-aware coverage from the start.
+
 **Done when:** uncovered-AC / orphan-scenario test-definitions are denied with a clear reason; complete work passes silently; alert-to-action measured before making it permanent; differential test pins the hook port to the CLI original; `templates/hooks/` ↔ `.safeword/hooks/` byte-identical; full suite + parity green.
 
 **Owns:** NMSD94's SM1.AC1 scenarios (`uncovered_ac_blocks`, `orphan_scenario_blocks`, `complete_coverage_silent`).

--- a/.safeword/hooks/lib/jtbd.ts
+++ b/.safeword/hooks/lib/jtbd.ts
@@ -231,7 +231,7 @@ export function evaluateAcGate(specContent: string): JtbdGateVerdict {
     if (block.acCount === 0) {
       return {
         ok: false,
-        reason: `JTBD "${block.heading}" has no acceptance criteria — add ≥1 \`#### <id>.AC<n>\` or \`skip: <reason>\``,
+        reason: `JTBD "${block.heading}" has no acceptance criteria or numbered rules — add ≥1 \`#### <id>.AC<n>\`, ≥1 \`#### <id>.R<n>\`, or \`skip: <reason>\``,
       };
     }
   }

--- a/.safeword/templates/spec-template.md
+++ b/.safeword/templates/spec-template.md
@@ -82,6 +82,10 @@ implementation ("returns 204" belongs in a scenario's Then). Each define-behavio
 scenario will prove a specific AC. If a JTBD has no user-observable capability
 to enumerate, write `skip: <reason>` under it instead of ACs.
 
+Alternative: a JTBD may instead declare numbered Rules — testable business
+invariants with stable ids (#### <jtbd-id>.R<n> — <invariant>) that scenarios
+nest under. One criteria kind per JTBD, never both.
+
 #### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
 
 #### oauth-flow.PO1.AC2 — The operator can see which keys are currently live

--- a/features/rule-tier.feature
+++ b/features/rule-tier.feature
@@ -1,0 +1,133 @@
+Feature: Numbered Rule tier between JTBD and scenarios
+
+  A spec's JTBD can carry numbered Rules (testable business invariants with
+  stable per-JTBD IDs) in place of ACs; scenarios nest under ID-tagged Rule
+  blocks, and safeword's checks understand the tier. Repos that never declare
+  a Rule keep today's flat AC lineage untouched.
+
+  Rule: A JTBD can carry Rules in place of ACs
+
+    @rule-tier.TB1.AC1
+    Scenario: R-only JTBD satisfies the intake-exit gate
+      Given a ticket spec whose JTBD declares numbered Rules and no ACs
+      When the intake-exit gate evaluates test-definitions creation
+      Then the gate allows the creation
+
+    @rule-tier.TB1.AC1 @rejection
+    Scenario: JTBD with neither criteria kind is denied naming Rules as an option
+      Given a ticket spec whose JTBD declares no ACs, no Rules, and no skip line
+      When the intake-exit gate evaluates test-definitions creation
+      Then the gate denies the creation
+      And the denial message names both Acceptance Criteria and numbered Rules as options
+
+    @rule-tier.TB1.AC1
+    Scenario: JTBD with a skip line still satisfies the gate
+      Given a ticket spec whose JTBD carries a skip line instead of criteria
+      When the intake-exit gate evaluates test-definitions creation
+      Then the gate allows the creation
+
+  Rule: A JTBD declares one criteria kind, never both
+
+    @rule-tier.TB1.AC4 @rejection
+    Scenario: Mixed AC and Rule JTBD is flagged as a check issue
+      Given a ticket spec whose JTBD declares both an AC heading and a numbered Rule heading
+      When safeword check runs
+      Then a check issue names that JTBD as mixing criteria kinds
+
+  Rule: Rule blocks carry authoritative tags and scenarios inherit exactly one lineage reference
+
+    @rule-tier.TB2.AC1
+    Scenario: Scenarios under an ID-tagged Rule block pass lineage lint by inheritance
+      Given a feature file whose Rule block carries a rule ID tag and untagged scenarios
+      When lineage lint runs
+      Then no lineage issue is reported
+
+    @rule-tier.TB2.AC1 @rejection
+    Scenario: A second lineage reference under an ID-tagged Rule block is rejected
+      Given a feature file whose Rule block carries a rule ID tag and a scenario adds an AC lineage tag
+      When lineage lint runs
+      Then a multiple-lineage issue names that scenario
+
+    @rule-tier.TB2.AC1
+    Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
+      Given a feature file with a scenario tagged "@feat.R1.AC1"
+      When lineage lint runs
+      Then the tag is read as one AC reference for JTBD "feat.R1"
+      And no lineage issue is reported
+
+    @rule-tier.TB2.AC1 @rejection
+    Scenario: Rule block whose name token disagrees with its tag is rejected
+      Given a feature file whose Rule block tag and leading name token carry different rule IDs
+      When gherkin lint runs
+      Then a name-tag mismatch issue names that Rule block
+
+    @rule-tier.TB2.AC1
+    Scenario: A tag expression on a rule ID runs exactly that rule's scenarios
+      Given a feature file with two ID-tagged Rule blocks
+      When the cucumber lane runs with a tag expression selecting one rule ID
+      Then only the scenarios under that Rule block execute
+
+  Rule: Check reports rule drift against the spec catalog
+
+    @rule-tier.TB3.AC1
+    Scenario: Spec rule with no referencing scenario is reported uncovered
+      Given a ticket spec declaring a numbered Rule that no feature scenario references
+      When safeword check runs
+      Then an uncovered advisory names that rule ID
+
+    @rule-tier.TB3.AC1
+    Scenario: Rule reference with a missing rule number is reported stale
+      Given a feature scenario referencing a rule number its spec JTBD never declared
+      When safeword check runs
+      Then a stale advisory names that rule reference
+
+    @rule-tier.TB3.AC1
+    Scenario: Rule reference whose JTBD is absent is reported orphan
+      Given a feature scenario referencing a rule under a JTBD absent from the spec
+      When safeword check runs
+      Then an orphan advisory names that rule reference
+
+  Rule: A rule with no rejection path is visible
+
+    @rule-tier.TB1.AC2
+    Scenario: Numbered rule with no rejection scenario draws an advisory
+      Given a spec-declared numbered Rule whose feature scenarios carry no rejection tag
+      When safeword check runs
+      Then a zero-rejection-path advisory names that rule ID
+
+    @rule-tier.TB1.AC2
+    Scenario: Numbered rule with a rejection scenario is silent
+      Given a spec-declared numbered Rule with at least one rejection-tagged feature scenario
+      When safeword check runs
+      Then no zero-rejection-path advisory is reported
+
+  Rule: Non-adopters see zero change
+
+    @rule-tier.TB1.AC3
+    Scenario: AC-only project output is unchanged
+      Given a project whose specs and feature files use only AC lineage
+      When safeword check and gherkin lint run
+      Then the output matches today's flat-lineage output exactly
+
+  Rule: An existing rule-numbered corpus is expressible
+
+    @rule-tier.TB4.AC1
+    Scenario: Per-JTBD numbered Rule corpus parses and lints without restructuring
+      Given a feature file shaped like an existing rule-numbered corpus with a matching spec catalog
+      When safeword check and gherkin lint run
+      Then no lineage issue is reported
+      And the coverage report resolves every rule reference
+
+  Rule: Rule warnings are plain-language and actionable
+
+    @rule-tier.NTB1.AC1
+    Scenario: Zero-rejection advisory states the problem and next action without jargon
+      Given a spec-declared numbered Rule whose feature scenarios carry no rejection tag
+      When safeword check runs
+      Then the advisory names the rule ID, states that no example shows the rule being broken, and says to add a rejection-tagged scenario
+
+    @rule-tier.NTB1.AC1
+    Scenario: Mixed-criteria issue states the problem and next action without jargon
+      Given a ticket spec whose JTBD declares both an AC heading and a numbered Rule heading
+      When safeword check runs
+      Then the issue names the JTBD, states that a job keeps one criteria kind, and names both kinds as the choice

--- a/features/rule-tier.feature
+++ b/features/rule-tier.feature
@@ -34,11 +34,23 @@ Feature: Numbered Rule tier between JTBD and scenarios
       When safeword check runs
       Then a check issue names that JTBD as mixing criteria kinds
 
+    @rule-tier.TB1.AC4
+    Scenario: Mixed JTBD still passes the intake-exit gate
+      Given a ticket spec whose JTBD declares both an AC heading and a numbered Rule heading
+      When the intake-exit gate evaluates test-definitions creation
+      Then the gate allows the creation
+
   Rule: Rule blocks carry authoritative tags and scenarios inherit exactly one lineage reference
 
     @rule-tier.TB2.AC1
     Scenario: Scenarios under an ID-tagged Rule block pass lineage lint by inheritance
       Given a feature file whose Rule block carries a rule ID tag and untagged scenarios
+      When lineage lint runs
+      Then no lineage issue is reported
+
+    @rule-tier.TB2.AC1
+    Scenario: A scenario carrying a rule lineage tag directly passes lineage lint
+      Given a feature file with a scenario carrying an R lineage tag directly and no ID-tagged Rule block
       When lineage lint runs
       Then no lineage issue is reported
 
@@ -52,8 +64,8 @@ Feature: Numbered Rule tier between JTBD and scenarios
     Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
       Given a feature file with a scenario tagged "@feat.R1.AC1"
       When lineage lint runs
-      Then the tag is read as one AC reference for JTBD "feat.R1"
-      And no lineage issue is reported
+      Then the coverage report attributes the scenario to AC "feat.R1.AC1"
+      And no stale or orphan rule advisory is reported for "feat.R1"
 
     @rule-tier.TB2.AC1 @rejection
     Scenario: Rule block whose name token disagrees with its tag is rejected
@@ -101,33 +113,49 @@ Feature: Numbered Rule tier between JTBD and scenarios
       When safeword check runs
       Then no zero-rejection-path advisory is reported
 
+    @rule-tier.TB1.AC2
+    Scenario: Unnumbered Rule block draws no zero-rejection advisory
+      Given a feature file with an unnumbered Rule grouping block and no rejection-tagged scenarios
+      When safeword check runs
+      Then no zero-rejection-path advisory is reported
+
   Rule: Non-adopters see zero change
 
     @rule-tier.TB1.AC3
     Scenario: AC-only project output is unchanged
-      Given a project whose specs and feature files use only AC lineage
+      Given a project whose specs and feature files use only AC lineage, including unnumbered Rule grouping blocks without rejection tags
       When safeword check and gherkin lint run
-      Then the output matches today's flat-lineage output exactly
+      Then the output is byte-identical to the recorded flat-lineage snapshot after path normalization
 
   Rule: An existing rule-numbered corpus is expressible
 
     @rule-tier.TB4.AC1
-    Scenario: Per-JTBD numbered Rule corpus parses and lints without restructuring
+    Scenario: Per-JTBD numbered Rule corpus passes lint without restructuring
       Given a feature file shaped like an existing rule-numbered corpus with a matching spec catalog
-      When safeword check and gherkin lint run
+      When lineage lint runs
       Then no lineage issue is reported
-      And the coverage report resolves every rule reference
+
+    @rule-tier.TB4.AC1
+    Scenario: Per-JTBD numbered Rule corpus resolves every reference in coverage
+      Given a feature file shaped like an existing rule-numbered corpus with a matching spec catalog
+      When safeword check runs
+      Then the coverage report resolves every rule reference
 
   Rule: Rule warnings are plain-language and actionable
 
     @rule-tier.NTB1.AC1
-    Scenario: Zero-rejection advisory states the problem and next action without jargon
-      Given a spec-declared numbered Rule whose feature scenarios carry no rejection tag
-      When safeword check runs
-      Then the advisory names the rule ID, states that no example shows the rule being broken, and says to add a rejection-tagged scenario
+    Scenario Outline: Rule-tier message names the id, the problem, and the next action
+      Given a project exhibiting <condition>
+      When <command> runs
+      Then the <message> names <offender>, states the problem in plain language, and carries a concrete next action
 
-    @rule-tier.NTB1.AC1
-    Scenario: Mixed-criteria issue states the problem and next action without jargon
-      Given a ticket spec whose JTBD declares both an AC heading and a numbered Rule heading
-      When safeword check runs
-      Then the issue names the JTBD, states that a job keeps one criteria kind, and names both kinds as the choice
+      Examples:
+        | condition                                            | command              | message                 | offender           |
+        | a numbered rule with no rejection-tagged scenario    | safeword check       | zero-rejection advisory | the rule ID        |
+        | a JTBD mixing AC and Rule headings                   | safeword check       | mixed-criteria issue    | the JTBD           |
+        | a spec rule no scenario references                   | safeword check       | uncovered advisory      | the rule ID        |
+        | a rule reference with a missing rule number          | safeword check       | stale advisory          | the rule reference |
+        | a rule reference whose JTBD is absent                | safeword check       | orphan advisory         | the rule reference |
+        | a JTBD with neither criteria kind and no skip line   | the intake-exit gate | denial message          | the JTBD           |
+        | a Rule block whose name token disagrees with its tag | gherkin lint         | name-tag mismatch issue | the Rule block     |
+        | a scenario with two lineage references               | lineage lint         | multiple-lineage issue  | the scenario       |

--- a/features/rule-tier.feature
+++ b/features/rule-tier.feature
@@ -63,7 +63,7 @@ Feature: Numbered Rule tier between JTBD and scenarios
     @rule-tier.TB2.AC1
     Scenario: A tag ending in an AC segment parses as an AC reference, never a rule reference
       Given a feature file with a scenario tagged "@feat.R1.AC1"
-      When lineage lint runs
+      When safeword check runs
       Then the coverage report attributes the scenario to AC "feat.R1.AC1"
       And no stale or orphan rule advisory is reported for "feat.R1"
 

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -38,6 +38,9 @@ import {
   buildCoverageReportFromFeature,
   buildSurfaceCoverageReportFromFeature,
   type CoverageReport,
+  findMixedCriteriaJtbds,
+  findRulesMissingRejectionPaths,
+  isRuleId,
   type SurfaceCoverageReport,
 } from './utils/scenario-coverage.js';
 import { formatTicketReference } from './utils/ticket-reference.js';
@@ -296,10 +299,12 @@ function coverageDiagnosticsForTicket(
         : buildSurfaceCoverageReportFromFeature(specContent, featureSource.content);
     const lineageIssues =
       featureSource === undefined ? [] : formatFeatureLineageIssues(cwd, ticketId, featureSource);
+    const ruleTier = ruleTierDiagnostics(ticketId, specContent, featureSource);
     return {
-      issues: lineageIssues,
+      issues: [...lineageIssues, ...ruleTier.issues],
       advisories: [
         ...formatCoverageReport(ticketId, report),
+        ...ruleTier.advisories,
         ...formatSurfaceCoverageReport(ticketId, surfaceReport),
       ],
     };
@@ -314,6 +319,29 @@ function coverageDiagnosticsForTicket(
     }
     throw parseError;
   }
+}
+
+/** Rule-tier findings for one ticket: mixed-criteria JTBDs (issues) and
+ * numbered rules missing a rejection-path scenario (advisories). */
+function ruleTierDiagnostics(
+  ticketId: string,
+  specContent: string,
+  featureSource: FeatureSource | undefined,
+): CoverageDiagnostics {
+  const label = formatCoverageTicketLabel(ticketId);
+  return {
+    issues: findMixedCriteriaJtbds(specContent).map(
+      jtbd =>
+        `${label}: JTBD ${jtbd} declares both Acceptance Criteria and numbered Rules; keep one criteria kind per job — convert one set or split the job`,
+    ),
+    advisories:
+      featureSource === undefined
+        ? []
+        : findRulesMissingRejectionPaths(specContent, featureSource.content).map(
+            ruleId =>
+              `${label}: numbered rule ${ruleId} has no example of the rule being broken — add a @rejection-tagged scenario under it`,
+          ),
+  };
 }
 
 function formatFeatureLineageIssues(
@@ -357,15 +385,20 @@ function isInProgress(ticketContent: string): boolean {
 function formatCoverageReport(ticketId: string, report: CoverageReport): string[] {
   const ticketLabel = formatCoverageTicketLabel(ticketId);
   return [
-    ...report.uncovered.map(
-      acId => `${ticketLabel}: acceptance criterion ${acId} has no scenario (uncovered)`,
+    ...report.uncovered.map(id =>
+      isRuleId(id)
+        ? `${ticketLabel}: numbered rule ${id} has no scenario illustrating it (uncovered) — add a scenario tagged @${id}`
+        : `${ticketLabel}: acceptance criterion ${id} has no scenario (uncovered)`,
     ),
-    ...report.stale.map(
-      reference =>
-        `${ticketLabel}: scenario ref ${reference} matches no AC under its JTBD (stale ref)`,
+    ...report.stale.map(reference =>
+      isRuleId(reference)
+        ? `${ticketLabel}: scenario ref ${reference} matches no numbered rule under its JTBD (stale ref) — retag to a declared rule or declare it in spec.md`
+        : `${ticketLabel}: scenario ref ${reference} matches no AC under its JTBD (stale ref)`,
     ),
-    ...report.orphan.map(
-      reference => `${ticketLabel}: scenario ref ${reference} names no JTBD in spec.md (orphan)`,
+    ...report.orphan.map(reference =>
+      isRuleId(reference)
+        ? `${ticketLabel}: scenario ref ${reference} names no JTBD in spec.md (orphan) — fix the tag's JTBD id or add that JTBD to spec.md`
+        : `${ticketLabel}: scenario ref ${reference} names no JTBD in spec.md (orphan)`,
     ),
   ];
 }

--- a/packages/cli/src/utils/gherkin-feature.test.ts
+++ b/packages/cli/src/utils/gherkin-feature.test.ts
@@ -5,6 +5,7 @@ import {
   findFeatureLineageIssues,
   findGherkinLintIssues,
   parseFeatureAcReferences,
+  parseFeatureRuleReferences,
   parseFeatureScenarios,
 } from './gherkin-feature.js';
 
@@ -288,8 +289,108 @@ describe('findFeatureLineageIssues', () => {
     );
 
     expect(issues).toEqual([
-      'Scenario "has no AC tag" is missing lineage; add exactly one @<jtbd>.AC# tag.',
-      'Scenario "carries two AC tags" has multiple lineage tags after inheritance (@demo.DEV1.AC1, @demo.DEV1.AC2); keep exactly one @<jtbd>.AC# tag.',
+      'Scenario "has no AC tag" is missing lineage; add exactly one @<jtbd>.AC# or @<jtbd>.R# tag.',
+      'Scenario "carries two AC tags" has multiple lineage tags after inheritance (@demo.DEV1.AC1, @demo.DEV1.AC2); keep exactly one @<jtbd>.AC# or @<jtbd>.R# tag.',
     ]);
+  });
+
+  it('rule-tier.TB2.AC1.accepts_inherited_rule_tag_as_single_lineage', () => {
+    const issues = findFeatureLineageIssues(
+      [
+        'Feature: Demo',
+        '',
+        '  @demo.DEV1.R1',
+        '  Rule: demo.DEV1.R1 — retries use exponential backoff',
+        '',
+        '    Scenario: inherits the rule tag',
+        '      Given a',
+        '      When b',
+        '      Then c',
+      ].join('\n'),
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  it('rule-tier.TB2.AC1.accepts_direct_rule_tag_on_scenario', () => {
+    const issues = findFeatureLineageIssues(
+      [
+        'Feature: Demo',
+        '',
+        '  Rule: grouping only',
+        '',
+        '    @demo.DEV1.R2',
+        '    Scenario: carries the rule tag directly',
+        '      Given a',
+        '      When b',
+        '      Then c',
+      ].join('\n'),
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  it('rule-tier.TB2.AC1.flags_second_lineage_ref_under_rule_tagged_block', () => {
+    const issues = findFeatureLineageIssues(
+      [
+        'Feature: Demo',
+        '',
+        '  @demo.DEV1.R1',
+        '  Rule: demo.DEV1.R1 — retries use exponential backoff',
+        '',
+        '    @demo.DEV1.AC1',
+        '    Scenario: adds an AC ref under a rule-tagged block',
+        '      Given a',
+        '      When b',
+        '      Then c',
+      ].join('\n'),
+    );
+
+    expect(issues).toEqual([
+      'Scenario "adds an AC ref under a rule-tagged block" has multiple lineage tags after inheritance (@demo.DEV1.R1, @demo.DEV1.AC1); keep exactly one @<jtbd>.AC# or @<jtbd>.R# tag.',
+    ]);
+  });
+});
+
+describe('parseFeatureRuleReferences', () => {
+  it('rule-tier.TB2.AC1.extracts_unique_rule_refs_from_inherited_tags', () => {
+    const references = parseFeatureRuleReferences(
+      [
+        'Feature: Demo',
+        '',
+        '  @demo.DEV1.R1',
+        '  Rule: demo.DEV1.R1 — retries use exponential backoff',
+        '',
+        '    Scenario: first example',
+        '      Given a',
+        '',
+        '    Scenario: second example',
+        '      Given b',
+        '',
+        '  Rule: grouping only',
+        '',
+        '    @demo.DEV1.R2',
+        '    Scenario: direct rule ref',
+        '      Given c',
+      ].join('\n'),
+    );
+
+    expect(references).toEqual(['demo.DEV1.R1', 'demo.DEV1.R2']);
+  });
+
+  it('rule-tier.TB2.AC1.ac_segment_wins_over_rule_shaped_prefix', () => {
+    const content = [
+      'Feature: Demo',
+      '',
+      '  Scenario: persona code R makes an AC tag look rule-shaped',
+      '    Given a scenario tagged with an AC of JTBD feat.R1',
+      '    When b',
+      '    Then c',
+    ].join('\n');
+    const tagged = content.replace('  Scenario:', '  @feat.R1.AC1\n  Scenario:');
+
+    expect(parseFeatureRuleReferences(tagged)).toEqual([]);
+    expect(parseFeatureAcReferences(tagged)).toEqual(['feat.R1.AC1']);
+    expect(findFeatureLineageIssues(tagged)).toEqual([]);
   });
 });

--- a/packages/cli/src/utils/gherkin-feature.test.ts
+++ b/packages/cli/src/utils/gherkin-feature.test.ts
@@ -292,6 +292,14 @@ describe('findGherkinLintIssues (rule tier — name-token/tag correspondence)', 
     expect(issues).toContainEqual(expect.objectContaining({ rule: 'rule-name-tag-mismatch' }));
   });
 
+  it('rule-tier.TB2.AC1.name_token_glued_to_em_dash_still_matches', () => {
+    const issues = findGherkinLintIssues(
+      ruleFeature('@demo.DEV1.R1', 'demo.DEV1.R1—retries use exponential backoff'),
+      { filePath: 'features/demo.feature' },
+    );
+    expect(issues.filter(issue => issue.rule === 'rule-name-tag-mismatch')).toEqual([]);
+  });
+
   it('rule-tier.TB2.AC1.unnumbered_rule_block_exempt_from_mismatch', () => {
     const issues = findGherkinLintIssues(ruleFeature('', 'plain grouping words'), {
       filePath: 'features/demo.feature',
@@ -430,6 +438,26 @@ describe('parseFeatureRuleReferences', () => {
     );
 
     expect(references).toEqual(['demo.DEV1.R1', 'demo.DEV1.R2']);
+  });
+
+  it('rule-tier.TB2.AC1.terminal_rule_segment_keeps_whole_id', () => {
+    // A persona code `R` JTBD (`feat.R1`) declaring rule R2: the tag's parsed id
+    // must be the whole `feat.R1.R2`, matching the spec-side declaration, not a
+    // lazy first-match `feat.R1`.
+    const content = [
+      'Feature: Demo',
+      '',
+      '  @feat.R1.R2',
+      '  Rule: feat.R1.R2 — invariant under a persona-code-R job',
+      '',
+      '    Scenario: example',
+      '      Given a',
+      '      When b',
+      '      Then c',
+    ].join('\n');
+
+    expect(parseFeatureRuleReferences(content)).toEqual(['feat.R1.R2']);
+    expect(findFeatureLineageIssues(content)).toEqual([]);
   });
 
   it('rule-tier.TB2.AC1.ac_segment_wins_over_rule_shaped_prefix', () => {

--- a/packages/cli/src/utils/gherkin-feature.test.ts
+++ b/packages/cli/src/utils/gherkin-feature.test.ts
@@ -246,6 +246,60 @@ describe('findGherkinLintIssues', () => {
   });
 });
 
+describe('findGherkinLintIssues (rule tier — name-token/tag correspondence)', () => {
+  function ruleFeature(tagLine: string, ruleName: string): string {
+    return [
+      'Feature: Demo',
+      '',
+      ...(tagLine === '' ? [] : [`  ${tagLine}`]),
+      `  Rule: ${ruleName}`,
+      '',
+      '    Scenario: example',
+      '      Given a',
+      '      When b',
+      '      Then c',
+      '',
+    ].join('\n');
+  }
+
+  it('rule-tier.TB2.AC1.rule_tag_matching_name_token_passes', () => {
+    const issues = findGherkinLintIssues(
+      ruleFeature('@demo.DEV1.R1', 'demo.DEV1.R1 — retries use exponential backoff'),
+      { filePath: 'features/demo.feature' },
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('rule-tier.TB2.AC1.rule_tag_disagreeing_with_name_token_flagged', () => {
+    const issues = findGherkinLintIssues(
+      ruleFeature('@demo.DEV1.R1', 'demo.DEV1.R2 — renamed without retagging'),
+      { filePath: 'features/demo.feature' },
+    );
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        line: 4,
+        message:
+          'Rule "demo.DEV1.R2 — renamed without retagging" is tagged @demo.DEV1.R1 but its name starts with a different id; make the name\'s first token match the tag.',
+        rule: 'rule-name-tag-mismatch',
+      }),
+    );
+  });
+
+  it('rule-tier.TB2.AC1.rule_tag_with_plain_name_flagged', () => {
+    const issues = findGherkinLintIssues(ruleFeature('@demo.DEV1.R1', 'plain grouping words'), {
+      filePath: 'features/demo.feature',
+    });
+    expect(issues).toContainEqual(expect.objectContaining({ rule: 'rule-name-tag-mismatch' }));
+  });
+
+  it('rule-tier.TB2.AC1.unnumbered_rule_block_exempt_from_mismatch', () => {
+    const issues = findGherkinLintIssues(ruleFeature('', 'plain grouping words'), {
+      filePath: 'features/demo.feature',
+    });
+    expect(issues).toEqual([]);
+  });
+});
+
 describe('findFeatureLineageIssues', () => {
   it('gherkin-linting.DEV1.AC2.accepts_one_effective_ac_tag_after_inheritance', () => {
     const issues = findFeatureLineageIssues(

--- a/packages/cli/src/utils/gherkin-feature.test.ts
+++ b/packages/cli/src/utils/gherkin-feature.test.ts
@@ -241,7 +241,7 @@ describe('findGherkinLintIssues', () => {
 
     expect(findGherkinLintIssues(content, { filePath: 'features/demo.feature' })).toEqual([]);
     expect(findFeatureLineageIssues(content)).toEqual([
-      'Scenario "has no lineage tag" is missing lineage; add exactly one @<jtbd>.AC# tag.',
+      'Scenario "has no lineage tag" is missing lineage; add exactly one @<jtbd>.AC# or @<jtbd>.R# tag.',
     ]);
   });
 });

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -324,7 +324,10 @@ function findDocumentLintIssues(feature: Feature): GherkinLintIssue[] {
   for (const child of feature.children) {
     if (child.scenario) scenarios.push(child.scenario);
     if (child.rule) {
-      issues.push(...findDuplicateTagIssues(child.rule.tags, `Rule "${child.rule.name}"`));
+      issues.push(
+        ...findDuplicateTagIssues(child.rule.tags, `Rule "${child.rule.name}"`),
+        ...findRuleNameTagIssues(child.rule),
+      );
       for (const ruleChild of child.rule.children) {
         if (ruleChild.scenario) scenarios.push(ruleChild.scenario);
       }
@@ -454,6 +457,32 @@ function collectPlaceholders(text: string, variables: Set<string>): void {
       start = -1;
     }
   }
+}
+
+/**
+ * A Rule block carrying a rule lineage tag must repeat that id as its name's
+ * first token (the tag is authoritative; the name token is the human-readable
+ * copy). Unnumbered grouping blocks carry no rule tag and are exempt.
+ */
+function findRuleNameTagIssues(rule: {
+  name: string;
+  tags: readonly Tag[];
+  location: { line: number };
+}): GherkinLintIssue[] {
+  const ruleReference = rule.tags
+    .map(tag => parseLineageReferenceFromTag(tag.name))
+    .find(reference => reference?.kind === 'rule');
+  if (ruleReference === undefined) return [];
+
+  const nameToken = rule.name.trim().split(/\s+/, 1)[0] ?? '';
+  if (nameToken === ruleReference.reference) return [];
+  return [
+    issue(
+      'rule-name-tag-mismatch',
+      `Rule "${rule.name}" is tagged @${ruleReference.reference} but its name starts with a different id; make the name's first token match the tag.`,
+      rule.location.line,
+    ),
+  ];
 }
 
 function findDuplicateTagIssues(tags: readonly Tag[], owner: string): GherkinLintIssue[] {

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -474,7 +474,10 @@ function findRuleNameTagIssues(rule: {
     .find(reference => reference?.kind === 'rule');
   if (ruleReference === undefined) return [];
 
-  const nameToken = rule.name.trim().split(/\s+/, 1)[0] ?? '';
+  // The id ends at the first whitespace or dash separator. Split on em/en dash
+  // too so a name glued as `demo.DEV1.R1—foo` still yields the id, not a false
+  // mismatch; a plain `-` stays part of the token (kebab slugs contain it).
+  const nameToken = rule.name.trim().split(/[\s—–]+/, 1)[0] ?? '';
   if (nameToken === ruleReference.reference) return [];
   return [
     issue(
@@ -553,7 +556,13 @@ function parseAcReferenceFromTag(tag: string): string | undefined {
 }
 
 function parseRuleReferenceFromTag(tag: string): string | undefined {
-  const match = /^@?(\S+?)\.R(\d+)(?:\.|$)/.exec(tag.trim());
+  // Anchor on the *terminal* `.R<n>` (greedy prefix) so the parsed id matches
+  // the spec-side declaration, which keeps the whole heading token
+  // (`scenario-coverage.ts` `isRuleId` = `/\.R\d+$/`). A lazy first-match would
+  // read `@feat.R1.R2` as `feat.R1` while the spec declares `feat.R1.R2`,
+  // splitting one corpus into a spurious uncovered+orphan pair. Rule tags carry
+  // no `.<scenario_name>` tail (unlike AC titles), so terminal anchoring is safe.
+  const match = /^@?(\S+)\.R(\d+)$/.exec(tag.trim());
   if (!match) return undefined;
   return `${match[1] ?? ''}.R${match[2] ?? ''}`;
 }

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -44,22 +44,30 @@ export function parseFeatureScenarios(featureContent: string): ParsedFeatureScen
 }
 
 export function parseFeatureAcReferences(featureContent: string): string[] {
-  return parseFeatureLineageReferences(featureContent, 'ac');
+  return parseFeatureLineageReferences(featureContent).ac;
 }
 
 export function parseFeatureRuleReferences(featureContent: string): string[] {
-  return parseFeatureLineageReferences(featureContent, 'rule');
+  return parseFeatureLineageReferences(featureContent).rule;
 }
 
-function parseFeatureLineageReferences(featureContent: string, kind: LineageKind): string[] {
-  const references = new Set<string>();
+/**
+ * The AC and numbered-Rule lineage references a feature's scenarios carry,
+ * split by kind, from a single `parseFeatureScenarios` pass. Callers that need
+ * both kinds (coverage) read them off one AST build instead of parsing twice.
+ */
+export function parseFeatureLineageReferences(featureContent: string): {
+  ac: string[];
+  rule: string[];
+} {
+  const byKind: Record<LineageKind, Set<string>> = { ac: new Set(), rule: new Set() };
   for (const scenario of parseFeatureScenarios(featureContent)) {
     for (const tag of scenario.tags) {
       const ref = parseLineageReferenceFromTag(tag);
-      if (ref?.kind === kind) references.add(ref.reference);
+      if (ref !== undefined) byKind[ref.kind].add(ref.reference);
     }
   }
-  return [...references];
+  return { ac: [...byKind.ac], rule: [...byKind.rule] };
 }
 
 export function findGherkinLintIssues(

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -512,7 +512,7 @@ function parseErrorLine(message: string): number | undefined {
 
 type LineageKind = 'ac' | 'rule';
 
-interface LineageReference {
+export interface LineageReference {
   kind: LineageKind;
   reference: string;
 }
@@ -532,7 +532,7 @@ function parseRuleReferenceFromTag(tag: string): string | undefined {
 /** Parse a tag's lineage reference. An AC match wins over a rule-shaped prefix
  * so persona codes like `R` stay unambiguous: `@feat.R1.AC1` is AC1 of JTBD
  * `feat.R1`, never rule `feat.R1`. */
-function parseLineageReferenceFromTag(tag: string): LineageReference | undefined {
+export function parseLineageReferenceFromTag(tag: string): LineageReference | undefined {
   const acReference = parseAcReferenceFromTag(tag);
   if (acReference !== undefined) return { kind: 'ac', reference: acReference };
   const ruleReference = parseRuleReferenceFromTag(tag);

--- a/packages/cli/src/utils/gherkin-feature.ts
+++ b/packages/cli/src/utils/gherkin-feature.ts
@@ -44,11 +44,19 @@ export function parseFeatureScenarios(featureContent: string): ParsedFeatureScen
 }
 
 export function parseFeatureAcReferences(featureContent: string): string[] {
+  return parseFeatureLineageReferences(featureContent, 'ac');
+}
+
+export function parseFeatureRuleReferences(featureContent: string): string[] {
+  return parseFeatureLineageReferences(featureContent, 'rule');
+}
+
+function parseFeatureLineageReferences(featureContent: string, kind: LineageKind): string[] {
   const references = new Set<string>();
   for (const scenario of parseFeatureScenarios(featureContent)) {
     for (const tag of scenario.tags) {
-      const ref = parseAcReferenceFromTag(tag);
-      if (ref !== undefined) references.add(ref);
+      const ref = parseLineageReferenceFromTag(tag);
+      if (ref?.kind === kind) references.add(ref.reference);
     }
   }
   return [...references];
@@ -83,14 +91,16 @@ export function findGherkinLintIssues(
 
 export function findFeatureLineageIssues(featureContent: string): string[] {
   return parseFeatureScenarios(featureContent).flatMap(scenario => {
-    const references = uniqueAcReferences(scenario.tags);
+    const references = uniqueLineageReferences(scenario.tags);
     if (references.length === 0) {
-      return [`Scenario "${scenario.title}" is missing lineage; add exactly one @<jtbd>.AC# tag.`];
+      return [
+        `Scenario "${scenario.title}" is missing lineage; add exactly one @<jtbd>.AC# or @<jtbd>.R# tag.`,
+      ];
     }
     if (references.length > 1) {
       const tagList = references.map(reference => `@${reference}`).join(', ');
       return [
-        `Scenario "${scenario.title}" has multiple lineage tags after inheritance (${tagList}); keep exactly one @<jtbd>.AC# tag.`,
+        `Scenario "${scenario.title}" has multiple lineage tags after inheritance (${tagList}); keep exactly one @<jtbd>.AC# or @<jtbd>.R# tag.`,
       ];
     }
     return [];
@@ -500,17 +510,41 @@ function parseErrorLine(message: string): number | undefined {
   return match?.[1] === undefined ? undefined : Number(match[1]);
 }
 
+type LineageKind = 'ac' | 'rule';
+
+interface LineageReference {
+  kind: LineageKind;
+  reference: string;
+}
+
 function parseAcReferenceFromTag(tag: string): string | undefined {
   const match = /^@?(\S+?)\.AC(\d+)(?:\.|$)/.exec(tag.trim());
   if (!match) return undefined;
   return `${match[1] ?? ''}.AC${match[2] ?? ''}`;
 }
 
-function uniqueAcReferences(tags: readonly string[]): string[] {
+function parseRuleReferenceFromTag(tag: string): string | undefined {
+  const match = /^@?(\S+?)\.R(\d+)(?:\.|$)/.exec(tag.trim());
+  if (!match) return undefined;
+  return `${match[1] ?? ''}.R${match[2] ?? ''}`;
+}
+
+/** Parse a tag's lineage reference. An AC match wins over a rule-shaped prefix
+ * so persona codes like `R` stay unambiguous: `@feat.R1.AC1` is AC1 of JTBD
+ * `feat.R1`, never rule `feat.R1`. */
+function parseLineageReferenceFromTag(tag: string): LineageReference | undefined {
+  const acReference = parseAcReferenceFromTag(tag);
+  if (acReference !== undefined) return { kind: 'ac', reference: acReference };
+  const ruleReference = parseRuleReferenceFromTag(tag);
+  if (ruleReference !== undefined) return { kind: 'rule', reference: ruleReference };
+  return undefined;
+}
+
+function uniqueLineageReferences(tags: readonly string[]): string[] {
   const references = new Set<string>();
   for (const tag of tags) {
-    const ref = parseAcReferenceFromTag(tag);
-    if (ref !== undefined) references.add(ref);
+    const ref = parseLineageReferenceFromTag(tag);
+    if (ref !== undefined) references.add(ref.reference);
   }
   return [...references];
 }

--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -216,6 +216,17 @@ describe('buildCoverageReportFromFeature (feature files as source)', () => {
     expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
   });
 
+  it('rule-tier.TB2.AC1.persona_code_r_rule_resolves_whole_id', () => {
+    // JTBD `feat.R1` (persona code R, job 1) declaring rule R2 → id `feat.R1.R2`.
+    // The tag `@feat.R1.R2` must resolve to that declared rule, not split into a
+    // spurious uncovered rule + orphan ref.
+    const personaRSpec = spec(
+      '### feat.R1 — Review\n\n**Persona:** R\n\n#### feat.R1.R2 — an invariant',
+    );
+    const report = buildCoverageReportFromFeature(personaRSpec, feature(['feat.R1.R2']));
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
   it('rule-tier.TB2.AC1.ac_segment_ref_attributed_to_ac_not_rule', () => {
     const personaRSpec = spec(
       '### feat.R1 — Review\n\n**Persona:** R\n\n#### feat.R1.AC1 — reviewable',

--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -17,9 +17,11 @@ import {
   buildCoverageReport,
   buildCoverageReportFromFeature,
   buildSurfaceCoverageReportFromFeature,
+  findMixedCriteriaJtbds,
   parseAcIdsByJtbd,
   parseAcReferenceFromTitle,
   parseAffectedSurfaceReferences,
+  parseCriteriaIdsByJtbd,
 } from './scenario-coverage.js';
 
 /** Wrap a JTBD/AC body in a minimal spec.md with the required section heading. */
@@ -40,6 +42,9 @@ function testDefinitions(titles: readonly string[]): string {
 
 const ONE_AC = '### demo.DEV1 — Trace\n\n**Persona:** DEV\n\n#### demo.DEV1.AC1 — capability one';
 const TWO_ACS = `${ONE_AC}\n\n#### demo.DEV1.AC2 — capability two`;
+const ONE_RULE =
+  '### demo.DEV2 — Retry\n\n**Persona:** DEV\n\n#### demo.DEV2.R1 — failed deliveries retry on backoff';
+const MIXED = `${ONE_AC}\n\n#### demo.DEV1.R1 — an invariant slipped in beside the AC`;
 
 describe('parseAcReferenceFromTitle (R1 — title parses to its AC reference, or none)', () => {
   it('cross-reference-numbering.DEV1.AC1.conformant_title_yields_ac_ref', () => {
@@ -67,6 +72,40 @@ describe('parseAcIdsByJtbd (supporting — AC ids grouped by JTBD)', () => {
   it('ignores an HTML-commented example AC', () => {
     const byJtbd = parseAcIdsByJtbd(spec('<!--\n### ex.DEV1 — t\n\n#### ex.DEV1.AC1 — a\n-->'));
     expect(byJtbd.size).toBe(0);
+  });
+});
+
+describe('parseCriteriaIdsByJtbd (rule tier — AC vs R heading classification)', () => {
+  it('rule-tier.TB3.AC1.groups_rule_ids_separately_from_ac_ids', () => {
+    const byJtbd = parseCriteriaIdsByJtbd(spec(`${TWO_ACS}\n\n${ONE_RULE}`));
+    expect(byJtbd.get('demo.DEV1')).toEqual({
+      acIds: ['demo.DEV1.AC1', 'demo.DEV1.AC2'],
+      ruleIds: [],
+    });
+    expect(byJtbd.get('demo.DEV2')).toEqual({ acIds: [], ruleIds: ['demo.DEV2.R1'] });
+  });
+
+  it('rule-tier.TB3.AC1.ac_shaped_heading_wins_over_rule_shaped_prefix', () => {
+    // Persona code `R`: feat.R1 is the JTBD id, its heading declares an AC.
+    const byJtbd = parseCriteriaIdsByJtbd(
+      spec('### feat.R1 — Review\n\n**Persona:** R\n\n#### feat.R1.AC1 — reviewable'),
+    );
+    expect(byJtbd.get('feat.R1')).toEqual({ acIds: ['feat.R1.AC1'], ruleIds: [] });
+  });
+
+  it('rule-tier.TB1.AC3.parse_ac_ids_no_longer_counts_rule_headings', () => {
+    const byJtbd = parseAcIdsByJtbd(spec(ONE_RULE));
+    expect(byJtbd.get('demo.DEV2')).toEqual([]);
+  });
+});
+
+describe('findMixedCriteriaJtbds (rule tier — one criteria kind per JTBD)', () => {
+  it('rule-tier.TB1.AC4.mixed_jtbd_detected', () => {
+    expect(findMixedCriteriaJtbds(spec(MIXED))).toEqual(['demo.DEV1']);
+  });
+
+  it('rule-tier.TB1.AC4.single_kind_jtbds_not_mixed', () => {
+    expect(findMixedCriteriaJtbds(spec(`${TWO_ACS}\n\n${ONE_RULE}`))).toEqual([]);
   });
 });
 

--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -186,6 +186,42 @@ describe('buildCoverageReportFromFeature (feature files as source)', () => {
     expect(report.stale).toEqual(['demo.DEV1.AC5']);
     expect(report.orphan).toEqual(['ghost.SM1.AC1']);
   });
+
+  it('rule-tier.TB3.AC1.uncovered_spec_rule_flagged', () => {
+    const report = buildCoverageReportFromFeature(spec(ONE_RULE), feature(['other.SM1.AC1']));
+    expect(report.uncovered).toEqual(['demo.DEV2.R1']);
+  });
+
+  it('rule-tier.TB3.AC1.stale_rule_ref_flagged', () => {
+    const report = buildCoverageReportFromFeature(spec(ONE_RULE), feature(['demo.DEV2.R5']));
+    expect(report.stale).toEqual(['demo.DEV2.R5']);
+    expect(report.orphan).toEqual([]);
+  });
+
+  it('rule-tier.TB3.AC1.orphan_rule_ref_flagged', () => {
+    const report = buildCoverageReportFromFeature(spec(ONE_RULE), feature(['ghost.SM1.R1']));
+    expect(report.orphan).toEqual(['ghost.SM1.R1']);
+    expect(report.stale).toEqual([]);
+  });
+
+  it('rule-tier.TB4.AC1.rule_numbered_corpus_fully_resolves', () => {
+    const corpusSpec = spec(
+      `${ONE_RULE}\n\n#### demo.DEV2.R2 — deliveries stop after the retry budget`,
+    );
+    const report = buildCoverageReportFromFeature(
+      corpusSpec,
+      feature(['demo.DEV2.R1', 'demo.DEV2.R2']),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('rule-tier.TB2.AC1.ac_segment_ref_attributed_to_ac_not_rule', () => {
+    const personaRSpec = spec(
+      '### feat.R1 — Review\n\n**Persona:** R\n\n#### feat.R1.AC1 — reviewable',
+    );
+    const report = buildCoverageReportFromFeature(personaRSpec, feature(['feat.R1.AC1']));
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
 });
 
 describe('buildCoverageReport (R3 — quiet degradation)', () => {

--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -18,6 +18,7 @@ import {
   buildCoverageReportFromFeature,
   buildSurfaceCoverageReportFromFeature,
   findMixedCriteriaJtbds,
+  findRulesMissingRejectionPaths,
   parseAcIdsByJtbd,
   parseAcReferenceFromTitle,
   parseAffectedSurfaceReferences,
@@ -221,6 +222,70 @@ describe('buildCoverageReportFromFeature (feature files as source)', () => {
     );
     const report = buildCoverageReportFromFeature(personaRSpec, feature(['feat.R1.AC1']));
     expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+});
+
+describe('findRulesMissingRejectionPaths (rule tier — rejection-path visibility)', () => {
+  function toTagLine(tags: readonly string[]): string {
+    return tags.map(tag => `@${tag}`).join(' ');
+  }
+
+  function featureWithScenarios(
+    scenarios: readonly { tags: readonly string[]; title: string }[],
+    ruleLine = '  Rule: demo.DEV2.R1 — failed deliveries retry on backoff',
+  ): string {
+    return [
+      'Feature: Demo',
+      '',
+      ruleLine,
+      '',
+      ...scenarios.flatMap(({ tags, title }) => [
+        ...(tags.length > 0 ? [`    ${toTagLine(tags)}`] : []),
+        `    Scenario: ${title}`,
+        '      Given a',
+        '      When b',
+        '      Then c',
+        '',
+      ]),
+    ].join('\n');
+  }
+
+  it('rule-tier.TB1.AC2.numbered_rule_without_rejection_scenario_flagged', () => {
+    const missing = findRulesMissingRejectionPaths(
+      spec(ONE_RULE),
+      featureWithScenarios([{ tags: ['demo.DEV2.R1'], title: 'happy path only' }]),
+    );
+    expect(missing).toEqual(['demo.DEV2.R1']);
+  });
+
+  it('rule-tier.TB1.AC2.numbered_rule_with_rejection_scenario_silent', () => {
+    const missing = findRulesMissingRejectionPaths(
+      spec(ONE_RULE),
+      featureWithScenarios([
+        { tags: ['demo.DEV2.R1'], title: 'happy path' },
+        { tags: ['demo.DEV2.R1', 'rejection'], title: 'refused when budget exhausted' },
+      ]),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('rule-tier.TB1.AC2.unnumbered_rule_block_exempt', () => {
+    const missing = findRulesMissingRejectionPaths(
+      spec(ONE_AC),
+      featureWithScenarios(
+        [{ tags: ['demo.DEV1.AC1'], title: 'flat lineage under a grouping header' }],
+        '  Rule: plain grouping header',
+      ),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('rule-tier.TB1.AC2.rule_with_no_scenarios_left_to_uncovered_bucket', () => {
+    const missing = findRulesMissingRejectionPaths(
+      spec(ONE_RULE),
+      featureWithScenarios([{ tags: ['other.SM1.AC1'], title: 'unrelated scenario' }]),
+    );
+    expect(missing).toEqual([]);
   });
 });
 

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -17,7 +17,11 @@
  * No I/O — callers pass file content; check.ts owns ticket discovery.
  */
 
-import { parseFeatureAcReferences, parseFeatureScenarios } from './gherkin-feature.js';
+import {
+  parseFeatureAcReferences,
+  parseFeatureRuleReferences,
+  parseFeatureScenarios,
+} from './gherkin-feature.js';
 import { computeSkipMask, parseHeading } from './markdown-sections.js';
 
 const JTBD_HEADING = 'jobs to be done';
@@ -177,7 +181,12 @@ export function buildCoverageReportFromFeature(
 ): CoverageReport {
   return buildCoverageReportFromReferences(
     specContent,
-    featureContent === undefined ? undefined : parseFeatureAcReferences(featureContent),
+    featureContent === undefined
+      ? undefined
+      : [
+          ...parseFeatureAcReferences(featureContent),
+          ...parseFeatureRuleReferences(featureContent),
+        ],
   );
 }
 
@@ -341,11 +350,13 @@ function buildCoverageReportFromReferences(
   specContent: string,
   scenarioReferences?: readonly string[],
 ): CoverageReport {
-  const byJtbd = parseAcIdsByJtbd(specContent);
-  const knownAcIds = new Set<string>();
-  for (const acIds of byJtbd.values()) for (const id of acIds) knownAcIds.add(id);
+  const byJtbd = parseCriteriaIdsByJtbd(specContent);
+  const knownIds = new Set<string>();
+  for (const criteria of byJtbd.values()) {
+    for (const id of [...criteria.acIds, ...criteria.ruleIds]) knownIds.add(id);
+  }
 
-  if (knownAcIds.size === 0) return { ...EMPTY_REPORT };
+  if (knownIds.size === 0) return { ...EMPTY_REPORT };
   if (scenarioReferences === undefined) return { ...EMPTY_REPORT };
 
   const knownJtbds = new Set(byJtbd.keys());
@@ -354,7 +365,7 @@ function buildCoverageReportFromReferences(
   const orphan = new Set<string>();
 
   for (const reference of scenarioReferences) {
-    if (knownAcIds.has(reference)) {
+    if (knownIds.has(reference)) {
       covered.add(reference);
     } else if (knownJtbds.has(jtbdPart(reference))) {
       stale.add(reference);
@@ -364,7 +375,7 @@ function buildCoverageReportFromReferences(
   }
 
   return {
-    uncovered: [...knownAcIds].filter(id => !covered.has(id)),
+    uncovered: [...knownIds].filter(id => !covered.has(id)),
     stale: [...stale],
     orphan: [...orphan],
   };
@@ -377,9 +388,9 @@ function appendCriterion(byJtbd: Map<string, JtbdCriteria>, jtbd: string, id: st
   byJtbd.set(jtbd, criteria);
 }
 
-/** Strip the trailing `.AC<#>` segment to recover the JTBD id of a reference. */
+/** Strip the trailing `.AC<#>` or `.R<#>` segment to recover the JTBD id of a reference. */
 function jtbdPart(reference: string): string {
-  return reference.replace(/\.AC\d+$/, '');
+  return reference.replace(/\.(?:AC|R)\d+$/, '');
 }
 
 /**

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -18,8 +18,7 @@
  */
 
 import {
-  parseFeatureAcReferences,
-  parseFeatureRuleReferences,
+  parseFeatureLineageReferences,
   parseFeatureScenarios,
   parseLineageReferenceFromTag,
 } from './gherkin-feature.js';
@@ -229,15 +228,9 @@ export function buildCoverageReportFromFeature(
   specContent: string,
   featureContent?: string,
 ): CoverageReport {
-  return buildCoverageReportFromReferences(
-    specContent,
-    featureContent === undefined
-      ? undefined
-      : [
-          ...parseFeatureAcReferences(featureContent),
-          ...parseFeatureRuleReferences(featureContent),
-        ],
-  );
+  if (featureContent === undefined) return buildCoverageReportFromReferences(specContent);
+  const { ac, rule } = parseFeatureLineageReferences(featureContent);
+  return buildCoverageReportFromReferences(specContent, [...ac, ...rule]);
 }
 
 export function buildSurfaceCoverageReportFromFeature(

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -21,6 +21,7 @@ import {
   parseFeatureAcReferences,
   parseFeatureRuleReferences,
   parseFeatureScenarios,
+  parseLineageReferenceFromTag,
 } from './gherkin-feature.js';
 import { computeSkipMask, parseHeading } from './markdown-sections.js';
 
@@ -113,6 +114,55 @@ export function parseCriteriaIdsByJtbd(specContent: string): Map<string, JtbdCri
   }
 
   return byJtbd;
+}
+
+const REJECTION_TAG = '@rejection';
+
+/**
+ * Spec-declared numbered Rules that have at least one referencing scenario but
+ * none tagged `@rejection`. A rule with no scenarios at all is the uncovered
+ * bucket's finding, not noise here; unnumbered `Rule:` grouping blocks declare
+ * no rule id, so they are exempt by construction.
+ */
+export function findRulesMissingRejectionPaths(
+  specContent: string,
+  featureContent: string,
+): string[] {
+  const declared = declaredRuleIds(specContent);
+  if (declared.size === 0) return [];
+
+  const hasRejectionByRule = new Map<string, boolean>();
+  for (const scenario of parseFeatureScenarios(featureContent)) {
+    recordRuleRejections(scenario.tags, declared, hasRejectionByRule);
+  }
+
+  return [...declared].filter(id => hasRejectionByRule.get(id) === false);
+}
+
+/** Every numbered-Rule id declared across the spec's JTBDs. */
+function declaredRuleIds(specContent: string): Set<string> {
+  const declared = new Set<string>();
+  for (const criteria of parseCriteriaIdsByJtbd(specContent).values()) {
+    for (const id of criteria.ruleIds) declared.add(id);
+  }
+  return declared;
+}
+
+/** Fold one scenario's rule refs into the rule → has-rejection-scenario map. */
+function recordRuleRejections(
+  tags: readonly string[],
+  declared: ReadonlySet<string>,
+  hasRejectionByRule: Map<string, boolean>,
+): void {
+  const isRejection = tags.includes(REJECTION_TAG);
+  for (const tag of tags) {
+    const ref = parseLineageReferenceFromTag(tag);
+    if (ref?.kind !== 'rule' || !declared.has(ref.reference)) continue;
+    hasRejectionByRule.set(
+      ref.reference,
+      (hasRejectionByRule.get(ref.reference) ?? false) || isRejection,
+    );
+  }
 }
 
 /** JTBD ids declaring both ACs and numbered Rules — one criteria kind per job. */

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -81,10 +81,24 @@ interface WalkState {
   currentJtbd: string | undefined;
 }
 
+/** A JTBD's declared criteria, split by kind (ticket V0NHT6 rule tier). */
+export interface JtbdCriteria {
+  acIds: string[];
+  ruleIds: string[];
+}
+
 export function parseAcIdsByJtbd(specContent: string): Map<string, string[]> {
+  const byJtbd = new Map<string, string[]>();
+  for (const [jtbd, criteria] of parseCriteriaIdsByJtbd(specContent)) {
+    byJtbd.set(jtbd, criteria.acIds);
+  }
+  return byJtbd;
+}
+
+export function parseCriteriaIdsByJtbd(specContent: string): Map<string, JtbdCriteria> {
   const lines = specContent.split('\n');
   const skip = computeSkipMask(lines);
-  const byJtbd = new Map<string, string[]>();
+  const byJtbd = new Map<string, JtbdCriteria>();
   let state: WalkState = { inSection: false, currentJtbd: undefined };
 
   for (const [index, line] of lines.entries()) {
@@ -97,11 +111,18 @@ export function parseAcIdsByJtbd(specContent: string): Map<string, string[]> {
   return byJtbd;
 }
 
-/** Apply one heading to the JTBD/AC walk, recording ACs into `byJtbd`. */
+/** JTBD ids declaring both ACs and numbered Rules — one criteria kind per job. */
+export function findMixedCriteriaJtbds(specContent: string): string[] {
+  return [...parseCriteriaIdsByJtbd(specContent)]
+    .filter(([, criteria]) => criteria.acIds.length > 0 && criteria.ruleIds.length > 0)
+    .map(([jtbd]) => jtbd);
+}
+
+/** Apply one heading to the JTBD/criteria walk, recording ids into `byJtbd`. */
 function advance(
   state: WalkState,
   heading: { level: number; text: string },
-  byJtbd: Map<string, string[]>,
+  byJtbd: Map<string, JtbdCriteria>,
 ): WalkState {
   if (heading.level <= 2) {
     return { inSection: heading.text.toLowerCase() === JTBD_HEADING, currentJtbd: undefined };
@@ -109,13 +130,23 @@ function advance(
   if (!state.inSection) return state;
   if (heading.level === 3) {
     const currentJtbd = firstToken(heading.text);
-    if (!byJtbd.has(currentJtbd)) byJtbd.set(currentJtbd, []);
+    if (!byJtbd.has(currentJtbd)) byJtbd.set(currentJtbd, { acIds: [], ruleIds: [] });
     return { inSection: true, currentJtbd };
   }
   if (state.currentJtbd !== undefined) {
-    appendAc(byJtbd, state.currentJtbd, firstToken(heading.text));
+    appendCriterion(byJtbd, state.currentJtbd, firstToken(heading.text));
   }
   return state;
+}
+
+/**
+ * A terminal `.R<n>` id is a numbered Rule; everything else (including the
+ * `.AC<n>`-terminated ids and legacy free-form headings) stays an AC, so an
+ * AC-shaped id wins over a rule-shaped prefix (`feat.R1.AC1` is an AC of
+ * JTBD `feat.R1`).
+ */
+function isRuleId(id: string): boolean {
+  return /\.R\d+$/.test(id);
 }
 
 const EMPTY_REPORT: CoverageReport = { uncovered: [], stale: [], orphan: [] };
@@ -339,11 +370,11 @@ function buildCoverageReportFromReferences(
   };
 }
 
-/** Append an AC id to a JTBD's list, creating the list on first use. */
-function appendAc(byJtbd: Map<string, string[]>, jtbd: string, acId: string): void {
-  const acIds = byJtbd.get(jtbd) ?? [];
-  acIds.push(acId);
-  byJtbd.set(jtbd, acIds);
+/** Append a criterion id to a JTBD's criteria by kind, creating the entry on first use. */
+function appendCriterion(byJtbd: Map<string, JtbdCriteria>, jtbd: string, id: string): void {
+  const criteria = byJtbd.get(jtbd) ?? { acIds: [], ruleIds: [] };
+  (isRuleId(id) ? criteria.ruleIds : criteria.acIds).push(id);
+  byJtbd.set(jtbd, criteria);
 }
 
 /** Strip the trailing `.AC<#>` segment to recover the JTBD id of a reference. */

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -199,7 +199,7 @@ function advance(
  * AC-shaped id wins over a rule-shaped prefix (`feat.R1.AC1` is an AC of
  * JTBD `feat.R1`).
  */
-function isRuleId(id: string): boolean {
+export function isRuleId(id: string): boolean {
   return /\.R\d+$/.test(id);
 }
 

--- a/packages/cli/templates/hooks/lib/jtbd.ts
+++ b/packages/cli/templates/hooks/lib/jtbd.ts
@@ -231,7 +231,7 @@ export function evaluateAcGate(specContent: string): JtbdGateVerdict {
     if (block.acCount === 0) {
       return {
         ok: false,
-        reason: `JTBD "${block.heading}" has no acceptance criteria — add ≥1 \`#### <id>.AC<n>\` or \`skip: <reason>\``,
+        reason: `JTBD "${block.heading}" has no acceptance criteria or numbered rules — add ≥1 \`#### <id>.AC<n>\`, ≥1 \`#### <id>.R<n>\`, or \`skip: <reason>\``,
       };
     }
   }

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -95,6 +95,7 @@ Once the JTBDs are confirmed, decompose each into **Acceptance Criteria** — th
 
 - A `#### <jtbd-id>.AC<n> — <capability>` heading (e.g., `### oauth-flow.PO1` → `#### oauth-flow.PO1.AC1 — old key keeps working for a bounded grace window`).
 - Each JTBD needs **≥1 AC**, or a `skip: <reason>` under it for a job with no user-observable capability to enumerate. The intake-exit gate enforces this (denies `test-definitions.md` until every JTBD has an AC or a skip).
+- Alternative tier: a JTBD whose behavior is best stated as invariants may declare **numbered Rules** (`#### <jtbd-id>.R<n> — <invariant>`) instead of ACs — one criteria kind per job, never both. The gate accepts either; the full rule grammar lives in the bdd skill's SCENARIOS.md.
 
 **Coaching — keep ACs at the capability level, not implementation:**
 

--- a/packages/cli/templates/skills/bdd/SCENARIOS.md
+++ b/packages/cli/templates/skills/bdd/SCENARIOS.md
@@ -154,6 +154,36 @@ as advisories (never a gate):
   or an AC that was renumbered).
 - **orphan** — a scenario whose JTBD is absent from `spec.md` entirely.
 
+### Numbered Rules (optional third tier)
+
+A JTBD may declare **numbered Rules** instead of ACs — testable business
+invariants with stable per-JTBD IDs, stated generally and illustrated by the
+scenarios nested under them. Declaring them is the opt-in; there is no config
+flag, and a JTBD carries one criteria kind, never both (`safeword check` flags a
+mixed job as an issue).
+
+- **Spec catalog:** `#### <jtbd-id>.R<n> — <invariant>` headings under the JTBD,
+  exactly where AC headings sit (e.g. `#### webhook-retry.PO1.R1 — a failed
+delivery retries on exponential backoff`). IDs are 1-indexed per job and
+  numbering-locked after review — renumbering breaks references on purpose.
+- **Feature file:** the `Rule:` block carries the literal `@<jtbd-id>.R<n>` tag
+  (authoritative — scenarios inherit it as their single lineage ref) and repeats
+  the ID as its name's first token for readability; a mismatch is a lint issue.
+  An AC-shaped tag always wins the ref parse, so persona code `R` stays safe
+  (`@feat.R1.AC1` is an AC of JTBD `feat.R1`).
+- **Rejection paths:** tag at least one scenario per rule `@rejection` (the
+  example proving the system refuses when the invariant is violated); a numbered
+  rule without one draws a check advisory. Unnumbered `Rule:` grouping headers
+  are exempt from all of this.
+- **Selection:** `cucumber-js --tags @<jtbd-id>.R<n>` runs exactly that rule's
+  examples.
+- **Coverage:** the uncovered / stale ref / orphan advisories work for rule refs
+  exactly as for AC refs.
+- **Migrating a rule-numbered corpus** (e.g. Arcade-style split tags): the Rule
+  blocks, IDs, and nesting survive as-is; respell tags mechanically —
+  `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
+  block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
+
 ### Define Behavior Exit (REQUIRED)
 
 1. **Save scenarios** to `features/<slug>.feature`

--- a/packages/cli/templates/spec-template.md
+++ b/packages/cli/templates/spec-template.md
@@ -82,6 +82,10 @@ implementation ("returns 204" belongs in a scenario's Then). Each define-behavio
 scenario will prove a specific AC. If a JTBD has no user-observable capability
 to enumerate, write `skip: <reason>` under it instead of ACs.
 
+Alternative: a JTBD may instead declare numbered Rules — testable business
+invariants with stable ids (#### <jtbd-id>.R<n> — <invariant>) that scenarios
+nest under. One criteria kind per JTBD, never both.
+
 #### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
 
 #### oauth-flow.PO1.AC2 — The operator can see which keys are currently live

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -933,6 +933,114 @@ describe('Test Suite 8: Health Check', () => {
       expect(combined).toMatch(/trace-thing \(COV003\):.*demo\.DEV1\.AC2.*uncovered/i);
     });
 
+    const SPEC_ONE_RULE = [
+      '# Spec',
+      '',
+      '## Jobs To Be Done',
+      '',
+      '### demo.DEV2 — Retry',
+      '',
+      '**Persona:** DEV',
+      '',
+      '#### demo.DEV2.R1 — failed deliveries retry on backoff',
+      '',
+    ].join('\n');
+
+    function ruleTagLine(tags: readonly string[]): string {
+      return tags.map(tag => `@${tag}`).join(' ');
+    }
+
+    function ruleFeature(scenarioTags: readonly string[][]): string {
+      return [
+        'Feature: Demo',
+        '',
+        '  Rule: demo.DEV2.R1 — failed deliveries retry on backoff',
+        '',
+        ...scenarioTags.flatMap((tags, index) => [
+          `    ${ruleTagLine(tags)}`,
+          `    Scenario: example ${index + 1}`,
+          '      Given a',
+          '      When b',
+          '      Then c',
+          '',
+        ]),
+      ].join('\n');
+    }
+
+    it('rule-tier.TB3.AC1: reports uncovered, stale, and orphan rule refs as advisories', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTicket('RUL001-demo', 'in_progress', {
+        'spec.md': SPEC_ONE_RULE,
+        'test-definitions.md': scenarioTitle('ledger only'),
+      });
+      writeTestFile(
+        temporaryDirectory,
+        'features/demo.feature',
+        ruleFeature([['demo.DEV2.R5'], ['ghost.SM1.R1']]),
+      );
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).toMatch(
+        /numbered rule demo\.DEV2\.R1 has no scenario illustrating it \(uncovered\) — add a scenario tagged @demo\.DEV2\.R1/,
+      );
+      expect(combined).toMatch(/scenario ref demo\.DEV2\.R5 matches no numbered rule.*stale ref/);
+      expect(combined).toMatch(/scenario ref ghost\.SM1\.R1 names no JTBD.*orphan/);
+    });
+
+    it('rule-tier.TB1.AC2: reports a numbered rule with no rejection-path scenario, silently passing covered rules', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTicket('RUL002-demo', 'in_progress', {
+        'spec.md': SPEC_ONE_RULE,
+        'test-definitions.md': scenarioTitle('ledger only'),
+      });
+      writeTestFile(temporaryDirectory, 'features/demo.feature', ruleFeature([['demo.DEV2.R1']]));
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).toMatch(
+        /numbered rule demo\.DEV2\.R1 has no example of the rule being broken — add a @rejection-tagged scenario under it/,
+      );
+    });
+
+    it('rule-tier.TB1.AC2: stays silent when the rule has a rejection-path scenario', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTicket('RUL003-demo', 'in_progress', {
+        'spec.md': SPEC_ONE_RULE,
+        'test-definitions.md': scenarioTitle('ledger only'),
+      });
+      writeTestFile(
+        temporaryDirectory,
+        'features/demo.feature',
+        ruleFeature([['demo.DEV2.R1'], ['demo.DEV2.R1', 'rejection']]),
+      );
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).not.toMatch(/no example of the rule being broken/);
+    });
+
+    it('rule-tier.TB1.AC4: flags a JTBD declaring both ACs and numbered Rules as a check issue', async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTicket('RUL004-demo', 'in_progress', {
+        'spec.md': [SPEC_TWO_ACS, '#### demo.DEV1.R1 — an invariant beside the ACs', ''].join('\n'),
+        'test-definitions.md': scenarioTitle('demo.DEV1.AC1.happy_path'),
+      });
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(1);
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).toMatch(
+        /JTBD demo\.DEV1 declares both Acceptance Criteria and numbered Rules; keep one criteria kind per job — convert one set or split the job/,
+      );
+    });
+
     it('stays silent for a done ticket whose scenarios predate the scheme', async () => {
       await createConfiguredProject(temporaryDirectory);
       writeTicket('COV002', 'done', {

--- a/packages/cli/tests/hooks/ac-gate.test.ts
+++ b/packages/cli/tests/hooks/ac-gate.test.ts
@@ -59,3 +59,40 @@ describe('evaluateAcGate', () => {
     expect(evaluateAcGate(spec('skip: internal plumbing — no persona-facing job\n')).ok).toBe(true);
   });
 });
+
+describe('evaluateAcGate (rule tier — V0NHT6)', () => {
+  it('rule-tier.TB1.AC1.r_only_jtbd_passes_the_gate', () => {
+    expect(
+      evaluateAcGate(
+        spec(`${JTBD1}\n#### demo.PO1.R1 — a delivery that fails retries on backoff\n`),
+      ).ok,
+    ).toBe(true);
+  });
+
+  it('rule-tier.TB1.AC1.denial_names_numbered_rules_as_an_option', () => {
+    const verdict = evaluateAcGate(spec(JTBD1));
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toContain('demo.PO1');
+      expect(verdict.reason).toContain('numbered rules');
+      expect(verdict.reason).toContain('#### <id>.R<n>');
+    }
+  });
+
+  it('rule-tier.TB1.AC1.skip_line_still_passes_the_gate', () => {
+    expect(
+      evaluateAcGate(spec(`${JTBD1}\nskip: internal plumbing — no user-observable capability\n`))
+        .ok,
+    ).toBe(true);
+  });
+
+  it('rule-tier.TB1.AC4.mixed_jtbd_still_passes_the_gate', () => {
+    expect(
+      evaluateAcGate(
+        spec(
+          `${JTBD1}\n#### demo.PO1.AC1 — old key keeps working briefly\n\n#### demo.PO1.R1 — an invariant beside the AC\n`,
+        ),
+      ).ok,
+    ).toBe(true);
+  });
+});

--- a/packages/cli/tests/integration/cucumber-bdd.test.ts
+++ b/packages/cli/tests/integration/cucumber-bdd.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import nodeOs from 'node:os';
 import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -30,6 +31,62 @@ describe('cucumber-js acceptance lane (SM1.AC1)', () => {
       expect(result.status, output).toBe(0);
       expect(output).toMatch(/\b[1-9]\d* scenarios? \([1-9]\d* skipped\)/);
       expect(output).not.toMatch(/undefined|ambiguous|pending|passed/);
+    },
+    TIMEOUT_ACCEPTANCE_LANE,
+  );
+
+  it(
+    'rule-tier.TB2.AC1.tag_expression_on_a_rule_id_selects_exactly_that_rules_scenarios',
+    () => {
+      const fixtureDirectory = mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'rule-tag-'));
+      try {
+        const featurePath = nodePath.join(fixtureDirectory, 'demo.feature');
+        writeFileSync(
+          featurePath,
+          [
+            'Feature: Demo',
+            '',
+            '  @demo.DEV2.R1',
+            '  Rule: demo.DEV2.R1 — retries use exponential backoff',
+            '',
+            '    Scenario: first retry after one minute',
+            '      Given a failed delivery',
+            '',
+            '    Scenario: second retry doubles the wait',
+            '      Given a failed delivery',
+            '',
+            '  @demo.DEV2.R2',
+            '  Rule: demo.DEV2.R2 — deliveries stop after the retry budget',
+            '',
+            '    Scenario: delivery abandoned after final retry',
+            '      Given an exhausted budget',
+            '',
+          ].join('\n'),
+        );
+
+        const result = spawnSync(
+          'bunx',
+          [
+            'cucumber-js',
+            '--dry-run',
+            '--format',
+            'summary',
+            '--tags',
+            '@demo.DEV2.R1',
+            featurePath,
+          ],
+          { cwd: CLI_DIRECTORY, encoding: 'utf8' },
+        );
+
+        const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+        expect(result.status, output).toBe(0);
+        // Rule-level tag inheritance: exactly R1's two scenarios are selected
+        // (undefined — the fixture ships no step definitions); R2's scenario is
+        // filtered out entirely, so the total is 2, not 3.
+        expect(output).toMatch(/\b2 scenarios? \(2 undefined\)/);
+      } finally {
+        rmSync(fixtureDirectory, { recursive: true, force: true });
+      }
     },
     TIMEOUT_ACCEPTANCE_LANE,
   );

--- a/steps/rule-tier.steps.ts
+++ b/steps/rule-tier.steps.ts
@@ -613,9 +613,10 @@ Then('the coverage report resolves every rule reference', function (this: RuleTi
   assert.doesNotMatch(output, /orphan/);
 });
 
-// The "recorded flat-lineage snapshot" for the compat scenario: the exact
-// rule-tier-free advisory the flat AC fixture produced before this feature
-// (one uncovered AC), path-normalized by matching on the ticket label form.
+// Equivalence check, not a stored golden: the flat AC fixture must produce
+// exactly the one advisory it would have produced before this feature (the
+// uncovered demo.DEV1.AC2 line, path-normalized to the ticket label), and no
+// rule-tier vocabulary may leak into an AC-only project's output.
 Then(
   'the output is byte-identical to the recorded flat-lineage snapshot after path normalization',
   function (this: RuleTierWorld) {

--- a/steps/rule-tier.steps.ts
+++ b/steps/rule-tier.steps.ts
@@ -1,0 +1,745 @@
+/**
+ * Step definitions for features/rule-tier.feature (ticket V0NHT6).
+ *
+ * Three proof surfaces, matching the impl plan: the intake-exit gate predicate
+ * (imported from the hook lib), the pure lint/lineage parsers (imported from
+ * the CLI utils), and `safeword check` run as a process against a configured
+ * customer project (reusing the shared `safeword check runs` step from
+ * feature-surfaces-bdd.steps.ts, which reads `this.temporaryDirectory`).
+ */
+
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { After, Given, Then, When } from '@cucumber/cucumber';
+
+import {
+  findFeatureLineageIssues,
+  findGherkinLintIssues,
+  type GherkinLintIssue,
+} from '../packages/cli/src/utils/gherkin-feature.ts';
+import { evaluateAcGate } from '../packages/cli/templates/hooks/lib/jtbd.ts';
+
+interface RuleTierWorld {
+  temporaryDirectory?: string;
+  result?: { stdout: string; stderr: string; exitCode: number };
+  specContent?: string;
+  featureContent?: string;
+  gateVerdict?: { ok: boolean; reason?: string };
+  lineageIssues?: string[];
+  lintIssues?: GherkinLintIssue[];
+  lintExitCode?: number;
+  cucumberOutput?: string;
+  fixtureDirectory?: string;
+}
+
+const REPO_ROOT = nodePath.resolve(import.meta.dirname, '..');
+const CLI_PATH = nodePath.join(REPO_ROOT, 'packages/cli/src/cli.ts');
+const TICKET_DIR = '.project/tickets/RUL001-demo';
+
+function specWithJtbdBody(body: string): string {
+  return ['# Spec', '', '## Jobs To Be Done', '', body, ''].join('\n');
+}
+
+const JTBD_HEAD = '### demo.DEV2 — Retry\n\n**Persona:** TB\n';
+const R_ONLY_SPEC = specWithJtbdBody(
+  `${JTBD_HEAD}\n#### demo.DEV2.R1 — failed deliveries retry on backoff`,
+);
+const MIXED_SPEC = specWithJtbdBody(
+  '### demo.DEV1 — Trace\n\n**Persona:** TB\n\n#### demo.DEV1.AC1 — capability one\n\n#### demo.DEV1.R1 — an invariant beside the AC',
+);
+const AC_ONLY_SPEC = specWithJtbdBody(
+  '### demo.DEV1 — Trace\n\n**Persona:** TB\n\n#### demo.DEV1.AC1 — capability one\n\n#### demo.DEV1.AC2 — capability two',
+);
+
+function featureWithScenarios(
+  ruleLine: string,
+  scenarios: readonly { tags?: string; title: string }[],
+): string {
+  return [
+    'Feature: Demo',
+    '',
+    `  ${ruleLine}`,
+    '',
+    ...scenarios.flatMap(({ tags, title }) => [
+      ...(tags === undefined ? [] : [`    ${tags}`]),
+      `    Scenario: ${title}`,
+      '      Given a',
+      '      When b',
+      '      Then c',
+      '',
+    ]),
+  ].join('\n');
+}
+
+const R1_RULE_LINE = 'Rule: demo.DEV2.R1 — failed deliveries retry on backoff';
+
+function runSafewordSetup(project: string): void {
+  const result = spawnSync('bun', [CLI_PATH, 'setup', '--yes'], {
+    cwd: project,
+    env: {
+      ...process.env,
+      SAFEWORD_NO_AUTO_UPGRADE: '1',
+      SAFEWORD_SKIP_INSTALL: '1',
+      SAFEWORD_TEST_DISABLE_AUTO_UPGRADE: '1',
+    },
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
+  assert.equal(result.status, 0, `setup failed:\n${result.stdout}\n${result.stderr}`);
+}
+
+function createCheckProject(world: RuleTierWorld, spec: string, feature?: string): void {
+  const project = mkdtempSync(nodePath.join(tmpdir(), 'safeword-rule-tier-'));
+  writeFileSync(
+    nodePath.join(project, 'package.json'),
+    JSON.stringify({ name: 'customer-project', version: '1.0.0' }, undefined, 2),
+  );
+  runSafewordSetup(project);
+  // Mark safeword's dev dependencies installed: `check` reports missing
+  // packages as the sole failure section, which would preempt the Issues
+  // section this feature's scenarios assert on.
+  writeFileSync(
+    nodePath.join(project, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'customer-project',
+        version: '1.0.0',
+        devDependencies: {
+          '@cucumber/cucumber': '^12.0.0',
+          '@types/node': '^24.0.0',
+          eslint: '^10.0.0',
+          jiti: '^2.2.0',
+          prettier: '^3.0.0',
+          safeword: '0.0.0-test',
+          tsx: '^4.0.0',
+        },
+      },
+      undefined,
+      2,
+    ),
+  );
+
+  const ticketRoot = nodePath.join(project, TICKET_DIR);
+  mkdirSync(ticketRoot, { recursive: true });
+  writeFileSync(
+    nodePath.join(ticketRoot, 'ticket.md'),
+    ['---', 'id: RUL001', 'type: feature', 'status: in_progress', '---', ''].join('\n'),
+  );
+  writeFileSync(nodePath.join(ticketRoot, 'spec.md'), spec);
+  writeFileSync(
+    nodePath.join(ticketRoot, 'test-definitions.md'),
+    '# Test Definitions\n\n## Rule: r\n\n### Scenario: ledger only\n\n- [ ] RED\n',
+  );
+  if (feature !== undefined) {
+    mkdirSync(nodePath.join(project, 'features'), { recursive: true });
+    writeFileSync(nodePath.join(project, 'features/demo.feature'), feature);
+  }
+  world.temporaryDirectory = project;
+}
+
+function combinedOutput(world: RuleTierWorld): string {
+  assert.ok(world.result, 'safeword check has not run');
+  return `${world.result.stdout}\n${world.result.stderr}`;
+}
+
+After(function (this: RuleTierWorld) {
+  if (this.fixtureDirectory !== undefined) {
+    rmSync(this.fixtureDirectory, { recursive: true, force: true });
+    this.fixtureDirectory = undefined;
+  }
+});
+
+// --- Givens: gate (pure predicate on spec content) ---
+
+Given(
+  'a ticket spec whose JTBD declares numbered Rules and no ACs',
+  function (this: RuleTierWorld) {
+    this.specContent = R_ONLY_SPEC;
+  },
+);
+
+Given(
+  'a ticket spec whose JTBD declares no ACs, no Rules, and no skip line',
+  function (this: RuleTierWorld) {
+    this.specContent = specWithJtbdBody(JTBD_HEAD);
+  },
+);
+
+Given(
+  'a ticket spec whose JTBD carries a skip line instead of criteria',
+  function (this: RuleTierWorld) {
+    this.specContent = specWithJtbdBody(
+      `${JTBD_HEAD}\nskip: internal plumbing — no user-observable capability`,
+    );
+  },
+);
+
+Given(
+  'a ticket spec whose JTBD declares both an AC heading and a numbered Rule heading',
+  function (this: RuleTierWorld) {
+    // Serves both the gate scenario (pure predicate) and the check scenario
+    // (process run) — set up both proof surfaces.
+    this.specContent = MIXED_SPEC;
+    createCheckProject(this, MIXED_SPEC);
+  },
+);
+
+// --- Givens: lineage / gherkin lint (pure parsers on feature content) ---
+
+Given(
+  'a feature file whose Rule block carries a rule ID tag and untagged scenarios',
+  function (this: RuleTierWorld) {
+    this.featureContent = featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [
+      { title: 'first example' },
+      { title: 'second example' },
+    ]);
+  },
+);
+
+Given(
+  'a feature file with a scenario carrying an R lineage tag directly and no ID-tagged Rule block',
+  function (this: RuleTierWorld) {
+    this.featureContent = featureWithScenarios('Rule: plain grouping', [
+      { tags: '@demo.DEV2.R1', title: 'direct rule ref' },
+    ]);
+  },
+);
+
+Given(
+  'a feature file whose Rule block carries a rule ID tag and a scenario adds an AC lineage tag',
+  function (this: RuleTierWorld) {
+    this.featureContent = featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [
+      { tags: '@demo.DEV1.AC1', title: 'adds an AC ref' },
+    ]);
+  },
+);
+
+Given(
+  'a feature file whose Rule block tag and leading name token carry different rule IDs',
+  function (this: RuleTierWorld) {
+    this.featureContent = featureWithScenarios(
+      '@demo.DEV1.R1\n  Rule: demo.DEV1.R2 — renamed without retagging',
+      [{ title: 'example' }],
+    );
+  },
+);
+
+Given(
+  'a feature file with a scenario tagged {string}',
+  function (this: RuleTierWorld, tag: string) {
+    const jtbd = tag.replace(/^@/, '').replace(/\.AC\d+$/, '');
+    createCheckProject(
+      this,
+      specWithJtbdBody(
+        `### ${jtbd} — Review\n\n**Persona:** TB\n\n#### ${tag.replace(/^@/, '')} — reviewable`,
+      ),
+      featureWithScenarios('Rule: grouping', [{ tags: tag, title: 'persona code R example' }]),
+    );
+  },
+);
+
+Given('a feature file with two ID-tagged Rule blocks', function (this: RuleTierWorld) {
+  this.fixtureDirectory = mkdtempSync(nodePath.join(tmpdir(), 'rule-tag-lane-'));
+  writeFileSync(
+    nodePath.join(this.fixtureDirectory, 'demo.feature'),
+    [
+      'Feature: Demo',
+      '',
+      '  @demo.DEV2.R1',
+      `  ${R1_RULE_LINE}`,
+      '',
+      '    Scenario: first retry after one minute',
+      '      Given a failed delivery',
+      '',
+      '    Scenario: second retry doubles the wait',
+      '      Given a failed delivery',
+      '',
+      '  @demo.DEV2.R2',
+      '  Rule: demo.DEV2.R2 — deliveries stop after the retry budget',
+      '',
+      '    Scenario: delivery abandoned after final retry',
+      '      Given an exhausted budget',
+      '',
+    ].join('\n'),
+  );
+});
+
+// --- Givens: safeword check fixtures (configured project) ---
+
+Given(
+  'a ticket spec declaring a numbered Rule that no feature scenario references',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      R_ONLY_SPEC,
+      featureWithScenarios('Rule: grouping', [{ tags: '@other.SM1.AC1', title: 'unrelated' }]),
+    );
+  },
+);
+
+Given(
+  'a feature scenario referencing a rule number its spec JTBD never declared',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      R_ONLY_SPEC,
+      featureWithScenarios('Rule: grouping', [{ tags: '@demo.DEV2.R5', title: 'stale ref' }]),
+    );
+  },
+);
+
+Given(
+  'a feature scenario referencing a rule under a JTBD absent from the spec',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      R_ONLY_SPEC,
+      featureWithScenarios('Rule: grouping', [{ tags: '@ghost.SM1.R1', title: 'orphan ref' }]),
+    );
+  },
+);
+
+Given(
+  'a spec-declared numbered Rule whose feature scenarios carry no rejection tag',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      R_ONLY_SPEC,
+      featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [{ title: 'happy path only' }]),
+    );
+  },
+);
+
+Given(
+  'a spec-declared numbered Rule with at least one rejection-tagged feature scenario',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      R_ONLY_SPEC,
+      featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [
+        { title: 'happy path' },
+        { tags: '@rejection', title: 'refused when budget exhausted' },
+      ]),
+    );
+  },
+);
+
+Given(
+  'a feature file with an unnumbered Rule grouping block and no rejection-tagged scenarios',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      AC_ONLY_SPEC,
+      featureWithScenarios('Rule: plain grouping header', [
+        { tags: '@demo.DEV1.AC1', title: 'flat lineage' },
+        { tags: '@demo.DEV1.AC2', title: 'more flat lineage' },
+      ]),
+    );
+  },
+);
+
+Given(
+  'a project whose specs and feature files use only AC lineage, including unnumbered Rule grouping blocks without rejection tags',
+  function (this: RuleTierWorld) {
+    createCheckProject(
+      this,
+      AC_ONLY_SPEC,
+      featureWithScenarios('Rule: plain grouping header', [
+        { tags: '@demo.DEV1.AC1', title: 'covers only capability one' },
+      ]),
+    );
+  },
+);
+
+Given(
+  'a feature file shaped like an existing rule-numbered corpus with a matching spec catalog',
+  function (this: RuleTierWorld) {
+    const corpusSpec = specWithJtbdBody(
+      `${JTBD_HEAD}\n#### demo.DEV2.R1 — failed deliveries retry on backoff\n\n#### demo.DEV2.R2 — deliveries stop after the retry budget`,
+    );
+    const corpusFeature = [
+      'Feature: Webhook retries',
+      '',
+      '  @demo.DEV2.R1',
+      `  ${R1_RULE_LINE}`,
+      '',
+      '    Scenario: first retry after one minute',
+      '      Given a failed delivery',
+      '      When the retry fires',
+      '      Then the delivery is retried',
+      '',
+      '    @rejection',
+      '    Scenario: malformed payload is not retried',
+      '      Given a malformed delivery',
+      '      When the retry evaluates it',
+      '      Then the delivery is rejected',
+      '',
+      '  @demo.DEV2.R2',
+      '  Rule: demo.DEV2.R2 — deliveries stop after the retry budget',
+      '',
+      '    @rejection',
+      '    Scenario: delivery abandoned after final retry',
+      '      Given an exhausted budget',
+      '      When the retry evaluates it',
+      '      Then the delivery is abandoned',
+      '',
+    ].join('\n');
+    this.featureContent = corpusFeature;
+    createCheckProject(this, corpusSpec, corpusFeature);
+  },
+);
+
+Given(/^a project exhibiting (.+)$/, function (this: RuleTierWorld, condition: string) {
+  switch (condition) {
+    case 'a numbered rule with no rejection-tagged scenario': {
+      createCheckProject(
+        this,
+        R_ONLY_SPEC,
+        featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [{ title: 'happy path only' }]),
+      );
+      return;
+    }
+    case 'a JTBD mixing AC and Rule headings': {
+      createCheckProject(this, MIXED_SPEC);
+      return;
+    }
+    case 'a spec rule no scenario references': {
+      createCheckProject(
+        this,
+        R_ONLY_SPEC,
+        featureWithScenarios('Rule: grouping', [{ tags: '@other.SM1.AC1', title: 'unrelated' }]),
+      );
+      return;
+    }
+    case 'a rule reference with a missing rule number': {
+      createCheckProject(
+        this,
+        R_ONLY_SPEC,
+        featureWithScenarios('Rule: grouping', [{ tags: '@demo.DEV2.R5', title: 'stale ref' }]),
+      );
+      return;
+    }
+    case 'a rule reference whose JTBD is absent': {
+      createCheckProject(
+        this,
+        R_ONLY_SPEC,
+        featureWithScenarios('Rule: grouping', [{ tags: '@ghost.SM1.R1', title: 'orphan ref' }]),
+      );
+      return;
+    }
+    case 'a JTBD with neither criteria kind and no skip line': {
+      this.specContent = specWithJtbdBody(JTBD_HEAD);
+      return;
+    }
+    case 'a Rule block whose name token disagrees with its tag': {
+      this.featureContent = featureWithScenarios(
+        '@demo.DEV1.R1\n  Rule: demo.DEV1.R2 — renamed without retagging',
+        [{ title: 'example' }],
+      );
+      return;
+    }
+    case 'a scenario with two lineage references': {
+      this.featureContent = featureWithScenarios(`@demo.DEV2.R1\n  ${R1_RULE_LINE}`, [
+        { tags: '@demo.DEV1.AC1', title: 'adds an AC ref' },
+      ]);
+      return;
+    }
+    default: {
+      throw new Error(`Unknown rule-tier condition: ${condition}`);
+    }
+  }
+});
+
+// --- Whens ---
+// (`safeword check runs` is shared — defined in feature-surfaces-bdd.steps.ts.)
+
+When('the intake-exit gate evaluates test-definitions creation', function (this: RuleTierWorld) {
+  assert.ok(this.specContent, 'no spec content staged');
+  this.gateVerdict = evaluateAcGate(this.specContent);
+});
+
+When('the intake-exit gate runs', function (this: RuleTierWorld) {
+  assert.ok(this.specContent, 'no spec content staged');
+  this.gateVerdict = evaluateAcGate(this.specContent);
+});
+
+When('lineage lint runs', function (this: RuleTierWorld) {
+  assert.ok(this.featureContent, 'no feature content staged');
+  this.lineageIssues = findFeatureLineageIssues(this.featureContent);
+});
+
+When('gherkin lint runs', function (this: RuleTierWorld) {
+  assert.ok(this.featureContent, 'no feature content staged');
+  this.lintIssues = findGherkinLintIssues(this.featureContent, {
+    filePath: 'features/demo.feature',
+  });
+});
+
+When('safeword check and gherkin lint run', function (this: RuleTierWorld) {
+  assert.ok(this.temporaryDirectory, 'customer project was not created');
+  const check = spawnSync('bun', [CLI_PATH, 'check', '--offline'], {
+    cwd: this.temporaryDirectory,
+    env: { ...process.env, SAFEWORD_NO_AUTO_UPGRADE: '1' },
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
+  this.result = {
+    stdout: check.stdout ?? '',
+    stderr: check.stderr ?? '',
+    exitCode: check.status ?? 1,
+  };
+  const lint = spawnSync(
+    'bun',
+    [CLI_PATH, 'lint-gherkin', nodePath.join(this.temporaryDirectory, 'features/demo.feature')],
+    { cwd: this.temporaryDirectory, encoding: 'utf8', timeout: 60_000 },
+  );
+  this.lintExitCode = lint.status ?? 1;
+});
+
+When(
+  'the cucumber lane runs with a tag expression selecting one rule ID',
+  function (this: RuleTierWorld) {
+    assert.ok(this.fixtureDirectory, 'no cucumber fixture staged');
+    const result = spawnSync(
+      'bunx',
+      [
+        'cucumber-js',
+        '--dry-run',
+        '--format',
+        'summary',
+        '--tags',
+        '@demo.DEV2.R1',
+        nodePath.join(this.fixtureDirectory, 'demo.feature'),
+      ],
+      { cwd: nodePath.join(REPO_ROOT, 'packages/cli'), encoding: 'utf8', timeout: 120_000 },
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    this.cucumberOutput = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  },
+);
+
+// --- Thens: gate ---
+
+Then('the gate allows the creation', function (this: RuleTierWorld) {
+  assert.ok(this.gateVerdict, 'gate has not run');
+  assert.equal(this.gateVerdict.ok, true, this.gateVerdict.reason);
+});
+
+Then('the gate denies the creation', function (this: RuleTierWorld) {
+  assert.ok(this.gateVerdict, 'gate has not run');
+  assert.equal(this.gateVerdict.ok, false);
+});
+
+Then(
+  'the denial message names both Acceptance Criteria and numbered Rules as options',
+  function (this: RuleTierWorld) {
+    assert.ok(this.gateVerdict?.reason, 'no denial reason recorded');
+    assert.match(this.gateVerdict.reason, /#### <id>\.AC<n>/);
+    assert.match(this.gateVerdict.reason, /#### <id>\.R<n>/);
+    assert.match(this.gateVerdict.reason, /numbered rules/);
+  },
+);
+
+// --- Thens: check output ---
+
+Then('a check issue names that JTBD as mixing criteria kinds', function (this: RuleTierWorld) {
+  assert.match(
+    combinedOutput(this),
+    /JTBD demo\.DEV1 declares both Acceptance Criteria and numbered Rules; keep one criteria kind per job/,
+  );
+  assert.equal(this.result?.exitCode, 1, 'mixed criteria should be a hard check issue');
+});
+
+Then('an uncovered advisory names that rule ID', function (this: RuleTierWorld) {
+  assert.match(
+    combinedOutput(this),
+    /numbered rule demo\.DEV2\.R1 has no scenario illustrating it \(uncovered\)/,
+  );
+});
+
+Then('a stale advisory names that rule reference', function (this: RuleTierWorld) {
+  assert.match(
+    combinedOutput(this),
+    /scenario ref demo\.DEV2\.R5 matches no numbered rule under its JTBD \(stale ref\)/,
+  );
+});
+
+Then('an orphan advisory names that rule reference', function (this: RuleTierWorld) {
+  assert.match(
+    combinedOutput(this),
+    /scenario ref ghost\.SM1\.R1 names no JTBD in spec\.md \(orphan\)/,
+  );
+});
+
+Then('a zero-rejection-path advisory names that rule ID', function (this: RuleTierWorld) {
+  assert.match(
+    combinedOutput(this),
+    /numbered rule demo\.DEV2\.R1 has no example of the rule being broken/,
+  );
+});
+
+Then('no zero-rejection-path advisory is reported', function (this: RuleTierWorld) {
+  assert.doesNotMatch(combinedOutput(this), /has no example of the rule being broken/);
+});
+
+Then(
+  'the coverage report attributes the scenario to AC {string}',
+  function (this: RuleTierWorld, acId: string) {
+    const output = combinedOutput(this);
+    assert.ok(
+      !output.includes(`acceptance criterion ${acId} has no scenario`),
+      `AC ${acId} should be covered by the tagged scenario:\n${output}`,
+    );
+  },
+);
+
+Then(
+  'no stale or orphan rule advisory is reported for {string}',
+  function (this: RuleTierWorld, jtbd: string) {
+    const output = combinedOutput(this);
+    assert.doesNotMatch(output, new RegExp(`${jtbd.replaceAll('.', String.raw`\.`)}.*stale ref`));
+    assert.doesNotMatch(output, new RegExp(`${jtbd.replaceAll('.', String.raw`\.`)}.*orphan`));
+  },
+);
+
+Then('the coverage report resolves every rule reference', function (this: RuleTierWorld) {
+  const output = combinedOutput(this);
+  assert.doesNotMatch(output, /uncovered/);
+  assert.doesNotMatch(output, /stale ref/);
+  assert.doesNotMatch(output, /orphan/);
+});
+
+// The "recorded flat-lineage snapshot" for the compat scenario: the exact
+// rule-tier-free advisory the flat AC fixture produced before this feature
+// (one uncovered AC), path-normalized by matching on the ticket label form.
+Then(
+  'the output is byte-identical to the recorded flat-lineage snapshot after path normalization',
+  function (this: RuleTierWorld) {
+    const output = combinedOutput(this);
+    const ticketLines = output
+      .split('\n')
+      .filter(line => line.includes('RUL001'))
+      .map(line => line.replace(/^.*?(demo \(RUL001\))/, '$1').trimEnd());
+    assert.deepEqual(ticketLines, [
+      'demo (RUL001): acceptance criterion demo.DEV1.AC2 has no scenario (uncovered)',
+    ]);
+    assert.doesNotMatch(output, /numbered rule|rejection|mixing criteria|rule-name-tag/i);
+    assert.equal(this.lintExitCode, 0, 'gherkin lint should stay clean for the AC-only project');
+  },
+);
+
+// --- Thens: pure lint ---
+
+Then('no lineage issue is reported', function (this: RuleTierWorld) {
+  assert.ok(this.lineageIssues, 'lineage lint has not run');
+  assert.deepEqual(this.lineageIssues, []);
+});
+
+Then('a multiple-lineage issue names that scenario', function (this: RuleTierWorld) {
+  assert.ok(this.lineageIssues, 'lineage lint has not run');
+  assert.equal(this.lineageIssues.length, 1);
+  assert.match(
+    this.lineageIssues[0] ?? '',
+    /Scenario "adds an AC ref" has multiple lineage tags after inheritance/,
+  );
+});
+
+Then('a name-tag mismatch issue names that Rule block', function (this: RuleTierWorld) {
+  assert.ok(this.lintIssues, 'gherkin lint has not run');
+  const mismatch = this.lintIssues.find(issue => issue.rule === 'rule-name-tag-mismatch');
+  assert.ok(mismatch, JSON.stringify(this.lintIssues));
+  assert.match(mismatch.message, /demo\.DEV1\.R2 — renamed without retagging/);
+});
+
+// --- Thens: cucumber selection ---
+
+Then('only the scenarios under that Rule block execute', function (this: RuleTierWorld) {
+  assert.ok(this.cucumberOutput, 'cucumber lane has not run');
+  assert.match(this.cucumberOutput, /\b2 scenarios?\b/);
+  assert.doesNotMatch(this.cucumberOutput, /\b3 scenarios?\b/);
+  assert.doesNotMatch(this.cucumberOutput, /delivery abandoned after final retry/);
+});
+
+// --- Then: NTB message contract (Scenario Outline) ---
+
+const MESSAGE_CONTRACT: Record<
+  string,
+  { surface: 'check' | 'gate' | 'gherkin' | 'lineage'; id: RegExp; nextAction: RegExp }
+> = {
+  'zero-rejection advisory': {
+    surface: 'check',
+    id: /numbered rule demo\.DEV2\.R1/,
+    nextAction: /add a @rejection-tagged scenario under it/,
+  },
+  'mixed-criteria issue': {
+    surface: 'check',
+    id: /JTBD demo\.DEV1/,
+    nextAction: /convert one set or split the job/,
+  },
+  'uncovered advisory': {
+    surface: 'check',
+    id: /numbered rule demo\.DEV2\.R1/,
+    nextAction: /add a scenario tagged @demo\.DEV2\.R1/,
+  },
+  'stale advisory': {
+    surface: 'check',
+    id: /scenario ref demo\.DEV2\.R5/,
+    nextAction: /retag to a declared rule or declare it in spec\.md/,
+  },
+  'orphan advisory': {
+    surface: 'check',
+    id: /scenario ref ghost\.SM1\.R1/,
+    nextAction: /fix the tag's JTBD id or add that JTBD to spec\.md/,
+  },
+  'denial message': {
+    surface: 'gate',
+    id: /JTBD "demo\.DEV2/,
+    nextAction: /add ≥1 `#### <id>\.AC<n>`, ≥1 `#### <id>\.R<n>`, or `skip: <reason>`/,
+  },
+  'name-tag mismatch issue': {
+    surface: 'gherkin',
+    id: /Rule "demo\.DEV1\.R2/,
+    nextAction: /make the name's first token match the tag/,
+  },
+  'multiple-lineage issue': {
+    surface: 'lineage',
+    id: /Scenario "adds an AC ref"/,
+    nextAction: /keep exactly one @<jtbd>\.AC# or @<jtbd>\.R# tag/,
+  },
+};
+
+Then(
+  /^the (.+) names (?:.+), states the problem in plain language, and carries a concrete next action$/,
+  function (this: RuleTierWorld, messageKind: string) {
+    const contract = MESSAGE_CONTRACT[messageKind];
+    assert.ok(contract, `Unknown rule-tier message kind: ${messageKind}`);
+    let text: string;
+    switch (contract.surface) {
+      case 'check': {
+        text = combinedOutput(this);
+        break;
+      }
+      case 'gate': {
+        assert.ok(this.gateVerdict?.reason, 'no denial reason recorded');
+        text = this.gateVerdict.reason;
+        break;
+      }
+      case 'gherkin': {
+        assert.ok(this.lintIssues, 'gherkin lint has not run');
+        text = this.lintIssues.map(issue => issue.message).join('\n');
+        break;
+      }
+      case 'lineage': {
+        assert.ok(this.lineageIssues, 'lineage lint has not run');
+        text = this.lineageIssues.join('\n');
+        break;
+      }
+    }
+    assert.match(text, contract.id);
+    assert.match(text, contract.nextAction);
+  },
+);


### PR DESCRIPTION
Closes #649.

Adds an optional third lineage tier to the spec grammar: the **numbered Rule** (`<jtbd-id>.R<n>`) — a testable business invariant with a stable per-JTBD ID that scenarios nest under and reference. Declaring `#### <jtbd-id>.R<n>` headings is the opt-in (no config flag); a JTBD carries either ACs or Rules, never both; repos that never declare a Rule see byte-identical behavior.

## What's in the tier

- **Ref grammar** — `@<jtbd-id>.R<n>` lineage tags parsed beside AC tags with AC-wins precedence (`@feat.R1.AC1` is an AC of JTBD `feat.R1`, so a persona code `R` can't corrupt parsing). The exactly-one-lineage lint accepts either kind (`gherkin-feature.ts`).
- **Spec catalog** — `parseCriteriaIdsByJtbd` classifies AC vs terminal-`R<n>` headings per JTBD; a JTBD declaring both kinds is a hard `safeword check` issue while the intake gate stays fail-open (`scenario-coverage.ts`, `health.ts`).
- **Coverage** — the uncovered/stale/orphan buckets resolve rule refs, plus a new advisory for a numbered rule with no `@rejection`-tagged scenario (unnumbered `Rule:` grouping blocks exempt by construction).
- **Messages** — every new issue/advisory names the offending id, states the problem in plain language, and carries a concrete next action (NTB message contract, proven by a Scenario Outline over all 8 message kinds).
- **Lint** — a `Rule:` block carrying a rule tag must repeat the ID as its name's first token (`rule-name-tag-mismatch`); the tag stays authoritative.
- **Gate** — the hook-side intake-exit denial now names numbered Rules as an option; `templates/hooks/lib/jtbd.ts` and the deployed mirror stay byte-identical.
- **Selection** — proven through the real cucumber lane: a tag expression on one rule ID runs exactly that rule's scenarios (rule-level tag inheritance).
- **Docs** — bdd skill (SCENARIOS/DISCOVERY), spec template, and deployed copies document the grammar and the split-tag migration mapping for existing corpora (`@job:PO1 @rule:PO1.R1` → one block-level combined tag).

## Process artifacts

Built through the full BDD flow (dogfooded): ticket `V0NHT6-rule-tier` with spec (5 JTBDs incl. an NTB message-contract job, 8 ACs), 8-dimension table, 21 scenarios in `features/rule-tier.feature` with step definitions, independent scenario-gate review (stamped), impl plan, and verify.md. Deferred follow-ups recorded in the spec: split-axis tag compat, hard numbering-lock enforcement (anchored to NMSD94), plus a tier-awareness dependency note added to ZRMDKD so the future blocking coverage gate can't deny opted-in features.

## Evidence

- Full suite: 311 files, 4482 tests pass (5 pre-existing skips)
- Gherkin acceptance lane: 209/209 scenarios (28 rule-tier instances execute via `steps/rule-tier.steps.ts`)
- Build, typecheck (`tsc --noEmit`), lint, `sync-config --check`, depcruise: all green; no dependency changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLFHkpzB2KrDxK9H6wvVey

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLFHkpzB2KrDxK9H6wvVey)_