### PR TITLE
feat(hooks): absorb the last two private shell tokenizers (KQ3MRV, EDDABK follow-up)

### DIFF
--- a/.project/tickets/KQ3MRV-tokenizer-absorption/ticket.md
+++ b/.project/tickets/KQ3MRV-tokenizer-absorption/ticket.md
@@ -1,0 +1,26 @@
+---
+id: KQ3MRV
+slug: tokenizer-absorption
+type: task
+phase: implement
+status: in_progress
+created: 2026-07-08T02:10:00.000Z
+last_modified: 2026-07-08T02:10:00.000Z
+---
+
+# Absorb the two remaining private shell tokenizers into shell-segments
+
+**Goal:** Migrate `cursor-run-identity.ts` and `branch-staleness.ts` — the two private shell tokenizers the EDDABK code review found outside the four Bash security gates — onto the shared `shell-segments.ts` tokenizer, so the "one tokenizer, one test surface" property holds repo-wide.
+
+**Why:** Follow-up spawned from ticket EDDABK / PR #959. `cursor-run-identity.ts` has a **real functional gap**, not just duplication: its `executableIndexOf` skips only `VAR=val` words, so `command bun .safeword/hooks/write-review-stamp.ts …` / `env bun …record-skill-invocation.ts <skill>` resolve the executable to `command`/`env`, the run-identity/stamp proof is never recorded, and the delegated fail-closed stamp gate can later deny a legitimate write. `branch-staleness.ts`'s `parseCheckoutTarget` uses a bare whitespace split: `git fetch && git checkout main` returns null (warn skipped), quoted prose probes bogus branches, and its flag scan crosses segment boundaries (`git checkout main && git branch -d old` → null; `git checkout -q && echo hi` → bogus target `&&`).
+
+## Constraints
+
+1. Depends on the unified tokenizer from EDDABK (`commandWords` export) — branch stacks on `frosty-yonath-9f2adb` (PR #959) until it merges.
+2. Byte-parity mirrors under `.safeword/hooks/lib/` (schema `ownedFiles`).
+3. No silent weakening: `sudo git checkout main` was caught by the old flat `indexOf('git')` scan — preserved via a local sudo-skip (kill-guard's pattern).
+4. `isInvocationHelperPath` stays slash-anchored-only (deliberate, per its own doc comment) — bare-relative record forms are out of scope.
+
+## Work Log
+
+- 2026-07-08T02:10 Created from the EDDABK follow-up task. Both files read; migration mapped (consumers keep positional contracts: `words[0]`=bun, `words[1]`=helper, `words[3]`=skill). 24-case smoke table green: all preserved behaviors (incl. the pinned newline `SELF_REVIEW_FALLBACK`, prose negatives, sudo checkout) + all gains (`command`/`env` prefixes now record proof; newline segmentation; per-segment checkout parse fixing the `&&` misses and the cross-segment flag bug). The one apparent regression in the smoke table was a wrong expectation: quoted bare-relative `record-skill-invocation` never matched (slash-anchored matcher, unchanged).

--- a/.safeword/hooks/lib/branch-staleness.ts
+++ b/.safeword/hooks/lib/branch-staleness.ts
@@ -1,28 +1,35 @@
 // Safeword: detect when a `git checkout` / `git switch` target branch is behind
 // or diverged from its upstream, so a "catch up to main" checkout doesn't
 // silently repoint the worktree to stale content (#366). Pure parsing + decision;
-// the git I/O lives in the hook.
+// the git I/O lives in the hook. Tokenization comes from the shared
+// shell-segments tokenizer (EDDABK follow-up), so a compound command is parsed
+// per segment: `git fetch && git checkout main` resolves `main`, and flags in a
+// neighboring segment can no longer null out or fake a checkout target.
+
+import { commandWords, splitShellSegments } from './shell-segments.js';
 
 /** Flags that mean the command creates/detaches a branch — no upstream-staleness risk. */
 const CREATE_OR_DETACH = new Set(['-b', '-B', '-c', '-C', '--orphan', '--detach', '-d']);
 
 /**
- * The branch a `git checkout` / `git switch` command switches to, or null when
- * the command creates a branch, detaches HEAD, or checks out paths (`--`).
+ * The branch the first `git checkout` / `git switch` segment of `command`
+ * switches to, or null when no segment is one, the command creates a branch,
+ * detaches HEAD, or checks out paths (`--`).
  */
 export function parseCheckoutTarget(command: string): string | null {
-  const tokens = command.trim().split(/\s+/);
-  const gitIndex = tokens.indexOf('git');
-  if (gitIndex === -1) return null;
-  const subcommand = tokens[gitIndex + 1];
-  if (subcommand !== 'checkout' && subcommand !== 'switch') return null;
+  for (const segment of splitShellSegments(command)) {
+    const words = commandWords(segment);
+    let index = 0;
+    while (words[index] === 'sudo') index += 1;
+    if (words[index] !== 'git') continue;
+    const subcommand = words[index + 1];
+    if (subcommand !== 'checkout' && subcommand !== 'switch') continue;
 
-  const args = tokens.slice(gitIndex + 2);
-  for (const arg of args) {
-    if (arg === '--') return null; // path checkout, not a branch switch
-    if (CREATE_OR_DETACH.has(arg)) return null;
+    const args = words.slice(index + 2);
+    if (args.some(arg => arg === '--' || CREATE_OR_DETACH.has(arg))) return null;
+    return args.find(arg => !arg.startsWith('-')) ?? null;
   }
-  return args.find(arg => !arg.startsWith('-')) ?? null;
+  return null;
 }
 
 export interface BranchDivergence {

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
+import { commandWords, splitShellSegments } from './shell-segments.js';
 
 const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
 const CODEX_RUN_IDENTITY_CACHE = 'codex-run-identity.json';
@@ -61,7 +62,6 @@ interface ReadFreshRunIdentityInput {
   maxAgeMs?: number;
 }
 
-const SHELL_OPERATORS = new Set([';', '&&', '||', '|']);
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function nonEmptyString(value: string | undefined): string | undefined {
@@ -71,10 +71,6 @@ function nonEmptyString(value: string | undefined): string | undefined {
 
 function cachePathForProject(projectDirectory: string, cacheFile: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), cacheFile);
-}
-
-function isEnvironmentAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
 function isBunExecutable(token: string | undefined): boolean {
@@ -101,114 +97,20 @@ function isReviewStampHelperPath(token: string | undefined): boolean {
   );
 }
 
-function tokenizeShellCommand(command: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | undefined;
-  let escaped = false;
-
-  function flush(): void {
-    if (current.length > 0) {
-      tokens.push(current);
-      current = '';
-    }
-  }
-
-  for (let index = 0; index < command.length; index += 1) {
-    const char = command[index];
-    if (char === undefined) continue;
-
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
-
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-
-    if (quote !== undefined) {
-      if (char === quote) {
-        quote = undefined;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-
-    if (/\s/.test(char)) {
-      flush();
-      continue;
-    }
-
-    if (char === '&' && command[index + 1] === '&') {
-      flush();
-      tokens.push('&&');
-      index += 1;
-      continue;
-    }
-
-    if (char === '|' && command[index + 1] === '|') {
-      flush();
-      tokens.push('||');
-      index += 1;
-      continue;
-    }
-
-    if (char === ';' || char === '|') {
-      flush();
-      tokens.push(char);
-      continue;
-    }
-
-    current += char;
-  }
-
-  flush();
-  return tokens;
-}
-
-function shellSegments(command: string): string[][] {
-  const tokens = tokenizeShellCommand(command);
-  const segments: string[][] = [];
-  let segmentStart = 0;
-
-  for (let index = 0; index <= tokens.length; index += 1) {
-    if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
-      continue;
-    }
-    segments.push(tokens.slice(segmentStart, index));
-    segmentStart = index + 1;
-  }
-
-  return segments;
-}
-
-function executableIndexOf(segment: string[]): number {
-  let executableIndex = 0;
-  while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
-    executableIndex += 1;
-  }
-  return executableIndex;
-}
-
 export function parseRecordSkillInvocationCommand(
   command: string,
 ): { skillName: string } | undefined {
-  for (const segment of shellSegments(command)) {
-    const executableIndex = executableIndexOf(segment);
+  // Tokenization is the shared shell-segments tokenizer (EDDABK follow-up), so
+  // execution prefixes (`command`, `env` + flags, `VAR=val`, corepack, subshell
+  // openers) are skipped before the bun word — a prefixed helper invocation
+  // still records its proof.
+  for (const segment of splitShellSegments(command)) {
+    const words = commandWords(segment);
 
-    if (!isBunExecutable(segment[executableIndex])) continue;
-    if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
+    if (!isBunExecutable(words[0])) continue;
+    if (!isInvocationHelperPath(words[1])) continue;
 
-    const skillName = nonEmptyString(segment[executableIndex + 3]);
+    const skillName = nonEmptyString(words[3]);
     if (skillName !== undefined && SKILL_NAME_PATTERN.test(skillName)) {
       return { skillName };
     }
@@ -219,12 +121,9 @@ export function parseRecordSkillInvocationCommand(
 
 /** True when any segment of `command` runs write-review-stamp.ts under bun. */
 export function commandInvokesWriteReviewStamp(command: string): boolean {
-  return shellSegments(command).some(segment => {
-    const executableIndex = executableIndexOf(segment);
-    return (
-      isBunExecutable(segment[executableIndex]) &&
-      isReviewStampHelperPath(segment[executableIndex + 1])
-    );
+  return splitShellSegments(command).some(segment => {
+    const words = commandWords(segment);
+    return isBunExecutable(words[0]) && isReviewStampHelperPath(words[1]);
   });
 }
 

--- a/packages/cli/templates/hooks/lib/branch-staleness.ts
+++ b/packages/cli/templates/hooks/lib/branch-staleness.ts
@@ -1,28 +1,35 @@
 // Safeword: detect when a `git checkout` / `git switch` target branch is behind
 // or diverged from its upstream, so a "catch up to main" checkout doesn't
 // silently repoint the worktree to stale content (#366). Pure parsing + decision;
-// the git I/O lives in the hook.
+// the git I/O lives in the hook. Tokenization comes from the shared
+// shell-segments tokenizer (EDDABK follow-up), so a compound command is parsed
+// per segment: `git fetch && git checkout main` resolves `main`, and flags in a
+// neighboring segment can no longer null out or fake a checkout target.
+
+import { commandWords, splitShellSegments } from './shell-segments.js';
 
 /** Flags that mean the command creates/detaches a branch — no upstream-staleness risk. */
 const CREATE_OR_DETACH = new Set(['-b', '-B', '-c', '-C', '--orphan', '--detach', '-d']);
 
 /**
- * The branch a `git checkout` / `git switch` command switches to, or null when
- * the command creates a branch, detaches HEAD, or checks out paths (`--`).
+ * The branch the first `git checkout` / `git switch` segment of `command`
+ * switches to, or null when no segment is one, the command creates a branch,
+ * detaches HEAD, or checks out paths (`--`).
  */
 export function parseCheckoutTarget(command: string): string | null {
-  const tokens = command.trim().split(/\s+/);
-  const gitIndex = tokens.indexOf('git');
-  if (gitIndex === -1) return null;
-  const subcommand = tokens[gitIndex + 1];
-  if (subcommand !== 'checkout' && subcommand !== 'switch') return null;
+  for (const segment of splitShellSegments(command)) {
+    const words = commandWords(segment);
+    let index = 0;
+    while (words[index] === 'sudo') index += 1;
+    if (words[index] !== 'git') continue;
+    const subcommand = words[index + 1];
+    if (subcommand !== 'checkout' && subcommand !== 'switch') continue;
 
-  const args = tokens.slice(gitIndex + 2);
-  for (const arg of args) {
-    if (arg === '--') return null; // path checkout, not a branch switch
-    if (CREATE_OR_DETACH.has(arg)) return null;
+    const args = words.slice(index + 2);
+    if (args.some(arg => arg === '--' || CREATE_OR_DETACH.has(arg))) return null;
+    return args.find(arg => !arg.startsWith('-')) ?? null;
   }
-  return args.find(arg => !arg.startsWith('-')) ?? null;
+  return null;
 }
 
 export interface BranchDivergence {

--- a/packages/cli/templates/hooks/lib/cursor-run-identity.ts
+++ b/packages/cli/templates/hooks/lib/cursor-run-identity.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import nodePath from 'node:path';
 
 import { resolveNamespaceRoot } from './namespace-root.js';
+import { commandWords, splitShellSegments } from './shell-segments.js';
 
 const CURSOR_RUN_IDENTITY_CACHE = 'cursor-run-identity.json';
 const CODEX_RUN_IDENTITY_CACHE = 'codex-run-identity.json';
@@ -61,7 +62,6 @@ interface ReadFreshRunIdentityInput {
   maxAgeMs?: number;
 }
 
-const SHELL_OPERATORS = new Set([';', '&&', '||', '|']);
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 function nonEmptyString(value: string | undefined): string | undefined {
@@ -71,10 +71,6 @@ function nonEmptyString(value: string | undefined): string | undefined {
 
 function cachePathForProject(projectDirectory: string, cacheFile: string): string {
   return nodePath.join(resolveNamespaceRoot(projectDirectory), cacheFile);
-}
-
-function isEnvironmentAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
 function isBunExecutable(token: string | undefined): boolean {
@@ -101,114 +97,20 @@ function isReviewStampHelperPath(token: string | undefined): boolean {
   );
 }
 
-function tokenizeShellCommand(command: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | undefined;
-  let escaped = false;
-
-  function flush(): void {
-    if (current.length > 0) {
-      tokens.push(current);
-      current = '';
-    }
-  }
-
-  for (let index = 0; index < command.length; index += 1) {
-    const char = command[index];
-    if (char === undefined) continue;
-
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
-
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-
-    if (quote !== undefined) {
-      if (char === quote) {
-        quote = undefined;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-
-    if (/\s/.test(char)) {
-      flush();
-      continue;
-    }
-
-    if (char === '&' && command[index + 1] === '&') {
-      flush();
-      tokens.push('&&');
-      index += 1;
-      continue;
-    }
-
-    if (char === '|' && command[index + 1] === '|') {
-      flush();
-      tokens.push('||');
-      index += 1;
-      continue;
-    }
-
-    if (char === ';' || char === '|') {
-      flush();
-      tokens.push(char);
-      continue;
-    }
-
-    current += char;
-  }
-
-  flush();
-  return tokens;
-}
-
-function shellSegments(command: string): string[][] {
-  const tokens = tokenizeShellCommand(command);
-  const segments: string[][] = [];
-  let segmentStart = 0;
-
-  for (let index = 0; index <= tokens.length; index += 1) {
-    if (index !== tokens.length && !SHELL_OPERATORS.has(tokens[index] ?? '')) {
-      continue;
-    }
-    segments.push(tokens.slice(segmentStart, index));
-    segmentStart = index + 1;
-  }
-
-  return segments;
-}
-
-function executableIndexOf(segment: string[]): number {
-  let executableIndex = 0;
-  while (isEnvironmentAssignment(segment[executableIndex] ?? '')) {
-    executableIndex += 1;
-  }
-  return executableIndex;
-}
-
 export function parseRecordSkillInvocationCommand(
   command: string,
 ): { skillName: string } | undefined {
-  for (const segment of shellSegments(command)) {
-    const executableIndex = executableIndexOf(segment);
+  // Tokenization is the shared shell-segments tokenizer (EDDABK follow-up), so
+  // execution prefixes (`command`, `env` + flags, `VAR=val`, corepack, subshell
+  // openers) are skipped before the bun word — a prefixed helper invocation
+  // still records its proof.
+  for (const segment of splitShellSegments(command)) {
+    const words = commandWords(segment);
 
-    if (!isBunExecutable(segment[executableIndex])) continue;
-    if (!isInvocationHelperPath(segment[executableIndex + 1])) continue;
+    if (!isBunExecutable(words[0])) continue;
+    if (!isInvocationHelperPath(words[1])) continue;
 
-    const skillName = nonEmptyString(segment[executableIndex + 3]);
+    const skillName = nonEmptyString(words[3]);
     if (skillName !== undefined && SKILL_NAME_PATTERN.test(skillName)) {
       return { skillName };
     }
@@ -219,12 +121,9 @@ export function parseRecordSkillInvocationCommand(
 
 /** True when any segment of `command` runs write-review-stamp.ts under bun. */
 export function commandInvokesWriteReviewStamp(command: string): boolean {
-  return shellSegments(command).some(segment => {
-    const executableIndex = executableIndexOf(segment);
-    return (
-      isBunExecutable(segment[executableIndex]) &&
-      isReviewStampHelperPath(segment[executableIndex + 1])
-    );
+  return splitShellSegments(command).some(segment => {
+    const words = commandWords(segment);
+    return isBunExecutable(words[0]) && isReviewStampHelperPath(words[1]);
   });
 }
 

--- a/packages/cli/tests/hooks/branch-staleness.test.ts
+++ b/packages/cli/tests/hooks/branch-staleness.test.ts
@@ -21,6 +21,14 @@ describe('parseCheckoutTarget', () => {
     ['git switch main', 'main'],
     ['git checkout feature/x', 'feature/x'],
     ['git switch develop', 'develop'],
+    // Shared-tokenizer parsing (EDDABK follow-up): per-segment, prefix-aware.
+    ['git fetch && git checkout main', 'main'],
+    ['cd repo; git switch develop', 'develop'],
+    ['sudo git checkout main', 'main'],
+    ['GIT_PAGER=cat git checkout main', 'main'],
+    // Flags in a NEIGHBORING segment must not null out the parse — the old
+    // flat-token scan read `git branch -d`'s flag as create/detach.
+    ['git checkout main && git branch -d old', 'main'],
   ])('%s → %s', (command, expected) => {
     expect(parseCheckoutTarget(command)).toBe(expected);
   });
@@ -32,6 +40,11 @@ describe('parseCheckoutTarget', () => {
     ['git checkout -- file.ts', 'path checkout'],
     ['git status', 'not a checkout'],
     ['git commit -m main', 'not a checkout'],
+    // Quoted prose is one word under the shared tokenizer — the old
+    // whitespace split probed a bogus branch here.
+    ['echo "use git checkout main"', 'prose, not a command'],
+    // The old flat-token scan returned `&&` as the target here.
+    ['git checkout -q && echo hi', 'no positional target'],
   ])('%s → null (%s)', command => {
     expect(parseCheckoutTarget(command)).toBeNull();
   });

--- a/packages/cli/tests/hooks/review-stamp-bridge.test.ts
+++ b/packages/cli/tests/hooks/review-stamp-bridge.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   commandInvokesWriteReviewStamp,
+  parseRecordSkillInvocationCommand,
   readFreshCodexReviewStampIdentity,
   readFreshCursorReviewStampIdentity,
   rememberCodexReviewStampIdentity,
@@ -55,6 +56,20 @@ describe('commandInvokesWriteReviewStamp (#630)', () => {
     ).toBe(true);
   });
 
+  it('recognizes execution-prefixed invocations via the shared tokenizer (EDDABK follow-up)', () => {
+    // The old private tokenizer skipped only VAR=val words, so `command`/`env`
+    // prefixes resolved the executable to the prefix and the stamp proof was
+    // never recorded — the fail-closed stamp gate then denied a legitimate write.
+    expect(
+      commandInvokesWriteReviewStamp('command bun .safeword/hooks/write-review-stamp.ts spec'),
+    ).toBe(true);
+    expect(
+      commandInvokesWriteReviewStamp(
+        'env bun .safeword/hooks/write-review-stamp.ts --phase implement',
+      ),
+    ).toBe(true);
+  });
+
   it('recognizes the helper in a chained command alongside the proof helper', () => {
     const chained =
       'bun ".safeword/hooks/record-skill-invocation.ts" "/repo" self-review && bun .safeword/hooks/write-review-stamp.ts spec';
@@ -80,6 +95,40 @@ describe('commandInvokesWriteReviewStamp (#630)', () => {
     expect(commandInvokesWriteReviewStamp('node .safeword/hooks/write-review-stamp.ts spec')).toBe(
       false,
     );
+  });
+});
+
+describe('parseRecordSkillInvocationCommand (shared tokenizer, EDDABK follow-up)', () => {
+  const HELPER = '/repo/.safeword/hooks/record-skill-invocation.ts';
+
+  it('parses the plain and quoted absolute forms', () => {
+    expect(parseRecordSkillInvocationCommand(`bun ${HELPER} /repo verify`)).toEqual({
+      skillName: 'verify',
+    });
+    expect(parseRecordSkillInvocationCommand(`bun "${HELPER}" "/repo" self-review`)).toEqual({
+      skillName: 'self-review',
+    });
+  });
+
+  it('parses execution-prefixed invocations the old tokenizer missed', () => {
+    expect(parseRecordSkillInvocationCommand(`command bun ${HELPER} /repo verify`)).toEqual({
+      skillName: 'verify',
+    });
+    expect(parseRecordSkillInvocationCommand(`env FOO=1 bun ${HELPER} /repo audit`)).toEqual({
+      skillName: 'audit',
+    });
+  });
+
+  it('parses an invocation on its own line of a multi-line command', () => {
+    // The old tokenizer treated newline as plain whitespace, merging both lines
+    // into one segment whose executable was `echo` — a missed proof.
+    expect(parseRecordSkillInvocationCommand(`echo hi\nbun ${HELPER} /repo retro`)).toEqual({
+      skillName: 'retro',
+    });
+  });
+
+  it('does not match the helper mentioned in a quoted string', () => {
+    expect(parseRecordSkillInvocationCommand(`echo "bun ${HELPER} /repo x"`)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Stacked on #959 (EDDABK). Absorbs the two remaining private shell tokenizers the EDDABK code review found **outside** the four Bash security gates, so the "one tokenizer, one test surface" property holds repo-wide. Both now parse via the shared `shell-segments.ts` (`splitShellSegments` + `commandWords`) that #959 introduced.

## `cursor-run-identity.ts` — a real functional gap, not just cleanup

Its private `executableIndexOf` skipped only `VAR=val` words, so an execution-prefixed helper invocation resolved the executable to the prefix:

- `command bun .safeword/hooks/write-review-stamp.ts …` and `env bun …record-skill-invocation.ts <skill>` resolved to `command`/`env` → the run-identity / review-stamp **proof was never recorded** → the delegated fail-closed stamp gate could then deny a legitimate stamp write.

Now they resolve to `bun` and record the proof. Newline-separated compounds also segment correctly. The ~100-line private tokenizer is deleted.

`isInvocationHelperPath` stays slash-anchored-only (deliberate, per its own doc comment) — bare-relative record forms remain out of scope.

## `branch-staleness.ts` — `parseCheckoutTarget` (warn-only hook)

The old bare `command.trim().split(/\s+/)` had three defects, all fixed by per-segment parsing:

- `git fetch && git checkout main` returned null (stale warning skipped) — now resolves `main`.
- Quoted prose (`echo "use git checkout main"`) probed a bogus branch — now null.
- The create/detach flag scan crossed segment boundaries: `git checkout main && git branch -d old` → null and `git checkout -q && echo hi` → target `&&`. Now scoped to the git segment.

A local `sudo`-skip preserves `sudo git checkout main` (the old flat `indexOf('git')` caught it).

## Tests

Pins added for every gain and every preserved behavior across `review-stamp-bridge.test.ts` and `branch-staleness.test.ts`. Affected suites: 87 tests green (4 unit files + 3 integration). Mirrors byte-identical (parity ✅), lint ✅.

Net −100 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)