### PR TITLE
fix(coverage): honor @-tag lineage in ledger-only test-definitions.md (#891)

### DIFF
--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -151,6 +151,77 @@ describe('buildCoverageReport (R2 — three buckets)', () => {
   });
 });
 
+describe('buildCoverageReport (issue #891 — @-tag lineage in a ledger-only test-definitions.md)', () => {
+  /** A test-definitions.md whose lineage rides an `@`-tag rather than the scenario title. */
+  function taggedDefinitions(tagLine: string): string {
+    return [
+      '# Test Definitions',
+      '',
+      tagLine,
+      '',
+      '### Scenario: The catalogue lists all shipped event types',
+      '',
+      '- [ ] RED',
+      '- [ ] GREEN',
+      '- [ ] REFACTOR',
+      '',
+    ].join('\n');
+  }
+
+  it('covers an AC via a bare tag on the ## Rule: heading', () => {
+    const report = buildCoverageReport(
+      spec(ONE_AC),
+      taggedDefinitions('## Rule: @demo.DEV1.AC1 — r'),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('covers an AC via a bare tag on its own line below the heading', () => {
+    const report = buildCoverageReport(
+      spec(ONE_AC),
+      taggedDefinitions('## Rule: r\n\n@demo.DEV1.AC1'),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('covers an AC via a backtick-wrapped tag on its own line (the shipped form)', () => {
+    const report = buildCoverageReport(
+      spec(ONE_AC),
+      taggedDefinitions('## Rule: r\n\n`@demo.DEV1.AC1`'),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('covers an AC via a backtick-wrapped tag on the ## Rule: heading', () => {
+    const report = buildCoverageReport(
+      spec(ONE_AC),
+      taggedDefinitions('## Rule: `@demo.DEV1.AC1` — r'),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('covers a numbered Rule via an @<jtbd>.R# tag', () => {
+    const report = buildCoverageReport(spec(ONE_RULE), taggedDefinitions('`@demo.DEV2.R1`'));
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+
+  it('ignores a tag inside a fenced code block (template example)', () => {
+    const report = buildCoverageReport(
+      spec(ONE_AC),
+      '# Test Definitions\n\n```\n@demo.DEV1.AC1\n```\n',
+    );
+    expect(report.uncovered).toEqual(['demo.DEV1.AC1']);
+  });
+
+  it('unions title-based and tag-based references in one ledger', () => {
+    const report = buildCoverageReport(
+      spec(TWO_ACS),
+      '# Test Definitions\n\n`@demo.DEV1.AC1`\n\n### Scenario: demo.DEV1.AC2.plain\n',
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
+});
+
 describe('buildCoverageReportFromFeature (feature files as source)', () => {
   function feature(tags: readonly string[]): string {
     return [

--- a/packages/cli/src/utils/scenario-coverage.test.ts
+++ b/packages/cli/src/utils/scenario-coverage.test.ts
@@ -220,6 +220,38 @@ describe('buildCoverageReport (issue #891 — @-tag lineage in a ledger-only tes
     );
     expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
   });
+
+  it('flags a tag whose AC# is absent under a known JTBD as stale', () => {
+    const report = buildCoverageReport(spec(ONE_AC), taggedDefinitions('`@demo.DEV1.AC5`'));
+    expect(report.stale).toEqual(['demo.DEV1.AC5']);
+    expect(report.orphan).toEqual([]);
+  });
+
+  it('flags a tag naming an unknown JTBD as orphan', () => {
+    const report = buildCoverageReport(spec(ONE_AC), taggedDefinitions('`@ghost.SM1.AC1`'));
+    expect(report.orphan).toEqual(['ghost.SM1.AC1']);
+    expect(report.stale).toEqual([]);
+  });
+
+  it('does not over-match prose: emails and `@<jtbd>.AC#` placeholders raise no ref', () => {
+    // A non-fenced line mentioning alex@arcade.dev and the literal placeholder
+    // `@<jtbd>.AC#` must not manufacture a stale/orphan advisory — the `@`-tokens
+    // are not `.AC<n>`/`.R<n>`-shaped, so they parse to nothing.
+    const report = buildCoverageReport(
+      spec(TWO_ACS),
+      [
+        '# Test Definitions',
+        '',
+        'Owner alex@arcade.dev; tag scenarios `@<jtbd>.AC#` per the guide.',
+        '',
+        '`@demo.DEV1.AC1`',
+        '',
+        '### Scenario: demo.DEV1.AC2.plain',
+        '',
+      ].join('\n'),
+    );
+    expect(report).toEqual({ uncovered: [], stale: [], orphan: [] });
+  });
 });
 
 describe('buildCoverageReportFromFeature (feature files as source)', () => {

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -22,6 +22,7 @@ import {
   parseFeatureScenarios,
   parseLineageReferenceFromTag,
 } from './gherkin-feature.js';
+// parseLineageReferenceFromTag also backs the test-definitions.md tag fallback (issue #891).
 import { computeSkipMask, parseHeading } from './markdown-sections.js';
 
 const JTBD_HEADING = 'jobs to be done';
@@ -209,7 +210,9 @@ const EMPTY_REPORT: CoverageReport = { uncovered: [], stale: [], orphan: [] };
  * pair. Degrades quietly: an empty report when the spec declares no ACs, or
  * when `testDefinitionsContent` is omitted (no test-definitions.md yet — a
  * ticket that hasn't reached define-behavior must not drown in uncovered-AC
- * noise). Free-text scenario titles contribute no coverage and raise no flag.
+ * noise). Coverage is read from conformant scenario titles and `@`-tag lineage
+ * (see `parseTestDefinitionReferences`); a free-text title carrying neither
+ * contributes no coverage and raises no flag.
  */
 export function buildCoverageReport(
   specContent: string,
@@ -218,9 +221,7 @@ export function buildCoverageReport(
   const scenarioReferences =
     testDefinitionsContent === undefined
       ? undefined
-      : parseScenarioTitles(testDefinitionsContent)
-          .map(title => parseAcReferenceFromTitle(title))
-          .filter((reference): reference is string => reference !== undefined);
+      : parseTestDefinitionReferences(testDefinitionsContent);
   return buildCoverageReportFromReferences(specContent, scenarioReferences);
 }
 
@@ -436,23 +437,42 @@ function jtbdPart(reference: string): string {
   return reference.replace(/\.(?:AC|R)\d+$/, '');
 }
 
+/** Every `@`-prefixed token on a line, once inline-code backticks are stripped. */
+const LINEAGE_TAG_TOKEN = /@\S+/g;
+
 /**
- * Extract every `### Scenario:` title from a test-definitions.md, skipping
- * commented/fenced regions.
+ * Lineage references a test-definitions.md declares, from two vehicles, skipping
+ * commented/fenced regions:
+ *   - conformant `### Scenario:` titles shaped `<jtbd>.AC#.<name>` (the encode-in-
+ *     the-title form the `testDefinitions` fixtures use); and
+ *   - `@<jtbd>.AC#` / `@<jtbd>.R#` lineage tags carried on a `## Rule:` heading or
+ *     on their own line beneath one — bare or wrapped in an inline `` `code span` ``.
+ *
+ * The tag vehicle mirrors what the `.feature` docs teach (lineage on the Rule
+ * block), so a ledger-only ticket that carries the same tag stays covered.
+ * Backticks are stripped before the tag parse because `parseLineageReferenceFromTag`
+ * is `^`-anchored — a leading `` ` `` would otherwise fold the whole reference into
+ * its lazy prefix and yield a malformed, never-matching id (issue #891).
  */
-function parseScenarioTitles(content: string): string[] {
+function parseTestDefinitionReferences(content: string): string[] {
   const lines = content.split('\n');
   const skip = computeSkipMask(lines);
-  const titles: string[] = [];
+  const references: string[] = [];
   for (const [index, line] of lines.entries()) {
-    const isSkipped = skip[index];
-    if (isSkipped) continue;
+    if (skip[index] === true) continue;
     const trimmed = line.trim();
     if (trimmed.startsWith(SCENARIO_PREFIX)) {
-      titles.push(trimmed.slice(SCENARIO_PREFIX.length).trim());
+      const reference = parseAcReferenceFromTitle(trimmed.slice(SCENARIO_PREFIX.length).trim());
+      if (reference !== undefined) references.push(reference);
+      continue;
+    }
+    const tagTokens = trimmed.replaceAll('`', '').match(LINEAGE_TAG_TOKEN) ?? [];
+    for (const token of tagTokens) {
+      const lineage = parseLineageReferenceFromTag(token);
+      if (lineage !== undefined) references.push(lineage.reference);
     }
   }
-  return titles;
+  return references;
 }
 
 /** First whitespace-delimited token of a heading's text (its id). */

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -466,6 +466,11 @@ function parseTestDefinitionReferences(content: string): string[] {
       if (reference !== undefined) references.push(reference);
       continue;
     }
+    // A concrete `@<jtbd>.AC#` token in prose or inline code on a non-fenced line
+    // is counted as a reference — inherent to treating the tag as a lineage
+    // vehicle. It stays advisory-only (health.ts routes coverage to advisories,
+    // not blocking issues); `@`-tokens that aren't `.AC<n>`/`.R<n>`-shaped
+    // (emails, decorators, `@rejection`, `@<jtbd>.AC#` placeholders) never match.
     const tagTokens = trimmed.replaceAll('`', '').match(LINEAGE_TAG_TOKEN) ?? [];
     for (const token of tagTokens) {
       const lineage = parseLineageReferenceFromTag(token);

--- a/packages/cli/src/utils/scenario-coverage.ts
+++ b/packages/cli/src/utils/scenario-coverage.ts
@@ -460,24 +460,30 @@ function parseTestDefinitionReferences(content: string): string[] {
   const references: string[] = [];
   for (const [index, line] of lines.entries()) {
     if (skip[index] === true) continue;
-    const trimmed = line.trim();
-    if (trimmed.startsWith(SCENARIO_PREFIX)) {
-      const reference = parseAcReferenceFromTitle(trimmed.slice(SCENARIO_PREFIX.length).trim());
-      if (reference !== undefined) references.push(reference);
-      continue;
-    }
-    // A concrete `@<jtbd>.AC#` token in prose or inline code on a non-fenced line
-    // is counted as a reference — inherent to treating the tag as a lineage
-    // vehicle. It stays advisory-only (health.ts routes coverage to advisories,
-    // not blocking issues); `@`-tokens that aren't `.AC<n>`/`.R<n>`-shaped
-    // (emails, decorators, `@rejection`, `@<jtbd>.AC#` placeholders) never match.
-    const tagTokens = trimmed.replaceAll('`', '').match(LINEAGE_TAG_TOKEN) ?? [];
-    for (const token of tagTokens) {
-      const lineage = parseLineageReferenceFromTag(token);
-      if (lineage !== undefined) references.push(lineage.reference);
-    }
+    references.push(...lineReferences(line.trim()));
   }
   return references;
+}
+
+/**
+ * Lineage references one non-skipped, trimmed test-definitions.md line declares:
+ * its `### Scenario:` title reference, else every `@`-tag reference it carries.
+ *
+ * A concrete `@<jtbd>.AC#` token in prose or inline code is counted — inherent
+ * to treating the tag as a lineage vehicle. It stays advisory-only (health.ts
+ * routes coverage to advisories, not blocking issues); `@`-tokens that aren't
+ * `.AC<n>`/`.R<n>`-shaped (emails, decorators, `@rejection`, `@<jtbd>.AC#`
+ * placeholders) never match.
+ */
+function lineReferences(trimmed: string): string[] {
+  if (trimmed.startsWith(SCENARIO_PREFIX)) {
+    const reference = parseAcReferenceFromTitle(trimmed.slice(SCENARIO_PREFIX.length).trim());
+    return reference === undefined ? [] : [reference];
+  }
+  const tagTokens = trimmed.replaceAll('`', '').match(LINEAGE_TAG_TOKEN) ?? [];
+  return tagTokens
+    .map(token => parseLineageReferenceFromTag(token)?.reference)
+    .filter((reference): reference is string => reference !== undefined);
 }
 
 /** First whitespace-delimited token of a heading's text (its id). */


### PR DESCRIPTION
## What

`safeword check`'s coverage report falsely flagged **every** acceptance criterion as "uncovered" for in-progress feature tickets whose scenarios live in `test-definitions.md` (no `features/*.feature`), even when each scenario group carried the correct `@<jtbd>.AC#` lineage tag. Fixes #891.

## Root cause

The two coverage fallbacks read lineage from different vehicles:

- `.feature` path (`buildCoverageReportFromFeature`) reads `@<jtbd>.AC#` / `@<jtbd>.R#` **tags**.
- `test-definitions.md` path (`buildCoverageReport`) read **only** scenario titles shaped `### Scenario: <jtbd>.AC#.<name>`.

A ledger-only ticket that carried lineage as a tag — the form the `.feature` docs teach — got zero recognized references, so all its criteria landed in `uncovered`. The reporter's shipped form wrapped the tag in an inline code span (`` `@…` ``), which also defeats the `^`-anchored tag regex (a leading backtick folds the whole id into the lazy prefix).

## Change

`packages/cli/src/utils/scenario-coverage.ts` — the `test-definitions.md` fallback now scans each non-fenced line for `@`-prefixed lineage tags in addition to the title form, and unions both. Inline-code backticks are stripped before parsing so the code-span form resolves.

Only the no-`.feature` path changes; the `.feature` path is untouched, title-based parsing is byte-identical (tickets covered before stay covered), and coverage remains advisory (non-blocking).

## Tests

`scenario-coverage.test.ts` (+7): all four shipped shapes — bare/backtick × Rule-heading/standalone-line — plus a `.R#` rule tag, a fenced-example tag that must stay ignored, and a title+tag union in one ledger.

- `scenario-coverage.test.ts`: 44/44 pass
- `tsc --noEmit`, eslint: clean

## Notes

- Not addressed here: the docs still advertise the `test-definitions.md` fallback; this fix makes the checker honor it rather than removing it. The path toward `.feature`-only (a `test-definitions.md → .feature` migration) is scoped separately.
- The secondary `## Arch alignment` `skip:` observation in #891 could not be reproduced on `main` and is left for its own issue pending the reporter's exact bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD4JSsVzspnYxGrnSbSWRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD4JSsVzspnYxGrnSbSWRB)_