### PR TITLE
chore(release): v0.65.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.64.0",
+      "version": "0.65.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.65.0** (minor — additive; auto-upgradeable).

Bumps `packages/cli/package.json` and `.claude-plugin/marketplace.json` to `0.65.0`.

## Since v0.63.0 (the last published version)

npm is still on 0.63.0 — the earlier 0.64.0 tag never published (blocked). This 0.65.0 rolls up everything since:

- **#823** — Rust langpack quality stack: new `deps` plan-kind (`cargo deny check advisories`), Rust `typecheck` → workspace clippy gate, auto-scaffolded `deny.toml` (the additive feature driving the minor).
- **#817** — `ticket new` epic + `--goal`/`--why`; retro quick-wins (AC-gate lineage fix, token-shape validation).
- **#756** — additive `bdd.conventions` config key.
- **#763** — audit follow-ups (dep hygiene, Rust/Go pack currency).
- **#764 / #786** — cucumber spawn retry + test-harness reliability.
- **#795 / #803 / #804** — tsx bump, de-prescribe instruction-layer pass, context-files-guide sweep.
- **#835** — post-48h refactor (fail() helper, shared cucumber spawn options).

All strictly additive/corrective — passes the "auto-upgrade at SessionStart, does anything break?" test in the negative → **minor**. (The breaking Node-24 work in #806 is deliberately **not** here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmPeTtB72TjBWquzo8t3Eo)_