### PR TITLE
docs+test: post-merge review notes for #886/#887

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,11 +75,11 @@ packages/cli/
 │   │   └── types.ts      # Shared type definitions
 │   ├── presets/          # ESLint presets (exported as safeword/eslint)
 │   │   └── typescript/   # ESLint configs, rules, detection
-│   ├── retro/            # Retrospective pipeline: transcript mining, drafts, egress guard, GitHub REST transport
+│   ├── retro/            # Retro pipeline: finding sanitization, drafts, egress guard, GitHub REST transport (miner front-end lives in commands/retro.ts)
 │   ├── skills/           # Skill package installer (harness side of the pack/harness skill split)
 │   ├── templates/        # Template content helpers
 │   ├── test-plan/        # Resolves per-language test/build/typecheck/bdd/deps command plans (verify + stop-gate source of truth)
-│   ├── ticket-sync/      # Generates tickets/INDEX.md + INDEX-completed.md discovery indexes
+│   ├── ticket-sync/      # Generates <namespace-root>/tickets/INDEX.md + INDEX-completed.md discovery indexes
 │   ├── tracker-connect/  # `safeword connect` flow: tracker credentials, config, secret store
 │   ├── tracker-sync/     # One-way projection of the ticket corpus into the configured tracker
 │   ├── upstream-monitor/ # Watches upstream agent-CLI changelogs (claude-code, codex-cli, cursor) via snapshots

--- a/packages/cli/src/templates/config.test.ts
+++ b/packages/cli/src/templates/config.test.ts
@@ -57,7 +57,11 @@ describe('getEslintConfig', () => {
     ],
     ['standard ignores', 'detect.getIgnores()'],
   ])('generated config wires %s', (_purpose, contractCall) => {
-    expect(getEslintConfig()).toContain(contractCall);
+    // Boundary-anchored so short rows can't pass via longer siblings
+    // (`configs.recommended` must not be satisfied by `configs.recommendedTypeScriptNext`).
+    const escaped = contractCall.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- escaped table literal
+    expect(getEslintConfig()).toMatch(new RegExp(`${escaped}(?![A-Za-z])`));
   });
 
   it('should include eslint-config-prettier when no existing formatter', () => {


### PR DESCRIPTION
#886 and #887 merged before the session's independent quality-review/refactor pass reached them, so a fresh-context post-merge review ran over both diffs as they exist in main. Verdict: **both CLEAN, zero must-fix** — every module one-liner, dependency claim, and strengthened assertion checked out against source. Three notes were worth a fix:

- **ARCHITECTURE.md `retro/` one-liner** misattributed transcript mining: the LLM miner front-end lives in `commands/retro.ts`; `src/retro/` is the sanitize/draft/triage/transport pipeline (its own `pipeline.ts` says so).
- **`ticket-sync/` line** now carries the `<namespace-root>/` prefix like its `learning-sync` sibling.
- **config.test.ts contract table**: matching is now boundary-anchored, so the `configs.recommended` and `configs.recommendedTypeScript` rows can no longer be satisfied by their longer siblings (`…TypeScriptNext`/`…TypeScriptReact`) — previously those two pins could never fail independently (a pre-existing weakness the table had carried over).

35/35 config template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_