### PR TITLE
Retro sweep: fix 9 issues from session retrospectives (#673, #723, #799, #801, #831, #832, #861–#863)

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -121,6 +121,11 @@ elif [ -f packages/cli/src/cli.ts ]; then
 else SW="bunx safeword"; fi
 $SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
+# Config-drift coverage is JS/TS-only (W005 knip hints, W007 depcruise config).
+# Native stacks have no comparable drift check yet — say so instead of letting
+# silence read as "no drift" (#831).
+(has_python_project || has_go_project || has_rust_project) && echo "Coverage limitation: config-drift checks (W005/W007) cover JS/TS tooling only — native lint configs (ruff.toml, .golangci.yml, Cargo [lints]) are not drift-checked; review them manually."
+
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)
 # =========================================================================
@@ -360,15 +365,17 @@ find . -name "*.test.*" -o -name "*.spec.*" -o -name "*_test.*" | grep -v node_m
 
 **For each sampled test file, check:**
 
-| Check                        | Criteria                                                                                                | Severity |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| Meaningful assertions        | Every test has specific value/behavior assertions (not just `toBeTruthy`, `toBeDefined`, `not.toThrow`) | error    |
-| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                  | error    |
-| Independence                 | No test depends on another test's side effects; fresh state per test                                    | error    |
-| No arbitrary timeouts        | No `sleep()`, `waitForTimeout()`, or hardcoded delays                                                   | error    |
-| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                       | error    |
-| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`)                                       | error    |
-| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")               | error    |
+The criteria are language-neutral; the parenthetical idioms are examples — map them to the project's test framework (Jest/Vitest, pytest, Go `testing`, Rust `#[test]`, …).
+
+| Check                        | Criteria                                                                                                                                                                  | Severity |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Meaningful assertions        | Every test asserts specific values/behavior — not bare existence/truthiness/no-error checks (`toBeTruthy`, bare `assert result`, only `err == nil`, `assert!(x.is_ok())`) | error    |
+| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                                                                                    | error    |
+| Independence                 | No test depends on another test's side effects; fresh state per test                                                                                                      | error    |
+| No arbitrary timeouts        | No sleeps or hardcoded delays (`sleep`, `waitForTimeout`, `time.Sleep`, `thread::sleep`)                                                                                  | error    |
+| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                                                                                         | error    |
+| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`, `pytest.mark.parametrize`, Go table-driven subtests, `rstest`)                                          | error    |
+| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")                                                                                 | error    |
 
 **Report format:**
 

--- a/.agents/skills/retro/SKILL.md
+++ b/.agents/skills/retro/SKILL.md
@@ -83,7 +83,8 @@ Optional: `--session-id <id>` for stable ledger attribution across fires;
 `--window-start <chars>` to digest only the transcript from an offset (delta mode).
 
 In a repo where the `safeword` binary isn't on PATH (e.g. this monorepo), substitute
-`bun packages/cli/src/cli.ts` for `safeword`.
+`bun run safeword` for `safeword` (runs the CLI from source via the root
+`package.json` script; `bunx safeword` also resolves the workspace-linked build).
 
 ## 3. Filing is code-owned — do not hand-write issues
 

--- a/.agents/skills/ticket-system/SKILL.md
+++ b/.agents/skills/ticket-system/SKILL.md
@@ -105,6 +105,10 @@ status: in_progress
 - Log immediately after each action
 - Re-read ticket before significant actions
 - For detailed scratch notes, use a separate work log (see Work Logs below)
+- **Cite durable anchors, not raw line numbers.** `file.md:18-22` goes stale
+  after any unrelated merge (#799). Anchor each edit site to something that
+  survives drift — heading text, a unique grep pattern, or a function name —
+  and re-grep before editing if you must quote a line number.
 - **CRITICAL:** Never mark `done` without user confirmation
 
 ---

--- a/.claude/commands/parity-check.md
+++ b/.claude/commands/parity-check.md
@@ -15,6 +15,8 @@ bun scripts/parity-check.ts --fix        # auto-sync: copy drifted templates →
 
 `--fix` (or `bun run parity:fix`) resolves pair drift by copying each canonical template over its dogfood mirror, so a hook edit no longer has to be hand-`cp`'d between `templates/` and `.safeword/`. Templates are canonical; `.safeword/` is the mirror.
 
+Run the `bun scripts/…` forms from the **repo root** — the path is root-relative, so from a package directory bun fails with a misleading `Module not found` (#861). `bun run parity:fix` works from the root or `packages/cli` (forwarding script).
+
 ## What gets checked
 
 - **Pairs** (from `SAFEWORD_SCHEMA.ownedFiles`): every entry with a `template` field is compared byte-for-byte against its dogfood counterpart.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,14 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-node24.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.safeword/hooks/session-bun-check.sh"
           }
         ]

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -121,6 +121,11 @@ elif [ -f packages/cli/src/cli.ts ]; then
 else SW="bunx safeword"; fi
 $SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
+# Config-drift coverage is JS/TS-only (W005 knip hints, W007 depcruise config).
+# Native stacks have no comparable drift check yet — say so instead of letting
+# silence read as "no drift" (#831).
+(has_python_project || has_go_project || has_rust_project) && echo "Coverage limitation: config-drift checks (W005/W007) cover JS/TS tooling only — native lint configs (ruff.toml, .golangci.yml, Cargo [lints]) are not drift-checked; review them manually."
+
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)
 # =========================================================================
@@ -360,15 +365,17 @@ find . -name "*.test.*" -o -name "*.spec.*" -o -name "*_test.*" | grep -v node_m
 
 **For each sampled test file, check:**
 
-| Check                        | Criteria                                                                                                | Severity |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| Meaningful assertions        | Every test has specific value/behavior assertions (not just `toBeTruthy`, `toBeDefined`, `not.toThrow`) | error    |
-| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                  | error    |
-| Independence                 | No test depends on another test's side effects; fresh state per test                                    | error    |
-| No arbitrary timeouts        | No `sleep()`, `waitForTimeout()`, or hardcoded delays                                                   | error    |
-| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                       | error    |
-| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`)                                       | error    |
-| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")               | error    |
+The criteria are language-neutral; the parenthetical idioms are examples — map them to the project's test framework (Jest/Vitest, pytest, Go `testing`, Rust `#[test]`, …).
+
+| Check                        | Criteria                                                                                                                                                                  | Severity |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Meaningful assertions        | Every test asserts specific values/behavior — not bare existence/truthiness/no-error checks (`toBeTruthy`, bare `assert result`, only `err == nil`, `assert!(x.is_ok())`) | error    |
+| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                                                                                    | error    |
+| Independence                 | No test depends on another test's side effects; fresh state per test                                                                                                      | error    |
+| No arbitrary timeouts        | No sleeps or hardcoded delays (`sleep`, `waitForTimeout`, `time.Sleep`, `thread::sleep`)                                                                                  | error    |
+| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                                                                                         | error    |
+| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`, `pytest.mark.parametrize`, Go table-driven subtests, `rstest`)                                          | error    |
+| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")                                                                                 | error    |
 
 **Report format:**
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -83,7 +83,8 @@ Optional: `--session-id <id>` for stable ledger attribution across fires;
 `--window-start <chars>` to digest only the transcript from an offset (delta mode).
 
 In a repo where the `safeword` binary isn't on PATH (e.g. this monorepo), substitute
-`bun packages/cli/src/cli.ts` for `safeword`.
+`bun run safeword` for `safeword` (runs the CLI from source via the root
+`package.json` script; `bunx safeword` also resolves the workspace-linked build).
 
 ## 3. Filing is code-owned — do not hand-write issues
 

--- a/.claude/skills/ticket-system/SKILL.md
+++ b/.claude/skills/ticket-system/SKILL.md
@@ -105,6 +105,10 @@ status: in_progress
 - Log immediately after each action
 - Re-read ticket before significant actions
 - For detailed scratch notes, use a separate work log (see Work Logs below)
+- **Cite durable anchors, not raw line numbers.** `file.md:18-22` goes stale
+  after any unrelated merge (#799). Anchor each edit site to something that
+  survives drift — heading text, a unique grep pattern, or a function name —
+  and re-grep before editing if you must quote a line number.
 - **CRITICAL:** Never mark `done` without user confirmation
 
 ---

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,14 @@
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2> /dev/null)
 [ -n "$GIT_COMMON_DIR" ] && git config -f "$GIT_COMMON_DIR/config" core.bare false 2> /dev/null
 
+# Nothing staged (e.g. `git commit --allow-empty`): every check below
+# validates staged or repo content that this commit cannot change, and
+# lint-staged prints a confusing "could not find any staged files" line
+# (issue #862). Exit quietly instead of running the full pipeline.
+if git rev-parse --verify HEAD > /dev/null 2>&1 && git diff --cached --quiet; then
+  exit 0
+fi
+
 # Fail if nested config directories/files exist (indicates setup ran from wrong directory)
 # Uses schema-derived patterns to stay in sync with what safeword creates
 bun scripts/check-nested-configs.ts || exit 1

--- a/.safeword/guides/retro.md
+++ b/.safeword/guides/retro.md
@@ -69,13 +69,20 @@ fresh context** that hasn't lived the session:
 
 ## Rules
 
-- **Autonomous** — no human approval. The schema + sanitizer + dedup + caps are
-  the safeguards, not a human gate.
-- **Upstream only** — `ArcadeAI/safeword`. Never the host project's tracker (the
-  friction is in safeword, not their product). If your agent lacks GitHub access
-  to the upstream repo, the command says so and no-ops — that's fine.
-- **Code owns egress.** You provide raw findings; the command sanitizes and
-  writes. Never file issues yourself from the transcript — that bypasses the
-  guard.
+The three bold invariants are shared word-for-word with
+`self-report-filing.md`; a parity contract (`packages/cli/src/schema.ts` →
+`contracts`) keeps the two guides from forking again (#801). Guide-specific
+rules follow them.
+
+- **Autonomous** — no human approval; sanitization + dedup + caps are the safeguards, not a human gate.
+- **Upstream only** — `ArcadeAI/safeword`, never the host project's tracker.
+- **Code owns egress** — nothing leaves beyond what the sanitized output contains.
+
+Specific to this playbook:
+
+- The friction is in safeword, not the host product. You provide raw findings;
+  the command sanitizes and files. Never file issues yourself from the
+  transcript — that bypasses the guard. If the agent lacks GitHub access to the
+  upstream repo, the command says so and no-ops — that's fine.
 - **Empty is a valid result.** A smooth session yields zero findings. Don't
   invent friction to fill the array.

--- a/.safeword/guides/self-report-filing.md
+++ b/.safeword/guides/self-report-filing.md
@@ -46,12 +46,20 @@ do not improvise another target.
 
 ## Rules
 
-- **File autonomously** — no human approval. (The cap + dedup + sanitization are
-  the safeguards, not a human gate.)
-- **Never** add anything to the issue beyond what the draft contains. The draft is
-  the sanitized surface; hand-adding context (paths, code, command output) defeats
-  the whole point and can leak customer data.
-- **Only** the upstream `ArcadeAI/safeword` repo — never the host project's tracker.
+The three bold invariants are shared word-for-word with `retro.md`; a parity
+contract (`packages/cli/src/schema.ts` → `contracts`) keeps the two guides
+from forking again (#801). Guide-specific rules follow them.
+
+- **Autonomous** — no human approval; sanitization + dedup + caps are the safeguards, not a human gate.
+- **Upstream only** — `ArcadeAI/safeword`, never the host project's tracker.
+- **Code owns egress** — nothing leaves beyond what the sanitized output contains.
+
+Specific to this playbook:
+
+- Post the drafts **verbatim** — hand-adding context (paths, code, command
+  output) defeats the sanitizer and can leak customer data. If GitHub access to
+  the upstream repo is missing, say so briefly and skip — do not improvise
+  another target.
 - If unsure whether a signal is worth a new issue, prefer **commenting on an
   existing one**.
 

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -166,7 +166,10 @@ function frontmatterField(content: string, field: string): string | undefined {
 }
 
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
-if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
+// Exact-basename match (#673): a suffix check would let decoys like
+// `sub-ticket.md` shadow the folder's canonical ticket.md and bind to a
+// stray/absent id instead of falling through to the artifact branch.
+if (isNamespacePath(editedFile, 'tickets/') && nodePath.basename(editedFile) === 'ticket.md') {
   const fullPath = editedFile.startsWith('/')
     ? editedFile
     : nodePath.join(projectDirectory, editedFile);

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -453,7 +453,7 @@ function frontmatterFromContent(content: string): Record<string, string | string
 // #404 readiness gate so "wrong step" is reported before "step not earned".
 // ---------------------------------------------------------------------------
 
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   // Only judge writes whose proposed content is reconstructable from the
   // payload (Write content, Edit old/new, MultiEdit edits). Payload shapes
   // carrying none of those (e.g. NotebookEdit, adapter probes) pass — the
@@ -476,7 +476,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // Feature readiness gate (#404): block new entries into define-behavior before
 // scenario work starts. The existing test-definitions.md gate still guards the
 // first scenario-file write; this catches the earlier phase edit.
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const priorMeta = frontmatterFromContent(priorContent);
@@ -508,7 +508,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // independent phase-exit review stamp exists for it. The stamp is produced by a
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
@@ -554,7 +554,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // not done (override with a substantive reason). Joins the phase-gate family.
 // ---------------------------------------------------------------------------
 
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const denial = evaluateBlockedOnGate(priorContent, proposedContent, id => {

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -446,6 +446,12 @@ function frontmatterFromContent(content: string): Record<string, string | string
   return match ? parseFrontmatter(match[1] ?? '') : {};
 }
 
+// Shared predicate for the four ticket.md gates below. Exact-basename match
+// (#673): a suffix check would let decoys like `sub-ticket.md` take the
+// canonical-ticket branches and be judged on their own frontmatter.
+const isCanonicalTicketEdit =
+  nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/');
+
 // ---------------------------------------------------------------------------
 // Phase-provenance gate (0KYEBN, #644 G2) — ALWAYS-ON. A feature ticket's
 // phase is earned, not declared: born at intake, one canonical step at a time,
@@ -453,7 +459,7 @@ function frontmatterFromContent(content: string): Record<string, string | string
 // #404 readiness gate so "wrong step" is reported before "step not earned".
 // ---------------------------------------------------------------------------
 
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   // Only judge writes whose proposed content is reconstructable from the
   // payload (Write content, Edit old/new, MultiEdit edits). Payload shapes
   // carrying none of those (e.g. NotebookEdit, adapter probes) pass — the
@@ -476,7 +482,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // Feature readiness gate (#404): block new entries into define-behavior before
 // scenario work starts. The existing test-definitions.md gate still guards the
 // first scenario-file write; this catches the earlier phase edit.
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const priorMeta = frontmatterFromContent(priorContent);
@@ -508,7 +514,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // independent phase-exit review stamp exists for it. The stamp is produced by a
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
@@ -554,7 +560,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // not done (override with a substantive reason). Joins the phase-gate family.
 // ---------------------------------------------------------------------------
 
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const denial = evaluateBlockedOnGate(priorContent, proposedContent, id => {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Local `bun publish` is still gated by `packages/cli/scripts/check-bun-publish.js
 
 - **Never run more than one vitest process.** If a test run is backgrounded, wait for the completion notification — do not retry.
 - Prefer targeted runs over the full suite during development.
-- **Where you run matters.** `vitest` is only installed in `packages/cli/node_modules/.bin`, so `npx vitest run …` works **from `packages/cli`**, not the repo root (from root it fails `vitest: not found` — issue #723). From the repo root, run package tests via `bun run test tests/path/to/file.test.ts` (paths are `packages/cli`-relative; it forwards through the build-lock wrapper, which also rebuilds `dist/` first). The `node scripts/run-vitest-with-build-lock.mjs` wrapper resolves a `vitest` even when PATH lacks one (issue #715).
+- **Where you run matters.** `vitest` is only installed in `packages/cli/node_modules/.bin`, so `npx vitest run …` works **from `packages/cli`**, not the repo root (from root it fails `vitest: not found` — issue #723). From the repo root, run package tests via `bun run test <path>` — both `packages/cli`-relative (`tests/foo.test.ts`) and repo-root-relative (`packages/cli/tests/foo.test.ts`) paths work; the build-lock wrapper rebases the latter (#723) and rebuilds `dist/` first. The `node scripts/run-vitest-with-build-lock.mjs` wrapper resolves a `vitest` even when PATH lacks one (issue #715).
 - Full suite only for final verification before commit.
 
 ---@./AGENTS.md

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . && bun run lint:gherkin && bun run --cwd packages/cli typecheck",
     "format": "prettier --write .",
     "parity:fix": "bun scripts/parity-check.ts --fix",
+    "safeword": "bun packages/cli/src/cli.ts",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#examples\" \"#dist\"",
     "lint:sh": "shellcheck **/*.sh .safeword/hooks/* packages/cli/templates/hooks/* packages/cli/templates/scripts/* 2>/dev/null || true",
     "lint:gherkin": "bun packages/cli/src/cli.ts lint-gherkin",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "test:release": "node scripts/run-vitest-with-build-lock.mjs --config vitest.release.config.ts",
     "test:slow": "node scripts/run-vitest-with-build-lock.mjs --config vitest.slow.config.ts",
     "generate:cursor-wrappers": "bun scripts/generate-cursor-wrappers.ts",
+    "parity:fix": "bun ../../scripts/parity-check.ts --fix",
     "pretest:watch": "tsup",
     "test:watch": "vitest",
     "test:coverage": "node scripts/run-vitest-with-build-lock.mjs --coverage",

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -7,7 +7,14 @@ import process from 'node:process';
 
 const scriptDirectory = import.meta.dirname;
 const cliRoot = nodePath.resolve(scriptDirectory, '..');
-const vitestArguments = process.argv.slice(2);
+// Vitest runs with cwd=cliRoot, so a repo-root-relative path — the natural
+// spelling when invoking `bun run test` from the workspace root (#723) —
+// would act as a filter that matches nothing. Rebase those onto the package.
+const vitestArguments = process.argv
+  .slice(2)
+  .map(argument =>
+    argument.startsWith('packages/cli/') ? argument.slice('packages/cli/'.length) : argument,
+  );
 
 // The package-local bin directory holds the `vitest` executable. `bun run test`
 // (and npm) inject it into PATH, but invoking this wrapper directly — e.g.

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -10,6 +10,8 @@ const cliRoot = nodePath.resolve(scriptDirectory, '..');
 // Vitest runs with cwd=cliRoot, so a repo-root-relative path — the natural
 // spelling when invoking `bun run test` from the workspace root (#723) —
 // would act as a filter that matches nothing. Rebase those onto the package.
+// Only standalone arguments are rebased; `=`-joined flag values
+// (`--config=packages/cli/x.ts`) pass through untouched.
 const vitestArguments = process.argv
   .slice(2)
   .map(argument =>

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -491,6 +491,17 @@ function bddLaneFile(templatePath: string): FileDefinition {
   };
 }
 
+// Filing invariants shared word-for-word by the retro and self-report-filing
+// guides (#801). Both carry guide-specific nuance around them, so the guides
+// can't be collapsed into one — instead the shared bullets are contract-pinned
+// in both files below. Single-line bullets on purpose: contracts match exact
+// substrings, so a rewrap would break the check.
+const SHARED_FILING_INVARIANTS = [
+  '- **Autonomous** — no human approval; sanitization + dedup + caps are the safeguards, not a human gate.',
+  "- **Upstream only** — `ArcadeAI/safeword`, never the host project's tracker.",
+  '- **Code owns egress** — nothing leaves beyond what the sanitized output contains.',
+];
+
 export const SAFEWORD_SCHEMA: SafewordSchema = {
   version: VERSION,
 
@@ -1434,6 +1445,16 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
   // Used by runParity() in src/parity.ts for both release tests and pre-commit
   // (see ticket 144). Path key = file relative to repo root.
   contracts: {
+    'packages/cli/templates/guides/self-report-filing.md': {
+      // Shared filing invariants with retro.md (#801): the two guides carried
+      // independently hand-tuned Rules blocks that silently forked. The exact
+      // bullet text below must appear in BOTH guides — edit them together.
+      requires: SHARED_FILING_INVARIANTS,
+    },
+    'packages/cli/templates/guides/retro.md': {
+      // See self-report-filing.md contract above (#801).
+      requires: SHARED_FILING_INVARIANTS,
+    },
     'packages/cli/templates/hooks/lib/quality.ts': {
       // Cursor's stop hook imports QUALITY_REVIEW_MESSAGE. The export must exist
       // or Cursor users get a broken hook. The four marker strings (CONFIDENT,

--- a/packages/cli/templates/guides/retro.md
+++ b/packages/cli/templates/guides/retro.md
@@ -69,13 +69,20 @@ fresh context** that hasn't lived the session:
 
 ## Rules
 
-- **Autonomous** — no human approval. The schema + sanitizer + dedup + caps are
-  the safeguards, not a human gate.
-- **Upstream only** — `ArcadeAI/safeword`. Never the host project's tracker (the
-  friction is in safeword, not their product). If your agent lacks GitHub access
-  to the upstream repo, the command says so and no-ops — that's fine.
-- **Code owns egress.** You provide raw findings; the command sanitizes and
-  writes. Never file issues yourself from the transcript — that bypasses the
-  guard.
+The three bold invariants are shared word-for-word with
+`self-report-filing.md`; a parity contract (`packages/cli/src/schema.ts` →
+`contracts`) keeps the two guides from forking again (#801). Guide-specific
+rules follow them.
+
+- **Autonomous** — no human approval; sanitization + dedup + caps are the safeguards, not a human gate.
+- **Upstream only** — `ArcadeAI/safeword`, never the host project's tracker.
+- **Code owns egress** — nothing leaves beyond what the sanitized output contains.
+
+Specific to this playbook:
+
+- The friction is in safeword, not the host product. You provide raw findings;
+  the command sanitizes and files. Never file issues yourself from the
+  transcript — that bypasses the guard. If the agent lacks GitHub access to the
+  upstream repo, the command says so and no-ops — that's fine.
 - **Empty is a valid result.** A smooth session yields zero findings. Don't
   invent friction to fill the array.

--- a/packages/cli/templates/guides/self-report-filing.md
+++ b/packages/cli/templates/guides/self-report-filing.md
@@ -46,12 +46,20 @@ do not improvise another target.
 
 ## Rules
 
-- **File autonomously** — no human approval. (The cap + dedup + sanitization are
-  the safeguards, not a human gate.)
-- **Never** add anything to the issue beyond what the draft contains. The draft is
-  the sanitized surface; hand-adding context (paths, code, command output) defeats
-  the whole point and can leak customer data.
-- **Only** the upstream `ArcadeAI/safeword` repo — never the host project's tracker.
+The three bold invariants are shared word-for-word with `retro.md`; a parity
+contract (`packages/cli/src/schema.ts` → `contracts`) keeps the two guides
+from forking again (#801). Guide-specific rules follow them.
+
+- **Autonomous** — no human approval; sanitization + dedup + caps are the safeguards, not a human gate.
+- **Upstream only** — `ArcadeAI/safeword`, never the host project's tracker.
+- **Code owns egress** — nothing leaves beyond what the sanitized output contains.
+
+Specific to this playbook:
+
+- Post the drafts **verbatim** — hand-adding context (paths, code, command
+  output) defeats the sanitizer and can leak customer data. If GitHub access to
+  the upstream repo is missing, say so briefly and skip — do not improvise
+  another target.
 - If unsure whether a signal is worth a new issue, prefer **commenting on an
   existing one**.
 

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -166,7 +166,10 @@ function frontmatterField(content: string, field: string): string | undefined {
 }
 
 // Active ticket binding (phase/TDD step no longer cached — derived at read time)
-if (isNamespacePath(editedFile, 'tickets/') && editedFile.endsWith('ticket.md')) {
+// Exact-basename match (#673): a suffix check would let decoys like
+// `sub-ticket.md` shadow the folder's canonical ticket.md and bind to a
+// stray/absent id instead of falling through to the artifact branch.
+if (isNamespacePath(editedFile, 'tickets/') && nodePath.basename(editedFile) === 'ticket.md') {
   const fullPath = editedFile.startsWith('/')
     ? editedFile
     : nodePath.join(projectDirectory, editedFile);

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -453,7 +453,7 @@ function frontmatterFromContent(content: string): Record<string, string | string
 // #404 readiness gate so "wrong step" is reported before "step not earned".
 // ---------------------------------------------------------------------------
 
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   // Only judge writes whose proposed content is reconstructable from the
   // payload (Write content, Edit old/new, MultiEdit edits). Payload shapes
   // carrying none of those (e.g. NotebookEdit, adapter probes) pass — the
@@ -476,7 +476,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // Feature readiness gate (#404): block new entries into define-behavior before
 // scenario work starts. The existing test-definitions.md gate still guards the
 // first scenario-file write; this catches the earlier phase edit.
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const priorMeta = frontmatterFromContent(priorContent);
@@ -508,7 +508,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // independent phase-exit review stamp exists for it. The stamp is produced by a
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
@@ -554,7 +554,7 @@ if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/'))
 // not done (override with a substantive reason). Joins the phase-gate family.
 // ---------------------------------------------------------------------------
 
-if (editedFile.endsWith('ticket.md') && isNamespacePath(editedFile, 'tickets/')) {
+if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const denial = evaluateBlockedOnGate(priorContent, proposedContent, id => {

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -446,6 +446,12 @@ function frontmatterFromContent(content: string): Record<string, string | string
   return match ? parseFrontmatter(match[1] ?? '') : {};
 }
 
+// Shared predicate for the four ticket.md gates below. Exact-basename match
+// (#673): a suffix check would let decoys like `sub-ticket.md` take the
+// canonical-ticket branches and be judged on their own frontmatter.
+const isCanonicalTicketEdit =
+  nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/');
+
 // ---------------------------------------------------------------------------
 // Phase-provenance gate (0KYEBN, #644 G2) — ALWAYS-ON. A feature ticket's
 // phase is earned, not declared: born at intake, one canonical step at a time,
@@ -453,7 +459,7 @@ function frontmatterFromContent(content: string): Record<string, string | string
 // #404 readiness gate so "wrong step" is reported before "step not earned".
 // ---------------------------------------------------------------------------
 
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   // Only judge writes whose proposed content is reconstructable from the
   // payload (Write content, Edit old/new, MultiEdit edits). Payload shapes
   // carrying none of those (e.g. NotebookEdit, adapter probes) pass — the
@@ -476,7 +482,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // Feature readiness gate (#404): block new entries into define-behavior before
 // scenario work starts. The existing test-definitions.md gate still guards the
 // first scenario-file write; this catches the earlier phase edit.
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const priorMeta = frontmatterFromContent(priorContent);
@@ -508,7 +514,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // independent phase-exit review stamp exists for it. The stamp is produced by a
 // fresh (context:fork) reviewer and logged via `write-review-stamp.ts --phase`,
 // so the author can't grade their own phase. Inert until reviewGate is enabled.
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   if (isReviewGateOn()) {
     const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
     const exitedPhase = detectPhaseAdvance(
@@ -554,7 +560,7 @@ if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile,
 // not done (override with a substantive reason). Joins the phase-gate family.
 // ---------------------------------------------------------------------------
 
-if (nodePath.basename(editedFile) === 'ticket.md' && isNamespacePath(editedFile, 'tickets/')) {
+if (isCanonicalTicketEdit) {
   const priorContent = existsSync(editedFile) ? readFileSync(editedFile, 'utf8') : '';
   const proposedContent = nextContentAfterEdit(input.tool_input, priorContent);
   const denial = evaluateBlockedOnGate(priorContent, proposedContent, id => {

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -121,6 +121,11 @@ elif [ -f packages/cli/src/cli.ts ]; then
 else SW="bunx safeword"; fi
 $SW sync-config --check 2>&1 || echo "[W007] Stale .safeword/depcruise-config.cjs — run \`safeword sync-config\` to refresh and commit"
 
+# Config-drift coverage is JS/TS-only (W005 knip hints, W007 depcruise config).
+# Native stacks have no comparable drift check yet — say so instead of letting
+# silence read as "no drift" (#831).
+(has_python_project || has_go_project || has_rust_project) && echo "Coverage limitation: config-drift checks (W005/W007) cover JS/TS tooling only — native lint configs (ruff.toml, .golangci.yml, Cargo [lints]) are not drift-checked; review them manually."
+
 # =========================================================================
 # ARCHITECTURE CHECKS (circular deps, layer violations)
 # =========================================================================
@@ -360,15 +365,17 @@ find . -name "*.test.*" -o -name "*.spec.*" -o -name "*_test.*" | grep -v node_m
 
 **For each sampled test file, check:**
 
-| Check                        | Criteria                                                                                                | Severity |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| Meaningful assertions        | Every test has specific value/behavior assertions (not just `toBeTruthy`, `toBeDefined`, `not.toThrow`) | error    |
-| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                  | error    |
-| Independence                 | No test depends on another test's side effects; fresh state per test                                    | error    |
-| No arbitrary timeouts        | No `sleep()`, `waitForTimeout()`, or hardcoded delays                                                   | error    |
-| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                       | error    |
-| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`)                                       | error    |
-| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")               | error    |
+The criteria are language-neutral; the parenthetical idioms are examples — map them to the project's test framework (Jest/Vitest, pytest, Go `testing`, Rust `#[test]`, …).
+
+| Check                        | Criteria                                                                                                                                                                  | Severity |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Meaningful assertions        | Every test asserts specific values/behavior — not bare existence/truthiness/no-error checks (`toBeTruthy`, bare `assert result`, only `err == nil`, `assert!(x.is_ok())`) | error    |
+| Behavior over implementation | Tests assert observable outcomes, not internal state or mock call args                                                                                                    | error    |
+| Independence                 | No test depends on another test's side effects; fresh state per test                                                                                                      | error    |
+| No arbitrary timeouts        | No sleeps or hardcoded delays (`sleep`, `waitForTimeout`, `time.Sleep`, `thread::sleep`)                                                                                  | error    |
+| Edge case coverage           | Tests include error paths and boundary cases, not just happy path                                                                                                         | error    |
+| No duplicate tests           | Similar tests use parameterized/table-driven patterns (`it.each`, `pytest.mark.parametrize`, Go table-driven subtests, `rstest`)                                          | error    |
+| Test naming                  | Names describe behavior, not implementation ("returns 401 when..." not "works correctly")                                                                                 | error    |
 
 **Report format:**
 

--- a/packages/cli/templates/skills/retro/SKILL.md
+++ b/packages/cli/templates/skills/retro/SKILL.md
@@ -83,7 +83,8 @@ Optional: `--session-id <id>` for stable ledger attribution across fires;
 `--window-start <chars>` to digest only the transcript from an offset (delta mode).
 
 In a repo where the `safeword` binary isn't on PATH (e.g. this monorepo), substitute
-`bun packages/cli/src/cli.ts` for `safeword`.
+`bun run safeword` for `safeword` (runs the CLI from source via the root
+`package.json` script; `bunx safeword` also resolves the workspace-linked build).
 
 ## 3. Filing is code-owned — do not hand-write issues
 

--- a/packages/cli/templates/skills/ticket-system/SKILL.md
+++ b/packages/cli/templates/skills/ticket-system/SKILL.md
@@ -105,6 +105,10 @@ status: in_progress
 - Log immediately after each action
 - Re-read ticket before significant actions
 - For detailed scratch notes, use a separate work log (see Work Logs below)
+- **Cite durable anchors, not raw line numbers.** `file.md:18-22` goes stale
+  after any unrelated merge (#799). Anchor each edit site to something that
+  survives drift — heading text, a unique grep pattern, or a function name —
+  and re-grep before editing if you must quote a line number.
 - **CRITICAL:** Never mark `done` without user confirmation
 
 ---

--- a/packages/cli/tests/integration/phase-derivation.test.ts
+++ b/packages/cli/tests/integration/phase-derivation.test.ts
@@ -497,6 +497,55 @@ describe('Phase Derivation (#124)', () => {
       const state = readState(projectDirectory);
       expect(state).not.toHaveProperty('lastKnownTddStep');
     });
+
+    it('6.3: a decoy file merely ending in ticket.md binds via the folder ticket, not itself (#673)', () => {
+      createTicket(projectDirectory, '099', 'test-ticket', { status: 'in_progress' });
+      const head = execSync('git rev-parse --short HEAD', {
+        cwd: projectDirectory,
+        encoding: 'utf8',
+      }).trim();
+      writeState(projectDirectory, baseState({ lastCommitHash: head }));
+
+      // Decoy carries its own id: frontmatter — must not be read as a ticket.md.
+      writeTestFile(
+        projectDirectory,
+        '.safeword-project/tickets/099-test-ticket/sub-ticket.md',
+        ['---', 'id: 777', 'status: in_progress', '---', '', '# Decoy', ''].join('\n'),
+      );
+
+      const decoyPath = nodePath.join(
+        projectDirectory,
+        '.safeword-project/tickets/099-test-ticket/sub-ticket.md',
+      );
+      runPostToolQuality(projectDirectory, 'Edit', decoyPath);
+
+      const state = readState(projectDirectory);
+      expect(state.activeTicket).toBe('099');
+    });
+
+    it('6.4: a frontmatter-less *ticket.md artifact still binds via the folder ticket (#673)', () => {
+      createTicket(projectDirectory, '099', 'test-ticket', { status: 'in_progress' });
+      const head = execSync('git rev-parse --short HEAD', {
+        cwd: projectDirectory,
+        encoding: 'utf8',
+      }).trim();
+      writeState(projectDirectory, baseState({ lastCommitHash: head }));
+
+      writeTestFile(
+        projectDirectory,
+        '.safeword-project/tickets/099-test-ticket/sub-ticket.md',
+        '# Notes, no frontmatter\n',
+      );
+
+      const decoyPath = nodePath.join(
+        projectDirectory,
+        '.safeword-project/tickets/099-test-ticket/sub-ticket.md',
+      );
+      runPostToolQuality(projectDirectory, 'Edit', decoyPath);
+
+      const state = readState(projectDirectory);
+      expect(state.activeTicket).toBe('099');
+    });
   });
 
   // =========================================================================

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -192,6 +192,33 @@ describe('package test runner lock (379)', () => {
     ]);
   });
 
+  it('rebases repo-root-relative test paths onto the package root (#723)', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+
+    const result = await runNodeScript(
+      runnerPath,
+      ['packages/cli/tests/first.test.ts', '--config', 'vitest.live.config.ts'],
+      {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      },
+    );
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      // The path arg is rebased; the flag value is left untouched.
+      expect.stringMatching(
+        /^vitest:start:.*:run,tests\/first\.test\.ts,--config,vitest\.live\.config\.ts$/,
+      ),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+  });
+
   it('every vitest test script builds before running (no stale dist — #352)', () => {
     const pkg = JSON.parse(readFileSync(nodePath.join(cliRoot, 'package.json'), 'utf8')) as {
       scripts: Record<string, string>;

--- a/scripts/session-node24.sh
+++ b/scripts/session-node24.sh
@@ -10,14 +10,17 @@ set -u
 
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 mkdir -p "$NVM_DIR"
-[ -s /opt/nvm/nvm.sh ] || exit 0
 
 node24_bin() {
   ls -d "$NVM_DIR"/versions/node/v24.*/bin 2> /dev/null | sort -V | tail -1
 }
 
+# Probe for an existing install BEFORE gating on nvm.sh — a container that
+# already has Node 24 on disk (resumed session, environment snapshot) should
+# get it on PATH even if the image's nvm checkout is missing.
 NODE24_BIN="$(node24_bin)"
 if [ -z "$NODE24_BIN" ]; then
+  [ -s /opt/nvm/nvm.sh ] || exit 0
   # shellcheck disable=SC1091
   \. /opt/nvm/nvm.sh > /dev/null 2>&1 || true
   if ! nvm install 24 > /dev/null 2>&1; then
@@ -26,8 +29,15 @@ if [ -z "$NODE24_BIN" ]; then
   fi
   NODE24_BIN="$(node24_bin)"
 fi
+[ -n "$NODE24_BIN" ] || exit 0
 
-if [ -n "$NODE24_BIN" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "session-node24: Node 24 is installed but CLAUDE_ENV_FILE is unset; PATH not persisted for Bash commands" >&2
+  exit 0
+fi
+
+# SessionStart fires on startup, resume, clear, and compact — append once.
+if ! grep -qF "$NODE24_BIN" "$CLAUDE_ENV_FILE" 2> /dev/null; then
   echo "export PATH=\"$NODE24_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
   echo "session-node24: $("$NODE24_BIN/node" --version) first on PATH for Bash commands (engines floor >=24; container image ships 22)."
 fi

--- a/scripts/session-node24.sh
+++ b/scripts/session-node24.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Claude Code cloud containers ship Node 20/21/22 only, but the CLI's engines
+# floor is Node 24 (v0.66.0, #806) — on the preinstalled runtime, Error.isError
+# is missing and CLI error paths crash (8 suite failures, exit 7). This is the
+# repo-owned equivalent of an environment setup script: install Node 24 via the
+# image's nvm checkout and put it first on PATH for every Bash command via
+# $CLAUDE_ENV_FILE. Local sessions are untouched (CLAUDE_CODE_REMOTE unset).
+set -u
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+mkdir -p "$NVM_DIR"
+[ -s /opt/nvm/nvm.sh ] || exit 0
+
+node24_bin() {
+  ls -d "$NVM_DIR"/versions/node/v24.*/bin 2> /dev/null | sort -V | tail -1
+}
+
+NODE24_BIN="$(node24_bin)"
+if [ -z "$NODE24_BIN" ]; then
+  # shellcheck disable=SC1091
+  \. /opt/nvm/nvm.sh > /dev/null 2>&1 || true
+  if ! nvm install 24 > /dev/null 2>&1; then
+    echo "session-node24: nvm install 24 failed (network?); Bash commands stay on $(node --version 2> /dev/null || echo 'unknown node')" >&2
+    exit 0
+  fi
+  NODE24_BIN="$(node24_bin)"
+fi
+
+if [ -n "$NODE24_BIN" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$NODE24_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "session-node24: $("$NODE24_BIN/node" --version) first on PATH for Bash commands (engines floor >=24; container image ships 22)."
+fi
+exit 0


### PR DESCRIPTION
## What

Fixes the 9 actionable issues from the retro backlog (the other 4 of the requested 13 were closed with evidence: #820/#845/#830 already fixed on main by #823/#822/#857; #821 duplicate of #540).

- **#673** — pre/post-tool-quality hooks match `ticket.md` by exact basename; decoys like `sub-ticket.md` can no longer steal/skip session binding (5 sites, 2 regression tests)
- **#862** — pre-commit exits quietly when nothing is staged (`--allow-empty` noise)
- **#861** — `parity:fix` forwarding script in `packages/cli` + cwd note in the command doc
- **#831/#832** — audit skill: coverage-limitation line for JS-only config-drift checks; language-neutral test-quality criteria
- **#801** — shared filing invariants word-for-word identical across `retro.md`/`self-report-filing.md`, pinned by two new parity contracts
- **#799** — durable-anchor rule (no raw line numbers) in the ticket-system skill
- **#863** — root `bun run safeword` script for in-monorepo CLI invocation
- **#723** — build-lock wrapper rebases repo-root-relative test paths onto `packages/cli` (+ regression test)

Plus two follow-ups surfaced by `/verify` + `/audit` on the branch:

- ARCHITECTURE.md runtime-deps table row for `@cucumber/gherkin` + `@cucumber/messages` (audit dep-drift warning)
- `scripts/session-node24.sh` SessionStart hook: cloud containers ship Node 20/21/22, below the engines floor of 24 (#806), which crashed CLI error paths (`Error.isError`); the hook is the docs-sanctioned repo-owned setup-script equivalent — cloud-gated via `CLAUDE_CODE_REMOTE`, persists PATH via `CLAUDE_ENV_FILE`, no-op locally

## Verification

- Full suite on Node 24: **4790/4790 pass** (332 files; the 8 pre-existing Node-22 failures are environmental and eliminated by the hook)
- Gherkin acceptance lane: **278/278 scenarios** (6045 steps)
- Build, typecheck, lint, `bun outdated`, depcruise, knip: clean; parity: 212 pairs + 5 contracts in sync
- `/audit`: passed (dep-table warning fixed in-branch)

Closes #673, #723, #799, #801, #831, #832, #861, #862, #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8gT3sN8HC5K4rMjCCsCGV

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8gT3sN8HC5K4rMjCCsCGV)_