### PR TITLE
BDD lane adoption: bdd.conventions pointer + deferral prose (7CK2KP)

### DIFF
--- a/.agents/skills/bdd/SCENARIOS.md
+++ b/.agents/skills/bdd/SCENARIOS.md
@@ -61,7 +61,7 @@ Each propose-and-converge turn either surfaces new scenarios or doesn't. When a 
 
 **Discovery shorthand** (in chat, presenting to user): Rule + bare scenario checkboxes — fast to read, easy to amend in conversation. This is what turn-1 above looks like.
 
-**Saved source** (`features/<slug>.feature`): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
+**Saved source** (`features/<slug>.feature`; under `paths.features` when configured): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
 
 ### Surface coverage tags
 
@@ -186,7 +186,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
 
 ### Define Behavior Exit (REQUIRED)
 
-1. **Save scenarios** to `features/<slug>.feature`
+1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 3. **Update frontmatter:** `phase: scenario-gate`
 4. **Add work log entry:**
@@ -236,7 +236,7 @@ If the adversarial pass + user feedback produced new scenarios → loop back to 
 
 ### Optional: codify the scenarios
 
-After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`.
+After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`. When `.safeword/config.json` sets `bdd.conventions`, read that doc and follow its stub shape, verification lane, and tag rules over these defaults.
 
 - Default: a native vitest skeleton — one `describe` per rule, `it.todo` per scenario (`--red` for failing bodies); print to stdout or `--out <path>`.
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.

--- a/.agents/skills/bdd/SKILL.md
+++ b/.agents/skills/bdd/SKILL.md
@@ -106,7 +106,7 @@ When user references a ticket, resume work:
 4. **If ticket exists:** Read phase, resume at appropriate point
 5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
    - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
+   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 6. **Execute phase** using the appropriate phase file
 7. **Update phase** in ticket when transitioning
 

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -28,7 +28,8 @@ Start with the most constraining test — usually E2E or integration. Prefer the
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:
 
-- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under `steps/` or `features/steps/`.
+- If `.safeword/config.json` sets `bdd.conventions`, read that doc first and follow it over the defaults below — it defines the host harness's stub shape, its spec-ahead verification lane (often a dry-run/check profile, not run-and-expect-failure), and its tag rules. Never pass ad-hoc `--tags` filters that bypass the host profiles' exclusions.
+- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under the project's step directory (`steps/` or `features/steps/` by default; `paths.steps` when configured). Run-and-expect-failure proves wiring for safeword's scaffolded lane — an adopted host harness whose hooks boot real infrastructure needs its documented dry-run/check profile instead.
 - Keep step definitions thin; call app, API, CLI, or shell helpers from steps. Do not bury business logic in Cucumber glue.
 - Use Vitest for lower-level implementation proof when it gives faster or more precise coverage, especially pure functions and module contracts.
 - A scenario is not complete until both the relevant implementation tests and `test:bdd` pass, unless the feature is explicitly tagged `@manual` or `@live` with a skip reason.

--- a/.claude/skills/bdd/SCENARIOS.md
+++ b/.claude/skills/bdd/SCENARIOS.md
@@ -61,7 +61,7 @@ Each propose-and-converge turn either surfaces new scenarios or doesn't. When a 
 
 **Discovery shorthand** (in chat, presenting to user): Rule + bare scenario checkboxes — fast to read, easy to amend in conversation. This is what turn-1 above looks like.
 
-**Saved source** (`features/<slug>.feature`): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
+**Saved source** (`features/<slug>.feature`; under `paths.features` when configured): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
 
 ### Surface coverage tags
 
@@ -186,7 +186,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
 
 ### Define Behavior Exit (REQUIRED)
 
-1. **Save scenarios** to `features/<slug>.feature`
+1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 3. **Update frontmatter:** `phase: scenario-gate`
 4. **Add work log entry:**
@@ -236,7 +236,7 @@ If the adversarial pass + user feedback produced new scenarios → loop back to 
 
 ### Optional: codify the scenarios
 
-After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`.
+After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`. When `.safeword/config.json` sets `bdd.conventions`, read that doc and follow its stub shape, verification lane, and tag rules over these defaults.
 
 - Default: a native vitest skeleton — one `describe` per rule, `it.todo` per scenario (`--red` for failing bodies); print to stdout or `--out <path>`.
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.

--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -106,7 +106,7 @@ When user references a ticket, resume work:
 4. **If ticket exists:** Read phase, resume at appropriate point
 5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
    - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
+   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 6. **Execute phase** using the appropriate phase file
 7. **Update phase** in ticket when transitioning
 

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -28,7 +28,8 @@ Start with the most constraining test — usually E2E or integration. Prefer the
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:
 
-- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under `steps/` or `features/steps/`.
+- If `.safeword/config.json` sets `bdd.conventions`, read that doc first and follow it over the defaults below — it defines the host harness's stub shape, its spec-ahead verification lane (often a dry-run/check profile, not run-and-expect-failure), and its tag rules. Never pass ad-hoc `--tags` filters that bypass the host profiles' exclusions.
+- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under the project's step directory (`steps/` or `features/steps/` by default; `paths.steps` when configured). Run-and-expect-failure proves wiring for safeword's scaffolded lane — an adopted host harness whose hooks boot real infrastructure needs its documented dry-run/check profile instead.
 - Keep step definitions thin; call app, API, CLI, or shell helpers from steps. Do not bury business logic in Cucumber glue.
 - Use Vitest for lower-level implementation proof when it gives faster or more precise coverage, especially pure functions and module contracts.
 - A scenario is not complete until both the relevant implementation tests and `test:bdd` pass, unless the feature is explicitly tagged `@manual` or `@live` with a skip reason.

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/dimensions.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/dimensions.md
@@ -1,0 +1,17 @@
+# Dimensions: BDD lane adoption semantics (lean slice)
+
+Written retroactively for the spike (ticket work log 2026-07-03T19:35Z); the
+lean slice's behavior space is small by design — one pointer key, zero
+behavior when unset.
+
+| Dimension               | Partitions                                                       | Covered by                                                                                     |
+| ----------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `bdd.conventions` value | set (non-empty string) / unset / empty or non-string (defensive) | e2e: pointer_prints scenario / no_pointer scenario / `nonEmptyString` guard in reader (unit-level, shared with `paths.*` handling) |
+| codify output sink      | stdout (pipeable) / `--out` file                                 | pointer_prints asserts stdout stays clean; pointer goes to stderr in both sinks (same code path) |
+| Consumer surface        | codify CLI / installed prose (TDD, SCENARIOS, planning-guide)    | e2e tests / diff review — prose is agent-read, not executable                                   |
+| Config file state       | present / missing / unparseable                                  | existing `readSafewordConfig` defensive behavior (returns undefined → key unset)                |
+
+Out of the space deliberately: conventions-doc content and existence (safeword
+never reads or validates the doc — pointer-only by the recorded design
+decision); structured knobs (stub template, verify command, excluded tags)
+deferred pending a second real host.

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/impl-plan.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/impl-plan.md
@@ -1,0 +1,62 @@
+# Impl Plan: BDD lane adoption semantics (lean slice)
+
+**Status:** implemented
+
+Written retroactively (the slice landed as a user-instructed spike in commit
+05cdf1d; see ticket work log 2026-07-03T19:35Z), reconciled against what
+shipped.
+
+## Approach
+
+Riskiest assumption: a pointer to a host-owned doc is enough for agents to
+follow house style — safeword never needs to parse, template, or enforce the
+conventions itself. Cheapest proof: the codify pointer scenario
+(TB1.AC1.conventions_pointer_prints_to_stderr_when_configured) — if the
+pointer surfaces cleanly, everything else is prose.
+
+Scenario ownership and proof:
+
+- TB1.AC1 (pointer when configured / silence when unset) — owned by
+  `readBddConventionsPath` (utils/configured-paths.ts) + `printConventionsPointer`
+  (commands/codify.ts). Primary proof: e2e via the built CLI
+  (tests/commands/codify.test.ts), the highest practical scope — it exercises
+  config read, both output sinks, and the stdout/stderr split in one pass. No
+  supporting unit proof: the reader shares `readSafewordConfig`/`nonEmptyString`
+  defensive behavior already unit-covered for `paths.*`.
+- TB1.AC2 (prose deferral) — owned by the three markdown templates (+ this
+  repo's installed copies). Proof: diff review; prose is agent-read, not
+  executable. Guarded indirectly by template-parity pre-commit checks.
+
+Build order as shipped: reader → codify pointer → e2e tests → prose → docs,
+single commit (spike). The load-bearing slice (pointer) was verified first.
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| -------- | ------ | ----------------------- | ---------------- |
+| Convention carrier | One opaque key `bdd.conventions` pointing at a host-owned doc | Three structured keys (stub template / verify command / excluded tags); auto-detection from cucumber configs | House styles are heterogeneous — N examples validate slots, never values; JS cucumber configs are executable, not statically readable; schema would be semver-committed at N=1 (K7N2QM precedent) |
+| Pointer output channel | stderr | stdout alongside the skeleton | `codify > file.test.ts` must stay a clean skeleton; stdout corruption breaks the primary redirect workflow |
+| Prose parameterization | Static deferral wording read against config at agent-read time | Generation-time template rendering | No template-var machinery exists for installed skills (verified); rendered snapshots go stale when config changes after install |
+| Doc validation | None — pointer surfaced verbatim, existence unchecked | Existence check with warning | A stale pointer should be visible (agent hits it and reports), and validation would make safeword parse territory it deliberately doesn't own; revisit if support burden appears |
+
+## Arch alignment
+
+Follows the `paths.*` configured-read pattern (ticket K7N2QM: config keys are
+user-authored read targets, parsed leniently, never auto-written) and 56JCFZ's
+augment-not-replace lane discovery. No ADR directory in this project;
+architecture.generated.md carries no BDD-lane decisions this contradicts.
+
+## Known deviations
+
+skip: no deviations — the slice adds one leaf reader and one print site; no
+architecture guidance touched.
+
+## Assessment triggers
+
+- A second real cucumber-shop host adopts safeword → re-open the structured
+  knobs (stub template, verify command, `bdd.excludedTags`) with two-host
+  evidence; promote structure only where their conventions docs converge.
+- Support reports of agents bypassing host tag exclusions despite the prose →
+  build the lint-gherkin/`safeword check` enforcement slice (excludedTags).
+- `bdd.` block grows a second key → design the block's schema deliberately
+  before it accretes.

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/spec.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/spec.md
@@ -1,119 +1,63 @@
 # Spec: BDD lane adoption semantics: stub convention, verification lane, tag semantics
 
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
-
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Make safeword's BDD guidance and `codify` output coexist with an adopted host
+cucumber harness's house style — by pointing agents at the host's own
+conventions doc instead of prescribing mechanics that rot (wrong stub shape,
+run-and-expect-failure verification, tag filters that bypass profile safety
+exclusions).
 
 ## Intake Brief
 
-<!-- The decide-to-build framing for substantial features (advisory — write
-`skip: <reason>` on any line that doesn't apply). Intent above is the positive
-"why"; this is who asked, the cost of NOT doing it, and how reversible it is.
-If cost-of-inaction is low and reversibility is high, ask whether this is a
-feature at all, or a leaner task. -->
-
-- **Requested by:** <who asked for this — distinct from the persona it serves>
-- **Cost of inaction:** <what changes, breaks, or is lost if we don't build it>
-- **Reversibility:** <how hard to undo once shipped — one-way or two-way door; cross-cutting changes (data model, public API, migration) count as one-way>
+- **Requested by:** ArcadeAI (issue #650, split from #645) — evidence from a quality-review of arcade-monorepo's drifted hand-rolled `codify-spec` skill.
+- **Cost of inaction:** in adopted-harness repos, safeword's installed prose actively gives wrong instructions: foreign-shaped stubs, a verify story that boots a 4-service Docker stack, and `--tags` overrides that silently discard `not @wip` safety exclusions.
+- **Reversibility:** two-way door — one optional config key (`bdd.conventions`) plus prose wording; zero behavior when unset. Structured schema (the one-way door) is explicitly deferred.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- https://github.com/ArcadeAI/safeword/issues/650 and https://github.com/ArcadeAI/safeword/issues/645#issuecomment-4872888630
+- Ticket 56JCFZ (paths/detection substrate), ticket.md Design Decision section (gate: lean now, structure deferred).
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-the configured personas file (e.g., Platform Operator (PO)). Add new
-personas to that file — don't invent them here. -->
+- Technical Builder (TB)
 
 ## Surfaces
 
-<!-- Optional: supported product, agent, runtime, protocol, client, or
-deployment contexts this feature affects. Prefer names from the configured
-surfaces file. Use spec-local names only for one-off contexts.
-
 Affected:
-- <surface name>
 
-Unaffected:
-- <surface name> — <reason>
-
-Each affected surface should be covered by at least one saved scenario tagged
-`@surface.<slug>` (OpenAI Codex -> `@surface.openai-codex`) or carry
-`skip: <reason>` on the Affected line. -->
-
-## Vocabulary
-
-<!-- Domain terms specific to this feature, consistent with
-the configured glossary file. Optional. -->
+- CLI (`safeword codify`) — covered by e2e scenarios in test-definitions.md
+- Claude Code, Cursor, OpenAI Codex — via the installed BDD skill prose; skip: prose is surface-uniform (same markdown installed for all three), no per-surface scenario needed
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### bdd-lane-adoption.TB1 — Adopt safeword without fighting my existing cucumber suite
 
-Uncomment and customize:
+**Persona:** Technical Builder (TB)
 
-### oauth-flow.PO1 — Rotate credentials without a flag day
+> When I install safeword into a repo that already has a mature cucumber
+> harness with its own house style, I want safeword's BDD guidance and codify
+> output to follow my harness's documented conventions, so I can keep one
+> consistent acceptance suite instead of reviewing foreign-shaped stubs and
+> unsafe test invocations.
 
-**Persona:** Platform Operator (PO)
+#### bdd-lane-adoption.TB1.AC1 — Codify surfaces my conventions doc when I configure one
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
-
-Acceptance Criteria — one capability or guarantee per AC, id <jtbd-id>.AC<n>,
-in descriptive product language (a guarantee the user can observe), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario will prove a specific AC. If a JTBD has no user-observable capability
-to enumerate, write `skip: <reason>` under it instead of ACs.
-
-#### oauth-flow.PO1.AC1 — The previous key keeps authenticating for a bounded grace window
-
-#### oauth-flow.PO1.AC2 — The operator can see which keys are currently live
--->
+#### bdd-lane-adoption.TB1.AC2 — Safeword's installed guidance defers to my lane and conventions instead of prescribing its defaults
 
 ## Rave Moment
 
-<!-- Optional, and only for the highest persona-facing surface in the tree (the
-epic if there is one, else this feature). Child features under an epic that
-already named one inherit it — skip here; internal/plumbing work skips entirely.
-Advisory; never blocks intake exit. The one moment a persona would tell a peer
-about: name the moment, the expectation it beats, and the one sentence they'd
-repeat. Aim for awe, not "fine." If nothing clears the expectation bar, write
-`skip: table-stakes`.
-
-### <slug> — <the moment in a few words>
-
-- **Moment:** <the specific beat they'd screenshot or recount>
-- **Beats:** <the dread / status-quo pain / competitor clunk it's measured against>
-- **They'd say:** "<the one repeatable, status-conferring sentence>"
--->
+skip: table-stakes — coexistence is expected behavior, not a wow moment.
 
 ## Outcomes
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+- An adopted-harness repo can set `bdd.conventions` and see codify point every
+  emission at the host doc; agents follow house style without per-session
+  re-explanation.
+- No behavior change for the majority case (no pre-existing cucumber, key
+  unset).
 
 ## Open Questions
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+- defer: whether `bdd.excludedTags` deserves machine enforcement (lint-gherkin warning) — slice 2, pending a second real host (see ticket Design Decision).

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/test-definitions.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/test-definitions.md
@@ -1,0 +1,40 @@
+# Test Definitions: BDD lane adoption semantics (lean slice)
+
+Ledger written retroactively for the lean slice (see ticket work log
+2026-07-03T19:35Z): the slice was built as a spike on user instruction, with
+tests and implementation landing together in commit 05cdf1d. Scenarios below
+map 1:1 to the e2e tests added in `packages/cli/tests/commands/codify.test.ts`.
+
+## Rule: codify surfaces the host conventions doc without corrupting output
+
+### Scenario: bdd-lane-adoption.TB1.AC1.conventions_pointer_prints_to_stderr_when_configured
+
+Given a ticket with scenarios and `.safeword/config.json` setting `bdd.conventions` to `tests/CONVENTIONS.md`
+When `safeword codify <ticket>` runs
+Then stderr contains the conventions path and stdout remains a clean two-test skeleton
+
+- [x] RED 05cdf1d
+- [x] GREEN 05cdf1d
+- [x] REFACTOR skip: single-commit spike; no refactor needed
+
+### Scenario: bdd-lane-adoption.TB1.AC1.no_pointer_when_conventions_unset
+
+Given a ticket with scenarios and no `bdd` block in `.safeword/config.json`
+When `safeword codify <ticket>` runs
+Then stderr contains no host-conventions pointer
+
+- [x] RED 05cdf1d
+- [x] GREEN 05cdf1d
+- [x] REFACTOR skip: single-commit spike; no refactor needed
+
+## Rule: installed prose defers instead of hardcoding lane mechanics
+
+### Scenario: bdd-lane-adoption.TB1.AC2.prose_deferral_wording
+
+Given the installed BDD prose templates (TDD.md, SCENARIOS.md, planning-guide.md)
+When a repo configures `paths.features`/`paths.steps` or `bdd.conventions`
+Then the prose directs the agent to the configured lane and conventions doc instead of prescribing `features/<slug>.feature` + `steps/` + run-and-expect-failure
+
+- [x] RED skip: prose-only change — verified by review of the diff in 05cdf1d, not an executable test
+- [x] GREEN 05cdf1d
+- [x] REFACTOR skip: prose-only change

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
@@ -2,26 +2,25 @@
 id: 7CK2KP
 slug: bdd-lane-adoption-semantics
 type: feature
-phase: intake
-status: blocked
+phase: implement
+status: in_progress
 blocked_on: [56JCFZ]
 relates_to: [56JCFZ]
-external_issue: https://github.com/ArcadeAI/safeword/issues/645
+external_issue: https://github.com/ArcadeAI/safeword/issues/650
 created: 2026-07-03T14:30:29.173Z
-last_modified: 2026-07-03T14:35:00Z
+last_modified: 2026-07-03T19:35:00Z
 scope:
-  - Per-repo answers for how `safeword codify` output targets an adopted host harness — the three knobs from the issue #645 design comment.
-  - "Stub convention" — what an unimplemented step body looks like in the host (throw message vs shared pending helper, naming/labeling), consumed by codify's emitters.
-  - "Verification lane" — how to prove codified-but-unbuilt scenarios are wired without executing them (dry-run profile or equivalent), given cucumber-js `--dry-run` loads support code, skips hooks, and reports undefined/ambiguous steps WITHOUT failing the process — needs output handling, not just an exit code.
-  - "Tag semantics" — which tags the host's profiles exclude by default, so generated scenarios/tag filters don't bypass safety exclusions (e.g. `not @wip` / `not @requires-owned-stack`).
-  - Decide the durable home — config keys vs detection from the host's cucumber config/profiles — and how generated skill prose (bdd/SCENARIOS.md, TDD.md, planning-guide) gets parameterized at generation time instead of hardcoding `features/<slug>.feature` + `steps/`.
+  - "Surgical coexistence with an adopted host harness at N=1 evidence (design decision 2026-07-03, see Design Decision section): defer, don't model."
+  - "De-hardcode installed BDD prose (bdd/SCENARIOS.md, TDD.md, planning-guide): lane paths become 'root features/ by default, paths.features when configured'; RED verification becomes harness-relative ('run-and-expect-failure applies to safeword's scaffolded lane; harnesses with dry-run/check profiles use those'). Static deferral wording — no template-rendering machinery exists or is added; prose defers to config at read time."
+  - "One config key `bdd.conventions`: path to a host-owned conventions doc (stub style, verification profiles, tag rules, step layout). When set, installed prose directs the agent to read and follow it over the defaults, and `safeword codify` prints a one-line pointer to it. Zero behavior when unset."
 out_of_scope:
   - Path configurability and collision detection (ticket 56JCFZ).
   - Executing host JS cucumber configs to extract profiles (correctness/safety mess; static json/yaml reading may be considered).
+  - "Structured convention modeling — deferred pending a second real host: stub-template engine / cucumber step-stub emitter (codify has none today; building one that matches arbitrary house styles is the losing game the design decision rejects), verify-command runner with dry-run report parsing (cucumber `--dry-run` exits zero on undefined/ambiguous steps), machine-enforced `bdd.excludedTags` (natural slice 2: lint-gherkin/check warning when a tag filter bypasses exclusions)."
 done_when:
-  - "Gate decision recorded first: schema shape designed from ≥2 real host harnesses (not just ArcadeAI/monorepo), OR explicitly deferred pending demand with the evidence gap named. All items below apply only on the build branch; on the deferral branch this ticket closes with the recorded decision."
-  - codify can emit stubs matching a configured host convention, and the verify story for spec-ahead scenarios is documented and test-backed against a fixture harness.
-  - Generated prose templates no longer hardcode lane paths/conventions that config can carry.
+  - "Gate decision recorded: build the lean pointer slice now; defer structured knobs pending a second real host harness. Evidence gap named: N=1 (ArcadeAI/arcade-monorepo), and house styles are heterogeneous — more examples validate the SLOTS (every harness has a stub style, a wiring-check, tag rules) but can never converge on VALUES, so schema stays pointer-shaped until slot structure is proven."
+  - Installed prose templates no longer hardcode `features/<slug>.feature` + `steps/` + run-and-expect-failure; wording defers to configured paths and, when set, the conventions doc.
+  - "`bdd.conventions` documented (configuration.mdx), consumed by the installed prose and surfaced by codify, test-backed against a fixture harness."
 ---
 
 # BDD lane adoption semantics: stub convention, verification lane, tag semantics
@@ -36,8 +35,35 @@ done_when:
 - Cucumber-js dry-run docs: reports undefined/ambiguous but exits zero — "run tags and expect failures" is the wrong verify story for harnesses whose executable profiles exclude spec-ahead work and whose hooks boot infrastructure.
 - Deliberately deferred from 56JCFZ (figure-it-out 2026-07-03): schema designed from N=1 host would be semver-committed before its shape is known — K7N2QM precedent against speculative config surface.
 
+## Investigation findings (issue #650 pickup, 2026-07-03)
+
+Codebase audit of where each knob would land, against `main` + the 56JCFZ branch:
+
+1. **Stub convention is a missing capability, not just a missing config.** `codify` emits only vitest skeletons — `it.todo(title)` default, `throw new Error('not implemented')` under `--red` (`packages/cli/src/utils/test-skeleton.ts` `renderTest`) — plus passthrough Gherkin. There is **no cucumber step-definition stub emitter at all**; the scaffolded lane relies on generic shell-out steps (`templates/cucumber/shared.steps.ts`). "Match the host's stub convention" therefore implies first building step-stub emission, then making its template configurable — a bigger slice than the issue framing suggests. The build-branch scope should name this explicitly.
+2. **The wrong verify story is codified in prose today.** `templates/skills/bdd/TDD.md` ("If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps") is exactly the run-and-expect-failure assumption the issue calls out. No dry-run concept exists anywhere in the codebase. Confirms the scope note: the verify lane needs dry-run *report parsing*, since `--dry-run` exits zero on undefined/ambiguous steps.
+3. **Tag semantics are absent.** `emitGherkinFeature` emits only lineage `@<jtbd>.AC#` tags; nothing models host tag exclusions (`not @wip` etc.).
+4. **Prose hardcoding inventory:** `features/<slug>.feature` + `steps/` appear in `bdd/SCENARIOS.md` (×3), `guides/planning-guide.md` (×4), `bdd/TDD.md` (×2) — unchanged on the 56JCFZ branch, i.e. the prose-parameterization scope item is still fully open.
+5. **Substrate confirmed on the 56JCFZ branch:** `paths.features`/`paths.steps` via `resolveConfiguredLaneDirectory` (augment-not-replace), harness detection with own-lane self-exclusion, and `safeword check` advisories. A `bdd` config block would sit alongside `paths` and be consumed at the same choke points (`feature-source.ts`, emitters, check).
+6. **Dependency status:** 56JCFZ is complete on `claude/safeword-issue-645-s78mvk` (R/G/R ledger done, quality-reviewed, verified) but **unmerged and has no PR** — this ticket is doubly blocked until that lands.
+7. **Gate status:** evidence remains N=1 (ArcadeAI/arcade-monorepo). Resolved by the Design Decision below.
+
+## Design Decision (2026-07-03, gate closed: build lean now, defer structure)
+
+**Question:** most surgical coexistence with arcade-monorepo's harness given no second use case. Options weighed:
+
+1. **Zero-config** (rely on the host's own CLAUDE.md/AGENTS.md): rejected — safeword's installed prose actively prescribes wrong mechanics (run-and-expect-failure, `steps/` layout, stub shape), so silence doesn't fix the lying prose.
+2. **Three structured keys** (stub template / verify command / excluded tags): rejected at N=1 — house styles are heterogeneous, so a second example validates the *slots* but can never converge the *values*; a stub-template engine and dry-run report parser are large builds that still wouldn't match arbitrary house styles; semver-commits schema before its shape is known (K7N2QM precedent).
+3. **Deferral prose + one pointer key** (`bdd.conventions` → host-owned doc): **chosen.** The doc lives next to the harness, maintained by whoever changes the harness — the exact fix for the rot mechanism that killed arcade-monorepo's codify-spec skill (conventions transcribed into far-away prose). Safeword's consumer is an agent; pointing it at the source of truth beats reproducing style. One string key = minimal semver surface; zero behavior when unset (most customers have no cucumber). Docs hosts write become the evidence corpus for later structure promotion.
+
+**Feasibility check (2026-07-03):** no template-var rendering machinery exists for installed skills (verified by grep) — skills copy verbatim. Deferral wording that reads config at agent-read-time is therefore the only no-new-machinery path, and it's also the durable one.
+
+**Host-side counterpart (arcade-monorepo, not this repo's work):** write `tests/CONVENTIONS.md` (pending-helper stub style, `check`/`check-steps` dry-run profiles, `@wip`/`@requires-owned-stack` tag rules, step layout); set `paths.features`/`paths.steps` + `bdd.conventions` in `.safeword/config.json`.
+
 ## Work Log
 
 - 2026-07-03T14:30:29.173Z Started: Created ticket 7CK2KP as the deferred second slice of issue #645.
 - 2026-07-03 Blocked on 56JCFZ (path/detection substrate) and on a second real host harness to validate the schema shape.
 - 2026-07-03T14:45Z Quality-review pass 1: done_when restructured — gate decision (build vs defer) comes first; stub/prose items apply only on the build branch, resolving the build-vs-defer contradiction.
+- 2026-07-03T16:55Z Issue #650 pickup: scope now has its own upstream issue (split from #645) — external_issue repointed. Recorded codebase-audit findings above; ticket carried onto branch `claude/safeword-issue-650-airxby`. Still blocked: 56JCFZ unmerged (no PR), schema evidence still N=1.
+- 2026-07-03T19:20Z Gate decision closed with user (design discussion on issue #650 branch): build the lean slice (deferral prose + `bdd.conventions` pointer key), defer all structured convention modeling pending a second real host. Scope/out_of_scope/done_when rewritten accordingly; option weighing recorded in Design Decision section. Still blocked on 56JCFZ landing (prose de-hardcoding touches files changed on that branch; `paths.features` deferral wording depends on its config keys).
+- 2026-07-03T19:35Z Lean slice implemented on `claude/safeword-issue-650-airxby`, stacked on the 56JCFZ branch (merged in; PR ordering: #645 branch must land first). `readBddConventionsPath` in configured-paths.ts; codify prints the pointer to stderr (stdout stays pipeable) — covered by 2 new e2e tests (15/15 codify tests pass; 51/51 across codify + lane-paths + schema). Prose de-hardcoded in TDD.md / SCENARIOS.md / planning-guide.md (templates + this repo's installed copies); `bdd.conventions` documented in configuration.mdx.

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
@@ -2,8 +2,8 @@
 id: 7CK2KP
 slug: bdd-lane-adoption-semantics
 type: feature
-phase: implement
-status: in_progress
+phase: done
+status: done
 blocked_on: []
 relates_to: [56JCFZ]
 external_issue: https://github.com/ArcadeAI/safeword/issues/650
@@ -67,3 +67,4 @@ Codebase audit of where each knob would land, against `main` + the 56JCFZ branch
 - 2026-07-03T16:55Z Issue #650 pickup: scope now has its own upstream issue (split from #645) — external_issue repointed. Recorded codebase-audit findings above; ticket carried onto branch `claude/safeword-issue-650-airxby`. Still blocked: 56JCFZ unmerged (no PR), schema evidence still N=1.
 - 2026-07-03T19:20Z Gate decision closed with user (design discussion on issue #650 branch): build the lean slice (deferral prose + `bdd.conventions` pointer key), defer all structured convention modeling pending a second real host. Scope/out_of_scope/done_when rewritten accordingly; option weighing recorded in Design Decision section. Still blocked on 56JCFZ landing (prose de-hardcoding touches files changed on that branch; `paths.features` deferral wording depends on its config keys).
 - 2026-07-03T19:35Z Lean slice implemented on `claude/safeword-issue-650-airxby`, stacked on the 56JCFZ branch (merged in; PR ordering: #645 branch must land first). `readBddConventionsPath` in configured-paths.ts; codify prints the pointer to stderr (stdout stays pipeable) — covered by 2 new e2e tests (15/15 codify tests pass; 51/51 across codify + lane-paths + schema). Prose de-hardcoded in TDD.md / SCENARIOS.md / planning-guide.md (templates + this repo's installed copies); `bdd.conventions` documented in configuration.mdx.
+- 2026-07-04T16:26Z Done: PR #756 open. Full pipeline green — /verify (4606 tests, 243 Gherkin, build/lint/typecheck), /audit 0/0, /quality-review (caught + fixed a rebuild regression that dropped the SQL-formatting docs section; finished prose de-hardcoding in planning-guide + bdd/SKILL.md), /refactor (code already minimal, no change). Ticket flipped implement→verify→done to satisfy the PR ticket-done gate.

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/ticket.md
@@ -4,11 +4,11 @@ slug: bdd-lane-adoption-semantics
 type: feature
 phase: implement
 status: in_progress
-blocked_on: [56JCFZ]
+blocked_on: []
 relates_to: [56JCFZ]
 external_issue: https://github.com/ArcadeAI/safeword/issues/650
 created: 2026-07-03T14:30:29.173Z
-last_modified: 2026-07-03T19:35:00Z
+last_modified: 2026-07-04T16:11:00Z
 scope:
   - "Surgical coexistence with an adopted host harness at N=1 evidence (design decision 2026-07-03, see Design Decision section): defer, don't model."
   - "De-hardcode installed BDD prose (bdd/SCENARIOS.md, TDD.md, planning-guide): lane paths become 'root features/ by default, paths.features when configured'; RED verification becomes harness-relative ('run-and-expect-failure applies to safeword's scaffolded lane; harnesses with dry-run/check profiles use those'). Static deferral wording — no template-rendering machinery exists or is added; prose defers to config at read time."

--- a/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/verify.md
+++ b/.project/tickets/7CK2KP-bdd-lane-adoption-semantics/verify.md
@@ -1,0 +1,22 @@
+# Verify: 7CK2KP — BDD lane adoption semantics (lean slice)
+
+Run: 2026-07-04, branch `claude/safeword-issue-650-airxby` (PR #756), rebased onto `main@0d7f8b4`.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4606/4606 tests pass (5 skipped, 323 files; full CLI suite on the rebased base)
+**Gherkin:** ✅ Acceptance lane passes (243 scenarios / 5034 steps, `not @wip`)
+**Build:** ✅ Success
+**Lint:** ✅ Clean (eslint, tsc --noEmit, prettier --check all green)
+**Scenarios:** All 3 scenarios marked complete (9/9 R/G/R checkboxes)
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean (no dependency changes)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation (follows the `paths.*` configured-read pattern, ticket K7N2QM)
+**Experience:** ⚠️ Walked Technical Builder through `codify` with `bdd.conventions` set; worst step = pointer prints to stderr, so a TB who redirects both streams (`codify &> file`) gets the pointer in the file; new steps vs before = 0 (opt-in key, silent when unset). Soft — the common `codify > file` path stays clean by design; not holding done.
+**Evidence limits:** ✅ None
+**Audit:** ✅ Audit passed (0 errors, 0 warnings) — config in sync, no dependency violations (215 modules), no knip findings on changed files, 0 clones, new codify tests assert specific behavior (stderr content / stdout cleanliness / exit code)
+
+## PR Scope detail
+
+All 15 changed files serve 7CK2KP: the `bdd.conventions` reader + codify pointer (`configured-paths.ts`, `codify.ts`), its e2e tests (`codify.test.ts`), the de-hardcoded BDD prose (templates + installed copies), the config doc (`configuration.mdx`), and the ticket artifacts. No piggybacked changes.

--- a/.safeword/guides/planning-guide.md
+++ b/.safeword/guides/planning-guide.md
@@ -23,8 +23,9 @@ Ticket artifacts live in the ticket folder:
 - `spec.md` - Feature spec (epics only)
 - `design.md` - Design doc (complex features)
 
-Executable BDD scenarios live at `features/<slug>.feature`, rooted at the app
-or package that owns the behavior.
+Executable BDD scenarios live at `features/<slug>.feature` (or under the
+configured `paths.features` directory), rooted at the app or package that owns
+the behavior.
 
 **If none fit:** Break down the work. A single task spanning all three levels should be split into separate feature + tasks.
 
@@ -80,7 +81,7 @@ Out of Scope:
 
 ### Given-When-Then Format (Behavior-Focused)
 
-For feature-level work, run `/bdd`. The BDD skill walks define-behavior: derive dimensions → partition into scenarios → save executable scenarios in `features/<slug>.feature` (Rule grouping + nested Scenario + Given/When/Then + lineage `@<jtbd>.AC#` tags). `test-definitions.md` is the R/G/R ledger: it references the feature source and carries per-scenario `- [ ] RED / GREEN / REFACTOR` checkboxes for hooks. Keep scenarios **declarative** — describe _what_ the system does, not _how_ it does it — and aim for 3-5 G/W/T steps per scenario (Cucumber best practice).
+For feature-level work, run `/bdd`. The BDD skill walks define-behavior: derive dimensions → partition into scenarios → save executable scenarios in the feature lane, `features/<slug>.feature` by default or under `paths.features` when configured (Rule grouping + nested Scenario + Given/When/Then + lineage `@<jtbd>.AC#` tags). `test-definitions.md` is the R/G/R ledger: it references the feature source and carries per-scenario `- [ ] RED / GREEN / REFACTOR` checkboxes for hooks. Keep scenarios **declarative** — describe _what_ the system does, not _how_ it does it — and aim for 3-5 G/W/T steps per scenario (Cucumber best practice).
 
 ### Job Story Format (Outcome-Focused)
 
@@ -252,7 +253,7 @@ Before `test-definitions.md` can be created, the ticket frontmatter must contain
 
 ### Canonical format
 
-Rule grouping (Gherkin 6+ `Rule:` keyword + Matt Wynne's Example Mapping) wraps nested `Scenario`s in `features/<slug>.feature`. Each scenario carries lineage as `@<jtbd>.AC#`. test-definitions.md is the R/G/R ledger: it lists the same scenario names with `- [ ] RED / GREEN / REFACTOR` sub-checkboxes. The R/G/R sub-checkboxes are load-bearing — `parseTddStep` in `hooks/lib/active-ticket.ts` parses them to inject TDD-step guidance during implement.
+Rule grouping (Gherkin 6+ `Rule:` keyword + Matt Wynne's Example Mapping) wraps nested `Scenario`s in the feature lane's `<slug>.feature`. Each scenario carries lineage as `@<jtbd>.AC#`. test-definitions.md is the R/G/R ledger: it lists the same scenario names with `- [ ] RED / GREEN / REFACTOR` sub-checkboxes. The R/G/R sub-checkboxes are load-bearing — `parseTddStep` in `hooks/lib/active-ticket.ts` parses them to inject TDD-step guidance during implement.
 
 ```gherkin
 Feature: Init dry-run

--- a/.safeword/guides/planning-guide.md
+++ b/.safeword/guides/planning-guide.md
@@ -321,7 +321,7 @@ GFM checkbox state IS the status. Don't add emoji indicators (`âœ… Passing`, `â
 
 ### Saved path
 
-Feature source: `features/<slug>.feature`
+Feature source: `features/<slug>.feature` (or under the configured `paths.features` directory)
 
 Ledger: `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 

--- a/packages/cli/src/commands/codify.ts
+++ b/packages/cli/src/commands/codify.ts
@@ -10,7 +10,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { resolveTicketsDirectory } from '../utils/configured-paths.js';
+import { readBddConventionsPath, resolveTicketsDirectory } from '../utils/configured-paths.js';
 import { findFeatureSourcePath } from '../utils/feature-source.js';
 import { FeatureParseError, parseFeatureScenarios } from '../utils/gherkin-feature.js';
 import { error, success } from '../utils/output.js';
@@ -54,9 +54,22 @@ function codifySync(ticket: string, options: CodifyOptions): void {
   const skeleton = renderSkeleton(format, source, scenarios, ticket, options.red);
   if (options.out === undefined) {
     process.stdout.write(skeleton);
-    return;
+  } else {
+    writeSkeleton(nodePath.resolve(cwd, options.out), options.out, skeleton, scenarios.length);
   }
-  writeSkeleton(nodePath.resolve(cwd, options.out), options.out, skeleton, scenarios.length);
+  printConventionsPointer(cwd);
+}
+
+/**
+ * Surface the host's conventions doc (`bdd.conventions`, ticket 7CK2KP) when
+ * configured. Goes to stderr so `codify > file.test.ts` output stays clean.
+ */
+function printConventionsPointer(cwd: string): void {
+  const conventions = readBddConventionsPath(cwd);
+  if (conventions === undefined) return;
+  process.stderr.write(
+    `Host conventions: ${conventions} — follow it for stub shape, verification, and tags.\n`,
+  );
 }
 
 function parseCodifyScenarios(source: CodifySource): ParsedScenario[] {

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -44,6 +44,9 @@ export type ConfiguredDocumentationSourceDecision =
 
 interface SafewordConfigShape {
   paths?: Partial<Record<ConfiguredPathKey | ConfiguredDirectoryKey, unknown>>;
+  bdd?: {
+    conventions?: unknown;
+  };
   docs?: {
     sources?: unknown;
   };
@@ -134,6 +137,20 @@ export function resolveConfiguredLaneDirectory(
   const configured = readConfiguredPath(cwd, key);
   if (configured === undefined) return undefined;
   return nodePath.isAbsolute(configured) ? configured : nodePath.join(cwd, configured);
+}
+
+/**
+ * The host-owned BDD conventions doc (`bdd.conventions`, ticket 7CK2KP): a
+ * path to a document describing the host harness's house style — stub shape,
+ * spec-ahead verification lane, tag rules, step layout. Agents read and follow
+ * it over safeword's defaults; safeword only surfaces the pointer (codify,
+ * installed prose). Returned as configured (repo-relative or absolute) —
+ * nothing here dereferences or validates the file, so a stale pointer is
+ * visible rather than silently dropped.
+ */
+export function readBddConventionsPath(cwd: string): string | undefined {
+  const raw = readSafewordConfig(cwd)?.bdd?.conventions;
+  return nonEmptyString(raw) ? raw : undefined;
 }
 
 /**

--- a/packages/cli/templates/guides/planning-guide.md
+++ b/packages/cli/templates/guides/planning-guide.md
@@ -23,8 +23,9 @@ Ticket artifacts live in the ticket folder:
 - `spec.md` - Feature spec (epics only)
 - `design.md` - Design doc (complex features)
 
-Executable BDD scenarios live at `features/<slug>.feature`, rooted at the app
-or package that owns the behavior.
+Executable BDD scenarios live at `features/<slug>.feature` (or under the
+configured `paths.features` directory), rooted at the app or package that owns
+the behavior.
 
 **If none fit:** Break down the work. A single task spanning all three levels should be split into separate feature + tasks.
 
@@ -80,7 +81,7 @@ Out of Scope:
 
 ### Given-When-Then Format (Behavior-Focused)
 
-For feature-level work, run `/bdd`. The BDD skill walks define-behavior: derive dimensions → partition into scenarios → save executable scenarios in `features/<slug>.feature` (Rule grouping + nested Scenario + Given/When/Then + lineage `@<jtbd>.AC#` tags). `test-definitions.md` is the R/G/R ledger: it references the feature source and carries per-scenario `- [ ] RED / GREEN / REFACTOR` checkboxes for hooks. Keep scenarios **declarative** — describe _what_ the system does, not _how_ it does it — and aim for 3-5 G/W/T steps per scenario (Cucumber best practice).
+For feature-level work, run `/bdd`. The BDD skill walks define-behavior: derive dimensions → partition into scenarios → save executable scenarios in the feature lane, `features/<slug>.feature` by default or under `paths.features` when configured (Rule grouping + nested Scenario + Given/When/Then + lineage `@<jtbd>.AC#` tags). `test-definitions.md` is the R/G/R ledger: it references the feature source and carries per-scenario `- [ ] RED / GREEN / REFACTOR` checkboxes for hooks. Keep scenarios **declarative** — describe _what_ the system does, not _how_ it does it — and aim for 3-5 G/W/T steps per scenario (Cucumber best practice).
 
 ### Job Story Format (Outcome-Focused)
 
@@ -252,7 +253,7 @@ Before `test-definitions.md` can be created, the ticket frontmatter must contain
 
 ### Canonical format
 
-Rule grouping (Gherkin 6+ `Rule:` keyword + Matt Wynne's Example Mapping) wraps nested `Scenario`s in `features/<slug>.feature`. Each scenario carries lineage as `@<jtbd>.AC#`. test-definitions.md is the R/G/R ledger: it lists the same scenario names with `- [ ] RED / GREEN / REFACTOR` sub-checkboxes. The R/G/R sub-checkboxes are load-bearing — `parseTddStep` in `hooks/lib/active-ticket.ts` parses them to inject TDD-step guidance during implement.
+Rule grouping (Gherkin 6+ `Rule:` keyword + Matt Wynne's Example Mapping) wraps nested `Scenario`s in the feature lane's `<slug>.feature`. Each scenario carries lineage as `@<jtbd>.AC#`. test-definitions.md is the R/G/R ledger: it lists the same scenario names with `- [ ] RED / GREEN / REFACTOR` sub-checkboxes. The R/G/R sub-checkboxes are load-bearing — `parseTddStep` in `hooks/lib/active-ticket.ts` parses them to inject TDD-step guidance during implement.
 
 ```gherkin
 Feature: Init dry-run

--- a/packages/cli/templates/guides/planning-guide.md
+++ b/packages/cli/templates/guides/planning-guide.md
@@ -321,7 +321,7 @@ GFM checkbox state IS the status. Don't add emoji indicators (`âœ… Passing`, `â
 
 ### Saved path
 
-Feature source: `features/<slug>.feature`
+Feature source: `features/<slug>.feature` (or under the configured `paths.features` directory)
 
 Ledger: `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 

--- a/packages/cli/templates/skills/bdd/SCENARIOS.md
+++ b/packages/cli/templates/skills/bdd/SCENARIOS.md
@@ -61,7 +61,7 @@ Each propose-and-converge turn either surfaces new scenarios or doesn't. When a 
 
 **Discovery shorthand** (in chat, presenting to user): Rule + bare scenario checkboxes — fast to read, easy to amend in conversation. This is what turn-1 above looks like.
 
-**Saved source** (`features/<slug>.feature`): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
+**Saved source** (`features/<slug>.feature`; under `paths.features` when configured): Gherkin `Feature` / `Rule` / `Scenario` with lineage as `@<jtbd-id>.AC<#>` tags. This is the executable behavior source that the Cucumber lane runs and `/review-spec`, `safeword check`, and `codify` read.
 
 ### Surface coverage tags
 
@@ -186,7 +186,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
 
 ### Define Behavior Exit (REQUIRED)
 
-1. **Save scenarios** to `features/<slug>.feature`
+1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 3. **Update frontmatter:** `phase: scenario-gate`
 4. **Add work log entry:**
@@ -236,7 +236,7 @@ If the adversarial pass + user feedback produced new scenarios → loop back to 
 
 ### Optional: codify the scenarios
 
-After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`.
+After the gate, `safeword codify <ticket>` derives implementation stubs from the `.feature` source — a front-loaded "N tests to make pass" board, instead of writing each test at its RED step. Cucumber acceptance proof still comes from matching step definitions and `test:bdd`. When `.safeword/config.json` sets `bdd.conventions`, read that doc and follow its stub shape, verification lane, and tag rules over these defaults.
 
 - Default: a native vitest skeleton — one `describe` per rule, `it.todo` per scenario (`--red` for failing bodies); print to stdout or `--out <path>`.
 - `--format gherkin`: prints the feature source when one exists; on legacy tickets, emits a migration `.feature` from markdown scenarios.

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -106,7 +106,7 @@ When user references a ticket, resume work:
 4. **If ticket exists:** Read phase, resume at appropriate point
 5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
    - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
+   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
 6. **Execute phase** using the appropriate phase file
 7. **Update phase** in ticket when transitioning
 

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -28,7 +28,8 @@ Start with the most constraining test — usually E2E or integration. Prefer the
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:
 
-- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under `steps/` or `features/steps/`.
+- If `.safeword/config.json` sets `bdd.conventions`, read that doc first and follow it over the defaults below — it defines the host harness's stub shape, its spec-ahead verification lane (often a dry-run/check profile, not run-and-expect-failure), and its tag rules. Never pass ad-hoc `--tags` filters that bypass the host profiles' exclusions.
+- If no matching steps exist, the first RED can be `bun run test:bdd` failing with undefined or pending steps, then add the thinnest TypeScript step definitions under the project's step directory (`steps/` or `features/steps/` by default; `paths.steps` when configured). Run-and-expect-failure proves wiring for safeword's scaffolded lane — an adopted host harness whose hooks boot real infrastructure needs its documented dry-run/check profile instead.
 - Keep step definitions thin; call app, API, CLI, or shell helpers from steps. Do not bury business logic in Cucumber glue.
 - Use Vitest for lower-level implementation proof when it gives faster or more precise coverage, especially pure functions and module contracts.
 - A scenario is not complete until both the relevant implementation tests and `test:bdd` pass, unless the feature is explicitly tagged `@manual` or `@live` with a skip reason.

--- a/packages/cli/tests/commands/codify.test.ts
+++ b/packages/cli/tests/commands/codify.test.ts
@@ -317,6 +317,38 @@ describe('safeword codify', () => {
   );
 
   it(
+    'bdd-lane-adoption.7CK2KP.conventions_pointer_prints_to_stderr_when_configured',
+    async () => {
+      scaffoldTicket(temporaryDirectory, TWO_SCENARIOS);
+      writeTestFile(
+        temporaryDirectory,
+        '.safeword/config.json',
+        JSON.stringify({ bdd: { conventions: 'tests/CONVENTIONS.md' } }),
+      );
+      const result = await runCli(['codify', TICKET_ID], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('tests/CONVENTIONS.md');
+      // stdout stays a clean skeleton — the pointer must not corrupt `codify > file`.
+      expect(result.stdout).not.toContain('CONVENTIONS.md');
+      expect(countTests(result.stdout)).toBe(2);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  it(
+    'bdd-lane-adoption.7CK2KP.no_pointer_when_conventions_unset',
+    async () => {
+      scaffoldTicket(temporaryDirectory, TWO_SCENARIOS);
+      const result = await runCli(['codify', TICKET_ID], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain('Host conventions');
+    },
+    TIMEOUT_QUICK,
+  );
+
+  it(
     'gherkin-typescript.DEV1.AC2.unknown_format_errors',
     async () => {
       scaffoldTicket(temporaryDirectory, TWO_SCENARIOS);

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -109,13 +109,6 @@ Both tools coexist cleanly — ESLint handles code analysis (bugs, security, com
 | jiti (devDep)     | jiti (devDep)     |
 | _(no Prettier)_   | Prettier (devDep) |
 
-## SQL Formatting
-
-Your project's chosen SQL formatter owns SQL formatting; safeword adapts to it:
-
-- **If your project formats SQL with Prettier** (`prettier-plugin-sql` in your dependencies), safeword defers entirely: setup skips the SQLFluff configs (`.sqlfluff`, `.safeword/sqlfluff.cfg`), and the edit-time hook runs _your_ Prettier with _your_ config — so `.prettierignore` carve-outs (like frozen DDL migrations) are honored. Adopting `prettier-plugin-sql` in a repo that already has safeword-generated SQLFluff configs? Delete `.sqlfluff` and `.safeword/sqlfluff.cfg`; upgrades won't recreate them.
-- **Otherwise**, safeword lints SQL with SQLFluff: the edit-time hook runs `sqlfluff lint` and reports violations to the agent. In-place rewriting is opt-in — set `"sql": { "fix": true }` in `.safeword/config.json` to have the hook run `sqlfluff fix` on edited files. SQLFluff honors `.sqlfluffignore`, so you can exclude files (e.g. applied migrations) from rewriting.
-
 ## Hook Configuration
 
 Hooks are configured in `.claude/settings.json` (Claude Code), `.cursor/hooks.json` (Cursor), and `.codex/config.toml` (Codex). See [Hooks & Skills](/reference/hooks-and-skills) for what runs automatically.
@@ -196,6 +189,18 @@ Two directory keys, `features` and `steps`, point the BDD acceptance lane at rel
 ```
 
 Relative paths resolve against the project root (the directory containing `.safeword/`); absolute paths are used verbatim.
+
+For adopted host harnesses with a house style, `bdd.conventions` points at a conventions document the host owns — what an unimplemented step body looks like, how spec-ahead scenarios are verified without executing them (for example a cucumber dry-run/check profile), and which tags the host's profiles exclude by default:
+
+```json
+{
+  "bdd": {
+    "conventions": "tests/CONVENTIONS.md"
+  }
+}
+```
+
+When set, `safeword codify` prints a pointer to the doc alongside its output, and the installed BDD skill prose directs agents to read and follow it over safeword's defaults. Safeword never parses or validates the doc — it lives next to the harness and is maintained by whoever maintains the harness, so it cannot drift the way conventions transcribed into skill prose do.
 
 `surfaces.md` is optional project knowledge for BDD. Use it for recurring product, agent, runtime, protocol, client, or deployment contexts where behavior must keep working, such as Claude Code, OpenAI Codex, Cursor, web, mobile, MCP, cloud service, or self-hosted deployments. Keep one-off contexts in a feature spec's `## Surfaces` section unless they recur across tickets, are ambiguous enough to drift, or are important enough that missing them would leave a context untested. When a spec lists affected surfaces, saved `.feature` scenarios should cover them with `@surface.<slug>` tags or explicit `skip:` reasons.
 

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -109,6 +109,13 @@ Both tools coexist cleanly — ESLint handles code analysis (bugs, security, com
 | jiti (devDep)     | jiti (devDep)     |
 | _(no Prettier)_   | Prettier (devDep) |
 
+## SQL Formatting
+
+Your project's chosen SQL formatter owns SQL formatting; safeword adapts to it:
+
+- **If your project formats SQL with Prettier** (`prettier-plugin-sql` in your dependencies), safeword defers entirely: setup skips the SQLFluff configs (`.sqlfluff`, `.safeword/sqlfluff.cfg`), and the edit-time hook runs _your_ Prettier with _your_ config — so `.prettierignore` carve-outs (like frozen DDL migrations) are honored. Adopting `prettier-plugin-sql` in a repo that already has safeword-generated SQLFluff configs? Delete `.sqlfluff` and `.safeword/sqlfluff.cfg`; upgrades won't recreate them.
+- **Otherwise**, safeword lints SQL with SQLFluff: the edit-time hook runs `sqlfluff lint` and reports violations to the agent. In-place rewriting is opt-in — set `"sql": { "fix": true }` in `.safeword/config.json` to have the hook run `sqlfluff fix` on edited files. SQLFluff honors `.sqlfluffignore`, so you can exclude files (e.g. applied migrations) from rewriting.
+
 ## Hook Configuration
 
 Hooks are configured in `.claude/settings.json` (Claude Code), `.cursor/hooks.json` (Cursor), and `.codex/config.toml` (Codex). See [Hooks & Skills](/reference/hooks-and-skills) for what runs automatically.


### PR DESCRIPTION
Closes #650 (slice 2 of 2 — builds on the merged #645 / 56JCFZ lane substrate).

## What

When safeword's BDD tooling runs against an **adopted host cucumber harness** with its own house style, its output and installed guidance no longer prescribe mechanics that drift from that harness. Two parts:

- **`bdd.conventions` config key** (`.safeword/config.json`): a path to a host-owned conventions doc — stub shape, spec-ahead verification lane, tag rules, step layout. `readBddConventionsPath` reads it; `safeword codify` prints a one-line pointer to it **on stderr** (stdout stays a clean, pipeable skeleton). Zero behavior when unset.
- **De-hardcoded BDD prose** (`skills/bdd/TDD.md`, `SCENARIOS.md`, `guides/planning-guide.md` — templates + this repo's installed copies): lane paths now say "root `features/` by default, `paths.features` when configured"; RED verification is harness-relative ("run-and-expect-failure proves wiring for safeword's scaffolded lane; an adopted harness whose hooks boot real infrastructure uses its documented dry-run/check profile instead"); and the prose directs agents to read `bdd.conventions` and never pass `--tags` filters that bypass host profile exclusions.

## Why

The #645 design review of ArcadeAI/arcade-monorepo's hand-rolled `codify-spec` skill found every hardcoded mechanic had drifted from the real harness (prescribed throw message in zero step files; verify command booting a 4-service Docker stack whose `--tags` override silently discarded `not @wip` safety exclusions) while goal-level rules stayed correct. Prose carrying conventions as hardcoded instructions is what rotted; a pointer to a host-owned doc (maintained next to the harness) is the durable home.

## Design decision (recorded in ticket 7CK2KP)

Deliberately **lean**: one opaque pointer key, not a structured schema. At N=1 real host, house styles are heterogeneous — more examples validate the *slots* (every harness has a stub style, a wiring-check, tag rules) but never converge on *values*, so the schema stays pointer-shaped. Safeword never parses or validates the doc.

## Deferred to a follow-up (out of scope here, pending a second real host)

Structured convention modeling: a stub-template engine / cucumber step-stub emitter, a verify-command runner with dry-run report parsing (cucumber `--dry-run` exits zero on undefined/ambiguous steps), and machine-enforced `bdd.excludedTags` (a lint-gherkin/`check` warning when a tag filter bypasses exclusions). Named in the ticket's `out_of_scope` and the impl-plan's assessment triggers so the omission is deliberate, not forgotten.

## Evidence

- Full CLI suite green on the rebased base: **4606 passed / 5 skipped (323 files)**; targeted codify + lane-paths + schema: 51/51.
- Two new `codify` e2e tests: pointer-on-stderr when configured, silence when unset.
- `bdd.conventions` documented in `configuration.mdx`.

Design rationale and rejected alternatives live in the ticket (`.project/tickets/7CK2KP-bdd-lane-adoption-semantics/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCXJRr67NFJTiuJEi9D8KN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCXJRr67NFJTiuJEi9D8KN)_