### PR TITLE
architecture generator: recognize flat/lib JS layouts + surface non-workspace Go/Python/Rust services (#843, #844)

### DIFF
--- a/features/monorepo-coverage-honesty.feature
+++ b/features/monorepo-coverage-honesty.feature
@@ -60,3 +60,22 @@ Feature: Honest monorepo coverage — pnpm discovery + un-introspected marker
       Then the package "svc" is marked "not introspected" in the root index
       And the package "web" is not marked "not introspected" in the root index
       And the package "web" has its own colocated leaf doc
+
+  Rule: The recognizer covers conventional non-src layouts (issue #843)
+
+    @monorepo-coverage-honesty.TB3.AC1
+    Scenario: A package whose sources live under lib/ is introspected, not marked
+      Given a pnpm monorepo with a package "ui" whose sources live under lib/
+      When safeword generates the architecture doc
+      Then a root index lists the package "ui"
+      And the package "ui" is not marked "not introspected" in the root index
+      And the package "ui" has its own colocated leaf doc
+
+  Rule: Non-JS services outside a declared workspace appear in the root index (issue #844)
+
+    @monorepo-coverage-honesty.TB4.AC1
+    Scenario: A standalone Go service is listed and gets a colocated leaf doc
+      Given a JS monorepo that also has a standalone Go service at "services/engine" with module "example.com/engine" and the golang pack installed
+      When safeword generates the architecture doc
+      Then a root index lists the package "example.com/engine"
+      And a colocated leaf doc exists at "services/engine"

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -18,7 +18,7 @@ import {
   discoverLeafDirectories,
   discoverUnreadableWorkspaces,
   extractMonorepoModel,
-  monorepoFingerprint,
+  monorepoFingerprintOf,
   type MonorepoModel,
   type PackageNode,
   type UnreadableWorkspace,
@@ -150,8 +150,8 @@ function leafTarget(packageDirectory: string): HealTarget {
 
 /** The derived root index: the package graph at the namespace-root path. */
 function rootIndexTarget(projectDirectory: string): HealTarget {
-  const fingerprint = monorepoFingerprint(projectDirectory);
   const model = extractMonorepoModel(projectDirectory);
+  const fingerprint = monorepoFingerprintOf(projectDirectory, model);
   return {
     path: resolveGeneratedArchitecturePath(projectDirectory),
     fingerprint,

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -402,11 +402,12 @@ function renderCoverageGaps(unreadable: UnreadableWorkspace[]): string {
 }
 
 function renderPackageSection(node: PackageNode, stamp: string): string {
-  // An un-introspected package (no recognized source layout, so no leaf doc) is
+  // An un-introspected package (no source modules to enumerate, so no leaf doc) is
   // marked explicitly — never shown with the bare prose placeholder, which would
-  // read as "described but empty" rather than "safeword can't see this" (ZRW21K).
-  const body = node.introspected
-    ? node.purpose
-    : '> ⚠ not introspected — no recognized source layout';
+  // read as "described but empty" rather than "nothing to map here" (ZRW21K). The
+  // wording says "no source modules" rather than "no recognized source layout":
+  // with the broadened recognizer (issue #843) a package reaches this only when it
+  // genuinely has no enumerable modules, not because its layout was misread.
+  const body = node.introspected ? node.purpose : '> ⚠ not introspected — no source modules to map';
   return `### ${node.name}\n\n${RECONCILED_PREFIX} ${stamp} -->\n\n${body}\n`;
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -139,10 +139,16 @@ export function discoverWorkspaces(projectDirectory: string): WorkspaceDiscovery
  * `[]` for a non-workspace project with no orphan packages.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  const workspaceLeaves = resolveLeafDirectories(
-    projectDirectory,
-    discoverWorkspaces(projectDirectory).patterns,
-  );
+  return leafDirectoriesFrom(projectDirectory, discoverWorkspaces(projectDirectory).patterns);
+}
+
+/**
+ * The declared-workspace ∪ orphan leaf union behind {@link discoverLeafDirectories},
+ * taking already-read workspace patterns so a caller that has run discovery (the
+ * model extractor) doesn't probe every manager a second time.
+ */
+function leafDirectoriesFrom(projectDirectory: string, patterns: string[]): string[] {
+  const workspaceLeaves = resolveLeafDirectories(projectDirectory, patterns);
   const orphanLeaves = discoverOrphanManifestDirectories(projectDirectory);
   return [...new Set([...workspaceLeaves, ...orphanLeaves])].toSorted(byString);
 }
@@ -302,9 +308,9 @@ function hasRecognizedManifest(directory: string): boolean {
 
 /** The package/edge model the root index renders over. */
 export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
-  const unreadableWorkspaces = discoverWorkspaces(projectDirectory).unreadable;
+  const { patterns, unreadable: unreadableWorkspaces } = discoverWorkspaces(projectDirectory);
   // Includes both declared workspace members and orphan non-JS packages (issue #844).
-  const packages: PackageNode[] = discoverLeafDirectories(projectDirectory)
+  const packages: PackageNode[] = leafDirectoriesFrom(projectDirectory, patterns)
     .map(dir => ({
       name: packageName(dir),
       dir,

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -33,10 +33,12 @@ export interface PackageNode {
   /** One-line purpose (the purpose floor); a placeholder until prose is written. */
   purpose: string;
   /**
-   * Whether the package has a recognized source layout (a non-empty `src/`
-   * skeleton, so it gets a leaf doc). A package that is `false` here is listed in
-   * the root index but explicitly marked "not introspected" rather than shown
-   * with a bare placeholder — incomplete, never silently complete (ZRW21K).
+   * Whether the package yields a non-empty skeleton (source modules to enumerate,
+   * so it gets a leaf doc) — across every layout the extractor recognizes: `src/`,
+   * `lib/`, or flat/top-level files for JS/TS, plus the Go/Rust/Python layouts
+   * (issue #843). A package that is `false` here is listed in the root index but
+   * explicitly marked "not introspected" rather than shown with a bare placeholder
+   * — incomplete, never silently complete (ZRW21K).
    */
   introspected: boolean;
 }

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -338,7 +338,15 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
  * and the shared boundary config. Distinct from per-leaf `shapeFingerprint`.
  */
 export function monorepoFingerprint(projectDirectory: string): string {
-  const model = extractMonorepoModel(projectDirectory);
+  return monorepoFingerprintOf(projectDirectory, extractMonorepoModel(projectDirectory));
+}
+
+/**
+ * {@link monorepoFingerprint} over an already-extracted model, so a caller that
+ * needs both (the root-index heal renders the model AND stamps its fingerprint)
+ * extracts once instead of re-running discovery and the orphan tree walk.
+ */
+export function monorepoFingerprintOf(projectDirectory: string, model: MonorepoModel): string {
   const inputs = {
     // Introspection status is part of the root shape: a package gaining or losing
     // a `src/` tree flips its root-index line (marker ↔ described), so the root

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -17,7 +17,7 @@ import nodePath from 'node:path';
 import { extractSkeleton, PURPOSE_PLACEHOLDER } from './architecture-skeleton.js';
 import { readBoundaryConfig } from './boundary-config.js';
 import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
-import { isDirectory, readFileSafe, readJson } from './fs.js';
+import { findAllInTree, isDirectory, readFileSafe, readJson } from './fs.js';
 import { readDelimitedBlock } from './manifest-block.js';
 import { dependencySectionNames } from './manifest-dependencies.js';
 import { readPyprojectName, readUvWorkspaceMembers } from './pyproject-manifest.js';
@@ -130,12 +130,102 @@ export function discoverWorkspaces(projectDirectory: string): WorkspaceDiscovery
 }
 
 /**
- * Absolute directories of the workspace leaf packages, sorted. Expands the
- * workspace globs from the manifest and keeps only directories that carry a
- * recognized manifest. Returns `[]` for a non-workspace project.
+ * Absolute directories of the leaf packages, sorted. The union of two sources:
+ * the DECLARED workspace members (workspace globs expanded, recognized-manifest
+ * dirs kept) and the ORPHAN non-JS packages a bounded tree walk finds outside any
+ * declared workspace (issue #844). A dir claimed by both is listed once. Returns
+ * `[]` for a non-workspace project with no orphan packages.
  */
 export function discoverLeafDirectories(projectDirectory: string): string[] {
-  return resolveLeafDirectories(projectDirectory, discoverWorkspaces(projectDirectory).patterns);
+  const workspaceLeaves = resolveLeafDirectories(
+    projectDirectory,
+    discoverWorkspaces(projectDirectory).patterns,
+  );
+  const orphanLeaves = discoverOrphanManifestDirectories(projectDirectory);
+  return [...new Set([...workspaceLeaves, ...orphanLeaves])].toSorted(byString);
+}
+
+/**
+ * Non-JS language manifests a polyglot monorepo often keeps as standalone modules
+ * that are NOT enrolled in a declared workspace (`go.work`, uv, Cargo `[workspace]`),
+ * so `discoverWorkspaces` never sees them and the root index — the doc the staleness
+ * gate anchors on — omits the platform's actual core (issue #844). JS is absent on
+ * purpose: its packages come from the workspace graph. Each entry is gated by its
+ * language pack so a project only pays for a language it opted into.
+ */
+const ORPHAN_MANIFESTS: {
+  /** `installedPacks` ids that enable this language's walk (`go`/`golang` are aliases). */
+  packs: string[];
+  filename: string;
+  /** Whether the manifest actually declares a package (vs. tooling/workspace-root config). */
+  declaresPackage: (content: string) => boolean;
+}[] = [
+  { packs: ['golang', 'go'], filename: 'go.mod', declaresPackage: content => hasGoModule(content) },
+  {
+    packs: ['python'],
+    filename: 'pyproject.toml',
+    // A real package declares [project] (PEP 621) or [tool.poetry]; a pyproject that
+    // only carries [tool.ruff]/[tool.black] tooling config is not a package leaf.
+    declaresPackage: content =>
+      hasTomlTable(content, 'project') || hasTomlTable(content, 'tool.poetry'),
+  },
+  {
+    packs: ['rust'],
+    filename: 'Cargo.toml',
+    // A member crate declares [package]; a bare [workspace] root is not a leaf.
+    declaresPackage: content => hasTomlTable(content, 'package'),
+  },
+];
+
+/**
+ * Directories of non-JS packages discovered outside any declared workspace (issue
+ * #844): for every installed language pack, tree-walk for its manifest (bounded by
+ * the shared exclude set in {@link findAllInTree}), keep the dirs whose manifest
+ * actually declares a package, and drop the repo root itself (a root
+ * `pyproject.toml`/`Cargo.toml` is tooling/workspace config, not a leaf). Empty when
+ * no non-JS pack is installed, so a JS-only project is unaffected and pays for no walk.
+ */
+function discoverOrphanManifestDirectories(projectDirectory: string): string[] {
+  const installed = installedPacks(projectDirectory);
+  const directories = new Set<string>();
+  for (const manifest of ORPHAN_MANIFESTS) {
+    if (manifest.packs.every(pack => !installed.has(pack))) continue;
+    for (const dir of orphanDirectoriesFor(projectDirectory, manifest)) directories.add(dir);
+  }
+  return [...directories];
+}
+
+/** Package dirs for one language's manifest: tree-walked, root dropped, package-declaring kept. */
+function orphanDirectoriesFor(
+  projectDirectory: string,
+  manifest: { filename: string; declaresPackage: (content: string) => boolean },
+): string[] {
+  return findAllInTree(projectDirectory, manifest.filename).filter(dir => {
+    if (dir === projectDirectory) return false; // the repo root is not a leaf package
+    const content = readFileSafe(nodePath.join(dir, manifest.filename));
+    return content !== undefined && manifest.declaresPackage(content);
+  });
+}
+
+/** Whether a `go.mod`'s content declares a `module` path. */
+function hasGoModule(content: string): boolean {
+  return /^module\s+\S+/m.test(content);
+}
+
+/**
+ * The language packs the project opted into, from `.safeword/config.json`
+ * `installedPacks` — the gate for the orphan-manifest walk (issue #844). Read
+ * locally (best-effort, a single field) rather than importing the packs module, so
+ * this discovery layer stays free of a `utils → packs` dependency; `test-plan`
+ * reads the same field the same way for the same reason. An absent/unreadable
+ * config yields an empty set — no orphan walk, discovery unchanged.
+ */
+function installedPacks(projectDirectory: string): Set<string> {
+  const config = readJson(nodePath.join(projectDirectory, '.safeword', 'config.json'));
+  if (config === null || typeof config !== 'object') return new Set();
+  const packs = (config as { installedPacks?: unknown }).installedPacks;
+  if (!Array.isArray(packs)) return new Set();
+  return new Set(packs.filter((pack): pack is string => typeof pack === 'string'));
 }
 
 /** The present-but-unparseable workspace managers at the root, if any (UWP4XK). */
@@ -210,8 +300,9 @@ function hasRecognizedManifest(directory: string): boolean {
 
 /** The package/edge model the root index renders over. */
 export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
-  const { patterns, unreadable: unreadableWorkspaces } = discoverWorkspaces(projectDirectory);
-  const packages: PackageNode[] = resolveLeafDirectories(projectDirectory, patterns)
+  const unreadableWorkspaces = discoverWorkspaces(projectDirectory).unreadable;
+  // Includes both declared workspace members and orphan non-JS packages (issue #844).
+  const packages: PackageNode[] = discoverLeafDirectories(projectDirectory)
     .map(dir => ({
       name: packageName(dir),
       dir,

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -11,7 +11,8 @@
 import { type Dirent, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { exists, isDirectory } from './fs.js';
+import { exists, isDirectory, readFileSafe, readJson } from './fs.js';
+import { hasTomlTable } from './toml.js';
 
 /** Placeholder purpose for a freshly extracted node awaiting human prose. */
 export const PURPOSE_PLACEHOLDER = 'No description yet — awaiting prose.';
@@ -128,8 +129,36 @@ export function extractSkeleton(projectDirectory: string): Skeleton {
   if (libraryNodes.length > 0) return { nodes: libraryNodes };
 
   // No source root at all: a flat or test-only package (e.g. top-level `*.test.ts`
-  // with no `src/`) is described by its top-level source files (issue #843).
+  // with no `src/`) is described by its top-level source files (issue #843) — but
+  // NEVER at a workspace-declaring root. A monorepo root whose declared members
+  // resolve to zero leaves used to yield an empty skeleton, and `decideAction`
+  // relies on that emptiness to noop rather than birth a single-repo doc; a stray
+  // root script (`jest.setup.js`, `gulpfile.js`) must not become "the architecture"
+  // of a repo that declares itself a monorepo (quality-review of #843).
+  if (declaresWorkspaces(projectDirectory)) return { nodes: [] };
   return { nodes: topLevelJsModuleNodes(projectDirectory) };
+}
+
+/**
+ * Whether a directory declares workspace membership — the discovery-layer managers
+ * `architecture-monorepo.ts` reads, probed shallowly here (that module imports this
+ * one, so this light re-probe avoids an import cycle). Cargo `[workspace]` is not
+ * checked: a dir with a Cargo.toml dispatches to the Rust extractor above and never
+ * reaches the top-level JS fallback this guards.
+ */
+function declaresWorkspaces(projectDirectory: string): boolean {
+  if (exists(nodePath.join(projectDirectory, 'pnpm-workspace.yaml'))) return true;
+  if (exists(nodePath.join(projectDirectory, 'go.work'))) return true;
+  const manifest = readJson(nodePath.join(projectDirectory, 'package.json'));
+  if (
+    manifest !== null &&
+    typeof manifest === 'object' &&
+    (manifest as Record<string, unknown>).workspaces !== undefined
+  ) {
+    return true;
+  }
+  const pyproject = readFileSafe(nodePath.join(projectDirectory, 'pyproject.toml'));
+  return pyproject !== undefined && hasTomlTable(pyproject, 'tool.uv.workspace');
 }
 
 /**
@@ -181,16 +210,37 @@ function topLevelJsModuleNodes(projectDirectory: string): SkeletonNode[] {
   return jsFileNodes(entries, name => name);
 }
 
-/** The source-file entries of a directory as skeleton nodes, sorted by name. */
+/**
+ * The source-file entries of a directory as skeleton nodes, sorted by name and
+ * deduped by module name — the same unique-node contract the Rust/Python
+ * extractors keep via their `byName` maps. A same-named pair across extensions
+ * (`util.ts` + `util.js`, a mid-migration package) yields ONE node, and the
+ * winner is deterministic: the extension earliest in {@link JS_SOURCE_EXTENSIONS}
+ * (TypeScript over JavaScript — the migration's source of truth). Without the
+ * dedupe, two `### util` sections would render and the surviving path would be
+ * readdir-order (platform) dependent.
+ */
 function jsFileNodes(entries: Dirent[], pathFor: (entryName: string) => string): SkeletonNode[] {
-  return entries
+  const files = entries
     .filter(entry => entry.isFile() && isJsSourceModuleFile(entry.name))
-    .map(entry => ({
-      name: jsModuleName(entry.name),
-      path: pathFor(entry.name),
-      purpose: PURPOSE_PLACEHOLDER,
-    }))
-    .toSorted(byNodeName);
+    .toSorted(
+      (a, b) =>
+        extensionPriority(a.name) - extensionPriority(b.name) || a.name.localeCompare(b.name),
+    );
+
+  const byName = new Map<string, SkeletonNode>();
+  for (const entry of files) {
+    const name = jsModuleName(entry.name);
+    if (!byName.has(name)) {
+      byName.set(name, { name, path: pathFor(entry.name), purpose: PURPOSE_PLACEHOLDER });
+    }
+  }
+  return byName.values().toArray().toSorted(byNodeName);
+}
+
+/** The rank of a filename's extension in {@link JS_SOURCE_EXTENSIONS} (lower wins dedupe). */
+function extensionPriority(filename: string): number {
+  return JS_SOURCE_EXTENSIONS.findIndex(extension => filename.endsWith(extension));
 }
 
 /**

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -42,6 +42,13 @@ const PYTHON_EXCLUDED_FILES = new Set([
   '__main__.py',
 ]);
 
+/**
+ * Extensions a JS/TS source file can carry (issue #843). A package whose modules are
+ * files rather than directories — a flat `src/`, a `lib/` root, or a top-level layout —
+ * is described by these, the way the Python/Rust extractors already describe `*.py`/`*.rs`.
+ */
+const JS_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
 export interface SkeletonNode {
   /** Module name — the top-level `src/` subdirectory. */
   name: string;
@@ -89,9 +96,12 @@ export function extractSkeleton(projectDirectory: string): Skeleton {
     return { nodes: rustModuleNodes(projectDirectory) };
   }
 
-  // The `src/` layout (TS/JS) is authoritative and unchanged: when it yields
-  // modules, that is the skeleton.
-  const sourceNodes = enumerateModuleDirectories(
+  // The `src/` layout (TS/JS) is authoritative: its child DIRECTORIES are the
+  // modules, unchanged — a package that already has them never churns. Broadened
+  // (issue #843) so a flat `src/` — holding only files, no subdirectories — is
+  // introspected via those files, the same files-and-flat recognition the
+  // Python/Rust extractors above already have.
+  const sourceNodes = enumerateJsSourceRoot(
     nodePath.join(projectDirectory, 'src'),
     name => `src/${name}`,
   );
@@ -100,23 +110,42 @@ export function extractSkeleton(projectDirectory: string): Skeleton {
   // No `src/` modules: a Go module (a `go.mod` is present) is described by its
   // conventional top-level layout directories instead (ticket ZD70P1). A flat Go
   // package with none of these stays an empty skeleton — honestly "not
-  // introspected" (ZRW21K), never falsely complete.
+  // introspected" (ZRW21K), never falsely complete. Checked BEFORE the lib/
+  // and top-level JS fallbacks so a Go service carrying a stray build script
+  // never dispatches to the JS recognizer.
   if (exists(nodePath.join(projectDirectory, 'go.mod'))) {
     return { nodes: goLayoutNodes(projectDirectory) };
   }
 
-  return { nodes: sourceNodes };
+  // Still nothing under `src/`: a `lib/`-rooted package (component libraries like
+  // design systems keep their sources under `lib/` — issue #843) is described the
+  // same files-or-directories way. Last-resort JS fallbacks, so they never preempt
+  // a recognized Go/Rust/Python layout above.
+  const libraryNodes = enumerateJsSourceRoot(
+    nodePath.join(projectDirectory, 'lib'),
+    name => `lib/${name}`,
+  );
+  if (libraryNodes.length > 0) return { nodes: libraryNodes };
+
+  // No source root at all: a flat or test-only package (e.g. top-level `*.test.ts`
+  // with no `src/`) is described by its top-level source files (issue #843).
+  return { nodes: topLevelJsModuleNodes(projectDirectory) };
 }
 
 /**
- * The immediate subdirectories of `directory` as skeleton nodes, sorted by name
- * (readdirSync order is not guaranteed; the rendered doc and fingerprint must be
- * deterministic). `pathFor` maps a module name to its forward-slashed code
- * reference — platform-stable, the way the fingerprint normalizes paths.
+ * A JS/TS source root (`src/` or `lib/`) as skeleton nodes, sorted by name
+ * (readdirSync order is not guaranteed; the doc and fingerprint must be
+ * deterministic). Its child DIRECTORIES when it has any — the directory is the
+ * module unit, so a package with `src/` subdirectories is byte-for-byte
+ * unchanged. Only when the root has NO subdirectories (a flat package — issue
+ * #843) does it fall back to the root's source FILES, mirroring how the Rust and
+ * Python extractors list `*.rs`/`*.py`. `pathFor` maps an entry name to its
+ * forward-slashed code reference — platform-stable, the way the fingerprint
+ * normalizes paths. `[]` when the root is absent.
  */
-function enumerateModuleDirectories(
+function enumerateJsSourceRoot(
   directory: string,
-  pathFor: (name: string) => string,
+  pathFor: (entryName: string) => string,
 ): SkeletonNode[] {
   let entries: Dirent[];
   try {
@@ -125,10 +154,60 @@ function enumerateModuleDirectories(
     return [];
   }
 
+  const directories = entries.filter(entry => entry.isDirectory());
+  if (directories.length > 0) {
+    return directories
+      .map(entry => ({ name: entry.name, path: pathFor(entry.name), purpose: PURPOSE_PLACEHOLDER }))
+      .toSorted(byNodeName);
+  }
+  return jsFileNodes(entries, pathFor);
+}
+
+/**
+ * Top-level JS/TS source FILES as modules (issue #843) — a flat or test-only
+ * package with no `src/`/`lib/` root (e.g. an integration-tests package whose
+ * `*.test.ts` live at the root). Files only: a package root's directories are
+ * ambiguous (build output, fixtures, docs) with no `__init__.py`-style marker to
+ * qualify them the way the Python flat-layout extractor can, so only the source
+ * roots above enumerate directories.
+ */
+function topLevelJsModuleNodes(projectDirectory: string): SkeletonNode[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(projectDirectory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return jsFileNodes(entries, name => name);
+}
+
+/** The source-file entries of a directory as skeleton nodes, sorted by name. */
+function jsFileNodes(entries: Dirent[], pathFor: (entryName: string) => string): SkeletonNode[] {
   return entries
-    .filter(entry => entry.isDirectory())
-    .map(entry => ({ name: entry.name, path: pathFor(entry.name), purpose: PURPOSE_PLACEHOLDER }))
+    .filter(entry => entry.isFile() && isJsSourceModuleFile(entry.name))
+    .map(entry => ({
+      name: jsModuleName(entry.name),
+      path: pathFor(entry.name),
+      purpose: PURPOSE_PLACEHOLDER,
+    }))
     .toSorted(byNodeName);
+}
+
+/**
+ * Whether a filename is a JS/TS source module: a recognized source extension that
+ * is neither a declaration file (`*.d.ts`) nor a tooling config (`*.config.*`) —
+ * the JS analogue of the Python dunder/tooling exclusion. Dotfiles are excluded here.
+ */
+function isJsSourceModuleFile(name: string): boolean {
+  if (name.startsWith('.')) return false; // dotfiles (.eslintrc.js, .prettierrc.cjs)
+  if (/\.d\.[mc]?ts$/.test(name)) return false; // type declarations, not modules
+  if (/\.config\.[mc]?[jt]sx?$/.test(name)) return false; // vite.config.ts, eslint.config.mjs, …
+  return JS_SOURCE_EXTENSIONS.some(extension => name.endsWith(extension));
+}
+
+/** A source file's module name: the filename minus its final extension (`db.test.ts` → `db.test`). */
+function jsModuleName(filename: string): string {
+  return filename.slice(0, filename.lastIndexOf('.'));
 }
 
 /** The recognized Go layout directories that actually exist, as sorted nodes. */

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -75,6 +75,9 @@ const SUBDIRECTORY_EXCLUDE = new Set([
   '.git',
   '.safeword',
   'vendor',
+  // Go toolchains ignore testdata/ entirely; repos keep fixture go.mod files there
+  // (with real module directives) that must not surface as discovered packages.
+  'testdata',
   'dist',
   'build',
   'target',

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -255,6 +255,32 @@ export function indexFilesInTree(
 }
 
 /**
+ * Every directory (root included) that DIRECTLY contains `filename`, in root-first
+ * BFS order, skipping hidden dirs and SUBDIRECTORY_EXCLUDE. The collect-all analogue
+ * of {@link findInTree} (which stops at the first match) — used to enumerate orphan
+ * language manifests (a `go.mod` / `pyproject.toml` / `Cargo.toml` that is not enrolled
+ * in any declared workspace) across a polyglot monorepo in one bounded walk.
+ */
+export function findAllInTree(cwd: string, filename: string, maxDepth = 10): string[] {
+  const found: string[] = [];
+  // Cursor-based BFS (not Array.shift()) so the walk stays O(dirs) on wide/deep trees,
+  // mirroring indexFilesInTree.
+  const queue: { directory: string; depth: number }[] = [{ directory: cwd, depth: 0 }];
+  let head = 0;
+  while (head < queue.length) {
+    const item = queue[head];
+    head += 1;
+    if (item === undefined) break;
+    if (existsSync(nodePath.join(item.directory, filename))) found.push(item.directory);
+    if (item.depth >= maxDepth) continue;
+    for (const subdirectory of getScannableSubdirectories(item.directory)) {
+      queue.push({ directory: subdirectory, depth: item.depth + 1 });
+    }
+  }
+  return found;
+}
+
+/**
  * Create directory recursively
  * @param path
  */

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -39,6 +39,20 @@ function makePackage(
   }
 }
 
+/** A Go module at `<root>/<relativeDirectory>` with a conventional `cmd/server` layout. */
+function writeGoModule(root: string, relativeDirectory: string, name: string): void {
+  const dir = nodePath.join(root, relativeDirectory);
+  mkdirSync(nodePath.join(dir, 'cmd', 'server'), { recursive: true });
+  writeFileSync(nodePath.join(dir, 'go.mod'), `module ${name}\n\ngo 1.22\n`);
+}
+
+/** A Python package at `<root>/<relativeDirectory>` with a `src/` tree and PEP 621 name. */
+function writePythonPackage(root: string, relativeDirectory: string, name: string): void {
+  const dir = nodePath.join(root, relativeDirectory);
+  mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
+  writeFileSync(nodePath.join(dir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
+}
+
 beforeEach(() => {
   context.directory = createTemporaryDirectory();
   writeManifest(context.directory, { name: 'root', workspaces: ['packages/*'] });
@@ -481,20 +495,10 @@ describe('discoverLeafDirectories — uv workspace discovery (ticket HWSEPV)', (
 });
 
 describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
-  function writeGoModule(root: string, relativeDirectory: string, name: string): void {
-    const dir = nodePath.join(root, relativeDirectory);
-    mkdirSync(nodePath.join(dir, 'cmd', 'server'), { recursive: true });
-    writeFileSync(nodePath.join(dir, 'go.mod'), `module ${name}\n\ngo 1.22\n`);
-  }
   function writeRustCrate(root: string, relativeDirectory: string, name: string): void {
     const dir = nodePath.join(root, relativeDirectory);
     mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
     writeFileSync(nodePath.join(dir, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
-  }
-  function writePythonPackage(root: string, relativeDirectory: string, name: string): void {
-    const dir = nodePath.join(root, relativeDirectory);
-    mkdirSync(nodePath.join(dir, 'src'), { recursive: true });
-    writeFileSync(nodePath.join(dir, 'pyproject.toml'), `[project]\nname = "${name}"\n`);
   }
 
   /** Declares a go.work (gosvc), a Cargo [workspace] (crates/rscore), and a uv
@@ -567,6 +571,89 @@ describe('discoverLeafDirectories — polyglot union (ticket MGWZ4P)', () => {
     expect(discoverLeafDirectories(context.directory)).toEqual([
       nodePath.join(context.directory, 'packages', 'web'),
     ]);
+  });
+});
+
+describe('discoverLeafDirectories — orphan non-JS services outside a workspace (issue #844)', () => {
+  function writeConfig(root: string, installedPacks: string[]): void {
+    writeFileSync(
+      nodePath.join(root, '.safeword', 'config.json'),
+      JSON.stringify({ installedPacks }),
+    );
+  }
+
+  beforeEach(() => {
+    mkdirSync(nodePath.join(context.directory, '.safeword'), { recursive: true });
+  });
+
+  it('surfaces a Go service that is not enrolled in any go.work when the golang pack is installed', () => {
+    writeConfig(context.directory, ['typescript', 'golang']);
+    // JS workspace (from the outer beforeEach) has packages/*; the Go service is standalone.
+    makePackage(context.directory, 'web', { modules: ['ui'] });
+    writeGoModule(context.directory, nodePath.join('services', 'engine'), 'example.com/engine');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'packages', 'web'),
+      nodePath.join(context.directory, 'services', 'engine'),
+    ]);
+  });
+
+  it('surfaces standalone Go and Python services together (polyglot)', () => {
+    writeConfig(context.directory, ['golang', 'python']);
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeGoModule(context.directory, 'engine', 'example.com/engine');
+    writePythonPackage(context.directory, 'coordinator', 'coordinator');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'coordinator'),
+      nodePath.join(context.directory, 'engine'),
+    ]);
+  });
+
+  it('does not walk for a language whose pack is not installed', () => {
+    writeConfig(context.directory, ['typescript']); // no golang pack
+    writeGoModule(context.directory, 'engine', 'example.com/engine');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+
+  it('does not treat the repo root or a tooling-only pyproject as a package', () => {
+    writeConfig(context.directory, ['python']);
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    // Root pyproject is workspace/tooling config, and services/tools has only [tool.ruff].
+    writeFileSync(
+      nodePath.join(context.directory, 'pyproject.toml'),
+      '[tool.uv.workspace]\nmembers = []\n',
+    );
+    mkdirSync(nodePath.join(context.directory, 'services', 'tools'), { recursive: true });
+    writeFileSync(
+      nodePath.join(context.directory, 'services', 'tools', 'pyproject.toml'),
+      '[tool.ruff]\nline-length = 100\n',
+    );
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+
+  it('lists a dir claimed by both a workspace and the orphan walk exactly once', () => {
+    writeConfig(context.directory, ['golang']);
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeFileSync(nodePath.join(context.directory, 'go.work'), 'go 1.22\n\nuse ./engine\n');
+    writeGoModule(context.directory, 'engine', 'example.com/engine');
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([
+      nodePath.join(context.directory, 'engine'),
+    ]);
+  });
+
+  it('makes the orphan service a package in the model, introspected via its Go layout', () => {
+    writeConfig(context.directory, ['golang']);
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    writeGoModule(context.directory, nodePath.join('services', 'engine'), 'example.com/engine');
+
+    const model = extractMonorepoModel(context.directory);
+
+    expect(model.packages.map(node => node.name)).toEqual(['example.com/engine']);
+    expect(model.packages[0]?.introspected).toBe(true);
   });
 });
 

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -617,6 +617,16 @@ describe('discoverLeafDirectories — orphan non-JS services outside a workspace
     expect(discoverLeafDirectories(context.directory)).toEqual([]);
   });
 
+  it('skips a go.mod that declares no module path (not a package)', () => {
+    writeConfig(context.directory, ['golang']);
+    rmSync(nodePath.join(context.directory, 'package.json'), { force: true });
+    const dir = nodePath.join(context.directory, 'engine');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(nodePath.join(dir, 'go.mod'), 'go 1.22\n'); // no `module` directive
+
+    expect(discoverLeafDirectories(context.directory)).toEqual([]);
+  });
+
   it('does not treat the repo root or a tooling-only pyproject as a package', () => {
     writeConfig(context.directory, ['python']);
     rmSync(nodePath.join(context.directory, 'package.json'), { force: true });

--- a/packages/cli/tests/utils/architecture-skeleton.test.ts
+++ b/packages/cli/tests/utils/architecture-skeleton.test.ts
@@ -146,12 +146,39 @@ describe('extractSkeleton — broadened JS/TS recognition (issue #843)', () => {
     writeFileSync(nodePath.join(context.directory, 'index.ts'), 'export {};\n');
     writeFileSync(nodePath.join(context.directory, 'vite.config.ts'), 'export default {};\n');
     writeFileSync(nodePath.join(context.directory, 'eslint.config.mjs'), 'export default [];\n');
+    writeFileSync(nodePath.join(context.directory, 'jest.config.cjs'), 'module.exports = {};\n');
+    writeFileSync(nodePath.join(context.directory, 'next.config.mjs'), 'export default {};\n');
     writeFileSync(nodePath.join(context.directory, 'types.d.ts'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, 'ambient.d.mts'), 'export {};\n');
     writeFileSync(nodePath.join(context.directory, '.eslintrc.cjs'), 'module.exports = {};\n');
 
     const skeleton = extractSkeleton(context.directory);
 
     expect(skeleton.nodes.map(node => node.name)).toEqual(['index']);
+  });
+
+  it('dedupes a same-named TS/JS pair to one node, TypeScript winning (mid-migration)', () => {
+    mkdirSync(nodePath.join(context.directory, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(context.directory, 'src', 'util.js'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, 'src', 'util.ts'), 'export {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes).toEqual([
+      { name: 'util', path: 'src/util.ts', purpose: expect.any(String) as string },
+    ]);
+  });
+
+  it('does not birth top-level modules at a workspace-declaring root (zero-leaf monorepo)', () => {
+    // A monorepo root whose declared members resolve to nothing yet must stay an
+    // empty skeleton (→ noop), not become a single-repo doc of stray root scripts.
+    writeFileSync(
+      nodePath.join(context.directory, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+    );
+    writeFileSync(nodePath.join(context.directory, 'jest.setup.js'), 'export {};\n');
+
+    expect(extractSkeleton(context.directory).nodes).toEqual([]);
   });
 
   it('lets a Go layout win over the JS fallbacks despite a stray top-level script', () => {

--- a/packages/cli/tests/utils/architecture-skeleton.test.ts
+++ b/packages/cli/tests/utils/architecture-skeleton.test.ts
@@ -90,6 +90,91 @@ describe('extractSkeleton — skeleton reflects the real project', () => {
   });
 });
 
+describe('extractSkeleton — broadened JS/TS recognition (issue #843)', () => {
+  it('lists src FILES as modules when src has no subdirectories (flat package)', () => {
+    mkdirSync(nodePath.join(context.directory, 'src'), { recursive: true });
+    writeFileSync(nodePath.join(context.directory, 'src', 'index.ts'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, 'src', 'auth.ts'), 'export {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['auth', 'index']);
+    const pathByName = Object.fromEntries(skeleton.nodes.map(node => [node.name, node.path]));
+    expect(pathByName.auth).toBe('src/auth.ts');
+  });
+
+  it('keeps src directories authoritative — files are ignored when subdirs exist (no churn)', () => {
+    mkdirSync(nodePath.join(context.directory, 'src', 'auth'), { recursive: true });
+    writeFileSync(nodePath.join(context.directory, 'src', 'index.ts'), 'export {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    // Directory is the module unit; the sibling index.ts file is not listed.
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['auth']);
+  });
+
+  it('recognizes a lib/ root (component libraries) — dirs then files', () => {
+    mkdirSync(nodePath.join(context.directory, 'lib', 'components'), { recursive: true });
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['components']);
+    expect(skeleton.nodes[0]?.path).toBe('lib/components');
+  });
+
+  it('recognizes a flat lib/ of files when it has no subdirectories', () => {
+    mkdirSync(nodePath.join(context.directory, 'lib'), { recursive: true });
+    writeFileSync(nodePath.join(context.directory, 'lib', 'button.tsx'), 'export {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['button']);
+    expect(skeleton.nodes[0]?.path).toBe('lib/button.tsx');
+  });
+
+  it('recognizes top-level source files for a test-only package (no src/ or lib/)', () => {
+    writeFileSync(nodePath.join(context.directory, 'auth.test.ts'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, 'billing.test.ts'), 'export {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['auth.test', 'billing.test']);
+    expect(skeleton.nodes[0]?.path).toBe('auth.test.ts');
+  });
+
+  it('excludes tooling config and declaration files from a flat layout', () => {
+    writeFileSync(nodePath.join(context.directory, 'index.ts'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, 'vite.config.ts'), 'export default {};\n');
+    writeFileSync(nodePath.join(context.directory, 'eslint.config.mjs'), 'export default [];\n');
+    writeFileSync(nodePath.join(context.directory, 'types.d.ts'), 'export {};\n');
+    writeFileSync(nodePath.join(context.directory, '.eslintrc.cjs'), 'module.exports = {};\n');
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['index']);
+  });
+
+  it('lets a Go layout win over the JS fallbacks despite a stray top-level script', () => {
+    writeFileSync(
+      nodePath.join(context.directory, 'go.mod'),
+      'module example.com/app\n\ngo 1.22\n',
+    );
+    mkdirSync(nodePath.join(context.directory, 'cmd', 'server'), { recursive: true });
+    writeFileSync(nodePath.join(context.directory, 'gen.ts'), 'export {};\n'); // stray codegen script
+
+    const skeleton = extractSkeleton(context.directory);
+
+    expect(skeleton.nodes.map(node => node.name)).toEqual(['cmd']);
+  });
+
+  it('stays empty for a package with only a manifest and no source', () => {
+    writeFileSync(nodePath.join(context.directory, 'package.json'), '{"name":"solo"}');
+    writeFileSync(nodePath.join(context.directory, 'README.md'), '# solo\n');
+
+    expect(extractSkeleton(context.directory).nodes).toEqual([]);
+  });
+});
+
 describe('extractSkeleton — Go layout (ticket ZD70P1)', () => {
   function writeGoModule(directory: string, modulePath = 'example.com/app'): void {
     writeFileSync(nodePath.join(directory, 'go.mod'), `module ${modulePath}\n\ngo 1.22\n`);

--- a/packages/cli/tests/utils/index-files-in-tree.test.ts
+++ b/packages/cli/tests/utils/index-files-in-tree.test.ts
@@ -82,6 +82,11 @@ describe('findAllInTree', () => {
     expect(findAllInTree(root, 'pyproject.toml')).toEqual([nodePath.join(root, 'pkg')]);
   });
 
+  it('skips Go testdata fixtures (toolchain-ignored, not real packages)', () => {
+    const root = makeRepo({ 'svc/go.mod': '', 'svc/testdata/fixture/go.mod': '' });
+    expect(findAllInTree(root, 'go.mod')).toEqual([nodePath.join(root, 'svc')]);
+  });
+
   it('respects maxDepth', () => {
     const root = makeRepo({ 'a/b/c/go.mod': '' });
     expect(findAllInTree(root, 'go.mod', 1)).toEqual([]);

--- a/packages/cli/tests/utils/index-files-in-tree.test.ts
+++ b/packages/cli/tests/utils/index-files-in-tree.test.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { indexFilesInTree } from '../../src/utils/fs';
+import { findAllInTree, indexFilesInTree } from '../../src/utils/fs';
 
 const temporaryDirectories: string[] = [];
 
@@ -52,5 +52,39 @@ describe('indexFilesInTree', () => {
     const root = makeRepo({ 'a/b/c/go.mod': '' });
     expect(indexFilesInTree(root, ['go.mod'], 1).has('go.mod')).toBe(false);
     expect(indexFilesInTree(root, ['go.mod'], 3).get('go.mod')).toBe(nodePath.join(root, 'a/b/c'));
+  });
+});
+
+describe('findAllInTree', () => {
+  it('collects every directory containing the file, root included', () => {
+    const root = makeRepo({
+      'go.mod': '',
+      'services/engine/go.mod': '',
+      'services/worker/go.mod': '',
+    });
+    const byString = (a: string, b: string): number => a.localeCompare(b);
+    expect(findAllInTree(root, 'go.mod').toSorted(byString)).toEqual(
+      [
+        root,
+        nodePath.join(root, 'services/engine'),
+        nodePath.join(root, 'services/worker'),
+      ].toSorted(byString),
+    );
+  });
+
+  it('returns an empty list when the file is nowhere in the tree', () => {
+    const root = makeRepo({ 'go.mod': '' });
+    expect(findAllInTree(root, 'Cargo.toml')).toEqual([]);
+  });
+
+  it('skips excluded directories like node_modules', () => {
+    const root = makeRepo({ 'pkg/pyproject.toml': '', 'node_modules/dep/pyproject.toml': '' });
+    expect(findAllInTree(root, 'pyproject.toml')).toEqual([nodePath.join(root, 'pkg')]);
+  });
+
+  it('respects maxDepth', () => {
+    const root = makeRepo({ 'a/b/c/go.mod': '' });
+    expect(findAllInTree(root, 'go.mod', 1)).toEqual([]);
+    expect(findAllInTree(root, 'go.mod', 3)).toEqual([nodePath.join(root, 'a/b/c')]);
   });
 });

--- a/steps/monorepo-coverage-honesty.steps.ts
+++ b/steps/monorepo-coverage-honesty.steps.ts
@@ -8,7 +8,7 @@
 
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { Given, Then, When } from '@cucumber/cucumber';
@@ -109,6 +109,34 @@ Given(
   },
 );
 
+Given(
+  /^a pnpm monorepo with a package "([^"]+)" whose sources live under lib\/$/,
+  function (this: CoverageWorld, name: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), { name: 'root' });
+    writePnpmWorkspace(this, ['packages/*']);
+    const packageDir = nodePath.join(dir(this), 'packages', name);
+    writeJson(nodePath.join(packageDir, 'package.json'), { name });
+    mkdirSync(nodePath.join(packageDir, 'lib', 'components'), { recursive: true });
+  },
+);
+
+Given(
+  /^a JS monorepo that also has a standalone Go service at "([^"]+)" with module "([^"]+)" and the golang pack installed$/,
+  function (this: CoverageWorld, servicePath: string, modulePath: string) {
+    writeJson(nodePath.join(dir(this), 'package.json'), {
+      name: 'root',
+      workspaces: ['packages/*'],
+    });
+    makePackage(this, 'web', { src: true });
+    writeJson(nodePath.join(dir(this), '.safeword', 'config.json'), {
+      installedPacks: ['typescript', 'golang'],
+    });
+    const serviceDir = nodePath.join(dir(this), servicePath);
+    mkdirSync(nodePath.join(serviceDir, 'cmd', 'server'), { recursive: true });
+    writeFileSync(nodePath.join(serviceDir, 'go.mod'), `module ${modulePath}\n\ngo 1.22\n`);
+  },
+);
+
 // --- When ---
 
 When('safeword generates the architecture doc', function (this: CoverageWorld) {
@@ -153,6 +181,14 @@ Then(
   /^the package "([^"]+)" has no colocated leaf doc$/,
   function (this: CoverageWorld, name: string) {
     assert.ok(!leafDocExists(this, name), `unexpected leaf doc for ${name}`);
+  },
+);
+
+Then(
+  /^a colocated leaf doc exists at "([^"]+)"$/,
+  function (this: CoverageWorld, relativeDirectory: string) {
+    const leafPath = nodePath.join(dir(this), relativeDirectory, 'architecture.generated.md');
+    assert.ok(existsSync(leafPath), `leaf doc missing at ${relativeDirectory}`);
   },
 );
 


### PR DESCRIPTION
Fixes #843, fixes #844.

## #843 — layout false-negatives ("no recognized source layout")

The JS/TS branch of `extractSkeleton` only enumerated subdirectories of `src/`, so `lib/`-rooted packages, flat `src/` (files only), and test-only/top-level packages produced zero nodes and were marked "not introspected" — 13 of 24 packages in the reported repro.

**Change** (`architecture-skeleton.ts`): give JS/TS the same flat-and-nested recognition Python/Rust already have —

- `src/` subdirectories still win first → packages that already have them are byte-for-byte unchanged (safeword's own three generated docs regenerate **unchanged**)
- new last-resort fallbacks, never preempting Go/Rust/Python dispatch: flat `src/` files → `lib/` (dirs-else-files) → top-level source files
- config (`*.config.*`), declaration (`*.d.ts`), and dotfiles excluded
- root-index marker reworded from "no recognized source layout" to **"no source modules to map"** — a package now reaches it only when there is genuinely nothing to enumerate

## #844 — root doc was JS-workspace-only

`discoverWorkspaces` only trusts declared workspace members, so Go/Python services living as standalone `go.mod`/`pyproject.toml` dirs (not enrolled in `go.work`/uv/Cargo workspaces) were invisible at the root — even though the packs system had already detected the languages.

**Change** (`architecture-monorepo.ts` + `findAllInTree` in `fs.ts`): a pack-gated orphan-manifest walk —

- for each installed non-JS pack (`golang`/`python`/`rust` in `installedPacks`, read the same way `test-plan` reads it), tree-walk for `go.mod`/`pyproject.toml`/`Cargo.toml`, bounded by the shared exclude set
- keep only dirs whose manifest actually declares a package (`module`, PEP 621 `[project]`/`[tool.poetry]`, `[package]`); drop the repo root; dedupe against declared workspace leaves
- discovered services join the root `## Packages` index **and get colocated leaf docs** through the existing leaf machinery (full introspection via the Go/Python/Rust extractors)
- JS-only repos install no non-JS packs → no walk, zero behavior change

## Verification

- Full suite: **4670/4670 pass** (326 files, 5 skipped by design); BDD acceptance lane green incl. 2 new scenarios driving the real CLI
- New unit tests: broadened JS recognizer (flat src, lib/, top-level, exclusions, Go precedence), orphan discovery (pack gating, root/tooling exclusion, workspace dedup, model introspection), `findAllInTree`
- ESLint / Gherkin lint / `tsc --noEmit` clean; depcruise 0 violations; knip 0 findings; `sync-config --check` in sync
- safeword's own generated architecture docs regenerate unchanged (no fingerprint churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nfb4uXwwx5hvuiAo9BUoQj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nfb4uXwwx5hvuiAo9BUoQj)_