### PR TITLE
refactor: post-48h cleanup — fail() helper + shared cucumber spawn options

### DIFF
--- a/packages/cli/src/commands/ticket-new.ts
+++ b/packages/cli/src/commands/ticket-new.ts
@@ -32,19 +32,15 @@ export function ticketNew(slug: string, options: TicketNewOptions): Promise<void
 function ticketNewSync(slug: string, options: TicketNewOptions): void {
   const type = resolveType(options.type);
   if (type === 'invalid') {
-    process.stderr.write(
-      `Invalid --type=${String(options.type)}. Must be one of: patch, task, feature, epic.\n`,
-    );
-    process.exit(1);
+    fail(`Invalid --type=${String(options.type)}. Must be one of: patch, task, feature, epic.`);
   }
 
   // Features keep motivation in spec.md (single source of truth), so they have
   // no **Why:** field for --why to fill — fail loud rather than silently drop it.
   if (options.why !== undefined && type === 'feature') {
-    process.stderr.write(
-      '--why does not apply to features — their motivation lives in spec.md. Use --goal, or edit spec.md.\n',
+    fail(
+      '--why does not apply to features — their motivation lives in spec.md. Use --goal, or edit spec.md.',
     );
-    process.exit(1);
   }
 
   let normalizedSlug: string;
@@ -52,8 +48,7 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
     normalizedSlug = normalizeSlug(slug);
   } catch (error: unknown) {
     if (error instanceof SlugError) {
-      process.stderr.write(`${error.message}\n`);
-      process.exit(1);
+      fail(error.message);
     }
     throw error;
   }
@@ -77,11 +72,16 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
     // The index refreshes via `safeword sync-tickets` and `safeword check`. 1GGD28.
   } catch (error: unknown) {
     if (error instanceof TicketIdCollisionError) {
-      process.stderr.write(`${error.message}\n`);
-      process.exit(1);
+      fail(error.message);
     }
     throw error;
   }
+}
+
+/** Write a one-line diagnostic to stderr and exit non-zero. */
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
 }
 
 function resolveType(value: string | undefined): TicketType | undefined | 'invalid' {

--- a/packages/cli/tests/integration/cucumber-bdd.test.ts
+++ b/packages/cli/tests/integration/cucumber-bdd.test.ts
@@ -26,18 +26,24 @@ const CUCUMBER_WIRING_CHECK_ARGS = ['cucumber-js', '--dry-run', '--format', 'sum
 // fails the status assertion with useful output instead of stalling the lane.
 const CUCUMBER_CHILD_TIMEOUT = 90_000;
 const CUCUMBER_CHILD_KILL_SIGNAL = 'SIGKILL';
+const CUCUMBER_SPAWN_OPTIONS = {
+  cwd: CLI_DIRECTORY,
+  encoding: 'utf8',
+  timeout: CUCUMBER_CHILD_TIMEOUT,
+  killSignal: CUCUMBER_CHILD_KILL_SIGNAL,
+} as const;
+
+/** stdout + stderr combined the way every assertion in this lane reads it. */
+function combinedOutput(result: { stdout?: string | null; stderr?: string | null }): string {
+  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+}
 
 describe('cucumber-js acceptance lane (SM1.AC1)', () => {
   it(
     'gherkin-typescript.SM1.AC1.dogfood_feature_wiring_loads_without_executing_steps',
     () => {
-      const result = spawnSync('bunx', CUCUMBER_WIRING_CHECK_ARGS, {
-        cwd: CLI_DIRECTORY,
-        encoding: 'utf8',
-        timeout: CUCUMBER_CHILD_TIMEOUT,
-        killSignal: CUCUMBER_CHILD_KILL_SIGNAL,
-      });
-      const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+      const result = spawnSync('bunx', CUCUMBER_WIRING_CHECK_ARGS, CUCUMBER_SPAWN_OPTIONS);
+      const output = combinedOutput(result);
       expect(result.status, output).toBe(0);
       expect(output).toMatch(/\b[1-9]\d* scenarios? \([1-9]\d* skipped\)/);
       expect(output).not.toMatch(/undefined|ambiguous|pending|passed/);
@@ -85,15 +91,10 @@ describe('cucumber-js acceptance lane (SM1.AC1)', () => {
             '@demo.DEV2.R1',
             featurePath,
           ],
-          {
-            cwd: CLI_DIRECTORY,
-            encoding: 'utf8',
-            timeout: CUCUMBER_CHILD_TIMEOUT,
-            killSignal: CUCUMBER_CHILD_KILL_SIGNAL,
-          },
+          CUCUMBER_SPAWN_OPTIONS,
         );
 
-        const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+        const output = combinedOutput(result);
         expect(result.status, output).toBe(0);
         // Rule-level tag inheritance: exactly R1's two scenarios are selected
         // (undefined — the fixture ships no step definitions); R2's scenario is


### PR DESCRIPTION
Behavior-preserving refactor pass over the code merged in the last ~48h (#764, #756, #763, #786, #817). A three-agent scout found the genuinely-new logic (`resolveRustEdition`, `readBddConventionsPath`, `looksLikeGitHubToken`, the jtbd AC-gate, the codify pointer) already clean — only two in-scope cleanups applied, each committed and tested individually per the refactor discipline.

## Changes

- **`refactor(ticket-new)`** — extract `fail(message): never` for the four identical `process.stderr.write(msg); process.exit(1)` sites (invalid `--type`, `--why`-on-feature, `SlugError`, `TicketIdCollisionError`; #817 added the fourth). Byte-identical stderr + exit code; the `never` return preserves the existing control-flow narrowing. `ticket-new.test.ts` 15/15.
- **`refactor(test)`** — hoist the byte-identical `spawnSync` options bag into `CUCUMBER_SPAWN_OPTIONS` and the repeated stdout+stderr combine into a `combinedOutput()` helper in the acceptance-lane test (#786 made both spawn bags identical). Test-only; `cucumber-bdd.test.ts` 3/3.

## Not applied (out of scope)

The scouts also surfaced cleanups in **pre-existing** code the 48h PRs merely sat near — rust clippy dedup, a `configured-paths` `isAbsolute?…:join` helper, `github-rest` pagination magic-`100`, golang nestif, a `ticket-writer` type-default. Left untouched (outside "merged in the last 48h"); worth a separate tidy-up ticket.

## Verification

- Full suite: **325 files, 4639 passed / 5 skipped**.
- eslint + `tsc --noEmit`: clean.

Cuts release **v0.64.0** on merge (already the version in both manifests from #785, never published — npm is still on 0.63.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmPeTtB72TjBWquzo8t3Eo)_