### PR TITLE
Retro backlog: low-risk quick-wins + `ticket new` epic/goal/why

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -177,7 +177,11 @@ DEPCRUISE_CONFIG=""
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
 [ -f Cargo.toml ] && {
-  cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  if command -v cargo > /dev/null 2>&1; then
+    cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  else
+    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+  fi
 }
 
 # =========================================================================

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -176,11 +176,14 @@ DEPCRUISE_CONFIG=""
 }
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
+# Gate on `cargo-clippy` (the binary `cargo clippy` runs), not `cargo`: clippy
+# is a rustup component that can be absent while cargo is on PATH, and `|| true`
+# would otherwise swallow its failure into a false "clean" result.
 [ -f Cargo.toml ] && {
-  if command -v cargo > /dev/null 2>&1; then
+  if command -v cargo-clippy > /dev/null 2>&1; then
     cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
   else
-    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+    echo "Manual evidence required: cargo clippy not available — Rust clippy check skipped"
   fi
 }
 

--- a/.agents/skills/ticket-system/SKILL.md
+++ b/.agents/skills/ticket-system/SKILL.md
@@ -22,10 +22,14 @@ elif [ -f packages/cli/src/cli.ts ]; then
   SW="bun packages/cli/src/cli.ts"
 else SW="bunx safeword"; fi
 
-$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+$SW ticket new <slug> # --type=patch|task|feature|epic, --title="...", --goal="...", --why="..."
 ```
 
+`--goal` fills the Goal field for any type; `--why` fills the rationale for task/patch/epic (features keep motivation in spec.md, so `--why` is rejected there). `--type=epic` scaffolds a container ticket with an empty `children:` list.
+
 The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**`ticket new` pre-populates ticket.md (and spec.md for features) with placeholder content.** Pass real values with `--goal`/`--title`/`--why` at creation, or **Edit** the scaffolded fields — do not blind-**Write** the whole file, which fails because the freshly-created file hasn't been Read yet.
 
 **Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
@@ -37,7 +41,7 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 │   ├── 7K9M3P-login-bug/       # Current format: Crockford ID + normalized slug
 │   │   ├── ticket.md           # Ticket definition (frontmatter + work log)
 │   │   ├── test-definitions.md # BDD scenarios (Given/When/Then)
-│   │   ├── spec.md             # Feature spec for epics (optional)
+│   │   ├── spec.md             # Product spec (features only; auto-created)
 │   │   └── design.md           # Design doc for complex features (optional)
 │   ├── 7K9M3P/                 # Historical Crockford ID-only format, still readable
 │   │   └── ticket.md
@@ -50,11 +54,12 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 
 **Artifact Levels:**
 
-| Level       | Artifacts                                           |
-| ----------- | --------------------------------------------------- |
-| **feature** | ticket.md + test-definitions.md (+ spec.md if epic) |
-| **task**    | ticket.md with inline tests                         |
-| **patch**   | ticket.md (minimal), existing tests                 |
+| Level       | Artifacts                                    |
+| ----------- | -------------------------------------------- |
+| **epic**    | ticket.md (frontmatter `children:`), no spec |
+| **feature** | ticket.md + spec.md + test-definitions.md    |
+| **task**    | ticket.md with inline tests                  |
+| **patch**   | ticket.md (minimal), existing tests          |
 
 **Create a ticket** when any of these holds: multiple attempts are likely,
 the work is multi-step with dependencies, it needs investigation/debugging, or

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -177,7 +177,11 @@ DEPCRUISE_CONFIG=""
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
 [ -f Cargo.toml ] && {
-  cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  if command -v cargo > /dev/null 2>&1; then
+    cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  else
+    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+  fi
 }
 
 # =========================================================================

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -176,11 +176,14 @@ DEPCRUISE_CONFIG=""
 }
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
+# Gate on `cargo-clippy` (the binary `cargo clippy` runs), not `cargo`: clippy
+# is a rustup component that can be absent while cargo is on PATH, and `|| true`
+# would otherwise swallow its failure into a false "clean" result.
 [ -f Cargo.toml ] && {
-  if command -v cargo > /dev/null 2>&1; then
+  if command -v cargo-clippy > /dev/null 2>&1; then
     cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
   else
-    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+    echo "Manual evidence required: cargo clippy not available — Rust clippy check skipped"
   fi
 }
 

--- a/.claude/skills/ticket-system/SKILL.md
+++ b/.claude/skills/ticket-system/SKILL.md
@@ -22,10 +22,14 @@ elif [ -f packages/cli/src/cli.ts ]; then
   SW="bun packages/cli/src/cli.ts"
 else SW="bunx safeword"; fi
 
-$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+$SW ticket new <slug> # --type=patch|task|feature|epic, --title="...", --goal="...", --why="..."
 ```
 
+`--goal` fills the Goal field for any type; `--why` fills the rationale for task/patch/epic (features keep motivation in spec.md, so `--why` is rejected there). `--type=epic` scaffolds a container ticket with an empty `children:` list.
+
 The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**`ticket new` pre-populates ticket.md (and spec.md for features) with placeholder content.** Pass real values with `--goal`/`--title`/`--why` at creation, or **Edit** the scaffolded fields — do not blind-**Write** the whole file, which fails because the freshly-created file hasn't been Read yet.
 
 **Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
@@ -37,7 +41,7 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 │   ├── 7K9M3P-login-bug/       # Current format: Crockford ID + normalized slug
 │   │   ├── ticket.md           # Ticket definition (frontmatter + work log)
 │   │   ├── test-definitions.md # BDD scenarios (Given/When/Then)
-│   │   ├── spec.md             # Feature spec for epics (optional)
+│   │   ├── spec.md             # Product spec (features only; auto-created)
 │   │   └── design.md           # Design doc for complex features (optional)
 │   ├── 7K9M3P/                 # Historical Crockford ID-only format, still readable
 │   │   └── ticket.md
@@ -50,11 +54,12 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 
 **Artifact Levels:**
 
-| Level       | Artifacts                                           |
-| ----------- | --------------------------------------------------- |
-| **feature** | ticket.md + test-definitions.md (+ spec.md if epic) |
-| **task**    | ticket.md with inline tests                         |
-| **patch**   | ticket.md (minimal), existing tests                 |
+| Level       | Artifacts                                    |
+| ----------- | -------------------------------------------- |
+| **epic**    | ticket.md (frontmatter `children:`), no spec |
+| **feature** | ticket.md + spec.md + test-definitions.md    |
+| **task**    | ticket.md with inline tests                  |
+| **patch**   | ticket.md (minimal), existing tests          |
 
 **Create a ticket** when any of these holds: multiple attempts are likely,
 the work is multi-step with dependencies, it needs investigation/debugging, or

--- a/.safeword/hooks/lib/jtbd.ts
+++ b/.safeword/hooks/lib/jtbd.ts
@@ -15,6 +15,13 @@ const PERSONA_PREFIX = '**Persona:**';
 const SKIP_PREFIX = 'skip:';
 /** Max persona short-code length — mirrors the CLI's `MAX_CODE_LENGTH`. */
 const MAX_CODE_LENGTH = 6;
+/**
+ * A level-4 heading only counts toward the AC gate when it carries a real
+ * lineage id — `<jtbd>.AC<n>` or `<jtbd>.R<n>` (#696). Without this, any
+ * `#### <heading>` (e.g. `#### Notes`) vacuously satisfied the "≥1 AC per JTBD"
+ * requirement. Matches the id token wherever it sits in the heading text.
+ */
+const AC_OR_RULE_HEADING = /(?:^|\.)(?:AC|R)\d+\b/i;
 
 export interface JtbdEntry {
   /** The raw `**Persona:**` reference (name, code, or `Name (CODE)`); may be empty. */
@@ -189,7 +196,12 @@ function parseAcsByJtbd(specContent: string): {
       } else if (inSection && heading.level === 3) {
         flush();
         current = { heading: heading.text, acCount: 0, skip: null };
-      } else if (inSection && heading.level >= 4 && current !== null) {
+      } else if (
+        inSection &&
+        heading.level >= 4 &&
+        current !== null &&
+        AC_OR_RULE_HEADING.test(heading.text)
+      ) {
         current.acCount++;
       }
       continue;

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -131,11 +131,11 @@ if (existsSync(stateFile)) {
         }
       } else {
         lines.push(
-          '- No active ticket. Classify (patch/task/feature) before starting. For features, run `/bdd`.',
+          '- No active ticket. Classify (patch/task/feature/epic) before starting. For features, run `/bdd`.',
         );
       }
     } else {
-      lines.push('- No active ticket. Classify (patch/task/feature) before starting.');
+      lines.push('- No active ticket. Classify (patch/task/feature/epic) before starting.');
     }
 
     // One-shot reminder: verify novel research claims before building on them.

--- a/.safeword/templates/ticket-template.md
+++ b/.safeword/templates/ticket-template.md
@@ -8,7 +8,7 @@ last_modified: YYYY-MM-DDTHH:MM:SSZ
 ---
 
 <!--
-type: patch | task | feature
+type: patch | task | feature | epic
 phase: intake | define-behavior | scenario-gate | implement | verify | done
   - patch/task: typically start at 'implement' or omit phase
   - feature: progresses through all phases via BDD workflow

--- a/knip.json
+++ b/knip.json
@@ -22,7 +22,10 @@
     "architecture",
     "test-plan",
     "verify",
-    "quality-review"
+    "quality-review",
+    "setup",
+    "check",
+    "lint-gherkin"
   ],
   "ignoreDependencies": [
     "safeword",

--- a/packages/cli/knip.json
+++ b/packages/cli/knip.json
@@ -1,6 +1,6 @@
 {
   "ignore": ["templates/**"],
-  "ignoreBinaries": ["shellcheck"],
+  "ignoreBinaries": ["shellcheck", "setup", "check", "lint-gherkin"],
   "ignoreDependencies": ["tsx"],
   "rules": {
     "duplicates": "off"

--- a/packages/cli/knip.json
+++ b/packages/cli/knip.json
@@ -1,6 +1,6 @@
 {
   "ignore": ["templates/**"],
-  "ignoreBinaries": ["shellcheck", "setup", "check", "lint-gherkin"],
+  "ignoreBinaries": ["shellcheck"],
   "ignoreDependencies": ["tsx"],
   "rules": {
     "duplicates": "off"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -136,12 +136,19 @@ const ticket = program.command('ticket').description('Ticket management');
 ticket
   .command('new <slug>')
   .description('Create a new ticket with a Crockford Base32 ID')
-  .option('--type <type>', 'Ticket type: patch, task, or feature', 'task')
+  .option('--type <type>', 'Ticket type: patch, task, feature, or epic', 'task')
   .option('--title <title>', 'Ticket title (defaults to slug)')
-  .action(async (slug: string, options: { type?: string; title?: string }) => {
-    const { ticketNew } = await import('./commands/ticket-new.js');
-    await ticketNew(slug, options);
-  });
+  .option('--goal <goal>', 'One-line goal; fills the Goal field instead of a placeholder')
+  .option('--why <why>', 'One-line rationale (task/patch/epic; features use spec.md)')
+  .action(
+    async (
+      slug: string,
+      options: { type?: string; title?: string; goal?: string; why?: string },
+    ) => {
+      const { ticketNew } = await import('./commands/ticket-new.js');
+      await ticketNew(slug, options);
+    },
+  );
 
 program
   .command('sync-learnings')

--- a/packages/cli/src/commands/ticket-new.ts
+++ b/packages/cli/src/commands/ticket-new.ts
@@ -15,11 +15,13 @@ import { normalizeSlug, SlugError } from '../utils/slug.js';
 import { formatTicketReference } from '../utils/ticket-reference.js';
 import { createTicket, TicketIdCollisionError, type TicketType } from '../utils/ticket-writer.js';
 
-const VALID_TYPES: ReadonlySet<TicketType> = new Set(['patch', 'task', 'feature']);
+const VALID_TYPES: ReadonlySet<TicketType> = new Set(['patch', 'task', 'feature', 'epic']);
 
 export interface TicketNewOptions {
   type?: string;
   title?: string;
+  goal?: string;
+  why?: string;
 }
 
 export function ticketNew(slug: string, options: TicketNewOptions): Promise<void> {
@@ -31,7 +33,16 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
   const type = resolveType(options.type);
   if (type === 'invalid') {
     process.stderr.write(
-      `Invalid --type=${String(options.type)}. Must be one of: patch, task, feature.\n`,
+      `Invalid --type=${String(options.type)}. Must be one of: patch, task, feature, epic.\n`,
+    );
+    process.exit(1);
+  }
+
+  // Features keep motivation in spec.md (single source of truth), so they have
+  // no **Why:** field for --why to fill — fail loud rather than silently drop it.
+  if (options.why !== undefined && type === 'feature') {
+    process.stderr.write(
+      '--why does not apply to features — their motivation lives in spec.md. Use --goal, or edit spec.md.\n',
     );
     process.exit(1);
   }
@@ -54,6 +65,8 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
       slug: normalizedSlug,
       type,
       title: options.title,
+      goal: options.goal,
+      why: options.why,
     });
     success(`Created ticket ${formatTicketReference(result.id, normalizedSlug)}`);
     info(`Folder: ${result.folderPath}`);

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -166,6 +166,34 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
   const envToken = `ghp_${'a'.repeat(32)}`;
   const ghToken = `ghp_${'b'.repeat(32)}`;
 
+  // #634 — every accepted GitHub token shape must survive resolution, or a
+  // regex that quietly stopped matching one form (e.g. fine-grained PATs) would
+  // break a working auth path with no test to catch it.
+  it.each([
+    ['classic PAT (ghp_)', `ghp_${'a'.repeat(32)}`],
+    ['OAuth (gho_)', `gho_${'b'.repeat(32)}`],
+    ['app server-to-server (ghs_)', `ghs_${'c'.repeat(32)}`],
+    ['fine-grained PAT (github_pat_)', `github_pat_${'d'.repeat(40)}`],
+    ['legacy 40-char hex', '0123456789'.repeat(4)],
+  ])('accepts a %s from GITHUB_TOKEN without consulting gh', (_label, shaped) => {
+    let ghConsulted = false;
+    const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
+      ghConsulted = true;
+      return ghToken;
+    });
+    expect(token).toBe(shaped);
+    expect(ghConsulted).toBe(false);
+  });
+
+  it.each([
+    ['a proxy placeholder', 'proxy-injected'],
+    ['an unknown prefix', `gha_${'a'.repeat(32)}`],
+    ['an empty string', ''],
+  ])('rejects %s and falls back to gh', (_label, bogus) => {
+    const token = resolveGitHubToken({ GITHUB_TOKEN: bogus }, () => ghToken);
+    expect(token).toBe(ghToken);
+  });
+
   // invisible-retro-claude.SM1.AC1 (token arm) — GITHUB_TOKEN present → the REST
   // transport is built from it; `gh` is never consulted.
   it('invisible-retro-claude.SM1.AC1.token_present_uses_the_rest_transport', () => {

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -161,18 +161,36 @@ describe('createRestTransport', () => {
 });
 
 describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () => {
+  // Build correctly-shaped tokens at runtime so the secret scanner doesn't flag
+  // a literal that looks like a real credential.
+  const envToken = `ghp_${'a'.repeat(32)}`;
+  const ghToken = `ghp_${'b'.repeat(32)}`;
+
   // invisible-retro-claude.SM1.AC1 (token arm) — GITHUB_TOKEN present → the REST
   // transport is built from it; `gh` is never consulted.
   it('invisible-retro-claude.SM1.AC1.token_present_uses_the_rest_transport', () => {
     let ghConsulted = false;
-    const token = resolveGitHubToken({ GITHUB_TOKEN: 'env-tok' }, () => {
+    const token = resolveGitHubToken({ GITHUB_TOKEN: envToken }, () => {
       ghConsulted = true;
-      return 'gh-tok';
+      return ghToken;
     });
-    expect(token).toBe('env-tok');
+    expect(token).toBe(envToken);
     expect(ghConsulted).toBe(false);
     // a transport is genuinely built from the resolved token
     expect(createRestTransport(token)).toBeDefined();
+  });
+
+  // #634 — a non-token-shaped placeholder (e.g. the `proxy-injected` value some
+  // cloud containers put in GITHUB_TOKEN) is treated as absent: it must NOT be
+  // passed to the API, and resolution falls through to `gh` instead.
+  it('ignores a non-token-shaped GITHUB_TOKEN and falls back to gh', () => {
+    let ghConsulted = false;
+    const token = resolveGitHubToken({ GITHUB_TOKEN: 'proxy-injected' }, () => {
+      ghConsulted = true;
+      return ghToken;
+    });
+    expect(token).toBe(ghToken);
+    expect(ghConsulted).toBe(true);
   });
 
   // invisible-retro-claude.SM1.AC1 (no-token arm) — no GITHUB_TOKEN but the

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -26,17 +26,36 @@ function ghAuthToken(): string | undefined {
 }
 
 /**
+ * A value shaped like a real GitHub token: a modern prefixed token
+ * (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, or fine-grained `github_pat_`) or a
+ * legacy 40-char hex PAT. Deliberately narrow so proxy-injected placeholders
+ * such as `proxy-injected` are rejected before they reach the API (#634).
+ */
+function looksLikeGitHubToken(value: string): boolean {
+  return (
+    /^gh[opusr]_[A-Za-z0-9]{20,}$/.test(value) ||
+    /^github_pat_\w{20,}$/.test(value) ||
+    /^[0-9a-f]{40}$/.test(value)
+  );
+}
+
+/**
  * Resolve the GitHub token for retro's code-owned write, dropping the hard
  * `GITHUB_TOKEN` requirement (7D8PJP): prefer the env var, else fall back to the
  * environment's existing GitHub access via `gh auth token`. Returns undefined when
  * neither is available, so the caller can no-op gracefully instead of failing.
+ *
+ * The env var is only honored when it is *shaped* like a GitHub token (#634):
+ * some environments (e.g. Claude cloud containers) populate `GITHUB_TOKEN` with
+ * a non-credential placeholder that would 401, muddying diagnosis — treat that
+ * as absent and fall through to `gh` instead of passing it to the API.
  */
 export function resolveGitHubToken(
   env: Record<string, string | undefined> = process.env,
   getGhToken: () => string | undefined = ghAuthToken,
 ): string | undefined {
   const fromEnvironment = env.GITHUB_TOKEN;
-  if (fromEnvironment && fromEnvironment.length > 0) return fromEnvironment;
+  if (fromEnvironment && looksLikeGitHubToken(fromEnvironment)) return fromEnvironment;
   return getGhToken();
 }
 

--- a/packages/cli/src/utils/ticket-writer.ts
+++ b/packages/cli/src/utils/ticket-writer.ts
@@ -28,12 +28,17 @@ import type { IdMinter } from './id-minter.js';
 const RETRY_BUDGET = 5;
 const NON_TICKET_ENTRIES = new Set(['completed', 'tmp']);
 
-export type TicketType = 'patch' | 'task' | 'feature';
+export type TicketType = 'patch' | 'task' | 'feature' | 'epic';
 
 export interface NewTicketOptions {
   slug: string;
   type?: TicketType;
   title?: string;
+  /** One-line Goal; fills the `**Goal:**` field instead of leaving a placeholder. */
+  goal?: string;
+  /** One-line Why; fills `**Why:**` for task/patch/epic. Not valid for features
+   * (their motivation lives in spec.md) — the CLI rejects `--why` there. */
+  why?: string;
   /** Override `new Date()` for tests. */
   now?: () => Date;
 }
@@ -140,13 +145,20 @@ out_of_scope:
 done_when:
 `
       : '';
+  // Epics are containers: they carry a `children:` list (bidirectional with each
+  // child's `parent:`). Born empty; children link in as they're created. Epics
+  // use the same inline **Goal:**/**Why:** body as tasks — matching the
+  // index-visible epic precedent (Q4FX8Y) so `sync-tickets` picks up the goal.
+  const childrenFrontmatter = type === 'epic' ? 'children: []\n' : '';
+
+  const goal = options.goal ?? '{One sentence: what are we trying to achieve?}';
 
   // Features keep motivation in spec.md's ## Intent (single source of truth)
-  // and point there; tasks/patches have no spec.md, so they keep **Why:**.
+  // and point there; task/patch/epic have no spec.md, so they keep **Why:**.
   const motivation =
     type === 'feature'
       ? '**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.'
-      : '**Why:** {One sentence: why does this matter?}';
+      : `**Why:** ${options.why ?? '{One sentence: why does this matter?}'}`;
 
   return `---
 id: ${id}
@@ -154,13 +166,13 @@ slug: ${options.slug}
 type: ${type}
 phase: intake
 status: in_progress
-${featureReadinessFrontmatter}created: ${now}
+${featureReadinessFrontmatter}${childrenFrontmatter}created: ${now}
 last_modified: ${now}
 ---
 
 # ${title}
 
-**Goal:** {One sentence: what are we trying to achieve?}
+**Goal:** ${goal}
 
 ${motivation}
 

--- a/packages/cli/src/utils/ticket-writer.ts
+++ b/packages/cli/src/utils/ticket-writer.ts
@@ -134,6 +134,11 @@ function idsAlreadyTaken(ticketsDirectory: string): Set<string> {
   return ids;
 }
 
+/** The value if it carries non-whitespace content, else the placeholder. */
+function filledOr(value: string | undefined, placeholder: string): string {
+  return value !== undefined && value.trim() !== '' ? value : placeholder;
+}
+
 function renderTicketMarkdown(id: string, options: NewTicketOptions): string {
   const type = options.type ?? 'task';
   const now = (options.now ?? (() => new Date()))().toISOString();
@@ -151,14 +156,16 @@ done_when:
   // index-visible epic precedent (Q4FX8Y) so `sync-tickets` picks up the goal.
   const childrenFrontmatter = type === 'epic' ? 'children: []\n' : '';
 
-  const goal = options.goal ?? '{One sentence: what are we trying to achieve?}';
+  // A blank/whitespace-only flag value keeps the placeholder rather than
+  // rendering `**Goal:** ` with a trailing space and no content.
+  const goal = filledOr(options.goal, '{One sentence: what are we trying to achieve?}');
 
   // Features keep motivation in spec.md's ## Intent (single source of truth)
   // and point there; task/patch/epic have no spec.md, so they keep **Why:**.
   const motivation =
     type === 'feature'
       ? '**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.'
-      : `**Why:** ${options.why ?? '{One sentence: why does this matter?}'}`;
+      : `**Why:** ${filledOr(options.why, '{One sentence: why does this matter?}')}`;
 
   return `---
 id: ${id}

--- a/packages/cli/templates/doc-templates/ticket-template.md
+++ b/packages/cli/templates/doc-templates/ticket-template.md
@@ -8,7 +8,7 @@ last_modified: YYYY-MM-DDTHH:MM:SSZ
 ---
 
 <!--
-type: patch | task | feature
+type: patch | task | feature | epic
 phase: intake | define-behavior | scenario-gate | implement | verify | done
   - patch/task: typically start at 'implement' or omit phase
   - feature: progresses through all phases via BDD workflow

--- a/packages/cli/templates/hooks/lib/jtbd.ts
+++ b/packages/cli/templates/hooks/lib/jtbd.ts
@@ -15,6 +15,13 @@ const PERSONA_PREFIX = '**Persona:**';
 const SKIP_PREFIX = 'skip:';
 /** Max persona short-code length — mirrors the CLI's `MAX_CODE_LENGTH`. */
 const MAX_CODE_LENGTH = 6;
+/**
+ * A level-4 heading only counts toward the AC gate when it carries a real
+ * lineage id — `<jtbd>.AC<n>` or `<jtbd>.R<n>` (#696). Without this, any
+ * `#### <heading>` (e.g. `#### Notes`) vacuously satisfied the "≥1 AC per JTBD"
+ * requirement. Matches the id token wherever it sits in the heading text.
+ */
+const AC_OR_RULE_HEADING = /(?:^|\.)(?:AC|R)\d+\b/i;
 
 export interface JtbdEntry {
   /** The raw `**Persona:**` reference (name, code, or `Name (CODE)`); may be empty. */
@@ -189,7 +196,12 @@ function parseAcsByJtbd(specContent: string): {
       } else if (inSection && heading.level === 3) {
         flush();
         current = { heading: heading.text, acCount: 0, skip: null };
-      } else if (inSection && heading.level >= 4 && current !== null) {
+      } else if (
+        inSection &&
+        heading.level >= 4 &&
+        current !== null &&
+        AC_OR_RULE_HEADING.test(heading.text)
+      ) {
         current.acCount++;
       }
       continue;

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -131,11 +131,11 @@ if (existsSync(stateFile)) {
         }
       } else {
         lines.push(
-          '- No active ticket. Classify (patch/task/feature) before starting. For features, run `/bdd`.',
+          '- No active ticket. Classify (patch/task/feature/epic) before starting. For features, run `/bdd`.',
         );
       }
     } else {
-      lines.push('- No active ticket. Classify (patch/task/feature) before starting.');
+      lines.push('- No active ticket. Classify (patch/task/feature/epic) before starting.');
     }
 
     // One-shot reminder: verify novel research claims before building on them.

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -177,7 +177,11 @@ DEPCRUISE_CONFIG=""
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
 [ -f Cargo.toml ] && {
-  cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  if command -v cargo > /dev/null 2>&1; then
+    cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
+  else
+    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+  fi
 }
 
 # =========================================================================

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -176,11 +176,14 @@ DEPCRUISE_CONFIG=""
 }
 
 # 2d. Rust-specific checks (Clippy catches unused code and quality issues)
+# Gate on `cargo-clippy` (the binary `cargo clippy` runs), not `cargo`: clippy
+# is a rustup component that can be absent while cargo is on PATH, and `|| true`
+# would otherwise swallow its failure into a false "clean" result.
 [ -f Cargo.toml ] && {
-  if command -v cargo > /dev/null 2>&1; then
+  if command -v cargo-clippy > /dev/null 2>&1; then
     cargo clippy --all-targets --all-features -- -D warnings 2>&1 || true
   else
-    echo "Manual evidence required: cargo not installed — Rust clippy check skipped"
+    echo "Manual evidence required: cargo clippy not available — Rust clippy check skipped"
   fi
 }
 

--- a/packages/cli/templates/skills/ticket-system/SKILL.md
+++ b/packages/cli/templates/skills/ticket-system/SKILL.md
@@ -22,10 +22,14 @@ elif [ -f packages/cli/src/cli.ts ]; then
   SW="bun packages/cli/src/cli.ts"
 else SW="bunx safeword"; fi
 
-$SW ticket new <slug> # optionally add --type=patch|task|feature and --title="..."
+$SW ticket new <slug> # --type=patch|task|feature|epic, --title="...", --goal="...", --why="..."
 ```
 
+`--goal` fills the Goal field for any type; `--why` fills the rationale for task/patch/epic (features keep motivation in spec.md, so `--why` is rejected there). `--type=epic` scaffolds a container ticket with an empty `children:` list.
+
 The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and writes a starter ticket.md. **Do not scan the tickets directory and pick the next ID yourself** — that races between parallel sessions and silently collides across git branches. If the resolver cannot run, stop and report that the CLI is unresolvable; do not hand-mint a fallback ID.
+
+**`ticket new` pre-populates ticket.md (and spec.md for features) with placeholder content.** Pass real values with `--goal`/`--title`/`--why` at creation, or **Edit** the scaffolded fields — do not blind-**Write** the whole file, which fails because the freshly-created file hasn't been Read yet.
 
 **Location:** `<namespace-root>/tickets/{ID}-{slug}/` for tickets created by the resolved `ticket new` command above (6-char Crockford ID plus normalized slug). Lookup remains backward-compatible with older `{ID}/` Crockford folders and legacy `{numeric-id}-{slug}/` folders — all formats remain reachable by ID.
 
@@ -37,7 +41,7 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 │   ├── 7K9M3P-login-bug/       # Current format: Crockford ID + normalized slug
 │   │   ├── ticket.md           # Ticket definition (frontmatter + work log)
 │   │   ├── test-definitions.md # BDD scenarios (Given/When/Then)
-│   │   ├── spec.md             # Feature spec for epics (optional)
+│   │   ├── spec.md             # Product spec (features only; auto-created)
 │   │   └── design.md           # Design doc for complex features (optional)
 │   ├── 7K9M3P/                 # Historical Crockford ID-only format, still readable
 │   │   └── ticket.md
@@ -50,11 +54,12 @@ The CLI mints a 6-char Crockford Base32 ID, creates the folder atomically, and w
 
 **Artifact Levels:**
 
-| Level       | Artifacts                                           |
-| ----------- | --------------------------------------------------- |
-| **feature** | ticket.md + test-definitions.md (+ spec.md if epic) |
-| **task**    | ticket.md with inline tests                         |
-| **patch**   | ticket.md (minimal), existing tests                 |
+| Level       | Artifacts                                    |
+| ----------- | -------------------------------------------- |
+| **epic**    | ticket.md (frontmatter `children:`), no spec |
+| **feature** | ticket.md + spec.md + test-definitions.md    |
+| **task**    | ticket.md with inline tests                  |
+| **patch**   | ticket.md (minimal), existing tests          |
 
 **Create a ticket** when any of these holds: multiple attempts are likely,
 the work is multi-step with dependencies, it needs investigation/debugging, or

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -6,7 +6,7 @@
  * slug suffix is for legibility when scanning `ls`. End-to-end via the built CLI.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -191,6 +191,82 @@ describe('safeword ticket new', () => {
       const result = await runCli(['ticket', 'new', ''], { cwd: temporaryDirectory });
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toMatch(/slug/i);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // #699 — epic is a first-class type; the CLI scaffolds a container ticket.
+  it(
+    'accepts --type=epic and scaffolds an empty children list, no spec.md (#699)',
+    async () => {
+      const result = await runCli(['ticket', 'new', 'big-rollout', '--type', 'epic'], {
+        cwd: temporaryDirectory,
+      });
+      expect(result.exitCode).toBe(0);
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const folder = nodePath.join(ticketsDirectory, folderName);
+      const ticketContent = readFileSync(nodePath.join(folder, 'ticket.md'), 'utf8');
+      expect(ticketContent).toMatch(/^type:\s*epic$/m);
+      expect(ticketContent).toMatch(/^children:\s*\[\]$/m);
+      // epics keep the inline **Goal:** shape (index-visible), not a ## Goal section
+      expect(ticketContent).toMatch(/^\*\*Goal:\*\*/m);
+      // container, not a feature: no spec.md and no scenario-gate readiness fields
+      expect(existsSync(nodePath.join(folder, 'spec.md'))).toBe(false);
+      expect(ticketContent).not.toMatch(/^scope:/m);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // #724 — --goal fills the Goal field instead of leaving a {placeholder}.
+  it(
+    'fills the Goal field from --goal, leaving no placeholder (#724)',
+    async () => {
+      await runCli(['ticket', 'new', 'auth-flow', '--goal', 'Ship SSO for admins'], {
+        cwd: temporaryDirectory,
+      });
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const ticketContent = readFileSync(
+        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
+        'utf8',
+      );
+      expect(ticketContent).toMatch(/^\*\*Goal:\*\* Ship SSO for admins$/m);
+      expect(ticketContent).not.toMatch(/\{One sentence: what/);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  it(
+    'fills the Why field from --why for a task',
+    async () => {
+      await runCli(['ticket', 'new', 'auth-flow', '--why', 'Customers keep asking'], {
+        cwd: temporaryDirectory,
+      });
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const ticketContent = readFileSync(
+        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
+        'utf8',
+      );
+      expect(ticketContent).toMatch(/^\*\*Why:\*\* Customers keep asking$/m);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // Features keep motivation in spec.md, so --why has no target there — fail loud.
+  it(
+    'rejects --why on a feature with exit code 1',
+    async () => {
+      const result = await runCli(
+        ['ticket', 'new', 'auth-flow', '--type', 'feature', '--why', 'nope'],
+        { cwd: temporaryDirectory },
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/spec\.md/);
     },
     TIMEOUT_QUICK,
   );

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -29,6 +29,17 @@ function readOnlyTicketFolderName(ticketsDirectory: string): string {
   return folderName;
 }
 
+/** Absolute path of the single ticket folder created under the temp dir. */
+function soleTicketFolder(temporaryDirectory: string): string {
+  const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+  return nodePath.join(ticketsDirectory, readOnlyTicketFolderName(ticketsDirectory));
+}
+
+/** Contents of the single created ticket.md. */
+function readSoleTicket(temporaryDirectory: string): string {
+  return readFileSync(nodePath.join(soleTicketFolder(temporaryDirectory), 'ticket.md'), 'utf8');
+}
+
 function extractIdFromFolder(folderName: string): string {
   const match = FOLDER_PATTERN.exec(folderName);
   const id = match?.[1];
@@ -71,13 +82,9 @@ describe('safeword ticket new', () => {
     async () => {
       await runCli(['ticket', 'new', 'login-bug'], { cwd: temporaryDirectory });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const folderName = nodePath.basename(soleTicketFolder(temporaryDirectory));
       const id = extractIdFromFolder(folderName);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
 
       expect(id).toMatch(ID_PATTERN);
       expect(ticketContent).toContain(`id: ${id}`);
@@ -109,12 +116,7 @@ describe('safeword ticket new', () => {
         cwd: temporaryDirectory,
       });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^type:\s*feature$/m);
     },
     TIMEOUT_QUICK,
@@ -127,12 +129,7 @@ describe('safeword ticket new', () => {
         cwd: temporaryDirectory,
       });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
 
       expect(ticketContent).toMatch(/^scope:\s*$/m);
       expect(ticketContent).toMatch(/^out_of_scope:\s*$/m);
@@ -158,12 +155,7 @@ describe('safeword ticket new', () => {
     async () => {
       await runCli(['ticket', 'new', 'Login Bug'], { cwd: temporaryDirectory });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^slug:\s*login-bug$/m);
     },
     TIMEOUT_QUICK,
@@ -174,12 +166,7 @@ describe('safeword ticket new', () => {
     async () => {
       await runCli(['ticket', 'new', 'fix/auth-flow!'], { cwd: temporaryDirectory });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^slug:\s*fix-auth-flow$/m);
     },
     TIMEOUT_QUICK,
@@ -204,9 +191,7 @@ describe('safeword ticket new', () => {
       });
       expect(result.exitCode).toBe(0);
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const folder = nodePath.join(ticketsDirectory, folderName);
+      const folder = soleTicketFolder(temporaryDirectory);
       const ticketContent = readFileSync(nodePath.join(folder, 'ticket.md'), 'utf8');
       expect(ticketContent).toMatch(/^type:\s*epic$/m);
       expect(ticketContent).toMatch(/^children:\s*\[\]$/m);
@@ -227,12 +212,7 @@ describe('safeword ticket new', () => {
         cwd: temporaryDirectory,
       });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^\*\*Goal:\*\* Ship SSO for admins$/m);
       expect(ticketContent).not.toMatch(/\{One sentence: what/);
     },
@@ -246,12 +226,7 @@ describe('safeword ticket new', () => {
         cwd: temporaryDirectory,
       });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^\*\*Why:\*\* Customers keep asking$/m);
     },
     TIMEOUT_QUICK,
@@ -291,12 +266,7 @@ describe('safeword ticket new', () => {
         { cwd: temporaryDirectory },
       );
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^\*\*Goal:\*\* Coordinate rollout$/m);
       expect(ticketContent).toMatch(/^\*\*Why:\*\* Too many moving parts$/m);
     },
@@ -311,12 +281,7 @@ describe('safeword ticket new', () => {
         cwd: temporaryDirectory,
       });
 
-      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-      const folderName = readOnlyTicketFolderName(ticketsDirectory);
-      const ticketContent = readFileSync(
-        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
-        'utf8',
-      );
+      const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^\*\*Goal:\*\* \{One sentence/m);
     },
     TIMEOUT_QUICK,

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -270,4 +270,55 @@ describe('safeword ticket new', () => {
     },
     TIMEOUT_QUICK,
   );
+
+  // The epic + --goal/--why interaction is the novel path: epics render the same
+  // inline **Goal:**/**Why:** fields as tasks, so both flags must land there.
+  it(
+    'fills Goal and Why from flags on an epic',
+    async () => {
+      await runCli(
+        [
+          'ticket',
+          'new',
+          'big-rollout',
+          '--type',
+          'epic',
+          '--goal',
+          'Coordinate rollout',
+          '--why',
+          'Too many moving parts',
+        ],
+        { cwd: temporaryDirectory },
+      );
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const ticketContent = readFileSync(
+        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
+        'utf8',
+      );
+      expect(ticketContent).toMatch(/^\*\*Goal:\*\* Coordinate rollout$/m);
+      expect(ticketContent).toMatch(/^\*\*Why:\*\* Too many moving parts$/m);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // A blank flag value keeps the placeholder rather than an empty, content-less field.
+  it(
+    'keeps the Goal placeholder when --goal is blank',
+    async () => {
+      await runCli(['ticket', 'new', 'auth-flow', '--goal', ' '.repeat(3)], {
+        cwd: temporaryDirectory,
+      });
+
+      const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+      const folderName = readOnlyTicketFolderName(ticketsDirectory);
+      const ticketContent = readFileSync(
+        nodePath.join(ticketsDirectory, folderName, 'ticket.md'),
+        'utf8',
+      );
+      expect(ticketContent).toMatch(/^\*\*Goal:\*\* \{One sentence/m);
+    },
+    TIMEOUT_QUICK,
+  );
 });

--- a/packages/cli/tests/hooks/ac-gate.test.ts
+++ b/packages/cli/tests/hooks/ac-gate.test.ts
@@ -61,6 +61,14 @@ describe('evaluateAcGate', () => {
     if (!verdict.ok) expect(verdict.reason).toContain('demo.PO1');
   });
 
+  // #696 — common non-lineage headings that could be mistaken for ACs must not
+  // satisfy the gate. "Acceptance Criteria" is the case-insensitivity trap (Ac…
+  // with no digit); "Rollback plan" starts with R but has no R<n>.
+  it('does not count "#### Acceptance Criteria" or "#### Rollback plan" (S1.8, #696)', () => {
+    const body = `${JTBD1}\n#### Acceptance Criteria\n\n#### Rollback plan\n`;
+    expect(evaluateAcGate(spec(body)).ok).toBe(false);
+  });
+
   it('passes vacuously when the whole JTBD section is skipped (S2.1)', () => {
     expect(evaluateAcGate(spec('skip: internal plumbing — no persona-facing job\n')).ok).toBe(true);
   });

--- a/packages/cli/tests/hooks/ac-gate.test.ts
+++ b/packages/cli/tests/hooks/ac-gate.test.ts
@@ -55,6 +55,12 @@ describe('evaluateAcGate', () => {
     expect(evaluateAcGate(spec(body)).ok).toBe(false);
   });
 
+  it('does not count a non-lineage level-4 heading like "#### Notes" (S1.7, #696)', () => {
+    const verdict = evaluateAcGate(spec(`${JTBD1}\n#### Notes — some context, not an AC\n`));
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toContain('demo.PO1');
+  });
+
   it('passes vacuously when the whole JTBD section is skipped (S2.1)', () => {
     expect(evaluateAcGate(spec('skip: internal plumbing — no persona-facing job\n')).ok).toBe(true);
   });


### PR DESCRIPTION
Fixes a batch of low-risk items surfaced during a triage of the `retro`-labeled issue backlog (72 issues reviewed; 34 already-fixed and 3 out-of-scope were closed; the rest ranked by value ÷ risk). This PR implements the top quick-wins plus the `ticket new` cluster.

## Commit 1 — low-risk quick-wins (`104800b`)

- **#696** — the AC intake gate no longer counts arbitrary level-4 headings; only lineage headings (`<jtbd>.AC<n>` / `<jtbd>.R<n>`) satisfy "≥1 AC per JTBD", so `#### Notes` can't vacuously pass it. (`jtbd.ts` + mirror; new discrimination test.)
- **#634** — `resolveGitHubToken` validates token shape, so a non-credential placeholder like `proxy-injected` is treated as absent and resolution falls through to `gh` instead of 401-ing against the API. (New rejection test.)
- **#705** — the audit skill guards `cargo clippy` behind `command -v cargo`, so a missing Rust toolchain reads as "skipped", not a clean result.
- **#793** — knip ignores the BDD step-definition CLI subcommands (`setup`, `check`, `lint-gherkin`) that were recurring false-positive unlisted binaries.

## Commit 2 — `ticket new` epic + `--goal`/`--why` (`c2662b0`)

- **#699** — `--type=epic` is now accepted and scaffolds a container ticket with an empty `children:` list, using the same inline `**Goal:**`/`**Why:**` body as a task (the index-visible epic precedent) — no spec.md, no scenario-gate readiness fields.
- **#724** — `--goal` fills the Goal field at creation instead of leaving a `{placeholder}` the caller must overwrite.
- **#700** — `--why` fills the rationale for task/patch/epic (rejected on features, whose motivation lives in spec.md). Supplying content at creation removes the Read-before-Write trap; the ticket-system skill now also tells agents to Edit the scaffold rather than blind-Write it.

Design was run through `/figure-it-out` and `/quality-review` before implementation — the review caught that a `## Goal` epic body would have silently dropped epics from index goal-extraction, so epics use the inline `**Goal:**` shape instead (smaller diff, index-visible).

## Not in scope (follow-up)

A `--parent <epicId>` linker for child creation that sets the child's `parent:`/`epic:` fields and appends to the epic's `children[]` — the piece that makes epic hierarchy navigation fully automatic.

## Verification

- Targeted suites green: `ac-gate`, `github-rest`, `jtbd`, `parser-parity`, `retro`, `ticket-new`, `ticket-writer`.
- `tsc --noEmit` clean; all pre-commit gates (parity contracts, schema, lint-staged) pass.
- Live CLI smoke confirmed epic scaffold, `--goal` fill, and the `--why`-on-feature rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXdv6zZRRJdCGf7XkCqvkh)_