### PR TITLE
Fix Codex retro extraction outside git worktrees

### DIFF
--- a/.project/tickets/24WR26-codex-retro-runtime-completion/ticket.md
+++ b/.project/tickets/24WR26-codex-retro-runtime-completion/ticket.md
@@ -1,0 +1,85 @@
+---
+id: 24WR26
+slug: codex-retro-runtime-completion
+type: task
+subtype: bug-investigated
+phase: verify
+status: in_progress
+external_issue: https://github.com/ArcadeAI/safeword/issues/960
+scope:
+  - Debug Codex retro auto-run behavior from real Stop hook input through child extraction, draft spooling, and filing-gate visibility.
+  - Add or use sanitized diagnostics that distinguish trigger skips, child failures, empty findings, and spool/filing behavior.
+  - Add or update focused smoke coverage where it proves the runtime boundary.
+out_of_scope:
+  - Redesigning the retro product flow or changing the filing policy.
+  - Filing this session's empty retro spool as a finding.
+  - Changing Claude or Cursor retro behavior unless the shared helper is proven to be the failing boundary.
+  - Logging raw transcript content or unsanitized findings.
+done_when:
+  - The failing boundary for Codex retro is identified with recorded evidence.
+  - A substantial Codex Stop smoke path proves successful child launch and offset-state write.
+  - Empty findings are visibly different from extractor failure.
+  - The hook remains fail-open for normal users.
+created: 2026-07-08T01:49:10.650Z
+last_modified: 2026-07-11T05:17:25Z
+---
+
+# Debug Codex retro runtime completion
+
+**Goal:** Identify the failing Codex retro runtime boundary and add focused smoke evidence for child launch and offset writes.
+
+**Why:** GitHub issue #960 reports silent Codex retro completion failures with no drafts or successful-run marker.
+
+## Work Log
+
+- 2026-07-08T01:49:10.650Z Started: Created ticket 24WR26
+- 2026-07-08T01:49:24Z Scoped: Mirrored GitHub issue #960 scope, exclusions, and done criteria into ticket frontmatter.
+- 2026-07-08T01:54:14Z RED: Focused baseline passed 42/42, then new diagnostics tests failed on missing debug JSONL and missing Codex extraction failure reasons.
+- 2026-07-08T02:02:20Z GREEN: Added opt-in `SAFEWORD_RETRO_DEBUG_LOG` JSONL diagnostics, Codex extraction failure reasons, child-exit tracing, offset-write tracing, and CLI spool/filing tracing. Focused tests pass 64/64; typecheck, schema registration test, and `git diff --check` pass.
+- 2026-07-08T02:06:46Z Verify: ESLint passed; wrote `verify.md` with the live Stop payload capture listed as the remaining evidence limit.
+- 2026-07-08T02:11:42Z Runtime capture armed: temporarily prefixed `.codex/config.toml` Stop hook with `SAFEWORD_RETRO_DEBUG_LOG=/Users/alex/.codex/worktrees/f80b/safeword/.project/tmp/codex-retro-stop-019f3f65-b385-7f31-b4be-57a8bbab420e.jsonl`.
+- 2026-07-08T02:17:29Z Runtime capture attempt: no debug JSONL was written, but the real Stop path created/touched an empty `.safeword/retro-drafts/019f3f65-b385-7f31-b4be-57a8bbab420e.jsonl` and wrote no offset-state file. Reverted the config prefix and armed a temporary thread-scoped fallback in the installed `.safeword/hooks/lib/retro-debug.ts` copy for the next Stop.
+- 2026-07-08T03:02:27Z Runtime capture retry: thread-env fallback still wrote no debug JSONL, while the real Stop path again touched the empty draft and wrote no offset-state file. Reverted that fallback and armed a temporary Stop-input-session switch in the installed `.safeword/hooks/codex/stop.ts` copy so the next Stop can propagate `SAFEWORD_RETRO_DEBUG_LOG` into the retro child.
+- 2026-07-08T03:37:15Z Runtime boundary captured: live Stop decided to run with readable transcript and 205 tool uses, the retro CLI reported `failureReason: spawn_nonzero` / `exitCode: 1` from Codex extraction, the parent child exited `status: 1`, no offset state was written, and filing gate stayed silent. Removed the temporary Stop-input-session switch after capture.
+- 2026-07-08T05:05:01Z Root cause fixed: exact helper replay captured Codex stderr `Not inside a trusted directory and --skip-git-repo-check was not specified.` Added `--skip-git-repo-check` to the Codex extractor argv; the same real transcript replay now exits 0 with `retro_cli_extraction ok:true`.
+- 2026-07-11T05:17:25Z Review cleanup: full audit/quality/refactor pass added direct redaction/fail-open coverage for `retro-debug.ts`, extracted shared test JSONL parsing, and fixed Knip's intentional external `shellcheck` binary finding.
+
+## Test Plan
+
+- RED: Run the existing Codex retro trigger and integration smoke tests to capture the current failing boundary.
+- RED: Add the narrowest failing smoke test that exercises `.safeword/hooks/codex/stop.ts` from Stop payload through child launch and offset-state write.
+- GREEN: Add sanitized diagnostics or runtime plumbing only where the failing boundary requires it.
+- REFACTOR: Keep diagnostics opt-in/test-only and preserve fail-open behavior for normal users.
+
+## Root Cause
+
+The confirmed code-level failure boundary was observability plus a live Codex headless extraction failure, not the deterministic Codex Stop trigger. Existing smoke coverage already proved a substantial Codex Stop payload can launch the retro child and write offset state when the child succeeds, but the runtime path swallowed child failures and extractor output failures without a sanitized trace.
+
+The failing behavior was confirmed by RED tests: no debug JSONL existed for a child exit, and `runCodexHeadlessExtractionChecked` returned the same collapsed `{ ok:false, findings:[] }` shape for non-zero child exit, missing output, and malformed output. Schema-valid empty findings already returned `{ ok:true, findings:[] }`, but the Stop hook had no opt-in trace to make that visible when running out of band.
+
+Live Codex Desktop evidence from a temporary sanitized debug log confirmed:
+
+- Trigger reached `outcome: run` with `transcriptPathPresent: true`, `transcriptReadable: true`, `toolUses: 205`, `threshold: 3`, and `fires: 1`.
+- Retro CLI extraction returned `ok: false`, `failureReason: spawn_nonzero`, `exitCode: 1`, and `findingsCount: 0`.
+- The child command returned `status: 1`, `timedOut: false`, `pendingOffsetState: true`, and `ok: false`.
+- Spooling skipped append with `draftsPassed: 0`; filing saw `remainingDrafts: 0`; the Stop filing gate did not dispatch.
+
+The underlying root cause was the Codex extractor's working directory. Safeword intentionally runs extraction from a neutral temp directory so project hooks do not recurse and the extractor cannot mutate the user's repo. Claude accepts that neutral cwd. Codex 0.141.0 refuses to run `codex exec` outside a trusted/git directory unless `--skip-git-repo-check` is supplied. Because the runner closed stdio and ignored stderr, this surfaced only as exit code 1.
+
+Confirmed by exact helper replay with captured stderr: `Not inside a trusted directory and --skip-git-repo-check was not specified.` Confirmed fix by injecting `--skip-git-repo-check` into the same generated argv against the same transcript: extraction returned `ok: true`, `findingsCount: 0`, and the retro command exited 0.
+
+Ruled out: trigger skip, missing transcript, unreadable transcript, empty-findings success, filing-gate dispatch, offset-write failure, invalid model/flag shape, and transcript-specific schema failure. The offset write was not attempted in the failing run because the retro child exited non-zero before the fix.
+
+## Verification
+
+- PASS: `bun run test tests/hooks/retro-trigger-codex.test.ts tests/integration/codex-stop-retro.test.ts tests/hooks/retro-extract.test.ts tests/hooks/retro-debug.test.ts tests/commands/retro.test.ts` — 66 tests.
+- PASS: `bun run lint`.
+- PASS: `bun run test tests/schema.test.ts -t "should have entry for every template file"`.
+- PASS: `bun run knip`.
+- PASS: Audit rerun: config sync clean, dependency-cruiser clean, Knip clean, with baseline jscpd duplication and `knip` patch-version freshness reported.
+- PASS: `git diff --check`.
+- LIMIT: Full `bun run test` is not clean in this worktree because two unrelated tests fail and reproduce in isolation: `tests/integration/rust-golden-path.test.ts` scenario 10 and `tests/scripts/cleanup-zombies.test.ts` preview/--yes scenario. Focused retro coverage is green.
+
+## Runtime Evidence
+
+Captured one real Codex Stop run with debug logging enabled. The temporary capture switch was removed after inspection, the scratch JSONL was summarized above and removed, and the installed dogfood hook now matches the source template again.

--- a/.project/tickets/24WR26-codex-retro-runtime-completion/ticket.md
+++ b/.project/tickets/24WR26-codex-retro-runtime-completion/ticket.md
@@ -3,8 +3,8 @@ id: 24WR26
 slug: codex-retro-runtime-completion
 type: task
 subtype: bug-investigated
-phase: verify
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/960
 scope:
   - Debug Codex retro auto-run behavior from real Stop hook input through child extraction, draft spooling, and filing-gate visibility.
@@ -21,7 +21,7 @@ done_when:
   - Empty findings are visibly different from extractor failure.
   - The hook remains fail-open for normal users.
 created: 2026-07-08T01:49:10.650Z
-last_modified: 2026-07-11T05:17:25Z
+last_modified: 2026-07-13T02:45:13Z
 ---
 
 # Debug Codex retro runtime completion
@@ -43,6 +43,7 @@ last_modified: 2026-07-11T05:17:25Z
 - 2026-07-08T03:37:15Z Runtime boundary captured: live Stop decided to run with readable transcript and 205 tool uses, the retro CLI reported `failureReason: spawn_nonzero` / `exitCode: 1` from Codex extraction, the parent child exited `status: 1`, no offset state was written, and filing gate stayed silent. Removed the temporary Stop-input-session switch after capture.
 - 2026-07-08T05:05:01Z Root cause fixed: exact helper replay captured Codex stderr `Not inside a trusted directory and --skip-git-repo-check was not specified.` Added `--skip-git-repo-check` to the Codex extractor argv; the same real transcript replay now exits 0 with `retro_cli_extraction ok:true`.
 - 2026-07-11T05:17:25Z Review cleanup: full audit/quality/refactor pass added direct redaction/fail-open coverage for `retro-debug.ts`, extracted shared test JSONL parsing, and fixed Knip's intentional external `shellcheck` binary finding.
+- 2026-07-13T02:45:13Z Done: PR #994 CI passed lint plus full test jobs on Node 22.22.3 and Node 24 after rebasing onto `198a8d35`; ticket metadata moved to done so the ready-PR ticket gate can run cleanly.
 
 ## Test Plan
 
@@ -78,7 +79,8 @@ Ruled out: trigger skip, missing transcript, unreadable transcript, empty-findin
 - PASS: `bun run knip`.
 - PASS: Audit rerun: config sync clean, dependency-cruiser clean, Knip clean, with baseline jscpd duplication and `knip` patch-version freshness reported.
 - PASS: `git diff --check`.
-- LIMIT: Full `bun run test` is not clean in this worktree because two unrelated tests fail and reproduce in isolation: `tests/integration/rust-golden-path.test.ts` scenario 10 and `tests/scripts/cleanup-zombies.test.ts` preview/--yes scenario. Focused retro coverage is green.
+- PASS: PR #994 GitHub CI passed full `bun run --cwd packages/cli test`, BDD, release tests, lint, format, typecheck, deps, architecture, and ticket-ID checks on rebased head `0c211f45`.
+- LOCAL LIMIT: Two unrelated tests were flaky/environment-sensitive in this Mac worktree before CI: `tests/integration/rust-golden-path.test.ts` scenario 10 depends on local Clippy suggestion behavior, and `tests/scripts/cleanup-zombies.test.ts` preview/--yes depends on macOS temp-path spelling in process command matching. CI passed both full-suite jobs on Linux.
 
 ## Runtime Evidence
 

--- a/.project/tickets/24WR26-codex-retro-runtime-completion/verify.md
+++ b/.project/tickets/24WR26-codex-retro-runtime-completion/verify.md
@@ -1,0 +1,32 @@
+## Verify Checklist
+
+**Test Suite:** ⚠️ Focused issue suite passes 66/66 (`bun run test tests/hooks/retro-trigger-codex.test.ts tests/integration/codex-stop-retro.test.ts tests/hooks/retro-extract.test.ts tests/hooks/retro-debug.test.ts tests/commands/retro.test.ts`); full `bun run test` has 2 unrelated isolated failures
+**Gherkin:** ✅ 340 passed, 3 skipped (`cucumber-js --tags 'not @wip'` via full verify block)
+**Build:** ✅ Success (targeted test wrapper rebuilt `packages/cli/dist` with `tsup`)
+**Lint:** ✅ Clean (`bun run lint`; `git diff --check`)
+**Scenarios:** ⏭️ Skipped — task ticket has no `test-definitions.md`
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean — no runtime dependency changes; Knip clean after marking `shellcheck` as an intentional external binary
+**Parent Epic:** N/A
+**Reconcile:** ✅ Template/dogfood hook copies match for touched files
+**Experience:** ⏭️ N/A — internal hook diagnostics
+**Evidence limits:** ⚠️ Full suite currently fails outside this PR's scope: Rust clippy workspace-member scenario and cleanup-zombies preview/--yes scenario both reproduce when run alone
+
+## Notes
+
+- `bun run lint` passed, including ESLint, Gherkin lint, and `packages/cli` typecheck.
+- `bun run test tests/schema.test.ts -t "should have entry for every template file"` passed.
+- Real Codex Desktop Stop capture passed through the trigger and child boundary: `codex_stop_retro_decision` was `outcome: run`, `retro_cli_extraction` reported `failureReason: spawn_nonzero` / `exitCode: 1`, `codex_stop_child_exit` reported `status: 1` and `pendingOffsetState: true`, and no offset-state file was written because the child failed.
+- Re-ran the focused retro suite, `bun run typecheck`, `bun run lint:eslint`, and `git diff --check` after removing the temporary capture switch.
+- Captured the nested extractor stderr with the exact helper argv: Codex refused the neutral temp cwd because `--skip-git-repo-check` was missing.
+- Replayed the same real transcript after adding `--skip-git-repo-check`; `retro_cli_extraction` returned `ok:true` and the retro command exited 0.
+- `bun run test tests/hooks/retro-extract.test.ts` passed after pinning the Codex argv flag.
+- `bun run test tests/schema.test.ts -t "should have entry for every template file"` passed after final cleanup.
+- `/verify` run proof was unavailable in this Codex shell (`no run identity`); this is a task ticket and is not being marked done.
+- Full audit rerun passed config sync, dependency-cruiser, and Knip after adding `shellcheck` to the intentional external binaries. It still reports baseline jscpd duplication and `knip` 6.25.0 patch freshness.
+- Quality-review improvement: added direct unit coverage for `recordRetroDebugEvent` redaction and fail-open behavior.
+- Refactor improvement: extracted shared `readJsonlFile` test helper for diagnostics JSONL parsing.
+- Full verify attempt: `bun run test` ran 4,999 tests with 4,992 passed, 5 skipped, and 2 unrelated failures; BDD then passed 343 scenarios (340 passed, 3 skipped), and typecheck passed.
+- Isolated reruns confirmed the two full-suite failures reproduce outside the retro changes:
+  - `bun run test tests/integration/rust-golden-path.test.ts -t "lint hook runs cargo clippy with -p <package> for workspace member"` fails expecting Clippy to rewrite `"l"` to `'l'`.
+  - `bun run test tests/scripts/cleanup-zombies.test.ts -t "the victim survives a bare preview and dies under --yes"` fails because preview finds no matching process.

--- a/.safeword/hooks/codex/stop.ts
+++ b/.safeword/hooks/codex/stop.ts
@@ -23,6 +23,7 @@ import process from 'node:process';
 import { getActiveTicket } from '../lib/active-ticket.ts';
 import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
 import { readSessionActiveTicket } from '../lib/quality-state.ts';
+import { recordRetroDebugEvent } from '../lib/retro-debug.ts';
 import { decideRetroFilingGate } from '../lib/retro-filing-gate.ts';
 import { RETRO_CHILD_ENV, retroChildArgs } from '../lib/retro-extract.ts';
 import { resolveRunIdentity } from '../lib/run-identity.ts';
@@ -77,8 +78,19 @@ function resolveExtractCommand(
     : ['bunx', ['safeword@latest', ...retroArgs]];
 }
 
+function argvShape(args: readonly string[]): string[] {
+  return args.map(arg => (arg === 'retro' || arg.startsWith('--') ? arg : '<value>'));
+}
+
 function runRetroExtraction(projectDirectory: string, input: CodexStopInput): void {
-  if (!readSelfReportConfig(projectDirectory).surface) return;
+  if (!readSelfReportConfig(projectDirectory).surface) {
+    recordRetroDebugEvent({
+      event: 'codex_stop_retro_decision',
+      outcome: 'skip',
+      reason: 'surface_disabled',
+    });
+    return;
+  }
 
   let pendingOffsetState:
     { sessionId: string; state: OffsetState; baseDirectory: string | undefined } | undefined;
@@ -86,6 +98,9 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     env: process.env,
     countToolUses: countToolUsesCodex,
     resolveSessionId: resolveCodexSessionId,
+    onDecision: trace => {
+      recordRetroDebugEvent({ event: 'codex_stop_retro_decision', ...trace });
+    },
     writeOffsetState: (sessionId, state, baseDirectory) => {
       pendingOffsetState = { sessionId, state, baseDirectory };
     },
@@ -93,6 +108,7 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
   if (!decision) return;
 
   const [command, args] = resolveExtractCommand(projectDirectory, decision);
+  const startedAt = Date.now();
   const result = spawnSync(command, args, {
     cwd: projectDirectory,
     env: {
@@ -103,7 +119,22 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     stdio: 'ignore',
     timeout: 600_000,
   });
-  if (result.status !== 0 || result.error || !pendingOffsetState) return;
+  const error = result.error as (Error & { code?: string }) | undefined;
+  const ok = result.status === 0 && !result.error && pendingOffsetState !== undefined;
+  recordRetroDebugEvent({
+    event: 'codex_stop_child_exit',
+    command: nodePath.basename(command),
+    argvShape: argvShape(args),
+    status: result.status,
+    signal: result.signal,
+    errorName: error?.name,
+    errorCode: error?.code,
+    elapsedMs: Date.now() - startedAt,
+    timedOut: error?.code === 'ETIMEDOUT',
+    pendingOffsetState: pendingOffsetState !== undefined,
+    ok,
+  });
+  if (!ok) return;
 
   try {
     writeOffsetState(
@@ -111,7 +142,17 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
       pendingOffsetState.state,
       pendingOffsetState.baseDirectory,
     );
+    recordRetroDebugEvent({
+      event: 'codex_stop_offset_write',
+      sessionId: pendingOffsetState.sessionId,
+      ok: true,
+    });
   } catch {
+    recordRetroDebugEvent({
+      event: 'codex_stop_offset_write',
+      sessionId: pendingOffsetState.sessionId,
+      ok: false,
+    });
     // A state-write failure must not make Stop visible or blocking.
   }
 }
@@ -142,6 +183,11 @@ async function main(): Promise<string> {
   // tripwire, file gates the dispatch — evaluate unconditionally.
   const sessionId = resolveCodexSessionId(input, process.env);
   const dispatch = sessionId ? decideRetroFilingGate(projectDirectory, sessionId) : undefined;
+  recordRetroDebugEvent({
+    event: 'codex_stop_filing_gate',
+    sessionId,
+    dispatch: dispatch !== undefined,
+  });
   if (dispatch) return JSON.stringify({ decision: 'block', reason: dispatch });
 
   return SILENT;

--- a/.safeword/hooks/lib/retro-debug.ts
+++ b/.safeword/hooks/lib/retro-debug.ts
@@ -1,0 +1,60 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+export const RETRO_DEBUG_LOG_ENV = 'SAFEWORD_RETRO_DEBUG_LOG';
+
+type DebugValue =
+  string | number | boolean | null | undefined | DebugValue[] | { [key: string]: DebugValue };
+
+export type RetroDebugEvent = {
+  event: string;
+  [key: string]: DebugValue;
+};
+
+const REDACTED = '[redacted]';
+const REDACT_KEY_PATTERN =
+  /^(?:transcript|transcriptText|transcriptContent|prompt|stdout|stderr|findings|rawFindings|body)$/i;
+
+function sanitizeDebugValue(key: string, value: DebugValue): DebugValue {
+  if (value === undefined) return undefined;
+  if (REDACT_KEY_PATTERN.test(key)) return REDACTED;
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeDebugValue(key, item));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const sanitized: Record<string, DebugValue> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      const clean = sanitizeDebugValue(childKey, childValue);
+      if (clean !== undefined) sanitized[childKey] = clean;
+    }
+    return sanitized;
+  }
+  return value;
+}
+
+function sanitizedEvent(event: RetroDebugEvent): Record<string, DebugValue> {
+  const result: Record<string, DebugValue> = {};
+  for (const [key, value] of Object.entries(event)) {
+    const clean = sanitizeDebugValue(key, value);
+    if (clean !== undefined) result[key] = clean;
+  }
+  return result;
+}
+
+export function recordRetroDebugEvent(
+  event: RetroDebugEvent,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const logPath = env[RETRO_DEBUG_LOG_ENV];
+  if (!logPath) return;
+  try {
+    mkdirSync(nodePath.dirname(logPath), { recursive: true });
+    appendFileSync(
+      logPath,
+      `${JSON.stringify({ timestamp: new Date().toISOString(), ...sanitizedEvent(event) })}\n`,
+    );
+  } catch {
+    // Debugging must never make a hook or CLI run visible or blocking.
+  }
+}

--- a/.safeword/hooks/lib/retro-extract.ts
+++ b/.safeword/hooks/lib/retro-extract.ts
@@ -183,11 +183,13 @@ export interface CodexExtractArgvOptions {
  * Build the `codex exec` argv for a headless retro extraction. The digest is
  * inline in the prompt because `--output-schema` is ignored by Codex when the
  * task requires Read/MCP tool use. Hooks and MCP servers are explicitly disabled,
- * stdin is closed by the runner, and the sandbox is read-only.
+ * stdin is closed by the runner, the sandbox is read-only, and Codex is allowed
+ * to run from the neutral temp cwd rather than requiring a git repository.
  */
 export function buildCodexExtractArgv(options: CodexExtractArgvOptions): string[] {
   return [
     'exec',
+    '--skip-git-repo-check',
     '--ignore-user-config',
     '--disable',
     'hooks',
@@ -354,6 +356,10 @@ export interface CodexExtractionResult {
   /** True only when the child exited successfully and wrote schema-valid JSON. */
   ok: boolean;
   findings: unknown[];
+  /** Present only on extraction failure; lets callers distinguish empty success from failure. */
+  failureReason?: 'spawn_nonzero' | 'missing_output' | 'invalid_output' | 'spawn_or_io_error';
+  /** Child exit code when a process ran and exited non-zero. */
+  exitCode?: number | null;
 }
 
 /**
@@ -415,11 +421,21 @@ export async function runCodexHeadlessExtractionChecked(
       env: { ...dependencies.env, [RETRO_CHILD_ENV]: '1' },
       stdio: 'ignore',
     });
-    if (code !== 0) return { ok: false, findings: [] };
-    const findings = parseCodexFindingsOutput(readFile(outputPath));
-    return findings === undefined ? { ok: false, findings: [] } : { ok: true, findings };
+    if (code !== 0) {
+      return { ok: false, failureReason: 'spawn_nonzero', exitCode: code, findings: [] };
+    }
+    let rawOutput: string;
+    try {
+      rawOutput = readFile(outputPath);
+    } catch {
+      return { ok: false, failureReason: 'missing_output', findings: [] };
+    }
+    const findings = parseCodexFindingsOutput(rawOutput);
+    return findings === undefined
+      ? { ok: false, failureReason: 'invalid_output', findings: [] }
+      : { ok: true, findings };
   } catch {
-    return { ok: false, findings: [] };
+    return { ok: false, failureReason: 'spawn_or_io_error', findings: [] };
   }
 }
 

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -329,7 +329,45 @@ export interface RetroTriggerDeps {
   readOffsetState?: (sessionId: string, baseDirectory?: string) => OffsetState | undefined;
   /** Offset-state writer (injected for tests; defaults to the atomic fs helper). */
   writeOffsetState?: (sessionId: string, state: OffsetState, baseDirectory?: string) => void;
+  /** Optional sanitized decision trace for opt-in diagnostics. */
+  onDecision?: (trace: RetroRunTrace) => void;
 }
+
+export type RetroRunSkipReason =
+  | 'retro_child'
+  | 'missing_session_id'
+  | 'missing_transcript_path'
+  | 'unreadable_transcript'
+  | 'below_threshold'
+  | 'max_fires_reached'
+  | 'below_rearm_growth';
+
+export type RetroRunTrace =
+  | {
+      outcome: 'skip';
+      reason: RetroRunSkipReason;
+      sessionId?: string;
+      transcriptPathPresent?: boolean;
+      transcriptReadable?: boolean;
+      toolUses?: number;
+      threshold?: number;
+      priorToolUses?: number;
+      rearmGrowth?: number;
+      priorFires?: number;
+      maxFires?: number;
+    }
+  | {
+      outcome: 'run';
+      sessionId: string;
+      transcriptPathPresent: true;
+      transcriptReadable: true;
+      toolUses: number;
+      threshold: number;
+      priorToolUses?: number;
+      priorFires?: number;
+      windowStart: number;
+      fires: number;
+    };
 
 /**
  * Decide whether to surface a retro nudge for this Stop, and (when it does) mark
@@ -423,22 +461,44 @@ export function decideRetroRun(
   dependencies: RetroTriggerDeps = {},
 ): RetroRunDecision | undefined {
   const env = dependencies.env ?? (process.env as Record<string, string | undefined>);
+  const trace = dependencies.onDecision;
   // Recursion guard first: the auth-working headless child runs with hooks, so
   // without this it would re-fire retro endlessly.
-  if (isRetroChild(env)) return undefined;
+  if (isRetroChild(env)) {
+    trace?.({ outcome: 'skip', reason: 'retro_child' });
+    return undefined;
+  }
 
   const resolve = dependencies.resolveSessionId ?? resolveSessionId;
   const sessionId = resolve(input, env);
-  if (!sessionId) return undefined;
+  if (!sessionId) {
+    trace?.({ outcome: 'skip', reason: 'missing_session_id' });
+    return undefined;
+  }
 
   const transcriptPath = input.transcript_path;
-  if (!transcriptPath || transcriptPath.length === 0) return undefined;
+  if (!transcriptPath || transcriptPath.length === 0) {
+    trace?.({
+      outcome: 'skip',
+      reason: 'missing_transcript_path',
+      sessionId,
+      transcriptPathPresent: false,
+    });
+    return undefined;
+  }
 
   const read = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
   let transcript: string;
   try {
     transcript = read(transcriptPath);
   } catch {
+    trace?.({
+      outcome: 'skip',
+      reason: 'unreadable_transcript',
+      sessionId,
+      transcriptPathPresent: true,
+      transcriptReadable: false,
+    });
     return undefined; // unreadable transcript → fail open
   }
 
@@ -456,16 +516,66 @@ export function decideRetroRun(
   let fires: number;
   if (!prior) {
     // First fire: substance gate, digest from the start of the transcript.
-    if (toolUses < threshold) return undefined;
+    if (toolUses < threshold) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'below_threshold',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        threshold,
+      });
+      return undefined;
+    }
     windowStart = 0;
     fires = 1;
   } else {
     // Re-fire: bounded by the runaway backstop, then gated by additive growth.
-    if (prior.fires >= maxFires) return undefined;
-    if (toolUses - prior.toolUses < rearmGrowth) return undefined;
+    if (prior.fires >= maxFires) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'max_fires_reached',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        priorToolUses: prior.toolUses,
+        priorFires: prior.fires,
+        maxFires,
+      });
+      return undefined;
+    }
+    if (toolUses - prior.toolUses < rearmGrowth) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'below_rearm_growth',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        priorToolUses: prior.toolUses,
+        rearmGrowth,
+        priorFires: prior.fires,
+      });
+      return undefined;
+    }
     windowStart = prior.offset;
     fires = prior.fires + 1;
   }
+
+  trace?.({
+    outcome: 'run',
+    sessionId,
+    transcriptPathPresent: true,
+    transcriptReadable: true,
+    toolUses,
+    threshold,
+    priorToolUses: prior?.toolUses,
+    priorFires: prior?.fires,
+    windowStart,
+    fires,
+  });
 
   try {
     writeState(sessionId, { offset: transcript.length, toolUses, fires }, baseDirectory);

--- a/.safeword/logs/ticket-24WR26-codex-retro-runtime-completion.md
+++ b/.safeword/logs/ticket-24WR26-codex-retro-runtime-completion.md
@@ -1,0 +1,34 @@
+# Work Log: Debug Codex retro runtime completion
+
+**Anchored to:** `.project/tickets/24WR26-codex-retro-runtime-completion/ticket.md`
+
+---
+
+## Session: 2026-07-08
+
+- [01:46] Read `CLAUDE.md` and source `packages/cli/templates/SAFEWORD.md` first, per user request.
+- [01:47] Fetched GitHub issue #960. Scope is internal Codex retro runtime debugging with fail-open and no raw transcript logging.
+- [01:49] Created task ticket `24WR26-codex-retro-runtime-completion`.
+- [01:50] Baseline focused tests passed: `retro-trigger-codex`, `codex-stop-retro`, and `retro-extract`.
+- [01:54] RED confirmed: new tests fail because no opt-in debug JSONL is written and `runCodexHeadlessExtractionChecked` collapses failure causes.
+- [02:00] GREEN confirmed: focused retro tests pass 51/51 after adding opt-in diagnostics and extraction failure reasons.
+- [02:01] Schema registration and typecheck passed; final targeted issue suite passes 64/64.
+- [02:02] Current shell exposes `CODEX_THREAD_ID` but not `transcript_path`; live desktop Stop cause remains a deferred runtime capture, not a code/test blocker.
+- [02:06] ESLint passed. Wrote partial `verify.md`; task remains `in_progress` because real Codex Stop evidence is still needed.
+- [02:11] Armed one real Stop capture by temporarily setting `SAFEWORD_RETRO_DEBUG_LOG` in `.codex/config.toml` to `.project/tmp/codex-retro-stop-019f3f65-b385-7f31-b4be-57a8bbab420e.jsonl`. Revert this config edit after inspection.
+- [02:17] First live capture attempt did not write debug JSONL. Evidence: empty draft file touched at 19:12:39 PDT, no `/tmp` offset state, and `.codex/config.toml` prefix likely did not reach the already-running trusted hook command. Reverted the config edit and armed a temporary current-thread fallback inside `.safeword/hooks/lib/retro-debug.ts`; remove it after the next Stop capture.
+- [03:02] Second live capture attempt did not write debug JSONL either. Evidence: empty draft file touched again at 19:18:25 PDT, still no `/tmp` offset state. Inference: Codex Stop does not expose `CODEX_THREAD_ID` in the hook process env. Removed that fallback and armed the capture from parsed Stop input session id in `.safeword/hooks/codex/stop.ts`; remove this temporary switch after the next Stop capture.
+- [03:37] Third live capture succeeded. Stop trigger ran with readable transcript and 205 tool uses; the retro CLI reported Codex extraction `spawn_nonzero` with exit code 1; parent child exit was status 1 with pending offset state; no offset state was written; filing gate did not dispatch. Removed the temporary Stop-input-session switch and confirmed installed hook copies match templates.
+- [03:39] Final cleanup verification passed: focused retro suite 64/64, typecheck, ESLint, and `git diff --check`.
+- [05:02] Replayed the retro CLI against the real Codex transcript outside Stop; reproduced exit 1 with `retro_cli_extraction failureReason=spawn_nonzero`.
+- [05:03] Captured nested `codex exec` stderr through an injected spawn: `Not inside a trusted directory and --skip-git-repo-check was not specified.` Injecting `--skip-git-repo-check` into the same argv returned `ok:true`.
+- [05:05] Added `--skip-git-repo-check` to the shipped Codex extractor argv. Real transcript replay now exits 0 with `retro_cli_extraction ok:true`.
+- [05:13] Full verify attempt was blocked by an active Vitest run in another safeword worktree holding the package build/test lock. Stopped only this waiting command; will retry full verify before PR after the external lock clears.
+- [05:17] Review pass complete: audit found `shellcheck` as an intentional external binary; added it to Knip ignore binaries. Quality review added direct `retro-debug` redaction/fail-open coverage. Refactor extracted shared `readJsonlFile` test helper.
+- [05:17] Verification update: focused retro suite now passes 66/66; `bun run lint`, schema registration, Knip, and `git diff --check` pass. Full `bun run test` still fails two unrelated tests, and both reproduce in isolation: Rust clippy workspace-member scenario and cleanup-zombies preview/--yes scenario.
+
+## Hypotheses
+
+- H1: Codex Stop reaches the child but the child exits non-zero; current `stdio: 'ignore'` hides that. RED test targets child status diagnostics.
+- H2: Extraction succeeds with `findings: []`; current external artifacts can look like failure unless success is recorded. RED test targets `ok:true` empty findings versus explicit failure reasons.
+- H3: Trigger gates skip before child launch; decision tracing needs reason codes so missing session, transcript, unreadable transcript, and below-threshold count are distinguishable.

--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,7 @@
     "claude",
     "codex",
     "gh",
+    "shellcheck",
     "rustup",
     "ruff",
     "golangci-lint",

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -21,7 +21,9 @@ import nodePath from 'node:path';
 import process from 'node:process';
 
 import { isDogfoodRepo } from '../../templates/hooks/lib/dogfood.js';
+import { recordRetroDebugEvent } from '../../templates/hooks/lib/retro-debug.js';
 import {
+  draftSpoolPath,
   markDraftsFiled,
   readSpooledDrafts,
   spoolDrafts,
@@ -140,11 +142,15 @@ export async function runRetro(
   // REST auth failure (cloud #568) can't lose them. Opt-in via projectDirectory.
   const { projectDirectory, sessionId } = dependencies;
   if (projectDirectory !== undefined) {
-    spoolDrafts(
-      projectDirectory,
+    const drafts = encounters.map(encounter => encounter.draft);
+    recordRetroDebugEvent({
+      event: 'retro_cli_spool',
       sessionId,
-      encounters.map(encounter => encounter.draft),
-    );
+      draftsPassed: drafts.length,
+      skippedAppend: drafts.length === 0,
+      spoolFile: nodePath.relative(projectDirectory, draftSpoolPath(projectDirectory, sessionId)),
+    });
+    spoolDrafts(projectDirectory, sessionId, drafts);
   }
 
   const provenance = dependencies.resolveProvenance?.();
@@ -159,7 +165,15 @@ export async function runRetro(
   // Drain the drafts that reached the tracker; failed/deferred stay spooled for the
   // agent path. agentFilingNeeded = anything still spooled after the drain.
   markDraftsFiled(projectDirectory, sessionId, result.filedSignatures);
-  const agentFilingNeeded = readSpooledDrafts(projectDirectory, sessionId).length > 0;
+  const remainingDrafts = readSpooledDrafts(projectDirectory, sessionId).length;
+  const agentFilingNeeded = remainingDrafts > 0;
+  recordRetroDebugEvent({
+    event: 'retro_cli_filing',
+    sessionId,
+    filedCount: result.filedSignatures.length,
+    remainingDrafts,
+    agentFilingNeeded,
+  });
   return { ok: true, result, agentFilingNeeded, drops };
 }
 
@@ -245,6 +259,14 @@ export async function buildAutoExtractor(
         model,
         schemaPath: nodePath.join(workDirectory, 'schema.json'),
         outputPath: nodePath.join(workDirectory, 'output.json'),
+      });
+      recordRetroDebugEvent({
+        event: 'retro_cli_extraction',
+        agent: 'codex',
+        ok: result.ok,
+        findingsCount: result.findings.length,
+        failureReason: result.failureReason,
+        exitCode: result.exitCode,
       });
       dependencies.onExtractionResult?.(result);
       return result.findings;

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -785,6 +785,7 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/hooks/lib/jsonl-spool.ts': { template: 'hooks/lib/jsonl-spool.ts' },
     '.safeword/hooks/lib/namespace-root.ts': { template: 'hooks/lib/namespace-root.ts' },
     '.safeword/hooks/lib/retro-draft-spool.ts': { template: 'hooks/lib/retro-draft-spool.ts' },
+    '.safeword/hooks/lib/retro-debug.ts': { template: 'hooks/lib/retro-debug.ts' },
     '.safeword/hooks/lib/retro-extract.ts': { template: 'hooks/lib/retro-extract.ts' },
     '.safeword/hooks/lib/retro-filing-gate.ts': { template: 'hooks/lib/retro-filing-gate.ts' },
     '.safeword/hooks/lib/retro-nudge.ts': { template: 'hooks/lib/retro-nudge.ts' },

--- a/packages/cli/templates/hooks/codex/stop.ts
+++ b/packages/cli/templates/hooks/codex/stop.ts
@@ -23,6 +23,7 @@ import process from 'node:process';
 import { getActiveTicket } from '../lib/active-ticket.ts';
 import { architectureDocumentNudgeForProject } from '../lib/architecture-document-nudge.ts';
 import { readSessionActiveTicket } from '../lib/quality-state.ts';
+import { recordRetroDebugEvent } from '../lib/retro-debug.ts';
 import { decideRetroFilingGate } from '../lib/retro-filing-gate.ts';
 import { RETRO_CHILD_ENV, retroChildArgs } from '../lib/retro-extract.ts';
 import { resolveRunIdentity } from '../lib/run-identity.ts';
@@ -77,8 +78,19 @@ function resolveExtractCommand(
     : ['bunx', ['safeword@latest', ...retroArgs]];
 }
 
+function argvShape(args: readonly string[]): string[] {
+  return args.map(arg => (arg === 'retro' || arg.startsWith('--') ? arg : '<value>'));
+}
+
 function runRetroExtraction(projectDirectory: string, input: CodexStopInput): void {
-  if (!readSelfReportConfig(projectDirectory).surface) return;
+  if (!readSelfReportConfig(projectDirectory).surface) {
+    recordRetroDebugEvent({
+      event: 'codex_stop_retro_decision',
+      outcome: 'skip',
+      reason: 'surface_disabled',
+    });
+    return;
+  }
 
   let pendingOffsetState:
     { sessionId: string; state: OffsetState; baseDirectory: string | undefined } | undefined;
@@ -86,6 +98,9 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     env: process.env,
     countToolUses: countToolUsesCodex,
     resolveSessionId: resolveCodexSessionId,
+    onDecision: trace => {
+      recordRetroDebugEvent({ event: 'codex_stop_retro_decision', ...trace });
+    },
     writeOffsetState: (sessionId, state, baseDirectory) => {
       pendingOffsetState = { sessionId, state, baseDirectory };
     },
@@ -93,6 +108,7 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
   if (!decision) return;
 
   const [command, args] = resolveExtractCommand(projectDirectory, decision);
+  const startedAt = Date.now();
   const result = spawnSync(command, args, {
     cwd: projectDirectory,
     env: {
@@ -103,7 +119,22 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     stdio: 'ignore',
     timeout: 600_000,
   });
-  if (result.status !== 0 || result.error || !pendingOffsetState) return;
+  const error = result.error as (Error & { code?: string }) | undefined;
+  const ok = result.status === 0 && !result.error && pendingOffsetState !== undefined;
+  recordRetroDebugEvent({
+    event: 'codex_stop_child_exit',
+    command: nodePath.basename(command),
+    argvShape: argvShape(args),
+    status: result.status,
+    signal: result.signal,
+    errorName: error?.name,
+    errorCode: error?.code,
+    elapsedMs: Date.now() - startedAt,
+    timedOut: error?.code === 'ETIMEDOUT',
+    pendingOffsetState: pendingOffsetState !== undefined,
+    ok,
+  });
+  if (!ok) return;
 
   try {
     writeOffsetState(
@@ -111,7 +142,17 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
       pendingOffsetState.state,
       pendingOffsetState.baseDirectory,
     );
+    recordRetroDebugEvent({
+      event: 'codex_stop_offset_write',
+      sessionId: pendingOffsetState.sessionId,
+      ok: true,
+    });
   } catch {
+    recordRetroDebugEvent({
+      event: 'codex_stop_offset_write',
+      sessionId: pendingOffsetState.sessionId,
+      ok: false,
+    });
     // A state-write failure must not make Stop visible or blocking.
   }
 }
@@ -142,6 +183,11 @@ async function main(): Promise<string> {
   // tripwire, file gates the dispatch — evaluate unconditionally.
   const sessionId = resolveCodexSessionId(input, process.env);
   const dispatch = sessionId ? decideRetroFilingGate(projectDirectory, sessionId) : undefined;
+  recordRetroDebugEvent({
+    event: 'codex_stop_filing_gate',
+    sessionId,
+    dispatch: dispatch !== undefined,
+  });
   if (dispatch) return JSON.stringify({ decision: 'block', reason: dispatch });
 
   return SILENT;

--- a/packages/cli/templates/hooks/lib/retro-debug.ts
+++ b/packages/cli/templates/hooks/lib/retro-debug.ts
@@ -1,0 +1,60 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+export const RETRO_DEBUG_LOG_ENV = 'SAFEWORD_RETRO_DEBUG_LOG';
+
+type DebugValue =
+  string | number | boolean | null | undefined | DebugValue[] | { [key: string]: DebugValue };
+
+export type RetroDebugEvent = {
+  event: string;
+  [key: string]: DebugValue;
+};
+
+const REDACTED = '[redacted]';
+const REDACT_KEY_PATTERN =
+  /^(?:transcript|transcriptText|transcriptContent|prompt|stdout|stderr|findings|rawFindings|body)$/i;
+
+function sanitizeDebugValue(key: string, value: DebugValue): DebugValue {
+  if (value === undefined) return undefined;
+  if (REDACT_KEY_PATTERN.test(key)) return REDACTED;
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeDebugValue(key, item));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const sanitized: Record<string, DebugValue> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      const clean = sanitizeDebugValue(childKey, childValue);
+      if (clean !== undefined) sanitized[childKey] = clean;
+    }
+    return sanitized;
+  }
+  return value;
+}
+
+function sanitizedEvent(event: RetroDebugEvent): Record<string, DebugValue> {
+  const result: Record<string, DebugValue> = {};
+  for (const [key, value] of Object.entries(event)) {
+    const clean = sanitizeDebugValue(key, value);
+    if (clean !== undefined) result[key] = clean;
+  }
+  return result;
+}
+
+export function recordRetroDebugEvent(
+  event: RetroDebugEvent,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const logPath = env[RETRO_DEBUG_LOG_ENV];
+  if (!logPath) return;
+  try {
+    mkdirSync(nodePath.dirname(logPath), { recursive: true });
+    appendFileSync(
+      logPath,
+      `${JSON.stringify({ timestamp: new Date().toISOString(), ...sanitizedEvent(event) })}\n`,
+    );
+  } catch {
+    // Debugging must never make a hook or CLI run visible or blocking.
+  }
+}

--- a/packages/cli/templates/hooks/lib/retro-extract.ts
+++ b/packages/cli/templates/hooks/lib/retro-extract.ts
@@ -183,11 +183,13 @@ export interface CodexExtractArgvOptions {
  * Build the `codex exec` argv for a headless retro extraction. The digest is
  * inline in the prompt because `--output-schema` is ignored by Codex when the
  * task requires Read/MCP tool use. Hooks and MCP servers are explicitly disabled,
- * stdin is closed by the runner, and the sandbox is read-only.
+ * stdin is closed by the runner, the sandbox is read-only, and Codex is allowed
+ * to run from the neutral temp cwd rather than requiring a git repository.
  */
 export function buildCodexExtractArgv(options: CodexExtractArgvOptions): string[] {
   return [
     'exec',
+    '--skip-git-repo-check',
     '--ignore-user-config',
     '--disable',
     'hooks',
@@ -354,6 +356,10 @@ export interface CodexExtractionResult {
   /** True only when the child exited successfully and wrote schema-valid JSON. */
   ok: boolean;
   findings: unknown[];
+  /** Present only on extraction failure; lets callers distinguish empty success from failure. */
+  failureReason?: 'spawn_nonzero' | 'missing_output' | 'invalid_output' | 'spawn_or_io_error';
+  /** Child exit code when a process ran and exited non-zero. */
+  exitCode?: number | null;
 }
 
 /**
@@ -415,11 +421,21 @@ export async function runCodexHeadlessExtractionChecked(
       env: { ...dependencies.env, [RETRO_CHILD_ENV]: '1' },
       stdio: 'ignore',
     });
-    if (code !== 0) return { ok: false, findings: [] };
-    const findings = parseCodexFindingsOutput(readFile(outputPath));
-    return findings === undefined ? { ok: false, findings: [] } : { ok: true, findings };
+    if (code !== 0) {
+      return { ok: false, failureReason: 'spawn_nonzero', exitCode: code, findings: [] };
+    }
+    let rawOutput: string;
+    try {
+      rawOutput = readFile(outputPath);
+    } catch {
+      return { ok: false, failureReason: 'missing_output', findings: [] };
+    }
+    const findings = parseCodexFindingsOutput(rawOutput);
+    return findings === undefined
+      ? { ok: false, failureReason: 'invalid_output', findings: [] }
+      : { ok: true, findings };
   } catch {
-    return { ok: false, findings: [] };
+    return { ok: false, failureReason: 'spawn_or_io_error', findings: [] };
   }
 }
 

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -329,7 +329,45 @@ export interface RetroTriggerDeps {
   readOffsetState?: (sessionId: string, baseDirectory?: string) => OffsetState | undefined;
   /** Offset-state writer (injected for tests; defaults to the atomic fs helper). */
   writeOffsetState?: (sessionId: string, state: OffsetState, baseDirectory?: string) => void;
+  /** Optional sanitized decision trace for opt-in diagnostics. */
+  onDecision?: (trace: RetroRunTrace) => void;
 }
+
+export type RetroRunSkipReason =
+  | 'retro_child'
+  | 'missing_session_id'
+  | 'missing_transcript_path'
+  | 'unreadable_transcript'
+  | 'below_threshold'
+  | 'max_fires_reached'
+  | 'below_rearm_growth';
+
+export type RetroRunTrace =
+  | {
+      outcome: 'skip';
+      reason: RetroRunSkipReason;
+      sessionId?: string;
+      transcriptPathPresent?: boolean;
+      transcriptReadable?: boolean;
+      toolUses?: number;
+      threshold?: number;
+      priorToolUses?: number;
+      rearmGrowth?: number;
+      priorFires?: number;
+      maxFires?: number;
+    }
+  | {
+      outcome: 'run';
+      sessionId: string;
+      transcriptPathPresent: true;
+      transcriptReadable: true;
+      toolUses: number;
+      threshold: number;
+      priorToolUses?: number;
+      priorFires?: number;
+      windowStart: number;
+      fires: number;
+    };
 
 /**
  * Decide whether to surface a retro nudge for this Stop, and (when it does) mark
@@ -423,22 +461,44 @@ export function decideRetroRun(
   dependencies: RetroTriggerDeps = {},
 ): RetroRunDecision | undefined {
   const env = dependencies.env ?? (process.env as Record<string, string | undefined>);
+  const trace = dependencies.onDecision;
   // Recursion guard first: the auth-working headless child runs with hooks, so
   // without this it would re-fire retro endlessly.
-  if (isRetroChild(env)) return undefined;
+  if (isRetroChild(env)) {
+    trace?.({ outcome: 'skip', reason: 'retro_child' });
+    return undefined;
+  }
 
   const resolve = dependencies.resolveSessionId ?? resolveSessionId;
   const sessionId = resolve(input, env);
-  if (!sessionId) return undefined;
+  if (!sessionId) {
+    trace?.({ outcome: 'skip', reason: 'missing_session_id' });
+    return undefined;
+  }
 
   const transcriptPath = input.transcript_path;
-  if (!transcriptPath || transcriptPath.length === 0) return undefined;
+  if (!transcriptPath || transcriptPath.length === 0) {
+    trace?.({
+      outcome: 'skip',
+      reason: 'missing_transcript_path',
+      sessionId,
+      transcriptPathPresent: false,
+    });
+    return undefined;
+  }
 
   const read = dependencies.readFile ?? ((path: string) => readFileSync(path, 'utf8'));
   let transcript: string;
   try {
     transcript = read(transcriptPath);
   } catch {
+    trace?.({
+      outcome: 'skip',
+      reason: 'unreadable_transcript',
+      sessionId,
+      transcriptPathPresent: true,
+      transcriptReadable: false,
+    });
     return undefined; // unreadable transcript → fail open
   }
 
@@ -456,16 +516,66 @@ export function decideRetroRun(
   let fires: number;
   if (!prior) {
     // First fire: substance gate, digest from the start of the transcript.
-    if (toolUses < threshold) return undefined;
+    if (toolUses < threshold) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'below_threshold',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        threshold,
+      });
+      return undefined;
+    }
     windowStart = 0;
     fires = 1;
   } else {
     // Re-fire: bounded by the runaway backstop, then gated by additive growth.
-    if (prior.fires >= maxFires) return undefined;
-    if (toolUses - prior.toolUses < rearmGrowth) return undefined;
+    if (prior.fires >= maxFires) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'max_fires_reached',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        priorToolUses: prior.toolUses,
+        priorFires: prior.fires,
+        maxFires,
+      });
+      return undefined;
+    }
+    if (toolUses - prior.toolUses < rearmGrowth) {
+      trace?.({
+        outcome: 'skip',
+        reason: 'below_rearm_growth',
+        sessionId,
+        transcriptPathPresent: true,
+        transcriptReadable: true,
+        toolUses,
+        priorToolUses: prior.toolUses,
+        rearmGrowth,
+        priorFires: prior.fires,
+      });
+      return undefined;
+    }
     windowStart = prior.offset;
     fires = prior.fires + 1;
   }
+
+  trace?.({
+    outcome: 'run',
+    sessionId,
+    transcriptPathPresent: true,
+    transcriptReadable: true,
+    toolUses,
+    threshold,
+    priorToolUses: prior?.toolUses,
+    priorFires: prior?.fires,
+    windowStart,
+    fires,
+  });
 
   try {
     writeState(sessionId, { offset: transcript.length, toolUses, fires }, baseDirectory);

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -24,6 +24,7 @@ import {
   verifyDraftBody,
 } from '../../templates/hooks/lib/retro-draft-spool.js';
 import { DIGEST_CAP, runHeadlessExtraction } from '../../templates/hooks/lib/retro-extract.js';
+import { readJsonlFile } from '../helpers.js';
 
 vi.mock('../../src/retro/github-rest.js', () => ({
   createRestTransport: () => {},
@@ -336,6 +337,52 @@ describe('runRetro', () => {
       }),
     );
     expect(transport.issues).toHaveLength(0);
+  });
+
+  it('traces empty post-egress spool calls separately from extraction failure', async () => {
+    const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-empty-spool-'));
+    const debugLog = nodePath.join(projectDirectory, 'retro-debug.jsonl');
+    const previousDebugLog = process.env.SAFEWORD_RETRO_DEBUG_LOG;
+    let events: Record<string, unknown>[] | undefined;
+    process.env.SAFEWORD_RETRO_DEBUG_LOG = debugLog;
+    try {
+      await runRetro(
+        { transcript: '/t.jsonl' },
+        dependencies({
+          projectDirectory,
+          extract: () => Promise.resolve([]),
+          transport: new FakeGitHub(),
+          sessionId: 'empty-findings',
+          readFile: () => 'transcript content',
+        }),
+      );
+      events = readJsonlFile(debugLog);
+    } finally {
+      if (previousDebugLog === undefined) {
+        delete process.env.SAFEWORD_RETRO_DEBUG_LOG;
+      } else {
+        process.env.SAFEWORD_RETRO_DEBUG_LOG = previousDebugLog;
+      }
+      rmSync(projectDirectory, { recursive: true, force: true });
+    }
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'retro_cli_spool',
+          sessionId: 'empty-findings',
+          draftsPassed: 0,
+          skippedAppend: true,
+        }),
+        expect.objectContaining({
+          event: 'retro_cli_filing',
+          sessionId: 'empty-findings',
+          filedCount: 0,
+          remainingDrafts: 0,
+          agentFilingNeeded: false,
+        }),
+      ]),
+    );
   });
 });
 

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -101,6 +101,13 @@ export function createTemporaryDirectory(): string {
   return mkdtempSync(nodePath.join(tmpdir(), 'safeword-test-'));
 }
 
+export function readJsonlFile(path: string): Record<string, unknown>[] {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter(line => line.trim().length > 0)
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
 export function installFakeCodexCli(projectRoot: string, version: string): string {
   const fakeBin = nodePath.join(projectRoot, 'bin');
   mkdirSync(fakeBin);

--- a/packages/cli/tests/hooks/retro-debug.test.ts
+++ b/packages/cli/tests/hooks/retro-debug.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  recordRetroDebugEvent,
+  RETRO_DEBUG_LOG_ENV,
+} from '../../templates/hooks/lib/retro-debug.js';
+import { readJsonlFile } from '../helpers.js';
+
+describe('recordRetroDebugEvent', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(nodePath.join(tmpdir(), 'retro-debug-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes opt-in sanitized JSONL without raw transcript or model output content', () => {
+    const logPath = nodePath.join(dir, 'nested', 'retro-debug.jsonl');
+
+    recordRetroDebugEvent(
+      {
+        event: 'retro_cli_extraction',
+        sessionId: 'session-1',
+        transcriptPathPresent: true,
+        transcriptText: 'RAW TRANSCRIPT',
+        prompt: 'RAW PROMPT',
+        stdout: 'RAW STDOUT',
+        stderr: 'RAW STDERR',
+        findings: [{ title: 'RAW FINDING' }],
+        nested: {
+          rawFindings: ['RAW NESTED FINDING'],
+          body: 'RAW BODY',
+          safeCount: 2,
+        },
+      },
+      { [RETRO_DEBUG_LOG_ENV]: logPath },
+    );
+
+    const [event] = readJsonlFile(logPath);
+    expect(event).toEqual(
+      expect.objectContaining({
+        event: 'retro_cli_extraction',
+        sessionId: 'session-1',
+        transcriptPathPresent: true,
+        transcriptText: '[redacted]',
+        prompt: '[redacted]',
+        stdout: '[redacted]',
+        stderr: '[redacted]',
+        findings: '[redacted]',
+        nested: {
+          rawFindings: '[redacted]',
+          body: '[redacted]',
+          safeCount: 2,
+        },
+      }),
+    );
+
+    const rawLog = readFileSync(logPath, 'utf8');
+    expect(rawLog).not.toContain('RAW TRANSCRIPT');
+    expect(rawLog).not.toContain('RAW FINDING');
+    expect(rawLog).not.toContain('RAW BODY');
+  });
+
+  it('stays silent when disabled and fail-open when the log path is unwritable', () => {
+    const disabledPath = nodePath.join(dir, 'disabled.jsonl');
+    recordRetroDebugEvent({ event: 'disabled' }, {});
+    expect(existsSync(disabledPath)).toBe(false);
+
+    const blockedParent = nodePath.join(dir, 'blocked');
+    writeFileSync(blockedParent, 'not a directory');
+    expect(() => {
+      recordRetroDebugEvent(
+        { event: 'unwritable', transcript: 'RAW TRANSCRIPT' },
+        { [RETRO_DEBUG_LOG_ENV]: nodePath.join(blockedParent, 'retro-debug.jsonl') },
+      );
+    }).not.toThrow();
+  });
+});

--- a/packages/cli/tests/hooks/retro-extract.test.ts
+++ b/packages/cli/tests/hooks/retro-extract.test.ts
@@ -158,7 +158,8 @@ describe('buildExtractArgv', () => {
 
 describe('buildCodexExtractArgv', () => {
   // codex-retro-parity.SM1.AC1 — Codex extraction runs through `codex exec` with
-  // structured output, closed stdin, no hooks/MCP, and an inline digest prompt.
+  // structured output, closed stdin, no hooks/MCP, a neutral temp cwd, and an
+  // inline digest prompt.
   it('builds the gated codex exec argv used by the Stop hook child', () => {
     const argv = buildCodexExtractArgv({
       model: 'gpt-5.5',
@@ -167,7 +168,7 @@ describe('buildCodexExtractArgv', () => {
       prompt: 'INLINE DIGEST',
     });
 
-    expect(argv.slice(0, 2)).toEqual(['exec', '--ignore-user-config']);
+    expect(argv.slice(0, 3)).toEqual(['exec', '--skip-git-repo-check', '--ignore-user-config']);
     expect(argv).toContain('--disable');
     expect(argv[argv.indexOf('--disable') + 1]).toBe('hooks');
     expect(argv).toContain('-c');
@@ -376,6 +377,8 @@ describe('runCodexHeadlessExtraction', () => {
     await expect(runCodexHeadlessExtraction('t', nonZero.deps)).resolves.toEqual([]);
     await expect(runCodexHeadlessExtractionChecked('t', nonZero.deps)).resolves.toEqual({
       ok: false,
+      failureReason: 'spawn_nonzero',
+      exitCode: 1,
       findings: [],
     });
 
@@ -391,6 +394,7 @@ describe('runCodexHeadlessExtraction', () => {
     await expect(runCodexHeadlessExtraction('t', invalid.deps)).resolves.toEqual([]);
     await expect(runCodexHeadlessExtractionChecked('t', invalid.deps)).resolves.toEqual({
       ok: false,
+      failureReason: 'invalid_output',
       findings: [],
     });
   });
@@ -408,6 +412,18 @@ describe('runCodexHeadlessExtraction', () => {
 
     await expect(runCodexHeadlessExtractionChecked('t', empty.deps)).resolves.toEqual({
       ok: true,
+      findings: [],
+    });
+  });
+
+  it('distinguishes missing output from a schema-valid empty findings array', async () => {
+    const missing = codexDependencies({
+      spawn: () => Promise.resolve({ code: 0, stdout: '' }),
+    });
+
+    await expect(runCodexHeadlessExtractionChecked('t', missing.deps)).resolves.toEqual({
+      ok: false,
+      failureReason: 'missing_output',
       findings: [],
     });
   });

--- a/packages/cli/tests/integration/codex-stop-retro.test.ts
+++ b/packages/cli/tests/integration/codex-stop-retro.test.ts
@@ -23,6 +23,7 @@ import { offsetStatePath, sentinelPath } from '../../templates/hooks/lib/retro-t
 import { readSessionReports } from '../../templates/hooks/lib/self-report.js';
 import {
   createTemporaryDirectory,
+  readJsonlFile,
   removeTemporaryDirectory,
   retroDraft,
   TIMEOUT_QUICK,
@@ -105,6 +106,7 @@ function expectNoContinuation(result: ReturnType<typeof runHook>): void {
 describe('codex/stop.ts retro adapter (CDX602)', () => {
   let dir: string;
   let recordPath: string;
+  let debugLogPath: string;
   const sessionIds: string[] = [];
 
   function freshSession(tag: string): string {
@@ -116,6 +118,7 @@ describe('codex/stop.ts retro adapter (CDX602)', () => {
   beforeEach(() => {
     dir = createTemporaryDirectory();
     recordPath = nodePath.join(dir, 'child-record.json');
+    debugLogPath = nodePath.join(dir, 'retro-debug.jsonl');
   });
   afterEach(() => {
     removeTemporaryDirectory(dir);
@@ -153,6 +156,49 @@ describe('codex/stop.ts retro adapter (CDX602)', () => {
     expect(record.argv[record.argv.indexOf('--transcript') + 1]).toBe(transcript);
     expect(record.argv[record.argv.indexOf('--window-start') + 1]).toBe('0');
     expect(record.argv[record.argv.indexOf('--session-id') + 1]).toBe(id);
+    expect(existsSync(offsetStatePath(id))).toBe(true);
+  });
+
+  it('writes opt-in sanitized diagnostics for Codex Stop child failures', () => {
+    writeConfig(dir, { surface: true });
+    installFakeLocalCli(dir, { exitCode: 7 });
+    const transcript = writeCodexRollout(dir, 'big.jsonl', 8);
+    const id = freshSession('debugfail');
+
+    const result = runHook(
+      dir,
+      { session_id: id, transcript_path: transcript, cwd: dir },
+      {
+        RECORD_PATH: recordPath,
+        SAFEWORD_RETRO_DEBUG_LOG: debugLogPath,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expectNoContinuation(result);
+    expect(existsSync(offsetStatePath(id))).toBe(false);
+
+    const events = readJsonlFile(debugLogPath);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'codex_stop_retro_decision',
+          outcome: 'run',
+          toolUses: 8,
+          windowStart: 0,
+        }),
+        expect.objectContaining({
+          event: 'codex_stop_child_exit',
+          status: 7,
+          ok: false,
+          timedOut: false,
+          pendingOffsetState: true,
+        }),
+      ]),
+    );
+    const rawTrace = readFileSync(debugLogPath, 'utf8');
+    expect(rawTrace).not.toContain('function_call');
+    expect(rawTrace).not.toContain(transcript);
   });
 
   it('codex-retro-parity.SM2.AC1.stays_silent_without_child_on_below_threshold_codex_session', () => {


### PR DESCRIPTION
## Summary

- Adds opt-in sanitized Codex retro diagnostics so trigger decisions, child exits, extraction failures, and spool/filing state are distinguishable without logging raw transcripts or findings.
- Fixes Codex retro extraction by passing `--skip-git-repo-check` to the neutral-cwd `codex exec` child.
- Adds focused coverage for Codex extraction failure reasons, empty-success vs failure, Stop child failure behavior, and debug-log redaction/fail-open behavior.

## Root Cause

Codex retro extraction runs from a neutral temporary cwd to avoid recursive project hooks and repo mutation. Claude accepts that cwd, but Codex CLI 0.141.0 exits outside a trusted/git directory unless `--skip-git-repo-check` is supplied. Because the child ran with ignored stdio, the live Stop path only surfaced as exit code 1 until diagnostics were added.

## Rebase Impact

Rebased onto `origin/main` at `198a8d35` and pushed head `8d0e3b72`. The only content conflict during catch-up was in `packages/cli/src/commands/retro.ts`; resolution keeps main's provenance/drop reporting and #994's debug instrumentation. Ticket metadata is now `done`, so the ready-only ticket gate passes locally.

## Verification

- GitHub CI on `0c211f45` passed lint plus full test jobs on Node 22.22.3 and Node 24. Each test job ran package tests, BDD, and release-gate tests.
- `gh pr diff 994 --name-only > /tmp/safeword-pr-994-files.txt && bun scripts/check-pr-ticket-done.ts --changed-files /tmp/safeword-pr-994-files.txt` - passed after the ticket metadata fix.
- `bun run test tests/hooks/retro-trigger-codex.test.ts tests/integration/codex-stop-retro.test.ts tests/hooks/retro-extract.test.ts tests/hooks/retro-debug.test.ts tests/commands/retro.test.ts` - 79 passed on `198a8d35`.
- `bun run test tests/schema.test.ts -t "should have entry for every template file"` - passed on `198a8d35`.
- Pre-push schema-drift gate - 667 passed.
- `bun run lint` - passed on `198a8d35`.
- `bun run knip` - passed on `198a8d35`.
- `git diff --check` - passed.
- Conflict-marker scan across the touched retro command/extraction/test files - clean.
- Live replay against the real Codex transcript now exits 0 with `retro_cli_extraction ok:true`.

## Local Investigation Notes

Two failures seen in this Mac worktree did not reproduce in GitHub CI and are outside #994's diff:

- `tests/scripts/cleanup-zombies.test.ts` depends on matching a temp path embedded in a process command; macOS can spell the temp directory as `/var/folders/...` in Node and `/private/var/folders/...` in shell output, so the project-scoped `pgrep` misses it locally.
- `tests/integration/rust-golden-path.test.ts` depends on the local Clippy toolchain applying the `s.contains("l")` to `s.contains('l')` suggestion. CI's Rust setup passed the full test suite; the local Clippy probe showed toolchain/config sensitivity.

Closes #960