### PR TITLE
refactor: dedupe boundary-shim command + frontmatter helpers (post-batch cleanup)

### DIFF
--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -52,14 +52,14 @@ const OK: ProvenanceVerdict = { ok: true };
 const SKIPS_SYNTAX =
   'record a deliberate skip for each bypassed phase as an indented phase_skips block sequence — e.g. `phase_skips:` on its own line, then `  - intake: <reason>` (two-space indent) for each skipped phase, each with a non-empty reason';
 
-function frontmatterOf(content: string): Record<string, string | string[]> | undefined {
+export function frontmatterOf(content: string): Record<string, string | string[]> | undefined {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return undefined;
   const parsed = parseFrontmatter(match[1] ?? '');
   return Object.keys(parsed).length > 0 ? parsed : undefined;
 }
 
-function scalar(
+export function scalar(
   meta: Record<string, string | string[]> | undefined,
   key: string,
 ): string | undefined {

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -10,12 +10,13 @@
  */
 
 import { checkVerifyArtifact } from '../../templates/hooks/lib/done-gate.js';
-import { parseFrontmatter } from '../../templates/hooks/lib/hierarchy.js';
 import { parseImplPlan } from '../../templates/hooks/lib/impl-plan.js';
 import { type ShaResolver, validateLedger } from '../../templates/hooks/lib/ledger-validation.js';
 import {
   detectUnanchoredPhaseTransition,
   evaluateTicketWrite,
+  frontmatterOf as parseTicketFrontmatter,
+  scalar,
 } from '../../templates/hooks/lib/phase-provenance.js';
 
 /** Ticket-artifact basenames the engine knows how to reconcile. */
@@ -79,16 +80,13 @@ export interface TicketReconciliation {
 /** Phases at which a feature's R/G/R ledger must already exist. */
 const LEDGER_REQUIRED_PHASES = new Set(['scenario-gate', 'implement', 'verify', 'done']);
 
+/**
+ * Ticket frontmatter, tolerant of CRLF git blobs — the shared parser is
+ * LF-only, so normalize before delegating (engine reads raw git content).
+ * `scalar` is imported from the same module.
+ */
 function frontmatterOf(content: string): Record<string, string | string[]> | undefined {
-  const match = /^---\n([\s\S]*?)\n---/.exec(content.replaceAll('\r\n', '\n'));
-  if (!match) return undefined;
-  const parsed = parseFrontmatter(match[1] ?? '');
-  return Object.keys(parsed).length > 0 ? parsed : undefined;
-}
-
-function scalar(meta: Record<string, string | string[]>, key: string): string | undefined {
-  const value = meta[key];
-  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+  return parseTicketFrontmatter(content.replaceAll('\r\n', '\n'));
 }
 
 function hasEntries(meta: Record<string, string | string[]>, key: string): boolean {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -512,6 +512,17 @@ const SHARED_FILING_INVARIANTS = [
 const BOUNDARY_SHIM_MARKER = '# Safeword boundary gate';
 
 /**
+ * The armored boundary-gate invocation, shared by every hook manager so the
+ * safety semantics can never drift: the `[ -x … ]` guard keeps a fresh clone
+ * (no node_modules) silent, and `|| true` keeps a crashing gate from blocking
+ * (warn-only contract, TB1.R4). Husky appends it via the textPatch below;
+ * the lefthook/pre-commit snippets interpolate it in hook-nudge.ts.
+ */
+export function boundaryShimCommand(at: 'commit' | 'push'): string {
+  return `[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at ${at} || true`;
+}
+
+/**
  * One-line boundary-gate shim for a husky hook file (see the textPatches
  * entry comment for the full design rationale). The marker is a trailing sh
  * comment on the command line itself, so the block IS the marker line.
@@ -519,7 +530,7 @@ const BOUNDARY_SHIM_MARKER = '# Safeword boundary gate';
 function boundaryShimPatch(at: 'commit' | 'push'): TextPatchDefinition {
   return {
     operation: 'append',
-    content: `[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at ${at} || true ${BOUNDARY_SHIM_MARKER}: warn-only; removed by \`safeword reset\`\n`,
+    content: `${boundaryShimCommand(at)} ${BOUNDARY_SHIM_MARKER}: warn-only; removed by \`safeword reset\`\n`,
     marker: BOUNDARY_SHIM_MARKER,
     rerender: true,
     // A hook file that setup alone created holds nothing but the shim after

--- a/packages/cli/src/utils/hook-nudge.ts
+++ b/packages/cli/src/utils/hook-nudge.ts
@@ -12,6 +12,7 @@
 import nodePath from 'node:path';
 
 import type { ProjectContext } from '../packs/types.js';
+import { boundaryShimCommand } from '../schema.js';
 import { readFileSafe } from './fs.js';
 import { gitToplevel } from './git.js';
 import { LEFTHOOK_CONFIGS } from './hook-manager.js';
@@ -19,21 +20,21 @@ import { LEFTHOOK_CONFIGS } from './hook-manager.js';
 /** Substring proving a config already invokes the gate — the quiesce signal. */
 const BOUNDARY_INVOCATION = 'safeword boundary';
 
-// Snippet lines carry the same armor as the husky shim (TB1.R4): the `[ -x ]`
-// guard keeps a fresh clone (no node_modules) silent, and `|| true` keeps a
-// crashing gate from blocking — pre-commit and lefthook both treat a non-zero
-// hook as failure, so an unguarded entry would break the warn-only contract.
+// Both snippets interpolate the shared boundaryShimCommand (schema.ts): the
+// `[ -x ]` guard keeps a fresh clone (no node_modules) silent, and `|| true`
+// keeps a crashing gate from blocking — pre-commit and lefthook both treat a
+// non-zero hook as failure, so an unguarded entry would break warn-only.
 const LEFTHOOK_SNIPPET = `Boundary gate: this repo uses lefthook, and safeword never edits lefthook.yml.
 To wire the warn-only boundary gate, add:
 
 pre-commit:
   commands:
     safeword-boundary:
-      run: '[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at commit || true'
+      run: '${boundaryShimCommand('commit')}'
 pre-push:
   commands:
     safeword-boundary:
-      run: '[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at push || true'`;
+      run: '${boundaryShimCommand('push')}'`;
 
 // `stages` is explicit on BOTH hooks: pre-commit's default_stages spreads a
 // stage-less hook to every installed hook type, so the commit-tier gate would
@@ -45,14 +46,14 @@ To wire the warn-only boundary gate, add under repos:
     hooks:
       - id: safeword-boundary-commit
         name: safeword boundary gate (commit)
-        entry: sh -c '[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at commit || true'
+        entry: sh -c '${boundaryShimCommand('commit')}'
         language: system
         always_run: true
         pass_filenames: false
         stages: [pre-commit]
       - id: safeword-boundary-push
         name: safeword boundary gate (push)
-        entry: sh -c '[ -x node_modules/.bin/safeword ] && node_modules/.bin/safeword boundary --at push || true'
+        entry: sh -c '${boundaryShimCommand('push')}'
         language: system
         always_run: true
         pass_filenames: false

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -52,14 +52,14 @@ const OK: ProvenanceVerdict = { ok: true };
 const SKIPS_SYNTAX =
   'record a deliberate skip for each bypassed phase as an indented phase_skips block sequence — e.g. `phase_skips:` on its own line, then `  - intake: <reason>` (two-space indent) for each skipped phase, each with a non-empty reason';
 
-function frontmatterOf(content: string): Record<string, string | string[]> | undefined {
+export function frontmatterOf(content: string): Record<string, string | string[]> | undefined {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return undefined;
   const parsed = parseFrontmatter(match[1] ?? '');
   return Object.keys(parsed).length > 0 ? parsed : undefined;
 }
 
-function scalar(
+export function scalar(
   meta: Record<string, string | string[]> | undefined,
   key: string,
 ): string | undefined {


### PR DESCRIPTION
Post-batch refactor pass (scout-led) over code merged in the last ~36h. The batch was clean; these are the two behavior-preserving dedups worth doing. Each is one commit, tested.

### 1. Extract `boundaryShimCommand` (schema.ts) — dedupe the shim string 5×
The armored `[ -x … ] && … boundary --at <tier> || true` invocation was hand-copied across `schema.ts` (husky textPatch) and `hook-nudge.ts` (lefthook + pre-commit snippets). A change to the `[ -x ]` guard or the `|| true` warn-only contract had to stay in lockstep across five copies with nothing enforcing it. Now single-sourced. Byte-identical output — `setup-hook-nudges` + `setup-hook-shims` (19 tests) green.

### 2. Single-source `frontmatterOf`/`scalar` in phase-provenance
`boundary/engine.ts` had re-copied both helpers from `phase-provenance.ts`. Exported them there; engine imports `scalar` directly and keeps a one-line CRLF-normalizing wrapper around the shared `frontmatterOf` (it reads raw git blobs), dropping its now-unused `parseFrontmatter` import. **No behavior change to the gate hook** (exports only); parity mirror kept byte-identical — boundary + phase-provenance + parity (91 tests) green.

Scope discipline: the ~10-site frontmatter-regex family and the `tryGit` wrappers were **deliberately left alone** (false-DRY / CRLF landmines, per the scout). Batch-adjacent findings (an `upgrade` Python-tools drift bug + a shell-tokenizer divergence) ship as separate PRs.