### PR TITLE
De-prescribe pass (#765): retune the instruction layer for modern models (#769–779)

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -449,6 +449,6 @@ Errors: N | Warnings: N | Passed: N
 **Next:** [imperative — which fix to start, which package to upgrade, which file to update].
 ```
 
-The `**Next:**` line is required, even on a clean pass. Name the immediate move (commit, mark ticket done, open a follow-up ticket for the warnings). A verdict without a concrete next action is incomplete — don't leave the user to guess which finding to address first.
+Close with the `**Next:**` line even on a clean pass — name the immediate move (commit, mark ticket done, open a follow-up for warnings) so the reader isn't left guessing which finding to start with (the stop hook reads it for the re-entry brief).
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.agents/skills/bdd/DISCOVERY.md
+++ b/.agents/skills/bdd/DISCOVERY.md
@@ -208,7 +208,7 @@ done_when:
 
 The arc end to end: a persona from `personas.md`, a job that names it, criteria under the job, an engineering contract on top, and scenarios that trace back to a criterion — each sub-phase closed by its gate.
 
-## Intake Exit (REQUIRED)
+## Intake Exit
 
 Before proceeding to define-behavior (the Intake Brief is advisory — a missing or `skip:`'d field never blocks this exit; only `scope` / `out_of_scope` / `done_when` are required):
 

--- a/.agents/skills/bdd/DONE.md
+++ b/.agents/skills/bdd/DONE.md
@@ -8,7 +8,7 @@ Done means the ticket is closed. All verification happened in the verify phase.
 
 1. Update parent epic if applicable (add completion entry to parent's work log; if all children done → update parent `status: done`)
 2. Update ticket: `phase: done`, `status: done`
-3. Final commit: `feat(scope): [summary]`
+3. Commit the close with a conventional-commit message summarizing the change
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
 

--- a/.agents/skills/bdd/SCENARIOS.md
+++ b/.agents/skills/bdd/SCENARIOS.md
@@ -184,7 +184,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
   `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
   block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
 
-### Define Behavior Exit (REQUIRED)
+### Define Behavior Exit
 
 1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
@@ -207,7 +207,7 @@ Run the **`/review-spec`** skill — it is the gate procedure (vacuous-pass, AOD
 
 If the adversarial pass + user feedback produced new scenarios → loop back to define-behavior. If nothing new surfaced → done.
 
-### Scenario Gate Exit (REQUIRED)
+### Scenario Gate Exit
 
 1. Each scenario passes the vacuous-pass test and AODI (Atomic, Observable, Deterministic, Independent)
 2. Adversarial pass + cross-cutting checks complete; findings presented in the findings format (or confirmed clean)

--- a/.agents/skills/bdd/SKILL.md
+++ b/.agents/skills/bdd/SKILL.md
@@ -75,12 +75,7 @@ ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
 
 ## Resume Logic
 
-When user references a ticket, resume work:
-
-1. **Read ticket** → get current `phase:`
-2. **Find progress** → first unchecked `[ ]` in test-definitions
-3. **Check context** → read last work log entry
-4. **Announce resume** → "Resuming at [phase]. Last: [log entry]."
+**Resuming** means reconstruct where the ticket left off and continue. The ticket's `phase:` and the first unchecked ledger item tell you _where_; the last work-log entry tells you _what_. Announce where you're resuming, then continue.
 
 **Resume by phase:**
 
@@ -97,18 +92,9 @@ When user references a ticket, resume work:
 
 ## Current Behavior
 
-1. Understand first (see SAFEWORD.md "Understanding") — propose-and-converge until user accepts proposal with structured scope
-2. Size internally (see SAFEWORD.md "Sizing") — state scope assessment in proposal, not as a separate announcement
-3. **If user references iteration/story/phase from a spec:**
-   - Check if child ticket exists for that iteration
-   - If not → create ticket, run full BDD
-   - If yes → resume at current phase
-4. **If ticket exists:** Read phase, resume at appropriate point
-5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
-   - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
-6. **Execute phase** using the appropriate phase file
-7. **Update phase** in ticket when transitioning
+Understand first and size internally (see SAFEWORD.md "Understanding" and "Sizing") — state the scope read inside your proposal, not as a separate announcement. If the user references an iteration/story/phase from a spec, resume its child ticket at the current phase, or create one and run full BDD if none exists; if a ticket already exists, read its phase and resume there.
+
+**Artifact-first:** before doing a phase's work, create or verify its artifact — intake → `<namespace-root>/tickets/{ID}-{slug}/ticket.md`; define-behavior → the feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus the R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`. Then execute the phase using its phase file, and update `phase:` on transition.
 
 ---
 

--- a/.agents/skills/bdd/SKILL.md
+++ b/.agents/skills/bdd/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: '*'
 
 Behavior-first development for features. Discovery → Scenarios → Implementation.
 
-**Iron Law:** DEFINE BEHAVIOR BEFORE IMPLEMENTATION
+Define the behavior before implementing it. When unsure whether work is a feature, default to a task (TDD directly) — the user can `/bdd` to override.
 
 ## Phase Tracking
 
@@ -126,15 +126,3 @@ Load the appropriate file based on current phase:
 | `done`            | DONE.md      |
 
 For splitting large features, see SPLITTING.md.
-
----
-
-## Key Takeaways
-
-- **patch/task** → TDD directly (RED → GREEN → REFACTOR)
-- **feature** → full BDD flow, track in ticket `phase:` field
-- **Resume** → read ticket, find first unchecked scenario, continue
-- **Split** → check thresholds at Entry, define-behavior, scenario-gate; user decides (see SPLITTING.md)
-- **Verify gate** → run /verify + /audit, writes verify.md. Stop hook blocks done without it.
-- **Done** → close ticket (trivial — verify.md must already exist)
-- When unsure → default to task, user can `/bdd` to override

--- a/.agents/skills/bdd/SPLITTING.md
+++ b/.agents/skills/bdd/SPLITTING.md
@@ -27,17 +27,9 @@ STEP 2: Assess depth
 
 ## Split Protocol
 
-**New ticket:**
+**New ticket:** create an epic with a `children:` array and child tickets that link back via `parent:`, then commit the split with a conventional-commit message.
 
-1. Create epic with `children:` array
-2. Create child tickets with `parent:` link
-3. Commit: "chore: split [name] into N features"
-
-**Existing ticket (promote):**
-
-1. Change `type: feature` → `type: epic`
-2. Add `children:` array
-3. Create child tickets with `parent:` link
+**Existing ticket (promote):** change `type: feature` → `type: epic`, add the `children:` array, and create the child tickets with `parent:` links.
 
 ## Restart Points After Split
 
@@ -49,10 +41,6 @@ STEP 2: Assess depth
 
 ## User Override
 
-User can decline: "Proceed anyway"
-
-- Log: "Split suggested but user declined"
-- Continue at current phase
-- Don't re-suggest at same checkpoint this session
+The user can decline a split and proceed anyway — note the declined suggestion in the work log, continue at the current phase, and don't re-suggest at the same checkpoint this session.
 
 **Avoid bloat.**

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -15,10 +15,10 @@ Before the first RED, confirm the project's test harness actually runs — judge
 
 Degradation is the intended path — no gate blocks on harness absence.
 
-## Iron Laws
+## Core rules
 
-1. **NO IMPLEMENTATION UNTIL TEST FAILS FOR THE RIGHT REASON** — behavior missing, not syntax error
-2. **ONLY WRITE CODE THE TEST REQUIRES** — GREEN is minimal, REFACTOR adds quality
+1. Write the failing test first and confirm it fails for the intended reason — behavior missing, not a syntax error — before writing any implementation.
+2. Write only the code the test requires: GREEN is minimal, REFACTOR adds quality.
 
 ## Test Scope
 
@@ -82,7 +82,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 
 **Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
-### Red Flags — STOP:
+### Red flags — stop and rethink:
 
 | Flag                    | Action                                        |
 | ----------------------- | --------------------------------------------- |

--- a/.agents/skills/bdd/VERIFY.md
+++ b/.agents/skills/bdd/VERIFY.md
@@ -13,7 +13,7 @@ user whether to proceed.
 
 If tests are flaky, investigate before proceeding.
 
-## Verify Exit (REQUIRED)
+## Verify Exit
 
 Before proceeding to done:
 

--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -36,7 +36,7 @@ Brainstorm is the explicit escape hatch from "commit to one path" — not from "
 
 ## When You Notice Convergence
 
-Offer a lightweight check-in: "Sounds like we're converging on X — want me to pull this together?"
+Offer a lightweight check-in — name the direction you're converging on and ask whether to pull it together.
 
 If yes → transition to SAFEWORD.md's understanding flow (scope / out of scope / done when).
 If no → keep exploring.

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -10,17 +10,12 @@ allowed-tools: '*'
 
 Find root cause before fixing. Symptom fixes are failure.
 
-**Iron Law:** NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+Investigate the root cause before attempting any fix.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. Bug, error, or test failure? → Use this skill
-2. Unexpected behavior? → Use this skill
-3. Previous fix didn't work? → Use this skill (especially important)
-4. Performance problem? → Use this skill
-5. None of above? → Skip this skill
+Use for bugs, errors, test failures, unexpected behavior, repeated failed fixes,
+or performance problems — skip for greenfield work.
 
 **Use especially when:**
 
@@ -150,7 +145,7 @@ Write each as "X could be root cause because Y", then ask: what evidence would _
 | Rules one out         | Eliminate it; test the next live hypothesis. None left? Form new ones (3.1) |
 | Inconclusive          | Pick a more discriminating (cheaper-to-disconfirm) test                     |
 
-### Root Cause Checkpoint (REQUIRED)
+### Root Cause Checkpoint
 
 Before proceeding to Phase 4:
 
@@ -197,7 +192,7 @@ it('handles empty input without crashing', () => {
 - [ ] Existing tests still pass
 - [ ] Issue actually resolved (not just test passing)
 
-End the fix report with **Next:** on its own line — imperative, name what's now (commit message to use, ticket to mark done, follow-up issue to open for related debt the investigation surfaced). A debug session that ends without naming the next move is incomplete.
+Close the fix report with a `**Next:**` line — imperative: the commit message to use, the ticket to mark done, or a follow-up issue for related debt the investigation surfaced (the stop hook reads it for the re-entry brief).
 
 Examples:
 

--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: '*'
 
 Draw out what the user knows and you can't research. Then check the latest evidence. Then explore options together.
 
-**Iron Law:** NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF. Read the code, search the docs, check git history first. Only ask what's left.
+Don't ask a question you could answer yourself. Read the code, search the docs, and check git history first; only ask what's left.
 
 ## When to Run
 

--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -57,7 +57,7 @@ Keep asking until one of:
 - You have enough to distinguish between options in Phase 3
 - User says "enough" or "go"
 
-Typical: 3-7 questions. Fewer for small scope, more for ambiguous scope.
+Usually a handful — fewer for small scope, more for ambiguous scope. Let the stop conditions above end it, not a target count.
 
 ## Phase 2: Research
 

--- a/.agents/skills/figure-it-out/SKILL.md
+++ b/.agents/skills/figure-it-out/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: '*'
 
 # Figure It Out: Evidence-Backed Option Weighing
 
-**Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
+No recommendation without current evidence. Training data is stale; verify before staking a position.
 
 **Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
 
@@ -87,7 +87,7 @@ Then commit. Format:
 
 The `**Premortem:**` line disconfirms your _choice_, not just the alternatives you steelmanned — the option you stop scrutinizing the moment you pick it is the one that bites. Keep it to one sentence.
 
-The `**Next:**` line is required. A recommendation without a next action is incomplete — name the file to edit, the command to run, or the question to ask. One line, imperative.
+Close with the `**Next:**` line — one imperative naming the file to edit, the command to run, or the question to ask (the stop hook reads it for the re-entry brief). A recommendation that doesn't say what to do now leaves the reader stranded.
 
 If two options tie on correctness and elegance, the smaller one wins.
 

--- a/.agents/skills/figure-it-out/SKILL.md
+++ b/.agents/skills/figure-it-out/SKILL.md
@@ -43,7 +43,7 @@ Two or three, concrete enough to debate. For each: **what** (one sentence), **lo
 
 ### Phase 3: Enumerate domains, then research
 
-**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A list with fewer than two or three entries means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
+**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A single-domain list means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
 
 Worked example — drafting a one-line block message for a CLI hook isn't just "writing copy." Domain list:
 

--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -115,7 +115,7 @@ Severity is bounded by evidence: **a CRITICAL or REQUEST CHANGES verdict must ci
 
 ## Loop: review → fix → re-review
 
-Run the review in passes (MAX_PASSES = 3), not one-and-done.
+Run the review in passes until it comes back clean — not one-and-done, but not an endless loop either (a couple of passes is usually plenty).
 
 Each pass:
 
@@ -137,8 +137,8 @@ Each pass:
 2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
    improvements** worth the change; list the rest — don't chase them.
 3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
-   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
-   if you edited code this pass.
+   optional, not a reason to loop. Don't loop indefinitely; a couple of passes is
+   the practical ceiling. Re-review only if you edited code this pass.
 
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real

--- a/.agents/skills/quality-review/SKILL.md
+++ b/.agents/skills/quality-review/SKILL.md
@@ -56,7 +56,7 @@ Run each angle that applies — angle _diversity_ is the lever, not search volum
 
 ### Version-currency & security
 
-**CRITICAL**: This is your main differentiator from automatic hook.
+This is your main differentiator from the automatic hook.
 
 Read the live `Current time:` line from the prompt timestamp hook and use that date as the current prompt timestamp.
 Search for: "[library name] latest stable version as of <current prompt timestamp date>"
@@ -66,7 +66,7 @@ Search for: "[library name] security vulnerabilities"
 
 - Major versions behind -> WARN (e.g., React 17 when 19 is stable)
 - Minor versions behind -> NOTE
-- Security vulnerabilities -> CRITICAL (must upgrade)
+- Security vulnerabilities -> CRITICAL (upgrade now)
 - Using latest -> Confirm
 
 ## 3. Verify Documentation — deprecation + primary-source (Primary Value)
@@ -143,13 +143,6 @@ Each pass:
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real
 stop condition; tests are the ground truth.
-
-## Reminders
-
-1. **Primary value: Web research** - Verify versions, docs, security
-2. **Complement automatic hook** - Hook prompts for the decision-brief verdict and per-phase evidence; you verify versions, primary-literature claims, and ecosystem context the hook can't see
-3. **Phase matters** - Adapt research focus to current BDD phase
-4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -231,7 +231,7 @@ Ledger entries remaining?
 ├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
+    └─ Report what was resolved and what was deferred (with reasons)
 ```
 
 A single-named-smell request has a one-entry ledger — resolve it, audit, done.
@@ -252,11 +252,11 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 - STOP refactoring
 - Note the bug location
-- Ask user: "Found potential bug at X. Fix it now (switching to tdd-enforcer) or continue refactoring?"
+- Ask the user whether to fix it now (switching to tdd-enforcer) or continue refactoring
 
 **User requests large refactoring:**
 
-- Break into steps: "I'll refactor this incrementally. First: [step 1]"
+- Break it into steps and name the first one before starting
 - Complete each step fully before next
 - Never batch multiple refactorings in one edit
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -12,17 +12,14 @@ allowed-tools: '*'
 
 Improve code structure without changing behavior. One small step at a time.
 
-**Iron Law:** ONE REFACTORING → TEST → COMMIT. Never batch changes.
+Work one refactoring at a time: change, test, commit. Don't batch changes.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. User says "refactor", "clean up", "restructure"? → Use this skill
-2. User asks to "extract", "rename", "simplify"? → Use this skill
-3. Code smell identified? → Use this skill
-4. User wants to add feature or fix bug? → Skip (use tdd-enforcer)
-5. User wants formatting/style fixes? → Skip (use /lint)
+Use when the user says "refactor", "clean up", "restructure", "extract",
+"rename", or "simplify", or when you've identified a code smell. Skip for adding
+a feature or fixing a bug (use tdd-enforcer) and for formatting/style fixes (use
+/lint).
 
 **Code smells** (common triggers):
 
@@ -90,9 +87,9 @@ it('processOrder returns current behavior', () => {
 
 ## Phase 3: REFACTOR
 
-**Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+One refactoring at a time; run tests after every change.
 
-**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The one-change rule is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -196,8 +193,8 @@ Choose exactly one outcome:
   creation would disturb the user's state or unrelated work is already present,
   defer the commit and report the exact branch/worktree reason.
 
-Deferring a commit is not skipping the Iron Law; it is preserving the same
-single-change attribution the Iron Law exists to protect.
+Deferring a commit is not skipping the one-change rule; it is preserving the same
+single-change attribution that rule exists to protect.
 
 ### Revert Protocol
 
@@ -275,14 +272,3 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 | Change behavior during refactor        | That's a feature/fix, not refactoring                         |
 | Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
 | Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
-
----
-
-## Key Takeaways
-
-1. **One change at a time** - Never batch refactorings
-2. **Tests before refactoring** - No safety net = no refactoring
-3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
-5. **Smallest scope first** - Rename < Extract < Move < Restructure
-6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/.agents/skills/tdd-review/SKILL.md
+++ b/.agents/skills/tdd-review/SKILL.md
@@ -67,7 +67,7 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 **Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
-**Agent review:**
+Illustrative only — apply the checks in your own words, not this exact wording:
 
 > **Atomic?** Yes — tests one behavior (passing files appear in verbose output).
 > **Right assertions?** `expect(output).toContain('src/index.ts: pass')` — asserts on observable output, not internals. Good.

--- a/.agents/skills/tdd-review/SKILL.md
+++ b/.agents/skills/tdd-review/SKILL.md
@@ -82,21 +82,11 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 ## Output discipline
 
-Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
+Close every review with a `**Next:**` line — imperative, naming the file/command/scenario, not a bare "proceed" or "commit and move on" (the stop hook reads it for the re-entry brief).
 
 - After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
 - After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
 - After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
 - After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
-
-A review without a Next: line is incomplete.
-
-## Reminders
-
-1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
-2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
-3. **Single source of truth** — this skill owns all TDD review content
-4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review internally, then commit to proceed
-5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-**Announce your decision:** "Test type: [unit/integration/E2E/eval] because [reason]."
+If the test-scope choice isn't obvious from context, state it and why in one line.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-If the test-scope choice isn't obvious from context, state it and why in one line.
+State the test-scope choice and why in one line, unless it's obvious from context.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/.agents/skills/ticket-system/SKILL.md
+++ b/.agents/skills/ticket-system/SKILL.md
@@ -56,13 +56,9 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 | **task**    | ticket.md with inline tests                         |
 | **patch**   | ticket.md (minimal), existing tests                 |
 
-**Create ticket? Answer IN ORDER, stop at first match:**
-
-1. Multiple attempts likely needed? → Create ticket
-2. Multi-step with dependencies? → Create ticket
-3. Investigation/debugging required? → Create ticket
-4. Risk of losing context mid-session? → Create ticket
-5. None of above? → Skip ticket
+**Create a ticket** when any of these holds: multiple attempts are likely,
+the work is multi-step with dependencies, it needs investigation/debugging, or
+there's a risk of losing context mid-session. Otherwise skip it.
 
 **Examples:** "Fix typo" → skip. "Debug slow login" → ticket. "Add OAuth" → ticket.
 
@@ -124,11 +120,9 @@ status: in_progress
 
 **One artifact = one log.** If log exists, append a new session. Don't spawn multiple logs for the same work.
 
-**Create log? Answer IN ORDER, stop at first match:**
-
-1. Executing a plan, ticket, or spec? → Create log
-2. Investigation/debugging with multiple attempts? → Create log
-3. Quick single-action task? → Skip log
+**Create a log** when executing a plan, ticket, or spec, or when
+investigation/debugging spans multiple attempts. Skip it for a quick
+single-action task.
 
 **Think hard behaviors:**
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -449,6 +449,6 @@ Errors: N | Warnings: N | Passed: N
 **Next:** [imperative — which fix to start, which package to upgrade, which file to update].
 ```
 
-The `**Next:**` line is required, even on a clean pass. Name the immediate move (commit, mark ticket done, open a follow-up ticket for the warnings). A verdict without a concrete next action is incomplete — don't leave the user to guess which finding to address first.
+Close with the `**Next:**` line even on a clean pass — name the immediate move (commit, mark ticket done, open a follow-up for warnings) so the reader isn't left guessing which finding to start with (the stop hook reads it for the re-entry brief).
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.claude/skills/bdd/DISCOVERY.md
+++ b/.claude/skills/bdd/DISCOVERY.md
@@ -208,7 +208,7 @@ done_when:
 
 The arc end to end: a persona from `personas.md`, a job that names it, criteria under the job, an engineering contract on top, and scenarios that trace back to a criterion — each sub-phase closed by its gate.
 
-## Intake Exit (REQUIRED)
+## Intake Exit
 
 Before proceeding to define-behavior (the Intake Brief is advisory — a missing or `skip:`'d field never blocks this exit; only `scope` / `out_of_scope` / `done_when` are required):
 

--- a/.claude/skills/bdd/DONE.md
+++ b/.claude/skills/bdd/DONE.md
@@ -8,7 +8,7 @@ Done means the ticket is closed. All verification happened in the verify phase.
 
 1. Update parent epic if applicable (add completion entry to parent's work log; if all children done → update parent `status: done`)
 2. Update ticket: `phase: done`, `status: done`
-3. Final commit: `feat(scope): [summary]`
+3. Commit the close with a conventional-commit message summarizing the change
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
 

--- a/.claude/skills/bdd/SCENARIOS.md
+++ b/.claude/skills/bdd/SCENARIOS.md
@@ -184,7 +184,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
   `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
   block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
 
-### Define Behavior Exit (REQUIRED)
+### Define Behavior Exit
 
 1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
@@ -207,7 +207,7 @@ Run the **`/review-spec`** skill — it is the gate procedure (vacuous-pass, AOD
 
 If the adversarial pass + user feedback produced new scenarios → loop back to define-behavior. If nothing new surfaced → done.
 
-### Scenario Gate Exit (REQUIRED)
+### Scenario Gate Exit
 
 1. Each scenario passes the vacuous-pass test and AODI (Atomic, Observable, Deterministic, Independent)
 2. Adversarial pass + cross-cutting checks complete; findings presented in the findings format (or confirmed clean)

--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -75,12 +75,7 @@ ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
 
 ## Resume Logic
 
-When user references a ticket, resume work:
-
-1. **Read ticket** → get current `phase:`
-2. **Find progress** → first unchecked `[ ]` in test-definitions
-3. **Check context** → read last work log entry
-4. **Announce resume** → "Resuming at [phase]. Last: [log entry]."
+**Resuming** means reconstruct where the ticket left off and continue. The ticket's `phase:` and the first unchecked ledger item tell you _where_; the last work-log entry tells you _what_. Announce where you're resuming, then continue.
 
 **Resume by phase:**
 
@@ -97,18 +92,9 @@ When user references a ticket, resume work:
 
 ## Current Behavior
 
-1. Understand first (see SAFEWORD.md "Understanding") — propose-and-converge until user accepts proposal with structured scope
-2. Size internally (see SAFEWORD.md "Sizing") — state scope assessment in proposal, not as a separate announcement
-3. **If user references iteration/story/phase from a spec:**
-   - Check if child ticket exists for that iteration
-   - If not → create ticket, run full BDD
-   - If yes → resume at current phase
-4. **If ticket exists:** Read phase, resume at appropriate point
-5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
-   - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
-6. **Execute phase** using the appropriate phase file
-7. **Update phase** in ticket when transitioning
+Understand first and size internally (see SAFEWORD.md "Understanding" and "Sizing") — state the scope read inside your proposal, not as a separate announcement. If the user references an iteration/story/phase from a spec, resume its child ticket at the current phase, or create one and run full BDD if none exists; if a ticket already exists, read its phase and resume there.
+
+**Artifact-first:** before doing a phase's work, create or verify its artifact — intake → `<namespace-root>/tickets/{ID}-{slug}/ticket.md`; define-behavior → the feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus the R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`. Then execute the phase using its phase file, and update `phase:` on transition.
 
 ---
 

--- a/.claude/skills/bdd/SKILL.md
+++ b/.claude/skills/bdd/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: '*'
 
 Behavior-first development for features. Discovery → Scenarios → Implementation.
 
-**Iron Law:** DEFINE BEHAVIOR BEFORE IMPLEMENTATION
+Define the behavior before implementing it. When unsure whether work is a feature, default to a task (TDD directly) — the user can `/bdd` to override.
 
 ## Phase Tracking
 
@@ -126,15 +126,3 @@ Load the appropriate file based on current phase:
 | `done`            | DONE.md      |
 
 For splitting large features, see SPLITTING.md.
-
----
-
-## Key Takeaways
-
-- **patch/task** → TDD directly (RED → GREEN → REFACTOR)
-- **feature** → full BDD flow, track in ticket `phase:` field
-- **Resume** → read ticket, find first unchecked scenario, continue
-- **Split** → check thresholds at Entry, define-behavior, scenario-gate; user decides (see SPLITTING.md)
-- **Verify gate** → run /verify + /audit, writes verify.md. Stop hook blocks done without it.
-- **Done** → close ticket (trivial — verify.md must already exist)
-- When unsure → default to task, user can `/bdd` to override

--- a/.claude/skills/bdd/SPLITTING.md
+++ b/.claude/skills/bdd/SPLITTING.md
@@ -27,17 +27,9 @@ STEP 2: Assess depth
 
 ## Split Protocol
 
-**New ticket:**
+**New ticket:** create an epic with a `children:` array and child tickets that link back via `parent:`, then commit the split with a conventional-commit message.
 
-1. Create epic with `children:` array
-2. Create child tickets with `parent:` link
-3. Commit: "chore: split [name] into N features"
-
-**Existing ticket (promote):**
-
-1. Change `type: feature` → `type: epic`
-2. Add `children:` array
-3. Create child tickets with `parent:` link
+**Existing ticket (promote):** change `type: feature` → `type: epic`, add the `children:` array, and create the child tickets with `parent:` links.
 
 ## Restart Points After Split
 
@@ -49,10 +41,6 @@ STEP 2: Assess depth
 
 ## User Override
 
-User can decline: "Proceed anyway"
-
-- Log: "Split suggested but user declined"
-- Continue at current phase
-- Don't re-suggest at same checkpoint this session
+The user can decline a split and proceed anyway — note the declined suggestion in the work log, continue at the current phase, and don't re-suggest at the same checkpoint this session.
 
 **Avoid bloat.**

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -15,10 +15,10 @@ Before the first RED, confirm the project's test harness actually runs — judge
 
 Degradation is the intended path — no gate blocks on harness absence.
 
-## Iron Laws
+## Core rules
 
-1. **NO IMPLEMENTATION UNTIL TEST FAILS FOR THE RIGHT REASON** — behavior missing, not syntax error
-2. **ONLY WRITE CODE THE TEST REQUIRES** — GREEN is minimal, REFACTOR adds quality
+1. Write the failing test first and confirm it fails for the intended reason — behavior missing, not a syntax error — before writing any implementation.
+2. Write only the code the test requires: GREEN is minimal, REFACTOR adds quality.
 
 ## Test Scope
 
@@ -82,7 +82,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 
 **Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
-### Red Flags — STOP:
+### Red flags — stop and rethink:
 
 | Flag                    | Action                                        |
 | ----------------------- | --------------------------------------------- |

--- a/.claude/skills/bdd/VERIFY.md
+++ b/.claude/skills/bdd/VERIFY.md
@@ -13,7 +13,7 @@ user whether to proceed.
 
 If tests are flaky, investigate before proceeding.
 
-## Verify Exit (REQUIRED)
+## Verify Exit
 
 Before proceeding to done:
 

--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -36,7 +36,7 @@ Brainstorm is the explicit escape hatch from "commit to one path" — not from "
 
 ## When You Notice Convergence
 
-Offer a lightweight check-in: "Sounds like we're converging on X — want me to pull this together?"
+Offer a lightweight check-in — name the direction you're converging on and ask whether to pull it together.
 
 If yes → transition to SAFEWORD.md's understanding flow (scope / out of scope / done when).
 If no → keep exploring.

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -10,17 +10,12 @@ allowed-tools: '*'
 
 Find root cause before fixing. Symptom fixes are failure.
 
-**Iron Law:** NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+Investigate the root cause before attempting any fix.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. Bug, error, or test failure? → Use this skill
-2. Unexpected behavior? → Use this skill
-3. Previous fix didn't work? → Use this skill (especially important)
-4. Performance problem? → Use this skill
-5. None of above? → Skip this skill
+Use for bugs, errors, test failures, unexpected behavior, repeated failed fixes,
+or performance problems — skip for greenfield work.
 
 **Use especially when:**
 
@@ -150,7 +145,7 @@ Write each as "X could be root cause because Y", then ask: what evidence would _
 | Rules one out         | Eliminate it; test the next live hypothesis. None left? Form new ones (3.1) |
 | Inconclusive          | Pick a more discriminating (cheaper-to-disconfirm) test                     |
 
-### Root Cause Checkpoint (REQUIRED)
+### Root Cause Checkpoint
 
 Before proceeding to Phase 4:
 
@@ -197,7 +192,7 @@ it('handles empty input without crashing', () => {
 - [ ] Existing tests still pass
 - [ ] Issue actually resolved (not just test passing)
 
-End the fix report with **Next:** on its own line — imperative, name what's now (commit message to use, ticket to mark done, follow-up issue to open for related debt the investigation surfaced). A debug session that ends without naming the next move is incomplete.
+Close the fix report with a `**Next:**` line — imperative: the commit message to use, the ticket to mark done, or a follow-up issue for related debt the investigation surfaced (the stop hook reads it for the re-entry brief).
 
 Examples:
 

--- a/.claude/skills/elicit/SKILL.md
+++ b/.claude/skills/elicit/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: '*'
 
 Draw out what the user knows and you can't research. Then check the latest evidence. Then explore options together.
 
-**Iron Law:** NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF. Read the code, search the docs, check git history first. Only ask what's left.
+Don't ask a question you could answer yourself. Read the code, search the docs, and check git history first; only ask what's left.
 
 ## When to Run
 

--- a/.claude/skills/elicit/SKILL.md
+++ b/.claude/skills/elicit/SKILL.md
@@ -57,7 +57,7 @@ Keep asking until one of:
 - You have enough to distinguish between options in Phase 3
 - User says "enough" or "go"
 
-Typical: 3-7 questions. Fewer for small scope, more for ambiguous scope.
+Usually a handful — fewer for small scope, more for ambiguous scope. Let the stop conditions above end it, not a target count.
 
 ## Phase 2: Research
 

--- a/.claude/skills/figure-it-out/SKILL.md
+++ b/.claude/skills/figure-it-out/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: '*'
 
 # Figure It Out: Evidence-Backed Option Weighing
 
-**Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
+No recommendation without current evidence. Training data is stale; verify before staking a position.
 
 **Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
 
@@ -87,7 +87,7 @@ Then commit. Format:
 
 The `**Premortem:**` line disconfirms your _choice_, not just the alternatives you steelmanned — the option you stop scrutinizing the moment you pick it is the one that bites. Keep it to one sentence.
 
-The `**Next:**` line is required. A recommendation without a next action is incomplete — name the file to edit, the command to run, or the question to ask. One line, imperative.
+Close with the `**Next:**` line — one imperative naming the file to edit, the command to run, or the question to ask (the stop hook reads it for the re-entry brief). A recommendation that doesn't say what to do now leaves the reader stranded.
 
 If two options tie on correctness and elegance, the smaller one wins.
 

--- a/.claude/skills/figure-it-out/SKILL.md
+++ b/.claude/skills/figure-it-out/SKILL.md
@@ -43,7 +43,7 @@ Two or three, concrete enough to debate. For each: **what** (one sentence), **lo
 
 ### Phase 3: Enumerate domains, then research
 
-**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A list with fewer than two or three entries means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
+**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A single-domain list means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
 
 Worked example — drafting a one-line block message for a CLI hook isn't just "writing copy." Domain list:
 

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -115,7 +115,7 @@ Severity is bounded by evidence: **a CRITICAL or REQUEST CHANGES verdict must ci
 
 ## Loop: review → fix → re-review
 
-Run the review in passes (MAX_PASSES = 3), not one-and-done.
+Run the review in passes until it comes back clean — not one-and-done, but not an endless loop either (a couple of passes is usually plenty).
 
 Each pass:
 
@@ -137,8 +137,8 @@ Each pass:
 2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
    improvements** worth the change; list the rest — don't chase them.
 3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
-   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
-   if you edited code this pass.
+   optional, not a reason to loop. Don't loop indefinitely; a couple of passes is
+   the practical ceiling. Re-review only if you edited code this pass.
 
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -56,7 +56,7 @@ Run each angle that applies — angle _diversity_ is the lever, not search volum
 
 ### Version-currency & security
 
-**CRITICAL**: This is your main differentiator from automatic hook.
+This is your main differentiator from the automatic hook.
 
 Read the live `Current time:` line from the prompt timestamp hook and use that date as the current prompt timestamp.
 Search for: "[library name] latest stable version as of <current prompt timestamp date>"
@@ -66,7 +66,7 @@ Search for: "[library name] security vulnerabilities"
 
 - Major versions behind -> WARN (e.g., React 17 when 19 is stable)
 - Minor versions behind -> NOTE
-- Security vulnerabilities -> CRITICAL (must upgrade)
+- Security vulnerabilities -> CRITICAL (upgrade now)
 - Using latest -> Confirm
 
 ## 3. Verify Documentation — deprecation + primary-source (Primary Value)
@@ -143,13 +143,6 @@ Each pass:
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real
 stop condition; tests are the ground truth.
-
-## Reminders
-
-1. **Primary value: Web research** - Verify versions, docs, security
-2. **Complement automatic hook** - Hook prompts for the decision-brief verdict and per-phase evidence; you verify versions, primary-literature claims, and ecosystem context the hook can't see
-3. **Phase matters** - Adapt research focus to current BDD phase
-4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -231,7 +231,7 @@ Ledger entries remaining?
 ├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
+    └─ Report what was resolved and what was deferred (with reasons)
 ```
 
 A single-named-smell request has a one-entry ledger — resolve it, audit, done.
@@ -252,11 +252,11 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 - STOP refactoring
 - Note the bug location
-- Ask user: "Found potential bug at X. Fix it now (switching to tdd-enforcer) or continue refactoring?"
+- Ask the user whether to fix it now (switching to tdd-enforcer) or continue refactoring
 
 **User requests large refactoring:**
 
-- Break into steps: "I'll refactor this incrementally. First: [step 1]"
+- Break it into steps and name the first one before starting
 - Complete each step fully before next
 - Never batch multiple refactorings in one edit
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -12,17 +12,14 @@ allowed-tools: '*'
 
 Improve code structure without changing behavior. One small step at a time.
 
-**Iron Law:** ONE REFACTORING → TEST → COMMIT. Never batch changes.
+Work one refactoring at a time: change, test, commit. Don't batch changes.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. User says "refactor", "clean up", "restructure"? → Use this skill
-2. User asks to "extract", "rename", "simplify"? → Use this skill
-3. Code smell identified? → Use this skill
-4. User wants to add feature or fix bug? → Skip (use tdd-enforcer)
-5. User wants formatting/style fixes? → Skip (use /lint)
+Use when the user says "refactor", "clean up", "restructure", "extract",
+"rename", or "simplify", or when you've identified a code smell. Skip for adding
+a feature or fixing a bug (use tdd-enforcer) and for formatting/style fixes (use
+/lint).
 
 **Code smells** (common triggers):
 
@@ -90,9 +87,9 @@ it('processOrder returns current behavior', () => {
 
 ## Phase 3: REFACTOR
 
-**Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+One refactoring at a time; run tests after every change.
 
-**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The one-change rule is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -196,8 +193,8 @@ Choose exactly one outcome:
   creation would disturb the user's state or unrelated work is already present,
   defer the commit and report the exact branch/worktree reason.
 
-Deferring a commit is not skipping the Iron Law; it is preserving the same
-single-change attribution the Iron Law exists to protect.
+Deferring a commit is not skipping the one-change rule; it is preserving the same
+single-change attribution that rule exists to protect.
 
 ### Revert Protocol
 
@@ -275,14 +272,3 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 | Change behavior during refactor        | That's a feature/fix, not refactoring                         |
 | Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
 | Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
-
----
-
-## Key Takeaways
-
-1. **One change at a time** - Never batch refactorings
-2. **Tests before refactoring** - No safety net = no refactoring
-3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
-5. **Smallest scope first** - Rename < Extract < Move < Restructure
-6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -67,7 +67,7 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 **Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
-**Agent review:**
+Illustrative only — apply the checks in your own words, not this exact wording:
 
 > **Atomic?** Yes — tests one behavior (passing files appear in verbose output).
 > **Right assertions?** `expect(output).toContain('src/index.ts: pass')` — asserts on observable output, not internals. Good.

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -82,21 +82,11 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 ## Output discipline
 
-Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
+Close every review with a `**Next:**` line — imperative, naming the file/command/scenario, not a bare "proceed" or "commit and move on" (the stop hook reads it for the re-entry brief).
 
 - After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
 - After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
 - After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
 - After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
-
-A review without a Next: line is incomplete.
-
-## Reminders
-
-1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
-2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
-3. **Single source of truth** — this skill owns all TDD review content
-4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review internally, then commit to proceed
-5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-**Announce your decision:** "Test type: [unit/integration/E2E/eval] because [reason]."
+If the test-scope choice isn't obvious from context, state it and why in one line.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-If the test-scope choice isn't obvious from context, state it and why in one line.
+State the test-scope choice and why in one line, unless it's obvious from context.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/.claude/skills/ticket-system/SKILL.md
+++ b/.claude/skills/ticket-system/SKILL.md
@@ -56,13 +56,9 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 | **task**    | ticket.md with inline tests                         |
 | **patch**   | ticket.md (minimal), existing tests                 |
 
-**Create ticket? Answer IN ORDER, stop at first match:**
-
-1. Multiple attempts likely needed? → Create ticket
-2. Multi-step with dependencies? → Create ticket
-3. Investigation/debugging required? → Create ticket
-4. Risk of losing context mid-session? → Create ticket
-5. None of above? → Skip ticket
+**Create a ticket** when any of these holds: multiple attempts are likely,
+the work is multi-step with dependencies, it needs investigation/debugging, or
+there's a risk of losing context mid-session. Otherwise skip it.
 
 **Examples:** "Fix typo" → skip. "Debug slow login" → ticket. "Add OAuth" → ticket.
 
@@ -124,11 +120,9 @@ status: in_progress
 
 **One artifact = one log.** If log exists, append a new session. Don't spawn multiple logs for the same work.
 
-**Create log? Answer IN ORDER, stop at first match:**
-
-1. Executing a plan, ticket, or spec? → Create log
-2. Investigation/debugging with multiple attempts? → Create log
-3. Quick single-action task? → Skip log
+**Create a log** when executing a plan, ticket, or spec, or when
+investigation/debugging spans multiple attempts. Skip it for a quick
+single-action task.
 
 **Think hard behaviors:**
 

--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -139,7 +139,7 @@ Training data drifts. Memory of "how X worked" is not authority — the current 
 
 **Adding a dependency** (a package not yet in the project) — there's no installed version to read, and the version you recall is stale by definition. Use the live `Current time:` line injected by `prompt-timestamp.ts` when the host provides one; otherwise use the current system date from the session. Then verify the current version for that date before pinning. Prefer the package manager's resolver command (`bun add <pkg>`, `npm install <pkg>`, `uv add`, `cargo add`, `go get <module>@latest`, etc.) or a registry command such as `npm view <pkg> version`, `pip index versions`, `go list -m -versions`, or crates.io. Pin what the registry reports today, never a number from memory.
 
-**Design choices** (algorithm, architecture, security, performance, concurrency, accessibility, ML/stats) — call `/figure-it-out`. Its iron law: no recommendation without current evidence. It enumerates research domains, fetches live docs, and weighs options before committing.
+**Design choices** (algorithm, architecture, security, performance, concurrency, accessibility, ML/stats) — call `/figure-it-out`. Its core rule: no recommendation without current evidence. It enumerates research domains, fetches live docs, and weighs options before committing.
 
 Blog posts, tweets, marketing, and "I remember reading…" don't count for any tier. Treat them as leads, not evidence.
 
@@ -199,7 +199,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 > Do: "Fixed — `packages/cli/src/auth.ts:42` was swallowing the refresh error."
 > Don't: "Great question! Let me walk you through what I found..."
 
-**End with the call.** Last line is what's next — a question, a choice, or a proposed step. For structured replies (verdicts, reviews, recommendations, audits), use a literal `**Next:** <imperative>` line — the same discipline safeword skills enforce in their output. Short conversational replies can end with the question itself; no bold preface needed. Don't bury the call mid-reply.
+**End with the call.** Close by naming what's next — a question, a choice, or a proposed step; don't bury it mid-reply. For structured replies (verdicts, reviews, recommendations, audits), make that closing line a literal `**Next:** <imperative>`: the stop hook captures it verbatim for the session's re-entry brief, so the token is load-bearing, not decoration. Short conversational replies can end with the question itself.
 
 **Debate-then-pick.** When there's a real choice, surface 2-3 options weighed in one breath, then the pick — one line each on the candidates, one on the tradeoff, one on the call. Don't ping-pong one option at a time. Skip the debate when there's no real choice (rename, mechanical edit, single obvious path).
 

--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -14,13 +14,7 @@ A safeword session runs through these phases in order. Each phase has an exit cr
 
 Understand what the user is asking before classifying or building. **Propose-and-Converge** means: lead with a perspective, then surface open questions _inside_ that proposal. Don't ask first — propose first.
 
-Each turn:
-
-1. Restate what you heard.
-2. Contribute a perspective, sketch, or reframe.
-3. Surface remaining open questions as part of that contribution.
-4. Incorporate what the user confirmed; narrow the open set.
-5. When zero open questions remain and the user accepts → advance.
+Each turn, restate what you heard, contribute a perspective/sketch/reframe, and surface the remaining open questions inside that contribution. Incorporate what the user confirms to narrow the open set; advance once none remain and the user accepts.
 
 Research before proposing anything significant — and the order is load-bearing:
 
@@ -123,7 +117,7 @@ Optimize for **Clarity → Simplicity → Correctness**, in that order. When in 
 | Factory for simple object    | Direct construction                              | Indirection without value |
 | `data`, `tmp`, `d`           | `userProfile`, `pendingOrder`                    | Names should explain      |
 | Code "for later"             | Delete it; add when needed                       | YAGNI                     |
-| >50 lines for nice-to-have   | Ask user: "Essential now?"                       | Scope creep               |
+| >50 lines for nice-to-have   | Ask whether it's essential now                   | Scope creep               |
 
 ---
 
@@ -149,24 +143,24 @@ Blog posts, tweets, marketing, and "I remember reading…" don't count for any t
 
 Read the matching guide when its trigger fires:
 
-| Trigger                                                        | Guide                                           |
-| -------------------------------------------------------------- | ----------------------------------------------- |
-| Starting a feature/task OR writing specs/test-definitions      | `./.safeword/guides/planning-guide.md`          |
-| Choosing test type, doing TDD, or a test is failing            | `./.safeword/guides/testing-guide.md`           |
-| Creating or updating a design doc                              | `./.safeword/guides/design-doc-guide.md`        |
-| Making an architectural decision or writing an ADR             | `./.safeword/guides/architecture-guide.md`      |
-| Understanding the generated `architecture.generated.md` doc    | `./.safeword/guides/architecture-guide.md`      |
-| Data-heavy project needing formal data architecture            | `./.safeword/guides/data-architecture-guide.md` |
-| Writing learnings or agent config (CLAUDE.md, .cursor/rules)   | `./.safeword/guides/llm-writing-guide.md`       |
-| Updating CLAUDE.md, SAFEWORD.md, or any context file           | `./.safeword/guides/context-files-guide.md`     |
-| Hit the same bug 3+ times or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
-| Process hanging, port in use, or zombie process suspected      | `./.safeword/guides/zombie-process-cleanup.md`  |
+| Trigger                                                          | Guide                                           |
+| ---------------------------------------------------------------- | ----------------------------------------------- |
+| Starting a feature/task OR writing specs/test-definitions        | `./.safeword/guides/planning-guide.md`          |
+| Choosing test type, doing TDD, or a test is failing              | `./.safeword/guides/testing-guide.md`           |
+| Creating or updating a design doc                                | `./.safeword/guides/design-doc-guide.md`        |
+| Making an architectural decision or writing an ADR               | `./.safeword/guides/architecture-guide.md`      |
+| Understanding the generated `architecture.generated.md` doc      | `./.safeword/guides/architecture-guide.md`      |
+| Data-heavy project needing formal data architecture              | `./.safeword/guides/data-architecture-guide.md` |
+| Writing learnings or agent config (CLAUDE.md, .cursor/rules)     | `./.safeword/guides/llm-writing-guide.md`       |
+| Updating CLAUDE.md, SAFEWORD.md, or any context file             | `./.safeword/guides/context-files-guide.md`     |
+| Hit the same bug repeatedly or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
+| Process hanging, port in use, or zombie process suspected        | `./.safeword/guides/zombie-process-cleanup.md`  |
 
 ---
 
 ## Standing Rules
 
-**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Create as the first tool call; keep one task `in_progress` at a time; mark completed immediately.
+**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Set it up before diving in; keep one task `in_progress` at a time; mark completed as you finish each.
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
@@ -211,7 +205,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **Gloss jargon at the decision point.** Don't assume the user reads code. The first time a stack or domain term is load-bearing in an _ask_ — a block, a decision, a step they must take — gloss it inline in one clause ("the refresh token (the credential that renews a login) expired"). Once per turn, never re-explained; a fluent reader skips it at no cost. Leave background narration unglossed.
 
-**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. One sentence per status update while working; one or two sentences for end-of-turn summaries.
+**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. Keep status updates terse and end-of-turn summaries brief — a sentence or two, not a paragraph.
 
 **Cite code as `path:line`.** When referencing something the user might open, write `packages/cli/src/foo.ts:142` inline. Not "the foo file." Not in a code block.
 
@@ -219,6 +213,6 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **Use structure only when it carries weight.** Headings when the reply is long enough to navigate — and make them information-carrying, not generic ("What changed" beats "Summary"). Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
 
-**At most one bolded phrase per paragraph**, and only when reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
+**Use bold sparingly** — only where reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
 
 **Skip:** preambles ("I'll now..."), recaps of what the user just said, sycophantic openers ("Great question!"), hedging caveats ("It depends, but..."), restating actions the user can see in the tool log.

--- a/.safeword/guides/architecture-guide.md
+++ b/.safeword/guides/architecture-guide.md
@@ -88,14 +88,16 @@ Required only when the ideal diverges from what exists:
 
 ---
 
-## Document Type Decision Tree (Follow in Order)
+## Document Type Decision Tree
 
-Answer **IN ORDER**. Stop at the first "Yes":
+The first matching row picks the doc type:
 
-1. **Technology or library choice?** → **Architecture Doc**
-2. **New data model or schema change?** → **Architecture Doc**
-3. **Project-wide pattern or convention?** → **Architecture Doc**
-4. **Implementing a specific feature?** → **Design Doc**
+| If the work is a…                  | Doc              |
+| ---------------------------------- | ---------------- |
+| technology or library choice       | Architecture Doc |
+| new data model or schema change    | Architecture Doc |
+| project-wide pattern or convention | Architecture Doc |
+| specific feature implementation    | Design Doc       |
 
 **Tie-breaker:** If a feature requires a new tech/schema choice, document the tech/schema in Architecture Doc first, then reference it in Design Doc.
 
@@ -301,12 +303,14 @@ Update in place with version/status tracking:
 
 ## Re-evaluation Path (When Unclear)
 
-Answer **IN ORDER**:
+The first matching row picks the doc type:
 
-1. **Affects 2+ features?** → Architecture Doc (stop)
-2. **Technology/data model choice?** → Architecture Doc (stop)
-3. **Future developers need this for whole project?** → Architecture Doc
-4. **Only for this feature?** → Design Doc
+| If the work…                                 | Doc              |
+| -------------------------------------------- | ---------------- |
+| affects 2+ features                          | Architecture Doc |
+| is a technology/data-model choice            | Architecture Doc |
+| future developers need for the whole project | Architecture Doc |
+| is only for this feature                     | Design Doc       |
 
 **Tie-breaker:** When still unclear, default to Design Doc. Easier to promote later than to split.
 

--- a/.safeword/guides/context-files-guide.md
+++ b/.safeword/guides/context-files-guide.md
@@ -322,6 +322,7 @@ Brief description. Current status.
 - Test: Can new developer understand "why" from reading this?
 - **Use imports** to keep main file under 200 lines
 - Verify loaded context matches intent (check hierarchical loading behavior)
+- Make critical rules findable through clear structure, not position tricks (burying them mid-file)
 
 ---
 
@@ -456,12 +457,3 @@ Brief description. Current status.
 - Bloated files cost more tokens and introduce noise
 - Keep under 50KB for optimal performance (though no hard limit)
 - Use imports to modularize instead of monolithic files
-
----
-
-## Key Takeaways
-
-- Keep context files under 200 lines—use imports to modularize
-- Short declarative bullets, not narrative paragraphs
-- Update immediately when architecture changes (stale docs = confusion)
-- Avoid burying critical rules in the middle — use clear structure over position tricks

--- a/.safeword/guides/context-files-guide.md
+++ b/.safeword/guides/context-files-guide.md
@@ -448,7 +448,7 @@ Brief description. Current status.
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
 - At Anthropic, teams use prompt improver to tune instructions
-- Add emphasis ("IMPORTANT", "YOU MUST") for critical rules
+- State critical rules as plain declarative facts — a literal model doesn't need shouting
 - Explicitly reference your context file in prompts ("following CLAUDE.md guidelines") for better adherence
 
 **Token Budget:**

--- a/.safeword/guides/context-files-guide.md
+++ b/.safeword/guides/context-files-guide.md
@@ -76,7 +76,7 @@ Loaded context:
 See root AGENTS.md for TDD workflow. This file covers test-specific patterns.
 ```
 
-**Reliability note:** Auto-loading works best when you explicitly reference your file in conversation (e.g., "following the guidelines in CLAUDE.md"). Implicit automatic reference can be less reliable.
+**Reliability note:** On current models the context file auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
 
 **Deprecated:** `*.local.md` is no longer recommended - use imports instead for better multi-worktree support
 
@@ -434,7 +434,7 @@ Brief description. Current status.
 
 ---
 
-## Best Practices from Anthropic
+## Authoring Best Practices
 
 **Conciseness:**
 
@@ -447,9 +447,13 @@ Brief description. Current status.
 
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
-- At Anthropic, teams use prompt improver to tune instructions
-- State critical rules as plain declarative facts — a literal model doesn't need shouting
-- Explicitly reference your context file in prompts ("following CLAUDE.md guidelines") for better adherence
+- State most rules as plain declarative facts; blanket `IMPORTANT`/`YOU MUST` decoration is noise a literal model doesn't need. Reserve emphasis for one job — flagging **when to reach for a capability** (a subagent, a tool, memory) that a model like Opus 4.8 otherwise under-uses.
+- The file auto-loads every session, so don't repeat a rule or name the file in the prompt to force adherence — brevity, not repetition, is what keeps rules followed.
+
+**Portability:**
+
+- Emphasis (`IMPORTANT`/`YOU MUST`) is a Claude-specific last-resort lever — don't teach it as portable reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
+- Default to **Markdown** structure (portable across vendors); treat XML-tag structuring as a Claude-specific optimization, not a baseline.
 
 **Token Budget:**
 

--- a/.safeword/guides/data-architecture-guide.md
+++ b/.safeword/guides/data-architecture-guide.md
@@ -8,15 +8,16 @@
 
 ## When to Document Data Architecture
 
-**Decision Tree (Answer IN ORDER, stop at first match):**
+The first matching row applies (rows run general → specific, so when several fit,
+the earlier one wins):
 
-1. **Project initialization?** → Create `DATA_ARCHITECTURE.md` or `ARCHITECTURE.md` with data section
-2. **Adding new data store?** (database, cache, file system) → Update architecture doc
-3. **Changing data model?** (schema, entities, relationships) → Update architecture doc
-4. **Data flow integration?** (API, ETL, sync) → Update architecture doc
-5. **Single feature implementation?** → Use design doc (reference architecture doc)
-
-**Tie-breaking rule:** If multiple apply, stop at first match (earlier = more general).
+| If the work is…                                           | Action                                                               |
+| --------------------------------------------------------- | -------------------------------------------------------------------- |
+| project initialization                                    | Create `DATA_ARCHITECTURE.md` or `ARCHITECTURE.md` with data section |
+| adding a new data store (database, cache, file system)    | Update architecture doc                                              |
+| changing the data model (schema, entities, relationships) | Update architecture doc                                              |
+| a data-flow integration (API, ETL, sync)                  | Update architecture doc                                              |
+| a single-feature implementation                           | Use design doc (reference architecture doc)                          |
 
 **Edge cases:**
 
@@ -199,12 +200,3 @@ Before finalizing data architecture doc:
 - [ ] Migration strategy covers both additive and breaking changes
 - [ ] Version and status match codebase (verify with git/deployment)
 - [ ] Cross-referenced from root ARCHITECTURE.md or SAFEWORD.md (link exists)
-
----
-
-## Key Takeaways
-
-- Data quality, governance, accessibility are core principles
-- Every entity needs: attributes, types, relationships, constraints
-- Performance targets use concrete numbers (e.g., <100ms, not "fast")
-- Migration strategy covers both additive and breaking changes

--- a/.safeword/guides/design-doc-guide.md
+++ b/.safeword/guides/design-doc-guide.md
@@ -94,7 +94,7 @@
 - Designing a specific feature implementation
 - Need component breakdown and interactions
 - Feature-specific technical decisions
-- 2-3 pages (~121 lines)
+- Concise — a few pages, not a sprawling doc
 
 **Use Architecture Doc when:**
 
@@ -151,7 +151,7 @@ Before saving, verify:
 - ✓ User flow has concrete examples
 - ✓ Key decisions have "what, why, trade-off"
 - ✓ All optional sections marked "(if applicable)"
-- ✓ ~121 lines (concise, LLM-optimized)
+- ✓ Concise, LLM-optimized (a few pages, not sprawling)
 
 ---
 
@@ -168,4 +168,4 @@ Before saving, verify:
 - Escalate to Architecture Doc if: new tech, new schema, or pattern affects 2+ features
 - Reference user stories and test definitions—don't duplicate them
 - Every decision needs: what, why, trade-off
-- ~121 lines target (concise, LLM-optimized)
+- Concise, LLM-optimized (a few pages, not sprawling)

--- a/.safeword/guides/design-doc-guide.md
+++ b/.safeword/guides/design-doc-guide.md
@@ -134,21 +134,11 @@
 
 ---
 
-## Example Commands
+## Working from a request
 
-**Creating design doc:**
-
-```text
-User: "Create design doc for three-pane layout"
-You: [Read user stories and test definitions, then create design doc]
-```
-
-**Updating design doc:**
-
-```text
-User: "Update design doc to add error handling section"
-You: [Read existing design doc, add Implementation Notes section with error handling]
-```
+Creating a design doc starts from the user stories and test definitions; updating
+one starts from the existing doc, extending the relevant section (e.g. adding
+Implementation Notes for error handling). Read the inputs first, then write.
 
 ---
 

--- a/.safeword/guides/learning-extraction.md
+++ b/.safeword/guides/learning-extraction.md
@@ -88,55 +88,12 @@ ls <namespace-root>/learnings/*keyword*.md
 
 ### When to Reference Existing Learnings
 
-**Found existing learning** → Read and apply it:
+Before extracting or advising, `ls` the learnings directory for the concept's keywords, then:
 
-```text
-"I found an existing learning about [concept] at [path]. Let me read it and apply to your case..."
-[Read the file]
-"Based on the learning, here's how to handle this: [specific guidance from learning]"
-```
-
-**No existing learning** → Proceed normally (no message needed)
-
-**Similar but different** → Reference and note difference:
-
-```text
-"This is similar to the [existing learning] at [path], but differs in [specific way].
-The existing learning covers [X], but your case involves [Y]."
-```
-
-### Example Workflow
-
-**Scenario 1: Found relevant learning**
-
-```text
-User: "I'm getting an async state update error with React hooks"
-→ Check: ls <namespace-root>/learnings/*react*.md *hooks*.md *async*.md
-→ Found: react-hooks-async.md
-→ Read: [file contents]
-→ Apply: "I found a learning about async React hooks. It mentions you should use useEffect
-         for side effects, not setState directly in callbacks. Applying this to your case..."
-```
-
-**Scenario 2: No existing learning**
-
-```text
-User: "IndexedDB quota is behaving strangely in Safari"
-→ Check: ls <namespace-root>/learnings/*indexeddb*.md *safari*.md *quota*.md
-→ Not found
-→ Proceed: Continue debugging normally, suggest extraction if triggers match
-```
-
-**Scenario 3: Update existing learning**
-
-```text
-User: Debugging for 6 cycles, discovers new IndexedDB quirk
-→ Suggest extraction
-→ Check: ls <namespace-root>/learnings/*indexeddb*.md
-→ Found: indexeddb-quota-api.md
-→ Suggest: "I found an existing learning about IndexedDB quota. Should I update it with
-           this new discovery instead of creating a separate learning?"
-```
+- **Found a relevant learning** → read it and apply it, telling the user what it says and how it maps to their case.
+- **Found one that's similar but different** → reference it and name the specific difference (what it covers vs. what this case involves).
+- **None found** → proceed normally; suggest extraction if the triggers match.
+- **Extraction triggered and a near-match exists** → offer to update that learning rather than create a separate one.
 
 ### Benefits of Checking Existing Learnings
 
@@ -327,11 +284,11 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 - Observable debugging complexity (5+ debug cycles, 3+ error states, user says "stuck")
 - Just discovered gotcha not in official docs
 - Just found anti-pattern (violated best practice)
-- Say: "I notice this pattern could save time on future work. Should I extract a learning after we fix this?"
+- Offer to extract a learning once the fix lands — note it could save time on future work.
 
 **Medium confidence - Ask AFTER completing task:**
 
-- "I noticed [pattern X] during implementation - should I document this as a learning?"
+- Ask whether to document the pattern you hit as a learning.
 
 **Low confidence - Don't suggest:**
 

--- a/.safeword/guides/learning-extraction.md
+++ b/.safeword/guides/learning-extraction.md
@@ -14,10 +14,10 @@ Extract after experiencing ANY of these:
 
 1. **Observable debugging complexity** - Any of these signals:
    - User says "still debugging", "been stuck on this", "tried many things"
-   - 5+ debug cycles (Read → Edit → Bash pattern repeated)
-   - 3+ different error states encountered
-   - Modified 3+ files while debugging same issue
-2. **Trial and error** - Tried 3+ different approaches before finding the right one
+   - Several debug cycles (Read → Edit → Bash pattern repeated)
+   - Multiple different error states encountered
+   - Modified several files while debugging the same issue
+2. **Trial and error** - Tried several different approaches before finding the right one
 3. **Undocumented gotcha** - Not in official library/framework docs
 4. **Integration struggle** - Two tools that don't work together smoothly
 5. **Testing trap** - Tests pass but UX is broken (or vice versa)
@@ -281,7 +281,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 **High confidence - Suggest IMMEDIATELY DURING debugging:**
 
-- Observable debugging complexity (5+ debug cycles, 3+ error states, user says "stuck")
+- Observable debugging complexity (several debug cycles, multiple error states, user says "stuck")
 - Just discovered gotcha not in official docs
 - Just found anti-pattern (violated best practice)
 - Offer to extract a learning once the fix lands — note it could save time on future work.
@@ -302,11 +302,10 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 **Living Documentation**: This process evolves with your needs.
 
-**Review Cycle**:
-
-1. **Monthly**: Review existing learnings for relevance
-2. **Quarterly**: Archive obsolete learnings (technology changed, pattern no longer used)
-3. **Per feature**: After major features, assess if new learnings emerged
+**Review Cycle**: Revisit a learning when you next touch its area or start a
+nearby feature — not on a calendar. That's when you'll notice it's gone stale
+(technology changed, pattern no longer used) and should be updated or archived,
+and when a just-finished feature might have surfaced something reusable.
 
 **Test the Process**:
 
@@ -339,7 +338,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 ### During Development
 
-1. **Recognize trigger** - Spent 45 min debugging race condition
+1. **Recognize trigger** - Several failed attempts before cracking a race condition
 2. **Assess scope** - Forward-looking? (YES) Global or project? (Project)
 3. **Choose location** - Needs examples → `<namespace-root>/learnings/race-conditions.md`
 4. **Extract** - Use template, write before/after examples
@@ -348,7 +347,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 ### After Completing Feature
 
 1. **Review** - Did we learn anything reusable?
-2. **Extract** - If threshold met (>30min debug, non-obvious pattern)
+2. **Extract** - If the signals are there (repeated failed attempts, non-obvious pattern)
 3. **Update** - Add SAFEWORD.md cross-reference if needed
 4. **Commit** - Include learning in commit message
 

--- a/.safeword/guides/learning-extraction.md
+++ b/.safeword/guides/learning-extraction.md
@@ -328,9 +328,8 @@ and when a just-finished feature might have surfaced something reusable.
 
 **Feedback Loop**:
 
-- After suggesting extraction: Note if user accepted or declined
-- After user accepts: Monitor if learning is referenced in future sessions
-- Adjust suggestion threshold based on acceptance rate (if <30% accepted, raise the bar)
+- After suggesting extraction, note whether the user accepted or declined.
+- If your suggestions aren't landing this session, ease off — stop offering and let the user ask. You can't track an acceptance rate across sessions, so gauge it from the ones in front of you.
 
 ---
 

--- a/.safeword/guides/learning-extraction.md
+++ b/.safeword/guides/learning-extraction.md
@@ -1,6 +1,6 @@
 # Learning Extraction Process
 
-Extract reusable knowledge from debugging sessions and implementation discoveries. Ensures insights compound across sessions.
+Extract reusable knowledge from debugging sessions and implementation discoveries. Ensures insights compound across sessions. When in doubt, extract more rather than less — you can archive later — and capture it while the context is fresh rather than deferring.
 
 **LLM Instruction Design:** Learnings are documentation that LLMs read and follow. Apply best practices from `@.safeword/guides/llm-writing-guide.md` when writing learning files (concrete examples, explicit definitions, MECE principles).
 
@@ -51,7 +51,7 @@ Extract after experiencing ANY of these:
 
 ## Using Existing Learnings
 
-**CRITICAL**: Before extracting new learnings, ALWAYS check if similar learnings already exist. This prevents duplication and keeps knowledge organized.
+Before extracting a new learning, check whether a similar one already exists — this prevents duplication and keeps the knowledge organized.
 
 ### When to Check for Existing Learnings
 
@@ -247,7 +247,7 @@ Actual: [What happened]
 
 ## SAFEWORD.md Integration
 
-**CRITICAL**: ALWAYS cross-reference in SAFEWORD.md after creating learning file.
+After creating a learning file, cross-reference it in SAFEWORD.md.
 
 After extracting to `<namespace-root>/learnings/`, add cross-reference in SAFEWORD.md:
 
@@ -488,47 +488,3 @@ The `post-tool-sync-learnings` hook flags `✅ Verified` and `Verified by …` s
 <namespace-root>/learnings/electron-ipc-patterns.md         (60 lines)
 <namespace-root>/learnings/electron-path-validation.md      (50 lines)
 ```
-
----
-
-## Summary
-
-This is a **living process** - iterate and refine based on what works.
-
-**Core Principle**: Extract knowledge that **compounds over time**. Each learning should save time on 2+ future features.
-
-**Decision Framework**:
-
-1. **Forward-looking?** → Extract (helps future work)
-2. **Global or project?** → Choose directory
-3. **Architectural or gotcha?** → Choose SAFEWORD.md or separate file
-4. **ALWAYS cross-reference** → Update SAFEWORD.md
-
-**Continuous Improvement**:
-
-- Monthly: Review existing learnings for relevance
-- Quarterly: Archive obsolete learnings
-- Per feature: Assess if new learnings emerged
-- Test: Did extracting this actually help on the next feature?
-
-**When in Doubt**:
-
-- Extract more rather than less (can archive later)
-- Prefer separate file over inline comments (keeps code clean)
-- Update immediately while fresh (don't defer to "later")
-
-**Maintenance**:
-
-- Remove when technology deprecated or pattern no longer used
-- Refactor when multiple learnings cover similar topics (consolidate)
-- Split when learning file >200 lines (focus on single concept)
-- Update SAFEWORD.md references when learnings move or merge
-
----
-
-## Key Takeaways
-
-- Extract after 5+ debug cycles or 3+ approaches tried
-- Check existing learnings first—update, don't duplicate
-- One concept per file, under 200 lines
-- Extract immediately while fresh (don't defer to "later")

--- a/.safeword/guides/llm-evals-guide.md
+++ b/.safeword/guides/llm-evals-guide.md
@@ -35,35 +35,20 @@ Agent chooses the right tool       → eval or trace eval
 
 ## Eval Decision Tree
 
-Answer in order. Stop at the first match.
+The first matching row picks the approach (rows run cheapest/most-deterministic →
+most model-graded, which is also the tie-break order):
 
-1. **Can a normal deterministic test fully prove the behavior?**
-   - YES → Use unit, integration, E2E, or migration coverage instead
-   - NO → Continue
+| If…                                                                     | Approach                                          |
+| ----------------------------------------------------------------------- | ------------------------------------------------- |
+| a normal deterministic test can fully prove the behavior                | Use unit, integration, E2E, or migration coverage |
+| a deterministic eval assertion can prove part of the AI output contract | Add that assertion before any model-graded scorer |
+| there's a known correct output, label, or fact set                      | Reference-based evals                             |
+| comparing two outputs is easier than scoring one absolutely             | Pairwise evals                                    |
+| the desired quality is subjective but describable                       | Rubric-based LLM-as-judge evals                   |
+| the behavior involves multiple steps, tools, retrieval, or agents       | Trace or trajectory evals                         |
 
-2. **Can a deterministic eval assertion prove part of the AI output contract?**
-   - YES → Add that assertion before any model-graded scorer
-   - NO → Continue
-
-3. **Is there a known correct output, label, or fact set?**
-   - YES → Use reference-based evals
-   - NO → Continue
-
-4. **Is it easier to compare two outputs than score one output absolutely?**
-   - YES → Use pairwise evals
-   - NO → Continue
-
-5. **Is the desired quality subjective but describable?**
-   - YES → Use rubric-based LLM-as-judge evals
-   - NO → Continue
-
-6. **Does the behavior involve multiple steps, tools, retrieval, or agents?**
-   - YES → Use trace or trajectory evals
-   - NO → Write the missing acceptance criteria before creating the eval
-
-**Tie-breaker:** deterministic checks first, reference-based checks second,
-LLM-as-judge last. Model-graded evals are powerful but add cost, latency, and
-grader failure modes.
+If none fit, write the missing acceptance criteria before creating the eval.
+Model-graded evals are powerful but add cost, latency, and grader failure modes.
 
 ---
 
@@ -112,7 +97,8 @@ A good eval catches a plausible AI failure that users would notice, and it tells
 the team what to do when it fails. A wasteful eval spends model calls without
 raising confidence.
 
-Before writing a new eval, answer in order. Stop at the first failure.
+A new eval earns its place only if every one of these holds; the first that
+fails tells you what to fix before writing it.
 
 1. **What user-visible failure would this catch?**
    - Clear answer → Continue
@@ -471,15 +457,3 @@ Minimal template:
 | Full AI eval  | `npm run eval:full`  | release | yes            | `evals/full.yml`  | AI team |
 | Drift monitor | scheduled            | no      | sampled traces | platform          |
 ```
-
----
-
-## Key Takeaways
-
-- Use deterministic tests before judge evals.
-- Evals need objectives, datasets, scorers, cadence, thresholds, and owners.
-- Judge one quality dimension at a time.
-- Calibrate LLM-as-judge scorers against human-labeled examples.
-- Keep historical failures as regression cases.
-- Separate cheap smoke evals from full, expensive eval suites.
-- Never put sensitive production data into eval fixtures without approval.

--- a/.safeword/guides/llm-writing-guide.md
+++ b/.safeword/guides/llm-writing-guide.md
@@ -80,22 +80,30 @@ Section B: "All user-facing features have E2E tests"
 
 ## Decision Tree Patterns
 
-### Sequential Over Parallel
+### Declarative Table Over Ordered Scan
 
-Structure as ordered steps, not simultaneous checks.
+A literal model resolves a lookup in one glance, so prefer a declarative "first
+matching row applies" table over an ordered "answer in order, stop at first
+match" scan — the scan makes the model serially walk rows it already sees at
+once. Keep the rows mutually exclusive and collectively exhaustive. Reserve
+ordered steps for a genuinely sequential _procedure_, where each step depends on
+the result of the one before.
 
 ```markdown
-❌ BAD - Parallel:
-├─ Pure function?
-├─ Multiple components?
-└─ Full user flow?
-
-✅ GOOD - Sequential:
+❌ BAD - ordered scan of mutually-exclusive rows:
 Answer IN ORDER, stop at first match:
 
 1. Pure function? → Unit
 2. Multiple components? → Integration
 3. Full user flow? → E2E
+
+✅ GOOD - declarative table, first matching row applies:
+
+| If the test…               | Type        |
+| -------------------------- | ----------- |
+| covers a pure function     | Unit        |
+| spans multiple components  | Integration |
+| exercises a full user flow | E2E         |
 ```
 
 ### Tie-Breaking Rules

--- a/.safeword/guides/llm-writing-guide.md
+++ b/.safeword/guides/llm-writing-guide.md
@@ -157,3 +157,33 @@ Provide concrete next steps for dead ends.
 | Percentages without context           | "70/20/10" meaningless without adjustment guidance |
 | Caveats in tables                     | Parentheticals break pattern matching              |
 | Critical info in middle               | Lost-in-middle phenomenon                          |
+
+---
+
+## De-prescription: convert, don't delete
+
+Modern models (Fable 5, Opus 4.8, Sonnet 5) follow instructions more literally
+than older ones, so imperative step-lists, forced ordering, and shouted
+`CRITICAL/MUST` emphasis now degrade output rather than improve it. When editing
+these guides, **convert prescription into principle** — state the intent, a
+measurable done-condition, and the explicit scope — rather than enumerating
+steps. Graduate true invariants out of prose and into hooks/lint.
+
+**Classify every edit into one of two columns:**
+
+- **Universal** — rephrases to intent, softens an imperative, drops
+  native-behavior scaffolding, or graduates an invariant into a hook. No
+  guidance is lost, so **apply it globally, no A/B needed.**
+- **Deletion** — removes guidance instead of restating it. A literal model
+  won't infer what you cut, so this **must pass an Opus 4.8 + Sonnet 5 A/B
+  before it ships globally** — never on single-model evidence.
+
+Two more rules keep the smaller and non-Fable drivers safe:
+
+- **Tag each finding with the model that surfaced it.** A regression seen only
+  on one model isn't yet evidence for a global change.
+- **Keep capability guidance as conditional "when-X" triggers, don't delete it.**
+  Prompts to delegate to subagents, consult learnings, or search-first are
+  scaffolding Fable doesn't need but Opus 4.8 does (it under-reaches). Phrase
+  them as "when the task fans out across independent items, delegate to
+  subagents" — harmless to Fable, measurable lift on Opus 4.8.

--- a/.safeword/guides/llm-writing-guide.md
+++ b/.safeword/guides/llm-writing-guide.md
@@ -157,25 +157,3 @@ Provide concrete next steps for dead ends.
 | Percentages without context           | "70/20/10" meaningless without adjustment guidance |
 | Caveats in tables                     | Parentheticals break pattern matching              |
 | Critical info in middle               | Lost-in-middle phenomenon                          |
-
----
-
-## Quality Checklist
-
-- [ ] Decision trees: MECE, sequential, with tie-breakers
-- [ ] All terms explicitly defined
-- [ ] Every rule has good vs bad examples
-- [ ] Edge cases covered
-- [ ] No contradictions between sections
-- [ ] Complex decisions have lookup tables
-- [ ] Dead-end paths have re-evaluation steps
-- [ ] Critical rules not buried in the middle of long documents
-
----
-
-## Key Takeaways
-
-- Decision trees: sequential, MECE, with tie-breakers
-- Every rule needs concrete examples (good vs bad)
-- Define all terms explicitly—assume nothing is obvious
-- Avoid burying critical rules in the middle — use clear structure over position tricks

--- a/.safeword/guides/llm-writing-guide.md
+++ b/.safeword/guides/llm-writing-guide.md
@@ -169,6 +169,12 @@ these guides, **convert prescription into principle** — state the intent, a
 measurable done-condition, and the explicit scope — rather than enumerating
 steps. Graduate true invariants out of prose and into hooks/lint.
 
+This is a cross-vendor shift, not an Anthropic quirk: OpenAI's GPT-5.5 guidance
+says the same — "reduce or remove detailed step-by-step process guidance… let
+the model choose the path unless the product requires that path," and "describe
+the expected outcome, success criteria, allowed side effects… and output shape"
+instead. Treat the convention as durable, not model-of-the-month.
+
 **Classify every edit into one of two columns:**
 
 - **Universal** — rephrases to intent, softens an imperative, drops

--- a/.safeword/guides/planning-guide.md
+++ b/.safeword/guides/planning-guide.md
@@ -6,7 +6,7 @@ How to write specs, user stories, and test definitions before implementation.
 
 ## Artifact Levels
 
-**Triage first - answer IN ORDER, stop at first match:**
+**Triage first — the first matching row sets the level:**
 
 | Question                                 | Level       | Artifacts                                            |
 | ---------------------------------------- | ----------- | ---------------------------------------------------- |
@@ -304,7 +304,7 @@ test-definitions.md is the R/G/R ledger.
 
 ### Testing Technical Constraints
 
-User stories include Technical Constraints. These MUST have corresponding scenarios.
+User stories include Technical Constraints; each one needs a corresponding scenario.
 
 | Constraint Category | Test Type                  | What to Verify                                |
 | ------------------- | -------------------------- | --------------------------------------------- |

--- a/.safeword/guides/testing-guide.md
+++ b/.safeword/guides/testing-guide.md
@@ -24,11 +24,11 @@ the lane. Higher scope gives more real-world confidence. Lower scope wins when
 it proves the same behavior faster, diagnoses failures better, or covers dense
 edge cases.
 
-**Always test what you build** — Run tests yourself before completion. Don't ask the user to verify.
+Test what you build — run the tests yourself before completion rather than asking the user to verify.
 
 ---
 
-## Test Integrity (CRITICAL)
+## Test Integrity
 
 **NEVER modify, skip, or delete tests without explicit human approval.**
 
@@ -78,7 +78,8 @@ A good test protects behavior that matters and would fail for a plausible
 regression. A busywork test satisfies "add tests" without raising useful
 confidence.
 
-Before adding a test, answer in order. Stop at the first failure.
+A test earns its place only if every one of these holds; the first that fails
+tells you what to fix before writing it.
 
 1. **What behavior or contract does this protect?**
    - Clear answer → Continue
@@ -171,29 +172,16 @@ Unit (milliseconds)      ← Pure functions, no I/O           ↓ cheaper diagno
 
 ## When to Use Each Test Type
 
-Answer these questions in order. Stop at first match.
+The first matching row picks the type (rows run general → specific):
 
-```text
-1. Does this test AI-generated content quality (tone, reasoning, creativity)?
-   └─ YES → LLM Evaluation
-   └─ NO → Continue to question 2
+| If the test…                                                      | Type           | Examples                                                                                                                                   |
+| ----------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| checks AI-generated content quality (tone, reasoning, creativity) | LLM Evaluation |                                                                                                                                            |
+| needs a real browser (Playwright/Cypress)                         | E2E            | Multi-page navigation, browser-specific behavior, visual regression (React Testing Library does _not_ need a browser — that's integration) |
+| exercises interactions between multiple components/services       | Integration    | API + database, React component + state store                                                                                              |
+| covers a pure function (input → output, no I/O)                   | Unit           | Calculations, formatters, validators, pure algorithms                                                                                      |
 
-2. Does this test require a real browser (Playwright/Cypress)?
-   └─ YES → E2E test
-      Examples: Multi-page navigation, browser-specific behavior, visual regression
-      Note: React Testing Library does NOT require a browser - that's integration
-   └─ NO → Continue to question 3
-
-3. Does this test interactions between multiple components/services?
-   └─ YES → Integration test
-      Examples: API + database, React component + state store
-   └─ NO → Continue to question 4
-
-4. Does this test a pure function (input → output, no I/O)?
-   └─ YES → Unit test
-      Examples: Calculations, formatters, validators, pure algorithms
-   └─ NO → Re-evaluate: What are you actually testing?
-```
+If none match, re-evaluate what you're actually testing.
 
 **Edge cases:**
 

--- a/.safeword/guides/verification-lanes-guide.md
+++ b/.safeword/guides/verification-lanes-guide.md
@@ -33,38 +33,20 @@ primary lane is smoke, release, or slow/performance.
 
 ## Lane Decision Tree
 
-Answer in order. Stop at the first match. Choose the lane that explains why this
-run exists now.
+The first matching row picks the lane (rows run specific → general). Choose the
+lane that explains why this run exists now.
 
-1. **Are you proving only the current change while writing code?**
-   - YES → Focused lane
-   - NO → Continue
+| If the run…                                                                                                              | Lane             |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| proves only the current change while writing code                                                                        | Focused          |
+| gives a quick signal that the product is basically usable                                                                | Smoke            |
+| proves behavior against real external systems, credentials, production-like infrastructure, or a real customer workspace | Live-fire        |
+| proves a built, packaged, or deployed artifact is ready to ship                                                          | Release          |
+| proves old data, config, or installs still work after an upgrade                                                         | Migration        |
+| runs static analysis rather than runtime behavior                                                                        | Static gate      |
+| is too expensive for normal local or per-commit runs                                                                     | Slow/performance |
 
-2. **Do you need a quick signal that the product is basically usable?**
-   - YES → Smoke lane
-   - NO → Continue
-
-3. **Is the main reason for this run to prove behavior against real external
-   systems, real credentials, production-like infrastructure, or a real
-   customer-like workspace?**
-   - YES → Live-fire lane
-   - NO → Continue
-
-4. **Are you proving that a built, packaged, or deployed artifact is ready to ship?**
-   - YES → Release lane
-   - NO → Continue
-
-5. **Are you proving old data, old config, or old installs still work after an upgrade?**
-   - YES → Migration lane
-   - NO → Continue
-
-6. **Is the check static analysis rather than runtime behavior?**
-   - YES → Static gate
-   - NO → Continue
-
-7. **Is the check too expensive for normal local or per-commit runs?**
-   - YES → Slow/performance lane
-   - NO → Re-evaluate the test type in `.safeword/guides/testing-guide.md`
+If none fit, re-evaluate the test type in `.safeword/guides/testing-guide.md`.
 
 **Tie-breaker:** if a check fits two lanes, choose the lane that explains why it
 is run at its cadence. Example: a Playwright checkout test that runs in two
@@ -96,7 +78,8 @@ A good verification lane changes an engineering decision. It tells the team
 whether to keep coding, hand off, merge, release, roll back, or investigate the
 environment. A busywork lane consumes time without changing the next action.
 
-Before adding a new lane or check, answer in order. Stop at the first failure.
+A new lane or check earns its place only if every one of these holds; the first
+that fails tells you what to fix before adding it.
 
 1. **What decision will this run unblock?**
    - Clear answer → Continue

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -166,17 +166,6 @@ tmux kill-session -t project-name
 
 ---
 
-## Best Practices
-
-1. **Assign unique ports** - Set `PORT=3000` in one project, `PORT=3001` in another
-2. **Use port-based cleanup first** - Simplest and safest
-3. **Create project cleanup scripts** - Reusable, documented
-4. **Never `killall node`** - Too broad when working on multiple projects
-5. **Clean up before starting** - Run cleanup script before `bun run dev`
-6. **Check what's running** - Use `lsof -i:PORT` to see what's using a port
-
----
-
 ## Debugging Zombie Processes
 
 ### Find What's Using a Port
@@ -223,21 +212,6 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 ---
 
-## What NOT to Do
-
-❌ **DON'T:** `killall node` (kills all projects)
-❌ **DON'T:** `pkill -9 node` (kills all projects)
-❌ **DON'T:** `pkill -f "pattern"` without `pgrep -f` first (matches full command line, can kill unintended processes)
-❌ **DON'T:** Kill processes without checking working directory
-❌ **DON'T:** Assume zombie browsers will clean themselves up (they won't)
-
-✅ **DO:** Use port-based cleanup
-✅ **DO:** Filter by project directory with `$(pwd)`
-✅ **DO:** Create project-specific cleanup scripts
-✅ **DO:** Clean up before AND after development sessions
-
----
-
 ## Advanced: Finding the Source
 
 When zombies keep coming back, find which test is creating them.
@@ -272,13 +246,3 @@ Runs each test individually, checks if `<process_pattern>` is left running.
 - Auto-detect package manager (bun/pnpm/yarn/npm)
 - Stop at first offending test
 - Show investigation commands
-
----
-
-## Key Takeaways
-
-- Use `./.safeword/scripts/cleanup-zombies.sh` for quick, safe cleanup
-- Always preview with `--dry-run` first when unsure
-- Never use `killall node` (affects all projects)
-- Clean up before AND after development sessions
-- If zombies recur, use bisect scripts to find the source

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -139,7 +139,7 @@ Training data drifts. Memory of "how X worked" is not authority — the current 
 
 **Adding a dependency** (a package not yet in the project) — there's no installed version to read, and the version you recall is stale by definition. Use the live `Current time:` line injected by `prompt-timestamp.ts` when the host provides one; otherwise use the current system date from the session. Then verify the current version for that date before pinning. Prefer the package manager's resolver command (`bun add <pkg>`, `npm install <pkg>`, `uv add`, `cargo add`, `go get <module>@latest`, etc.) or a registry command such as `npm view <pkg> version`, `pip index versions`, `go list -m -versions`, or crates.io. Pin what the registry reports today, never a number from memory.
 
-**Design choices** (algorithm, architecture, security, performance, concurrency, accessibility, ML/stats) — call `/figure-it-out`. Its iron law: no recommendation without current evidence. It enumerates research domains, fetches live docs, and weighs options before committing.
+**Design choices** (algorithm, architecture, security, performance, concurrency, accessibility, ML/stats) — call `/figure-it-out`. Its core rule: no recommendation without current evidence. It enumerates research domains, fetches live docs, and weighs options before committing.
 
 Blog posts, tweets, marketing, and "I remember reading…" don't count for any tier. Treat them as leads, not evidence.
 
@@ -199,7 +199,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 > Do: "Fixed — `packages/cli/src/auth.ts:42` was swallowing the refresh error."
 > Don't: "Great question! Let me walk you through what I found..."
 
-**End with the call.** Last line is what's next — a question, a choice, or a proposed step. For structured replies (verdicts, reviews, recommendations, audits), use a literal `**Next:** <imperative>` line — the same discipline safeword skills enforce in their output. Short conversational replies can end with the question itself; no bold preface needed. Don't bury the call mid-reply.
+**End with the call.** Close by naming what's next — a question, a choice, or a proposed step; don't bury it mid-reply. For structured replies (verdicts, reviews, recommendations, audits), make that closing line a literal `**Next:** <imperative>`: the stop hook captures it verbatim for the session's re-entry brief, so the token is load-bearing, not decoration. Short conversational replies can end with the question itself.
 
 **Debate-then-pick.** When there's a real choice, surface 2-3 options weighed in one breath, then the pick — one line each on the candidates, one on the tradeoff, one on the call. Don't ping-pong one option at a time. Skip the debate when there's no real choice (rename, mechanical edit, single obvious path).
 

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -14,13 +14,7 @@ A safeword session runs through these phases in order. Each phase has an exit cr
 
 Understand what the user is asking before classifying or building. **Propose-and-Converge** means: lead with a perspective, then surface open questions _inside_ that proposal. Don't ask first — propose first.
 
-Each turn:
-
-1. Restate what you heard.
-2. Contribute a perspective, sketch, or reframe.
-3. Surface remaining open questions as part of that contribution.
-4. Incorporate what the user confirmed; narrow the open set.
-5. When zero open questions remain and the user accepts → advance.
+Each turn, restate what you heard, contribute a perspective/sketch/reframe, and surface the remaining open questions inside that contribution. Incorporate what the user confirms to narrow the open set; advance once none remain and the user accepts.
 
 Research before proposing anything significant — and the order is load-bearing:
 
@@ -123,7 +117,7 @@ Optimize for **Clarity → Simplicity → Correctness**, in that order. When in 
 | Factory for simple object    | Direct construction                              | Indirection without value |
 | `data`, `tmp`, `d`           | `userProfile`, `pendingOrder`                    | Names should explain      |
 | Code "for later"             | Delete it; add when needed                       | YAGNI                     |
-| >50 lines for nice-to-have   | Ask user: "Essential now?"                       | Scope creep               |
+| >50 lines for nice-to-have   | Ask whether it's essential now                   | Scope creep               |
 
 ---
 
@@ -149,24 +143,24 @@ Blog posts, tweets, marketing, and "I remember reading…" don't count for any t
 
 Read the matching guide when its trigger fires:
 
-| Trigger                                                        | Guide                                           |
-| -------------------------------------------------------------- | ----------------------------------------------- |
-| Starting a feature/task OR writing specs/test-definitions      | `./.safeword/guides/planning-guide.md`          |
-| Choosing test type, doing TDD, or a test is failing            | `./.safeword/guides/testing-guide.md`           |
-| Creating or updating a design doc                              | `./.safeword/guides/design-doc-guide.md`        |
-| Making an architectural decision or writing an ADR             | `./.safeword/guides/architecture-guide.md`      |
-| Understanding the generated `architecture.generated.md` doc    | `./.safeword/guides/architecture-guide.md`      |
-| Data-heavy project needing formal data architecture            | `./.safeword/guides/data-architecture-guide.md` |
-| Writing learnings or agent config (CLAUDE.md, .cursor/rules)   | `./.safeword/guides/llm-writing-guide.md`       |
-| Updating CLAUDE.md, SAFEWORD.md, or any context file           | `./.safeword/guides/context-files-guide.md`     |
-| Hit the same bug 3+ times or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
-| Process hanging, port in use, or zombie process suspected      | `./.safeword/guides/zombie-process-cleanup.md`  |
+| Trigger                                                          | Guide                                           |
+| ---------------------------------------------------------------- | ----------------------------------------------- |
+| Starting a feature/task OR writing specs/test-definitions        | `./.safeword/guides/planning-guide.md`          |
+| Choosing test type, doing TDD, or a test is failing              | `./.safeword/guides/testing-guide.md`           |
+| Creating or updating a design doc                                | `./.safeword/guides/design-doc-guide.md`        |
+| Making an architectural decision or writing an ADR               | `./.safeword/guides/architecture-guide.md`      |
+| Understanding the generated `architecture.generated.md` doc      | `./.safeword/guides/architecture-guide.md`      |
+| Data-heavy project needing formal data architecture              | `./.safeword/guides/data-architecture-guide.md` |
+| Writing learnings or agent config (CLAUDE.md, .cursor/rules)     | `./.safeword/guides/llm-writing-guide.md`       |
+| Updating CLAUDE.md, SAFEWORD.md, or any context file             | `./.safeword/guides/context-files-guide.md`     |
+| Hit the same bug repeatedly or discovered an undocumented gotcha | `./.safeword/guides/learning-extraction.md`     |
+| Process hanging, port in use, or zombie process suspected        | `./.safeword/guides/zombie-process-cleanup.md`  |
 
 ---
 
 ## Standing Rules
 
-**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Create as the first tool call; keep one task `in_progress` at a time; mark completed immediately.
+**TodoWrite.** Use for 3+ step or non-trivial work, or when the user provides multiple requests. Set it up before diving in; keep one task `in_progress` at a time; mark completed as you finish each.
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
@@ -211,7 +205,7 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **Gloss jargon at the decision point.** Don't assume the user reads code. The first time a stack or domain term is load-bearing in an _ask_ — a block, a decision, a step they must take — gloss it inline in one clause ("the refresh token (the credential that renews a login) expired"). Once per turn, never re-explained; a fluent reader skips it at no cost. Leave background narration unglossed.
 
-**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. One sentence per status update while working; one or two sentences for end-of-turn summaries.
+**Match length to the ask.** A one-line question gets a one-line reply — no headers, no bullets, no preamble. Complex tasks get a short answer followed by the detail that supports it. Keep status updates terse and end-of-turn summaries brief — a sentence or two, not a paragraph.
 
 **Cite code as `path:line`.** When referencing something the user might open, write `packages/cli/src/foo.ts:142` inline. Not "the foo file." Not in a code block.
 
@@ -219,6 +213,6 @@ This is the most-read surface of safeword. **Write to be scanned, not read.** Sh
 
 **Use structure only when it carries weight.** Headings when the reply is long enough to navigate — and make them information-carrying, not generic ("What changed" beats "Summary"). Tables only for actual reference material — never as decision trees in disguise. Bullets only when items are genuinely parallel. Default to prose. Never output a series of overly short bullet points.
 
-**At most one bolded phrase per paragraph**, and only when reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
+**Use bold sparingly** — only where reading the bold alone would tell the story. Bold-on-every-sentence reads as noise.
 
 **Skip:** preambles ("I'll now..."), recaps of what the user just said, sycophantic openers ("Great question!"), hedging caveats ("It depends, but..."), restating actions the user can see in the tool log.

--- a/packages/cli/templates/guides/architecture-guide.md
+++ b/packages/cli/templates/guides/architecture-guide.md
@@ -88,14 +88,16 @@ Required only when the ideal diverges from what exists:
 
 ---
 
-## Document Type Decision Tree (Follow in Order)
+## Document Type Decision Tree
 
-Answer **IN ORDER**. Stop at the first "Yes":
+The first matching row picks the doc type:
 
-1. **Technology or library choice?** → **Architecture Doc**
-2. **New data model or schema change?** → **Architecture Doc**
-3. **Project-wide pattern or convention?** → **Architecture Doc**
-4. **Implementing a specific feature?** → **Design Doc**
+| If the work is a…                  | Doc              |
+| ---------------------------------- | ---------------- |
+| technology or library choice       | Architecture Doc |
+| new data model or schema change    | Architecture Doc |
+| project-wide pattern or convention | Architecture Doc |
+| specific feature implementation    | Design Doc       |
 
 **Tie-breaker:** If a feature requires a new tech/schema choice, document the tech/schema in Architecture Doc first, then reference it in Design Doc.
 
@@ -301,12 +303,14 @@ Update in place with version/status tracking:
 
 ## Re-evaluation Path (When Unclear)
 
-Answer **IN ORDER**:
+The first matching row picks the doc type:
 
-1. **Affects 2+ features?** → Architecture Doc (stop)
-2. **Technology/data model choice?** → Architecture Doc (stop)
-3. **Future developers need this for whole project?** → Architecture Doc
-4. **Only for this feature?** → Design Doc
+| If the work…                                 | Doc              |
+| -------------------------------------------- | ---------------- |
+| affects 2+ features                          | Architecture Doc |
+| is a technology/data-model choice            | Architecture Doc |
+| future developers need for the whole project | Architecture Doc |
+| is only for this feature                     | Design Doc       |
 
 **Tie-breaker:** When still unclear, default to Design Doc. Easier to promote later than to split.
 

--- a/packages/cli/templates/guides/context-files-guide.md
+++ b/packages/cli/templates/guides/context-files-guide.md
@@ -322,6 +322,7 @@ Brief description. Current status.
 - Test: Can new developer understand "why" from reading this?
 - **Use imports** to keep main file under 200 lines
 - Verify loaded context matches intent (check hierarchical loading behavior)
+- Make critical rules findable through clear structure, not position tricks (burying them mid-file)
 
 ---
 
@@ -456,12 +457,3 @@ Brief description. Current status.
 - Bloated files cost more tokens and introduce noise
 - Keep under 50KB for optimal performance (though no hard limit)
 - Use imports to modularize instead of monolithic files
-
----
-
-## Key Takeaways
-
-- Keep context files under 200 lines—use imports to modularize
-- Short declarative bullets, not narrative paragraphs
-- Update immediately when architecture changes (stale docs = confusion)
-- Avoid burying critical rules in the middle — use clear structure over position tricks

--- a/packages/cli/templates/guides/context-files-guide.md
+++ b/packages/cli/templates/guides/context-files-guide.md
@@ -448,7 +448,7 @@ Brief description. Current status.
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
 - At Anthropic, teams use prompt improver to tune instructions
-- Add emphasis ("IMPORTANT", "YOU MUST") for critical rules
+- State critical rules as plain declarative facts — a literal model doesn't need shouting
 - Explicitly reference your context file in prompts ("following CLAUDE.md guidelines") for better adherence
 
 **Token Budget:**

--- a/packages/cli/templates/guides/context-files-guide.md
+++ b/packages/cli/templates/guides/context-files-guide.md
@@ -76,7 +76,7 @@ Loaded context:
 See root AGENTS.md for TDD workflow. This file covers test-specific patterns.
 ```
 
-**Reliability note:** Auto-loading works best when you explicitly reference your file in conversation (e.g., "following the guidelines in CLAUDE.md"). Implicit automatic reference can be less reliable.
+**Reliability note:** On current models the context file auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
 
 **Deprecated:** `*.local.md` is no longer recommended - use imports instead for better multi-worktree support
 
@@ -434,7 +434,7 @@ Brief description. Current status.
 
 ---
 
-## Best Practices from Anthropic
+## Authoring Best Practices
 
 **Conciseness:**
 
@@ -447,9 +447,13 @@ Brief description. Current status.
 
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
-- At Anthropic, teams use prompt improver to tune instructions
-- State critical rules as plain declarative facts — a literal model doesn't need shouting
-- Explicitly reference your context file in prompts ("following CLAUDE.md guidelines") for better adherence
+- State most rules as plain declarative facts; blanket `IMPORTANT`/`YOU MUST` decoration is noise a literal model doesn't need. Reserve emphasis for one job — flagging **when to reach for a capability** (a subagent, a tool, memory) that a model like Opus 4.8 otherwise under-uses.
+- The file auto-loads every session, so don't repeat a rule or name the file in the prompt to force adherence — brevity, not repetition, is what keeps rules followed.
+
+**Portability:**
+
+- Emphasis (`IMPORTANT`/`YOU MUST`) is a Claude-specific last-resort lever — don't teach it as portable reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
+- Default to **Markdown** structure (portable across vendors); treat XML-tag structuring as a Claude-specific optimization, not a baseline.
 
 **Token Budget:**
 

--- a/packages/cli/templates/guides/data-architecture-guide.md
+++ b/packages/cli/templates/guides/data-architecture-guide.md
@@ -8,15 +8,16 @@
 
 ## When to Document Data Architecture
 
-**Decision Tree (Answer IN ORDER, stop at first match):**
+The first matching row applies (rows run general → specific, so when several fit,
+the earlier one wins):
 
-1. **Project initialization?** → Create `DATA_ARCHITECTURE.md` or `ARCHITECTURE.md` with data section
-2. **Adding new data store?** (database, cache, file system) → Update architecture doc
-3. **Changing data model?** (schema, entities, relationships) → Update architecture doc
-4. **Data flow integration?** (API, ETL, sync) → Update architecture doc
-5. **Single feature implementation?** → Use design doc (reference architecture doc)
-
-**Tie-breaking rule:** If multiple apply, stop at first match (earlier = more general).
+| If the work is…                                           | Action                                                               |
+| --------------------------------------------------------- | -------------------------------------------------------------------- |
+| project initialization                                    | Create `DATA_ARCHITECTURE.md` or `ARCHITECTURE.md` with data section |
+| adding a new data store (database, cache, file system)    | Update architecture doc                                              |
+| changing the data model (schema, entities, relationships) | Update architecture doc                                              |
+| a data-flow integration (API, ETL, sync)                  | Update architecture doc                                              |
+| a single-feature implementation                           | Use design doc (reference architecture doc)                          |
 
 **Edge cases:**
 
@@ -199,12 +200,3 @@ Before finalizing data architecture doc:
 - [ ] Migration strategy covers both additive and breaking changes
 - [ ] Version and status match codebase (verify with git/deployment)
 - [ ] Cross-referenced from root ARCHITECTURE.md or SAFEWORD.md (link exists)
-
----
-
-## Key Takeaways
-
-- Data quality, governance, accessibility are core principles
-- Every entity needs: attributes, types, relationships, constraints
-- Performance targets use concrete numbers (e.g., <100ms, not "fast")
-- Migration strategy covers both additive and breaking changes

--- a/packages/cli/templates/guides/design-doc-guide.md
+++ b/packages/cli/templates/guides/design-doc-guide.md
@@ -94,7 +94,7 @@
 - Designing a specific feature implementation
 - Need component breakdown and interactions
 - Feature-specific technical decisions
-- 2-3 pages (~121 lines)
+- Concise — a few pages, not a sprawling doc
 
 **Use Architecture Doc when:**
 
@@ -151,7 +151,7 @@ Before saving, verify:
 - ✓ User flow has concrete examples
 - ✓ Key decisions have "what, why, trade-off"
 - ✓ All optional sections marked "(if applicable)"
-- ✓ ~121 lines (concise, LLM-optimized)
+- ✓ Concise, LLM-optimized (a few pages, not sprawling)
 
 ---
 
@@ -168,4 +168,4 @@ Before saving, verify:
 - Escalate to Architecture Doc if: new tech, new schema, or pattern affects 2+ features
 - Reference user stories and test definitions—don't duplicate them
 - Every decision needs: what, why, trade-off
-- ~121 lines target (concise, LLM-optimized)
+- Concise, LLM-optimized (a few pages, not sprawling)

--- a/packages/cli/templates/guides/design-doc-guide.md
+++ b/packages/cli/templates/guides/design-doc-guide.md
@@ -134,21 +134,11 @@
 
 ---
 
-## Example Commands
+## Working from a request
 
-**Creating design doc:**
-
-```text
-User: "Create design doc for three-pane layout"
-You: [Read user stories and test definitions, then create design doc]
-```
-
-**Updating design doc:**
-
-```text
-User: "Update design doc to add error handling section"
-You: [Read existing design doc, add Implementation Notes section with error handling]
-```
+Creating a design doc starts from the user stories and test definitions; updating
+one starts from the existing doc, extending the relevant section (e.g. adding
+Implementation Notes for error handling). Read the inputs first, then write.
 
 ---
 

--- a/packages/cli/templates/guides/learning-extraction.md
+++ b/packages/cli/templates/guides/learning-extraction.md
@@ -88,55 +88,12 @@ ls <namespace-root>/learnings/*keyword*.md
 
 ### When to Reference Existing Learnings
 
-**Found existing learning** → Read and apply it:
+Before extracting or advising, `ls` the learnings directory for the concept's keywords, then:
 
-```text
-"I found an existing learning about [concept] at [path]. Let me read it and apply to your case..."
-[Read the file]
-"Based on the learning, here's how to handle this: [specific guidance from learning]"
-```
-
-**No existing learning** → Proceed normally (no message needed)
-
-**Similar but different** → Reference and note difference:
-
-```text
-"This is similar to the [existing learning] at [path], but differs in [specific way].
-The existing learning covers [X], but your case involves [Y]."
-```
-
-### Example Workflow
-
-**Scenario 1: Found relevant learning**
-
-```text
-User: "I'm getting an async state update error with React hooks"
-→ Check: ls <namespace-root>/learnings/*react*.md *hooks*.md *async*.md
-→ Found: react-hooks-async.md
-→ Read: [file contents]
-→ Apply: "I found a learning about async React hooks. It mentions you should use useEffect
-         for side effects, not setState directly in callbacks. Applying this to your case..."
-```
-
-**Scenario 2: No existing learning**
-
-```text
-User: "IndexedDB quota is behaving strangely in Safari"
-→ Check: ls <namespace-root>/learnings/*indexeddb*.md *safari*.md *quota*.md
-→ Not found
-→ Proceed: Continue debugging normally, suggest extraction if triggers match
-```
-
-**Scenario 3: Update existing learning**
-
-```text
-User: Debugging for 6 cycles, discovers new IndexedDB quirk
-→ Suggest extraction
-→ Check: ls <namespace-root>/learnings/*indexeddb*.md
-→ Found: indexeddb-quota-api.md
-→ Suggest: "I found an existing learning about IndexedDB quota. Should I update it with
-           this new discovery instead of creating a separate learning?"
-```
+- **Found a relevant learning** → read it and apply it, telling the user what it says and how it maps to their case.
+- **Found one that's similar but different** → reference it and name the specific difference (what it covers vs. what this case involves).
+- **None found** → proceed normally; suggest extraction if the triggers match.
+- **Extraction triggered and a near-match exists** → offer to update that learning rather than create a separate one.
 
 ### Benefits of Checking Existing Learnings
 
@@ -327,11 +284,11 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 - Observable debugging complexity (5+ debug cycles, 3+ error states, user says "stuck")
 - Just discovered gotcha not in official docs
 - Just found anti-pattern (violated best practice)
-- Say: "I notice this pattern could save time on future work. Should I extract a learning after we fix this?"
+- Offer to extract a learning once the fix lands — note it could save time on future work.
 
 **Medium confidence - Ask AFTER completing task:**
 
-- "I noticed [pattern X] during implementation - should I document this as a learning?"
+- Ask whether to document the pattern you hit as a learning.
 
 **Low confidence - Don't suggest:**
 

--- a/packages/cli/templates/guides/learning-extraction.md
+++ b/packages/cli/templates/guides/learning-extraction.md
@@ -14,10 +14,10 @@ Extract after experiencing ANY of these:
 
 1. **Observable debugging complexity** - Any of these signals:
    - User says "still debugging", "been stuck on this", "tried many things"
-   - 5+ debug cycles (Read → Edit → Bash pattern repeated)
-   - 3+ different error states encountered
-   - Modified 3+ files while debugging same issue
-2. **Trial and error** - Tried 3+ different approaches before finding the right one
+   - Several debug cycles (Read → Edit → Bash pattern repeated)
+   - Multiple different error states encountered
+   - Modified several files while debugging the same issue
+2. **Trial and error** - Tried several different approaches before finding the right one
 3. **Undocumented gotcha** - Not in official library/framework docs
 4. **Integration struggle** - Two tools that don't work together smoothly
 5. **Testing trap** - Tests pass but UX is broken (or vice versa)
@@ -281,7 +281,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 **High confidence - Suggest IMMEDIATELY DURING debugging:**
 
-- Observable debugging complexity (5+ debug cycles, 3+ error states, user says "stuck")
+- Observable debugging complexity (several debug cycles, multiple error states, user says "stuck")
 - Just discovered gotcha not in official docs
 - Just found anti-pattern (violated best practice)
 - Offer to extract a learning once the fix lands — note it could save time on future work.
@@ -302,11 +302,10 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 **Living Documentation**: This process evolves with your needs.
 
-**Review Cycle**:
-
-1. **Monthly**: Review existing learnings for relevance
-2. **Quarterly**: Archive obsolete learnings (technology changed, pattern no longer used)
-3. **Per feature**: After major features, assess if new learnings emerged
+**Review Cycle**: Revisit a learning when you next touch its area or start a
+nearby feature — not on a calendar. That's when you'll notice it's gone stale
+(technology changed, pattern no longer used) and should be updated or archived,
+and when a just-finished feature might have surfaced something reusable.
 
 **Test the Process**:
 
@@ -339,7 +338,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 
 ### During Development
 
-1. **Recognize trigger** - Spent 45 min debugging race condition
+1. **Recognize trigger** - Several failed attempts before cracking a race condition
 2. **Assess scope** - Forward-looking? (YES) Global or project? (Project)
 3. **Choose location** - Needs examples → `<namespace-root>/learnings/race-conditions.md`
 4. **Extract** - Use template, write before/after examples
@@ -348,7 +347,7 @@ Project-specific gotchas in `<namespace-root>/learnings/`:
 ### After Completing Feature
 
 1. **Review** - Did we learn anything reusable?
-2. **Extract** - If threshold met (>30min debug, non-obvious pattern)
+2. **Extract** - If the signals are there (repeated failed attempts, non-obvious pattern)
 3. **Update** - Add SAFEWORD.md cross-reference if needed
 4. **Commit** - Include learning in commit message
 

--- a/packages/cli/templates/guides/learning-extraction.md
+++ b/packages/cli/templates/guides/learning-extraction.md
@@ -328,9 +328,8 @@ and when a just-finished feature might have surfaced something reusable.
 
 **Feedback Loop**:
 
-- After suggesting extraction: Note if user accepted or declined
-- After user accepts: Monitor if learning is referenced in future sessions
-- Adjust suggestion threshold based on acceptance rate (if <30% accepted, raise the bar)
+- After suggesting extraction, note whether the user accepted or declined.
+- If your suggestions aren't landing this session, ease off — stop offering and let the user ask. You can't track an acceptance rate across sessions, so gauge it from the ones in front of you.
 
 ---
 

--- a/packages/cli/templates/guides/learning-extraction.md
+++ b/packages/cli/templates/guides/learning-extraction.md
@@ -1,6 +1,6 @@
 # Learning Extraction Process
 
-Extract reusable knowledge from debugging sessions and implementation discoveries. Ensures insights compound across sessions.
+Extract reusable knowledge from debugging sessions and implementation discoveries. Ensures insights compound across sessions. When in doubt, extract more rather than less — you can archive later — and capture it while the context is fresh rather than deferring.
 
 **LLM Instruction Design:** Learnings are documentation that LLMs read and follow. Apply best practices from `@.safeword/guides/llm-writing-guide.md` when writing learning files (concrete examples, explicit definitions, MECE principles).
 
@@ -51,7 +51,7 @@ Extract after experiencing ANY of these:
 
 ## Using Existing Learnings
 
-**CRITICAL**: Before extracting new learnings, ALWAYS check if similar learnings already exist. This prevents duplication and keeps knowledge organized.
+Before extracting a new learning, check whether a similar one already exists — this prevents duplication and keeps the knowledge organized.
 
 ### When to Check for Existing Learnings
 
@@ -247,7 +247,7 @@ Actual: [What happened]
 
 ## SAFEWORD.md Integration
 
-**CRITICAL**: ALWAYS cross-reference in SAFEWORD.md after creating learning file.
+After creating a learning file, cross-reference it in SAFEWORD.md.
 
 After extracting to `<namespace-root>/learnings/`, add cross-reference in SAFEWORD.md:
 
@@ -488,47 +488,3 @@ The `post-tool-sync-learnings` hook flags `✅ Verified` and `Verified by …` s
 <namespace-root>/learnings/electron-ipc-patterns.md         (60 lines)
 <namespace-root>/learnings/electron-path-validation.md      (50 lines)
 ```
-
----
-
-## Summary
-
-This is a **living process** - iterate and refine based on what works.
-
-**Core Principle**: Extract knowledge that **compounds over time**. Each learning should save time on 2+ future features.
-
-**Decision Framework**:
-
-1. **Forward-looking?** → Extract (helps future work)
-2. **Global or project?** → Choose directory
-3. **Architectural or gotcha?** → Choose SAFEWORD.md or separate file
-4. **ALWAYS cross-reference** → Update SAFEWORD.md
-
-**Continuous Improvement**:
-
-- Monthly: Review existing learnings for relevance
-- Quarterly: Archive obsolete learnings
-- Per feature: Assess if new learnings emerged
-- Test: Did extracting this actually help on the next feature?
-
-**When in Doubt**:
-
-- Extract more rather than less (can archive later)
-- Prefer separate file over inline comments (keeps code clean)
-- Update immediately while fresh (don't defer to "later")
-
-**Maintenance**:
-
-- Remove when technology deprecated or pattern no longer used
-- Refactor when multiple learnings cover similar topics (consolidate)
-- Split when learning file >200 lines (focus on single concept)
-- Update SAFEWORD.md references when learnings move or merge
-
----
-
-## Key Takeaways
-
-- Extract after 5+ debug cycles or 3+ approaches tried
-- Check existing learnings first—update, don't duplicate
-- One concept per file, under 200 lines
-- Extract immediately while fresh (don't defer to "later")

--- a/packages/cli/templates/guides/llm-evals-guide.md
+++ b/packages/cli/templates/guides/llm-evals-guide.md
@@ -35,35 +35,20 @@ Agent chooses the right tool       → eval or trace eval
 
 ## Eval Decision Tree
 
-Answer in order. Stop at the first match.
+The first matching row picks the approach (rows run cheapest/most-deterministic →
+most model-graded, which is also the tie-break order):
 
-1. **Can a normal deterministic test fully prove the behavior?**
-   - YES → Use unit, integration, E2E, or migration coverage instead
-   - NO → Continue
+| If…                                                                     | Approach                                          |
+| ----------------------------------------------------------------------- | ------------------------------------------------- |
+| a normal deterministic test can fully prove the behavior                | Use unit, integration, E2E, or migration coverage |
+| a deterministic eval assertion can prove part of the AI output contract | Add that assertion before any model-graded scorer |
+| there's a known correct output, label, or fact set                      | Reference-based evals                             |
+| comparing two outputs is easier than scoring one absolutely             | Pairwise evals                                    |
+| the desired quality is subjective but describable                       | Rubric-based LLM-as-judge evals                   |
+| the behavior involves multiple steps, tools, retrieval, or agents       | Trace or trajectory evals                         |
 
-2. **Can a deterministic eval assertion prove part of the AI output contract?**
-   - YES → Add that assertion before any model-graded scorer
-   - NO → Continue
-
-3. **Is there a known correct output, label, or fact set?**
-   - YES → Use reference-based evals
-   - NO → Continue
-
-4. **Is it easier to compare two outputs than score one output absolutely?**
-   - YES → Use pairwise evals
-   - NO → Continue
-
-5. **Is the desired quality subjective but describable?**
-   - YES → Use rubric-based LLM-as-judge evals
-   - NO → Continue
-
-6. **Does the behavior involve multiple steps, tools, retrieval, or agents?**
-   - YES → Use trace or trajectory evals
-   - NO → Write the missing acceptance criteria before creating the eval
-
-**Tie-breaker:** deterministic checks first, reference-based checks second,
-LLM-as-judge last. Model-graded evals are powerful but add cost, latency, and
-grader failure modes.
+If none fit, write the missing acceptance criteria before creating the eval.
+Model-graded evals are powerful but add cost, latency, and grader failure modes.
 
 ---
 
@@ -112,7 +97,8 @@ A good eval catches a plausible AI failure that users would notice, and it tells
 the team what to do when it fails. A wasteful eval spends model calls without
 raising confidence.
 
-Before writing a new eval, answer in order. Stop at the first failure.
+A new eval earns its place only if every one of these holds; the first that
+fails tells you what to fix before writing it.
 
 1. **What user-visible failure would this catch?**
    - Clear answer → Continue
@@ -471,15 +457,3 @@ Minimal template:
 | Full AI eval  | `npm run eval:full`  | release | yes            | `evals/full.yml`  | AI team |
 | Drift monitor | scheduled            | no      | sampled traces | platform          |
 ```
-
----
-
-## Key Takeaways
-
-- Use deterministic tests before judge evals.
-- Evals need objectives, datasets, scorers, cadence, thresholds, and owners.
-- Judge one quality dimension at a time.
-- Calibrate LLM-as-judge scorers against human-labeled examples.
-- Keep historical failures as regression cases.
-- Separate cheap smoke evals from full, expensive eval suites.
-- Never put sensitive production data into eval fixtures without approval.

--- a/packages/cli/templates/guides/llm-writing-guide.md
+++ b/packages/cli/templates/guides/llm-writing-guide.md
@@ -80,22 +80,30 @@ Section B: "All user-facing features have E2E tests"
 
 ## Decision Tree Patterns
 
-### Sequential Over Parallel
+### Declarative Table Over Ordered Scan
 
-Structure as ordered steps, not simultaneous checks.
+A literal model resolves a lookup in one glance, so prefer a declarative "first
+matching row applies" table over an ordered "answer in order, stop at first
+match" scan — the scan makes the model serially walk rows it already sees at
+once. Keep the rows mutually exclusive and collectively exhaustive. Reserve
+ordered steps for a genuinely sequential _procedure_, where each step depends on
+the result of the one before.
 
 ```markdown
-❌ BAD - Parallel:
-├─ Pure function?
-├─ Multiple components?
-└─ Full user flow?
-
-✅ GOOD - Sequential:
+❌ BAD - ordered scan of mutually-exclusive rows:
 Answer IN ORDER, stop at first match:
 
 1. Pure function? → Unit
 2. Multiple components? → Integration
 3. Full user flow? → E2E
+
+✅ GOOD - declarative table, first matching row applies:
+
+| If the test…               | Type        |
+| -------------------------- | ----------- |
+| covers a pure function     | Unit        |
+| spans multiple components  | Integration |
+| exercises a full user flow | E2E         |
 ```
 
 ### Tie-Breaking Rules

--- a/packages/cli/templates/guides/llm-writing-guide.md
+++ b/packages/cli/templates/guides/llm-writing-guide.md
@@ -157,3 +157,33 @@ Provide concrete next steps for dead ends.
 | Percentages without context           | "70/20/10" meaningless without adjustment guidance |
 | Caveats in tables                     | Parentheticals break pattern matching              |
 | Critical info in middle               | Lost-in-middle phenomenon                          |
+
+---
+
+## De-prescription: convert, don't delete
+
+Modern models (Fable 5, Opus 4.8, Sonnet 5) follow instructions more literally
+than older ones, so imperative step-lists, forced ordering, and shouted
+`CRITICAL/MUST` emphasis now degrade output rather than improve it. When editing
+these guides, **convert prescription into principle** — state the intent, a
+measurable done-condition, and the explicit scope — rather than enumerating
+steps. Graduate true invariants out of prose and into hooks/lint.
+
+**Classify every edit into one of two columns:**
+
+- **Universal** — rephrases to intent, softens an imperative, drops
+  native-behavior scaffolding, or graduates an invariant into a hook. No
+  guidance is lost, so **apply it globally, no A/B needed.**
+- **Deletion** — removes guidance instead of restating it. A literal model
+  won't infer what you cut, so this **must pass an Opus 4.8 + Sonnet 5 A/B
+  before it ships globally** — never on single-model evidence.
+
+Two more rules keep the smaller and non-Fable drivers safe:
+
+- **Tag each finding with the model that surfaced it.** A regression seen only
+  on one model isn't yet evidence for a global change.
+- **Keep capability guidance as conditional "when-X" triggers, don't delete it.**
+  Prompts to delegate to subagents, consult learnings, or search-first are
+  scaffolding Fable doesn't need but Opus 4.8 does (it under-reaches). Phrase
+  them as "when the task fans out across independent items, delegate to
+  subagents" — harmless to Fable, measurable lift on Opus 4.8.

--- a/packages/cli/templates/guides/llm-writing-guide.md
+++ b/packages/cli/templates/guides/llm-writing-guide.md
@@ -157,25 +157,3 @@ Provide concrete next steps for dead ends.
 | Percentages without context           | "70/20/10" meaningless without adjustment guidance |
 | Caveats in tables                     | Parentheticals break pattern matching              |
 | Critical info in middle               | Lost-in-middle phenomenon                          |
-
----
-
-## Quality Checklist
-
-- [ ] Decision trees: MECE, sequential, with tie-breakers
-- [ ] All terms explicitly defined
-- [ ] Every rule has good vs bad examples
-- [ ] Edge cases covered
-- [ ] No contradictions between sections
-- [ ] Complex decisions have lookup tables
-- [ ] Dead-end paths have re-evaluation steps
-- [ ] Critical rules not buried in the middle of long documents
-
----
-
-## Key Takeaways
-
-- Decision trees: sequential, MECE, with tie-breakers
-- Every rule needs concrete examples (good vs bad)
-- Define all terms explicitly—assume nothing is obvious
-- Avoid burying critical rules in the middle — use clear structure over position tricks

--- a/packages/cli/templates/guides/llm-writing-guide.md
+++ b/packages/cli/templates/guides/llm-writing-guide.md
@@ -169,6 +169,12 @@ these guides, **convert prescription into principle** — state the intent, a
 measurable done-condition, and the explicit scope — rather than enumerating
 steps. Graduate true invariants out of prose and into hooks/lint.
 
+This is a cross-vendor shift, not an Anthropic quirk: OpenAI's GPT-5.5 guidance
+says the same — "reduce or remove detailed step-by-step process guidance… let
+the model choose the path unless the product requires that path," and "describe
+the expected outcome, success criteria, allowed side effects… and output shape"
+instead. Treat the convention as durable, not model-of-the-month.
+
 **Classify every edit into one of two columns:**
 
 - **Universal** — rephrases to intent, softens an imperative, drops

--- a/packages/cli/templates/guides/planning-guide.md
+++ b/packages/cli/templates/guides/planning-guide.md
@@ -6,7 +6,7 @@ How to write specs, user stories, and test definitions before implementation.
 
 ## Artifact Levels
 
-**Triage first - answer IN ORDER, stop at first match:**
+**Triage first — the first matching row sets the level:**
 
 | Question                                 | Level       | Artifacts                                            |
 | ---------------------------------------- | ----------- | ---------------------------------------------------- |
@@ -304,7 +304,7 @@ test-definitions.md is the R/G/R ledger.
 
 ### Testing Technical Constraints
 
-User stories include Technical Constraints. These MUST have corresponding scenarios.
+User stories include Technical Constraints; each one needs a corresponding scenario.
 
 | Constraint Category | Test Type                  | What to Verify                                |
 | ------------------- | -------------------------- | --------------------------------------------- |

--- a/packages/cli/templates/guides/testing-guide.md
+++ b/packages/cli/templates/guides/testing-guide.md
@@ -24,11 +24,11 @@ the lane. Higher scope gives more real-world confidence. Lower scope wins when
 it proves the same behavior faster, diagnoses failures better, or covers dense
 edge cases.
 
-**Always test what you build** — Run tests yourself before completion. Don't ask the user to verify.
+Test what you build — run the tests yourself before completion rather than asking the user to verify.
 
 ---
 
-## Test Integrity (CRITICAL)
+## Test Integrity
 
 **NEVER modify, skip, or delete tests without explicit human approval.**
 
@@ -78,7 +78,8 @@ A good test protects behavior that matters and would fail for a plausible
 regression. A busywork test satisfies "add tests" without raising useful
 confidence.
 
-Before adding a test, answer in order. Stop at the first failure.
+A test earns its place only if every one of these holds; the first that fails
+tells you what to fix before writing it.
 
 1. **What behavior or contract does this protect?**
    - Clear answer → Continue
@@ -171,29 +172,16 @@ Unit (milliseconds)      ← Pure functions, no I/O           ↓ cheaper diagno
 
 ## When to Use Each Test Type
 
-Answer these questions in order. Stop at first match.
+The first matching row picks the type (rows run general → specific):
 
-```text
-1. Does this test AI-generated content quality (tone, reasoning, creativity)?
-   └─ YES → LLM Evaluation
-   └─ NO → Continue to question 2
+| If the test…                                                      | Type           | Examples                                                                                                                                   |
+| ----------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| checks AI-generated content quality (tone, reasoning, creativity) | LLM Evaluation |                                                                                                                                            |
+| needs a real browser (Playwright/Cypress)                         | E2E            | Multi-page navigation, browser-specific behavior, visual regression (React Testing Library does _not_ need a browser — that's integration) |
+| exercises interactions between multiple components/services       | Integration    | API + database, React component + state store                                                                                              |
+| covers a pure function (input → output, no I/O)                   | Unit           | Calculations, formatters, validators, pure algorithms                                                                                      |
 
-2. Does this test require a real browser (Playwright/Cypress)?
-   └─ YES → E2E test
-      Examples: Multi-page navigation, browser-specific behavior, visual regression
-      Note: React Testing Library does NOT require a browser - that's integration
-   └─ NO → Continue to question 3
-
-3. Does this test interactions between multiple components/services?
-   └─ YES → Integration test
-      Examples: API + database, React component + state store
-   └─ NO → Continue to question 4
-
-4. Does this test a pure function (input → output, no I/O)?
-   └─ YES → Unit test
-      Examples: Calculations, formatters, validators, pure algorithms
-   └─ NO → Re-evaluate: What are you actually testing?
-```
+If none match, re-evaluate what you're actually testing.
 
 **Edge cases:**
 

--- a/packages/cli/templates/guides/verification-lanes-guide.md
+++ b/packages/cli/templates/guides/verification-lanes-guide.md
@@ -33,38 +33,20 @@ primary lane is smoke, release, or slow/performance.
 
 ## Lane Decision Tree
 
-Answer in order. Stop at the first match. Choose the lane that explains why this
-run exists now.
+The first matching row picks the lane (rows run specific → general). Choose the
+lane that explains why this run exists now.
 
-1. **Are you proving only the current change while writing code?**
-   - YES → Focused lane
-   - NO → Continue
+| If the run…                                                                                                              | Lane             |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| proves only the current change while writing code                                                                        | Focused          |
+| gives a quick signal that the product is basically usable                                                                | Smoke            |
+| proves behavior against real external systems, credentials, production-like infrastructure, or a real customer workspace | Live-fire        |
+| proves a built, packaged, or deployed artifact is ready to ship                                                          | Release          |
+| proves old data, config, or installs still work after an upgrade                                                         | Migration        |
+| runs static analysis rather than runtime behavior                                                                        | Static gate      |
+| is too expensive for normal local or per-commit runs                                                                     | Slow/performance |
 
-2. **Do you need a quick signal that the product is basically usable?**
-   - YES → Smoke lane
-   - NO → Continue
-
-3. **Is the main reason for this run to prove behavior against real external
-   systems, real credentials, production-like infrastructure, or a real
-   customer-like workspace?**
-   - YES → Live-fire lane
-   - NO → Continue
-
-4. **Are you proving that a built, packaged, or deployed artifact is ready to ship?**
-   - YES → Release lane
-   - NO → Continue
-
-5. **Are you proving old data, old config, or old installs still work after an upgrade?**
-   - YES → Migration lane
-   - NO → Continue
-
-6. **Is the check static analysis rather than runtime behavior?**
-   - YES → Static gate
-   - NO → Continue
-
-7. **Is the check too expensive for normal local or per-commit runs?**
-   - YES → Slow/performance lane
-   - NO → Re-evaluate the test type in `.safeword/guides/testing-guide.md`
+If none fit, re-evaluate the test type in `.safeword/guides/testing-guide.md`.
 
 **Tie-breaker:** if a check fits two lanes, choose the lane that explains why it
 is run at its cadence. Example: a Playwright checkout test that runs in two
@@ -96,7 +78,8 @@ A good verification lane changes an engineering decision. It tells the team
 whether to keep coding, hand off, merge, release, roll back, or investigate the
 environment. A busywork lane consumes time without changing the next action.
 
-Before adding a new lane or check, answer in order. Stop at the first failure.
+A new lane or check earns its place only if every one of these holds; the first
+that fails tells you what to fix before adding it.
 
 1. **What decision will this run unblock?**
    - Clear answer → Continue

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -166,17 +166,6 @@ tmux kill-session -t project-name
 
 ---
 
-## Best Practices
-
-1. **Assign unique ports** - Set `PORT=3000` in one project, `PORT=3001` in another
-2. **Use port-based cleanup first** - Simplest and safest
-3. **Create project cleanup scripts** - Reusable, documented
-4. **Never `killall node`** - Too broad when working on multiple projects
-5. **Clean up before starting** - Run cleanup script before `bun run dev`
-6. **Check what's running** - Use `lsof -i:PORT` to see what's using a port
-
----
-
 ## Debugging Zombie Processes
 
 ### Find What's Using a Port
@@ -223,21 +212,6 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 ---
 
-## What NOT to Do
-
-❌ **DON'T:** `killall node` (kills all projects)
-❌ **DON'T:** `pkill -9 node` (kills all projects)
-❌ **DON'T:** `pkill -f "pattern"` without `pgrep -f` first (matches full command line, can kill unintended processes)
-❌ **DON'T:** Kill processes without checking working directory
-❌ **DON'T:** Assume zombie browsers will clean themselves up (they won't)
-
-✅ **DO:** Use port-based cleanup
-✅ **DO:** Filter by project directory with `$(pwd)`
-✅ **DO:** Create project-specific cleanup scripts
-✅ **DO:** Clean up before AND after development sessions
-
----
-
 ## Advanced: Finding the Source
 
 When zombies keep coming back, find which test is creating them.
@@ -272,13 +246,3 @@ Runs each test individually, checks if `<process_pattern>` is left running.
 - Auto-detect package manager (bun/pnpm/yarn/npm)
 - Stop at first offending test
 - Show investigation commands
-
----
-
-## Key Takeaways
-
-- Use `./.safeword/scripts/cleanup-zombies.sh` for quick, safe cleanup
-- Always preview with `--dry-run` first when unsure
-- Never use `killall node` (affects all projects)
-- Clean up before AND after development sessions
-- If zombies recur, use bisect scripts to find the source

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -449,6 +449,6 @@ Errors: N | Warnings: N | Passed: N
 **Next:** [imperative — which fix to start, which package to upgrade, which file to update].
 ```
 
-The `**Next:**` line is required, even on a clean pass. Name the immediate move (commit, mark ticket done, open a follow-up ticket for the warnings). A verdict without a concrete next action is incomplete — don't leave the user to guess which finding to address first.
+Close with the `**Next:**` line even on a clean pass — name the immediate move (commit, mark ticket done, open a follow-up for warnings) so the reader isn't left guessing which finding to start with (the stop hook reads it for the re-entry brief).
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/packages/cli/templates/skills/bdd/DISCOVERY.md
+++ b/packages/cli/templates/skills/bdd/DISCOVERY.md
@@ -208,7 +208,7 @@ done_when:
 
 The arc end to end: a persona from `personas.md`, a job that names it, criteria under the job, an engineering contract on top, and scenarios that trace back to a criterion — each sub-phase closed by its gate.
 
-## Intake Exit (REQUIRED)
+## Intake Exit
 
 Before proceeding to define-behavior (the Intake Brief is advisory — a missing or `skip:`'d field never blocks this exit; only `scope` / `out_of_scope` / `done_when` are required):
 

--- a/packages/cli/templates/skills/bdd/DONE.md
+++ b/packages/cli/templates/skills/bdd/DONE.md
@@ -8,7 +8,7 @@ Done means the ticket is closed. All verification happened in the verify phase.
 
 1. Update parent epic if applicable (add completion entry to parent's work log; if all children done → update parent `status: done`)
 2. Update ticket: `phase: done`, `status: done`
-3. Final commit: `feat(scope): [summary]`
+3. Commit the close with a conventional-commit message summarizing the change
 
 The stop hook hard-blocks if verify.md is missing or empty — you cannot reach done without completing the verify phase first.
 

--- a/packages/cli/templates/skills/bdd/SCENARIOS.md
+++ b/packages/cli/templates/skills/bdd/SCENARIOS.md
@@ -184,7 +184,7 @@ delivery retries on exponential backoff`). IDs are 1-indexed per job and
   `@job:PO1 @rule:PO1.R1 @scenario:<name>` on a scenario becomes the single
   block-level `@<slug>.PO1.R1` tag, and scenario names go back to plain English.
 
-### Define Behavior Exit (REQUIRED)
+### Define Behavior Exit
 
 1. **Save scenarios** to the feature lane: `features/<slug>.feature` (under `paths.features` when configured)
 2. **Save the R/G/R ledger** to `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
@@ -207,7 +207,7 @@ Run the **`/review-spec`** skill — it is the gate procedure (vacuous-pass, AOD
 
 If the adversarial pass + user feedback produced new scenarios → loop back to define-behavior. If nothing new surfaced → done.
 
-### Scenario Gate Exit (REQUIRED)
+### Scenario Gate Exit
 
 1. Each scenario passes the vacuous-pass test and AODI (Atomic, Observable, Deterministic, Independent)
 2. Adversarial pass + cross-cutting checks complete; findings presented in the findings format (or confirmed clean)

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -75,12 +75,7 @@ ticket 2VCSZY), every phase advance requires a stamp, or a logged skip reason
 
 ## Resume Logic
 
-When user references a ticket, resume work:
-
-1. **Read ticket** → get current `phase:`
-2. **Find progress** → first unchecked `[ ]` in test-definitions
-3. **Check context** → read last work log entry
-4. **Announce resume** → "Resuming at [phase]. Last: [log entry]."
+**Resuming** means reconstruct where the ticket left off and continue. The ticket's `phase:` and the first unchecked ledger item tell you _where_; the last work-log entry tells you _what_. Announce where you're resuming, then continue.
 
 **Resume by phase:**
 
@@ -97,18 +92,9 @@ When user references a ticket, resume work:
 
 ## Current Behavior
 
-1. Understand first (see SAFEWORD.md "Understanding") — propose-and-converge until user accepts proposal with structured scope
-2. Size internally (see SAFEWORD.md "Sizing") — state scope assessment in proposal, not as a separate announcement
-3. **If user references iteration/story/phase from a spec:**
-   - Check if child ticket exists for that iteration
-   - If not → create ticket, run full BDD
-   - If yes → resume at current phase
-4. **If ticket exists:** Read phase, resume at appropriate point
-5. **Artifact-first rule:** Before doing work, create/verify the phase artifact:
-   - intake → ticket at `<namespace-root>/tickets/{ID}-{slug}/ticket.md`
-   - define-behavior → feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`
-6. **Execute phase** using the appropriate phase file
-7. **Update phase** in ticket when transitioning
+Understand first and size internally (see SAFEWORD.md "Understanding" and "Sizing") — state the scope read inside your proposal, not as a separate announcement. If the user references an iteration/story/phase from a spec, resume its child ticket at the current phase, or create one and run full BDD if none exists; if a ticket already exists, read its phase and resume there.
+
+**Artifact-first:** before doing a phase's work, create or verify its artifact — intake → `<namespace-root>/tickets/{ID}-{slug}/ticket.md`; define-behavior → the feature source at `features/<slug>.feature` (or the configured `paths.features` directory) plus the R/G/R ledger at `<namespace-root>/tickets/{ID}-{slug}/test-definitions.md`. Then execute the phase using its phase file, and update `phase:` on transition.
 
 ---
 

--- a/packages/cli/templates/skills/bdd/SKILL.md
+++ b/packages/cli/templates/skills/bdd/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: '*'
 
 Behavior-first development for features. Discovery → Scenarios → Implementation.
 
-**Iron Law:** DEFINE BEHAVIOR BEFORE IMPLEMENTATION
+Define the behavior before implementing it. When unsure whether work is a feature, default to a task (TDD directly) — the user can `/bdd` to override.
 
 ## Phase Tracking
 
@@ -126,15 +126,3 @@ Load the appropriate file based on current phase:
 | `done`            | DONE.md      |
 
 For splitting large features, see SPLITTING.md.
-
----
-
-## Key Takeaways
-
-- **patch/task** → TDD directly (RED → GREEN → REFACTOR)
-- **feature** → full BDD flow, track in ticket `phase:` field
-- **Resume** → read ticket, find first unchecked scenario, continue
-- **Split** → check thresholds at Entry, define-behavior, scenario-gate; user decides (see SPLITTING.md)
-- **Verify gate** → run /verify + /audit, writes verify.md. Stop hook blocks done without it.
-- **Done** → close ticket (trivial — verify.md must already exist)
-- When unsure → default to task, user can `/bdd` to override

--- a/packages/cli/templates/skills/bdd/SPLITTING.md
+++ b/packages/cli/templates/skills/bdd/SPLITTING.md
@@ -27,17 +27,9 @@ STEP 2: Assess depth
 
 ## Split Protocol
 
-**New ticket:**
+**New ticket:** create an epic with a `children:` array and child tickets that link back via `parent:`, then commit the split with a conventional-commit message.
 
-1. Create epic with `children:` array
-2. Create child tickets with `parent:` link
-3. Commit: "chore: split [name] into N features"
-
-**Existing ticket (promote):**
-
-1. Change `type: feature` → `type: epic`
-2. Add `children:` array
-3. Create child tickets with `parent:` link
+**Existing ticket (promote):** change `type: feature` → `type: epic`, add the `children:` array, and create the child tickets with `parent:` links.
 
 ## Restart Points After Split
 
@@ -49,10 +41,6 @@ STEP 2: Assess depth
 
 ## User Override
 
-User can decline: "Proceed anyway"
-
-- Log: "Split suggested but user declined"
-- Continue at current phase
-- Don't re-suggest at same checkpoint this session
+The user can decline a split and proceed anyway — note the declined suggestion in the work log, continue at the current phase, and don't re-suggest at the same checkpoint this session.
 
 **Avoid bloat.**

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -15,10 +15,10 @@ Before the first RED, confirm the project's test harness actually runs — judge
 
 Degradation is the intended path — no gate blocks on harness absence.
 
-## Iron Laws
+## Core rules
 
-1. **NO IMPLEMENTATION UNTIL TEST FAILS FOR THE RIGHT REASON** — behavior missing, not syntax error
-2. **ONLY WRITE CODE THE TEST REQUIRES** — GREEN is minimal, REFACTOR adds quality
+1. Write the failing test first and confirm it fails for the intended reason — behavior missing, not a syntax error — before writing any implementation.
+2. Write only the code the test requires: GREEN is minimal, REFACTOR adds quality.
 
 ## Test Scope
 
@@ -82,7 +82,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 
 **Evidence before claims:** Show test output, don't just claim "tests pass". Run the targeted suite at GREEN for fast feedback; run the FULL suite once at scenario close (after REFACTOR) to catch cross-module regressions.
 
-### Red Flags — STOP:
+### Red flags — stop and rethink:
 
 | Flag                    | Action                                        |
 | ----------------------- | --------------------------------------------- |

--- a/packages/cli/templates/skills/bdd/VERIFY.md
+++ b/packages/cli/templates/skills/bdd/VERIFY.md
@@ -13,7 +13,7 @@ user whether to proceed.
 
 If tests are flaky, investigate before proceeding.
 
-## Verify Exit (REQUIRED)
+## Verify Exit
 
 Before proceeding to done:
 

--- a/packages/cli/templates/skills/brainstorm/SKILL.md
+++ b/packages/cli/templates/skills/brainstorm/SKILL.md
@@ -36,7 +36,7 @@ Brainstorm is the explicit escape hatch from "commit to one path" — not from "
 
 ## When You Notice Convergence
 
-Offer a lightweight check-in: "Sounds like we're converging on X — want me to pull this together?"
+Offer a lightweight check-in — name the direction you're converging on and ask whether to pull it together.
 
 If yes → transition to SAFEWORD.md's understanding flow (scope / out of scope / done when).
 If no → keep exploring.

--- a/packages/cli/templates/skills/debug/SKILL.md
+++ b/packages/cli/templates/skills/debug/SKILL.md
@@ -10,17 +10,12 @@ allowed-tools: '*'
 
 Find root cause before fixing. Symptom fixes are failure.
 
-**Iron Law:** NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+Investigate the root cause before attempting any fix.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. Bug, error, or test failure? → Use this skill
-2. Unexpected behavior? → Use this skill
-3. Previous fix didn't work? → Use this skill (especially important)
-4. Performance problem? → Use this skill
-5. None of above? → Skip this skill
+Use for bugs, errors, test failures, unexpected behavior, repeated failed fixes,
+or performance problems — skip for greenfield work.
 
 **Use especially when:**
 
@@ -150,7 +145,7 @@ Write each as "X could be root cause because Y", then ask: what evidence would _
 | Rules one out         | Eliminate it; test the next live hypothesis. None left? Form new ones (3.1) |
 | Inconclusive          | Pick a more discriminating (cheaper-to-disconfirm) test                     |
 
-### Root Cause Checkpoint (REQUIRED)
+### Root Cause Checkpoint
 
 Before proceeding to Phase 4:
 
@@ -197,7 +192,7 @@ it('handles empty input without crashing', () => {
 - [ ] Existing tests still pass
 - [ ] Issue actually resolved (not just test passing)
 
-End the fix report with **Next:** on its own line — imperative, name what's now (commit message to use, ticket to mark done, follow-up issue to open for related debt the investigation surfaced). A debug session that ends without naming the next move is incomplete.
+Close the fix report with a `**Next:**` line — imperative: the commit message to use, the ticket to mark done, or a follow-up issue for related debt the investigation surfaced (the stop hook reads it for the re-entry brief).
 
 Examples:
 

--- a/packages/cli/templates/skills/elicit/SKILL.md
+++ b/packages/cli/templates/skills/elicit/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: '*'
 
 Draw out what the user knows and you can't research. Then check the latest evidence. Then explore options together.
 
-**Iron Law:** NEVER ASK A QUESTION YOU COULD ANSWER YOURSELF. Read the code, search the docs, check git history first. Only ask what's left.
+Don't ask a question you could answer yourself. Read the code, search the docs, and check git history first; only ask what's left.
 
 ## When to Run
 

--- a/packages/cli/templates/skills/elicit/SKILL.md
+++ b/packages/cli/templates/skills/elicit/SKILL.md
@@ -57,7 +57,7 @@ Keep asking until one of:
 - You have enough to distinguish between options in Phase 3
 - User says "enough" or "go"
 
-Typical: 3-7 questions. Fewer for small scope, more for ambiguous scope.
+Usually a handful — fewer for small scope, more for ambiguous scope. Let the stop conditions above end it, not a target count.
 
 ## Phase 2: Research
 

--- a/packages/cli/templates/skills/figure-it-out/SKILL.md
+++ b/packages/cli/templates/skills/figure-it-out/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: '*'
 
 # Figure It Out: Evidence-Backed Option Weighing
 
-**Iron Law:** No recommendation without current evidence. Training data is stale; verify before staking a position.
+No recommendation without current evidence. Training data is stale; verify before staking a position.
 
 **Stakes set depth.** Investigate as if your recommendation ships unreviewed — a decision gets built on it with no second analysis pass. That standard, not "it's just advice," sets how hard you research. Before researching, write the investigation plan: the sub-questions each domain (Phase 3a) must answer, then work the list. Plan the _investigation_, not the answer — committing to a conclusion before the evidence is the failure this skill exists to prevent.
 
@@ -87,7 +87,7 @@ Then commit. Format:
 
 The `**Premortem:**` line disconfirms your _choice_, not just the alternatives you steelmanned — the option you stop scrutinizing the moment you pick it is the one that bites. Keep it to one sentence.
 
-The `**Next:**` line is required. A recommendation without a next action is incomplete — name the file to edit, the command to run, or the question to ask. One line, imperative.
+Close with the `**Next:**` line — one imperative naming the file to edit, the command to run, or the question to ask (the stop hook reads it for the re-entry brief). A recommendation that doesn't say what to do now leaves the reader stranded.
 
 If two options tie on correctness and elegance, the smaller one wins.
 

--- a/packages/cli/templates/skills/figure-it-out/SKILL.md
+++ b/packages/cli/templates/skills/figure-it-out/SKILL.md
@@ -43,7 +43,7 @@ Two or three, concrete enough to debate. For each: **what** (one sentence), **lo
 
 ### Phase 3: Enumerate domains, then research
 
-**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A list with fewer than two or three entries means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
+**3a — Name the domains.** Before searching, list every domain your decision touches. Multiple, not one. Write them down explicitly. A single-domain list means you haven't looked hard enough — decisions live at the intersection of multiple bodies of work.
 
 Worked example — drafting a one-line block message for a CLI hook isn't just "writing copy." Domain list:
 

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -115,7 +115,7 @@ Severity is bounded by evidence: **a CRITICAL or REQUEST CHANGES verdict must ci
 
 ## Loop: review → fix → re-review
 
-Run the review in passes (MAX_PASSES = 3), not one-and-done.
+Run the review in passes until it comes back clean — not one-and-done, but not an endless loop either (a couple of passes is usually plenty).
 
 Each pass:
 
@@ -137,8 +137,8 @@ Each pass:
 2. **Triage.** Fix every **Critical issue** this pass. Apply the **Suggested
    improvements** worth the change; list the rest — don't chase them.
 3. **Decide.** Stop when **Critical issues = None** — remaining suggestions are
-   optional, not a reason to loop. Cap at MAX_PASSES regardless. Re-review only
-   if you edited code this pass.
+   optional, not a reason to loop. Don't loop indefinitely; a couple of passes is
+   the practical ceiling. Re-review only if you edited code this pass.
 
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -56,7 +56,7 @@ Run each angle that applies — angle _diversity_ is the lever, not search volum
 
 ### Version-currency & security
 
-**CRITICAL**: This is your main differentiator from automatic hook.
+This is your main differentiator from the automatic hook.
 
 Read the live `Current time:` line from the prompt timestamp hook and use that date as the current prompt timestamp.
 Search for: "[library name] latest stable version as of <current prompt timestamp date>"
@@ -66,7 +66,7 @@ Search for: "[library name] security vulnerabilities"
 
 - Major versions behind -> WARN (e.g., React 17 when 19 is stable)
 - Minor versions behind -> NOTE
-- Security vulnerabilities -> CRITICAL (must upgrade)
+- Security vulnerabilities -> CRITICAL (upgrade now)
 - Using latest -> Confirm
 
 ## 3. Verify Documentation — deprecation + primary-source (Primary Value)
@@ -143,13 +143,6 @@ Each pass:
 A pass isn't done until `/verify` (tests, lint, typecheck) is green. That
 objective signal — not the reviewer running out of suggestions — is the real
 stop condition; tests are the ground truth.
-
-## Reminders
-
-1. **Primary value: Web research** - Verify versions, docs, security
-2. **Complement automatic hook** - Hook prompts for the decision-brief verdict and per-phase evidence; you verify versions, primary-literature claims, and ecosystem context the hook can't see
-3. **Phase matters** - Adapt research focus to current BDD phase
-4. **Be concise** - Hook already prompts for general quality, focus on what it can't do
 
 **Voice:** plainspoken and concise — write to be scanned.
 

--- a/packages/cli/templates/skills/refactor/SKILL.md
+++ b/packages/cli/templates/skills/refactor/SKILL.md
@@ -231,7 +231,7 @@ Ledger entries remaining?
 ├─ Yes → take next leaf-first entry → Phase 3 (one refactoring) → Phase 4 → mark done
 └─ No → Done
     ├─ Run `/audit` to verify no dead code or new issues
-    └─ Report: "Refactoring complete. Resolved: [ledger summary]. Deferred: [items + why]."
+    └─ Report what was resolved and what was deferred (with reasons)
 ```
 
 A single-named-smell request has a one-entry ledger — resolve it, audit, done.
@@ -252,11 +252,11 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 
 - STOP refactoring
 - Note the bug location
-- Ask user: "Found potential bug at X. Fix it now (switching to tdd-enforcer) or continue refactoring?"
+- Ask the user whether to fix it now (switching to tdd-enforcer) or continue refactoring
 
 **User requests large refactoring:**
 
-- Break into steps: "I'll refactor this incrementally. First: [step 1]"
+- Break it into steps and name the first one before starting
 - Complete each step fully before next
 - Never batch multiple refactorings in one edit
 

--- a/packages/cli/templates/skills/refactor/SKILL.md
+++ b/packages/cli/templates/skills/refactor/SKILL.md
@@ -12,17 +12,14 @@ allowed-tools: '*'
 
 Improve code structure without changing behavior. One small step at a time.
 
-**Iron Law:** ONE REFACTORING → TEST → COMMIT. Never batch changes.
+Work one refactoring at a time: change, test, commit. Don't batch changes.
 
 ## When to Use
 
-Answer IN ORDER. Stop at first match:
-
-1. User says "refactor", "clean up", "restructure"? → Use this skill
-2. User asks to "extract", "rename", "simplify"? → Use this skill
-3. Code smell identified? → Use this skill
-4. User wants to add feature or fix bug? → Skip (use tdd-enforcer)
-5. User wants formatting/style fixes? → Skip (use /lint)
+Use when the user says "refactor", "clean up", "restructure", "extract",
+"rename", or "simplify", or when you've identified a code smell. Skip for adding
+a feature or fixing a bug (use tdd-enforcer) and for formatting/style fixes (use
+/lint).
 
 **Code smells** (common triggers):
 
@@ -90,9 +87,9 @@ it('processOrder returns current behavior', () => {
 
 ## Phase 3: REFACTOR
 
-**Iron Law:** ONE refactoring at a time. Run tests after EVERY change.
+One refactoring at a time; run tests after every change.
 
-**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The Iron Law is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
+**Discovery fans out; mutation never does.** The scout step (in "When to Use", above) may run parallel read-only passes. Execution is the opposite — one change, in isolation, then test, then commit — because the safety net lives here. Parallel or batched edits forfeit the revert protocol (Phase 4), break `git bisect`, and destroy single-change test attribution: you can no longer tell which edit turned the suite red. The one-change rule is **per-edit, not per-session** — you still work through every ledger entry (Phase 5), just one at a time.
 
 ### Refactoring Catalog
 
@@ -196,8 +193,8 @@ Choose exactly one outcome:
   creation would disturb the user's state or unrelated work is already present,
   defer the commit and report the exact branch/worktree reason.
 
-Deferring a commit is not skipping the Iron Law; it is preserving the same
-single-change attribution the Iron Law exists to protect.
+Deferring a commit is not skipping the one-change rule; it is preserving the same
+single-change attribution that rule exists to protect.
 
 ### Revert Protocol
 
@@ -275,14 +272,3 @@ A single-named-smell request has a one-entry ledger — resolve it, audit, done.
 | Change behavior during refactor        | That's a feature/fix, not refactoring                         |
 | Create a mixed feature+refactor commit | Commit only an isolated refactor, or defer with the reason    |
 | Skip a safe commit                     | Commit after every green test when the commit can stay scoped |
-
----
-
-## Key Takeaways
-
-1. **One change at a time** - Never batch refactorings
-2. **Tests before refactoring** - No safety net = no refactoring
-3. **Revert on failure** - Don't fix, revert and retry smaller
-4. **Commit after each success when safe** - `refactor: [description]`, or defer with a concrete mixed-tree/detached-HEAD reason
-5. **Smallest scope first** - Rename < Extract < Move < Restructure
-6. **Audit when done** - Run `/audit` to verify no dead code or new issues

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -67,7 +67,7 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 **Context:** Agent just wrote a failing test for scenario 2 (verbose shows passing files) — RED is the last checked box, so the review focuses on the test.
 
-**Agent review:**
+Illustrative only — apply the checks in your own words, not this exact wording:
 
 > **Atomic?** Yes — tests one behavior (passing files appear in verbose output).
 > **Right assertions?** `expect(output).toContain('src/index.ts: pass')` — asserts on observable output, not internals. Good.

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -82,21 +82,11 @@ If issues found: address before starting next scenario. If clean: commit and pro
 
 ## Output discipline
 
-Every review ends with a **Next:** line on its own line — imperative, name the file/command/scenario. Don't end with "proceed" or "commit and move on" alone; name what to do.
+Close every review with a `**Next:**` line — imperative, naming the file/command/scenario, not a bare "proceed" or "commit and move on" (the stop hook reads it for the re-entry brief).
 
 - After RED, clean → `**Next:** implement minimum code in {file} to make this test pass.`
 - After RED, issues → `**Next:** rewrite assertion in {file}:{line} to check observable output, then re-review.`
 - After GREEN, clean → `**Next:** run /refactor on {file}, then commit and mark next [ ] RED.`
 - After REFACTOR, clean → `**Next:** commit, then start scenario {N} — write the failing test in {file}.`
-
-A review without a Next: line is incomplete.
-
-## Reminders
-
-1. **Depth matches step** — lightweight after RED, moderate after GREEN, full after REFACTOR
-2. **Local by default** — per-step reviews need no web research; reserve **/quality-review** for a scenario that introduces a new external dependency/API and for the whole-ticket pass at implement-exit
-3. **Single source of truth** — this skill owns all TDD review content
-4. **Advisory, not a wall** — these reviews guide; the commit ledger and done-gate are the hard gates. Review internally, then commit to proceed
-5. **Mark sub-checkbox** — ensure the current step's `[x]` is marked in test-definitions.md
 
 **Voice:** plainspoken and concise — write to be scanned.

--- a/packages/cli/templates/skills/testing/SKILL.md
+++ b/packages/cli/templates/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-**Announce your decision:** "Test type: [unit/integration/E2E/eval] because [reason]."
+If the test-scope choice isn't obvious from context, state it and why in one line.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/packages/cli/templates/skills/testing/SKILL.md
+++ b/packages/cli/templates/skills/testing/SKILL.md
@@ -45,7 +45,7 @@ Fallback (lowest scope):
 - Multiple modules must cooperate → integration or E2E
 - "If this breaks, users notice immediately" → E2E
 
-If the test-scope choice isn't obvious from context, state it and why in one line.
+State the test-scope choice and why in one line, unless it's obvious from context.
 
 For the full decision tree, bug detection matrix, and edge cases: `.safeword/guides/testing-guide.md`
 

--- a/packages/cli/templates/skills/ticket-system/SKILL.md
+++ b/packages/cli/templates/skills/ticket-system/SKILL.md
@@ -56,13 +56,9 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 | **task**    | ticket.md with inline tests                         |
 | **patch**   | ticket.md (minimal), existing tests                 |
 
-**Create ticket? Answer IN ORDER, stop at first match:**
-
-1. Multiple attempts likely needed? → Create ticket
-2. Multi-step with dependencies? → Create ticket
-3. Investigation/debugging required? → Create ticket
-4. Risk of losing context mid-session? → Create ticket
-5. None of above? → Skip ticket
+**Create a ticket** when any of these holds: multiple attempts are likely,
+the work is multi-step with dependencies, it needs investigation/debugging, or
+there's a risk of losing context mid-session. Otherwise skip it.
 
 **Examples:** "Fix typo" → skip. "Debug slow login" → ticket. "Add OAuth" → ticket.
 
@@ -124,11 +120,9 @@ status: in_progress
 
 **One artifact = one log.** If log exists, append a new session. Don't spawn multiple logs for the same work.
 
-**Create log? Answer IN ORDER, stop at first match:**
-
-1. Executing a plan, ticket, or spec? → Create log
-2. Investigation/debugging with multiple attempts? → Create log
-3. Quick single-action task? → Skip log
+**Create a log** when executing a plan, ticket, or spec, or when
+investigation/debugging spans multiple attempts. Skip it for a quick
+single-action task.
 
 **Think hard behaviors:**
 


### PR DESCRIPTION
Implements the de-prescription sub-tickets of #765 (#769–779). Canonical edits in `packages/cli/templates/**`, propagated to every dogfood mirror via `parity:fix`.

## Why

Modern models (Fable 5, Opus 4.8, Sonnet 5 — and, independently, OpenAI GPT-5.5) follow instructions more literally, so the imperative step-lists, forced ordering, and shouted `CRITICAL/MUST` emphasis that older models needed now degrade output. This pass converts prescription → principle (intent + measurable done-condition + explicit scope), graduates true invariants into hooks, and **keeps** capability triggers as conditional "when-X" (Opus 4.8 under-reaches for subagents).

## What landed

| # | Ticket | Outcome |
|---|--------|---------|
| 769 | ordered-scan decision trees | 13 sites → declarative "first matching row" tables/criteria |
| 770 | `**Next:**` token | kept the token (machine contract for `stop-reentry.ts`), de-prescribed the surrounding nag |
| 771 | all-caps emphasis | ~18 sites → plain declarative |
| 772 | work-log + `(REQUIRED)` | dropped 5 `(REQUIRED)` labels (already hook-enforced); auto-writer hook deferred |
| 773 | enforcement prose | verified → no safe cuts (load-bearing gate machinery / not-yet-graduated invariants) |
| 774 | recap tails | deleted across 9 files, net-new lines folded back |
| 775 | scripted dialogue | replaced with intent across 6 files |
| 776 | author-facing guides | U-edit + documented the two-column de-prescription rule (#765's final checkbox) |
| 777 | SAFEWORD.md rituals | rituals → intent; load-bearing ordered methods kept |
| 778 | time/count triggers | calendars/durations/counts → qualitative conditions |
| 779 | KEEP capability-triggers | audited, retained, none deleted |

## Deliberately deferred (not in this PR)

- **DELETION-class edits** (llm-writing-guide meta-rule, context-files "Best Practices" block, architecture-guide anti-anchoring twin, the acceptance-rate trigger) → the Opus-4.8/Sonnet-5 A/B ticket (#780). None applied on single-model evidence.
- **The #772 auto-work-log-writer hook** → its own TDD cycle: it mutates `ticket.md`, needs duplicate-entry avoidance + timestamp injection + a format contract with `stop-reentry.ts`/`explain`.
- **#773 re-scope** → several "prose the hooks own" invariants aren't hook-enforced yet (verified: no denylist blocks `killall node`); recommend graduate-first, then trim.

## Notable judgment call

`**Next:**` reads as pure formatting ceremony but is parsed verbatim by `stop-reentry.ts` (shipped feature 645W8H) to build the session re-entry brief. Per #765's own graduate-and-keep rule, the token stays and only the surrounding nag was de-prescribed. If you'd rather drop the token, the hook's parser needs loosening in the same change.

## Verification

- Canonical → mirror parity: **212 pairs + 3 contracts in sync**.
- `test:smoke:fast`: **1037 passed / 76 files**.
- `markdownlint`: **0 errors** across 39 edited files.
- `/audit`: 0 errors from this diff (knip/jscpd findings are pre-existing TS baselines, not from this markdown change).
- `/quality-review`: independent fresh-context reviewer verdict **faithful**; direction verified against the published Opus 4.8 and GPT-5.5 prompting guides. One LOW finding fixed in `1872f41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCTEqXfKZvmMEDY12FfMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTCTEqXfKZvmMEDY12FfMT)_