### PR TITLE
Post-merge quality sweep: dedup + scope two context-files-guide claims (#765 follow-up)

### DIFF
--- a/.safeword/guides/context-files-guide.md
+++ b/.safeword/guides/context-files-guide.md
@@ -76,7 +76,7 @@ Loaded context:
 See root AGENTS.md for TDD workflow. This file covers test-specific patterns.
 ```
 
-**Reliability note:** On current models the context file auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
+**Reliability note:** On current models the tool's main context file (e.g. `CLAUDE.md` in Claude Code, `AGENTS.md` in Codex) auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
 
 **Deprecated:** `*.local.md` is no longer recommended - use imports instead for better multi-worktree support
 
@@ -448,11 +448,10 @@ Brief description. Current status.
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
 - State most rules as plain declarative facts; blanket `IMPORTANT`/`YOU MUST` decoration is noise a literal model doesn't need. Reserve emphasis for one job — flagging **when to reach for a capability** (a subagent, a tool, memory) that a model like Opus 4.8 otherwise under-uses.
-- The file auto-loads every session, so don't repeat a rule or name the file in the prompt to force adherence — brevity, not repetition, is what keeps rules followed.
 
 **Portability:**
 
-- Emphasis (`IMPORTANT`/`YOU MUST`) is a Claude-specific last-resort lever — don't teach it as portable reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
+- Emphasis (`IMPORTANT`/`YOU MUST`) is an Anthropic-popularized last-resort lever — other vendors respond to emphasis too, but don't teach it as _portable_ reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
 - Default to **Markdown** structure (portable across vendors); treat XML-tag structuring as a Claude-specific optimization, not a baseline.
 
 **Token Budget:**

--- a/packages/cli/templates/guides/context-files-guide.md
+++ b/packages/cli/templates/guides/context-files-guide.md
@@ -76,7 +76,7 @@ Loaded context:
 See root AGENTS.md for TDD workflow. This file covers test-specific patterns.
 ```
 
-**Reliability note:** On current models the context file auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
+**Reliability note:** On current models the tool's main context file (e.g. `CLAUDE.md` in Claude Code, `AGENTS.md` in Codex) auto-loads reliably every session — you don't need to name it in the prompt to get it applied. The real reliability lever is **brevity**: a bloated file buries its own rules, so a rule the model ignores is usually a length problem, not a reference problem. Keep it short and the auto-loaded rules land.
 
 **Deprecated:** `*.local.md` is no longer recommended - use imports instead for better multi-worktree support
 
@@ -448,11 +448,10 @@ Brief description. Current status.
 - **Treat as living document** - Constantly refine based on what works
 - Periodically review and refactor for clarity
 - State most rules as plain declarative facts; blanket `IMPORTANT`/`YOU MUST` decoration is noise a literal model doesn't need. Reserve emphasis for one job — flagging **when to reach for a capability** (a subagent, a tool, memory) that a model like Opus 4.8 otherwise under-uses.
-- The file auto-loads every session, so don't repeat a rule or name the file in the prompt to force adherence — brevity, not repetition, is what keeps rules followed.
 
 **Portability:**
 
-- Emphasis (`IMPORTANT`/`YOU MUST`) is a Claude-specific last-resort lever — don't teach it as portable reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
+- Emphasis (`IMPORTANT`/`YOU MUST`) is an Anthropic-popularized last-resort lever — other vendors respond to emphasis too, but don't teach it as _portable_ reliability. OpenAI models lean on the system > developer > user instruction hierarchy instead.
 - Default to **Markdown** structure (portable across vendors); treat XML-tag structuring as a Claude-specific optimization, not a baseline.
 
 **Token Budget:**


### PR DESCRIPTION
Follow-up to the merged de-prescription pass (#803). A verify / audit / quality-review / refactor sweep over the merged result surfaced three small prose fixes, all in `context-files-guide.md` (+ its dogfood mirror).

## Fixes

- **audit — dedup.** The auto-load/brevity point was stated twice: the Reliability note (`:79`) and an Effectiveness bullet. Removed the duplicate bullet (exactly the recap/duplication drift-trap this pass exists to remove); `:79` is the natural home.
- **quality-review — accuracy.** "Emphasis (`IMPORTANT`/`YOU MUST`) is a Claude-specific lever" overstated — other vendors respond to emphasis too, it just doesn't transfer as *portable* reliability. Reworded to "Anthropic-popularized … don't teach as portable."
- **quality-review — scope.** "Context file auto-loads reliably every session" over-generalized across the filenames the guide names (Cursor's real convention differs). Scoped to the primary files (`CLAUDE.md` in Claude Code, `AGENTS.md` in Codex).

An independent fresh-context reviewer confirmed the rest of the #776 portability edits are accurate and coherent (the OpenAI instruction-hierarchy and Markdown-vs-XML claims verified correct); these two overstatements were the only findings.

## Verification

- Parity: **212 pairs + 3 contracts in sync**.
- `test:smoke:fast`: **1037 passed / 76 files**.
- typecheck ✓, gherkin lint ✓, `markdownlint` 0 errors on changed files.
- refactor: the only self-introduced duplication was the auto-load one (fixed); remaining clones are the pre-existing, intentional per-skill invocation-log boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCTEqXfKZvmMEDY12FfMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTCTEqXfKZvmMEDY12FfMT)_