### PR TITLE
chore(tickets): file audit follow-ups JCC69C + J2R9HY (#644 G8 verify)

### DIFF
--- a/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
+++ b/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
@@ -8,11 +8,13 @@ external_issue: https://github.com/ArcadeAI/safeword/issues/718
 scope: |
   Investigate and remove (or intentionally retain with justification) the five
   unused exports flagged by knip in the 2026-07-04 audit:
-    - CODEX_SESSION_START_HOOK_PATCH   packages/cli/src/schema.ts:191
+    - CODEX_SESSION_START_HOOK_PATCH   packages/cli/src/schema.ts:194
     - OWNED_LABEL_PREFIXES             packages/cli/src/tracker-sync/labels.ts:11
     - MONITOR_SOURCES                  packages/cli/src/upstream-monitor/index.ts:59
     - normalizeMarkdown (function)     packages/cli/src/upstream-monitor/index.ts:94
     - SYNCTICKETS_QUIET_COMMAND        packages/cli/src/utils/ticket-index-warnings.ts:1
+  Line numbers are as-of the branch base and drift with edits — re-run
+  `bunx knip` to get current locations.
   For each: confirm it is genuinely unreferenced (knip cannot see consumers
   wired via config/runtime resolution, e.g. the .safeword/hooks dogfood pattern),
   then either delete it or downgrade `export` to module-private.
@@ -20,7 +22,7 @@ out_of_scope: |
   - knip's "unresolved imports" findings — those are the known dogfood-hook
     pattern (test files importing .safeword/hooks/* resolved at runtime), not
     dead code. No action; do not silence with config.
-  - Dependency version bumps from the same audit — tracked in JCC69C.
+  - Dependency version bumps from the same audit — tracked in JCC69C (#717).
   - Broader dead-code sweep beyond these five named exports.
 done_when: |
   - Each of the five exports is either removed, or de-exported to module scope,

--- a/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
+++ b/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
@@ -1,0 +1,49 @@
+---
+id: J2R9HY
+slug: prune-unused-exports
+type: task
+phase: intake
+status: backlog
+scope: |
+  Investigate and remove (or intentionally retain with justification) the five
+  unused exports flagged by knip in the 2026-07-04 audit:
+    - CODEX_SESSION_START_HOOK_PATCH   packages/cli/src/schema.ts:191
+    - OWNED_LABEL_PREFIXES             packages/cli/src/tracker-sync/labels.ts:11
+    - MONITOR_SOURCES                  packages/cli/src/upstream-monitor/index.ts:59
+    - normalizeMarkdown (function)     packages/cli/src/upstream-monitor/index.ts:94
+    - SYNCTICKETS_QUIET_COMMAND        packages/cli/src/utils/ticket-index-warnings.ts:1
+  For each: confirm it is genuinely unreferenced (knip cannot see consumers
+  wired via config/runtime resolution, e.g. the .safeword/hooks dogfood pattern),
+  then either delete it or downgrade `export` to module-private.
+out_of_scope: |
+  - knip's "unresolved imports" findings — those are the known dogfood-hook
+    pattern (test files importing .safeword/hooks/* resolved at runtime), not
+    dead code. No action; do not silence with config.
+  - Dependency version bumps from the same audit — tracked in JCC69C.
+  - Broader dead-code sweep beyond these five named exports.
+done_when: |
+  - Each of the five exports is either removed, or de-exported to module scope,
+    or explicitly retained with a one-line comment naming the real (config- or
+    runtime-wired) consumer knip cannot see.
+  - `bunx knip` no longer reports these five under "Unused exports".
+  - `bun run test` and `/lint` (incl. tsc --noEmit) stay green.
+created: 2026-07-04T00:18:53.927Z
+last_modified: 2026-07-04T00:18:53.927Z
+---
+
+# Remove 5 unused exports flagged by knip (audit follow-up)
+
+**Goal:** Resolve the five unused exports knip flagged — delete the truly dead
+ones and justify any kept for a consumer knip can't see.
+
+**Why:** Surfaced by the 2026-07-04 audit during the #644 G8 verify pass. These
+predate the docs-cleanup change and were out of its scope. Each needs a quick
+human check before removal because knip is blind to config-wired and
+runtime-resolved consumers (the same reason its "unresolved imports" noise is a
+false positive) — so this is a small investigate-then-prune task, not a blind
+delete.
+
+## Work Log
+
+- 2026-07-04T00:18:53.927Z Started: Created ticket J2R9HY
+- 2026-07-04T00:20:00Z Scoped from audit follow-up (parent context: #644 G8 verify). status → backlog.

--- a/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
+++ b/.project/tickets/J2R9HY-prune-unused-exports/ticket.md
@@ -4,6 +4,7 @@ slug: prune-unused-exports
 type: task
 phase: intake
 status: backlog
+external_issue: https://github.com/ArcadeAI/safeword/issues/718
 scope: |
   Investigate and remove (or intentionally retain with justification) the five
   unused exports flagged by knip in the 2026-07-04 audit:

--- a/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
+++ b/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
@@ -4,6 +4,7 @@ slug: dev-tooling-version-bumps
 type: task
 phase: intake
 status: backlog
+external_issue: https://github.com/ArcadeAI/safeword/issues/717
 scope: |
   Bump six dev-only tooling dependencies flagged outdated by the 2026-07-04
   audit (all devDependencies; no runtime deps involved):

--- a/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
+++ b/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
@@ -14,15 +14,21 @@ scope: |
     - prettier          3.8.4  → 3.9.4     (minor)
     - tsx               4.22.4 → 4.23.0    (minor)
     - markdownlint-cli2 0.22.1 → 0.23.0    (0.x minor — treat as major per audit risk matrix)
-  Update package.json + lockfile, run the full suite + lint, and fix any
-  formatter/lint churn the prettier and markdownlint-cli2 bumps introduce.
+  Five of the six (all but markdownlint-cli2, which is root-only) are ALSO
+  declared in packages/cli/package.json — bump both root and the workspace
+  package in lockstep or the two will skew. Note eslint already skews today
+  (root ^10.5.0, packages/cli ^10.4.0 as devDep + peerDependency); align both.
+  Update every affected package.json + the bun lockfile, run the full suite +
+  lint, and fix any formatter/lint churn the prettier and markdownlint-cli2
+  bumps introduce.
 out_of_scope: |
   - Runtime/production dependency upgrades (none were flagged).
   - eslint/prettier config rewrites beyond what the bump strictly requires.
-  - The 5 unused exports flagged by the same audit — tracked in J2R9HY.
+  - The 5 unused exports flagged by the same audit — tracked in J2R9HY (#718).
 done_when: |
-  - All six packages are at the listed target versions in package.json and the
-    bun lockfile.
+  - All six packages are at the listed target versions in the root package.json,
+    in packages/cli/package.json for the five declared there (incl. eslint's
+    peerDependency), and in the bun lockfile.
   - `bun run test`, `/lint` (eslint + prettier + tsc --noEmit) are green.
   - Any prettier 3.9 / markdownlint-cli2 0.23 reformatting is committed so the
     pre-commit hook is a no-op on a clean tree.

--- a/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
+++ b/.project/tickets/JCC69C-dev-tooling-version-bumps/ticket.md
@@ -1,0 +1,49 @@
+---
+id: JCC69C
+slug: dev-tooling-version-bumps
+type: task
+phase: intake
+status: backlog
+scope: |
+  Bump six dev-only tooling dependencies flagged outdated by the 2026-07-04
+  audit (all devDependencies; no runtime deps involved):
+    - @types/node       26.0.1 → 26.1.0   (minor)
+    - eslint            10.5.0 → 10.6.0    (minor)
+    - knip              6.20.0 → 6.24.0    (minor)
+    - prettier          3.8.4  → 3.9.4     (minor)
+    - tsx               4.22.4 → 4.23.0    (minor)
+    - markdownlint-cli2 0.22.1 → 0.23.0    (0.x minor — treat as major per audit risk matrix)
+  Update package.json + lockfile, run the full suite + lint, and fix any
+  formatter/lint churn the prettier and markdownlint-cli2 bumps introduce.
+out_of_scope: |
+  - Runtime/production dependency upgrades (none were flagged).
+  - eslint/prettier config rewrites beyond what the bump strictly requires.
+  - The 5 unused exports flagged by the same audit — tracked in J2R9HY.
+done_when: |
+  - All six packages are at the listed target versions in package.json and the
+    bun lockfile.
+  - `bun run test`, `/lint` (eslint + prettier + tsc --noEmit) are green.
+  - Any prettier 3.9 / markdownlint-cli2 0.23 reformatting is committed so the
+    pre-commit hook is a no-op on a clean tree.
+  - markdownlint-cli2's 0.x-minor bump is verified against its changelog for
+    rule-default changes before merging (audit matrix flags 0.x minors as
+    breaking-risk).
+created: 2026-07-04T00:18:53.861Z
+last_modified: 2026-07-04T00:18:53.861Z
+---
+
+# Bump 6 dev-tool dependencies (audit follow-up)
+
+**Goal:** Bring the six outdated dev-tool dependencies up to their current
+minor versions and absorb any resulting formatter/lint churn.
+
+**Why:** Surfaced by the 2026-07-04 audit during the #644 G8 verify pass. All
+six are low-risk dev tooling (only `markdownlint-cli2`'s 0.x minor warrants a
+changelog check), but they were out of scope for the docs-cleanup ticket. Kept
+as a standalone maintenance task so the bumps and their reformatting land in one
+reviewable diff instead of riding along with unrelated work.
+
+## Work Log
+
+- 2026-07-04T00:18:53.861Z Started: Created ticket JCC69C
+- 2026-07-04T00:20:00Z Scoped from audit follow-up (parent context: #644 G8 verify). status → backlog.


### PR DESCRIPTION
## What & why

Files two backlog maintenance tickets surfaced by the `/audit` run during the #644 G8 verify pass. Both were out of scope for the merged docs-cleanup PR (#714), so they're recorded as standalone tickets rather than smuggled into unrelated work.

This PR adds **two `ticket.md` files only** — no code, no behavior change (100 insertions, 0 deletions).

## Tickets

- **JCC69C** — `dev-tooling-version-bumps` → tracks **#717**. Bump 6 outdated dev-only deps (`@types/node`, `eslint`, `knip`, `prettier`, `tsx`, `markdownlint-cli2`); the 0.x-minor `markdownlint-cli2` gets a changelog check before merge.
- **J2R9HY** — `prune-unused-exports` → tracks **#718**. Investigate-then-prune 5 knip-flagged unused exports; the knip "unresolved imports" noise (the dogfood-hook false positive) is explicitly out of scope.

Both are `status: backlog` and carry `external_issue:` links to their GitHub issues.

## Notes

- Branch was rebased onto current `main` (`3994451b`) so the diff is only the two new tickets.
- No PR template exists in the repo; body written directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PVMS5fJ5R3a11JVWQd5vh

---
_Generated by [Claude Code](https://claude.ai/code/session_018PVMS5fJ5R3a11JVWQd5vh)_