### PR TITLE
fix(python): upgrade installs the same tool set as setup (deadcode + import-linter)

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -15,6 +15,7 @@ import { hasImportLinterScaffoldTarget } from '../packs/python/files.js';
 import {
   detectPythonPackageManager,
   getPythonInstallCommand,
+  getPythonTools,
   hasRuffDependency,
   installPythonDependencies,
 } from '../packs/python/setup.js';
@@ -173,13 +174,6 @@ interface PythonSetupStatus {
   files: string[];
   installFailed: boolean;
   importLinter: boolean;
-}
-
-/** Base Python tools to install. Import-linter added when layers detected. */
-function getPythonTools(includeImportLinter: boolean): string[] {
-  const tools = ['ruff', 'mypy', 'deadcode'];
-  if (includeImportLinter) tools.push('import-linter');
-  return tools;
 }
 
 /**

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -9,9 +9,11 @@ import nodePath from 'node:path';
 import { checkHealth, reportHealthSummary } from '../health.js';
 import { migratePackId } from '../packs/config.js';
 import { installPack } from '../packs/install.js';
+import { hasImportLinterScaffoldTarget } from '../packs/python/files.js';
 import {
   detectPythonPackageManager,
   getPythonInstallCommand,
+  getPythonTools,
   hasRuffDependency,
   installPythonDependencies,
 } from '../packs/python/setup.js';
@@ -199,7 +201,9 @@ function installPythonBasedTools(pythonDirectory: string, packages: string[], la
 function installPythonTools(cwd: string): void {
   const pythonDirectory = findInTree(cwd, 'pyproject.toml') ?? cwd;
   if (hasRuffDependency(pythonDirectory)) return;
-  installPythonBasedTools(pythonDirectory, ['ruff', 'mypy'], 'Python tools');
+  // Same set as `setup` — via the shared getPythonTools so the two can't drift.
+  const tools = getPythonTools(hasImportLinterScaffoldTarget(pythonDirectory));
+  installPythonBasedTools(pythonDirectory, tools, 'Python tools');
 }
 
 function installSqlTools(cwd: string, ctx: ProjectContext): void {

--- a/packages/cli/src/packs/python/setup.ts
+++ b/packages/cli/src/packs/python/setup.ts
@@ -231,6 +231,19 @@ export function getPythonInstallCommand(cwd: string, tools: string[] = ['ruff'])
  * @param tools - Tools to install (e.g., ['ruff', 'mypy', 'import-linter'])
  * @returns true if installation succeeded, false otherwise
  */
+/**
+ * The Python tools safeword installs: ruff, mypy, deadcode, plus import-linter
+ * when safeword would scaffold a config for it (layers OR an unambiguous single
+ * package — the hasImportLinterScaffoldTarget predicate). Single source so
+ * `setup` and `upgrade` install the same set; they had drifted (upgrade shipped
+ * only ruff + mypy).
+ */
+export function getPythonTools(includeImportLinter: boolean): string[] {
+  const tools = ['ruff', 'mypy', 'deadcode'];
+  if (includeImportLinter) tools.push('import-linter');
+  return tools;
+}
+
 export function installPythonDependencies(cwd: string, tools: string[]): boolean {
   if (tools.length === 0) return true;
   if (process.env.SAFEWORD_SKIP_INSTALL) return true;

--- a/packages/cli/tests/utils/python-setup.test.ts
+++ b/packages/cli/tests/utils/python-setup.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   detectPythonPackageManager,
+  getPythonTools,
   hasRuffDependency,
   installPythonDependencies,
 } from '../../src/packs/python/setup.js';
@@ -31,6 +32,20 @@ afterEach(() => {
   if (context.projectDirectory) {
     removeTemporaryDirectory(context.projectDirectory);
   }
+});
+
+// =============================================================================
+// Tool set (shared by setup + upgrade — the anti-drift source of truth)
+// =============================================================================
+
+describe('getPythonTools', () => {
+  it('installs ruff, mypy, and deadcode by default', () => {
+    expect(getPythonTools(false)).toEqual(['ruff', 'mypy', 'deadcode']);
+  });
+
+  it('adds import-linter when a config would be scaffolded', () => {
+    expect(getPythonTools(true)).toEqual(['ruff', 'mypy', 'deadcode', 'import-linter']);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Surfaced by the post-batch refactor scout (batch-adjacent, not a 36h-merge — filed separately from the refactor PR because it's a behavior change).

**Bug:** `installPythonTools` in `upgrade.ts` hardcoded `['ruff', 'mypy']`, while `setup.ts` installs `ruff` + `mypy` + `deadcode` (+ `import-linter` when `hasImportLinterScaffoldTarget`). A repo that got Python tooling via `upgrade` (rather than a fresh `setup`) silently missed **deadcode** and **import-linter** — #895 widened setup's list and made the drift worse.

**Fix:** move `getPythonTools` into `packs/python/setup.ts` as the single source of truth; both `setup` and `upgrade` call it. Stale comment ("added when layers detected") corrected. Unit test pins the tool set including `deadcode`, so setup/upgrade can't drift again.

setup behavior unchanged; 48 tests green (python-setup unit + upgrade + setup-python).