### PR TITLE
fix(architecture): surface narrative-drift advisory in --stage when enforcement is opted out

### DIFF
--- a/packages/cli/src/commands/architecture.ts
+++ b/packages/cli/src/commands/architecture.ts
@@ -92,6 +92,10 @@ function architectureStage(cwd: string): Promise<void> {
   warnUnreadableWorkspaces(cwd);
   if (!isArchitectureDocumentEnforcementEnabled(cwd)) {
     success('Architecture doc enforcement is opted out (architectureDocEnforcement: false).');
+    // Coverage honesty is not enforcement (see warnNarrativeDrift): surface drift
+    // even when opted out, matching --check and default mode. No heal runs here,
+    // so this reads the doc as-is — the same as --check's opt-out path.
+    warnNarrativeDrift(cwd);
     return Promise.resolve();
   }
 

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -12,7 +12,11 @@ import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { readDocumentFingerprint, selfHeal } from '../../src/utils/architecture-document.js';
+import {
+  readDocumentFingerprint,
+  selfHeal,
+  selfHealProject,
+} from '../../src/utils/architecture-document.js';
 import {
   resolveGeneratedArchitecturePath,
   resolveNamespaceRoot,
@@ -163,6 +167,45 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
     expect(execFileSync('cat', [DOC_RELATIVE], { cwd: context.directory, encoding: 'utf8' })).toBe(
       before,
     );
+  });
+
+  it('still surfaces the narrative-drift advisory when enforcement is opted out', async () => {
+    // Coverage honesty is independent of enforcement: an opted-out host running
+    // --stage must still be told the narrative omits a generated package, matching
+    // --check and default mode (#864 follow-up). Needs a monorepo — drift is a
+    // root `## Packages` concern; single-repo `## Modules` names are never scanned.
+    execFileSync('rm', ['-rf', 'src'], { cwd: context.directory });
+    writeFileSync(
+      nodePath.join(context.directory, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+    );
+    for (const pkg of ['web', 'billing']) {
+      mkdirSync(nodePath.join(context.directory, 'packages', pkg, 'src'), { recursive: true });
+      writeFileSync(
+        nodePath.join(context.directory, 'packages', pkg, 'package.json'),
+        JSON.stringify({ name: pkg }),
+      );
+      writeFileSync(
+        nodePath.join(context.directory, 'packages', pkg, 'src', 'index.ts'),
+        'export {};\n',
+      );
+    }
+    // Narrative mentions only "web" → "billing" is drift.
+    writeFileSync(
+      nodePath.join(context.directory, 'ARCHITECTURE.md'),
+      '# Architecture\n\nThe web package serves the UI.\n',
+    );
+    // Pre-generate the root `## Packages` index: the opt-out branch skips the heal,
+    // so the drift check reads whatever generated doc already exists on disk.
+    selfHealProject(context.directory);
+    writeEnforcementConfig(context.directory, false);
+
+    const result = await runCli(['architecture', '--stage'], { cwd: context.directory });
+
+    expect(result.exitCode).toBe(0);
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(output).toContain('does not mention');
+    expect(output).toContain('billing');
   });
 
   it('exits zero even with no modules and no doc (noop never blocks)', async () => {


### PR DESCRIPTION
Follow-up to #864 (the LOW finding from its review).

## The gap

In `architecture --stage`, `warnNarrativeDrift(cwd)` sat *after* the `architectureDocEnforcement: false` opt-out early-return, so an opted-out host running `--stage` never saw the drift advisory there — inconsistent with `--check` (which warns *before* its opt-out) and default mode, and contrary to the code's own stated rationale ("coverage honesty is not enforcement").

## Fix

Call `warnNarrativeDrift(cwd)` in the opt-out branch too, before returning. No heal runs on the opt-out path, so it reads the generated doc as-is — exactly matching `--check`'s opt-out behavior. The enforced path keeps its existing post-heal call (which reads the doc the commit will carry), so both placements are intentional and unchanged for enforced hosts.

## Verification

- New integration test (`architecture-stage.test.ts`): opt-out `--stage` in a monorepo whose narrative omits a generated package still emits the "does not mention … billing" advisory, exit 0.
- Existing `--stage` suite unchanged: 9/9 pass (the pre-existing opt-out test — no heal/stage on opt-out — still holds; this only adds a `warn()`, never an exit-code or staging change).
- eslint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmPeTtB72TjBWquzo8t3Eo)_