### PR TITLE
feat(hooks): basename-match command words + tokenizer edge cases (HRDN42, EDDABK follow-up)

### DIFF
--- a/.project/tickets/HRDN42-gate-basename-hardening/ticket.md
+++ b/.project/tickets/HRDN42-gate-basename-hardening/ticket.md
@@ -2,8 +2,8 @@
 id: HRDN42
 slug: gate-basename-hardening
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-07-08T03:40:00.000Z
 last_modified: 2026-07-08T03:40:00.000Z
 ---
@@ -41,4 +41,8 @@ Basename matching mirrors dep-readiness's established `nodePath.basename(binary)
 
 ## Work Log
 
+- 2026-07-08T03:52 Implemented + 3-lens adversarial review (false-positive / gate-weakening / tokenizer-regression), every claim bun-verified against the real modules → **clean sweep, zero findings survived**. Confirmed: no legit command newly over-blocked; nothing caught at base now evades (base-vs-HEAD diffed); single-quote line-continuation correctly NOT collapsed (guarded by `quote !== "'"`, matches bash for all three quoting contexts); `|&` and `command -p` are strict hardening wins; `>|&` and combined `command -pv` are correct fail-safe non-resolutions; the only messier case (`a |&& b`) is a bash syntax error that never executes (inert). 221/221 gate tests (8 new pins), lint + parity green. Phase implement → verify.
 - 2026-07-08T03:40 Created from the EDDABK follow-up chip. All 16 evasions re-verified reproducing on #959 HEAD, then all 6 in-scope fixes verified landing (basename ×3, command -p, line-continuation, `|&`) with the `command -v git` query guardrail preserved and 5c/5d deliberately still evading. Scope call: 1–4 + 5a/5b are accident-path or clear tokenizer-correctness; 5c/5d are adversarial + risky shared-tokenizer changes, deferred with backstops.
+- 2026-07-08T03:51:18.007Z Phase: implement → verify
+- 2026-07-08T04:14:36.924Z Phase: verify → done
+- 2026-07-08T04:15 **/verify + /audit green → done.** Full suite 5017/5024 (2 failures = the known-unrelated rust-golden-path + cleanup-zombies pair, byte-identical to base, none of this diff's files); build ✅, lint ✅, typecheck ✅, parity ✅. Audit 0 errors (depcruise clean, knip silent on changed files, jscpd +8 clones = new test pins only). verify.md written. Stacks on EDDABK #959, parallel to KQ3MRV #961. Closure rides the PR (per the #959 CI-guard lesson). Deferred 5c/5d remain a documented follow-up.

--- a/.project/tickets/HRDN42-gate-basename-hardening/ticket.md
+++ b/.project/tickets/HRDN42-gate-basename-hardening/ticket.md
@@ -1,0 +1,44 @@
+---
+id: HRDN42
+slug: gate-basename-hardening
+type: task
+phase: implement
+status: in_progress
+created: 2026-07-08T03:40:00.000Z
+last_modified: 2026-07-08T03:40:00.000Z
+---
+
+# Harden Bash gates: basename-match the command word + tokenizer edge cases
+
+**Goal:** Close the cluster of gate evasions the EDDABK code review found: gates exact-match the resolved command word while the shared tokenizer basename-matches env/corepack — an asymmetry that lets absolute-path forms (`/usr/bin/pkill`, `/usr/bin/tee`, `/usr/bin/git`) slip. Plus two tokenizer-correctness gaps.
+
+**Why:** Follow-up from ticket EDDABK / PR #959. All items were verified PRE-EXISTING (identical at base d5905a72) — not EDDABK regressions — so deferred out of the consolidation. Each changes gate behavior → semver-surfaced.
+
+## Scope (this pass)
+
+Every gate becomes strictly stricter (more forms caught); no gate loses a catch. Fixes:
+
+1. **kill-guard** (`process-kill-guard.ts`): basename the killer word — `/usr/bin/pkill node` now detected.
+2. **ledger** (`bash-ledger-writes.ts`): basename the command word — `/usr/bin/tee <ledger>`, `/usr/bin/sed -i … <ledger>`, `/bin/cp x <ledger>` now detected.
+3. **cursor git** (`gate-adapter.ts`): basename before comparing to `git` — `/usr/bin/git commit` now fail-closed-routed.
+4. **`command -p`** (`shell-segments.ts commandWordIndex`): skip `command`'s `-p` (runs the command with default PATH) so the real command resolves — `command -p git commit` / `command -p pkill node` now caught. `command -v`/`-V` (DESCRIBE, don't run) are left in place, so `command -v git` stays a non-commit (verified `false`).
+5. **line-continuation** (`splitShellSegments`): `\`+newline collapses (bash line continuation) instead of fusing a literal newline onto the next word — `pkill \<newline>node` now detected.
+6. **`|&`** (`splitShellSegments`): the stdout+stderr pipe is a boundary whose trailing `&` is consumed — `tail -f log |& pkill node` now detected (was: `&` became a phantom command word).
+
+Basename matching mirrors dep-readiness's established `nodePath.basename(binary)` pattern — no new shared abstraction; the shared tokenizer already resolves the command word, each gate basenames it at its name comparison.
+
+## Deferred (NOT in this pass — documented, needs its own effort)
+
+- **5c glued subshell `(pkill node)`**: `(`/`)` are bash metacharacters that should tokenize as their own words, but splitting them in `parseShellWords` has broad blast radius (`$(…)` command substitution, `x=(…)` array assignment, `<(…)` process substitution) that could *weaken* a gate — a risky shared-tokenizer change deserving its own corpus-diffed effort like EDDABK. The spaced form `( pkill node )` IS caught. Adversarial-path (deliberate space-omission); kill-guard doctrine is "accident path, not every adversarial path".
+- **5d escaped `\>|`** (`echo x\>| pkill node`): the `>|` no-split exception's `command[index-1] !== '>'` lookback is escape-blind. Fixing it needs new escape-state tracking in the hot splitter loop; adversarial construction (escaping a `>` right before a pipe). Left with 5c.
+
+## Constraints
+
+1. Stacks on EDDABK #959 (needs the unified tokenizer + `commandWords`). Branched off `frosty-yonath-9f2adb`, parallel to KQ3MRV #961 (different files, no conflict).
+2. Byte-parity mirrors under `.safeword/hooks/` (schema `ownedFiles`).
+3. No silent weakening: `command -v git` must stay a non-commit; the `>|` ledger pin must stay denied; `sudo /usr/bin/pkill node` must be caught (sudo-skip + basename compose).
+4. Semver: strictly-stricter gate behavior → minor; new-detection list in the PR body.
+
+## Work Log
+
+- 2026-07-08T03:40 Created from the EDDABK follow-up chip. All 16 evasions re-verified reproducing on #959 HEAD, then all 6 in-scope fixes verified landing (basename ×3, command -p, line-continuation, `|&`) with the `command -v git` query guardrail preserved and 5c/5d deliberately still evading. Scope call: 1–4 + 5a/5b are accident-path or clear tokenizer-correctness; 5c/5d are adversarial + risky shared-tokenizer changes, deferred with backstops.

--- a/.project/tickets/HRDN42-gate-basename-hardening/verify.md
+++ b/.project/tickets/HRDN42-gate-basename-hardening/verify.md
@@ -1,0 +1,24 @@
+# Verify — HRDN42 (gate-basename-hardening)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 221/221 tests pass across the 8 tokenizer/gate files (8 new HRDN42 pins). Full suite 5017/5024; the 2 failures are unrelated — see Evidence limits.
+**Gherkin:** ⏭️ Skipped — no acceptance lane for this task
+**Build:** ✅ Success (tsup ESM + DTS)
+**Lint:** ✅ Clean (eslint + tsc --noEmit + gherkin)
+**Scenarios:** ⏭️ Skipped — task ticket, no test-definitions.md
+**PR Scope:** ✅ Diff matches ticket scope — only the 4 gate/tokenizer hook libs (shell-segments, process-kill-guard, bash-ledger-writes, cursor/gate-adapter) + byte-identical `.safeword/` mirrors, their test files, and this ticket. No unrelated files; the deferred 5c/5d are documented, not touched.
+**Dep Drift:** ⏭️ Skipped — no dependency manifest changes, no ARCHITECTURE.md
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — basename-matching reuses dep-readiness's established `nodePath.basename(binary)` pattern; no new abstraction introduced.
+**Experience:** ⏭️ N/A — internal security-gate plumbing, not persona-facing
+**Evidence limits:** ⚠️ Two full-suite failures are pre-existing and unrelated to this diff — `tests/integration/rust-golden-path.test.ts` (a `cargo clippy` workspace-targeting E2E, environment-gated on the local Rust toolchain, ~5 min runtime) and `tests/scripts/cleanup-zombies.test.ts` (a `pgrep`-based victim-process-detection pin from #949). Both SUTs are byte-identical to base; this diff touches only shell-segments/kill-guard/ledger/gate-adapter, none of which those tests exercise. CI's isolated suite is authoritative.
+
+Audit passed — 0 errors, 0 new warnings. Config in sync (W007 ✓); depcruise clean (no cycles / violations, 602 modules — the new `nodePath` imports add none); knip flagged nothing on the changed files; jscpd 426 clones / 8.64% [repo minus `.safeword`,`.project`], +8 vs the 418 EDDABK baseline — entirely the new gate test pins' repeated `it.each` assertion shapes (benign test duplication), no source clones.
+
+## Notes
+
+- All 16 evasions re-verified reproducing on base, then all 6 in-scope fixes verified landing; `command -v git` query guardrail preserved.
+- 3-lens adversarial review (false-positive / gate-weakening / tokenizer-regression), every claim bun-verified → clean sweep, zero findings survived.
+- Deferred (documented in ticket, filed conceptually): glued `(pkill node)` and escaped `\>|` — both need risky shared-tokenizer changes (splitting `(`/`)` as metacharacters; escape-state in the splitter) and are adversarial-path; backstops exist (ledger done-gate distinct-SHA validation; kill-guard's documented subshell limitation).
+- Semver: every gate strictly stricter / more forms caught — surface as a minor at next release; new-detection list in the PR body.

--- a/.safeword/hooks/cursor/gate-adapter.ts
+++ b/.safeword/hooks/cursor/gate-adapter.ts
@@ -14,6 +14,8 @@ import { spawnSync } from 'node:child_process';
 
 import { detectLedgerWrite } from '../lib/bash-ledger-writes.js';
 import { detectBroadProcessKill } from '../lib/process-kill-guard.js';
+import nodePath from 'node:path';
+
 import { commandWordIndex, parseShellWords, splitShellSegments } from '../lib/shell-segments.js';
 
 /** Fields present on every Cursor agent hook request (the "common schema"). */
@@ -262,9 +264,10 @@ function isGitCommitSegment(words: string[]): boolean {
   // commandWordIndex skips `VAR=val` assignments and `command`/`env`/
   // `corepack` prefixes (looping, env matched by basename with its flags) so
   // neither `GIT_AUTHOR_NAME=bot git commit` nor `/usr/bin/env git commit`
-  // can slip the fail-closed gate.
+  // can slip the fail-closed gate. The command word is basename-matched too, so
+  // `/usr/bin/git commit` is caught the same as bare `git commit`.
   let index = commandWordIndex(words);
-  if (words[index] !== 'git') return false;
+  if (nodePath.basename(words[index] ?? '') !== 'git') return false;
 
   index += 1;
   while (index < words.length && words[index]?.startsWith('-')) {

--- a/.safeword/hooks/lib/bash-ledger-writes.ts
+++ b/.safeword/hooks/lib/bash-ledger-writes.ts
@@ -32,6 +32,8 @@
 // whatever detection misses. Silence from this predicate means "nothing
 // detectable", never "nothing happened".
 
+import nodePath from 'node:path';
+
 import { isNamespacePath } from './namespace-root.js';
 import { commandWordIndex, parseShellWords, splitShellSegments } from './shell-segments.js';
 
@@ -143,7 +145,10 @@ function detectInSegment(segment: string): LedgerWriteDetection | undefined {
   if (redirection !== undefined) return redirection;
 
   const commandIndex = commandWordIndex(words);
-  const commandWord = words[commandIndex] ?? '';
+  // Match writers by basename so `/usr/bin/tee` / `/bin/cp` are judged the same
+  // as the bare names in the writer sets (consistent with the tokenizer's
+  // basename-matching of env/corepack).
+  const commandWord = nodePath.basename(words[commandIndex] ?? '');
   const rest = words.slice(commandIndex + 1);
   const arguments_ = rest.filter(word => !word.startsWith('-'));
 

--- a/.safeword/hooks/lib/process-kill-guard.ts
+++ b/.safeword/hooks/lib/process-kill-guard.ts
@@ -21,6 +21,8 @@
 // backslash before an ordinary letter is that letter, so the pattern still
 // kills every `java` process (EDDABK).
 
+import nodePath from 'node:path';
+
 import { commandWordIndex, parseShellWords, splitShellSegments } from './shell-segments.js';
 
 export interface ProcessKillDetection {
@@ -90,8 +92,13 @@ export function detectBroadProcessKill(command: string): ProcessKillDetection | 
     const words = parseShellWords(segment);
     let index = commandWordIndex(words);
     while (words[index] === 'sudo') index += 1;
-    const commandWord = words[index];
-    if (commandWord === undefined || !NAME_MATCHING_KILLERS.has(commandWord)) continue;
+    const rawCommandWord = words[index];
+    if (rawCommandWord === undefined) continue;
+    // Match by basename so an absolute path (`/usr/bin/pkill`) is judged the
+    // same as the bare name — consistent with how the shared tokenizer already
+    // basename-matches env/corepack.
+    const commandWord = nodePath.basename(rawCommandWord);
+    if (!NAME_MATCHING_KILLERS.has(commandWord)) continue;
     const args = words.slice(index + 1);
     for (let argIndex = 0; argIndex < args.length; argIndex += 1) {
       const word = args[argIndex] ?? '';

--- a/.safeword/hooks/lib/shell-segments.ts
+++ b/.safeword/hooks/lib/shell-segments.ts
@@ -30,6 +30,14 @@ export function splitShellSegments(command: string): string[] {
       continue;
     }
     if (char === '\\' && quote !== "'") {
+      // A backslash-newline is a bash line continuation: both characters are
+      // removed and the surrounding text joins, so `pkill \<newline>node`
+      // runs `pkill node` — drop both rather than letting the literal newline
+      // fuse onto the next word and hide it from the gates.
+      if (command[index + 1] === '\n') {
+        index += 1;
+        continue;
+      }
       current += char;
       escaped = true;
       continue;
@@ -52,6 +60,15 @@ export function splitShellSegments(command: string): string[] {
       continue;
     }
     if ((char === '&' && next === '&') || (char === '|' && next === '|')) {
+      pushSegment(segments, current);
+      current = '';
+      index += 1;
+      continue;
+    }
+    // `|&` pipes stdout+stderr (bash) — a boundary whose trailing `&` must be
+    // consumed, else it becomes the next segment's phantom command word. The
+    // `>|` clobber-redirect exception applies here too (`>|&` is not a pipe).
+    if (char === '|' && next === '&' && command[index - 1] !== '>') {
       pushSegment(segments, current);
       current = '';
       index += 1;
@@ -129,8 +146,8 @@ const ENV_OPTIONS_WITH_VALUES = new Set(['--argv0', '--chdir', '--unset', '-a', 
  * word, not `(`; looping means `FOO=1 env BAR=2 corepack pnpm install`
  * resolves to `pnpm`.
  *
- * Deliberately NOT skipped (pre-existing behavior, out of EDDABK's scope):
- * `sudo` (the kill-guard skips it itself), `nohup`/`nice`/`time`/`xargs`.
+ * Deliberately NOT skipped (pre-existing behavior): `sudo` (the kill-guard
+ * skips it itself), `nohup`/`nice`/`time`/`xargs`.
  */
 export function commandWordIndex(words: string[]): number {
   let index = 0;
@@ -142,6 +159,11 @@ export function commandWordIndex(words: string[]): number {
     if (word === undefined) return index;
     if (word === 'command') {
       index += 1;
+      // `command -p CMD` runs CMD with the default PATH, so CMD is the real
+      // command word — skip the `-p`. `command -v`/`-V` DESCRIBE without
+      // running, so they are left in place and never mistaken for a run of
+      // the command they name.
+      while (words[index] === '-p') index += 1;
       continue;
     }
     const binary = nodePath.basename(word);

--- a/packages/cli/templates/hooks/cursor/gate-adapter.ts
+++ b/packages/cli/templates/hooks/cursor/gate-adapter.ts
@@ -14,6 +14,8 @@ import { spawnSync } from 'node:child_process';
 
 import { detectLedgerWrite } from '../lib/bash-ledger-writes.js';
 import { detectBroadProcessKill } from '../lib/process-kill-guard.js';
+import nodePath from 'node:path';
+
 import { commandWordIndex, parseShellWords, splitShellSegments } from '../lib/shell-segments.js';
 
 /** Fields present on every Cursor agent hook request (the "common schema"). */
@@ -262,9 +264,10 @@ function isGitCommitSegment(words: string[]): boolean {
   // commandWordIndex skips `VAR=val` assignments and `command`/`env`/
   // `corepack` prefixes (looping, env matched by basename with its flags) so
   // neither `GIT_AUTHOR_NAME=bot git commit` nor `/usr/bin/env git commit`
-  // can slip the fail-closed gate.
+  // can slip the fail-closed gate. The command word is basename-matched too, so
+  // `/usr/bin/git commit` is caught the same as bare `git commit`.
   let index = commandWordIndex(words);
-  if (words[index] !== 'git') return false;
+  if (nodePath.basename(words[index] ?? '') !== 'git') return false;
 
   index += 1;
   while (index < words.length && words[index]?.startsWith('-')) {

--- a/packages/cli/templates/hooks/lib/bash-ledger-writes.ts
+++ b/packages/cli/templates/hooks/lib/bash-ledger-writes.ts
@@ -32,6 +32,8 @@
 // whatever detection misses. Silence from this predicate means "nothing
 // detectable", never "nothing happened".
 
+import nodePath from 'node:path';
+
 import { isNamespacePath } from './namespace-root.js';
 import { commandWordIndex, parseShellWords, splitShellSegments } from './shell-segments.js';
 
@@ -143,7 +145,10 @@ function detectInSegment(segment: string): LedgerWriteDetection | undefined {
   if (redirection !== undefined) return redirection;
 
   const commandIndex = commandWordIndex(words);
-  const commandWord = words[commandIndex] ?? '';
+  // Match writers by basename so `/usr/bin/tee` / `/bin/cp` are judged the same
+  // as the bare names in the writer sets (consistent with the tokenizer's
+  // basename-matching of env/corepack).
+  const commandWord = nodePath.basename(words[commandIndex] ?? '');
   const rest = words.slice(commandIndex + 1);
   const arguments_ = rest.filter(word => !word.startsWith('-'));
 

--- a/packages/cli/templates/hooks/lib/process-kill-guard.ts
+++ b/packages/cli/templates/hooks/lib/process-kill-guard.ts
@@ -21,6 +21,8 @@
 // backslash before an ordinary letter is that letter, so the pattern still
 // kills every `java` process (EDDABK).
 
+import nodePath from 'node:path';
+
 import { commandWordIndex, parseShellWords, splitShellSegments } from './shell-segments.js';
 
 export interface ProcessKillDetection {
@@ -90,8 +92,13 @@ export function detectBroadProcessKill(command: string): ProcessKillDetection | 
     const words = parseShellWords(segment);
     let index = commandWordIndex(words);
     while (words[index] === 'sudo') index += 1;
-    const commandWord = words[index];
-    if (commandWord === undefined || !NAME_MATCHING_KILLERS.has(commandWord)) continue;
+    const rawCommandWord = words[index];
+    if (rawCommandWord === undefined) continue;
+    // Match by basename so an absolute path (`/usr/bin/pkill`) is judged the
+    // same as the bare name — consistent with how the shared tokenizer already
+    // basename-matches env/corepack.
+    const commandWord = nodePath.basename(rawCommandWord);
+    if (!NAME_MATCHING_KILLERS.has(commandWord)) continue;
     const args = words.slice(index + 1);
     for (let argIndex = 0; argIndex < args.length; argIndex += 1) {
       const word = args[argIndex] ?? '';

--- a/packages/cli/templates/hooks/lib/shell-segments.ts
+++ b/packages/cli/templates/hooks/lib/shell-segments.ts
@@ -30,6 +30,14 @@ export function splitShellSegments(command: string): string[] {
       continue;
     }
     if (char === '\\' && quote !== "'") {
+      // A backslash-newline is a bash line continuation: both characters are
+      // removed and the surrounding text joins, so `pkill \<newline>node`
+      // runs `pkill node` — drop both rather than letting the literal newline
+      // fuse onto the next word and hide it from the gates.
+      if (command[index + 1] === '\n') {
+        index += 1;
+        continue;
+      }
       current += char;
       escaped = true;
       continue;
@@ -52,6 +60,15 @@ export function splitShellSegments(command: string): string[] {
       continue;
     }
     if ((char === '&' && next === '&') || (char === '|' && next === '|')) {
+      pushSegment(segments, current);
+      current = '';
+      index += 1;
+      continue;
+    }
+    // `|&` pipes stdout+stderr (bash) — a boundary whose trailing `&` must be
+    // consumed, else it becomes the next segment's phantom command word. The
+    // `>|` clobber-redirect exception applies here too (`>|&` is not a pipe).
+    if (char === '|' && next === '&' && command[index - 1] !== '>') {
       pushSegment(segments, current);
       current = '';
       index += 1;
@@ -129,8 +146,8 @@ const ENV_OPTIONS_WITH_VALUES = new Set(['--argv0', '--chdir', '--unset', '-a', 
  * word, not `(`; looping means `FOO=1 env BAR=2 corepack pnpm install`
  * resolves to `pnpm`.
  *
- * Deliberately NOT skipped (pre-existing behavior, out of EDDABK's scope):
- * `sudo` (the kill-guard skips it itself), `nohup`/`nice`/`time`/`xargs`.
+ * Deliberately NOT skipped (pre-existing behavior): `sudo` (the kill-guard
+ * skips it itself), `nohup`/`nice`/`time`/`xargs`.
  */
 export function commandWordIndex(words: string[]): number {
   let index = 0;
@@ -142,6 +159,11 @@ export function commandWordIndex(words: string[]): number {
     if (word === undefined) return index;
     if (word === 'command') {
       index += 1;
+      // `command -p CMD` runs CMD with the default PATH, so CMD is the real
+      // command word — skip the `-p`. `command -v`/`-V` DESCRIBE without
+      // running, so they are left in place and never mistaken for a run of
+      // the command they name.
+      while (words[index] === '-p') index += 1;
       continue;
     }
     const binary = nodePath.basename(word);

--- a/packages/cli/tests/cursor-shell-gate.test.ts
+++ b/packages/cli/tests/cursor-shell-gate.test.ts
@@ -41,6 +41,10 @@ describe('Cursor beforeShellExecution gate', () => {
     'command git commit -m "save"',
     'env GIT_AUTHOR_NAME=bot git commit -m "save"',
     '/usr/bin/env git commit -m "save"',
+    // git itself matched by basename — an absolute path is a real commit (HRDN42).
+    '/usr/bin/git commit -m "save"',
+    // `command -p git commit` runs git with the default PATH — a real commit.
+    'command -p git commit -m "save"',
     // Bare leading env-assignments must not slip the gate (the env(1) wrapper is
     // optional in real shells): `VAR=val git commit …` is still a commit.
     'GIT_AUTHOR_NAME=bot git commit -m "save"',
@@ -62,6 +66,9 @@ describe('Cursor beforeShellExecution gate', () => {
     expect(requiresFailClosedShellGate({ command: 'echo "git commit -m save"' })).toBe(false);
     // The env-assignment skip must not over-trigger on non-commit git subcommands.
     expect(requiresFailClosedShellGate({ command: 'GIT_PAGER=cat git status' })).toBe(false);
+    // `command -v git` DESCRIBES git (a lookup), it does not run a commit — the
+    // `-p`-only skip must leave `-v` in place so this stays fail-open (HRDN42).
+    expect(requiresFailClosedShellGate({ command: 'command -v git' })).toBe(false);
   });
 
   it('preserves a real denial from the delegated gate', () => {

--- a/packages/cli/tests/hooks/bash-ledger-writes.test.ts
+++ b/packages/cli/tests/hooks/bash-ledger-writes.test.ts
@@ -67,6 +67,10 @@ describe('detectLedgerWrite', () => {
       ['fd-prefixed output redirection', `echo '- [x] RED' 1> ${LEDGER}`],
       ['subshell in-place edit', String.raw`( sed -i 's/^- \[ \] /- [x] /' ${LEDGER} )`],
       ['env-by-basename prefixed tee', `/usr/bin/env tee ${LEDGER}`],
+      // Writer matched by basename — an absolute path does not evade (HRDN42).
+      ['absolute-path tee', `/usr/bin/tee ${LEDGER}`],
+      ['absolute-path sed in-place', `/usr/bin/sed -i 's/a/b/' ${LEDGER}`],
+      ['absolute-path cp destination', `/bin/cp /tmp/forged.md ${LEDGER}`],
       [
         'inline interpreter that only reads (over-approximate deny)',
         `python3 -c 'print(open("${LEDGER}").read())'`,

--- a/packages/cli/tests/hooks/process-kill-guard.test.ts
+++ b/packages/cli/tests/hooks/process-kill-guard.test.ts
@@ -59,6 +59,34 @@ describe('detectBroadProcessKill', () => {
         command: 'pkill',
         target: 'node',
       });
+      // The killer itself matched by basename — an absolute path does not evade
+      // (HRDN42). sudo + abspath compose.
+      expect(detectBroadProcessKill('/usr/bin/pkill node')).toEqual({
+        command: 'pkill',
+        target: 'node',
+      });
+      expect(detectBroadProcessKill('sudo /usr/bin/killall node')).toEqual({
+        command: 'killall',
+        target: 'node',
+      });
+      // `command -p CMD` runs CMD with the default PATH — the CMD resolves,
+      // so a broad kill behind it is caught (HRDN42).
+      expect(detectBroadProcessKill('command -p pkill node')).toEqual({
+        command: 'pkill',
+        target: 'node',
+      });
+      // A backslash-newline is a bash line continuation: `pkill \<newline>node`
+      // runs `pkill node` and must not evade (HRDN42).
+      expect(detectBroadProcessKill('pkill \\\nnode')).toEqual({
+        command: 'pkill',
+        target: 'node',
+      });
+      // `|&` pipes stdout+stderr — the trailing `&` is consumed, so the piped
+      // command is a real segment, not a phantom `&`-led one (HRDN42).
+      expect(detectBroadProcessKill('tail -f log |& pkill node')).toEqual({
+        command: 'pkill',
+        target: 'node',
+      });
       // POSIX single-quote rule: the backslash does not escape the closing
       // quote, so the `;` splits and the kill segment is visible (EDDABK).
       expect(detectBroadProcessKill(String.raw`echo 'a\'; pkill node`)).toEqual({

--- a/packages/cli/tests/hooks/shell-segments.test.ts
+++ b/packages/cli/tests/hooks/shell-segments.test.ts
@@ -60,6 +60,20 @@ describe('splitShellSegments', () => {
     ]);
   });
 
+  it('Scenario: `|&` (stdout+stderr pipe) is a boundary that consumes the `&`', () => {
+    // The trailing `&` must not survive as the next segment's first word (HRDN42).
+    expect(splitShellSegments('tail -f log |& pkill node')).toEqual(['tail -f log', 'pkill node']);
+    expect(splitShellSegments('a|&b')).toEqual(['a', 'b']);
+  });
+
+  it('Scenario: a backslash-newline line continuation collapses (HRDN42)', () => {
+    // bash removes `\<newline>` entirely and joins the surrounding text.
+    expect(splitShellSegments('pkill \\\nnode')).toEqual(['pkill node']);
+    expect(splitShellSegments('pk\\\nill node')).toEqual(['pkill node']);
+    // A backslash before any other char stays a literal escape in the segment.
+    expect(splitShellSegments(String.raw`echo a\;b`)).toEqual([String.raw`echo a\;b`]);
+  });
+
   it('Scenario: segments are trimmed and empty segments dropped', () => {
     expect(splitShellSegments('bun ci ||')).toEqual(['bun ci']);
     expect(splitShellSegments('| npm ci')).toEqual(['npm ci']);
@@ -99,6 +113,16 @@ describe('commandWordIndex', () => {
   it('Scenario: skips environment assignments and the command builtin', () => {
     expect(resolve('FOO=1 BAR=2 npm ci')).toEqual(['npm', 'ci']);
     expect(resolve('command npm ci')).toEqual(['npm', 'ci']);
+  });
+
+  it('Scenario: skips `command -p` (runs CMD) but not `command -v` (describes it)', () => {
+    // `command -p git commit` runs git → resolve past the -p (HRDN42).
+    expect(resolve('command -p git commit')).toEqual(['git', 'commit']);
+    expect(resolve('command -p -p pkill node')).toEqual(['pkill', 'node']);
+    // `command -v`/`-V` DESCRIBE without running — leave the flag as the word so
+    // callers never treat `command -v git` as a run of git.
+    expect(resolve('command -v git')).toEqual(['-v', 'git']);
+    expect(resolve('command -V pkill')).toEqual(['-V', 'pkill']);
   });
 
   it('Scenario: skips env by basename, including its options', () => {


### PR DESCRIPTION
Stacked on #959 (EDDABK). Closes the pre-existing gate-evasion cluster the EDDABK code review found — all verified **identical at base** (not EDDABK regressions), so deferred out of the consolidation. The theme: safeword's Bash gates exact-match the resolved command word, while the shared tokenizer basename-matches env/corepack — an asymmetry that let absolute-path forms slip.

## Fixes (every gate strictly stricter — new forms caught, none lost)

**Basename the command word** (mirrors dep-readiness's existing `nodePath.basename(binary)` pattern — no new abstraction):
- kill-guard: `/usr/bin/pkill node`, `/usr/bin/killall node` now detected.
- ledger: `/usr/bin/tee <ledger>`, `/usr/bin/sed -i … <ledger>`, `/bin/cp x <ledger>` now detected.
- cursor git gate: `/usr/bin/git commit` now fail-closed-routed.

**`command -p`** (`commandWordIndex`): skip `command -p` (runs the command with the default PATH) so the real command resolves — `command -p git commit` / `command -p pkill node` caught. `command -v`/`-V` DESCRIBE without running, so they're left in place: `command -v git` stays a non-commit (verified).

**Tokenizer correctness** (`splitShellSegments`):
- Backslash-newline line continuations collapse (bash removes them) — `pkill \<newline>node` runs `pkill node` and no longer hides behind a fused literal newline.
- `|&` (stdout+stderr pipe) is a boundary that consumes the trailing `&` — `tail -f log |& pkill node` no longer leaves `&` as a phantom command word.

## Verification

- All 16 evasions re-verified reproducing on the base, then all 6 fixes verified landing; the `command -v git` query guardrail preserved.
- **3-lens adversarial review** (false-positive / gate-weakening / tokenizer-regression), every claim bun-verified against the real modules → **clean sweep, zero findings**. Notably: single-quote line-continuation correctly NOT collapsed (bash doesn't either); no gate weakened (base-vs-HEAD diffed); `>|&` and combined `command -pv` are correct fail-safe non-resolutions.
- 221/221 gate tests (8 new pins); full suite 5017/5024 (2 failures are the pre-existing unrelated rust-golden-path + cleanup-zombies pair); parity + lint + typecheck green.

## Deferred (documented, out of scope — needs its own effort)

- **Glued subshell `(pkill node)`**: `(`/`)` are bash metacharacters, but splitting them in the shared tokenizer has broad blast radius (`$(…)`, `x=(…)`, `<(…)`) that could weaken a gate — deserves its own corpus-diffed effort. Spaced `( pkill node )` IS caught.
- **Escaped `\>|`** (`echo x\>| pkill node`): the `>|` no-split lookback is escape-blind; fixing needs new escape-state in the hot splitter loop. Adversarial construction; backstops exist.

## Semver

Every gate becomes strictly stricter / catches more forms → **minor** at next release. New detections listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)