### PR TITLE
test: strengthen weak assertions flagged by the full audit (A7192X)

### DIFF
--- a/.project/tickets/A7192X-audit-test-quality-fixes/ticket.md
+++ b/.project/tickets/A7192X-audit-test-quality-fixes/ticket.md
@@ -1,0 +1,29 @@
+---
+id: A7192X
+slug: audit-test-quality-fixes
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-06T03:42:50.504Z
+last_modified: 2026-07-06T03:42:50.504Z
+scope:
+  - golden-path graceful-handling tests assert exit code, on-disk content, and output
+  - git.test no-op cases assert an unchanged index / surviving file
+  - config.test.ts per-internal-call tests deduped into one it.each contract table
+out_of_scope:
+  - full behavioral rewrite of config codegen tests (golden-path already covers behavior)
+  - other files sampled clean by the audit
+done_when:
+  - the four audit findings no longer reproduce and the three suites pass
+---
+
+# Strengthen weak assertions flagged by the full audit
+
+**Goal:** The four audit test-quality findings no longer reproduce: golden-path graceful-handling tests and git.test no-op cases assert observable outcomes, config.test.ts stops pinning codegen internals and dedups via it.each
+
+**Why:** Audit sampling found tests that pass regardless of behavior: not.toThrow-only assertions can't catch silent corruption, and config.test.ts's one-assert-per-internal-call pattern breaks on harmless refactors while proving nothing behavioral
+
+## Work Log
+
+- 2026-07-06T03:42:50.504Z Started: Created ticket A7192X
+- Fixed all four audit findings: golden-path graceful tests assert exit 0 + byte-identical content + surfaced/silent output; git.test no-op cases assert an unchanged index against a seeded tracked file (and on-disk survival outside a repo); config.test.ts's ten per-internal-call tests collapsed into one it.each contract table routing behavioral coverage to golden-path. 52/52 tests pass across the three suites

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -32,46 +32,32 @@ describe('getEslintConfig', () => {
     expect(config).toContain('const { detect, configs } = safeword');
   });
 
-  it('should use detect.collectAllDeps for dependency scanning', () => {
-    const config = getEslintConfig();
-
-    expect(config).toContain('detect.collectAllDeps(__dirname)');
-    expect(config).toContain('detect.detectFramework(deps)');
-  });
-
-  it('should include framework detection for config selection', () => {
-    const config = getEslintConfig();
-
-    // Config should have baseConfigs mapping
-    expect(config).toContain('configs.recommendedTypeScriptNext');
-    expect(config).toContain('configs.recommendedTypeScriptReact');
-    expect(config).toContain('configs.recommendedTypeScript');
-    expect(config).toContain('configs.recommended');
-    expect(config).toContain('baseConfigs[framework]');
-  });
-
-  it('should include testing, storybook, and query configs conditionally', () => {
-    const config = getEslintConfig();
-
-    // All framework plugins are conditional (peer deps require the framework)
-    expect(config).toContain('detect.hasVitest(deps)');
-    expect(config).toContain('detect.hasBunTest(deps, __dirname)');
-    expect(config).toContain('detect.hasPlaywright(deps)');
-    expect(config).toContain('detect.hasStorybook(deps)');
-    expect(config).toContain('detect.hasTanstackQuery(deps)');
-  });
-
-  it('should use detection only for Tailwind (plugin needs config to validate classes)', () => {
-    const config = getEslintConfig();
-
-    // Tailwind still needs detection because plugin may require tailwind.config.js
-    expect(config).toContain('detect.hasTailwind(deps)');
-  });
-
-  it('should use detect.getIgnores for standard ignores', () => {
-    const config = getEslintConfig();
-
-    expect(config).toContain('detect.getIgnores()');
+  // Contract pins over the emitted source, deduped into one table (audit A7192X):
+  // each entry is part of the generated config's public wiring — the safeword/eslint
+  // detection API it calls and the base-config selection it performs. Behavioral
+  // coverage (the config actually linting) lives in tests/integration/golden-path.test.ts;
+  // these only guard the emitted contract, so a rename in the safeword/eslint API
+  // shows up here before it ships broken configs to users.
+  it.each([
+    ['dependency scanning', 'detect.collectAllDeps(__dirname)'],
+    ['framework detection', 'detect.detectFramework(deps)'],
+    ['framework base-config selection', 'baseConfigs[framework]'],
+    ['Next.js base config', 'configs.recommendedTypeScriptNext'],
+    ['React base config', 'configs.recommendedTypeScriptReact'],
+    ['TypeScript base config', 'configs.recommendedTypeScript'],
+    ['plain-JS base config', 'configs.recommended'],
+    ['conditional Vitest plugin', 'detect.hasVitest(deps)'],
+    ['conditional bun:test plugin', 'detect.hasBunTest(deps, __dirname)'],
+    ['conditional Playwright plugin', 'detect.hasPlaywright(deps)'],
+    ['conditional Storybook plugin', 'detect.hasStorybook(deps)'],
+    ['conditional TanStack Query plugin', 'detect.hasTanstackQuery(deps)'],
+    [
+      'Tailwind detection (plugin needs tailwind.config to validate classes)',
+      'detect.hasTailwind(deps)',
+    ],
+    ['standard ignores', 'detect.getIgnores()'],
+  ])('generated config wires %s', (_purpose, contractCall) => {
+    expect(getEslintConfig()).toContain(contractCall);
   });
 
   it('should include eslint-config-prettier when no existing formatter', () => {

--- a/packages/cli/tests/git.test.ts
+++ b/packages/cli/tests/git.test.ts
@@ -43,17 +43,32 @@ describe('untrackIgnoredFiles', () => {
   });
 
   it('is a no-op when the pathspec matches nothing tracked', () => {
-    expect(() => {
-      untrackIgnoredFiles(directory, ['.safeword-project/failure-counts.json']);
-    }).not.toThrow();
+    // Seed a tracked file so "no-op" is observable, not vacuous: the index
+    // must be byte-identical after the unmatched untrack, not merely un-thrown.
+    writeFileSync(nodePath.join(directory, 'keep.txt'), 'tracked\n');
+    execSync('git add -A && git commit -q -m init', { cwd: directory });
+    const indexBefore = execSync('git ls-files', { cwd: directory, encoding: 'utf8' });
+
+    untrackIgnoredFiles(directory, ['.safeword-project/failure-counts.json']);
+
+    expect(execSync('git ls-files', { cwd: directory, encoding: 'utf8' })).toBe(indexBefore);
+    expect(existsSync(nodePath.join(directory, 'keep.txt'))).toBe(true);
   });
 
   it('is a no-op outside a git repository', () => {
     const plain = createTemporaryDirectory();
     try {
+      const relative = '.safeword-project/re-entry.md';
+      const absolute = nodePath.join(plain, relative);
+      mkdirSync(nodePath.dirname(absolute), { recursive: true });
+      writeFileSync(absolute, 'session log\n');
+
       expect(() => {
-        untrackIgnoredFiles(plain, ['.safeword-project/re-entry.md']);
+        untrackIgnoredFiles(plain, [relative]);
       }).not.toThrow();
+
+      // The named file survives on disk — nothing was deleted in lieu of untracking.
+      expect(existsSync(absolute)).toBe(true);
     } finally {
       removeTemporaryDirectory(plain);
     }

--- a/packages/cli/tests/integration/golden-path.test.ts
+++ b/packages/cli/tests/integration/golden-path.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
-import { unlinkSync } from 'node:fs';
+import { existsSync, unlinkSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -174,19 +174,29 @@ describe('E2E: Golden Path', () => {
   });
 
   describe('Lint Hook Graceful Handling', () => {
-    it('hook completes without crashing on syntax error file', () => {
-      writeTestFile(projectDirectory, 'src/syntax-error.ts', 'const x = {{{{ invalid');
+    it('exits cleanly on a syntax-error file and leaves its content untouched', () => {
+      const unparseable = 'const x = {{{{ invalid';
+      writeTestFile(projectDirectory, 'src/syntax-error.ts', unparseable);
       const filePath = nodePath.join(projectDirectory, 'src/syntax-error.ts');
 
-      // Should not throw - hook uses .nothrow()
-      expect(() => runLintHook(projectDirectory, filePath)).not.toThrow();
+      const result = runLintHook(projectDirectory, filePath);
+
+      // Graceful = exit 0 (hook uses .nothrow()), the unfixable content is
+      // preserved byte-for-byte, and the failure is surfaced, not swallowed.
+      expect(result.status).toBe(0);
+      expect(readTestFile(projectDirectory, 'src/syntax-error.ts')).toBe(unparseable);
+      expect(result.stdout).toContain('Lint errors remain after auto-fix');
     });
 
-    it('hook completes without crashing on non-existent file', () => {
+    it('exits cleanly and silently on a non-existent file', () => {
       const filePath = nodePath.join(projectDirectory, 'src/does-not-exist.ts');
 
-      // Should not throw - hook uses .nothrow()
-      expect(() => runLintHook(projectDirectory, filePath)).not.toThrow();
+      const result = runLintHook(projectDirectory, filePath);
+
+      // Missing file is a silent no-op: exit 0, no output, nothing created.
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe('');
+      expect(existsSync(filePath)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Follow-up from the full audit run alongside #878 — the four test-quality findings from sampling 13 test files.

- **`tests/integration/golden-path.test.ts` (Lint Hook Graceful Handling):** both tests asserted only `not.toThrow()` — a hook that crashed internally *or corrupted the file* still passed. They now assert the observable contract: exit 0, the unfixable file preserved byte-for-byte with the failure surfaced via `Lint errors remain after auto-fix`, and the missing-file path exiting silently with nothing created.
- **`tests/git.test.ts` (untrackIgnoredFiles no-op cases):** the unmatched-pathspec case now seeds a tracked file and asserts `git ls-files` is byte-identical after the call (a regression that silently mutated the index used to pass); the outside-a-repo case asserts the named file survives on disk.
- **`src/templates/config.test.ts`:** ten near-identical one-assert-per-internal-call tests collapse into a single `it.each` contract table, with a comment routing behavioral coverage to golden-path — the pins still catch a safeword/eslint API rename before it ships broken configs, without ten separate test bodies.

52/52 tests pass across the three suites. Note: #878 also touches `config.test.ts` (adds a separate test near the SETTINGS_HOOKS block); the edits are in different regions, so whichever lands second should auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_