### PR TITLE
Document uncommittable RED evidence path

### DIFF
--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -63,6 +63,8 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
+**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 
 ```markdown
@@ -77,6 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Mark `RED` and `GREEN` in the same edit — one checkbox per edit, commit between
 - `- [x] RED` with no SHA and no `skip:` — blocked at write-time
 - `- [x] REFACTOR skip:` with empty or whitespace-only reason — blocked at write-time
+- `git commit --no-verify` to force a structurally broken RED code commit — use the `RED skip:` evidence path above instead
 - Reuse the same SHA across two steps in one scenario — caught at the done-gate (each step needs its own distinct commit)
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR

--- a/.agents/skills/bdd/TDD.md
+++ b/.agents/skills/bdd/TDD.md
@@ -63,7 +63,17 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
-**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+**Uncommittable RED states:** Prefer a real RED commit. Use this escape hatch only when a partial RED state cannot pass structural commit gates because the repo rejects incomplete code, such as:
+
+- a type-only scaffold that trips unused-property lint before behavior exists
+- an interface rename that cannot compile until all callers are updated
+
+Do not weaken the gate or force it through with `--no-verify`. Instead:
+
+1. Run the smallest command that proves the intended RED.
+2. Record the command and failure in the work log.
+3. Mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`.
+4. Move directly to GREEN and cite the GREEN commit on its own checkbox.
 
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -63,6 +63,8 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
+**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 
 ```markdown
@@ -77,6 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Mark `RED` and `GREEN` in the same edit — one checkbox per edit, commit between
 - `- [x] RED` with no SHA and no `skip:` — blocked at write-time
 - `- [x] REFACTOR skip:` with empty or whitespace-only reason — blocked at write-time
+- `git commit --no-verify` to force a structurally broken RED code commit — use the `RED skip:` evidence path above instead
 - Reuse the same SHA across two steps in one scenario — caught at the done-gate (each step needs its own distinct commit)
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR

--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -63,7 +63,17 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
-**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+**Uncommittable RED states:** Prefer a real RED commit. Use this escape hatch only when a partial RED state cannot pass structural commit gates because the repo rejects incomplete code, such as:
+
+- a type-only scaffold that trips unused-property lint before behavior exists
+- an interface rename that cannot compile until all callers are updated
+
+Do not weaken the gate or force it through with `--no-verify`. Instead:
+
+1. Run the smallest command that proves the intended RED.
+2. Record the command and failure in the work log.
+3. Mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`.
+4. Move directly to GREEN and cite the GREEN commit on its own checkbox.
 
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 

--- a/.project/tickets/J555B9-track-decompress-critical-audit-regression/ticket.md
+++ b/.project/tickets/J555B9-track-decompress-critical-audit-regression/ticket.md
@@ -1,0 +1,42 @@
+---
+id: J555B9
+slug: track-decompress-critical-audit-regression
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-07T05:34:36.978Z
+last_modified: 2026-07-07T05:34:43Z
+external_issue: https://github.com/advisories/GHSA-mp2f-45pm-3cg9
+---
+
+# Track decompress critical audit regression
+
+**Goal:** Track and resolve the new critical bun audit advisory in the root shellcheck dependency chain.
+
+**Why:** The July 2026 quality review found GHSA-mp2f-45pm-3cg9 through shellcheck -> decompress@4.2.1 after the earlier audit advisory ticket had been closed as clean.
+
+## Work Log
+
+- 2026-07-07T05:34:36.978Z Started: Created ticket J555B9
+- 2026-07-07T05:34:43Z Found: `bun audit --json` reports critical `decompress <=4.2.1` via `shellcheck@4.1.0`.
+- 2026-07-07T05:34:43Z Found: `bun pm why decompress` resolves the chain as `safeword -> shellcheck@4.1.0 -> decompress@4.2.1`.
+- 2026-07-07T05:34:43Z Found: `bun pm view shellcheck version` reports `4.1.0`, and `bun pm view decompress version` reports `4.2.1`; neither package currently has a newer npm release that clears the advisory.
+- 2026-07-07T05:34:43Z Decided: Track as follow-up remediation, not part of the #586 docs patch, because replacing the shellcheck npm wrapper or changing audit policy is a separate dependency decision.
+
+## Scope
+
+**In:**
+
+- Decide whether to replace the `shellcheck` npm wrapper, vendor/use a system binary, or accept a narrowed dev-only advisory.
+- Verify any remediation with `bun audit --json`, `bun run lint`, and the relevant shell-hook tests.
+- Update the earlier audit-advisory documentation if the accepted posture changes.
+
+**Out of Scope:**
+
+- General dependency refreshes unrelated to `shellcheck`, `decompress`, or the audit result.
+- Changing the #586 TDD guidance.
+
+**Done When:**
+
+- `bun audit --json` is clean for this advisory, or the remaining risk has an explicit accepted-risk note with rationale and owner.
+- The selected path is verified with the repo lint/typecheck flow.

--- a/.project/tickets/M8NNX0-document-uncommittable-red-evidence/ticket.md
+++ b/.project/tickets/M8NNX0-document-uncommittable-red-evidence/ticket.md
@@ -1,0 +1,23 @@
+---
+id: M8NNX0
+slug: document-uncommittable-red-evidence
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-07T04:44:45.942Z
+last_modified: 2026-07-07T04:49:06Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/586
+---
+
+# Document uncommittable RED evidence path
+
+**Goal:** Make the TDD instructions explicitly handle RED states that cannot be committed because structural quality gates reject partial code.
+
+**Why:** Issue #586 shows the current RED-commit rule conflicts with lint/typecheck gates for type-only scaffolds and atomic interface renames.
+
+## Work Log
+
+- 2026-07-07T04:44:45.942Z Started: Created ticket M8NNX0
+- 2026-07-07T04:45:30Z Decided: Use a documented `RED skip:` evidence path for structurally uncommittable partial states. Do not weaken lint/typecheck or add a broad hook bypass.
+- 2026-07-07T04:47:48Z Implemented: Added the `RED skip:` evidence path to the BDD TDD guidance in the template and dogfood-installed skill copies.
+- 2026-07-07T04:49:06Z Verified: `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run test tests/hooks/reconciliation-documentation.test.ts` passed, and `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run test --config vitest.release.config.ts tests/dogfood-parity.release.test.ts` passed.

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -63,6 +63,8 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
+**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 
 ```markdown
@@ -77,6 +79,7 @@ At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-s
 - Mark `RED` and `GREEN` in the same edit — one checkbox per edit, commit between
 - `- [x] RED` with no SHA and no `skip:` — blocked at write-time
 - `- [x] REFACTOR skip:` with empty or whitespace-only reason — blocked at write-time
+- `git commit --no-verify` to force a structurally broken RED code commit — use the `RED skip:` evidence path above instead
 - Reuse the same SHA across two steps in one scenario — caught at the done-gate (each step needs its own distinct commit)
 - Modify test files in a REFACTOR commit — blocked at commit-time (test changes during cleanup are behavior changes in disguise)
 - Add extra checkboxes like `- [ ] REVIEW` — only RED/GREEN/REFACTOR

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -63,7 +63,17 @@ Then they see the dashboard
 
 **Annotation rule (enforced by hook):** every `[x]` transition must carry either a commit SHA (proving which commit did that step) or `skip: <non-empty reason>` (a deliberate, auditable omission). Bare `[x]` without an annotation is blocked at the write-time hook. Pre-existing bare `[x]` from before this rule shipped is silently allowed — the validation is forward-looking only.
 
-**Uncommittable RED states:** Prefer a real RED commit. If a partial RED state cannot pass structural commit gates because the repo rejects incomplete code (for example, a type-only scaffold trips unused-property lint, or an interface rename cannot compile until all callers are updated), do not weaken the gate and do not force it through with `--no-verify`. Run the smallest command that proves the intended RED, record the command and failure in the work log, and mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`. Then move directly to GREEN and cite the GREEN commit on its own checkbox.
+**Uncommittable RED states:** Prefer a real RED commit. Use this escape hatch only when a partial RED state cannot pass structural commit gates because the repo rejects incomplete code, such as:
+
+- a type-only scaffold that trips unused-property lint before behavior exists
+- an interface rename that cannot compile until all callers are updated
+
+Do not weaken the gate or force it through with `--no-verify`. Instead:
+
+1. Run the smallest command that proves the intended RED.
+2. Record the command and failure in the work log.
+3. Mark the scenario `RED skip: uncommittable partial state — <command> failed before GREEN because <reason>`.
+4. Move directly to GREEN and cite the GREEN commit on its own checkbox.
 
 At the bottom of `test-definitions.md`, add one row for the whole-ticket cross-scenario refactor pass (same annotation rule applies). It's **completed at implement-exit** (see "whole-ticket quality review + refactor" below), and the done-gate requires it only when the ticket has **two or more RGR loops** — a single-loop ticket has nothing to cross and may leave it unmarked:
 


### PR DESCRIPTION
## Summary

- Document the narrow `RED skip: uncommittable partial state` evidence path for RED states blocked by structural lint/typecheck gates.
- Mirror the guidance across the canonical BDD TDD template and dogfood-installed Claude/Codex skill copies.
- Add local tickets for the #586 docs work and the follow-up `shellcheck -> decompress` critical audit finding surfaced during quality review.

## Verification

- `bun run lint`
- `bunx prettier --check .project/tickets/M8NNX0-document-uncommittable-red-evidence/ticket.md .project/tickets/J555B9-track-decompress-critical-audit-regression/ticket.md packages/cli/templates/skills/bdd/TDD.md .claude/skills/bdd/TDD.md .agents/skills/bdd/TDD.md`
- `bunx markdownlint-cli2 .project/tickets/M8NNX0-document-uncommittable-red-evidence/ticket.md .project/tickets/J555B9-track-decompress-critical-audit-regression/ticket.md packages/cli/templates/skills/bdd/TDD.md .claude/skills/bdd/TDD.md .agents/skills/bdd/TDD.md`
- `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run test tests/hooks/reconciliation-documentation.test.ts`
- `SAFEWORD_TEST_LOCK_MAX_WAIT_MS=0 bun run test --config vitest.release.config.ts tests/dogfood-parity.release.test.ts`

## Notes

`bun audit --json` currently reports GHSA-mp2f-45pm-3cg9 through `shellcheck -> decompress@4.2.1`; this PR tracks that as `J555B9-track-decompress-critical-audit-regression` rather than changing dependencies in the #586 docs patch.