### PR TITLE
cleanup-zombies.sh kills only with explicit --yes (#773 rung 4, 2KG1JW)

### DIFF
--- a/.agents/skills/cleanup-zombies/SKILL.md
+++ b/.agents/skills/cleanup-zombies/SKILL.md
@@ -12,16 +12,17 @@ Kill zombie processes (dev servers, Playwright browsers, test runners) for the c
 
 ## Instructions
 
-Run the cleanup script with `--dry-run` first to preview what will be killed:
-
-```bash
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-```
-
-If the output looks correct, run without `--dry-run`:
+Run the cleanup script — it previews what would be killed (nothing dies without
+explicit consent; the preview-first ritual is script-enforced):
 
 ```bash
 ./.safeword/scripts/cleanup-zombies.sh
+```
+
+If the preview looks correct, confirm the kill with `--yes`:
+
+```bash
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 ## What It Does
@@ -36,11 +37,11 @@ If the output looks correct, run without `--dry-run`:
 If auto-detection fails or you need a specific port:
 
 ```bash
-# Explicit port
+# Explicit port (preview, then add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 ## When to Use

--- a/.claude/skills/cleanup-zombies/SKILL.md
+++ b/.claude/skills/cleanup-zombies/SKILL.md
@@ -12,16 +12,17 @@ Kill zombie processes (dev servers, Playwright browsers, test runners) for the c
 
 ## Instructions
 
-Run the cleanup script with `--dry-run` first to preview what will be killed:
-
-```bash
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-```
-
-If the output looks correct, run without `--dry-run`:
+Run the cleanup script — it previews what would be killed (nothing dies without
+explicit consent; the preview-first ritual is script-enforced):
 
 ```bash
 ./.safeword/scripts/cleanup-zombies.sh
+```
+
+If the preview looks correct, confirm the kill with `--yes`:
+
+```bash
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 ## What It Does
@@ -36,11 +37,11 @@ If the output looks correct, run without `--dry-run`:
 If auto-detection fails or you need a specific port:
 
 ```bash
-# Explicit port
+# Explicit port (preview, then add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 ## When to Use

--- a/.cursor/commands/cleanup-zombies.md
+++ b/.cursor/commands/cleanup-zombies.md
@@ -8,16 +8,17 @@ Kill zombie processes (dev servers, Playwright browsers, test runners) for the c
 
 ## Instructions
 
-Run the cleanup script with `--dry-run` first to preview what will be killed:
-
-```bash
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-```
-
-If the output looks correct, run without `--dry-run`:
+Run the cleanup script — it previews what would be killed (nothing dies without
+explicit consent; the preview-first ritual is script-enforced):
 
 ```bash
 ./.safeword/scripts/cleanup-zombies.sh
+```
+
+If the preview looks correct, confirm the kill with `--yes`:
+
+```bash
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 ## What It Does
@@ -32,11 +33,11 @@ If the output looks correct, run without `--dry-run`:
 If auto-detection fails or you need a specific port:
 
 ```bash
-# Explicit port
+# Explicit port (preview, then add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 ## When to Use

--- a/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
+++ b/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
@@ -1,0 +1,35 @@
+---
+id: 2KG1JW
+slug: cleanup-zombies-confirm
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-07T17:59:01.912Z
+last_modified: 2026-07-07T17:59:01.912Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/773
+scope:
+  - cleanup-zombies.sh previews by default (bare invocation = today's --dry-run) and only kills with an explicit --yes/-y
+  - the preview summary names the confirm flag; --dry-run stays accepted as an explicit alias (back-compat)
+  - script tests pin default-preview, --yes kill-mode messaging, and --dry-run back-compat
+  - pre-tool-quality.ts deny message + the three prose sites (skill, command, guide) drop the "run --dry-run first" ritual — the script enforces it now
+out_of_scope:
+  - changing kill semantics (kill -9, port+1000 convention, pattern scoping) — the rung is only who decides, not what is killed
+  - the process-kill-guard predicate (rung 1, shipped)
+  - an interactive TTY prompt (agents run non-interactive; a flag is the auditable consent artifact)
+done_when:
+  - bare invocation in a project with zombies reports what would be killed and exits without killing
+  - --yes kills exactly what the preview showed; --dry-run still previews
+  - prose sites describe one-step usage with the flag instead of the two-step ritual
+  - repo tests/lint green; parity synced
+---
+
+# cleanup-zombies.sh kills only with an explicit confirm flag
+
+**Goal:** Bare invocation previews (deny-by-default); killing requires --yes — graduating the skill's "run --dry-run first, then re-run" prose ritual into the script itself
+
+**Why:** #773 graduate-then-trim, rung 4: the two-step safety ritual lives only in SKILL.md/command prose, so an agent that skips the guide goes straight to kill -9; inverting the default makes the safe path the only unmarked path
+
+## Work Log
+
+- 2026-07-07T17:59:01.912Z Started: Created ticket 2KG1JW
+- Scouted: no code callers of cleanup-zombies.sh (grep: prose sites + pre-tool-quality deny message only); existing tests/scripts/cleanup-zombies.test.ts runs every case with --dry-run so the inversion is low-blast-radius; #938 (boundary gate) touches neither the script nor its prose

--- a/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
+++ b/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
@@ -2,8 +2,8 @@
 id: 2KG1JW
 slug: cleanup-zombies-confirm
 type: task
-phase: intake
-status: in_progress
+phase: done
+status: done
 created: 2026-07-07T17:59:01.912Z
 last_modified: 2026-07-07T17:59:01.912Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/773
@@ -33,3 +33,4 @@ done_when:
 
 - 2026-07-07T17:59:01.912Z Started: Created ticket 2KG1JW
 - Scouted: no code callers of cleanup-zombies.sh (grep: prose sites + pre-tool-quality deny message only); existing tests/scripts/cleanup-zombies.test.ts runs every case with --dry-run so the inversion is low-blast-radius; #938 (boundary gate) touches neither the script nor its prose
+- 2026-07-07T18:30:49.043Z Phase: intake → done

--- a/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
+++ b/.project/tickets/2KG1JW-cleanup-zombies-confirm/ticket.md
@@ -34,3 +34,4 @@ done_when:
 - 2026-07-07T17:59:01.912Z Started: Created ticket 2KG1JW
 - Scouted: no code callers of cleanup-zombies.sh (grep: prose sites + pre-tool-quality deny message only); existing tests/scripts/cleanup-zombies.test.ts runs every case with --dry-run so the inversion is low-blast-radius; #938 (boundary gate) touches neither the script nor its prose
 - 2026-07-07T18:30:49.043Z Phase: intake → done
+- 3-stage pass: stage 1 satisfied by the done-gate run minutes earlier on the same commit (all lanes green, audit clean); quality-review APPROVE, 0 critical — applied 3 findings (behavioral kill pin with a real sacrificial process, sticky --dry-run over --yes regardless of flag order, findings-preview hint now provably pinned); declined unknown-dash-arg rejection (pre-existing, now fail-safe); refactor: single runScriptRaw invocation seam (22/22, knip + depcruise clean after)

--- a/.project/tickets/2KG1JW-cleanup-zombies-confirm/verify.md
+++ b/.project/tickets/2KG1JW-cleanup-zombies-confirm/verify.md
@@ -1,0 +1,19 @@
+# Verify: cleanup-zombies-confirm (2KG1JW)
+
+Ran 2026-07-07 on branch claude/cleanup-zombies-confirm (base: post-#938 main), Node 24 container.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 4980/4980 tests pass (347 files, 7 conditional skips; includes the 5 new consent scenarios — bare preview, --yes/-y kill mode, --dry-run alias, findings-preview hint)
+**Gherkin:** ✅ Acceptance lane passes (340/343 scenarios, 3 environment-conditional skips)
+**Build:** ✅ Success (tsup ESM + DTS)
+**Lint:** ✅ Clean (tsc --noEmit clean via typecheck lane; eslint + markdownlint + shellcheck clean on changed files; lint-staged ran at commit)
+**Scenarios:** ⏭️ Skipped — task ticket (inline tests: deny-by-default preview, explicit consent flag, back-compat alias)
+**PR Scope:** ✅ Diff matches ticket scope (cleanup-zombies.sh default inversion + tests + 3 prose sites + deny-message wording + parity mirrors + ticket artifacts; nothing else)
+**Dep Drift:** ✅ Clean (no new dependencies)
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation (same graduate-then-trim shape as rungs 1–3: script-enforced invariant, prose points at the enforcement; --dry-run kept as alias mirrors the fail-open back-compat convention)
+**Experience:** ⚠️ 1 deliberate new step — walked TB through "port blocked → cleanup": preview now always comes first, so the kill takes two invocations instead of one (`cleanup-zombies.sh` then `--yes`). Worst step = an agent that already knows what it wants to kill must still run twice — which is the invariant working as designed (the ritual the prose demanded is now unskippable). Zero new steps for anyone who followed the documented flow before.
+**Evidence limits:** ✅ None (all lanes ran clean locally; shellcheck via system binary 0.9.0 — the npm wrapper's download is proxy-blocked in this container)
+
+Audit passed — sync-config ✓, depcruise ✓ (600 modules, 0 violations), knip ✓ clean (no findings, no W005 hints), jscpd 426 clones (8.52%) [repo minus .safeword/.project] — vs 427 at the same scope on the pre-#938 baseline, no new duplication from this diff; learnings Covers: ✓; outdated deps all dev-only patch/minor plus the three already-tracked majors (unicorn 71 pin, typescript 6 → ticket 091, cucumber-messages 34).

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -9,11 +9,11 @@
 Use the built-in cleanup script:
 
 ```bash
-# Preview what would be killed (safe)
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-
-# Kill zombie processes
+# Preview what would be killed (the default — nothing dies without --yes)
 ./.safeword/scripts/cleanup-zombies.sh
+
+# Kill what the preview showed
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 The script auto-detects your framework (Vite, Next.js, etc.) and kills only processes belonging to this project.
@@ -75,17 +75,17 @@ sleep 2
 Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 
 ```bash
-# Auto-detect framework and clean up
+# Preview (the default — auto-detects framework; nothing dies without --yes)
 ./.safeword/scripts/cleanup-zombies.sh
 
-# Preview first (recommended)
-./.safeword/scripts/cleanup-zombies.sh --dry-run
+# Kill what the preview showed
+./.safeword/scripts/cleanup-zombies.sh --yes
 
-# Explicit port override
+# Explicit port override (add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 **Features:**
@@ -201,8 +201,8 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 | Situation                                | Command                                                          |
 | ---------------------------------------- | ---------------------------------------------------------------- |
-| Quick cleanup (recommended)              | `./.safeword/scripts/cleanup-zombies.sh`                         |
-| Preview before killing                   | `./.safeword/scripts/cleanup-zombies.sh --dry-run`               |
+| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`                         |
+| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`                   |
 | Kill dev + test servers (use your ports) | `lsof -ti:$DEV_PORT -ti:$TEST_PORT \| xargs kill -9 2>/dev/null` |
 | Kill Playwright (this project)           | `pkill -f "playwright.*$(pwd)"`                                  |
 | Check what's on port                     | `lsof -i:3000`                                                   |

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -271,7 +271,7 @@ if (tool === 'Bash') {
   if (processKill) {
     deny(
       `Broad process kill blocked: \`${processKill.command} ${processKill.target}\` matches by name across the whole machine, killing every project's ${processKill.target} processes (dev servers, test runners, other sessions), not just this project's. Use the project-scoped \`./.safeword/scripts/cleanup-zombies.sh\` instead.`,
-      `Project-scoped alternatives: \`./.safeword/scripts/cleanup-zombies.sh\` (auto-detects this project's processes; --dry-run to preview), \`lsof -ti:<port> | xargs kill -9\` (port-scoped), or \`pkill -f "<pattern>.*$(pwd)"\` (path-scoped). See .safeword/guides/zombie-process-cleanup.md.`,
+      `Project-scoped alternatives: \`./.safeword/scripts/cleanup-zombies.sh\` (auto-detects this project's processes; previews by default, --yes to kill), \`lsof -ti:<port> | xargs kill -9\` (port-scoped), or \`pkill -f "<pattern>.*$(pwd)"\` (path-scoped). See .safeword/guides/zombie-process-cleanup.md.`,
     );
   }
   if (GIT_COMMIT_COMMAND.test(command)) {

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -6,12 +6,15 @@
 #
 # Auto-detection: Checks root, packages/*/, apps/*/ for framework configs (monorepo support)
 #
-# Usage: ./cleanup-zombies.sh [port] [pattern]
-# Example: ./cleanup-zombies.sh                    # auto-detect from config files
-# Example: ./cleanup-zombies.sh 5173               # explicit port
-# Example: ./cleanup-zombies.sh 5173 "vite"        # port + pattern
-# Example: ./cleanup-zombies.sh --dry-run          # preview what would be killed
-# Example: ./cleanup-zombies.sh --dry-run 5173     # preview with explicit port
+# Deny-by-default (#773 rung 4): a bare invocation PREVIEWS what would be
+# killed; nothing dies without an explicit --yes. The preview-first ritual is
+# script-enforced, not a guide instruction.
+#
+# Usage: ./cleanup-zombies.sh [--yes] [port] [pattern]
+# Example: ./cleanup-zombies.sh                    # preview (auto-detect from config files)
+# Example: ./cleanup-zombies.sh --yes              # kill what the preview shows
+# Example: ./cleanup-zombies.sh --yes 5173         # kill on explicit port
+# Example: ./cleanup-zombies.sh --yes 5173 "vite"  # kill on port + pattern
 
 set -e
 
@@ -21,22 +24,28 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # Parse arguments
-DRY_RUN=false
+DRY_RUN=true
 PORT=""
 PATTERN=""
 
 for arg in "$@"; do
   case "$arg" in
+    --yes | -y)
+      DRY_RUN=false
+      ;;
     --dry-run)
+      # Explicit alias for the default; kept so existing invocations stay valid.
       DRY_RUN=true
       ;;
     --help | -h)
-      echo "Usage: $0 [--dry-run] [port] [pattern]"
+      echo "Usage: $0 [--yes] [port] [pattern]"
       echo ""
       echo "Cleanup zombie processes for the current project."
+      echo "Previews by default; killing requires --yes."
       echo ""
       echo "Options:"
-      echo "  --dry-run    Show what would be killed without killing"
+      echo "  --yes, -y    Kill the processes the preview shows"
+      echo "  --dry-run    Explicit preview (the default behavior)"
       echo "  --help       Show this help message"
       echo ""
       echo "Arguments:"
@@ -44,10 +53,10 @@ for arg in "$@"; do
       echo "  pattern      Additional process pattern to match"
       echo ""
       echo "Examples:"
-      echo "  $0                     # Auto-detect port from config files"
-      echo "  $0 5173                # Kill processes on port 5173"
-      echo "  $0 5173 electron       # Port 5173 + electron processes"
-      echo "  $0 --dry-run           # Preview without killing"
+      echo "  $0                     # Preview (auto-detect port from config files)"
+      echo "  $0 --yes               # Kill what the preview shows"
+      echo "  $0 --yes 5173          # Kill processes on port 5173"
+      echo "  $0 --yes 5173 electron # Port 5173 + electron processes"
       exit 0
       ;;
     *)
@@ -118,7 +127,7 @@ echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
 [ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
 [ -n "$PATTERN" ] && echo "   Pattern: $PATTERN"
-$DRY_RUN && echo -e "   ${YELLOW}DRY RUN - no processes will be killed${NC}"
+$DRY_RUN && echo -e "   ${YELLOW}DRY RUN (default) - no processes will be killed; pass --yes to kill${NC}"
 echo ""
 
 # Track what we find/kill
@@ -206,7 +215,7 @@ if [ "$FOUND_COUNT" -eq 0 ]; then
   echo -e "${GREEN}No zombie processes found - already clean!${NC}"
 elif [ "$DRY_RUN" = true ]; then
   echo -e "${YELLOW}Found $FOUND_COUNT process(es) that would be killed${NC}"
-  echo "   Run without --dry-run to kill them"
+  echo "   Re-run with --yes to kill them"
 else
   echo -e "${GREEN}Killed $KILLED_COUNT process(es)${NC}"
 

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -25,6 +25,7 @@ NC='\033[0m' # No Color
 
 # Parse arguments
 DRY_RUN=true
+DRY_RUN_EXPLICIT=false
 PORT=""
 PATTERN=""
 
@@ -35,7 +36,9 @@ for arg in "$@"; do
       ;;
     --dry-run)
       # Explicit alias for the default; kept so existing invocations stay valid.
+      # Sticky: in a contradictory `--dry-run --yes` mix, preview wins.
       DRY_RUN=true
+      DRY_RUN_EXPLICIT=true
       ;;
     --help | -h)
       echo "Usage: $0 [--yes] [port] [pattern]"
@@ -68,6 +71,10 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+# A contradictory `--dry-run --yes` mix resolves to preview regardless of flag
+# order — the safest reading of an ambiguous request.
+[ "$DRY_RUN_EXPLICIT" = true ] && DRY_RUN=true
 
 # Check if any file matching pattern exists (supports globs)
 has_config() {

--- a/packages/cli/templates/commands/cleanup-zombies.md
+++ b/packages/cli/templates/commands/cleanup-zombies.md
@@ -8,16 +8,17 @@ Kill zombie processes (dev servers, Playwright browsers, test runners) for the c
 
 ## Instructions
 
-Run the cleanup script with `--dry-run` first to preview what will be killed:
-
-```bash
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-```
-
-If the output looks correct, run without `--dry-run`:
+Run the cleanup script — it previews what would be killed (nothing dies without
+explicit consent; the preview-first ritual is script-enforced):
 
 ```bash
 ./.safeword/scripts/cleanup-zombies.sh
+```
+
+If the preview looks correct, confirm the kill with `--yes`:
+
+```bash
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 ## What It Does
@@ -32,11 +33,11 @@ If the output looks correct, run without `--dry-run`:
 If auto-detection fails or you need a specific port:
 
 ```bash
-# Explicit port
+# Explicit port (preview, then add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 ## When to Use

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -9,11 +9,11 @@
 Use the built-in cleanup script:
 
 ```bash
-# Preview what would be killed (safe)
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-
-# Kill zombie processes
+# Preview what would be killed (the default — nothing dies without --yes)
 ./.safeword/scripts/cleanup-zombies.sh
+
+# Kill what the preview showed
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 The script auto-detects your framework (Vite, Next.js, etc.) and kills only processes belonging to this project.
@@ -75,17 +75,17 @@ sleep 2
 Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 
 ```bash
-# Auto-detect framework and clean up
+# Preview (the default — auto-detects framework; nothing dies without --yes)
 ./.safeword/scripts/cleanup-zombies.sh
 
-# Preview first (recommended)
-./.safeword/scripts/cleanup-zombies.sh --dry-run
+# Kill what the preview showed
+./.safeword/scripts/cleanup-zombies.sh --yes
 
-# Explicit port override
+# Explicit port override (add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 **Features:**
@@ -201,8 +201,8 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 | Situation                                | Command                                                          |
 | ---------------------------------------- | ---------------------------------------------------------------- |
-| Quick cleanup (recommended)              | `./.safeword/scripts/cleanup-zombies.sh`                         |
-| Preview before killing                   | `./.safeword/scripts/cleanup-zombies.sh --dry-run`               |
+| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`                         |
+| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`                   |
 | Kill dev + test servers (use your ports) | `lsof -ti:$DEV_PORT -ti:$TEST_PORT \| xargs kill -9 2>/dev/null` |
 | Kill Playwright (this project)           | `pkill -f "playwright.*$(pwd)"`                                  |
 | Check what's on port                     | `lsof -i:3000`                                                   |

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -271,7 +271,7 @@ if (tool === 'Bash') {
   if (processKill) {
     deny(
       `Broad process kill blocked: \`${processKill.command} ${processKill.target}\` matches by name across the whole machine, killing every project's ${processKill.target} processes (dev servers, test runners, other sessions), not just this project's. Use the project-scoped \`./.safeword/scripts/cleanup-zombies.sh\` instead.`,
-      `Project-scoped alternatives: \`./.safeword/scripts/cleanup-zombies.sh\` (auto-detects this project's processes; --dry-run to preview), \`lsof -ti:<port> | xargs kill -9\` (port-scoped), or \`pkill -f "<pattern>.*$(pwd)"\` (path-scoped). See .safeword/guides/zombie-process-cleanup.md.`,
+      `Project-scoped alternatives: \`./.safeword/scripts/cleanup-zombies.sh\` (auto-detects this project's processes; previews by default, --yes to kill), \`lsof -ti:<port> | xargs kill -9\` (port-scoped), or \`pkill -f "<pattern>.*$(pwd)"\` (path-scoped). See .safeword/guides/zombie-process-cleanup.md.`,
     );
   }
   if (GIT_COMMIT_COMMAND.test(command)) {

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -6,12 +6,15 @@
 #
 # Auto-detection: Checks root, packages/*/, apps/*/ for framework configs (monorepo support)
 #
-# Usage: ./cleanup-zombies.sh [port] [pattern]
-# Example: ./cleanup-zombies.sh                    # auto-detect from config files
-# Example: ./cleanup-zombies.sh 5173               # explicit port
-# Example: ./cleanup-zombies.sh 5173 "vite"        # port + pattern
-# Example: ./cleanup-zombies.sh --dry-run          # preview what would be killed
-# Example: ./cleanup-zombies.sh --dry-run 5173     # preview with explicit port
+# Deny-by-default (#773 rung 4): a bare invocation PREVIEWS what would be
+# killed; nothing dies without an explicit --yes. The preview-first ritual is
+# script-enforced, not a guide instruction.
+#
+# Usage: ./cleanup-zombies.sh [--yes] [port] [pattern]
+# Example: ./cleanup-zombies.sh                    # preview (auto-detect from config files)
+# Example: ./cleanup-zombies.sh --yes              # kill what the preview shows
+# Example: ./cleanup-zombies.sh --yes 5173         # kill on explicit port
+# Example: ./cleanup-zombies.sh --yes 5173 "vite"  # kill on port + pattern
 
 set -e
 
@@ -21,22 +24,28 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # Parse arguments
-DRY_RUN=false
+DRY_RUN=true
 PORT=""
 PATTERN=""
 
 for arg in "$@"; do
   case "$arg" in
+    --yes | -y)
+      DRY_RUN=false
+      ;;
     --dry-run)
+      # Explicit alias for the default; kept so existing invocations stay valid.
       DRY_RUN=true
       ;;
     --help | -h)
-      echo "Usage: $0 [--dry-run] [port] [pattern]"
+      echo "Usage: $0 [--yes] [port] [pattern]"
       echo ""
       echo "Cleanup zombie processes for the current project."
+      echo "Previews by default; killing requires --yes."
       echo ""
       echo "Options:"
-      echo "  --dry-run    Show what would be killed without killing"
+      echo "  --yes, -y    Kill the processes the preview shows"
+      echo "  --dry-run    Explicit preview (the default behavior)"
       echo "  --help       Show this help message"
       echo ""
       echo "Arguments:"
@@ -44,10 +53,10 @@ for arg in "$@"; do
       echo "  pattern      Additional process pattern to match"
       echo ""
       echo "Examples:"
-      echo "  $0                     # Auto-detect port from config files"
-      echo "  $0 5173                # Kill processes on port 5173"
-      echo "  $0 5173 electron       # Port 5173 + electron processes"
-      echo "  $0 --dry-run           # Preview without killing"
+      echo "  $0                     # Preview (auto-detect port from config files)"
+      echo "  $0 --yes               # Kill what the preview shows"
+      echo "  $0 --yes 5173          # Kill processes on port 5173"
+      echo "  $0 --yes 5173 electron # Port 5173 + electron processes"
       exit 0
       ;;
     *)
@@ -118,7 +127,7 @@ echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
 [ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
 [ -n "$PATTERN" ] && echo "   Pattern: $PATTERN"
-$DRY_RUN && echo -e "   ${YELLOW}DRY RUN - no processes will be killed${NC}"
+$DRY_RUN && echo -e "   ${YELLOW}DRY RUN (default) - no processes will be killed; pass --yes to kill${NC}"
 echo ""
 
 # Track what we find/kill
@@ -206,7 +215,7 @@ if [ "$FOUND_COUNT" -eq 0 ]; then
   echo -e "${GREEN}No zombie processes found - already clean!${NC}"
 elif [ "$DRY_RUN" = true ]; then
   echo -e "${YELLOW}Found $FOUND_COUNT process(es) that would be killed${NC}"
-  echo "   Run without --dry-run to kill them"
+  echo "   Re-run with --yes to kill them"
 else
   echo -e "${GREEN}Killed $KILLED_COUNT process(es)${NC}"
 

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -25,6 +25,7 @@ NC='\033[0m' # No Color
 
 # Parse arguments
 DRY_RUN=true
+DRY_RUN_EXPLICIT=false
 PORT=""
 PATTERN=""
 
@@ -35,7 +36,9 @@ for arg in "$@"; do
       ;;
     --dry-run)
       # Explicit alias for the default; kept so existing invocations stay valid.
+      # Sticky: in a contradictory `--dry-run --yes` mix, preview wins.
       DRY_RUN=true
+      DRY_RUN_EXPLICIT=true
       ;;
     --help | -h)
       echo "Usage: $0 [--yes] [port] [pattern]"
@@ -68,6 +71,10 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+# A contradictory `--dry-run --yes` mix resolves to preview regardless of flag
+# order — the safest reading of an ambiguous request.
+[ "$DRY_RUN_EXPLICIT" = true ] && DRY_RUN=true
 
 # Check if any file matching pattern exists (supports globs)
 has_config() {

--- a/packages/cli/templates/skills/cleanup-zombies/SKILL.md
+++ b/packages/cli/templates/skills/cleanup-zombies/SKILL.md
@@ -12,16 +12,17 @@ Kill zombie processes (dev servers, Playwright browsers, test runners) for the c
 
 ## Instructions
 
-Run the cleanup script with `--dry-run` first to preview what will be killed:
-
-```bash
-./.safeword/scripts/cleanup-zombies.sh --dry-run
-```
-
-If the output looks correct, run without `--dry-run`:
+Run the cleanup script — it previews what would be killed (nothing dies without
+explicit consent; the preview-first ritual is script-enforced):
 
 ```bash
 ./.safeword/scripts/cleanup-zombies.sh
+```
+
+If the preview looks correct, confirm the kill with `--yes`:
+
+```bash
+./.safeword/scripts/cleanup-zombies.sh --yes
 ```
 
 ## What It Does
@@ -36,11 +37,11 @@ If the output looks correct, run without `--dry-run`:
 If auto-detection fails or you need a specific port:
 
 ```bash
-# Explicit port
+# Explicit port (preview, then add --yes to kill)
 ./.safeword/scripts/cleanup-zombies.sh 5173
 
 # Port + additional pattern
-./.safeword/scripts/cleanup-zombies.sh 5173 "electron"
+./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
 ## When to Use

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -165,6 +165,53 @@ describe('cleanup-zombies.sh', () => {
     });
   });
 
+  // 2KG1JW (#773 rung 4): the skill's "run --dry-run first, then re-run" ritual
+  // is script-enforced — bare invocation previews, killing needs explicit consent.
+  describe('Rule: killing requires an explicit --yes (deny-by-default)', () => {
+    function runScriptBare(args: string[] = []): string {
+      const command = `bash "${SCRIPT_PATH}" ${args.join(' ')}`;
+      return execSync(command, { cwd: temporaryDirectory, encoding: 'utf8' });
+    }
+
+    it('Scenario: a bare invocation is a preview that names the consent flag', () => {
+      const output = runScriptBare();
+
+      expect(output).toContain('no processes will be killed');
+      expect(output).toContain('--yes');
+    });
+
+    it('Scenario: --yes enters kill mode (no preview banner)', () => {
+      // Empty temp dir: no detected port, no project-scoped matches — kill mode
+      // runs safely and reports clean. The mode flip is what's under test.
+      const output = runScriptBare(['--yes']);
+
+      expect(output).not.toContain('no processes will be killed');
+      expect(output).toContain('already clean');
+    });
+
+    it('Scenario: -y is the short form of consent', () => {
+      const output = runScriptBare(['-y']);
+
+      expect(output).not.toContain('no processes will be killed');
+    });
+
+    it('Scenario: --dry-run stays an explicit preview (back-compat)', () => {
+      const output = runScriptBare(['--dry-run']);
+
+      expect(output).toContain('no processes will be killed');
+    });
+
+    it('Scenario: a preview with findings tells the reader how to proceed', () => {
+      createFile('vite.config.ts');
+
+      const output = runScriptBare();
+
+      // Bare preview still runs the full detection pass (port + pattern shown).
+      expect(output).toContain('Port: 5173');
+      expect(output).toContain('--yes');
+    });
+  });
+
   describe('test port convention', () => {
     it('shows test port = dev port + 1000', () => {
       createFile('vite.config.ts');

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -5,7 +5,7 @@
  * in temp directories with mock config files.
  */
 
-import { execSync } from 'node:child_process';
+import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -209,6 +209,74 @@ describe('cleanup-zombies.sh', () => {
       // Bare preview still runs the full detection pass (port + pattern shown).
       expect(output).toContain('Port: 5173');
       expect(output).toContain('--yes');
+    });
+
+    it('Scenario: preview wins a contradictory flag mix, regardless of order', () => {
+      for (const args of [
+        ['--yes', '--dry-run'],
+        ['--dry-run', '--yes'],
+      ]) {
+        expect(runScriptBare(args)).toContain('no processes will be killed');
+      }
+    });
+  });
+
+  // The behavioral pin for kill mode: a real project-scoped process survives the
+  // bare preview and dies under --yes. Everything above proves messaging; this
+  // proves the mode flip reaches kill(1).
+  describe('Rule: --yes kills what the preview showed (behavioral pin)', () => {
+    let victim: ChildProcess | undefined;
+
+    afterEach(() => {
+      if (victim?.pid && victim.exitCode === null) {
+        try {
+          process.kill(victim.pid, 'SIGKILL');
+        } catch {
+          // already dead — the desired end state
+        }
+      }
+      victim = undefined;
+    });
+
+    function spawnVictim(): number {
+      // The marker + temp-dir path in the raw argv is what the script's
+      // project-scoped pgrep ("<pattern>.*<project dir>") matches. The `; exit 0`
+      // keeps bash resident (a lone simple command would exec-optimize into
+      // `sleep 60`, discarding the marker from the command line).
+      victim = spawn('bash', ['-c', `sleep 60; exit 0 # swzombie ${temporaryDirectory}`], {
+        detached: true,
+        stdio: 'ignore',
+      });
+      if (victim.pid === undefined) throw new Error('failed to spawn victim');
+      return victim.pid;
+    }
+
+    function isAlive(pid: number): boolean {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    it('Scenario: the victim survives a bare preview and dies under --yes', async () => {
+      const pid = spawnVictim();
+      await expect.poll(() => isAlive(pid)).toBe(true);
+
+      const preview = execSync(`bash "${SCRIPT_PATH}" swzombie`, {
+        cwd: temporaryDirectory,
+        encoding: 'utf8',
+      });
+      expect(preview).toContain('swzombie');
+      expect(preview).toContain('Re-run with --yes to kill them');
+      expect(isAlive(pid)).toBe(true); // preview never kills
+
+      execSync(`bash "${SCRIPT_PATH}" --yes swzombie`, {
+        cwd: temporaryDirectory,
+        encoding: 'utf8',
+      });
+      await expect.poll(() => isAlive(pid)).toBe(false); // consent kills
     });
   });
 

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -25,9 +25,15 @@ describe('cleanup-zombies.sh', () => {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   });
 
-  function runScript(args: string[] = []): string {
-    const command = `bash "${SCRIPT_PATH}" --dry-run ${args.join(' ')}`;
+  /** Run the real script with the args exactly as given. */
+  function runScriptRaw(args: string[] = []): string {
+    const command = `bash "${SCRIPT_PATH}" ${args.join(' ')}`;
     return execSync(command, { cwd: temporaryDirectory, encoding: 'utf8' });
+  }
+
+  /** Detection-suite default: always preview explicitly. */
+  function runScript(args: string[] = []): string {
+    return runScriptRaw(['--dry-run', ...args]);
   }
 
   function createFile(relativePath: string, content = ''): void {
@@ -168,13 +174,8 @@ describe('cleanup-zombies.sh', () => {
   // 2KG1JW (#773 rung 4): the skill's "run --dry-run first, then re-run" ritual
   // is script-enforced — bare invocation previews, killing needs explicit consent.
   describe('Rule: killing requires an explicit --yes (deny-by-default)', () => {
-    function runScriptBare(args: string[] = []): string {
-      const command = `bash "${SCRIPT_PATH}" ${args.join(' ')}`;
-      return execSync(command, { cwd: temporaryDirectory, encoding: 'utf8' });
-    }
-
     it('Scenario: a bare invocation is a preview that names the consent flag', () => {
-      const output = runScriptBare();
+      const output = runScriptRaw();
 
       expect(output).toContain('no processes will be killed');
       expect(output).toContain('--yes');
@@ -183,20 +184,20 @@ describe('cleanup-zombies.sh', () => {
     it('Scenario: --yes enters kill mode (no preview banner)', () => {
       // Empty temp dir: no detected port, no project-scoped matches — kill mode
       // runs safely and reports clean. The mode flip is what's under test.
-      const output = runScriptBare(['--yes']);
+      const output = runScriptRaw(['--yes']);
 
       expect(output).not.toContain('no processes will be killed');
       expect(output).toContain('already clean');
     });
 
     it('Scenario: -y is the short form of consent', () => {
-      const output = runScriptBare(['-y']);
+      const output = runScriptRaw(['-y']);
 
       expect(output).not.toContain('no processes will be killed');
     });
 
     it('Scenario: --dry-run stays an explicit preview (back-compat)', () => {
-      const output = runScriptBare(['--dry-run']);
+      const output = runScriptRaw(['--dry-run']);
 
       expect(output).toContain('no processes will be killed');
     });
@@ -204,7 +205,7 @@ describe('cleanup-zombies.sh', () => {
     it('Scenario: a preview with findings tells the reader how to proceed', () => {
       createFile('vite.config.ts');
 
-      const output = runScriptBare();
+      const output = runScriptRaw();
 
       // Bare preview still runs the full detection pass (port + pattern shown).
       expect(output).toContain('Port: 5173');
@@ -216,7 +217,7 @@ describe('cleanup-zombies.sh', () => {
         ['--yes', '--dry-run'],
         ['--dry-run', '--yes'],
       ]) {
-        expect(runScriptBare(args)).toContain('no processes will be killed');
+        expect(runScriptRaw(args)).toContain('no processes will be killed');
       }
     });
   });
@@ -264,18 +265,12 @@ describe('cleanup-zombies.sh', () => {
       const pid = spawnVictim();
       await expect.poll(() => isAlive(pid)).toBe(true);
 
-      const preview = execSync(`bash "${SCRIPT_PATH}" swzombie`, {
-        cwd: temporaryDirectory,
-        encoding: 'utf8',
-      });
+      const preview = runScriptRaw(['swzombie']);
       expect(preview).toContain('swzombie');
       expect(preview).toContain('Re-run with --yes to kill them');
       expect(isAlive(pid)).toBe(true); // preview never kills
 
-      execSync(`bash "${SCRIPT_PATH}" --yes swzombie`, {
-        cwd: temporaryDirectory,
-        encoding: 'utf8',
-      });
+      runScriptRaw(['--yes', 'swzombie']);
       await expect.poll(() => isAlive(pid)).toBe(false); // consent kills
     });
   });


### PR DESCRIPTION
## What

Graduates the cleanup-zombies "preview first, then kill" ritual from prose to the script itself (#773 rung 4):

- **Bare invocation now previews** — exactly what `--dry-run` did before, plus a `pass --yes to kill` pointer in the banner and a `Re-run with --yes to kill them` line in the findings summary.
- **Killing requires explicit consent**: `--yes` / `-y` is the only way processes die.
- **`--dry-run` stays accepted** as an explicit alias of the default, so every existing invocation keeps working (nothing that worked before now kills more; the only behavior change is that a bare run no longer kills).
- **Prose trims to one-step flag usage** at the three instruction sites (cleanup-zombies SKILL.md, the command file, zombie-process-cleanup.md) and the broad-kill deny message in pre-tool-quality.ts now says "previews by default, --yes to kill".

## Why

The two-step safety ritual ("run `--dry-run` first; if the output looks correct, run again") lived only in skill/command prose — an agent that skipped the guide went straight to `kill -9`. Inverting the default makes the safe path the only unmarked path: the ritual is unskippable because the script enforces it. Same graduate-then-trim shape as rungs 1–3 (#878 broad-kill deny, #906/#922 test-integrity lint, #933 draft body seal).

Kill semantics are untouched — same `kill -9`, same port+1000 convention, same project-scoped patterns. The rung changes only who decides, not what is killed.

## Tests

5 new scenarios in `tests/scripts/cleanup-zombies.test.ts`: bare invocation previews and names the consent flag; `--yes` and `-y` enter kill mode (no preview banner); `--dry-run` back-compat; a findings preview still runs the full detection pass. Existing 15 detection tests unchanged and green.

Full suite 4980/4980 (347 files), Gherkin 340/343 (3 env-conditional skips), build/typecheck/deps lanes green, shellcheck clean, audit passed (depcruise 0 violations across 600 modules, knip clean, jscpd flat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae2oEdbqL2xGgGzfo9JCAi)_