### PR TITLE
docs: seven-phase flow + current gate inventory (stacked on #988)

### DIFF
--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -172,9 +172,10 @@ Read the matching guide when its trigger fires:
 
 ## Enforcement
 
-Safeword runs hooks each turn to track your phase and TDD step. Three gates hard-block:
+Safeword runs hooks each turn to track your phase and TDD step. Four gates hard-block:
 
 - **Phase gate** — can't start TDD without `test-definitions.md`; can't create `test-definitions.md` without `scope` / `out_of_scope` / `done_when` in ticket frontmatter.
+- **Plan gate** — a new-flow feature can't enter `implement` without a valid `impl-plan.md` (authored during the plan-implementation phase, status `planned`), and can't reach `verify`/`done` until the plan is reconciled to `implemented`.
 - **LOC gate** — commit every ~400 lines of project code (blast-radius control).
 - **Done gate** — can't close a ticket without `verify.md` in the ticket folder.
 

--- a/.safeword/guides/planning-guide.md
+++ b/.safeword/guides/planning-guide.md
@@ -8,11 +8,11 @@ How to write specs, user stories, and test definitions before implementation.
 
 **Triage first — the first matching row sets the level:**
 
-| Question                                 | Level       | Artifacts                                            |
-| ---------------------------------------- | ----------- | ---------------------------------------------------- |
-| User-facing feature with business value? | **feature** | Feature Spec + Test Definitions (+ Design Doc if 3+) |
-| Bug, improvement, internal, or refactor? | **task**    | Task Spec with inline tests                          |
-| Typo, config, or trivial change?         | **patch**   | Minimal Task Spec, existing tests                    |
+| Question                                 | Level       | Artifacts                                                        |
+| ---------------------------------------- | ----------- | ---------------------------------------------------------------- |
+| User-facing feature with business value? | **feature** | Feature Spec + Test Definitions + Impl Plan (+ Design Doc if 3+) |
+| Bug, improvement, internal, or refactor? | **task**    | Task Spec with inline tests                                      |
+| Typo, config, or trivial change?         | **patch**   | Minimal Task Spec, existing tests                                |
 
 **Location:** `<namespace-root>/tickets/{ID}-{slug}/`
 
@@ -21,6 +21,7 @@ Ticket artifacts live in the ticket folder:
 - `ticket.md` - Ticket definition
 - `test-definitions.md` - R/G/R ledger for BDD scenarios
 - `spec.md` - Feature spec (epics only)
+- `impl-plan.md` - Implementation design record for new-flow features — authored during the plan-implementation phase (after scenarios validate, before TDD), scaffolded from `.safeword/templates/impl-plan-template.md`; the plan gate blocks `implement` until it parses valid (see the bdd skill's `PLAN_IMPLEMENTATION.md`)
 - `design.md` - Design doc (complex features)
 
 Executable BDD scenarios live at `features/<slug>.feature` (or under the

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -172,9 +172,10 @@ Read the matching guide when its trigger fires:
 
 ## Enforcement
 
-Safeword runs hooks each turn to track your phase and TDD step. Three gates hard-block:
+Safeword runs hooks each turn to track your phase and TDD step. Four gates hard-block:
 
 - **Phase gate** — can't start TDD without `test-definitions.md`; can't create `test-definitions.md` without `scope` / `out_of_scope` / `done_when` in ticket frontmatter.
+- **Plan gate** — a new-flow feature can't enter `implement` without a valid `impl-plan.md` (authored during the plan-implementation phase, status `planned`), and can't reach `verify`/`done` until the plan is reconciled to `implemented`.
 - **LOC gate** — commit every ~400 lines of project code (blast-radius control).
 - **Done gate** — can't close a ticket without `verify.md` in the ticket folder.
 

--- a/packages/cli/templates/guides/planning-guide.md
+++ b/packages/cli/templates/guides/planning-guide.md
@@ -8,11 +8,11 @@ How to write specs, user stories, and test definitions before implementation.
 
 **Triage first — the first matching row sets the level:**
 
-| Question                                 | Level       | Artifacts                                            |
-| ---------------------------------------- | ----------- | ---------------------------------------------------- |
-| User-facing feature with business value? | **feature** | Feature Spec + Test Definitions (+ Design Doc if 3+) |
-| Bug, improvement, internal, or refactor? | **task**    | Task Spec with inline tests                          |
-| Typo, config, or trivial change?         | **patch**   | Minimal Task Spec, existing tests                    |
+| Question                                 | Level       | Artifacts                                                        |
+| ---------------------------------------- | ----------- | ---------------------------------------------------------------- |
+| User-facing feature with business value? | **feature** | Feature Spec + Test Definitions + Impl Plan (+ Design Doc if 3+) |
+| Bug, improvement, internal, or refactor? | **task**    | Task Spec with inline tests                                      |
+| Typo, config, or trivial change?         | **patch**   | Minimal Task Spec, existing tests                                |
 
 **Location:** `<namespace-root>/tickets/{ID}-{slug}/`
 
@@ -21,6 +21,7 @@ Ticket artifacts live in the ticket folder:
 - `ticket.md` - Ticket definition
 - `test-definitions.md` - R/G/R ledger for BDD scenarios
 - `spec.md` - Feature spec (epics only)
+- `impl-plan.md` - Implementation design record for new-flow features — authored during the plan-implementation phase (after scenarios validate, before TDD), scaffolded from `.safeword/templates/impl-plan-template.md`; the plan gate blocks `implement` until it parses valid (see the bdd skill's `PLAN_IMPLEMENTATION.md`)
 - `design.md` - Design doc (complex features)
 
 Executable BDD scenarios live at `features/<slug>.feature` (or under the

--- a/packages/website/src/content/docs/getting-started/workflow.mdx
+++ b/packages/website/src/content/docs/getting-started/workflow.mdx
@@ -30,7 +30,10 @@ flowchart TD
     phase0 --> g1{{"Phase gate:<br/>scope / out_of_scope / done_when"}}
     g1 --> scenarios["Define-behavior scenarios"]
     scenarios --> g2{{"Phase gate:<br/>test-definitions.md exists"}}
-    g2 --> build
+    g2 --> sgate["Scenario gate:<br/>adversarial scenario review"]
+    sgate --> plan["Plan implementation:<br/>impl-plan.md — proof plan, build order, ADRs"]
+    plan --> g2b{{"Plan gate:<br/>valid impl-plan.md before TDD"}}
+    g2b --> build
 
     task --> build["3 · Build<br/>RED → GREEN → REFACTOR"]
     patch --> verify
@@ -60,7 +63,7 @@ The agent sizes the work — it doesn't announce a label, it just picks the righ
 
 - **patch** goes straight to the fix.
 - **task** runs the TDD loop: a failing test (RED), the minimum code to pass (GREEN), then cleanup (REFACTOR).
-- **feature** writes define-behavior scenarios first, then implements each one through that same TDD loop.
+- **feature** writes define-behavior scenarios first, validates them at the scenario gate, plans the implementation (`impl-plan.md` — the proof plan, build order, and any architecture decisions, written in the plan-implementation phase), then implements each scenario through that same TDD loop.
 
 ## 4 · Verify
 
@@ -70,10 +73,11 @@ The agent runs the relevant tests itself after every fix, task, or feature. It n
 
 A ticket can't close until `verify.md` exists in its folder — the artifact the `/verify` skill produces. No artifact, no done.
 
-<Aside type="caution" title="The three gates hard-block">
-Safeword runs hooks every turn to track which phase the agent is in. Three of them stop work cold rather than warn:
+<Aside type="caution" title="The gates hard-block">
+Safeword runs hooks every turn to track which phase the agent is in. Four of them stop work cold rather than warn:
 
 - **Phase gate** — can't start TDD without `test-definitions.md`; can't write that file without `scope` / `out_of_scope` / `done_when` in the ticket.
+- **Plan gate** — a feature can't enter the implement phase without a valid `impl-plan.md` (written in the plan-implementation phase), and can't reach verify until that plan is reconciled against what actually shipped.
 - **LOC gate** — commit roughly every 400 lines of project code, so no single change grows an unreviewable blast radius.
 - **Done gate** — can't close a ticket without `verify.md`.
 

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -122,6 +122,13 @@ Hooks are configured in `.claude/settings.json` (Claude Code), `.cursor/hooks.js
 
 To disable a specific hook, remove the safeword hook entry from that agent's config.
 
+### Review gates
+
+Two opt-in review gates (both default off) add independent-review requirements on top of the always-on gates:
+
+- `reviewGate: true` — every ticket phase advance requires an independent phase-exit review stamp (a fresh-context reviewer, logged via `write-review-stamp.ts --phase <phase>`), or an explicitly logged skip reason. Built for autonomous runs where user checkpoints auto-confirm.
+- `architectureReviewGate: true` — a new-flow feature can't reach verify/done until its `impl-plan.md` design has been independently reviewed: the Decisions section must cite evidence (URL or `[n]` marker), and the review stamp binds to the plan's content hash — editing the design after review invalidates it. Add `crossModelReview: true` to require the reviewer run on a different model than the author.
+
 ### Design approval gate
 
 `designApprovalGate` (default: off) keeps the plan-implementation phase autonomous: the independently reviewed implementation plan advances to TDD without a human checkpoint. Technical builders who want to approve the design before any code can opt in:


### PR DESCRIPTION
Stacked on #988 — retarget to `main` after it merges.

Brings the two-generations-stale workflow docs up to the seven-phase reality:

- `workflow.mdx`: mermaid diagram gains scenario gate → plan-implementation → plan gate; the "three gates" aside becomes the four hard gates (Phase, Plan, LOC, Done).
- `templates/SAFEWORD.md` (+ dogfood pair): same four-gate inventory — the Enforcement section finally names the impl-plan gate that has existed since M6D315.
- `templates/guides/planning-guide.md` (+ pair): learns `impl-plan.md` exists — artifact table + levels row.
- `configuration.mdx`: documents `reviewGate`, `architectureReviewGate`, and `crossModelReview` alongside `designApprovalGate`.

Full suite green at the same 5049/5056 as the base branch (identical environmental pair); parity mode=all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)