### PR TITLE
chore(release): v0.67.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.67.0 — catch-up release

npm/last tag is **0.63.0**, but `main` reached **0.66.0** via three `chore(release)` bumps (0.64.0, 0.65.0, 0.66.0) that **were never tagged**, so they never published. This release catches npm up to `main` **and** ships 8 additional PRs merged on top of 0.66.0, in a single publish (npm will go 0.63.0 → 0.67.0 cumulatively).

### Bump class: minor (additive)
New PRs since 0.66.0 are strictly additive — new hooks, a new language-pack file, new lint rules, plus fixes/docs:

- #878 — Bash process-kill denylist + real-time work-log stamps (new hooks)
- #895 — python import-linter scaffold (new managed file `.importlinter`)
- #906 — graduate test-integrity/no-sleep rules from prose to lint (new lint rules)
- #890 — retro sweep (9 fixes) · #908 — @-tag lineage coverage fix (#891)
- #886 / #887 / #900 — architecture-doc + test-assertion hardening

### ⚠️ Rolls in the 0.66.0 breaking change
Because 0.64–0.66 never published, this release also delivers **0.66.0's breaking Node-floor→24 change (#806)** to npm consumers for the first time. Auto-upgraders on 0.63.0 will jump straight to 0.67.0 and pick it up.

Publish is CI-driven via OIDC on tag push after merge.