### PR TITLE
Single lint-staged config + deterministic shellcheck lane (#966)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Shellcheck
+        # The deterministic shell-lint gate (#966): pre-commit's *.sh rule is
+        # guarded (skips on machines without shellcheck), so this lane is where
+        # the check is guaranteed to run — ubuntu-latest preinstalls shellcheck.
+        run: git ls-files '*.sh' | xargs -r shellcheck
+
       - name: Format check
         # prettier --check . — guards against formatting drift that eslint
         # does not catch. Pre-commit (lint-staged) only formats staged files,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         # The deterministic shell-lint gate (#966): pre-commit's *.sh rule is
         # guarded (skips on machines without shellcheck), so this lane is where
         # the check is guaranteed to run — ubuntu-latest preinstalls shellcheck.
-        run: git ls-files '*.sh' | xargs -r shellcheck
+        run: git ls-files -z '*.sh' | xargs -0 -r shellcheck
 
       - name: Format check
         # prettier --check . — guards against formatting drift that eslint

--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,7 @@
     "packages/cli/vitest.slow.config.ts"
   ],
   "ignoreBinaries": [
+    "shellcheck",
     "shfmt",
     "dot",
     "claude",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -29,6 +29,11 @@ export default {
   // CI's `prettier --check .`, which does cover .mdx (the gap that let an
   // unformatted .mdx commit pass the hook and fail CI on PR #692).
   '*.mdx': ['prettier --write'],
-  '*.sh': ['shellcheck'],
+  // Guarded: shellcheck is a system binary, not a devDependency — a clean
+  // machine without it must not fail pre-commit. The deterministic, strict
+  // gate is CI's lint job, where the runner preinstalls shellcheck (#966).
+  '*.sh': [
+    `sh -c 'if command -v shellcheck >/dev/null 2>&1; then shellcheck "$@"; else echo "shellcheck not installed; skipping (CI runs it strictly)"; fi' --`,
+  ],
   '*.feature': ['bun packages/cli/src/cli.ts lint-gherkin'],
 };

--- a/package.json
+++ b/package.json
@@ -46,29 +46,6 @@
     "safeword": "workspace:*",
     "tsx": "^4.23.0"
   },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}": [
-      "eslint --fix --config eslint.config.ts",
-      "prettier --write"
-    ],
-    "*.{vue,svelte,astro}": [
-      "eslint --fix --config eslint.config.ts",
-      "prettier --write"
-    ],
-    "*.{json,css,scss,html,yaml,yml,graphql}": [
-      "prettier --write"
-    ],
-    "*.md": [
-      "markdownlint-cli2 --fix",
-      "prettier --write"
-    ],
-    "*.sh": [
-      "sh -c 'if command -v shellcheck >/dev/null 2>&1; then shellcheck \"$@\"; else echo \"shellcheck not installed; skipping\"; fi' --"
-    ],
-    "*.feature": [
-      "bun packages/cli/src/cli.ts lint-gherkin"
-    ]
-  },
   "overrides": {
     "@felipecrs/decompress-tarxz": "5.0.6",
     "@types/estree": "^1.0.9",

--- a/scripts/session-node24.sh
+++ b/scripts/session-node24.sh
@@ -12,7 +12,9 @@ export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 mkdir -p "$NVM_DIR"
 
 node24_bin() {
-  ls -d "$NVM_DIR"/versions/node/v24.*/bin 2> /dev/null | sort -V | tail -1
+  # find, not `ls -d` — same v24.*/bin candidates without SC2012's
+  # non-alphanumeric-filename caveat (versions sort cleanly under -V either way).
+  find "$NVM_DIR"/versions/node -mindepth 2 -maxdepth 2 -type d -path '*/v24.*/bin' 2> /dev/null | sort -V | tail -1
 }
 
 # Probe for an existing install BEFORE gating on nvm.sh — a container that


### PR DESCRIPTION
Fixes the dual-lint-staged-config drift from #966 (surfaced by #964's independent quality review; pre-dates that branch).

## What changed

- **Deleted the dead `package.json` `lint-staged` block.** lint-staged resolves same-directory configs alphabetically and assigns each file to exactly one config, so `lint-staged.config.mjs` ('l' < 'p') always shadowed it — verified against lint-staged's `searchConfigs.js`/`groupFilesByConfig.js`. The dead block disagreed with the live one (carried a shellcheck guard the live config lacked; lacked the `.mdx` rule and generated-file filtering the live one has).
- **Ported the guard into the live config:** `*.sh` now skips loudly ("shellcheck not installed; skipping (CI runs it strictly)") on machines without shellcheck — a system binary deliberately not a devDependency — instead of hard-failing pre-commit on clean machines.
- **Added a strict `Shellcheck` step to CI's lint job** so the check runs deterministically somewhere: `git ls-files -z '*.sh' | xargs -0 -r shellcheck` (null-delimited per independent review — handles any tracked filename). ubuntu-latest preinstalls shellcheck 0.9.0 (the version this change was validated against), so no install step. A guarded local hook plus no CI lane would have left the lint running nowhere reliably — a configured-looking check that quietly doesn't exist.
- **Fixed the tree's one existing finding** (SC2012 in `scripts/session-node24.sh`): `ls -d … | sort -V | tail -1` → an equivalent `find -path '*/v24.*/bin'`; output verified byte-identical against a live nvm Node 24 install.
- **Persisted the system-binary decision in knip's baseline:** `shellcheck` added to `knip.json` `ignoreBinaries`, so fresh-clone audits stop re-flagging it as an unlisted binary (past audits re-triaged this by hand; the finding was masked on machines carrying the orphaned node_modules wrapper below).

## Verification

Strict `shellcheck` over all 13 tracked `.sh` files: clean. Guard verified on both branches (runs shellcheck when present; loud zero-exit skip on a shellcheck-less PATH). The commits' own pre-commit hooks exercised the new `*.sh` rule and single-config resolution end-to-end. Config parse checks green (`lint-staged.config.mjs` loads as the only config — debug-verified; `package.json` valid with the block gone). Full suite on the branch: 5035/5035 tests, acceptance lane green, build/typecheck/deps green, `bunx knip` clean. Independent quality review: APPROVE, 0 criticals — the `sh -c` idiom live-tested injection-safe against hostile filenames; lint-staged 17.0.8 confirmed latest with the precedence claim verified in its installed source. Follow-up filed: #987 (never-failing `lint:sh` scripts, out of scope here).

One environment note from testing: an orphaned npm `shellcheck@4.1.0` wrapper (absent from bun.lock — stale node_modules leftover) can shadow the system binary under lint-staged and crash trying to download its binary behind restricted egress. Fresh/frozen-lockfile installs are unaffected; `rm -rf node_modules/shellcheck` clears it on machines that hit it.

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvXuj3us862ZSZxqxfxJQs