### PR TITLE
Graduate test-integrity + no-sleep rules from prose to lint (#773 rung 2, VFD6X1)

### DIFF
--- a/.project/tickets/VFD6X1-test-lint-graduation/ticket.md
+++ b/.project/tickets/VFD6X1-test-lint-graduation/ticket.md
@@ -2,8 +2,8 @@
 id: VFD6X1
 slug: test-lint-graduation
 type: task
-phase: intake
-status: in_progress
+phase: done
+status: done
 created: 2026-07-07T02:19:20.221Z
 last_modified: 2026-07-07T02:19:20.221Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/773
@@ -33,3 +33,4 @@ done_when:
 - 2026-07-07T02:19:20.221Z Started: Created ticket VFD6X1
 - Scouted: all in-tree skips are env-conditional skipIf (legal under the new rule); the only sleep-shaped lines live in template-string fixtures (not AST calls) — rules can land at error with zero suppressions
 - TDD: 15 RED tests (config pins + functional Linter runs incl. the load-bearing skipIf no-flag pin) → GREEN via vitest/no-disabled-tests + 4 no-restricted-syntax selectors; 81/81 preset tests, repo-wide test-file lint zero violations, parity synced, prose trimmed to pointers at both sites
+- 2026-07-07T03:27:31.164Z Phase: intake → done

--- a/.project/tickets/VFD6X1-test-lint-graduation/ticket.md
+++ b/.project/tickets/VFD6X1-test-lint-graduation/ticket.md
@@ -1,0 +1,35 @@
+---
+id: VFD6X1
+slug: test-lint-graduation
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-07T02:19:20.221Z
+last_modified: 2026-07-07T02:19:20.221Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/773
+scope:
+  - vitest lane gains vitest/no-disabled-tests (error) — .skip/xit/xdescribe need an inline eslint-disable with reason (the auditable approval artifact)
+  - vitest lane gains no-restricted-syntax selectors for the sleep idioms (awaited Promise+setTimeout, Bun.sleep, sleep()) and it/test/describe.todo
+  - functional Linter tests pin each selector's flag/no-flag behavior (skipIf must stay legal)
+  - testing-guide.md Test Integrity table + no-sleep section trim their lint-owned rows to pointers
+out_of_scope:
+  - assertion-weakening / test-deletion detection (not statically lintable without noise; stays prose + REFACTOR commit gate)
+  - testing-guide.md:470 CI coverage thresholds (separate heavier rung)
+  - playwright lane (already has no-wait-for-timeout, no-skipped-test, no-focused-test)
+done_when:
+  - it.skip without a disable comment and await-sleep idioms fail lint in the vitest lane
+  - skipIf-conditional tests and template-string fixtures stay clean
+  - repo lint stays green with zero new suppressions
+---
+
+# Graduate test-integrity + no-sleep rules from prose to lint
+
+**Goal:** The lintable subset of testing-guide's Test Integrity table (.skip/.only/xit/.todo, commented-out tests) and the no-arbitrary-sleep rule are ESLint-enforced in the vitest lane, and the prose trims to pointers
+
+**Why:** #773 graduate-then-trim: testing-guide.md:33 and :438 are prose-only invariants; the vitest lane already bans .only and commented-out tests but .skip/.todo and sleep idioms rely on the agent reading the guide
+
+## Work Log
+
+- 2026-07-07T02:19:20.221Z Started: Created ticket VFD6X1
+- Scouted: all in-tree skips are env-conditional skipIf (legal under the new rule); the only sleep-shaped lines live in template-string fixtures (not AST calls) — rules can land at error with zero suppressions
+- TDD: 15 RED tests (config pins + functional Linter runs incl. the load-bearing skipIf no-flag pin) → GREEN via vitest/no-disabled-tests + 4 no-restricted-syntax selectors; 81/81 preset tests, repo-wide test-file lint zero violations, parity synced, prose trimmed to pointers at both sites

--- a/.project/tickets/VFD6X1-test-lint-graduation/verify.md
+++ b/.project/tickets/VFD6X1-test-lint-graduation/verify.md
@@ -1,0 +1,19 @@
+# Verify: test-lint-graduation (VFD6X1)
+
+Ran 2026-07-07 on branch claude/test-lint-rungs (PR #906), Node 24 container.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4881/4881 tests pass (338 files, 7 conditional skips; first fully-green local run — the prior container's Node 22 workers caused the historical Error.isError noise, now gone)
+**Gherkin:** ✅ Acceptance lane passes (295/298 scenarios, 3 environment-conditional skips)
+**Build:** ✅ Success (tsup ESM + DTS)
+**Lint:** ✅ Clean (`tsc --noEmit` clean; repo-wide test-file lint passes under the NEW rules with zero suppressions)
+**Scenarios:** ⏭️ Skipped — task ticket (inline tests: 15 config-pin + functional Linter scenarios, including the load-bearing skipIf no-flag pin)
+**PR Scope:** ✅ Diff matches ticket scope (vitest.ts rules + test-integrity-rules.test.ts + testing-guide trim + parity mirrors + ticket artifacts; nothing else)
+**Dep Drift:** ✅ Clean (no new dependencies)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation (rules live in the existing vitest lane config; tests follow the plugins.test.ts pin idiom + functional Linter runs)
+**Experience:** ✅ No new friction — walked TB hitting the new deny: lint message names the violation, the poll alternatives, and the guide; the sanctioned escape hatch (inline disable with reason) is one line. Walked TB with env-conditional skips: skipIf untouched, zero new steps. Worst step = authoring the disable-comment reason when a skip is genuinely wanted — which is the invariant working as designed.
+**Evidence limits:** ✅ None (Node 24 container; all lanes ran clean locally)
+
+Audit passed — sync-config ✓, depcruise ✓ (583 modules, 0 violations), knip ✓ clean (no W005 hints), jscpd 425 clones (9.05%) [repo minus .safeword/.project] — new post-merge-main baseline at the same scope, no new duplication from this diff; learnings Covers: ✓; outdated deps all dev-only patch/minor plus the three already-tracked majors (unicorn 70 pin, typescript 6 → ticket 091, cucumber-messages 34).

--- a/.safeword/guides/testing-guide.md
+++ b/.safeword/guides/testing-guide.md
@@ -36,13 +36,18 @@ Tests are the specification. When a test fails, the implementation is wrong—no
 
 ### Forbidden Actions (Require Approval)
 
-| Action                                          | Why It's Forbidden                |
-| ----------------------------------------------- | --------------------------------- |
-| Changing assertions to match broken code        | Hides bugs instead of fixing them |
-| Adding `.skip()`, `.only()`, `xit()`, `.todo()` | Makes failures invisible          |
-| Deleting tests you can't get passing            | Removes coverage for edge cases   |
-| Weakening assertions (`toBe` → `toBeTruthy`)    | Reduces test precision            |
-| Commenting out test code                        | Same as skipping                  |
+| Action                                       | Why It's Forbidden                |
+| -------------------------------------------- | --------------------------------- |
+| Changing assertions to match broken code     | Hides bugs instead of fixing them |
+| Deleting tests you can't get passing         | Removes coverage for edge cases   |
+| Weakening assertions (`toBe` → `toBeTruthy`) | Reduces test precision            |
+
+Skipping, focusing, deferring, or commenting out tests is lint-denied in the
+vitest lane (`vitest/no-disabled-tests`, `no-focused-tests`,
+`no-commented-out-tests`, plus the deferred-marker selector). The sanctioned
+escape hatch is an inline eslint-disable with a reason — that comment is the
+auditable approval artifact. Environment-conditional `skipIf`/`runIf` stay
+legal.
 
 ### What To Do Instead
 
@@ -423,13 +428,11 @@ it('should increase stress when resisting', () => {
 
 ### Async Testing
 
-**NEVER use arbitrary timeouts:**
+Arbitrary sleeps are lint-denied (`no-restricted-syntax` sleep selectors in the
+vitest lane; `playwright/no-wait-for-timeout` in the e2e lane). Poll an
+observable condition instead:
 
 ```typescript
-// ❌ BAD - Arbitrary timeout
-await page.waitForTimeout(3000);
-await sleep(500);
-
 // ✅ GOOD - Poll until condition
 await expect.poll(() => getStatus()).toBe('ready');
 await page.waitForSelector('[data-testid="loaded"]');

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the graduated test-integrity + no-sleep lint rules (ticket VFD6X1,
+ * issue #773 — enforce-then-trim of testing-guide.md's prose invariants).
+ *
+ * Config pins prove the rules ship in the vitest lane; functional Linter runs
+ * prove each restricted-syntax selector flags the forbidden idiom and stays
+ * silent on the sanctioned neighbors (skipIf-conditional tests, fake-timer
+ * setTimeout, sleep idioms inside template-string fixtures).
+ */
+
+import vitestPlugin from '@vitest/eslint-plugin';
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+import { vitestConfig } from '../vitest.js';
+import { getRuleConfig, getSeverityNumber } from './test-utilities.js';
+
+const ERROR = 2;
+
+/** Lint a snippet with only the vitest-lane rule under test. */
+function messagesFor(code: string, rules: Record<string, unknown>): Linter.LintMessage[] {
+  const linter = new Linter();
+  return linter.verify(code, {
+    plugins: { vitest: vitestPlugin },
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: rules as Linter.RulesRecord,
+  });
+}
+
+/** The vitest lane's no-restricted-syntax entry (severity + selectors). */
+function restrictedSyntaxRule(): unknown {
+  return getRuleConfig(vitestConfig, 'no-restricted-syntax');
+}
+
+describe('Test-integrity rules ship in the vitest lane (VFD6X1)', () => {
+  it('vitest/no-disabled-tests is at error', () => {
+    expect(getSeverityNumber(getRuleConfig(vitestConfig, 'vitest/no-disabled-tests'))).toBe(ERROR);
+  });
+
+  it('no-restricted-syntax is at error with the sleep/todo selectors', () => {
+    const rule = restrictedSyntaxRule() as [string, ...{ selector: string }[]];
+    expect(getSeverityNumber(rule)).toBe(ERROR);
+    const selectors = rule.slice(1).map(entry => (entry as { selector: string }).selector);
+    // One selector per forbidden idiom family: awaited Promise+setTimeout,
+    // Bun.sleep, bare sleep(), and the deferred-test marker.
+    expect(selectors.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('no-disabled-tests: unconditional skips flag, conditional skips stay legal', () => {
+  const RULES = { 'vitest/no-disabled-tests': 'error' };
+
+  it.each([
+    ['it.skip', `it.skip('later', () => {});`],
+    ['describe.skip', `describe.skip('later', () => {});`],
+    ['xit', `xit('later', () => {});`],
+  ])('flags %s', (_name, code) => {
+    expect(messagesFor(code, RULES).length).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag environment-conditional skipIf', () => {
+    const code = `it.skipIf(!process.env.RUFF)('needs ruff', () => {});`;
+    expect(messagesFor(code, RULES)).toEqual([]);
+  });
+});
+
+describe('no-restricted-syntax: sleep idioms flag, sanctioned neighbors stay legal', () => {
+  function sleepMessages(code: string): Linter.LintMessage[] {
+    return messagesFor(code, { 'no-restricted-syntax': restrictedSyntaxRule() });
+  }
+
+  it.each([
+    ['awaited Promise+setTimeout sleep', `await new Promise(r => setTimeout(r, 500));`],
+    ['Bun.sleep', `await Bun.sleep(100);`],
+    ['bare sleep()', `await sleep(500);`],
+    ['it.todo', `it.todo('write this later');`],
+    ['test.todo', `test.todo('write this later');`],
+  ])('flags %s', (_name, code) => {
+    expect(sleepMessages(code).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['polling via expect.poll', `await expect.poll(() => getStatus()).toBe('ready');`],
+    ['fake-timer setTimeout (not awaited-promise idiom)', `setTimeout(tick, 100);`],
+    [
+      'sleep idiom inside a template-string fixture',
+      'const fixture = `await new Promise(r => setTimeout(r, 120));`;',
+    ],
+    ['a variable named sleep', `const sleep = readConfig(); use(sleep);`],
+  ])('does NOT flag %s', (_name, code) => {
+    expect(sleepMessages(code)).toEqual([]);
+  });
+});

--- a/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
@@ -50,6 +50,45 @@ export const vitestConfig: any[] = [
       'vitest/no-focused-tests': 'error', // No .only() in CI
       'vitest/max-nested-describe': ['error', { max: 5 }], // Limit describe nesting depth
 
+      // Test-integrity graduation (VFD6X1, #773): testing-guide.md's "never
+      // skip/park tests without approval" invariant, lint-owned. Unconditional
+      // skips (it.skip, xit, xdescribe) need an inline eslint-disable with a
+      // reason — that comment IS the auditable approval artifact. Environment-
+      // conditional skipIf/runIf stay legal (the rule doesn't match them).
+      'vitest/no-disabled-tests': 'error',
+
+      // No-arbitrary-sleep graduation (VFD6X1, #773): the guide's "poll, never
+      // sleep" rule for the vitest lane (the playwright lane already has
+      // no-wait-for-timeout). Selectors match the sleep *idioms*, not every
+      // setTimeout — fake-timer scheduling and template-string fixtures stay
+      // legal. The deferred-test marker rides along: parking a test that way
+      // hides a gap the suite then reports as green.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "AwaitExpression > NewExpression[callee.name='Promise'] CallExpression[callee.name='setTimeout']",
+          message:
+            'Arbitrary sleep (await new Promise + setTimeout) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+        },
+        {
+          selector: "CallExpression[callee.object.name='Bun'][callee.property.name='sleep']",
+          message:
+            'Arbitrary sleep (Bun.sleep) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+        },
+        {
+          selector: "CallExpression[callee.name='sleep']",
+          message:
+            'Arbitrary sleep — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+        },
+        {
+          selector:
+            "CallExpression > MemberExpression[property.name='todo'][object.name=/^(it|test|describe)$/]",
+          message:
+            'Deferred-test marker parks a gap the suite then reports as green — write the test or delete the stub (an inline eslint-disable with a reason is the sanctioned escape hatch).',
+        },
+      ],
+
       // Relax base rules for test files - each override has documented justification:
       //
       // no-empty-function: Tests often need empty callbacks for mocks/stubs:

--- a/packages/cli/templates/guides/testing-guide.md
+++ b/packages/cli/templates/guides/testing-guide.md
@@ -36,13 +36,18 @@ Tests are the specification. When a test fails, the implementation is wrong—no
 
 ### Forbidden Actions (Require Approval)
 
-| Action                                          | Why It's Forbidden                |
-| ----------------------------------------------- | --------------------------------- |
-| Changing assertions to match broken code        | Hides bugs instead of fixing them |
-| Adding `.skip()`, `.only()`, `xit()`, `.todo()` | Makes failures invisible          |
-| Deleting tests you can't get passing            | Removes coverage for edge cases   |
-| Weakening assertions (`toBe` → `toBeTruthy`)    | Reduces test precision            |
-| Commenting out test code                        | Same as skipping                  |
+| Action                                       | Why It's Forbidden                |
+| -------------------------------------------- | --------------------------------- |
+| Changing assertions to match broken code     | Hides bugs instead of fixing them |
+| Deleting tests you can't get passing         | Removes coverage for edge cases   |
+| Weakening assertions (`toBe` → `toBeTruthy`) | Reduces test precision            |
+
+Skipping, focusing, deferring, or commenting out tests is lint-denied in the
+vitest lane (`vitest/no-disabled-tests`, `no-focused-tests`,
+`no-commented-out-tests`, plus the deferred-marker selector). The sanctioned
+escape hatch is an inline eslint-disable with a reason — that comment is the
+auditable approval artifact. Environment-conditional `skipIf`/`runIf` stay
+legal.
 
 ### What To Do Instead
 
@@ -423,13 +428,11 @@ it('should increase stress when resisting', () => {
 
 ### Async Testing
 
-**NEVER use arbitrary timeouts:**
+Arbitrary sleeps are lint-denied (`no-restricted-syntax` sleep selectors in the
+vitest lane; `playwright/no-wait-for-timeout` in the e2e lane). Poll an
+observable condition instead:
 
 ```typescript
-// ❌ BAD - Arbitrary timeout
-await page.waitForTimeout(3000);
-await sleep(500);
-
 // ✅ GOOD - Poll until condition
 await expect.poll(() => getStatus()).toBe('ready');
 await page.waitForSelector('[data-testid="loaded"]');


### PR DESCRIPTION
Second enforce-then-trim rung of #773 (after #878's process-kill denylist): `testing-guide.md:33` (Test Integrity table) and `:438` (no arbitrary sleeps) were prose-only invariants; their lintable subset is now ESLint-owned in the vitest lane.

## What's enforced

- **`vitest/no-disabled-tests` (error)** — unconditional skips (`it.skip`, `xit`, `xdescribe`) now require an inline eslint-disable with a reason: that comment is the auditable "explicit human approval" the prose demanded. Environment-conditional `skipIf`/`runIf` stay legal (pinned by a functional test — all of this repo's own skips are `skipIf(ruff/golangci absent)` and pass untouched).
- **`no-restricted-syntax` (error), four selectors** — the awaited `new Promise`+`setTimeout` sleep idiom, `Bun.sleep()`, bare `sleep()`, and the deferred-test (`.todo`) marker. Selectors match the *idioms*, not every `setTimeout`: fake-timer scheduling and sleep-shaped lines inside template-string fixtures stay legal, each pinned by a functional Linter test. (The playwright lane already had `no-wait-for-timeout`; `.only` and commented-out tests were already lint-owned.)

## Evidence

- 15 new tests: config pins + functional Linter runs for every flag/no-flag pair (81/81 preset tests green).
- Repo-wide test-file lint passes with **zero new suppressions** — scouting confirmed every in-tree skip was already conditional and every sleep-shaped line lives in a string fixture.
- Prose trim: the Test Integrity table keeps its unlintable rows (assertion weakening, test deletion — agent-behavior guarded by the REFACTOR commit gate); the skip/focus/defer/comment-out rows and the BAD-sleep examples become pointers to the lint rules.

Remaining #773 rungs (ticket write-gate, PII-scan, CI coverage at `:470`, etc.) stay open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_