### PR TITLE
refactor: post-36h cleanup — name lane-config literal + dedup workspace roots

### DIFF
--- a/packages/cli/src/utils/boundaries.ts
+++ b/packages/cli/src/utils/boundaries.ts
@@ -14,6 +14,7 @@ import { readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { exists } from './fs.js';
+import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /**
  * Architecture layer definitions with alternative names.
@@ -58,10 +59,7 @@ export interface DetectedArchitecture {
 function findMonorepoPackages(projectDirectory: string): string[] {
   const packages: string[] = [];
 
-  // Check common monorepo patterns
-  const monorepoRoots = ['packages', 'apps', 'libs', 'modules'];
-
-  for (const root of monorepoRoots) {
+  for (const root of WORKSPACE_ROOTS) {
     const rootPath = nodePath.join(projectDirectory, root);
     if (!exists(rootPath)) continue;
 

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -2,8 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
-
-const WORKSPACE_FEATURE_ROOTS = ['packages', 'apps', 'libs', 'modules'] as const;
+import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
 function slugFromTicketFolder(ticketFolder: string): string {
@@ -30,7 +29,7 @@ export function collectExecutableFeatureFiles(cwd: string, fileName?: string): s
 function collectExecutableFeatureDirectories(cwd: string): string[] {
   const directories = [
     nodePath.join(cwd, 'features'),
-    ...WORKSPACE_FEATURE_ROOTS.flatMap(root =>
+    ...WORKSPACE_ROOTS.flatMap(root =>
       collectWorkspaceFeatureDirectories(nodePath.join(cwd, root)),
     ),
   ];

--- a/packages/cli/src/utils/project-detector.ts
+++ b/packages/cli/src/utils/project-detector.ts
@@ -13,6 +13,7 @@ import type { Languages, ProjectType } from '../packs/types.js';
 import { detect } from '../presets/typescript/detect.js';
 import { isShippedCucumberTemplateRevision } from './cucumber-template-revisions.js';
 import { findInTree, readFileSafe, readJson } from './fs.js';
+import { WORKSPACE_ROOTS } from './workspaces.js';
 
 const {
   TAILWIND_PACKAGES,
@@ -472,10 +473,6 @@ function isSafewordLaneTemplate(configPath: string): boolean {
   return content !== undefined && isShippedCucumberTemplateRevision(content);
 }
 
-// Direct workspace-package radius for harness evidence — the same
-// conventional roots feature-source.ts scans for feature files.
-const WORKSPACE_PACKAGE_ROOTS = ['packages', 'apps', 'libs', 'modules'] as const;
-
 function manifestDependsOnCucumber(manifestPath: string): boolean {
   const manifest = readJson(manifestPath) as
     | { dependencies?: Record<string, string>; devDependencies?: Record<string, string> }
@@ -521,7 +518,7 @@ function findCucumberEvidenceUnderRoot(cwd: string, root: string): string | unde
 
 /** First direct workspace package with cucumber evidence (config file or dep). */
 function detectWorkspaceCucumberDependency(cwd: string): string | undefined {
-  for (const root of WORKSPACE_PACKAGE_ROOTS) {
+  for (const root of WORKSPACE_ROOTS) {
     const evidence = findCucumberEvidenceUnderRoot(cwd, root);
     if (evidence !== undefined) return evidence;
   }

--- a/packages/cli/src/utils/project-detector.ts
+++ b/packages/cli/src/utils/project-detector.ts
@@ -442,6 +442,12 @@ export function hasJsSource(cwd: string, maxDepth = 6): boolean {
   return scanForJsSource(cwd, 0, maxDepth);
 }
 
+// The cucumber-js config filename safeword scaffolds its own lane as. Load-bearing
+// for own-scaffold identity: its membership in the discovery list (below), the
+// self-exclusion in detectCucumberHarnessEvidence, and the own-lane probe in
+// detectCucumberLane must all name the same file so a scaffold rename stays in lockstep.
+const SAFEWORD_LANE_CONFIG_FILE = 'cucumber.mjs';
+
 // Cucumber-js native config discovery order (first wins). A root config with
 // any of these names is a harness safeword must not compete with — except
 // safeword's own scaffolded cucumber.mjs, excluded by content match below.
@@ -451,7 +457,7 @@ const CUCUMBER_CONFIG_FILES = [
   'cucumber.yml',
   'cucumber.js',
   'cucumber.cjs',
-  'cucumber.mjs',
+  SAFEWORD_LANE_CONFIG_FILE,
 ] as const;
 
 /**
@@ -532,7 +538,7 @@ function detectCucumberHarnessEvidence(cwd: string, ownLanePresent: boolean): st
   for (const name of CUCUMBER_CONFIG_FILES) {
     const configPath = nodePath.join(cwd, name);
     if (!existsSync(configPath)) continue;
-    if (name === 'cucumber.mjs' && ownLanePresent) continue;
+    if (name === SAFEWORD_LANE_CONFIG_FILE && ownLanePresent) continue;
     return name;
   }
 
@@ -558,7 +564,7 @@ function detectCucumberHarnessEvidence(cwd: string, ownLanePresent: boolean): st
 export function detectCucumberLane(cwd: string | undefined): CucumberLaneDetection {
   if (!cwd) return { existingCucumberHarness: undefined, scaffoldBddLane: true };
 
-  const ownLanePresent = isSafewordLaneTemplate(nodePath.join(cwd, 'cucumber.mjs'));
+  const ownLanePresent = isSafewordLaneTemplate(nodePath.join(cwd, SAFEWORD_LANE_CONFIG_FILE));
   const evidence = detectCucumberHarnessEvidence(cwd, ownLanePresent);
   return {
     existingCucumberHarness: evidence,

--- a/packages/cli/src/utils/workspaces.ts
+++ b/packages/cli/src/utils/workspaces.ts
@@ -9,6 +9,14 @@ import nodePath from 'node:path';
 
 import { exists, readJson } from './fs.js';
 
+/**
+ * The conventional monorepo package-root directories. Shared so the scanners
+ * that walk them — workspace-member, BDD feature-source, and cucumber-harness
+ * detection — cannot drift (a root added in one place but not another silently
+ * breaks detection or discovery).
+ */
+export const WORKSPACE_ROOTS = ['packages', 'apps', 'libs', 'modules'] as const;
+
 interface PackageJson {
   name?: string;
   workspaces?: string[] | { packages?: string[] };


### PR DESCRIPTION
## Refactor: post-0.63.0 tidy of the last 36h of merged code

Two behavior-preserving refactors from a scout pass over the source touched by the 14 PRs in v0.63.0. Both are pure constant extractions — no logic, predicate, or control-flow change.

### Changes
1. **`SAFEWORD_LANE_CONFIG_FILE`** (`project-detector.ts`) — the `'cucumber.mjs'` literal was repeated at the three own-scaffold identity sites (config-discovery list, self-exclusion guard, own-lane probe). Named so a scaffold rename stays in lockstep.
2. **`WORKSPACE_ROOTS`** (`workspaces.ts`) — the `['packages','apps','libs','modules']` monorepo-roots list was triplicated across `project-detector` (`WORKSPACE_PACKAGE_ROOTS`), `feature-source` (`WORKSPACE_FEATURE_ROOTS`), and `boundaries` (inline `monorepoRoots`) — the comments even noted they were the same list. Hoisted to one shared const so a new root can't be added to one scanner and silently missed by the others.

### Scouted but deliberately NOT changed (recorded for transparency)
- **AC-reference grammar dedup** (gherkin tag vs scenario title parsers): declined — they differ by a leading `@?`; a shared regex would change title behavior for `@`-prefixed inputs. Not a safe refactor.
- **Dash-separator "dedup"**: declined — a regex char-class and a string array, not a true duplication.
- **`allCriterionIds` helper**: deferred — N=2, extract when a third call-site lands.
- **Test-only wrappers** (`parseAcIdsByJtbd`, `parseFeature{Ac,Rule}References`): left — they provide focused unit coverage; removal is a coverage-vs-tidiness judgment for the team, not a clear win.

Hook-lib scouts returned clean (already well-factored; the merges themselves extracted `shell-segments`).

### Verification
- Typecheck clean; affected unit tests green (project-detector 43, boundaries + feature-source 59).
- No dangling refs to the removed consts; knip adds no new unused export.
- Full suite via CI.