### PR TITLE
`ticket new --parent`: link a child ticket to its epic in one command (F9W3JP)

### DIFF
--- a/.project/tickets/F9W3JP-epic-child-linker/dimensions.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/dimensions.md
@@ -1,0 +1,21 @@
+# Dimensions: `ticket new --parent` epic-child linker (F9W3JP)
+
+Derived from spec.md (TB1.AC1–AC4, done_when) + domain knowledge (bidirectional
+`parent:`⇄`children:` link, atomic frontmatter mutation, index grouping).
+
+| Dimension                    | Partitions                                                                                          | AC       |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- | -------- |
+| `--parent` reference         | valid `type: epic`; id of a non-epic ticket (task/feature/patch); id with no folder                 | AC1, AC3 |
+| Epic `children:` prior state | empty `[]`; non-empty list; list already containing this child id (idempotency)                     | AC1, AC4 |
+| Child link written           | child `parent:` equals the epicId; navigation (`findNextWork`) reaches the child                    | AC1      |
+| Index grouping               | linked child appears under its epic's heading in `INDEX.md` (grouped via `parent:`, no `epic:` set) | AC2      |
+| Failure atomicity            | on a rejected `--parent`, no child folder is created and the epic file is untouched                 | AC3      |
+| Append safety                | existing `children:` entries preserved; id added at most once; epic written atomically (tmp+rename)  | AC4      |
+| No-`--parent` (regression)   | `ticket new` without `--parent` writes no `parent:` and mutates no other ticket                     | —        |
+
+**Test layers:** the link mechanics — validate-epic, append-if-absent, atomic write — are a **unit** on a pure helper exercised against a real temp-dir fs (mirrors `hierarchy.ts` helper tests; only fs is the boundary). End-to-end `--parent` behavior (child frontmatter + epic `children:` + exit codes + no-op-on-error) is **command-level** via `runCli` in a temp dir, like `tests/commands/ticket-new.test.ts`. Index grouping is asserted at the **sync-tickets** command level (temp dir → generate `INDEX.md` → assert the child sits under its epic).
+
+**Baked decision (from /figure-it-out):** the child→epic relationship has a
+single source of truth, `parent:`. No `epic:` field is written; `INDEX.md`
+grouping resolves the epic from `parent:`. This rejects the dual-write
+(`parent:` + `epic:`) alternative to avoid drift.

--- a/.project/tickets/F9W3JP-epic-child-linker/impl-plan.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/impl-plan.md
@@ -1,6 +1,6 @@
 # Impl Plan: ticket new --parent links epic and child
 
-**Status:** planned
+**Status:** implemented
 
 ## Approach
 
@@ -62,7 +62,17 @@ The INDEX grouping key moves from `epic:` to `parent:` — a deliberate
 reconciliation of two competing relationship representations toward the single
 source of truth. Kept backward-compatible: a legacy `epic:` value is used as a
 fallback when `parent:` is absent, and tickets with neither still group under
-`(no epic)`. No other deviation from arch guidance.
+`(no epic)`.
+
+**Reconciliation (what actually shipped vs. plan):** the plan implied all 7
+scenarios would run in the Gherkin acceptance lane. In practice the two internal
+contracts with no CLI surface — findNextWork navigation (S2) and append
+idempotency (S7) — were removed from the black-box `.feature` and kept as
+vitest-only proofs (integration + unit, already green), because the cucumber
+lane drives the built CLI and neither behavior is reachable through it. The
+`.feature` documents this in place of the removed scenarios; AC1 and AC4 each
+still carry a tagged acceptance scenario (S1, S6). Decisions and Arch alignment
+above held as written — no change.
 
 ## Assessment triggers
 

--- a/.project/tickets/F9W3JP-epic-child-linker/impl-plan.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/impl-plan.md
@@ -1,0 +1,72 @@
+# Impl Plan: ticket new --parent links epic and child
+
+**Status:** planned
+
+## Approach
+
+**Riskiest assumption:** that grouping `INDEX.md` by `parent:` (AC2) won't regress
+the index for tickets that don't participate — the change touches `index.ts` for
+*every* ticket, not just linked children. Cheapest proof: scenario 3
+(`AC2.index_groups_child_under_epic`) plus keeping the existing `ticket-sync` /
+index test suite green. Sequence that slice **last**, after linking works, so a
+wrong grouping choice fails a cheap, isolated slice rather than the whole feature.
+
+The second load-bearing slice is the append itself: mutating the epic's varied
+existing `children:` formats without corruption. Proven by the AC4 pair.
+
+**Proof plan (per scenario, highest practical scope):**
+
+| Scenario | Primary proof | Why enough / supporting |
+| --- | --- | --- |
+| AC1 `linking_records_parent_and_appends_to_epic` (S1) | command (`runCli` in temp dir) | asserts child `parent:` + epic `children[]` — the observable both-ways contract; supported by a unit test of the `linkChildToEpic` helper |
+| AC1 `navigation_from_epic_reaches_child` (S2) | integration | **proof-plan constraint (gate strengthen):** the `Given` builds the link through the real `ticket new --parent` command, then calls `findNextWork` — so it exercises the new feature, not pre-existing navigation |
+| AC2 `index_groups_child_under_epic` (S3) | command (`sync-tickets`) | create epic+child via `--parent`, regenerate `INDEX.md`, assert child under the epic heading |
+| AC3 `missing_parent_rejected` (S4) | command | `runCli --parent ZZZZZZ` → exit≠0, message names missing epic, no child folder |
+| AC3 `non_epic_parent_rejected` (S5) | command | `--parent` on a task → exit≠0, "not an epic" message, target frontmatter unchanged, no child folder |
+| AC4 `second_child_preserves_first` (S6) | unit + command | append a second id, assert both present (order-insensitive) |
+| AC4 `linking_twice_adds_at_most_once` (S7) | unit | call `linkChildToEpic` twice with the same id from an unlisted start → id present exactly once |
+| no-`--parent` regression (no AC) | command (`tests/commands/ticket-new.test.ts`) | **gate strengthen:** `ticket new` without `--parent` produces a ticket with **no `parent:` key** and touches **no other ticket/epic file** — proves `--parent` logic doesn't leak into the default create path |
+
+Atomic tmp+rename write (AC4) is asserted at the **unit** layer only — an
+interrupted mid-write can't be induced deterministically via `runCli`; a
+behavioral scenario would be flaky or white-box (gate confirmed this deferral).
+
+**Build order (load-bearing sequencing):**
+
+1. `linkChildToEpic(childId, epicId)` helper — validate epic exists & is `type: epic`, append-if-absent, atomic write-then-rename. Unit tests S6, S7. *(load-bearing append)*
+2. Wire `--parent` into `ticket new` — write child `parent:`, call the helper, surface validation errors. Command tests S1, S4, S5 + regression test.
+3. Navigation proof S2 (integration) once wiring is green.
+4. INDEX grouping-by-`parent:` in `ticket-sync/index.ts` — S3. *(riskiest, biggest blast radius, last)*
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| -------- | ------ | ----------------------- | ---------------- |
+| Relationship representation | single `parent:` on child + epic `children[]` | dual-write `parent:` + `epic:` on child | two fields for one relationship drift; existing corpus never maintains `epic:` |
+| CLI surface | `--parent` flag on `ticket new` | standalone `ticket link <child> <epic>` command | primary use is create-time; a link verb is more surface for the rarer retro-link path — deferred, both would share the helper |
+| Epic file mutation | read → inline-parse → append-if-absent → tmp-write + `renameSync` | in-place regex substitution | regex can't safely handle the varied `children:` formats (flow array, bare string); atomic write prevents half-written epics |
+| INDEX grouping source | resolve group from `parent:`, falling back to legacy `epic:` if present | keep grouping on `epic:` only | single source of truth; `epic:` is unset in practice so children never group today |
+
+## Arch alignment
+
+Honors **ARCHITECTURE.md → "Hierarchy Navigation on Ticket Completion"** (§468):
+the `parent:` ⇄ `children:` bidirectional contract that `findNextWork` walks, and
+the **zero-dependency inline `parseFrontmatter`** rule (hooks/CLI run where the
+`yaml` package isn't installed). `linkChildToEpic` reuses `hierarchy.ts`'s
+existing inline parser + the `updateTicketStatus` write-then-rename pattern
+rather than adding a YAML dependency.
+
+## Known deviations
+
+The INDEX grouping key moves from `epic:` to `parent:` — a deliberate
+reconciliation of two competing relationship representations toward the single
+source of truth. Kept backward-compatible: a legacy `epic:` value is used as a
+fallback when `parent:` is absent, and tickets with neither still group under
+`(no epic)`. No other deviation from arch guidance.
+
+## Assessment triggers
+
+Revisit these choices if: nested / multi-level epic hierarchies are introduced;
+a standalone re-parent or unlink command is added (would promote the shared
+helper to a first-class command); or the `children:` frontmatter format is ever
+normalized (the append helper's format-tolerance could then simplify).

--- a/.project/tickets/F9W3JP-epic-child-linker/spec.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/spec.md
@@ -1,0 +1,93 @@
+# Spec: ticket new --parent links epic and child
+
+## Intent
+
+When a builder decomposes a large piece of work into an epic plus child tickets,
+safeword's hierarchy only "works" if the child records `parent:` **and** the
+epic's `children:` list names the child — a bidirectional link that today is
+hand-wired after every `ticket new`. This feature makes `ticket new --parent
+<epicId>` write both ends of that link in one step (and surface the child under
+its epic in the index), so epic decomposition is a single command instead of a
+create-then-hand-edit ritual.
+
+## Intake Brief
+
+- **Requested by:** Filed as the deferred A2 follow-up to the epic-scaffolding
+  work (issue #699); surfaced again by the quality-review of PR #817.
+- **Cost of inaction:** Every epic child is hand-linked by editing two files
+  (`parent:` on the child, `children:` append on the epic). Miss either end and
+  `findNextWork` silently returns `all-done`, skipping the sub-tickets — a
+  correctness gap that reads as "the workflow lost my tickets."
+- **Reversibility:** Two-way door. Additive CLI flag + one grouping change in a
+  generated, always-regenerated index; no data migration, no public API break.
+
+## References
+
+- #699 (`--type=epic` scaffolding — shipped in PR #817); this is its deferred A2 linker.
+- `packages/cli/templates/hooks/lib/hierarchy.ts` — `findNextWork` navigation contract (`parent:` ⇄ `children:`).
+- `packages/cli/src/ticket-sync/index.ts` — INDEX grouping (currently keyed to `epic:`).
+- `/figure-it-out` design record: single source of truth (`parent:`), no duplicate `epic:` field.
+
+## Personas
+
+- Technical Builder (TB)
+
+## Surfaces
+
+Affected:
+
+- The `safeword ticket new` CLI command — behaves identically across every agent
+  surface (Claude Code, Codex, Cursor) because they all invoke the same binary.
+  `skip: no surface-specific behavior — one code path for all CLI surfaces`
+
+## Vocabulary
+
+- **Epic** — a container ticket (`type: epic`) whose `children:` frontmatter
+  lists the ids of the tickets decomposed under it.
+- **Child** — a ticket whose `parent:` frontmatter names its epic.
+- **Link** — the bidirectional pair: child `parent:` + epic `children[]` entry.
+
+## Jobs To Be Done
+
+### epic-child-linker.TB1 — Wire a child to its epic in one command
+
+**Persona:** Technical Builder (TB)
+
+> When I break an epic into child tickets, I want creating a child to record
+> both ends of the epic↔child link, so the workflow can navigate the hierarchy
+> and show it in the index without me hand-editing two files.
+
+#### epic-child-linker.TB1.AC1 — Creating a child with `--parent` links it both ways
+
+The child's `parent:` names the epic and the epic's `children:` list gains the
+child's id, so `findNextWork` navigates epic → child correctly.
+
+#### epic-child-linker.TB1.AC2 — The linked child appears under its epic in the index
+
+`safeword sync-tickets` / `safeword check` group the child under its epic in
+`INDEX.md`, driven by the same `parent:` link — no separate `epic:` field to
+drift.
+
+#### epic-child-linker.TB1.AC3 — A bad `--parent` fails loud, creating nothing
+
+`--parent` pointing at a missing ticket, or at a ticket that is not `type:
+epic`, exits non-zero with an actionable message and does not create a
+half-linked child or mutate any epic.
+
+#### epic-child-linker.TB1.AC4 — Linking is idempotent and never corrupts the epic
+
+Appending the child preserves the epic's existing `children:` entries and adds
+the new id at most once; the epic file is written atomically so an interrupted
+run can't leave it half-written.
+
+## Rave Moment
+
+skip: table-stakes — this is hierarchy plumbing; the reward is the absence of a
+chore, not a moment worth recounting.
+
+## Outcomes
+
+- Creating a child with `--parent <epicId>` yields a child whose `parent:` and
+  the epic's `children:` agree, with zero manual edits.
+- `INDEX.md` lists the new child under its epic heading.
+- A wrong `--parent` value stops with a clear error and leaves the tree unchanged.

--- a/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
@@ -1,0 +1,62 @@
+# Test Definitions: `ticket new --parent` epic-child linker (F9W3JP)
+
+Feature source: `packages/cli/features/epic-child-linker.feature`
+
+<!-- Scenario lineage: epic-child-linker.TB1.AC<#>. AC1 = bidirectional link
+     (child parent: + epic children[] append) + navigation; AC2 = index grouping
+     via parent:; AC3 = fail-loud validation with no mutation; AC4 = idempotent,
+     order-preserving append. Test layers: link mechanics (validate-epic,
+     append-if-absent, atomic write) are unit tests of a pure helper over a real
+     temp-dir fs; end-to-end --parent behavior + exit codes are command-level via
+     runCli; index grouping is asserted at the sync-tickets command level.
+     test-definitions.md is the R/G/R ledger — G/W/T lives in the .feature. -->
+
+## Rule: --parent links a new child to its epic both ways
+
+### Scenario: epic-child-linker.TB1.AC1.linking_records_parent_and_appends_to_epic
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: epic-child-linker.TB1.AC1.navigation_from_epic_reaches_child
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: A linked child appears under its epic in the index
+
+### Scenario: epic-child-linker.TB1.AC2.index_groups_child_under_epic
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: An invalid --parent fails loud and changes nothing
+
+### Scenario: epic-child-linker.TB1.AC3.missing_parent_rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: epic-child-linker.TB1.AC3.non_epic_parent_rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Linking is idempotent and preserves the epic's existing children
+
+### Scenario: epic-child-linker.TB1.AC4.second_child_preserves_first
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: epic-child-linker.TB1.AC4.linking_twice_adds_at_most_once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
@@ -21,17 +21,17 @@ Feature source: `packages/cli/features/epic-child-linker.feature`
 
 ### Scenario: epic-child-linker.TB1.AC1.navigation_from_epic_reaches_child
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: findNextWork navigation contract pre-exists; scenario proves the --parent link feeds it (green on first run)
+- [x] GREEN a2c2060
+- [x] REFACTOR skip: integration proof, no production code
 
 ## Rule: A linked child appears under its epic in the index
 
 ### Scenario: epic-child-linker.TB1.AC2.index_groups_child_under_epic
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED d8699c1
+- [x] GREEN 0f17529
+- [x] REFACTOR skip: one-line grouping-key change, nothing to restructure
 
 ## Rule: An invalid --parent fails loud and changes nothing
 

--- a/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/test-definitions.md
@@ -15,9 +15,9 @@ Feature source: `packages/cli/features/epic-child-linker.feature`
 
 ### Scenario: epic-child-linker.TB1.AC1.linking_records_parent_and_appends_to_epic
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9aecb5f
+- [x] GREEN ff52e24
+- [x] REFACTOR ff52e24 extracted assertOptionsValid/resolveSlug guards to hold complexity
 
 ### Scenario: epic-child-linker.TB1.AC1.navigation_from_epic_reaches_child
 
@@ -37,26 +37,26 @@ Feature source: `packages/cli/features/epic-child-linker.feature`
 
 ### Scenario: epic-child-linker.TB1.AC3.missing_parent_rejected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9aecb5f
+- [x] GREEN ff52e24
+- [x] REFACTOR skip: validation is a single guard, nothing to restructure
 
 ### Scenario: epic-child-linker.TB1.AC3.non_epic_parent_rejected
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 9aecb5f
+- [x] GREEN ff52e24
+- [x] REFACTOR skip: shares the validateEpicParent guard with the missing-parent case
 
 ## Rule: Linking is idempotent and preserves the epic's existing children
 
 ### Scenario: epic-child-linker.TB1.AC4.second_child_preserves_first
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 2db17dc
+- [x] GREEN edf4b05
+- [x] REFACTOR skip: helper authored clean in GREEN; no separate refactor step
 
 ### Scenario: epic-child-linker.TB1.AC4.linking_twice_adds_at_most_once
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 2db17dc
+- [x] GREEN edf4b05
+- [x] REFACTOR skip: idempotency covered by the same GREEN helper

--- a/.project/tickets/F9W3JP-epic-child-linker/ticket.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/ticket.md
@@ -2,8 +2,8 @@
 id: F9W3JP
 slug: epic-child-linker
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 scope:
   - a `--parent <epicId>` flag on `ticket new` that writes `parent: <epicId>` on the new child
   - idempotent, atomic append of the child id to the epic's `children:` list
@@ -37,3 +37,5 @@ last_modified: 2026-07-05T17:25:42.420Z
 - 2026-07-05T17:30:00.000Z Complete: define-behavior - 7 scenarios across 4 rules (AC1 link+navigate, AC2 index, AC3 validation, AC4 idempotent-preserve)
 - 2026-07-05T17:35:00.000Z Complete: scenario-gate - independent /review-spec PASS (fixed 1 vacuous scenario); impl-plan.md written (proof plan + build order, riskiest slice = INDEX grouping last)
 - 2026-07-05T18:03:00.000Z Complete: implement - all 7 scenarios GREEN via outside-in TDD (helper → CLI wiring → navigation → index grouping); RGR ledger annotated with SHAs
+- 2026-07-05T19:35:00.000Z Complete: verify - full suite 4651/4651 + Gherkin 28/28 over final HEAD; /quality-review criticals fixed (block-sequence children, surfaced LinkResult) + re-review PASS; /refactor ledger closed (−10 jscpd clones); audit passed; verify.md written
+- 2026-07-05T19:36:00.000Z Complete: done - ticket closed; follow-ups recorded in verify.md (INDEX nesting, ticket link command)

--- a/.project/tickets/F9W3JP-epic-child-linker/ticket.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/ticket.md
@@ -1,0 +1,36 @@
+---
+id: F9W3JP
+slug: epic-child-linker
+type: feature
+phase: define-behavior
+status: in_progress
+scope:
+  - a `--parent <epicId>` flag on `ticket new` that writes `parent: <epicId>` on the new child
+  - idempotent, atomic append of the child id to the epic's `children:` list
+  - validation that `--parent` names an existing `type: epic` ticket, failing loud otherwise
+  - INDEX grouping of children under their epic resolved from `parent:` (single source of truth)
+out_of_scope:
+  - a standalone `ticket link` command for re-linking pre-existing tickets (deferred; `--parent` is create-time only)
+  - re-parenting or unlinking a child
+  - a separate `epic:` frontmatter field (rejected — would duplicate the `parent:` relationship)
+  - nested epics / multi-level hierarchies beyond one epic→child level
+done_when:
+  - "`ticket new <slug> --parent <epicId>` creates a child with `parent:` set and appends its id to the epic's `children:`"
+  - "`findNextWork` navigates from the epic to the newly created child"
+  - "`INDEX.md` lists the child under its epic's heading"
+  - "`--parent` with a missing or non-epic id exits non-zero and mutates no files"
+  - "re-running or interrupting the append leaves the epic's `children:` with the id exactly once and the file intact"
+created: 2026-07-05T17:25:42.420Z
+last_modified: 2026-07-05T17:25:42.420Z
+---
+
+# ticket new --parent links epic and child
+
+**Goal:** One command wires a new child ticket to its epic across navigation and the index, with no dual-write drift
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-07-05T17:25:42.420Z Started: Created ticket F9W3JP
+- 2026-07-05T17:27:00.000Z Complete: intake - one JTBD (TB1), four ACs, scope/out_of_scope/done_when set; design from /figure-it-out (single source of truth via parent:)

--- a/.project/tickets/F9W3JP-epic-child-linker/ticket.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/ticket.md
@@ -2,7 +2,7 @@
 id: F9W3JP
 slug: epic-child-linker
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 scope:
   - a `--parent <epicId>` flag on `ticket new` that writes `parent: <epicId>` on the new child
@@ -36,3 +36,4 @@ last_modified: 2026-07-05T17:25:42.420Z
 - 2026-07-05T17:27:00.000Z Complete: intake - one JTBD (TB1), four ACs, scope/out_of_scope/done_when set; design from /figure-it-out (single source of truth via parent:)
 - 2026-07-05T17:30:00.000Z Complete: define-behavior - 7 scenarios across 4 rules (AC1 link+navigate, AC2 index, AC3 validation, AC4 idempotent-preserve)
 - 2026-07-05T17:35:00.000Z Complete: scenario-gate - independent /review-spec PASS (fixed 1 vacuous scenario); impl-plan.md written (proof plan + build order, riskiest slice = INDEX grouping last)
+- 2026-07-05T18:03:00.000Z Complete: implement - all 7 scenarios GREEN via outside-in TDD (helper → CLI wiring → navigation → index grouping); RGR ledger annotated with SHAs

--- a/.project/tickets/F9W3JP-epic-child-linker/ticket.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/ticket.md
@@ -2,7 +2,7 @@
 id: F9W3JP
 slug: epic-child-linker
 type: feature
-phase: define-behavior
+phase: implement
 status: in_progress
 scope:
   - a `--parent <epicId>` flag on `ticket new` that writes `parent: <epicId>` on the new child
@@ -34,3 +34,5 @@ last_modified: 2026-07-05T17:25:42.420Z
 
 - 2026-07-05T17:25:42.420Z Started: Created ticket F9W3JP
 - 2026-07-05T17:27:00.000Z Complete: intake - one JTBD (TB1), four ACs, scope/out_of_scope/done_when set; design from /figure-it-out (single source of truth via parent:)
+- 2026-07-05T17:30:00.000Z Complete: define-behavior - 7 scenarios across 4 rules (AC1 link+navigate, AC2 index, AC3 validation, AC4 idempotent-preserve)
+- 2026-07-05T17:35:00.000Z Complete: scenario-gate - independent /review-spec PASS (fixed 1 vacuous scenario); impl-plan.md written (proof plan + build order, riskiest slice = INDEX grouping last)

--- a/.project/tickets/F9W3JP-epic-child-linker/verify.md
+++ b/.project/tickets/F9W3JP-epic-child-linker/verify.md
@@ -1,0 +1,29 @@
+# Verify: ticket new --parent links epic and child (F9W3JP)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4651/4651 tests pass (327 files, 5 skipped; full suite over final HEAD after review fixes + refactors)
+**Gherkin:** ✅ Acceptance lane passes (28 scenarios / 217 steps, including the 5 new epic-child-linker scenarios)
+**Build:** ✅ Success (tsup build precedes each suite run; dist-driven cucumber lane green)
+**Lint:** ✅ Clean (eslint + `tsc --noEmit` green on all touched files)
+**Scenarios:** All 7 scenarios marked complete (5 black-box acceptance + 2 vitest-only white-box: navigation S2, idempotency S7 — lane split recorded in impl-plan.md)
+**PR Scope:** ✅ Diff matches ticket scope (every commit since branch reset serves F9W3JP: linker, CLI wiring, index grouping, tests, review fixes, refactors, ticket artifacts)
+**Dep Drift:** ✅ Clean (zero new dependencies — inline parsing per the zero-dep hooks ADR)
+**Parent Epic:** N/A
+**Reconcile:** ⚠️ 1 deviation, documented — INDEX grouping key moved from `epic:` to `parent:` (single source of truth), backward-compatible fallback retained; recorded in impl-plan.md Known deviations (soft, never blocks)
+**Experience:** ⚠️ Walked TB through epic decomposition: `--parent` removes both hand-edits (new steps vs before = −2); worst step = INDEX shows children under the bare epic id heading while the epic itself lists under "(no epic)" — recorded follow-up (soft, never blocks)
+**Evidence limits:** ✅ None
+
+Audit passed — sync-config ✓, depcruise 0 violations (568 modules), knip 0 findings, jscpd 581 clones (−10 vs the 591 baseline; refactors reduced duplication).
+
+## Quality gates run
+
+- Scenario-gate: independent /review-spec — PASS after 1 vacuous-scenario fix.
+- /quality-review (cross-model, Opus reviewer): REQUEST CHANGES → both criticals fixed
+  (block-sequence `children:` corruption; ignored LinkResult) → re-review PASS.
+- /refactor: 3 resolved (dead export, test parser reuse, slug-helper hoist), 3 struck with reasons.
+
+## Follow-ups (recorded, out of scope)
+
+- INDEX nesting: epic ticket itself groups under "(no epic)"; child group heading is the bare epic id, not the title.
+- Standalone `ticket link` / re-parent command (deferred at intake).

--- a/packages/cli/features/epic-child-linker.feature
+++ b/packages/cli/features/epic-child-linker.feature
@@ -15,11 +15,9 @@ Feature: ticket new --parent links a child to its epic
       Then the child's parent field names the epic
       And the epic's children list contains the new child's id
 
-    @epic-child-linker.TB1.AC1
-    Scenario: Navigation from the epic reaches the linked child
-      Given an epic linked to one in-progress child via --parent
-      When the workflow looks for the next work under that epic
-      Then it navigates to the linked child
+    # Navigation (findNextWork reaches the linked child) is an internal contract
+    # with no CLI surface — proven by the integration test
+    # tests/integration/epic-child-linker-navigation.test.ts, not this black-box lane.
 
   Rule: A linked child appears under its epic in the index
 
@@ -54,8 +52,6 @@ Feature: ticket new --parent links a child to its epic
       When I link a second child to that epic with --parent
       Then the epic's children list names both children
 
-    @epic-child-linker.TB1.AC4
-    Scenario: Linking the same child twice adds it at most once
-      Given an epic whose children list does not yet name child C
-      When C is linked to the epic and then the same C id is linked again
-      Then the epic's children list names C exactly once
+    # Idempotency (re-linking the same id adds it once) has no CLI path — each
+    # `ticket new` mints a fresh id — so it is proven at the unit layer in
+    # src/utils/epic-linker.test.ts, not this black-box lane.

--- a/packages/cli/features/epic-child-linker.feature
+++ b/packages/cli/features/epic-child-linker.feature
@@ -1,0 +1,61 @@
+@epic-child-linker.TB1
+Feature: ticket new --parent links a child to its epic
+
+  A Technical Builder decomposing an epic creates each child with
+  --parent <epicId>; the command writes both ends of the epic-child link and
+  the index groups the child under its epic. The child-epic relationship has a
+  single source of truth: the child's parent field.
+
+  Rule: --parent links a new child to its epic both ways
+
+    @epic-child-linker.TB1.AC1
+    Scenario: Linking records the child's parent and appends to the epic
+      Given an epic ticket with an empty children list
+      When I create a child ticket with --parent naming that epic
+      Then the child's parent field names the epic
+      And the epic's children list contains the new child's id
+
+    @epic-child-linker.TB1.AC1
+    Scenario: Navigation from the epic reaches the linked child
+      Given an epic linked to one in-progress child via --parent
+      When the workflow looks for the next work under that epic
+      Then it navigates to the linked child
+
+  Rule: A linked child appears under its epic in the index
+
+    @epic-child-linker.TB1.AC2
+    Scenario: The index groups the child under its epic heading
+      Given an epic and a child linked to it with --parent
+      When the ticket index is regenerated
+      Then the child is listed under the epic's heading
+
+  Rule: An invalid --parent fails loud and changes nothing
+
+    @epic-child-linker.TB1.AC3
+    Scenario: --parent naming no existing ticket is rejected
+      Given no ticket exists with the id "ZZZZZZ"
+      When I create a child ticket with --parent "ZZZZZZ"
+      Then the command exits non-zero reporting the epic was not found
+      And no child ticket folder is created
+
+    @epic-child-linker.TB1.AC3
+    Scenario: --parent naming a non-epic ticket is rejected
+      Given a task ticket that is not an epic
+      When I create a child ticket with --parent naming that task
+      Then the command exits non-zero reporting the parent is not an epic
+      And the target ticket's frontmatter is unchanged
+      And no child ticket folder is created
+
+  Rule: Linking is idempotent and preserves the epic's existing children
+
+    @epic-child-linker.TB1.AC4
+    Scenario: Appending a second child preserves the first
+      Given an epic whose children list already names one child
+      When I link a second child to that epic with --parent
+      Then the epic's children list names both children
+
+    @epic-child-linker.TB1.AC4
+    Scenario: Linking the same child twice adds it at most once
+      Given an epic whose children list does not yet name child C
+      When C is linked to the epic and then the same C id is linked again
+      Then the epic's children list names C exactly once

--- a/packages/cli/features/steps/epic-child-linker.steps.ts
+++ b/packages/cli/features/steps/epic-child-linker.steps.ts
@@ -1,0 +1,180 @@
+/**
+ * Acceptance steps for F9W3JP — `ticket new --parent` epic-child linker.
+ * Black-box: drives the built CLI in a temp project (only the process boundary
+ * is real). Internal contracts with no CLI surface — findNextWork navigation
+ * and append idempotency — are proven in vitest (see the .feature comments).
+ */
+
+import { strict as assert } from 'node:assert';
+import { execFile } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+import { After, Given, Then, When } from '@cucumber/cucumber';
+
+import type { SafewordWorld } from './world.js';
+
+const execFileAsync = promisify(execFile);
+const CLI_PATH = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
+
+// Before-image captured before a mutating step so a later Then can assert the
+// target was untouched. Scenarios run serially, so a module object is safe.
+const scenarioState = { taskBefore: '' };
+
+function ticketsDirectoryOf(world: SafewordWorld): string {
+  return nodePath.join(world.temporaryDirectory, '.project', 'tickets');
+}
+
+function folderBySlug(world: SafewordWorld, slug: string): string {
+  const match = readdirSync(ticketsDirectoryOf(world)).find(entry => entry.endsWith(`-${slug}`));
+  if (match === undefined) throw new Error(`no ticket folder for slug ${slug}`);
+  return nodePath.join(ticketsDirectoryOf(world), match);
+}
+
+function idBySlug(world: SafewordWorld, slug: string): string {
+  const [id] = nodePath.basename(folderBySlug(world, slug)).split('-');
+  if (id === undefined) throw new Error(`no id for slug ${slug}`);
+  return id;
+}
+
+function readTicket(world: SafewordWorld, slug: string): string {
+  return readFileSync(nodePath.join(folderBySlug(world, slug), 'ticket.md'), 'utf8');
+}
+
+async function runCli(world: SafewordWorld, args: string[]): Promise<void> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [CLI_PATH, ...args], {
+      cwd: world.temporaryDirectory,
+    });
+    world.result = { stdout, stderr, exitCode: 0 };
+  } catch (error) {
+    const failure = error as { stdout?: string; stderr?: string; code?: number };
+    world.result = {
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? '',
+      exitCode: failure.code ?? 1,
+    };
+  }
+}
+
+function newTicket(world: SafewordWorld, args: string[]): Promise<void> {
+  return runCli(world, ['ticket', 'new', ...args]);
+}
+
+function freshProject(world: SafewordWorld): void {
+  world.temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-epic-link-'));
+}
+
+After(function (this: SafewordWorld) {
+  if (this.temporaryDirectory) rmSync(this.temporaryDirectory, { recursive: true, force: true });
+});
+
+Given('an epic ticket with an empty children list', async function (this: SafewordWorld) {
+  freshProject(this);
+  await newTicket(this, ['the-epic', '--type', 'epic']);
+});
+
+Given('an epic and a child linked to it with --parent', async function (this: SafewordWorld) {
+  freshProject(this);
+  await newTicket(this, ['the-epic', '--type', 'epic']);
+  await newTicket(this, ['the-child', '--parent', idBySlug(this, 'the-epic')]);
+});
+
+Given('no ticket exists with the id {string}', function (this: SafewordWorld, _missingId: string) {
+  freshProject(this);
+});
+
+Given('a task ticket that is not an epic', async function (this: SafewordWorld) {
+  freshProject(this);
+  await newTicket(this, ['a-task', '--type', 'task']);
+});
+
+Given('an epic whose children list already names one child', async function (this: SafewordWorld) {
+  freshProject(this);
+  await newTicket(this, ['the-epic', '--type', 'epic']);
+  await newTicket(this, ['first-child', '--parent', idBySlug(this, 'the-epic')]);
+});
+
+When(
+  'I create a child ticket with --parent naming that epic',
+  async function (this: SafewordWorld) {
+    await newTicket(this, ['the-child', '--parent', idBySlug(this, 'the-epic')]);
+  },
+);
+
+When(
+  'I create a child ticket with --parent {string}',
+  async function (this: SafewordWorld, epicId: string) {
+    await newTicket(this, ['orphan', '--parent', epicId]);
+  },
+);
+
+When(
+  'I create a child ticket with --parent naming that task',
+  async function (this: SafewordWorld) {
+    scenarioState.taskBefore = readTicket(this, 'a-task');
+    await newTicket(this, ['the-child', '--parent', idBySlug(this, 'a-task')]);
+  },
+);
+
+When('I link a second child to that epic with --parent', async function (this: SafewordWorld) {
+  await newTicket(this, ['second-child', '--parent', idBySlug(this, 'the-epic')]);
+});
+
+When('the ticket index is regenerated', async function (this: SafewordWorld) {
+  await runCli(this, ['sync-tickets']);
+});
+
+Then("the child's parent field names the epic", function (this: SafewordWorld) {
+  assert.ok(readTicket(this, 'the-child').includes(`parent: ${idBySlug(this, 'the-epic')}`));
+});
+
+Then("the epic's children list contains the new child's id", function (this: SafewordWorld) {
+  assert.ok(readTicket(this, 'the-epic').includes(idBySlug(this, 'the-child')));
+});
+
+Then("the child is listed under the epic's heading", function (this: SafewordWorld) {
+  const epicId = idBySlug(this, 'the-epic');
+  const childId = idBySlug(this, 'the-child');
+  const index = readFileSync(nodePath.join(ticketsDirectoryOf(this), 'INDEX.md'), 'utf8');
+  const start = index.indexOf(`### ${epicId}`);
+  assert.ok(start !== -1, 'epic heading present');
+  const rest = index.slice(start + `### ${epicId}`.length);
+  const next = rest.indexOf('\n### ');
+  const block = next === -1 ? rest : rest.slice(0, next);
+  assert.ok(block.includes(childId), 'child under epic heading');
+});
+
+Then('the command exits non-zero reporting the epic was not found', function (this: SafewordWorld) {
+  assert.notEqual(this.result.exitCode, 0);
+  assert.match(this.result.stderr, /not found|ZZZZZZ/);
+});
+
+Then(
+  'the command exits non-zero reporting the parent is not an epic',
+  function (this: SafewordWorld) {
+    assert.notEqual(this.result.exitCode, 0);
+    assert.match(this.result.stderr, /not an epic/);
+  },
+);
+
+Then('no child ticket folder is created', function (this: SafewordWorld) {
+  const directory = ticketsDirectoryOf(this);
+  const entries = existsSync(directory) ? readdirSync(directory) : [];
+  const orphan = entries.some(entry => entry.endsWith('-orphan'));
+  const child = entries.some(entry => entry.endsWith('-the-child'));
+  assert.ok(!orphan && !child, 'no child folder created');
+});
+
+Then("the target ticket's frontmatter is unchanged", function (this: SafewordWorld) {
+  assert.equal(readTicket(this, 'a-task'), scenarioState.taskBefore);
+});
+
+Then("the epic's children list names both children", function (this: SafewordWorld) {
+  const epic = readTicket(this, 'the-epic');
+  assert.ok(epic.includes(idBySlug(this, 'first-child')), 'first child present');
+  assert.ok(epic.includes(idBySlug(this, 'second-child')), 'second child present');
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -140,10 +140,14 @@ ticket
   .option('--title <title>', 'Ticket title (defaults to slug)')
   .option('--goal <goal>', 'One-line goal; fills the Goal field instead of a placeholder')
   .option('--why <why>', 'One-line rationale (task/patch/epic; features use spec.md)')
+  .option(
+    '--parent <epicId>',
+    'Link this ticket to an epic (sets parent: and appends to its children)',
+  )
   .action(
     async (
       slug: string,
-      options: { type?: string; title?: string; goal?: string; why?: string },
+      options: { type?: string; title?: string; goal?: string; why?: string; parent?: string },
     ) => {
       const { ticketNew } = await import('./commands/ticket-new.js');
       await ticketNew(slug, options);

--- a/packages/cli/src/commands/ticket-new.ts
+++ b/packages/cli/src/commands/ticket-new.ts
@@ -9,6 +9,7 @@
 
 import process from 'node:process';
 
+import { linkChildToEpic, validateEpicParent } from '../utils/epic-linker.js';
 import { cryptoIdMinter, type IdMinter } from '../utils/id-minter.js';
 import { header, info, success } from '../utils/output.js';
 import { normalizeSlug, SlugError } from '../utils/slug.js';
@@ -22,6 +23,7 @@ export interface TicketNewOptions {
   title?: string;
   goal?: string;
   why?: string;
+  parent?: string;
 }
 
 export function ticketNew(slug: string, options: TicketNewOptions): Promise<void> {
@@ -29,34 +31,49 @@ export function ticketNew(slug: string, options: TicketNewOptions): Promise<void
   return Promise.resolve();
 }
 
-function ticketNewSync(slug: string, options: TicketNewOptions): void {
-  const type = resolveType(options.type);
-  if (type === 'invalid') {
-    process.stderr.write(
-      `Invalid --type=${String(options.type)}. Must be one of: patch, task, feature, epic.\n`,
-    );
-    process.exit(1);
-  }
+/** Exit non-zero with a message. */
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
 
+/** Validate all option constraints, exiting before anything is created;
+ * returns the type narrowed past the `invalid` sentinel. */
+function assertOptionsValid(
+  options: TicketNewOptions,
+  type: TicketType | undefined | 'invalid',
+): TicketType | undefined {
+  if (type === 'invalid') {
+    fail(`Invalid --type=${String(options.type)}. Must be one of: patch, task, feature, epic.`);
+  }
   // Features keep motivation in spec.md (single source of truth), so they have
   // no **Why:** field for --why to fill — fail loud rather than silently drop it.
   if (options.why !== undefined && type === 'feature') {
-    process.stderr.write(
-      '--why does not apply to features — their motivation lives in spec.md. Use --goal, or edit spec.md.\n',
+    fail(
+      '--why does not apply to features — their motivation lives in spec.md. Use --goal, or edit spec.md.',
     );
-    process.exit(1);
   }
+  // Validate --parent BEFORE creating anything, so a bad epic reference leaves
+  // no half-linked child behind (AC3).
+  if (options.parent !== undefined) {
+    const check = validateEpicParent(process.cwd(), options.parent);
+    if (!check.ok) fail(check.reason);
+  }
+  return type;
+}
 
-  let normalizedSlug: string;
+function resolveSlug(slug: string): string {
   try {
-    normalizedSlug = normalizeSlug(slug);
+    return normalizeSlug(slug);
   } catch (error: unknown) {
-    if (error instanceof SlugError) {
-      process.stderr.write(`${error.message}\n`);
-      process.exit(1);
-    }
+    if (error instanceof SlugError) fail(error.message);
     throw error;
   }
+}
+
+function ticketNewSync(slug: string, options: TicketNewOptions): void {
+  const type = assertOptionsValid(options, resolveType(options.type));
+  const normalizedSlug = resolveSlug(slug);
 
   header('Create ticket');
 
@@ -67,7 +84,12 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
       title: options.title,
       goal: options.goal,
       why: options.why,
+      parent: options.parent,
     });
+    // Write the reverse index on the epic: append the child to its children[].
+    if (options.parent !== undefined) {
+      linkChildToEpic(process.cwd(), result.id, options.parent);
+    }
     success(`Created ticket ${formatTicketReference(result.id, normalizedSlug)}`);
     info(`Folder: ${result.folderPath}`);
     info(`File:   ${result.ticketPath}`);

--- a/packages/cli/src/commands/ticket-new.ts
+++ b/packages/cli/src/commands/ticket-new.ts
@@ -87,8 +87,15 @@ function ticketNewSync(slug: string, options: TicketNewOptions): void {
       parent: options.parent,
     });
     // Write the reverse index on the epic: append the child to its children[].
+    // The epic was validated pre-create, but could have changed since — the
+    // child already exists here, so surface a recoverable warning, not a fail.
     if (options.parent !== undefined) {
-      linkChildToEpic(process.cwd(), result.id, options.parent);
+      const linked = linkChildToEpic(process.cwd(), result.id, options.parent);
+      if (!linked.ok) {
+        process.stderr.write(
+          `Warning: ${linked.reason} — created ${result.id} with parent: ${options.parent}, but the epic's children list was not updated. Add '${result.id}' to its children: manually.\n`,
+        );
+      }
     }
     success(`Created ticket ${formatTicketReference(result.id, normalizedSlug)}`);
     info(`Folder: ${result.folderPath}`);

--- a/packages/cli/src/ticket-sync/index.ts
+++ b/packages/cli/src/ticket-sync/index.ts
@@ -34,7 +34,8 @@ export interface TicketEntry {
   relativePath: string; // e.g. <namespace-root>/tickets/1GGD28-ticket-discovery-index
   title: string;
   status: string;
-  epic: string | undefined; // undefined → grouped under "(no epic)"
+  epic: string | undefined; // literal `epic:` field (tracker back-link); may be undefined
+  parent: string | undefined; // `parent:` epic id — the INDEX grouping key (F9W3JP)
   goal: string | undefined; // the **Goal:** one-liner, when present
   externalIssue: string | undefined; // canonical tracker issue link (optional)
   externalPullRequests: string[]; // active/relevant PR links (optional)
@@ -147,10 +148,8 @@ function parseTicket(
   const bodyLines = content.split('\n').slice(bodyStart);
   const title = fields.get('title') ?? firstHeading(bodyLines) ?? fields.get('slug') ?? folder;
   const status = fields.get('status') ?? '—';
-  // Group by the child's `parent:` — the single source of truth for the
-  // epic↔child link (F9W3JP). Fall back to a legacy `epic:` field for any
-  // ticket that predates parent-based linking.
-  const epic = fields.get('parent') ?? fields.get('epic');
+  const epic = fields.get('epic');
+  const parent = fields.get('parent');
 
   return {
     ok: true,
@@ -160,6 +159,7 @@ function parseTicket(
       title,
       status,
       epic,
+      parent,
       externalIssue: fields.get('external_issue') ?? fields.get('external'),
       externalPullRequests: parseStringList(fields.get('external_prs')),
       goal: goalLine(bodyLines),
@@ -270,7 +270,10 @@ function renderEntry(
 function groupByEpic(entries: TicketEntry[]): [string, TicketEntry[]][] {
   const groups = new Map<string, TicketEntry[]>();
   for (const entry of entries) {
-    const key = entry.epic ?? NO_EPIC_GROUP;
+    // Group by `parent:` (single source of truth for the epic↔child link,
+    // F9W3JP), falling back to the legacy `epic:` field. Keeps `entry.epic`
+    // itself literal so the tracker-sync corpus back-link is unaffected.
+    const key = entry.parent ?? entry.epic ?? NO_EPIC_GROUP;
     const bucket = groups.get(key);
     if (bucket) bucket.push(entry);
     else groups.set(key, [entry]);

--- a/packages/cli/src/ticket-sync/index.ts
+++ b/packages/cli/src/ticket-sync/index.ts
@@ -147,7 +147,10 @@ function parseTicket(
   const bodyLines = content.split('\n').slice(bodyStart);
   const title = fields.get('title') ?? firstHeading(bodyLines) ?? fields.get('slug') ?? folder;
   const status = fields.get('status') ?? '—';
-  const epic = fields.get('epic');
+  // Group by the child's `parent:` — the single source of truth for the
+  // epic↔child link (F9W3JP). Fall back to a legacy `epic:` field for any
+  // ticket that predates parent-based linking.
+  const epic = fields.get('parent') ?? fields.get('epic');
 
   return {
     ok: true,

--- a/packages/cli/src/utils/epic-linker.test.ts
+++ b/packages/cli/src/utils/epic-linker.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { linkChildToEpic } from './epic-linker.js';
+
+function writeEpic(cwd: string, id: string, children: string[]): void {
+  const dir = nodePath.join(cwd, '.project', 'tickets', `${id}-epic`);
+  mkdirSync(dir, { recursive: true });
+  const quoted = children.map(child => `'${child}'`).join(', ');
+  const list = `[${quoted}]`;
+  writeFileSync(
+    nodePath.join(dir, 'ticket.md'),
+    `---\nid: ${id}\nslug: epic\ntype: epic\nphase: intake\nstatus: in_progress\nchildren: ${list}\ncreated: 2026-01-01T00:00:00.000Z\nlast_modified: 2026-01-01T00:00:00.000Z\n---\n\n# Epic\n`,
+  );
+}
+
+function readEpicChildren(cwd: string, id: string): string[] {
+  const content = readFileSync(
+    nodePath.join(cwd, '.project', 'tickets', `${id}-epic`, 'ticket.md'),
+    'utf8',
+  );
+  const match = /^children:\s*\[(.*)\]\s*$/m.exec(content);
+  if (match?.[1] === undefined) return [];
+  const inner = match[1].trim();
+  return inner === ''
+    ? []
+    : inner.split(',').map(entry => entry.trim().replaceAll(/^['"]|['"]$/g, ''));
+}
+
+describe('linkChildToEpic', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(nodePath.join(tmpdir(), 'epic-linker-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  // epic-child-linker.TB1.AC4.second_child_preserves_first
+  it('appends a second child without dropping the first', () => {
+    writeEpic(cwd, 'EPIC01', ['CHILD1']);
+    const result = linkChildToEpic(cwd, 'CHILD2', 'EPIC01');
+    expect(result.ok).toBe(true);
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['CHILD1', 'CHILD2']);
+  });
+
+  // epic-child-linker.TB1.AC4.linking_twice_adds_at_most_once
+  it('linking the same child twice adds it at most once', () => {
+    writeEpic(cwd, 'EPIC01', []);
+    expect(linkChildToEpic(cwd, 'CHILD2', 'EPIC01').ok).toBe(true);
+    expect(linkChildToEpic(cwd, 'CHILD2', 'EPIC01').ok).toBe(true);
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['CHILD2']);
+  });
+});

--- a/packages/cli/src/utils/epic-linker.test.ts
+++ b/packages/cli/src/utils/epic-linker.test.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { linkChildToEpic } from './epic-linker.js';
+import { linkChildToEpic, parseChildrenList } from './epic-linker.js';
 
 function writeEpic(cwd: string, id: string, children: string[]): void {
   const dir = nodePath.join(cwd, '.project', 'tickets', `${id}-epic`);
@@ -14,6 +14,17 @@ function writeEpic(cwd: string, id: string, children: string[]): void {
   writeFileSync(
     nodePath.join(dir, 'ticket.md'),
     `---\nid: ${id}\nslug: epic\ntype: epic\nphase: intake\nstatus: in_progress\nchildren: ${list}\ncreated: 2026-01-01T00:00:00.000Z\nlast_modified: 2026-01-01T00:00:00.000Z\n---\n\n# Epic\n`,
+  );
+}
+
+/** An epic whose children use the corpus's block-sequence YAML form. */
+function writeBlockSequenceEpic(cwd: string, id: string, children: string[]): void {
+  const dir = nodePath.join(cwd, '.project', 'tickets', `${id}-epic`);
+  mkdirSync(dir, { recursive: true });
+  const items = children.map(child => `  - ${child}`).join('\n');
+  writeFileSync(
+    nodePath.join(dir, 'ticket.md'),
+    `---\nid: ${id}\nslug: epic\ntype: epic\nphase: intake\nstatus: in_progress\nchildren:\n${items}\ncreated: 2026-01-01T00:00:00.000Z\nlast_modified: 2026-01-01T00:00:00.000Z\n---\n\n# Epic\n`,
   );
 }
 
@@ -53,5 +64,42 @@ describe('linkChildToEpic', () => {
     expect(linkChildToEpic(cwd, 'CHILD2', 'EPIC01').ok).toBe(true);
     expect(linkChildToEpic(cwd, 'CHILD2', 'EPIC01').ok).toBe(true);
     expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['CHILD2']);
+  });
+
+  // Quality-review critical #1: the corpus carries block-sequence children
+  // (`children:` followed by `  - id` lines). Appending must preserve those
+  // entries and leave no orphaned `- id` lines under the rewritten flow array.
+  it('appends to a block-sequence children list without dropping or orphaning entries', () => {
+    writeBlockSequenceEpic(cwd, 'EPIC01', ['049a', '049b']);
+    expect(linkChildToEpic(cwd, 'NEWKID', 'EPIC01').ok).toBe(true);
+
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['049a', '049b', 'NEWKID']);
+    const content = readFileSync(
+      nodePath.join(cwd, '.project', 'tickets', 'EPIC01-epic', 'ticket.md'),
+      'utf8',
+    );
+    // No dangling block items may survive the rewrite.
+    expect(content).not.toMatch(/^[ \t]+-[ \t]/m);
+  });
+
+  it('re-linking a block-sequence child is idempotent (no rewrite needed)', () => {
+    writeBlockSequenceEpic(cwd, 'EPIC01', ['049a']);
+    expect(linkChildToEpic(cwd, '049a', 'EPIC01').ok).toBe(true);
+    // Already linked → no-op: the file may legitimately stay in block form,
+    // so assert via the format-tolerant parser, not the flow-array reader.
+    const content = readFileSync(
+      nodePath.join(cwd, '.project', 'tickets', 'EPIC01-epic', 'ticket.md'),
+      'utf8',
+    );
+    expect(parseChildrenList(content)).toEqual(['049a']);
+  });
+
+  // Quality-review critical #2 (throw path): a folder that resolves but has no
+  // readable ticket.md must yield a reasoned failure, not an ENOENT throw.
+  it('returns a reasoned failure when the resolved folder has no ticket.md', () => {
+    mkdirSync(nodePath.join(cwd, '.project', 'tickets', 'EPIC01-epic'), { recursive: true });
+    const result = linkChildToEpic(cwd, 'CHILD1', 'EPIC01');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/no readable ticket\.md/);
   });
 });

--- a/packages/cli/src/utils/epic-linker.test.ts
+++ b/packages/cli/src/utils/epic-linker.test.ts
@@ -28,17 +28,13 @@ function writeBlockSequenceEpic(cwd: string, id: string, children: string[]): vo
   );
 }
 
+function epicTicketPath(cwd: string, id: string): string {
+  return nodePath.join(cwd, '.project', 'tickets', `${id}-epic`, 'ticket.md');
+}
+
+/** Children as the production parser reads them — the contract under test. */
 function readEpicChildren(cwd: string, id: string): string[] {
-  const content = readFileSync(
-    nodePath.join(cwd, '.project', 'tickets', `${id}-epic`, 'ticket.md'),
-    'utf8',
-  );
-  const match = /^children:\s*\[(.*)\]\s*$/m.exec(content);
-  if (match?.[1] === undefined) return [];
-  const inner = match[1].trim();
-  return inner === ''
-    ? []
-    : inner.split(',').map(entry => entry.trim().replaceAll(/^['"]|['"]$/g, ''));
+  return parseChildrenList(readFileSync(epicTicketPath(cwd, id), 'utf8'));
 }
 
 describe('linkChildToEpic', () => {
@@ -74,24 +70,16 @@ describe('linkChildToEpic', () => {
     expect(linkChildToEpic(cwd, 'NEWKID', 'EPIC01').ok).toBe(true);
 
     expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['049a', '049b', 'NEWKID']);
-    const content = readFileSync(
-      nodePath.join(cwd, '.project', 'tickets', 'EPIC01-epic', 'ticket.md'),
-      'utf8',
-    );
     // No dangling block items may survive the rewrite.
+    const content = readFileSync(epicTicketPath(cwd, 'EPIC01'), 'utf8');
     expect(content).not.toMatch(/^[ \t]+-[ \t]/m);
   });
 
   it('re-linking a block-sequence child is idempotent (no rewrite needed)', () => {
     writeBlockSequenceEpic(cwd, 'EPIC01', ['049a']);
     expect(linkChildToEpic(cwd, '049a', 'EPIC01').ok).toBe(true);
-    // Already linked → no-op: the file may legitimately stay in block form,
-    // so assert via the format-tolerant parser, not the flow-array reader.
-    const content = readFileSync(
-      nodePath.join(cwd, '.project', 'tickets', 'EPIC01-epic', 'ticket.md'),
-      'utf8',
-    );
-    expect(parseChildrenList(content)).toEqual(['049a']);
+    // Already linked → no-op: the file may legitimately stay in block form.
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['049a']);
   });
 
   // Quality-review critical #2 (throw path): a folder that resolves but has no

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -29,7 +29,10 @@ export function linkChildToEpic(cwd: string, childId: string, epicId: string): L
     return { ok: false, reason: `--parent epic "${epicId}" not found` };
   }
   const epicPath = nodePath.join(epicFolder, 'ticket.md');
-  const content = readFileSync(epicPath, 'utf8');
+  const content = readTicketFileOrUndefined(epicPath);
+  if (content === undefined) {
+    return { ok: false, reason: `--parent "${epicId}" has no readable ticket.md` };
+  }
   if (!isEpicTicket(content)) {
     return { ok: false, reason: `--parent "${epicId}" is not an epic` };
   }
@@ -51,10 +54,24 @@ export function validateEpicParent(cwd: string, epicId: string): LinkResult {
   if (epicFolder === undefined) {
     return { ok: false, reason: `--parent epic "${epicId}" not found` };
   }
-  if (!isEpicTicket(readFileSync(nodePath.join(epicFolder, 'ticket.md'), 'utf8'))) {
+  const content = readTicketFileOrUndefined(nodePath.join(epicFolder, 'ticket.md'));
+  if (content === undefined) {
+    // e.g. `--parent completed` resolves the archive dir, which has no ticket.md.
+    return { ok: false, reason: `--parent "${epicId}" has no readable ticket.md` };
+  }
+  if (!isEpicTicket(content)) {
     return { ok: false, reason: `--parent "${epicId}" is not an epic` };
   }
   return { ok: true };
+}
+
+/** ticket.md contents, or undefined when missing/unreadable — never throws. */
+function readTicketFileOrUndefined(ticketPath: string): string | undefined {
+  try {
+    return readFileSync(ticketPath, 'utf8');
+  } catch {
+    return undefined;
+  }
 }
 
 /** Resolve a ticket folder by id (`{id}-{slug}` or legacy `{id}`), or undefined. */
@@ -83,17 +100,35 @@ function unquote(value: string): string {
   return trimmed;
 }
 
+/** Index of the `children:` line, or -1. */
+function childrenLineIndex(lines: string[]): number {
+  return lines.findIndex(line => line.startsWith('children:'));
+}
+
+/** Block-sequence items (`  - id`) immediately following `children:`. */
+function blockItemsAfter(lines: string[], start: number): string[] {
+  const items: string[] = [];
+  for (let index = start; index < lines.length; index += 1) {
+    const match = /^[ \t]+-[ \t](.*)$/.exec(lines[index] ?? '');
+    if (match?.[1] === undefined) break;
+    const value = unquote(match[1]);
+    if (value) items.push(value);
+  }
+  return items;
+}
+
 /**
  * The epic's current children ids. Tolerant of the formats the corpus carries:
  * flow array (`['A', 'B']` / `[]`), a legacy comma-separated scalar
- * (`'A, B'`), or an absent line. Preserves existing entries so an append never
- * drops them.
+ * (`'A, B'`), a block sequence (`children:` followed by `  - id` lines), or an
+ * absent line. Preserves existing entries so an append never drops them.
  */
 export function parseChildrenList(content: string): string[] {
-  const match = /^children:(.*)$/m.exec(content);
-  if (match?.[1] === undefined) return [];
-  const raw = match[1].trim();
-  if (raw === '') return [];
+  const lines = content.split('\n');
+  const index = childrenLineIndex(lines);
+  if (index === -1) return [];
+  const raw = (lines[index] ?? '').slice('children:'.length).trim();
+  if (raw === '') return blockItemsAfter(lines, index + 1);
   if (raw.startsWith('[') && raw.endsWith(']')) {
     const inner = raw.slice(1, -1).trim();
     return inner === ''
@@ -110,15 +145,24 @@ export function parseChildrenList(content: string): string[] {
     .filter(Boolean);
 }
 
-/** Rewrite (or insert) the `children:` line as a single-quoted flow array. */
+/**
+ * Rewrite (or insert) the `children:` value as a single-quoted flow array,
+ * consuming any block-sequence item lines so a block-form epic is rewritten
+ * whole rather than left with orphaned `- id` lines under a flow scalar.
+ */
 function replaceChildrenList(content: string, ids: string[]): string {
   const quoted = ids.map(id => `'${id}'`).join(', ');
   const rendered = `children: [${quoted}]`;
-  if (/^children:.*$/m.test(content)) {
-    return content.replace(/^children:.*$/m, () => rendered);
+  const lines = content.split('\n');
+  const index = childrenLineIndex(lines);
+  if (index === -1) {
+    // No children line yet — insert just before the closing frontmatter fence.
+    return content.replace('\n---\n', () => `\n${rendered}\n---\n`);
   }
-  // No children line yet — insert just before the closing frontmatter fence.
-  return content.replace('\n---\n', () => `\n${rendered}\n---\n`);
+  let end = index + 1;
+  while (end < lines.length && /^[ \t]+-[ \t]/.test(lines[end] ?? '')) end += 1;
+  lines.splice(index, end - index, rendered);
+  return lines.join('\n');
 }
 
 /** Write-then-rename so an interrupted run can't leave a half-written epic. */

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -1,0 +1,41 @@
+/**
+ * Link a child ticket to its epic (ticket F9W3JP): append the child id to the
+ * epic's `children:` list, idempotently and atomically. The child→epic
+ * relationship's single source of truth is the child's `parent:` field; this
+ * helper maintains the reverse index (`children:`) the navigation contract in
+ * `hierarchy.ts` walks.
+ *
+ * Mirrors `hierarchy.ts`'s zero-dependency approach: inline frontmatter parsing
+ * (no `yaml` package) and a write-then-rename atomic mutation, matching
+ * `updateTicketStatus`.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { resolveTicketsDirectory } from './configured-paths.js';
+
+export type LinkResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Append `childId` to the `epicId` epic's `children:` list. Validates the epic
+ * exists and is `type: epic`; appends only if absent (idempotent); writes
+ * atomically. Returns a reason on failure so the caller can fail loud without
+ * having created anything.
+ */
+export function linkChildToEpic(_cwd: string, _childId: string, _epicId: string): LinkResult {
+  // RED stub — implemented in GREEN.
+  return { ok: false, reason: 'not implemented' };
+}
+
+/** Resolve a ticket folder by id (`{id}-{slug}` or legacy `{id}`), or undefined. */
+export function resolveTicketFolderById(cwd: string, id: string): string | undefined {
+  const ticketsDirectory = resolveTicketsDirectory(cwd);
+  if (!existsSync(ticketsDirectory)) return undefined;
+  for (const entry of readdirSync(ticketsDirectory)) {
+    if (entry === id || entry.startsWith(`${id}-`)) {
+      return nodePath.join(ticketsDirectory, entry);
+    }
+  }
+  return undefined;
+}

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -75,7 +75,7 @@ function readTicketFileOrUndefined(ticketPath: string): string | undefined {
 }
 
 /** Resolve a ticket folder by id (`{id}-{slug}` or legacy `{id}`), or undefined. */
-export function resolveTicketFolderById(cwd: string, id: string): string | undefined {
+function resolveTicketFolderById(cwd: string, id: string): string | undefined {
   const ticketsDirectory = resolveTicketsDirectory(cwd);
   if (!existsSync(ticketsDirectory)) return undefined;
   for (const entry of readdirSync(ticketsDirectory)) {

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -41,6 +41,22 @@ export function linkChildToEpic(cwd: string, childId: string, epicId: string): L
   return { ok: true };
 }
 
+/**
+ * Validate that `epicId` names an existing `type: epic` ticket, without
+ * mutating anything — so `ticket new --parent` can fail before it creates a
+ * child (AC3: a bad `--parent` creates nothing).
+ */
+export function validateEpicParent(cwd: string, epicId: string): LinkResult {
+  const epicFolder = resolveTicketFolderById(cwd, epicId);
+  if (epicFolder === undefined) {
+    return { ok: false, reason: `--parent epic "${epicId}" not found` };
+  }
+  if (!isEpicTicket(readFileSync(nodePath.join(epicFolder, 'ticket.md'), 'utf8'))) {
+    return { ok: false, reason: `--parent "${epicId}" is not an epic` };
+  }
+  return { ok: true };
+}
+
 /** Resolve a ticket folder by id (`{id}-{slug}` or legacy `{id}`), or undefined. */
 export function resolveTicketFolderById(cwd: string, id: string): string | undefined {
   const ticketsDirectory = resolveTicketsDirectory(cwd);

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -10,7 +10,7 @@
  * `updateTicketStatus`.
  */
 
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveTicketsDirectory } from './configured-paths.js';
@@ -23,9 +23,22 @@ export type LinkResult = { ok: true } | { ok: false; reason: string };
  * atomically. Returns a reason on failure so the caller can fail loud without
  * having created anything.
  */
-export function linkChildToEpic(_cwd: string, _childId: string, _epicId: string): LinkResult {
-  // RED stub — implemented in GREEN.
-  return { ok: false, reason: 'not implemented' };
+export function linkChildToEpic(cwd: string, childId: string, epicId: string): LinkResult {
+  const epicFolder = resolveTicketFolderById(cwd, epicId);
+  if (epicFolder === undefined) {
+    return { ok: false, reason: `--parent epic "${epicId}" not found` };
+  }
+  const epicPath = nodePath.join(epicFolder, 'ticket.md');
+  const content = readFileSync(epicPath, 'utf8');
+  if (!isEpicTicket(content)) {
+    return { ok: false, reason: `--parent "${epicId}" is not an epic` };
+  }
+
+  const children = parseChildrenList(content);
+  if (children.includes(childId)) return { ok: true }; // idempotent — already linked
+
+  atomicWrite(epicPath, replaceChildrenList(content, [...children, childId]));
+  return { ok: true };
 }
 
 /** Resolve a ticket folder by id (`{id}-{slug}` or legacy `{id}`), or undefined. */
@@ -38,4 +51,63 @@ export function resolveTicketFolderById(cwd: string, id: string): string | undef
     }
   }
   return undefined;
+}
+
+function isEpicTicket(content: string): boolean {
+  return /^type:\s*epic\s*$/m.test(content);
+}
+
+/** Strip one layer of surrounding single/double quotes. */
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  const first = trimmed.at(0);
+  if (trimmed.length >= 2 && (first === "'" || first === '"') && trimmed.at(-1) === first) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * The epic's current children ids. Tolerant of the formats the corpus carries:
+ * flow array (`['A', 'B']` / `[]`), a legacy comma-separated scalar
+ * (`'A, B'`), or an absent line. Preserves existing entries so an append never
+ * drops them.
+ */
+export function parseChildrenList(content: string): string[] {
+  const match = /^children:(.*)$/m.exec(content);
+  if (match?.[1] === undefined) return [];
+  const raw = match[1].trim();
+  if (raw === '') return [];
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    const inner = raw.slice(1, -1).trim();
+    return inner === ''
+      ? []
+      : inner
+          .split(',')
+          .map(entry => unquote(entry))
+          .filter(Boolean);
+  }
+  // Legacy scalar form: `children: 'A, B, C'`
+  return unquote(raw)
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+/** Rewrite (or insert) the `children:` line as a single-quoted flow array. */
+function replaceChildrenList(content: string, ids: string[]): string {
+  const quoted = ids.map(id => `'${id}'`).join(', ');
+  const rendered = `children: [${quoted}]`;
+  if (/^children:.*$/m.test(content)) {
+    return content.replace(/^children:.*$/m, () => rendered);
+  }
+  // No children line yet — insert just before the closing frontmatter fence.
+  return content.replace('\n---\n', () => `\n${rendered}\n---\n`);
+}
+
+/** Write-then-rename so an interrupted run can't leave a half-written epic. */
+function atomicWrite(filePath: string, content: string): void {
+  const temporaryPath = `${filePath}.tmp`;
+  writeFileSync(temporaryPath, content);
+  renameSync(temporaryPath, filePath);
 }

--- a/packages/cli/src/utils/ticket-writer.ts
+++ b/packages/cli/src/utils/ticket-writer.ts
@@ -39,6 +39,8 @@ export interface NewTicketOptions {
   /** One-line Why; fills `**Why:**` for task/patch/epic. Not valid for features
    * (their motivation lives in spec.md) — the CLI rejects `--why` there. */
   why?: string;
+  /** Epic id this ticket is a child of; written as `parent:` frontmatter. */
+  parent?: string;
   /** Override `new Date()` for tests. */
   now?: () => Date;
 }
@@ -155,6 +157,10 @@ done_when:
   // use the same inline **Goal:**/**Why:** body as tasks — matching the
   // index-visible epic precedent (Q4FX8Y) so `sync-tickets` picks up the goal.
   const childrenFrontmatter = type === 'epic' ? 'children: []\n' : '';
+  // A child records its epic via `parent:` — the single source of truth the
+  // epic's `children:` reverse-index and hierarchy navigation read (F9W3JP).
+  const parentFrontmatter =
+    options.parent !== undefined && options.parent !== '' ? `parent: ${options.parent}\n` : '';
 
   // A blank/whitespace-only flag value keeps the placeholder rather than
   // rendering `**Goal:** ` with a trailing space and no content.
@@ -173,7 +179,7 @@ slug: ${options.slug}
 type: ${type}
 phase: intake
 status: in_progress
-${featureReadinessFrontmatter}${childrenFrontmatter}created: ${now}
+${featureReadinessFrontmatter}${childrenFrontmatter}${parentFrontmatter}created: ${now}
 last_modified: ${now}
 ---
 

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -15,6 +15,8 @@ import {
   createTemporaryDirectory,
   removeTemporaryDirectory,
   runCli,
+  ticketFolderBySlug,
+  ticketIdBySlug as idBySlug,
   TIMEOUT_QUICK,
 } from '../helpers.js';
 
@@ -40,25 +42,11 @@ function readSoleTicket(temporaryDirectory: string): string {
   return readFileSync(nodePath.join(soleTicketFolder(temporaryDirectory), 'ticket.md'), 'utf8');
 }
 
-/** Ticket folder whose slug suffix matches, when several tickets exist. */
-function ticketFolderBySlug(temporaryDirectory: string, slug: string): string {
-  const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
-  const match = readdirSync(ticketsDirectory).find(entry => entry.endsWith(`-${slug}`));
-  if (match === undefined) throw new Error(`no ticket folder for slug ${slug}`);
-  return nodePath.join(ticketsDirectory, match);
-}
-
 function readTicketBySlug(temporaryDirectory: string, slug: string): string {
   return readFileSync(
     nodePath.join(ticketFolderBySlug(temporaryDirectory, slug), 'ticket.md'),
     'utf8',
   );
-}
-
-function idBySlug(temporaryDirectory: string, slug: string): string {
-  const [id] = nodePath.basename(ticketFolderBySlug(temporaryDirectory, slug)).split('-');
-  if (id === undefined) throw new Error(`no id in folder for slug ${slug}`);
-  return id;
 }
 
 /** True if any ticket folder under the temp dir carries the given slug suffix. */

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -6,7 +6,7 @@
  * slug suffix is for legibility when scanning `ls`. End-to-end via the built CLI.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -364,6 +364,28 @@ describe('safeword ticket new', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toMatch(/not an epic/);
       expect(readTicketBySlug(temporaryDirectory, 'a-task')).toBe(taskBefore);
+      expect(ticketExistsForSlug(temporaryDirectory, 'the-child')).toBe(false);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // Quality-review edge: `completed/` is a real tickets-dir entry, so
+  // `--parent completed` resolves a folder with no ticket.md — must reject
+  // cleanly (exit 1, reasoned message), not crash with a raw ENOENT.
+  it(
+    'rejects --parent naming the completed archive dir with a clean error',
+    async () => {
+      await runCli(['ticket', 'new', 'the-epic', '--type', 'epic'], { cwd: temporaryDirectory });
+      mkdirSync(nodePath.join(temporaryDirectory, '.project', 'tickets', 'completed'), {
+        recursive: true,
+      });
+
+      const result = await runCli(['ticket', 'new', 'the-child', '--parent', 'completed'], {
+        cwd: temporaryDirectory,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/no readable ticket\.md/);
+      expect(result.stderr).not.toMatch(/ENOENT/);
       expect(ticketExistsForSlug(temporaryDirectory, 'the-child')).toBe(false);
     },
     TIMEOUT_QUICK,

--- a/packages/cli/tests/commands/ticket-new.test.ts
+++ b/packages/cli/tests/commands/ticket-new.test.ts
@@ -40,6 +40,36 @@ function readSoleTicket(temporaryDirectory: string): string {
   return readFileSync(nodePath.join(soleTicketFolder(temporaryDirectory), 'ticket.md'), 'utf8');
 }
 
+/** Ticket folder whose slug suffix matches, when several tickets exist. */
+function ticketFolderBySlug(temporaryDirectory: string, slug: string): string {
+  const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+  const match = readdirSync(ticketsDirectory).find(entry => entry.endsWith(`-${slug}`));
+  if (match === undefined) throw new Error(`no ticket folder for slug ${slug}`);
+  return nodePath.join(ticketsDirectory, match);
+}
+
+function readTicketBySlug(temporaryDirectory: string, slug: string): string {
+  return readFileSync(
+    nodePath.join(ticketFolderBySlug(temporaryDirectory, slug), 'ticket.md'),
+    'utf8',
+  );
+}
+
+function idBySlug(temporaryDirectory: string, slug: string): string {
+  const [id] = nodePath.basename(ticketFolderBySlug(temporaryDirectory, slug)).split('-');
+  if (id === undefined) throw new Error(`no id in folder for slug ${slug}`);
+  return id;
+}
+
+/** True if any ticket folder under the temp dir carries the given slug suffix. */
+function ticketExistsForSlug(temporaryDirectory: string, slug: string): boolean {
+  const ticketsDirectory = nodePath.join(temporaryDirectory, '.project', 'tickets');
+  return (
+    existsSync(ticketsDirectory) &&
+    readdirSync(ticketsDirectory).some(entry => entry.endsWith(`-${slug}`))
+  );
+}
+
 function extractIdFromFolder(folderName: string): string {
   const match = FOLDER_PATTERN.exec(folderName);
   const id = match?.[1];
@@ -283,6 +313,73 @@ describe('safeword ticket new', () => {
 
       const ticketContent = readSoleTicket(temporaryDirectory);
       expect(ticketContent).toMatch(/^\*\*Goal:\*\* \{One sentence/m);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // F9W3JP — epic-child-linker.TB1.AC1.linking_records_parent_and_appends_to_epic (S1)
+  it(
+    'links a child to its epic both ways with --parent',
+    async () => {
+      await runCli(['ticket', 'new', 'the-epic', '--type', 'epic'], { cwd: temporaryDirectory });
+      const epicId = idBySlug(temporaryDirectory, 'the-epic');
+
+      const result = await runCli(['ticket', 'new', 'the-child', '--parent', epicId], {
+        cwd: temporaryDirectory,
+      });
+      expect(result.exitCode).toBe(0);
+
+      const childId = idBySlug(temporaryDirectory, 'the-child');
+      expect(readTicketBySlug(temporaryDirectory, 'the-child')).toContain(`parent: ${epicId}`);
+      expect(readTicketBySlug(temporaryDirectory, 'the-epic')).toContain(childId);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // epic-child-linker.TB1.AC3.missing_parent_rejected (S4)
+  it(
+    'rejects --parent naming no existing ticket and creates no child',
+    async () => {
+      const result = await runCli(['ticket', 'new', 'orphan', '--parent', 'ZZZZZZ'], {
+        cwd: temporaryDirectory,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/not found|ZZZZZZ/);
+      expect(ticketExistsForSlug(temporaryDirectory, 'orphan')).toBe(false);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // epic-child-linker.TB1.AC3.non_epic_parent_rejected (S5)
+  it(
+    'rejects --parent naming a non-epic ticket, leaving it unchanged and creating no child',
+    async () => {
+      await runCli(['ticket', 'new', 'a-task', '--type', 'task'], { cwd: temporaryDirectory });
+      const taskId = idBySlug(temporaryDirectory, 'a-task');
+      const taskBefore = readTicketBySlug(temporaryDirectory, 'a-task');
+
+      const result = await runCli(['ticket', 'new', 'the-child', '--parent', taskId], {
+        cwd: temporaryDirectory,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/not an epic/);
+      expect(readTicketBySlug(temporaryDirectory, 'a-task')).toBe(taskBefore);
+      expect(ticketExistsForSlug(temporaryDirectory, 'the-child')).toBe(false);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  // Regression (no AC): --parent logic must not leak into the default create path.
+  it(
+    'ticket new without --parent writes no parent: and touches no other ticket',
+    async () => {
+      await runCli(['ticket', 'new', 'the-epic', '--type', 'epic'], { cwd: temporaryDirectory });
+      const epicBefore = readTicketBySlug(temporaryDirectory, 'the-epic');
+
+      await runCli(['ticket', 'new', 'standalone'], { cwd: temporaryDirectory });
+
+      expect(readTicketBySlug(temporaryDirectory, 'standalone')).not.toMatch(/^parent:/m);
+      expect(readTicketBySlug(temporaryDirectory, 'the-epic')).toBe(epicBefore);
     },
     TIMEOUT_QUICK,
   );

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1173,3 +1173,18 @@ export function appendRetroAck(
 export function writeSelfReportConfig(dir: string, selfReport: Record<string, boolean>): void {
   writeTestFile(dir, '.safeword/config.json', JSON.stringify({ selfReport }));
 }
+
+/** Absolute path of the ticket folder whose slug suffix matches, in a temp project. */
+export function ticketFolderBySlug(projectDirectory: string, slug: string): string {
+  const ticketsDirectory = nodePath.join(projectDirectory, '.project', 'tickets');
+  const match = readdirSync(ticketsDirectory).find(entry => entry.endsWith(`-${slug}`));
+  if (match === undefined) throw new Error(`no ticket folder for slug ${slug}`);
+  return nodePath.join(ticketsDirectory, match);
+}
+
+/** The minted id portion of a `{id}-{slug}` ticket folder, found by slug. */
+export function ticketIdBySlug(projectDirectory: string, slug: string): string {
+  const [id] = nodePath.basename(ticketFolderBySlug(projectDirectory, slug)).split('-');
+  if (id === undefined) throw new Error(`no id in folder for slug ${slug}`);
+  return id;
+}

--- a/packages/cli/tests/integration/epic-child-linker-navigation.test.ts
+++ b/packages/cli/tests/integration/epic-child-linker-navigation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Integration proof for F9W3JP AC1: a link built through the real
+ * `ticket new --parent` command is walkable by the hierarchy navigation
+ * contract — `findNextWork` reaches the linked child. This exercises the new
+ * feature end-to-end (the Given builds the link via the command, not by
+ * hand-writing frontmatter), per the scenario-gate strengthen.
+ */
+
+import { readdirSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { findNextWork } from '../../templates/hooks/lib/hierarchy.js';
+import {
+  createTemporaryDirectory,
+  removeTemporaryDirectory,
+  runCli,
+  TIMEOUT_QUICK,
+} from '../helpers.js';
+
+function ticketsDirectoryOf(temporaryDirectory: string): string {
+  return nodePath.join(temporaryDirectory, '.project', 'tickets');
+}
+
+function folderBySlug(temporaryDirectory: string, slug: string): string {
+  const ticketsDirectory = ticketsDirectoryOf(temporaryDirectory);
+  const match = readdirSync(ticketsDirectory).find(entry => entry.endsWith(`-${slug}`));
+  if (match === undefined) throw new Error(`no ticket for slug ${slug}`);
+  return nodePath.join(ticketsDirectory, match);
+}
+
+function idBySlug(temporaryDirectory: string, slug: string): string {
+  const [id] = nodePath.basename(folderBySlug(temporaryDirectory, slug)).split('-');
+  if (id === undefined) throw new Error(`no id for slug ${slug}`);
+  return id;
+}
+
+describe('epic-child --parent navigation (F9W3JP AC1)', () => {
+  let temporaryDirectory: string;
+  beforeEach(() => {
+    temporaryDirectory = createTemporaryDirectory();
+  });
+  afterEach(() => {
+    removeTemporaryDirectory(temporaryDirectory);
+  });
+
+  // epic-child-linker.TB1.AC1.navigation_from_epic_reaches_child
+  it(
+    'findNextWork reaches a child linked through ticket new --parent',
+    async () => {
+      await runCli(['ticket', 'new', 'the-epic', '--type', 'epic'], { cwd: temporaryDirectory });
+      const epicId = idBySlug(temporaryDirectory, 'the-epic');
+      await runCli(['ticket', 'new', 'the-child', '--parent', epicId], {
+        cwd: temporaryDirectory,
+      });
+
+      const childFolder = folderBySlug(temporaryDirectory, 'the-child');
+      const childId = idBySlug(temporaryDirectory, 'the-child');
+
+      // From the child (in-progress), the epic's children[] link makes it the
+      // next undone work — proving the reverse index the command wrote is walked.
+      const action = findNextWork(childFolder, ticketsDirectoryOf(temporaryDirectory));
+      expect(action.type).toBe('navigate');
+      if (action.type === 'navigate') expect(action.ticketId).toBe(childId);
+    },
+    TIMEOUT_QUICK,
+  );
+});

--- a/packages/cli/tests/integration/epic-child-linker-navigation.test.ts
+++ b/packages/cli/tests/integration/epic-child-linker-navigation.test.ts
@@ -6,7 +6,6 @@
  * hand-writing frontmatter), per the scenario-gate strengthen.
  */
 
-import { readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -16,24 +15,13 @@ import {
   createTemporaryDirectory,
   removeTemporaryDirectory,
   runCli,
+  ticketFolderBySlug,
+  ticketIdBySlug as idBySlug,
   TIMEOUT_QUICK,
 } from '../helpers.js';
 
 function ticketsDirectoryOf(temporaryDirectory: string): string {
   return nodePath.join(temporaryDirectory, '.project', 'tickets');
-}
-
-function folderBySlug(temporaryDirectory: string, slug: string): string {
-  const ticketsDirectory = ticketsDirectoryOf(temporaryDirectory);
-  const match = readdirSync(ticketsDirectory).find(entry => entry.endsWith(`-${slug}`));
-  if (match === undefined) throw new Error(`no ticket for slug ${slug}`);
-  return nodePath.join(ticketsDirectory, match);
-}
-
-function idBySlug(temporaryDirectory: string, slug: string): string {
-  const [id] = nodePath.basename(folderBySlug(temporaryDirectory, slug)).split('-');
-  if (id === undefined) throw new Error(`no id for slug ${slug}`);
-  return id;
 }
 
 describe('epic-child --parent navigation (F9W3JP AC1)', () => {
@@ -55,7 +43,7 @@ describe('epic-child --parent navigation (F9W3JP AC1)', () => {
         cwd: temporaryDirectory,
       });
 
-      const childFolder = folderBySlug(temporaryDirectory, 'the-child');
+      const childFolder = ticketFolderBySlug(temporaryDirectory, 'the-child');
       const childId = idBySlug(temporaryDirectory, 'the-child');
 
       // From the child (in-progress), the epic's children[] link makes it the

--- a/packages/cli/tests/ticket-sync/ticket-sync.test.ts
+++ b/packages/cli/tests/ticket-sync/ticket-sync.test.ts
@@ -431,4 +431,27 @@ describe('ticket-sync', () => {
       expect(skipped.map(skip => skip.folder)).not.toContain('tmp');
     });
   });
+
+  // F9W3JP — epic-child-linker.TB1.AC2.index_groups_child_under_epic (S3)
+  it('groups a child under its epic heading via parent:', () => {
+    writeTicket(
+      'EPIC01-the-epic',
+      { id: 'EPIC01', type: 'epic', status: 'in_progress', children: "['CHILD1']" },
+      '# The epic\n',
+    );
+    writeTicket(
+      'CHILD1-the-child',
+      { id: 'CHILD1', type: 'task', status: 'in_progress', parent: 'EPIC01' },
+      '# The child\n',
+    );
+    const { active } = readTickets(ticketsDirectory);
+    const index = buildIndexContent(active, { variant: 'active' });
+
+    const start = index.indexOf('### EPIC01');
+    expect(start).toBeGreaterThanOrEqual(0);
+    const rest = index.slice(start + '### EPIC01'.length);
+    const next = rest.indexOf('\n### ');
+    const epicBlock = next === -1 ? rest : rest.slice(0, next);
+    expect(epicBlock).toContain('CHILD1');
+  });
 });


### PR DESCRIPTION
Implements the A2 epic-child linker deferred from #699/PR #817, built through the full safeword BDD workflow (ticket F9W3JP: intake → scenario-gate → outside-in TDD → verify).

## What it does

`safeword ticket new <slug> --parent <epicId>` wires a new child ticket to its epic in one command instead of two hand-edits:

- **Validates first, creates second** — a missing or non-`type: epic` parent (including the `completed/` archive dir) exits 1 with a reasoned message and creates nothing.
- **Writes both link ends** — `parent: <epicId>` on the child, and an idempotent, atomic (tmp+rename) append of the child id to the epic's `children:` list.
- **Format-tolerant append** — handles every `children:` shape in the corpus: flow array, legacy comma scalar, and block-sequence (`- id` lines), rewriting block form whole rather than corrupting it.
- **INDEX grouping by `parent:`** — children now group under their epic's heading in `INDEX.md`, resolved from the same single source of truth (legacy `epic:` honored as a fallback; the tracker-sync corpus back-link is untouched).
- If the epic changes between validation and link, the CLI warns with recovery instructions instead of failing silently or crashing.

## Design

`/figure-it-out` (evidence-cited) chose a single `parent:` source of truth over a dual `parent:`+`epic:` write (drift risk; the corpus never maintained `epic:`) and a create-time flag over a standalone `ticket link` verb (deferred follow-up). Zero new dependencies — inline frontmatter parsing per the hooks ADR, reusing `hierarchy.ts` patterns. Full rationale in `.project/tickets/F9W3JP-epic-child-linker/impl-plan.md`.

## Quality gates

- Scenario-gate: independent `/review-spec` pass (caught and fixed one vacuous scenario).
- Cross-model `/quality-review`: two verified criticals found and fixed — block-sequence `children:` corruption, and a discarded link-failure signal — then re-review PASS.
- `/refactor`: dead export demoted, tests now exercise the production parser, duplicated test helpers hoisted (−10 jscpd clones).

## Verification

- Full suite: 4651/4651 tests pass (327 files); Gherkin acceptance lane 28 scenarios / 217 steps green (5 new black-box scenarios for this feature; the two CLI-unreachable contracts — `findNextWork` navigation and append idempotency — are vitest-proven, noted in the `.feature`).
- `tsc --noEmit`, eslint, depcruise, knip all clean; jscpd down 10 clones vs baseline.

## Follow-ups (recorded in verify.md, out of scope)

- INDEX nesting polish: the epic itself still lists under "(no epic)" and child groups show the bare epic id, not its title.
- Standalone `ticket link` / re-parent command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXdv6zZRRJdCGf7XkCqvkh)_