### PR TITLE
fix(lint): harden the deferred-test marker + mirror integrity rules to the bun:test lane

### DIFF
--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
@@ -35,6 +35,13 @@ function restrictedSyntaxRule(config: unknown[]): unknown {
   return getRuleConfig(config, 'no-restricted-syntax');
 }
 
+/** The selector strings of a no-restricted-syntax rule entry. */
+function selectorsOf(rule: unknown): string[] {
+  return (rule as [string, ...{ selector: string }[]])
+    .slice(1)
+    .map(entry => (entry as { selector: string }).selector);
+}
+
 describe('Test-integrity rules ship in the vitest lane (VFD6X1)', () => {
   it('vitest/no-disabled-tests is at error', () => {
     expect(getSeverityNumber(getRuleConfig(vitestConfig, 'vitest/no-disabled-tests'))).toBe(ERROR);
@@ -45,21 +52,19 @@ describe('Test-integrity rules ship in the vitest lane (VFD6X1)', () => {
   });
 
   it('no-restricted-syntax is at error with the sleep selectors', () => {
-    const rule = restrictedSyntaxRule(vitestConfig) as [string, ...{ selector: string }[]];
+    const rule = restrictedSyntaxRule(vitestConfig);
     expect(getSeverityNumber(rule)).toBe(ERROR);
-    const selectors = rule.slice(1).map(entry => (entry as { selector: string }).selector);
     // One selector per sleep-idiom family: awaited Promise+setTimeout,
     // Bun.sleep, bare sleep().
-    expect(selectors.length).toBeGreaterThanOrEqual(3);
+    expect(selectorsOf(rule).length).toBeGreaterThanOrEqual(3);
   });
 });
 
 describe('Test-integrity rules ship in the bun:test lane (review hardening)', () => {
   it('no-restricted-syntax is at error with sleep + deferred-marker selectors', () => {
-    const rule = restrictedSyntaxRule(bunTestConfig) as [string, ...{ selector: string }[]];
+    const rule = restrictedSyntaxRule(bunTestConfig);
     expect(getSeverityNumber(rule)).toBe(ERROR);
-    const selectors = rule.slice(1).map(entry => (entry as { selector: string }).selector);
-    expect(selectors.length).toBeGreaterThanOrEqual(4);
+    expect(selectorsOf(rule).length).toBeGreaterThanOrEqual(4);
   });
 
   it('flags direct and chained deferred markers, not non-test members', () => {

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/test-integrity-rules.test.ts
@@ -1,23 +1,26 @@
 /**
  * Tests for the graduated test-integrity + no-sleep lint rules (ticket VFD6X1,
- * issue #773 — enforce-then-trim of testing-guide.md's prose invariants).
+ * issue #773 — enforce-then-trim of testing-guide.md's prose invariants; the
+ * deferred-marker coverage hardened after a quality review verified the
+ * chained `it.concurrent` bypass of the original direct-only selector).
  *
- * Config pins prove the rules ship in the vitest lane; functional Linter runs
- * prove each restricted-syntax selector flags the forbidden idiom and stays
- * silent on the sanctioned neighbors (skipIf-conditional tests, fake-timer
- * setTimeout, sleep idioms inside template-string fixtures).
+ * Config pins prove the rules ship in both test lanes; functional Linter runs
+ * prove each rule/selector flags the forbidden idiom and stays silent on the
+ * sanctioned neighbors (skipIf-conditional tests, fake-timer setTimeout,
+ * sleep idioms inside template-string fixtures, non-test deferred members).
  */
 
 import vitestPlugin from '@vitest/eslint-plugin';
 import { Linter } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
+import { bunTestConfig } from '../bun-test.js';
 import { vitestConfig } from '../vitest.js';
 import { getRuleConfig, getSeverityNumber } from './test-utilities.js';
 
 const ERROR = 2;
 
-/** Lint a snippet with only the vitest-lane rule under test. */
+/** Lint a snippet with only the rule under test. */
 function messagesFor(code: string, rules: Record<string, unknown>): Linter.LintMessage[] {
   const linter = new Linter();
   return linter.verify(code, {
@@ -27,9 +30,9 @@ function messagesFor(code: string, rules: Record<string, unknown>): Linter.LintM
   });
 }
 
-/** The vitest lane's no-restricted-syntax entry (severity + selectors). */
-function restrictedSyntaxRule(): unknown {
-  return getRuleConfig(vitestConfig, 'no-restricted-syntax');
+/** A lane's no-restricted-syntax entry (severity + selectors). */
+function restrictedSyntaxRule(config: unknown[]): unknown {
+  return getRuleConfig(config, 'no-restricted-syntax');
 }
 
 describe('Test-integrity rules ship in the vitest lane (VFD6X1)', () => {
@@ -37,13 +40,33 @@ describe('Test-integrity rules ship in the vitest lane (VFD6X1)', () => {
     expect(getSeverityNumber(getRuleConfig(vitestConfig, 'vitest/no-disabled-tests'))).toBe(ERROR);
   });
 
-  it('no-restricted-syntax is at error with the sleep/todo selectors', () => {
-    const rule = restrictedSyntaxRule() as [string, ...{ selector: string }[]];
+  it('vitest/warn-todo is at error (plugin rule — covers chained modifiers)', () => {
+    expect(getSeverityNumber(getRuleConfig(vitestConfig, 'vitest/warn-todo'))).toBe(ERROR);
+  });
+
+  it('no-restricted-syntax is at error with the sleep selectors', () => {
+    const rule = restrictedSyntaxRule(vitestConfig) as [string, ...{ selector: string }[]];
     expect(getSeverityNumber(rule)).toBe(ERROR);
     const selectors = rule.slice(1).map(entry => (entry as { selector: string }).selector);
-    // One selector per forbidden idiom family: awaited Promise+setTimeout,
-    // Bun.sleep, bare sleep(), and the deferred-test marker.
+    // One selector per sleep-idiom family: awaited Promise+setTimeout,
+    // Bun.sleep, bare sleep().
+    expect(selectors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('Test-integrity rules ship in the bun:test lane (review hardening)', () => {
+  it('no-restricted-syntax is at error with sleep + deferred-marker selectors', () => {
+    const rule = restrictedSyntaxRule(bunTestConfig) as [string, ...{ selector: string }[]];
+    expect(getSeverityNumber(rule)).toBe(ERROR);
+    const selectors = rule.slice(1).map(entry => (entry as { selector: string }).selector);
     expect(selectors.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('flags direct and chained deferred markers, not non-test members', () => {
+    const rules = { 'no-restricted-syntax': restrictedSyntaxRule(bunTestConfig) };
+    expect(messagesFor(`it.todo('later');`, rules).length).toBeGreaterThan(0);
+    expect(messagesFor(`it.concurrent.todo('later');`, rules).length).toBeGreaterThan(0);
+    expect(messagesFor(`myQueue.todo('item');`, rules)).toEqual([]);
   });
 });
 
@@ -64,17 +87,30 @@ describe('no-disabled-tests: unconditional skips flag, conditional skips stay le
   });
 });
 
+describe('warn-todo: deferred markers flag in every form', () => {
+  const RULES = { 'vitest/warn-todo': 'error' };
+
+  it.each([
+    ['it.todo', `it.todo('write this later');`],
+    ['test.todo', `test.todo('write this later');`],
+    ['describe.todo', `describe.todo('write this later');`],
+    // The chained form was a verified bypass of the direct-only selector this
+    // plugin rule replaced (quality review, 2026-07-07).
+    ['it.concurrent.todo', `it.concurrent.todo('write this later');`],
+  ])('flags %s', (_name, code) => {
+    expect(messagesFor(code, RULES).length).toBeGreaterThan(0);
+  });
+});
+
 describe('no-restricted-syntax: sleep idioms flag, sanctioned neighbors stay legal', () => {
   function sleepMessages(code: string): Linter.LintMessage[] {
-    return messagesFor(code, { 'no-restricted-syntax': restrictedSyntaxRule() });
+    return messagesFor(code, { 'no-restricted-syntax': restrictedSyntaxRule(vitestConfig) });
   }
 
   it.each([
     ['awaited Promise+setTimeout sleep', `await new Promise(r => setTimeout(r, 500));`],
     ['Bun.sleep', `await Bun.sleep(100);`],
     ['bare sleep()', `await sleep(500);`],
-    ['it.todo', `it.todo('write this later');`],
-    ['test.todo', `test.todo('write this later');`],
   ])('flags %s', (_name, code) => {
     expect(sleepMessages(code).length).toBeGreaterThan(0);
   });

--- a/packages/cli/src/presets/typescript/eslint-configs/bun-test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/bun-test.ts
@@ -17,6 +17,10 @@
  */
 
 import { TEST_FILE_GLOBS } from './test-file-globs.js';
+import {
+  DEFERRED_TEST_RESTRICTED_SYNTAX,
+  SLEEP_RESTRICTED_SYNTAX,
+} from './test-integrity-syntax.js';
 
 /**
  * `bun:test` global names, all read-only (Bun owns these bindings).
@@ -63,6 +67,18 @@ export const bunTestConfig: any[] = [
     files: [...TEST_FILE_GLOBS],
     languageOptions: {
       globals: BUN_TEST_GLOBALS,
+    },
+    rules: {
+      // Test-integrity graduation (VFD6X1 review hardening, #773): bun:test
+      // projects share testing-guide.md, so the plugin-free invariants apply
+      // here too — sleep idioms plus the deferred-test marker (selector-based
+      // in this lane, since the vitest plugin's rule isn't available; the
+      // selector covers both direct and chained-modifier forms).
+      'no-restricted-syntax': [
+        'error',
+        ...SLEEP_RESTRICTED_SYNTAX,
+        ...DEFERRED_TEST_RESTRICTED_SYNTAX,
+      ],
     },
   },
 ];

--- a/packages/cli/src/presets/typescript/eslint-configs/test-integrity-syntax.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/test-integrity-syntax.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared no-restricted-syntax entries for the test-integrity graduation
+ * (VFD6X1 + review hardening, issue #773): the testing-guide invariants that
+ * need no plugin, consumable by both the vitest lane and the bun:test lane so
+ * the guide's promise holds on either runner.
+ */
+
+interface RestrictedSyntaxEntry {
+  selector: string;
+  message: string;
+}
+
+/**
+ * Arbitrary-sleep idioms. Selectors match the *idioms*, not every setTimeout —
+ * fake-timer scheduling and template-string fixtures stay legal. Known
+ * accepted false positive: a timeout-guard race (`await new Promise((res,
+ * rej) => { start(res); setTimeout(() => rej(...), 5000); })`) matches the
+ * descendant selector even though it isn't a sleep — vi.waitFor/expect.poll
+ * are the better pattern there anyway, and an inline disable with a reason is
+ * the escape hatch.
+ */
+export const SLEEP_RESTRICTED_SYNTAX: RestrictedSyntaxEntry[] = [
+  {
+    selector:
+      "AwaitExpression > NewExpression[callee.name='Promise'] CallExpression[callee.name='setTimeout']",
+    message:
+      'Arbitrary sleep (await new Promise + setTimeout) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+  },
+  {
+    selector: "CallExpression[callee.object.name='Bun'][callee.property.name='sleep']",
+    message:
+      'Arbitrary sleep (Bun.sleep) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+  },
+  {
+    selector: "CallExpression[callee.name='sleep']",
+    message:
+      'Arbitrary sleep — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
+  },
+];
+
+/**
+ * Deferred-test marker for lanes WITHOUT the vitest plugin (the vitest lane
+ * uses the plugin's warn rule for this marker, which robustly covers chained
+ * modifiers). Two attribute shapes: a direct `it.<marker>(...)` and a chained
+ * `it.concurrent.<marker>(...)` — the chained form was a verified bypass of
+ * the direct-only selector (quality review, 2026-07-07).
+ */
+export const DEFERRED_TEST_RESTRICTED_SYNTAX: RestrictedSyntaxEntry[] = [
+  {
+    selector:
+      "CallExpression > MemberExpression[property.name='todo']:matches([object.name=/^(it|test|describe)$/], [object.object.name=/^(it|test|describe)$/])",
+    message:
+      'Deferred-test marker parks a gap the suite then reports as green — write the test or delete the stub (an inline eslint-disable with a reason is the sanctioned escape hatch).',
+  },
+];

--- a/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
@@ -20,6 +20,7 @@
 import vitestPlugin from '@vitest/eslint-plugin';
 
 import { TEST_FILE_GLOBS } from './test-file-globs.js';
+import { SLEEP_RESTRICTED_SYNTAX } from './test-integrity-syntax.js';
 
 /**
  * Vitest test linting config
@@ -57,37 +58,19 @@ export const vitestConfig: any[] = [
       // conditional skipIf/runIf stay legal (the rule doesn't match them).
       'vitest/no-disabled-tests': 'error',
 
+      // Deferred-test marker (review hardening of VFD6X1): the plugin rule —
+      // NOT a custom selector — because it also catches chained modifiers
+      // (it.concurrent + marker), a verified bypass of the direct-only
+      // selector this replaced. The plugin docs suggest warn severity; error-
+      // with-disable-comment is deliberately safeword's policy (LLMs ignore
+      // warnings, and the disable comment is the auditable approval).
+      'vitest/warn-todo': 'error',
+
       // No-arbitrary-sleep graduation (VFD6X1, #773): the guide's "poll, never
       // sleep" rule for the vitest lane (the playwright lane already has
-      // no-wait-for-timeout). Selectors match the sleep *idioms*, not every
-      // setTimeout — fake-timer scheduling and template-string fixtures stay
-      // legal. The deferred-test marker rides along: parking a test that way
-      // hides a gap the suite then reports as green.
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector:
-            "AwaitExpression > NewExpression[callee.name='Promise'] CallExpression[callee.name='setTimeout']",
-          message:
-            'Arbitrary sleep (await new Promise + setTimeout) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
-        },
-        {
-          selector: "CallExpression[callee.object.name='Bun'][callee.property.name='sleep']",
-          message:
-            'Arbitrary sleep (Bun.sleep) — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
-        },
-        {
-          selector: "CallExpression[callee.name='sleep']",
-          message:
-            'Arbitrary sleep — poll an observable condition instead (expect.poll / vi.waitFor). See testing-guide.md.',
-        },
-        {
-          selector:
-            "CallExpression > MemberExpression[property.name='todo'][object.name=/^(it|test|describe)$/]",
-          message:
-            'Deferred-test marker parks a gap the suite then reports as green — write the test or delete the stub (an inline eslint-disable with a reason is the sanctioned escape hatch).',
-        },
-      ],
+      // no-wait-for-timeout). Shared selectors — see test-integrity-syntax.ts
+      // for the idiom list and its documented accepted false positive.
+      'no-restricted-syntax': ['error', ...SLEEP_RESTRICTED_SYNTAX],
 
       // Relax base rules for test files - each override has documented justification:
       //


### PR DESCRIPTION
Independent quality-review follow-up to #906, which merged while its review pass was still running. The review (fresh-context, empirically probed against the installed `@vitest/eslint-plugin` 1.6.20) found one verified critical and two improvements worth shipping:

- **Critical — chained-modifier bypass:** #906's custom deferred-marker selector matched `it.todo(...)` but not `it.concurrent.todo(...)` (the object is a MemberExpression with no `.name`), so an agent blocked on `it.todo` could park a test as `it.concurrent.todo` and the suite reports green — the exact failure mode the graduation exists to close. The plugin already ships `vitest/warn-todo`, which catches every chained form; the vitest lane now uses it at error (error-with-disable-comment is safeword's deliberate policy; the docs' warn-severity advice is workflow opinion). The original comment's premise — "no plugin rule covers this" — was wrong and is corrected.
- **bun:test lane gap:** `bunTestConfig` carried zero integrity rules, so a bun-lane project shared the trimmed testing-guide prose without gaining any enforcement. The plugin-free invariants now ship there too — the three sleep selectors plus a chained-form-proof deferred-marker selector — via a shared `test-integrity-syntax.ts` consumed by both lanes.
- **Test hardening:** new flag-side cases for `describe.todo` and `it.concurrent.todo` (the latter fails against the old selector — it would have caught the bypass), bun-lane config pins + functional Linter runs, and the known timeout-guard false-positive class documented in the shared module.

86/86 preset tests green; repo-wide test-file lint passes with zero suppressions; typecheck + parity clean. The review also re-verified #906's other claims (skipIf staying legal, wiring through `getEslintConfig` → `configs.vitest`, guide parity) and gave a clean second opinion on #900's boundary-anchored regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_