### PR TITLE
chore(release): v0.63.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.63.0 (minor)

Rolls up 14 PRs since `v0.62.0`. Minor per the versioning contract: additive capability plus three behavior-changing gates shipped as a 0.x minor (owner-approved — safeword's 0.x reserves the right to change behavior in minors, with the changes flagged here).

### ⚠️ Behavior changes (auto-applied at SessionStart — read before upgrading)
- **SQL now lints by default instead of auto-formatting on every edit** (#669). Restore auto-format with `"sql": { "fix": true }` in `.safeword/config.json`. safeword also now defers entirely to host-owned SQL formatting (e.g. `prettier-plugin-sql`) when present.
- **Feature-ticket phases are now gated** (#693): feature tickets must be born at intake and advance one canonical step at a time. Multi-step jumps are blocked unless justified via a `phase_skips:` frontmatter entry. Tickets at rest and non-feature types (task/patch/epic) are unaffected.
- **Bash-channel writes to the R/G/R ledger are now blocked** (#721): review-stamp / phase-ledger mutations must go through the tool (Edit) path, not raw shell (`>>`, `tee`, `sed -i`, `cp`, …). Closes the bypass of the #693 gate.

### Added
- Retro cloud filing: Stop-gate dispatches the `safeword-retro-filer` subagent for reliable filing in cloud sessions (#659), with an ack + bare-drain tripwire so a drained spool no longer self-certifies (#684).
- `--skip` flag for review stamps — a deliberate skip is now explicit and recorded (#654).
- BDD lane detects an existing cucumber harness and honors configurable feature/step paths (#692).
- Numbered Rule tier between JTBD and scenarios (invariant catalog with stable IDs) (#713).
- lint-staged formats `.mdx` at commit time (#694).

### Fixed
- self-report captures only genuine CLI crashes, not deliberate non-zero exits (#720/#729).
- write-review-stamp multi-ticket resolution across Claude/Codex/Cursor (#630/#653).

### Internal
- Refactor verify + audit skills; command→pointer collapse, stricter gate steps (#701).
- Audit follow-up tickets + retro-ledger doc labels (#719/#714).

### Version
- `packages/cli/package.json` + `.claude-plugin/marketplace.json`: 0.62.0 → 0.63.0
- `bun.lock` unchanged (bun 1.3.14 does not track the workspace self-version)

Tag push after merge triggers OIDC trusted publish to npm.