### PR TITLE
docs(architecture): reconcile narrative with the generated module map (25TJAR)

### DIFF
--- a/.project/tickets/25TJAR-architecture-narrative-reconcile/ticket.md
+++ b/.project/tickets/25TJAR-architecture-narrative-reconcile/ticket.md
@@ -1,0 +1,30 @@
+---
+id: 25TJAR
+slug: architecture-narrative-reconcile
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-06T03:40:11.819Z
+last_modified: 2026-07-06T03:40:11.819Z
+scope:
+  - ARCHITECTURE.md CLI Structure tree gains the 8 undocumented src/ modules with one-line purposes
+  - Runtime dependencies table gains @cucumber/gherkin + @cucumber/messages
+  - plugin/ line corrected (Claude Code plugin, non-workspace, marketplace-distributed)
+out_of_scope:
+  - rewriting generated architecture.generated.md prose sections (machine-owned)
+  - website docs (audit found them clean)
+done_when:
+  - every module in packages/cli/architecture.generated.md appears in ARCHITECTURE.md
+  - audit E002-E007 structural/dependency findings no longer reproduce
+---
+
+# Reconcile ARCHITECTURE.md narrative with the generated module map
+
+**Goal:** ARCHITECTURE.md documents all 13 real CLI modules, the test-plan module location, the plugin/ packaging note, and the cucumber runtime deps
+
+**Why:** Full audit found 9 structural/dependency documentation errors: 7 CLI modules missing from the narrative, test-plan documented as a command file when it is a top-level module, plugin/ absent from the generated package map, and @cucumber/gherkin+messages runtime deps undocumented
+
+## Work Log
+
+- 2026-07-06T03:40:11.819Z Started: Created ticket 25TJAR
+- Reconciled: CLI Structure tree now lists all 13 generated-map modules (one-liners sourced from each module's own doc comments); cucumber runtime deps added to the Dependencies table; plugin/ line fixed — it is the Claude Code plugin (plugin/.claude-plugin/plugin.json), not Cursor, and deliberately not a workspace package; header bumped to 1.16

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Safeword Architecture
 
-**Version:** 1.15
-**Last Updated:** 2026-07-02
+**Version:** 1.16
+**Last Updated:** 2026-07-06
 **Status:** Production
 
 ---
@@ -48,7 +48,7 @@ Safeword is a CLI tool that configures linting, hooks, and development guides fo
 packages/
 ├── cli/            # Main CLI tool + ESLint configs (bunx safeword)
 └── website/        # Documentation site (Astro/Starlight)
-plugin/             # Cursor IDE plugin (commands, hooks)
+plugin/             # Claude Code plugin (commands, hooks) — not a workspace package; distributed via .claude-plugin/marketplace.json
 ```
 
 | Package             | Purpose                                                 | Published As |
@@ -65,19 +65,27 @@ ESLint configs are bundled in the main package and accessed via `import safeword
 ```text
 packages/cli/
 ├── src/
-│   ├── commands/       # CLI commands (setup, upgrade, check, diff, reset, sync-config, sync-learnings, test-plan)
-│   ├── packs/          # Language packs + registry
-│   │   ├── {lang}/     # index.ts, files.ts, setup.ts per language
-│   │   ├── registry.ts # Central pack registry and detection
-│   │   ├── config.ts   # Pack config management (.safeword/config.json)
-│   │   ├── install.ts  # Pack installation logic
-│   │   └── types.ts    # Shared type definitions
-│   ├── presets/        # ESLint presets (exported as safeword/eslint)
-│   │   └── typescript/ # ESLint configs, rules, detection
-│   ├── templates/      # Template content helpers
-│   ├── utils/          # Detection, file ops, git, version
-│   ├── schema.ts       # Single source of truth for all managed files
-│   └── reconcile.ts    # Schema-based file management
+│   ├── commands/         # CLI commands (setup, upgrade, check, diff, reset, sync-config, sync-learnings, …)
+│   ├── learning-sync/    # Generates <namespace-root>/learnings/INDEX.md from learning files
+│   ├── packs/            # Language packs + registry
+│   │   ├── {lang}/       # index.ts, files.ts, setup.ts per language
+│   │   ├── registry.ts   # Central pack registry and detection
+│   │   ├── config.ts     # Pack config management (.safeword/config.json)
+│   │   ├── install.ts    # Pack installation logic
+│   │   └── types.ts      # Shared type definitions
+│   ├── presets/          # ESLint presets (exported as safeword/eslint)
+│   │   └── typescript/   # ESLint configs, rules, detection
+│   ├── retro/            # Retrospective pipeline: transcript mining, drafts, egress guard, GitHub REST transport
+│   ├── skills/           # Skill package installer (harness side of the pack/harness skill split)
+│   ├── templates/        # Template content helpers
+│   ├── test-plan/        # Resolves per-language test/build/typecheck/bdd/deps command plans (verify + stop-gate source of truth)
+│   ├── ticket-sync/      # Generates tickets/INDEX.md + INDEX-completed.md discovery indexes
+│   ├── tracker-connect/  # `safeword connect` flow: tracker credentials, config, secret store
+│   ├── tracker-sync/     # One-way projection of the ticket corpus into the configured tracker
+│   ├── upstream-monitor/ # Watches upstream agent-CLI changelogs (claude-code, codex-cli, cursor) via snapshots
+│   ├── utils/            # Detection, file ops, git, version
+│   ├── schema.ts         # Single source of truth for all managed files
+│   └── reconcile.ts      # Schema-based file management
 ├── templates/
 │   ├── SAFEWORD.md     # Core instructions (installed to .safeword/)
 │   ├── AGENTS.md       # Project context template
@@ -335,6 +343,8 @@ CLI command
 | `yaml`                                            | YAML config parsing (failsafe mode)                                                        |
 | `@secretlint/core`                                | Retro egress: in-process secret detection over a raw string (returns spans)                |
 | `@secretlint/secretlint-rule-preset-recommend`    | Retro egress: maintained provider-key rule-packs (28 formats) layered over the regex floor |
+| `@cucumber/gherkin`                               | Gherkin parse engine for `lint-gherkin` and `.feature` scenario-source validation          |
+| `@cucumber/messages`                              | Gherkin AST message types consumed alongside the parser                                    |
 | `@eslint/js`                                      | ESLint core rules                                                                          |
 | `typescript-eslint`                               | TypeScript ESLint parser + rules                                                           |
 | `eslint-config-prettier`                          | Disable formatting rules                                                                   |


### PR DESCRIPTION
Follow-up from the full audit run on #878's branch (structural reconciliation of ARCHITECTURE.md against `packages/cli/architecture.generated.md`, which is the deterministic ground truth).

- **CLI Structure tree** documented only 5 of the 13 real `src/` modules. Adds `learning-sync`, `retro`, `skills`, `test-plan`, `ticket-sync`, `tracker-connect`, `tracker-sync`, `upstream-monitor` — one-line purposes sourced from each module's own doc comments. This also fixes `test-plan`'s location claim (it's a top-level module, not a file in `commands/`).
- **Runtime dependencies table** gains `@cucumber/gherkin` + `@cucumber/messages` — they moved to runtime `dependencies` as the `lint-gherkin` parse engine but the table never followed.
- **`plugin/` line corrected**: it's the Claude Code plugin (`plugin/.claude-plugin/plugin.json`), not "Cursor IDE plugin", and deliberately not a workspace package (distributed via `.claude-plugin/marketplace.json`) — which is why it's absent from the generated package map.
- Header bumped to 1.16 / 2026-07-06.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_