### PR TITLE
chore(release): v0.68.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.68.0 — minor (additive)

Ships the backlog merged since v0.67.0 (npm's current latest). Bump class **minor**: dominated by additive capability; the two behavior changes are both safe (see note).

### Added
- **`safeword boundary` reconciliation gate** — new warn-only commit/push gate + host-repo install (#938, #810 slices 1–2)
- **Node 22 support restored** — engines `^22.22.3 || ^24.16.0 || >=26.3.0` (adds 22 back; 24/26+ unaffected); removes the vulnerable `shellcheck → decompress@4.2.1` dep (GHSA-mp2f-45pm-3cg9) (#927)
- **bun:test lint lane** now enforces the test-integrity/no-sleep rules (#922)
- **Retro draft-body seal** — filing refuses tampered bodies (#933, #773 rung 3)

### Fixed
- `safeword upgrade` now installs the same Python tool set as `setup` (was missing `deadcode` + `import-linter`) (#947)

### Changed — ⚠️ behavior note
- **`cleanup-zombies.sh` now previews by default and requires `--yes` to kill** (#949, #773 rung 4). Safer default (no accidental kills); if you scripted it expecting kills, add `--yes`.

### Internal
- Dedup refactor (boundary-shim + frontmatter helpers) (#946); test-suite refactor (#925); tokenizer-consolidation intake ticket EDDABK (#948).

Full suite green on **Node 22.22.3 and Node 24**. Publish is CI-driven via OIDC on tag push after merge.