### PR TITLE
chore(release): v0.64.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.64.0** (minor — strictly additive; auto-upgradeable).

Bumps `packages/cli/package.json` and `.claude-plugin/marketplace.json` to `0.64.0`.

## Rolled up since v0.63.0

- **#756** — BDD lane adoption: new additive `bdd.conventions` config key + `safeword codify` stderr pointer + de-hardcoded BDD prose. Unset = zero behavior (the additive capability that drives the minor bump).
- **#763** — Audit follow-ups: non-major dep bumps, dead-export cleanup, prettier 3.9 reformat, and Rust pack now derives the rustfmt edition from `Cargo.toml` (corrective/additive — a 2021 crate is unchanged).
- **#764** — Test-infra: retry a cucumber CLI spawn once when killed with no output.
- **#755** — Internal refactor: name lane-config literal + dedup workspace roots.

## Bump rationale

New optional config field with a default and no removed/changed behavior. Passes the "auto-upgrade at SessionStart — does anything break?" test in the negative → **minor**, not major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmPeTtB72TjBWquzo8t3Eo)_