### PR TITLE
audit: check personas/surfaces/glossary namespace docs for emptiness + drift

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -451,6 +451,10 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 # same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
 # blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
 # as an unclosed range and wipe every following line to EOF.
+# Line-based limitation (accepted): a `## ` heading that shares its line with a
+# multi-line comment OPENER (`## Foo <!-- note` … `-->`) is deleted with the
+# comment — well-formed markdown keeps headings on their own line, so this never
+# bites the real docs; pinned by a test so any change to it stays conscious.
 strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -516,6 +516,12 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -g
 fi
 ```
 
+**Content is human-owned — advisory only, never an error.** This check judges _references_ (a slug/code that is or isn't defined) and _emptiness_ — observable facts. Whether a glossary term's meaning, or a persona/surface _description_, is still accurate is a human judgment: raise it as an advisory note at most, never as an error code. Only the three codes above (E008, E009, W008) are emitted here.
+
+**Empty-doc offer (W008):** report the empty doc and point the user to its template — do **not** draft entries or write the file during the audit pass (read-only). Filling it is a follow-up the user approves.
+
+**Coverage limitation:** the block reads the default namespace-root locations; per-file `paths.personas` / `paths.surfaces` / `paths.glossary` overrides are validated by `safeword check` (structure), not here. Persona drift reads spec `**Persona:**` lines only — feature lineage tags are not a reliable persona source.
+
 ---
 
 ## Report Format
@@ -531,6 +537,8 @@ Report findings by severity with codes:
 - [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
 - [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
 - [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
+- [E008] Surface drift: `@surface.safeword-cli` is referenced in `features/` but has no matching entry in `surfaces.md`
+- [E009] Persona drift: persona code `DEV` is named in a spec `**Persona:**` line but has no matching entry in `personas.md`
 
 ### Warnings (should review)
 
@@ -540,6 +548,7 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Empty domain doc: `surfaces.md` has no uncommented entries — fill from its template (BDD intake references degrade until filled)
 
 ### Code Quality
 

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -449,10 +449,13 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
+# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
+# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
 # Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
 # substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -472,7 +475,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -492,9 +495,13 @@ personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
 dd_file="$personas_file"
 if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
-  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
-  # initials, single -> first two chars, uppercased).
-  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  # Defined codes: explicit trailing `## Name (CODE)` wins; else derived
+  # best-effort (multi-word -> initials, single -> first two chars, uppercased).
+  # Derivation is naive (particles/hyphens mis-derive, e.g. Site-Reliability
+  # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
+  # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
+  # writes, to avoid a spurious E009.
+  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
     if [ -n "$explicit" ]; then
@@ -510,7 +517,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -481,6 +481,39 @@ if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -g
     fi
   done
 fi
+
+# --- Persona drift (E009): spec **Persona:** code referenced but undefined ---
+# Spec lines only, comment-stripped (feature lineage tags carry ticket-ids, not
+# personas). Suppressed when personas.md is empty/absent.
+personas_file="$NS_ROOT/personas.md"
+tickets_dir="$NS_ROOT/tickets"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
+  # initials, single -> first two chars, uppercased).
+  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+    name="${heading#\#\# }"
+    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    if [ -n "$explicit" ]; then
+      printf '%s\n' "$explicit"
+      continue
+    fi
+    base="${name%% (*}"
+    if [ "$(printf '%s' "$base" | wc -w | tr -d ' ')" -ge 2 ]; then
+      printf '%s' "$base" | awk '{s="";for(i=1;i<=NF;i++)s=s toupper(substr($i,1,1));print s}'
+    else
+      printf '%s' "$base" | cut -c1-2 | tr '[:lower:]' '[:upper:]'
+    fi
+  done)"
+  # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
+  referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
+    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+  done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
+  for code in $referenced_codes; do
+    if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then
+      echo "[E009] Persona drift: code $code referenced in a spec but no matching entry in personas.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -449,15 +449,17 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
+# substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
 for doc in personas surfaces glossary; do
-  file="$NS_ROOT/$doc.md"
-  [ -f "$file" ] || continue
-  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+  dd_file="$NS_ROOT/$doc.md"
+  [ -f "$dd_file" ] || continue
+  if [ "$(domain_docs_entry_count)" -eq 0 ]; then
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
@@ -466,7 +468,8 @@ done
 # Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
 FEATURES_DIR="$PROJECT_DIR/features"
 surfaces_file="$NS_ROOT/surfaces.md"
-if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+dd_file="$surfaces_file"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
   defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
@@ -487,7 +490,8 @@ fi
 # personas). Suppressed when personas.md is empty/absent.
 personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
-if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+dd_file="$personas_file"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
   # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
   # initials, single -> first two chars, uppercased).
   defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -461,6 +461,26 @@ for doc in personas surfaces glossary; do
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
+
+# --- Surface drift (E008): @surface.<slug> tag referenced but undefined ---
+# Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
+FEATURES_DIR="$PROJECT_DIR/features"
+surfaces_file="$NS_ROOT/surfaces.md"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+  # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
+  # `tr` — BSD/macOS sed lacks `\L`.
+  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+    | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
+  # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
+  # with @), so a slug mentioned in step prose is not a reference.
+  referenced_slugs="$(grep -rhE '^[[:space:]]*@' "$FEATURES_DIR" 2> /dev/null \
+    | grep -oE '@surface\.[a-z0-9-]+' | sed 's/^@surface\.//' | sort -u)"
+  for slug in $referenced_slugs; do
+    if ! printf '%s\n' $defined_slugs | grep -qxF "$slug"; then
+      echo "[E008] Surface drift: @surface.$slug referenced in features/ but no matching entry in surfaces.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -447,15 +447,18 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
   if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
 }
 
+# Single-source the HTML-comment strip used by every check below. Strips
+# same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
+# blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
+# as an unclosed range and wipe every following line to EOF.
+strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
+
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
-# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
-# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
-# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
-# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
-# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
-# substitution clobbers `$1` in the injected block body.
+# live inside its comment, so a verbatim scaffold counts as zero. Reads the
+# named var `dd_file`, NOT positional `$1`: skill/command argument substitution
+# clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed "$strip_html_comments" "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -475,7 +478,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed "$strip_html_comments" "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -501,7 +504,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
   # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
   # writes, to avoid a spurious E009.
-  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  defined_codes="$(sed "$strip_html_comments" "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
     # after a stripped inline comment left a trailing space; capture only the code.
@@ -519,7 +522,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed "$strip_html_comments" "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -503,7 +503,9 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # writes, to avoid a spurious E009.
   defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
-    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
+    # after a stripped inline comment left a trailing space; capture only the code.
+    explicit="$(printf '%s' "$name" | sed -nE 's/.*\(([A-Z][A-Z0-9]{1,5})\)[[:space:]]*$/\1/p')"
     if [ -n "$explicit" ]; then
       printf '%s\n' "$explicit"
       continue

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -430,6 +430,39 @@ Test Quality:
 
 Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
+### 6. Namespace Domain Docs
+
+Reconcile the three namespace domain docs — `personas.md`, `surfaces.md`, `glossary.md` — against what the code actually references, and report empty scaffolds. These docs feed the BDD intake flow, so silent rot there degrades every downstream spec. This check is **read-only and class-2** (observable facts only): it reports and offers, it never rewrites a doc. **Run the block below verbatim, as ONE bash invocation.**
+
+```bash
+# domain-docs-check — read-only reconciliation of the namespace domain docs.
+# Class-2: observable facts only. Emits W008 (empty). Never writes the tree.
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}" || exit 1
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
+
+# Resolve the namespace root (honors config paths.projectRoot in real runs).
+# Fall back on directory existence — robust when the resolver hook is absent.
+NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJECT_DIR" 2> /dev/null)"
+[ -d "$NS_ROOT" ] || {
+  if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
+}
+
+# Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
+# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+domain_docs_entry_count() {
+  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+}
+
+# --- Emptiness (W008): a domain doc with no uncommented entries ---
+for doc in personas surfaces glossary; do
+  file="$NS_ROOT/$doc.md"
+  [ -f "$file" ] || continue
+  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+    echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
+  fi
+done
+```
+
 ---
 
 ## Report Format

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -451,6 +451,10 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 # same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
 # blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
 # as an unclosed range and wipe every following line to EOF.
+# Line-based limitation (accepted): a `## ` heading that shares its line with a
+# multi-line comment OPENER (`## Foo <!-- note` … `-->`) is deleted with the
+# comment — well-formed markdown keeps headings on their own line, so this never
+# bites the real docs; pinned by a test so any change to it stays conscious.
 strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -516,6 +516,12 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -g
 fi
 ```
 
+**Content is human-owned — advisory only, never an error.** This check judges _references_ (a slug/code that is or isn't defined) and _emptiness_ — observable facts. Whether a glossary term's meaning, or a persona/surface _description_, is still accurate is a human judgment: raise it as an advisory note at most, never as an error code. Only the three codes above (E008, E009, W008) are emitted here.
+
+**Empty-doc offer (W008):** report the empty doc and point the user to its template — do **not** draft entries or write the file during the audit pass (read-only). Filling it is a follow-up the user approves.
+
+**Coverage limitation:** the block reads the default namespace-root locations; per-file `paths.personas` / `paths.surfaces` / `paths.glossary` overrides are validated by `safeword check` (structure), not here. Persona drift reads spec `**Persona:**` lines only — feature lineage tags are not a reliable persona source.
+
 ---
 
 ## Report Format
@@ -531,6 +537,8 @@ Report findings by severity with codes:
 - [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
 - [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
 - [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
+- [E008] Surface drift: `@surface.safeword-cli` is referenced in `features/` but has no matching entry in `surfaces.md`
+- [E009] Persona drift: persona code `DEV` is named in a spec `**Persona:**` line but has no matching entry in `personas.md`
 
 ### Warnings (should review)
 
@@ -540,6 +548,7 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Empty domain doc: `surfaces.md` has no uncommented entries — fill from its template (BDD intake references degrade until filled)
 
 ### Code Quality
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -449,10 +449,13 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
+# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
+# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
 # Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
 # substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -472,7 +475,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -492,9 +495,13 @@ personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
 dd_file="$personas_file"
 if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
-  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
-  # initials, single -> first two chars, uppercased).
-  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  # Defined codes: explicit trailing `## Name (CODE)` wins; else derived
+  # best-effort (multi-word -> initials, single -> first two chars, uppercased).
+  # Derivation is naive (particles/hyphens mis-derive, e.g. Site-Reliability
+  # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
+  # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
+  # writes, to avoid a spurious E009.
+  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
     if [ -n "$explicit" ]; then
@@ -510,7 +517,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -481,6 +481,39 @@ if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -g
     fi
   done
 fi
+
+# --- Persona drift (E009): spec **Persona:** code referenced but undefined ---
+# Spec lines only, comment-stripped (feature lineage tags carry ticket-ids, not
+# personas). Suppressed when personas.md is empty/absent.
+personas_file="$NS_ROOT/personas.md"
+tickets_dir="$NS_ROOT/tickets"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
+  # initials, single -> first two chars, uppercased).
+  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+    name="${heading#\#\# }"
+    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    if [ -n "$explicit" ]; then
+      printf '%s\n' "$explicit"
+      continue
+    fi
+    base="${name%% (*}"
+    if [ "$(printf '%s' "$base" | wc -w | tr -d ' ')" -ge 2 ]; then
+      printf '%s' "$base" | awk '{s="";for(i=1;i<=NF;i++)s=s toupper(substr($i,1,1));print s}'
+    else
+      printf '%s' "$base" | cut -c1-2 | tr '[:lower:]' '[:upper:]'
+    fi
+  done)"
+  # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
+  referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
+    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+  done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
+  for code in $referenced_codes; do
+    if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then
+      echo "[E009] Persona drift: code $code referenced in a spec but no matching entry in personas.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -449,15 +449,17 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
+# substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
 for doc in personas surfaces glossary; do
-  file="$NS_ROOT/$doc.md"
-  [ -f "$file" ] || continue
-  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+  dd_file="$NS_ROOT/$doc.md"
+  [ -f "$dd_file" ] || continue
+  if [ "$(domain_docs_entry_count)" -eq 0 ]; then
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
@@ -466,7 +468,8 @@ done
 # Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
 FEATURES_DIR="$PROJECT_DIR/features"
 surfaces_file="$NS_ROOT/surfaces.md"
-if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+dd_file="$surfaces_file"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
   defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
@@ -487,7 +490,8 @@ fi
 # personas). Suppressed when personas.md is empty/absent.
 personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
-if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+dd_file="$personas_file"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
   # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
   # initials, single -> first two chars, uppercased).
   defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -461,6 +461,26 @@ for doc in personas surfaces glossary; do
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
+
+# --- Surface drift (E008): @surface.<slug> tag referenced but undefined ---
+# Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
+FEATURES_DIR="$PROJECT_DIR/features"
+surfaces_file="$NS_ROOT/surfaces.md"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+  # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
+  # `tr` — BSD/macOS sed lacks `\L`.
+  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+    | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
+  # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
+  # with @), so a slug mentioned in step prose is not a reference.
+  referenced_slugs="$(grep -rhE '^[[:space:]]*@' "$FEATURES_DIR" 2> /dev/null \
+    | grep -oE '@surface\.[a-z0-9-]+' | sed 's/^@surface\.//' | sort -u)"
+  for slug in $referenced_slugs; do
+    if ! printf '%s\n' $defined_slugs | grep -qxF "$slug"; then
+      echo "[E008] Surface drift: @surface.$slug referenced in features/ but no matching entry in surfaces.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -447,15 +447,18 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
   if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
 }
 
+# Single-source the HTML-comment strip used by every check below. Strips
+# same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
+# blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
+# as an unclosed range and wipe every following line to EOF.
+strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
+
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
-# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
-# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
-# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
-# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
-# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
-# substitution clobbers `$1` in the injected block body.
+# live inside its comment, so a verbatim scaffold counts as zero. Reads the
+# named var `dd_file`, NOT positional `$1`: skill/command argument substitution
+# clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed "$strip_html_comments" "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -475,7 +478,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed "$strip_html_comments" "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -501,7 +504,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
   # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
   # writes, to avoid a spurious E009.
-  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  defined_codes="$(sed "$strip_html_comments" "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
     # after a stripped inline comment left a trailing space; capture only the code.
@@ -519,7 +522,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed "$strip_html_comments" "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -503,7 +503,9 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # writes, to avoid a spurious E009.
   defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
-    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
+    # after a stripped inline comment left a trailing space; capture only the code.
+    explicit="$(printf '%s' "$name" | sed -nE 's/.*\(([A-Z][A-Z0-9]{1,5})\)[[:space:]]*$/\1/p')"
     if [ -n "$explicit" ]; then
       printf '%s\n' "$explicit"
       continue

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -430,6 +430,39 @@ Test Quality:
 
 Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
+### 6. Namespace Domain Docs
+
+Reconcile the three namespace domain docs — `personas.md`, `surfaces.md`, `glossary.md` — against what the code actually references, and report empty scaffolds. These docs feed the BDD intake flow, so silent rot there degrades every downstream spec. This check is **read-only and class-2** (observable facts only): it reports and offers, it never rewrites a doc. **Run the block below verbatim, as ONE bash invocation.**
+
+```bash
+# domain-docs-check — read-only reconciliation of the namespace domain docs.
+# Class-2: observable facts only. Emits W008 (empty). Never writes the tree.
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}" || exit 1
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
+
+# Resolve the namespace root (honors config paths.projectRoot in real runs).
+# Fall back on directory existence — robust when the resolver hook is absent.
+NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJECT_DIR" 2> /dev/null)"
+[ -d "$NS_ROOT" ] || {
+  if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
+}
+
+# Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
+# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+domain_docs_entry_count() {
+  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+}
+
+# --- Emptiness (W008): a domain doc with no uncommented entries ---
+for doc in personas surfaces glossary; do
+  file="$NS_ROOT/$doc.md"
+  [ -f "$file" ] || continue
+  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+    echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
+  fi
+done
+```
+
 ---
 
 ## Report Format

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/dimensions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/dimensions.md
@@ -1,0 +1,39 @@
+# Dimensions: Audit checks namespace domain docs (N0W5KG)
+
+| Dimension            | Partitions                                                                                          | Source   |
+| -------------------- | --------------------------------------------------------------------------------------------------- | -------- |
+| Doc kind             | personas.md · surfaces.md · glossary.md                                                              | TB1      |
+| Doc state            | empty (zero `##` entries, scaffold only) · populated                                                | TB1.R3   |
+| Reference status     | referenced-and-defined (clean) · referenced-but-undefined (drift) · defined-but-unreferenced (fine) | TB1.R1/R2 |
+| Persona ref source   | ticket spec.md `**Persona:**` line (comment-stripped) — feature-tag source dropped (ticket-ID noise) | TB1.R2   |
+| Content type         | structural/observable (surface slug, persona code) · human-curated prose (term meaning, description) | TB1.R4   |
+
+## Partition → scenario mapping
+
+- surfaces × referenced-but-undefined → **R1** (E008): `@surface.safeword-cli` tag in a `.feature`, no `## Safeword CLI` in surfaces.md.
+- surfaces × referenced-and-defined → **R1 clean**: every `@surface.<slug>` resolves → no finding.
+- personas × referenced-but-undefined × spec source → **R2** (E009): a spec `**Persona:** Foo (FOO)` with no `## … (FOO)` in personas.md.
+- personas × referenced-but-undefined × feature source → **R2** (E009): a scenario names a persona code absent from personas.md.
+- personas × referenced-and-defined → **R2 clean**: no finding.
+- (any doc) × empty → **R3** (W008): zero `##` entries → warn + offer to fill from template, naming path + stake.
+- (any doc) × populated → **R3 clean**: not reported empty.
+- glossary × human-curated prose × plausibly-stale → **R4**: never an error; at most advisory warn.
+- personas/surfaces × description prose × plausibly-stale → **R4**: never an error.
+
+## Boundary notes
+
+- **defined-but-unreferenced is NOT drift.** A surface/persona defined in the
+  inventory but not yet referenced by any scenario is legitimate (inventory can
+  lead usage) → no finding. Only referenced-but-undefined is the observable
+  dead-ref.
+- **Empty ≠ missing.** Install ships all three docs at scaffold state; the file
+  is never absent. "Empty" = present with zero parsed `##` entries. The HTML
+  comment scaffold does not count as an entry (mirrors DISCOVERY.md's rule).
+- **Structure vs content boundary (R4).** Observable = a slug/code token that
+  does or doesn't have a matching heading (deterministic by reading). Human
+  judgment = whether a definition/description is still *accurate* — audit never
+  adjudicates this; class-2 emits only observable facts.
+- **Read-only.** The W008 fill offer names the template and the stake; it writes
+  nothing during the audit pass (decided via /figure-it-out).
+- Out of scope here: glossary term-drift heuristics, auto-drafting entries,
+  gating/blocking, and any new CLI code (health.ts already validates structure).

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/impl-plan.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/impl-plan.md
@@ -1,6 +1,25 @@
 # Impl Plan: Audit checks namespace domain docs for emptiness and drift
 
-**Status:** planned
+**Status:** implemented
+
+## Reconciliation (implement exit)
+
+Shipped as planned across 4 TDD slices (be88ad48 emptiness, 55efd801 surface,
+53b3f63a persona, b599c826 advisory+legend). Every Decision held:
+
+- **E009 spec-only** — feature lineage source dropped; verified on the real repo
+  it emits the true `DEV` drift, no ticket-ID storm.
+- **Comment-aware emptiness** — `sed '/<!--/,/-->/d'` then `^##` count (perl
+  swapped for sed to avoid a runtime dep, as the plan already recorded).
+- **`[ -d "$NS_ROOT" ]` fallback**, **`tr` slugify** (no `\L`), **empty-suppresses-drift**,
+  **marker-based extractor** — all implemented and covered by the 18 tests.
+- **Derivation fallback** — implemented AND covered by a dedicated test
+  (`resolves a persona defined by name only via derived code`).
+- **Report Format legend** — E008/E009/W008 added; content-parity asserted
+  across all 3 mirrors.
+
+No new deviations beyond those already listed under Known deviations; no ADR
+emitted (skill-behavior extension of an existing pattern).
 
 ## Approach
 

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/impl-plan.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/impl-plan.md
@@ -1,0 +1,63 @@
+# Impl Plan: Audit checks namespace domain docs for emptiness and drift
+
+**Status:** planned
+
+## Approach
+
+**Riskiest assumption:** the reference-extraction can distinguish a *real reference* from an incidental string — a slug/code that lives only in prose, or inside an HTML-commented scaffold example, must not fire drift. The plan-review proved the naive versions break: a `##`-count counts commented example headings (every scaffold has them), and feature lineage tags carry ticket-IDs (`MGWZ4P`, `UWP4XK`) indistinguishable from persona codes. **Cheapest proof:** the guard scenarios — R1 "prose-only mention", R2 "commented-out spec example", R3 "verbatim scaffold reported empty" — run the extracted bash against tiny fixtures and assert the expected presence/absence. They fail early while the block is small.
+
+**Shape:** one deterministic `bash` block added to `/audit` SKILL.md Section 5 as a new subsection "Namespace domain docs", mirroring the Section 3 W006 learning-file loop. No new CLI code. The block:
+
+1. **Namespace root:** `NS_ROOT="$(bun $PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts "$PROJECT_DIR" 2>/dev/null)"`, then **fall back whenever `[ -d "$NS_ROOT" ]` is false** (covers both the resolver-absent case and the fake-`bun`-echo case) to `$PROJECT_DIR/.project`, else `$PROJECT_DIR/.safeword-project`. Features dir = `paths.features` or default `features/`.
+2. **Emptiness (W008) — comment-aware:** strip `<!-- … -->` blocks from the doc with `sed '/<!--/,/-->/d'` (no new runtime dep — stays on the skill's existing grep/sed/find toolset; block comments in these docs span whole lines), then count `^##` headings; zero → `[W008] Empty domain doc: <file> — fill from packages/cli/templates/<doc>-template.md (BDD intake references degrade until filled)`. Absent file → no output. The install scaffold's example headings sit inside its comment, so a verbatim scaffold counts as zero.
+3. **Surface drift (E008):** build the defined-slug set by slugifying each uncommented `^##` heading in `surfaces.md` with a **portable** pipeline — `tr '[:upper:]' '[:lower:]'` then `sed 's/[^a-z0-9]\{1,\}/-/g; s/^-//; s/-$//'` (NOT `sed \L`, which BSD/macOS sed does not support — proven by a `laude-ode` misfire during planning). Collect referenced slugs from `@surface.<slug>` on **tag lines only** (`^[[:space:]]*@…`) across `features/**`. Each referenced slug absent from the defined set → `[E008] Surface drift: @surface.<slug> referenced in features/ but no matching entry in surfaces.md`. **Suppressed when `surfaces.md` is empty/absent** (W008 already says "fill it").
+4. **Persona drift (E009) — spec lines only:** decided with the user — the feature lineage-tag source is dropped (ticket-ID pollution). Build the defined-code set from `personas.md` headings: explicit `## Name (CODE)` first, else derived fallback (multi-word → initials, single → first two chars, uppercased). Collect referenced codes from ticket `spec.md` `**Persona:** … (CODE)` lines **after stripping HTML comments** (`sed '/<!--/,/-->/d'`, so the template's commented `Platform Operator (PO)` example does not fire — verified: comment-stripping drops the 29 PO hits and leaves one real `DEV` drift). Each referenced code absent from the defined set → `[E009] Persona drift: code <CODE> referenced in a spec but no matching entry in personas.md`. **Suppressed when `personas.md` is empty/absent.**
+
+**Proof plan (per scenario → highest practical scope):**
+
+| Scenario group | Primary proof | Why enough |
+| -------------- | ------------- | ---------- |
+| R1 (E008: drift, multi-word clean, defined-unreferenced, prose-only) | **integration** — extract the block, `spawnSync bash` against mkdtemp fixtures, assert stdout has/omits the E008 line | Exercises the real bash end-to-end (wiring); portable slugify + tag-line anchoring proven |
+| R2 (E009: live-spec drift, clean, commented-example) | **integration** — fixtures with `.project/tickets/X/spec.md` (live + commented variants) | The comment-strip anchoring must run, not be asserted as prose |
+| R3 (W008: verbatim surfaces/glossary scaffold, populated, absent, empty-suppresses-drift) | **integration** — fixtures use the real template bytes for the scaffold cases | comment-aware `##` count + doc→template map + absent-skip + suppression exercised |
+| R4 (in-sync → silent; edited-definition → same result) | **integration** — in-sync fixture asserts zero E/W; edited-definition fixture asserts byte-identical output to the in-sync run | Proves the detector never touches content meaning |
+| R4 doc-text; all rules parity | **unit (content assertion)** — `it.each(AUDIT_SURFACES)` asserts the advisory-only sentence + codes E008/E009/W008 present in the new subsection AND the Report Format legend across all 3 byte-identical `SKILL.md` mirrors | Locks parity + the human-owned-content instruction + the legend |
+
+**Wiring:** entry point is the bash block; integration proofs run it via `bash -c "<extracted block>"` using a **marker-based** extractor (find the block containing the `# domain-docs-check` sentinel), robust to added blocks. The fixtures do NOT stub `bun`; the `[ -d "$NS_ROOT" ]` fallback makes the block resolve the fixture's `.project/` without the real resolver present.
+
+**Build order (harness first, then load-bearing):**
+
+1. **Emptiness (R3)** — thinnest vertical slice: stands up the block skeleton, NS-root resolution + `[ -d ]` fallback, comment-aware counting, doc→template map, and the marker-based fixture harness.
+2. **Persona drift (R2)** — the comment-strip anchoring; built early so a wrong extraction fails on its guard scenarios while cheap.
+3. **Surface drift (E008/R1)** — portable slugify + tag-line anchoring + empty-suppression; also feeds R4's in-sync fixture.
+4. **R4 integration + content assertions + Report Format legend + 3-mirror parity sync.**
+
+## Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| -------- | ------ | ----------------------- | ---------------- |
+| Where detection lives | Deterministic `bash` block in the audit SKILL.md | New `safeword check --docs-coverage`; extend `health.ts` | figure-it-out Option A: matches Section 3 W006; no cross-harness CLI code; ships identically to 3 mirrors |
+| E009 reference source | Comment-stripped spec `**Persona:**` lines ONLY | Specs + feature lineage tags | Empirically proven: lineage field-2 carries ticket-IDs/foreign codes indistinguishable from persona codes → E009 storm. Spec lines resolve cleanly + catch the real DEV drift (user-confirmed) |
+| Emptiness detection | Comment-aware `##` count (strip `<!-- -->` first) | Raw `^##` count; scaffold byte-match | Raw count counts the scaffold's commented example headings → never zero; byte-match is brittle to any edit. Comment-aware matches parsePersonas/parseGlossary semantics |
+| Namespace-root fallback trigger | `[ -d "$NS_ROOT" ]` false | Empty-stdout or non-zero-exit | The reused harness stubs `bun` as an echo → resolver "succeeds" with garbage stdout; only a directory-existence guard is robust |
+| Slugify casing | `tr '[:upper:]' '[:lower:]'` | `sed 's/.*/\L&/'` | BSD/macOS sed lacks `\L` — misfired `laude-ode` in planning; must run on darwin + Linux CI |
+| Empty/absent doc precedence | Suppress that doc's drift codes; emit only W008 | Emit W008 + one drift per reference | An empty personas.md would bury W008 under an E009 per referenced code — noise, not signal |
+| Test block extraction | Marker-comment-based extractor | Ordinal (Nth ```bash block) | Ordinal breaks when a block is added earlier; existing harness hard-codes block 2 |
+
+## Arch alignment
+
+Honors the audit skill's stated **class-2 / report-only / read-only** principle (`SKILL.md:13`, `PRINCIPLES.md §1`) and the Section 5 precedent of reconciling prose against a machine-readable source of truth without auto-overwriting prose (`SKILL.md:404-418`). `skip: no new architectural decision — extends an existing documented pattern`.
+
+## Known deviations
+
+- Per-file config overrides (`paths.personas` / `paths.surfaces` / `paths.glossary`) are NOT honored — the block reads default namespace-root locations. Acceptable: `safeword check` (`health.ts`) already validates the configured-path variants; this check is a complementary reporter. Documented as a coverage limitation in the subsection.
+- Persona-code derivation fallback does not reproduce `safeword check`'s collision-suffix numbering (`PO2`) — acceptable because post-check headings carry explicit codes the explicit-extraction path reads directly.
+- Persona drift reads spec lines only (no feature-tag source) — a persona named only in a scenario's prose (not a spec) is not checked; features carry no reliable structured persona reference.
+
+## Doc impact
+
+`docs.sources` not configured. The authoritative code legend is the skill's own **Report Format** (`SKILL.md:439-456`) — add E008/E009/W008 there in all 3 mirrors alongside the new subsection. During implement, also grep `packages/website/**` for any audit-code enumeration; add there if one exists, else `skip: no canonical audit-code list outside the skill`.
+
+## Assessment triggers
+
+Revisit if: persona references gain a reliable structured form in `.feature` files (reopen the feature-source); a per-file `paths.*` override becomes common enough that default-location reading misfires; surface heading conventions add qualifiers that break slugify; or the block outgrows readable bash — then promote to a tested helper reusing `resolvePersonaCodes`/`parseGlossary` (the figure-it-out Option B/C boundary).

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/spec.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/spec.md
@@ -1,0 +1,87 @@
+# Spec: Audit checks namespace domain docs for emptiness and drift
+
+## Intent
+
+`/audit` reviews codebase health but never looks at the three namespace domain
+docs — `personas.md`, `surfaces.md`, `glossary.md` — so they rot silently: a
+project ships with empty template scaffold, or a surface/persona gets referenced
+in scenarios while its inventory entry is never added. These docs power the BDD
+intake flow, so when they drift, every downstream spec references stale ground.
+This feature makes `/audit` observe their emptiness and their drift against what
+the code actually references, so the reader is told to fix them.
+
+## Intake Brief
+
+- **Requested by:** Repo owner (alex), while auditing skill docs — GitHub issue #1027.
+- **Cost of inaction:** Domain docs drift undetected. Concrete live proof: `@surface.safeword-cli` is tagged in 3 `.feature` files today but is absent from `surfaces.md`; nothing surfaces it. Empty docs on a fresh install stay empty because nothing prompts the maintainer to fill them, and BDD intake references degrade.
+- **Reversibility:** Two-way door. Pure-prose additions to one skill file (plus its two parity mirrors); no data model, no public API, no migration. Revertible by deleting the added subsection.
+
+## References
+
+- GitHub issue [#1027](https://github.com/ArcadeAI/safeword/issues/1027)
+- Design: `/figure-it-out` → Option A (pure-prose skill check, no new CLI code)
+- Precedent: `SKILL.md` Section 5 structural-drift reconciliation (ARCHITECTURE.md ↔ `architecture.generated.md`) — "report only, never auto-overwrite prose"
+- Structure already validated elsewhere: `health.ts` → `validatePersonas` / `validateGlossary` (this check must not duplicate it)
+
+## Personas
+
+- **Technical Builder (TB)** — runs `/audit` on a real project and relies on it to keep the domain docs that feed BDD intake honest.
+- **Safeword Maintainer (SM)** — dogfoods `/audit` in this repo; is the one who hits the live `@surface.safeword-cli` gap.
+
+## Surfaces
+
+Affected:
+
+- Claude Code — primary; `/audit` runs the inline `!`-bash and reads the docs.
+- OpenAI Codex — parity mirror `.agents/skills/`; no `!`-bash auto-expansion, so the check degrades to model-reads-and-reasons.
+- Cursor — parity mirror `.mdc`.
+
+Unaffected:
+
+- Claude Code on the Web / Codex Cloud / Cursor Cloud Agents — same skill files apply; no cloud-lifecycle-specific behavior in this check.
+
+Each affected surface is covered by the audit skill's parity mirrors, not by
+per-surface runtime branches — the behavior is one prose block read identically.
+
+## Vocabulary
+
+- **Surface** — a supported runtime/client/deployment context where behavior must keep working; inventory in `surfaces.md`, referenced by scenarios via `@surface.<slug>` tags (glossary term "Surface" pending — this feature exercises the drift it describes).
+- **Domain docs** — this feature's shorthand for the three namespace files `personas.md` / `surfaces.md` / `glossary.md`. Spec-local; not a project glossary term.
+- **Drift** — an inventory doc out of sync with what the code/scenarios actually reference (referenced-but-undefined).
+- **Emptiness** — a domain doc containing only template scaffold (`# Heading` + HTML comment), zero `##` entries parsed.
+
+## Jobs To Be Done
+
+### audit-domain-docs.TB1 — Catch domain-doc rot during audit
+
+**Persona:** Technical Builder (TB)
+
+> When I run `/audit` on my project, I want it to tell me when a domain doc is
+> empty or has drifted from what my code references, so I can keep the personas,
+> surfaces, and glossary that power BDD intake accurate instead of discovering
+> the rot months later inside a broken spec.
+
+#### audit-domain-docs.TB1.R1 — A surface referenced by a scenario tag but absent from the surfaces inventory is reported as a drift error
+
+#### audit-domain-docs.TB1.R2 — A persona named in a comment-stripped spec `**Persona:**` line but absent from the personas inventory is reported as a drift error (feature lineage-tag source dropped — ticket-ID noise)
+
+#### audit-domain-docs.TB1.R3 — A domain doc containing only template scaffold (zero entries) is reported as empty, with an offer to fill it from its template
+
+#### audit-domain-docs.TB1.R4 — Human-curated content (glossary terms, persona/surface descriptions) is never reported as an error; content staleness is advisory only
+
+## Rave Moment
+
+skip: table-stakes — a documentation-freshness check is a quiet correctness
+guard, not a shareable peak. The value is the absence of silent rot, which
+nobody screenshots.
+
+## Outcomes
+
+- Running `/audit` on this repo today reports the `@surface.safeword-cli` gap as an error.
+- Running `/audit` on a fresh install (empty domain docs) reports each empty doc and offers to fill it from its template.
+- Running `/audit` on a fully-populated, in-sync repo produces zero domain-doc findings.
+- `/audit` never rewrites a domain doc as part of the audit pass (read-only) and never emits an error for human-curated content on a hunch.
+
+## Open Questions
+
+<!-- none open -->

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
@@ -34,21 +34,21 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Persona code named in a live spec Persona line but undefined is reported
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 53b3f63a
+- [x] GREEN 53b3f63a
+- [x] REFACTOR 53b3f63a
 
 ### Scenario: Every persona code referenced in a live spec line resolves to an inventory entry
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 53b3f63a
+- [x] GREEN 53b3f63a
+- [x] REFACTOR 53b3f63a
 
 ### Scenario: A persona code appearing only in a commented-out spec example is not reported
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 53b3f63a
+- [x] GREEN 53b3f63a
+- [x] REFACTOR 53b3f63a
 
 ## Rule: audit-domain-docs.TB1.R3 — Empty domain doc is a warning with a fill offer (W008)
 

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
@@ -1,0 +1,103 @@
+# Test Definitions: Audit checks namespace domain docs for emptiness and drift
+
+Feature source: `features/audit-domain-docs-freshness.feature`
+
+test-definitions.md is the R/G/R ledger.
+
+## Rule: audit-domain-docs.TB1.R1 — Surface drift is an error (E008)
+
+### Scenario: Surface tag with no matching inventory entry is reported
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Every referenced surface tag resolves, including multi-word headings
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A surface defined in the inventory but referenced by no tag is not reported
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A surface slug that appears only in prose is not treated as a reference
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: audit-domain-docs.TB1.R2 — Persona drift is an error (E009)
+
+### Scenario: Persona code named in a live spec Persona line but undefined is reported
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Every persona code referenced in a live spec line resolves to an inventory entry
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A persona code appearing only in a commented-out spec example is not reported
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: audit-domain-docs.TB1.R3 — Empty domain doc is a warning with a fill offer (W008)
+
+### Scenario: A verbatim surfaces scaffold is reported empty
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A verbatim glossary scaffold is reported empty
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A populated domain doc is not reported empty
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An absent domain doc is skipped, not reported empty
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An empty domain doc suppresses its own drift codes
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: audit-domain-docs.TB1.R4 — Human-curated content is advisory only, never an error
+
+### Scenario: A fully-populated, in-sync docs set produces no domain-doc findings
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Editing a curated definition changes no finding
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The skill instructs that glossary and description prose is advisory, never an error
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
@@ -54,27 +54,27 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A verbatim surfaces scaffold is reported empty
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED be88ad48
+- [x] GREEN be88ad48
+- [x] REFACTOR be88ad48
 
 ### Scenario: A verbatim glossary scaffold is reported empty
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED be88ad48
+- [x] GREEN be88ad48
+- [x] REFACTOR be88ad48
 
 ### Scenario: A populated domain doc is not reported empty
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED be88ad48
+- [x] GREEN be88ad48
+- [x] REFACTOR be88ad48
 
 ### Scenario: An absent domain doc is skipped, not reported empty
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED be88ad48
+- [x] GREEN be88ad48
+- [x] REFACTOR be88ad48
 
 ### Scenario: An empty domain doc suppresses its own drift codes
 

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
@@ -8,27 +8,27 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Surface tag with no matching inventory entry is reported
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 55efd801
+- [x] GREEN 55efd801
+- [x] REFACTOR 55efd801
 
 ### Scenario: Every referenced surface tag resolves, including multi-word headings
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 55efd801
+- [x] GREEN 55efd801
+- [x] REFACTOR 55efd801
 
 ### Scenario: A surface defined in the inventory but referenced by no tag is not reported
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 55efd801
+- [x] GREEN 55efd801
+- [x] REFACTOR 55efd801
 
 ### Scenario: A surface slug that appears only in prose is not treated as a reference
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 55efd801
+- [x] GREEN 55efd801
+- [x] REFACTOR 55efd801
 
 ## Rule: audit-domain-docs.TB1.R2 — Persona drift is an error (E009)
 
@@ -78,9 +78,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: An empty domain doc suppresses its own drift codes
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED 55efd801
+- [x] GREEN 55efd801
+- [x] REFACTOR 55efd801
 
 ## Rule: audit-domain-docs.TB1.R4 — Human-curated content is advisory only, never an error
 

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/test-definitions.md
@@ -86,18 +86,18 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: A fully-populated, in-sync docs set produces no domain-doc findings
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED b599c826
+- [x] GREEN b599c826
+- [x] REFACTOR b599c826
 
 ### Scenario: Editing a curated definition changes no finding
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED b599c826
+- [x] GREEN b599c826
+- [x] REFACTOR b599c826
 
 ### Scenario: The skill instructs that glossary and description prose is advisory, never an error
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED b599c826
+- [x] GREEN b599c826
+- [x] REFACTOR b599c826

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
@@ -2,8 +2,8 @@
 id: N0W5KG
 slug: audit-domain-docs-freshness
 type: feature
-phase: verify
-status: in_progress
+phase: done
+status: done
 scope: |
   Add a "Namespace domain docs" subsection to /audit SKILL.md Section 5
   (Project Documentation Checks) — pure prose + bash, no new CLI code — that
@@ -54,3 +54,4 @@ last_modified: 2026-07-13T19:07:06.009Z
 - 2026-07-13T19:37:05.626Z Phase: scenario-gate → plan-implementation
 - 2026-07-13T19:58:42.766Z Phase: plan-implementation → implement
 - 2026-07-13T20:13:59.532Z Phase: implement → verify
+- 2026-07-13T20:45:28.465Z Phase: verify → done

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
@@ -1,0 +1,55 @@
+---
+id: N0W5KG
+slug: audit-domain-docs-freshness
+type: feature
+phase: implement
+status: in_progress
+scope: |
+  Add a "Namespace domain docs" subsection to /audit SKILL.md Section 5
+  (Project Documentation Checks) — pure prose + bash, no new CLI code — that
+  checks personas.md / surfaces.md / glossary.md for:
+    - Emptiness: zero `##` entries (template scaffold only) → W008 + offer to
+      fill from packages/cli/templates/<doc>-template.md, naming the path and
+      the stake (BDD intake references degrade until filled). Report-only; no
+      writes in the audit pass.
+    - Surface drift: an @surface.<slug> tag in features/** with no matching
+      `##` heading in surfaces.md → E008.
+    - Persona drift: a persona code named in a comment-stripped ticket spec.md
+      **Persona:** … (CODE) line, absent from personas.md → E009. (Feature
+      lineage-tag source dropped — field-2 ticket-ID noise.)
+  Sync all three byte-identical audit SKILL.md mirrors (.claude/skills,
+  .agents/skills, packages/cli/templates/skills).
+out_of_scope: |
+  - New `safeword check` subcommand or CLI code (health.ts already validates
+    personas/glossary STRUCTURE; this check must not duplicate it).
+  - Any gating/blocking (audit reports; done-flip unaffected).
+  - Auto-mutating the docs (fill happens only on user yes, outside the pass).
+  - Term-by-term glossary/persona CONTENT staleness heuristics — human-curated,
+    advisory warn only, never an error (R4).
+done_when: |
+  - Section 5 has the domain-docs subsection covering emptiness + surface drift
+    + persona drift, with codes W008 / E008 / E009 and the R4 advisory rule.
+  - Running /audit on this repo reports the live @surface.safeword-cli gap as E008.
+  - A verbatim scaffold (zero `##` entries once HTML comments are stripped) is
+    reported W008 with a fill offer.
+  - A fully-populated, in-sync FIXTURE produces zero domain-doc findings. (This
+    repo legitimately emits E009 `DEV` + E008 `safeword-cli` — real drifts.)
+  - Human-curated content is never reported as an error.
+  - All three audit SKILL.md mirrors are byte-identical.
+created: 2026-07-13T19:07:06.009Z
+last_modified: 2026-07-13T19:07:06.009Z
+---
+
+# Audit checks namespace domain docs for emptiness and drift
+
+**Goal:** {One sentence: what are we trying to achieve?}
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-07-13T19:07:06.009Z Started: Created ticket N0W5KG
+- 2026-07-13T19:25:14.458Z Phase: intake → define-behavior
+- 2026-07-13T19:27:55.049Z Phase: define-behavior → scenario-gate
+- 2026-07-13T19:37:05.626Z Phase: scenario-gate → plan-implementation
+- 2026-07-13T19:58:42.766Z Phase: plan-implementation → implement

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/ticket.md
@@ -2,7 +2,7 @@
 id: N0W5KG
 slug: audit-domain-docs-freshness
 type: feature
-phase: implement
+phase: verify
 status: in_progress
 scope: |
   Add a "Namespace domain docs" subsection to /audit SKILL.md Section 5
@@ -53,3 +53,4 @@ last_modified: 2026-07-13T19:07:06.009Z
 - 2026-07-13T19:27:55.049Z Phase: define-behavior → scenario-gate
 - 2026-07-13T19:37:05.626Z Phase: scenario-gate → plan-implementation
 - 2026-07-13T19:58:42.766Z Phase: plan-implementation → implement
+- 2026-07-13T20:13:59.532Z Phase: implement → verify

--- a/.project/tickets/N0W5KG-audit-domain-docs-freshness/verify.md
+++ b/.project/tickets/N0W5KG-audit-domain-docs-freshness/verify.md
@@ -1,0 +1,25 @@
+# Verify: Audit checks namespace domain docs for emptiness and drift (N0W5KG)
+
+## Verify Checklist
+
+**Test Suite:** ✓ 19/19 tests pass (`packages/cli/tests/skills/audit-domain-documentation.test.ts`) — full suite 5195 passed / 2 unrelated environment failures (see Evidence limits)
+**Gherkin:** ⏭️ Skipped — no cucumber step lane for this skill-bash feature; the 15 scenarios are proven executably by the extracted-block integration tests (each `When audit runs the domain-docs check` runs the real bash against a fixture)
+**Build:** ✅ Success (`bun run build`, tsup + dts clean)
+**Lint:** ✅ Clean (eslint 0, `tsc --noEmit` 0 after fixing the TS18048 group-coercion)
+**Scenarios:** All 15 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope — audit `SKILL.md` (3 byte-identical mirrors), one new test file, and ticket artifacts; no unrelated changes
+**Dep Drift:** ✅ Clean — no dependencies added
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — conforms to the existing Section-3 W006 bash-block-in-skill pattern; no new pattern introduced
+**Experience:** ✅ No new friction — Walked Technical Builder through running `/audit`; worst step = a TB who intentionally left a domain doc empty gets a repeating W008, but it is a warn with a one-line fix (fill from the named template) and empty-suppresses-drift prevents a pile-on; new steps vs before = 0 (audit already ran; this only adds findings). Rave Moment was `skip: table-stakes`, so no peak to walk.
+**Evidence limits:** ⚠️ Full-suite had 2 failures unrelated to this change — `rust-golden-path.test.ts` Scenario 10 (clippy `--fix` char-literal autofix, toolchain-version-dependent) and a preview-server `isAlive(pid)` process-timing E2E. This diff touches only the audit skill markdown + one test file — neither failing test exercises anything in the diff; both are pre-existing/local-toolchain, not product evidence. CI's isolated suite is authoritative.
+
+## Audit Result
+
+Audit passed with warnings. The ticket's deliverable is clean: architecture 0 violations (610 modules), knip flags no new dead code, the new test file meets the test-quality bar, and no new clones were introduced (431 total, repo-minus-.safeword/.project baseline). Learnings W006: 0.
+
+The new check, run against this repo (dogfooding), surfaced **2 pre-existing domain-doc drifts** — `[E008] @surface.safeword-cli` (tagged in `features/` but absent from `surfaces.md`) and `[E009] persona DEV` (named in a spec but absent from `personas.md`). Both pre-date this ticket (my diff adds neither reference) and are out of scope for "add the check" — routed to follow-up tasks (add the Safeword CLI surface; resolve the DEV persona). They are the check working as designed, not defects in this deliverable.
+
+A latent bug in the check's own bash — a positional `$1` in a shell function, which skill/command argument-substitution clobbers to empty in a live session — was caught by dogfooding `/audit` here and fixed (commit c3272a79, named-var `$dd_file` + regression guard test).
+
+**Next:** Mark N0W5KG done; the two spawned follow-up tasks fix the real repo drifts the check surfaced.

--- a/features/audit-domain-docs-freshness.feature
+++ b/features/audit-domain-docs-freshness.feature
@@ -1,3 +1,10 @@
+# Acceptance is proven by the vitest lane, not cucumber step definitions:
+# packages/cli/tests/skills/audit-domain-documentation.test.ts extracts the real
+# domain-docs bash block and runs it via spawnSync against fixtures (W008/E008/
+# E009 asserted end-to-end). Tagged @wip to exclude this feature from the
+# cucumber acceptance lane (proof lives in vitest) while staying discoverable for
+# `safeword check` AC-coverage.
+@audit-domain-docs.TB1 @wip
 Feature: Audit checks namespace domain docs for emptiness and drift
 
   Audit's Project Documentation Checks reconcile the three namespace domain

--- a/features/audit-domain-docs-freshness.feature
+++ b/features/audit-domain-docs-freshness.feature
@@ -1,0 +1,115 @@
+Feature: Audit checks namespace domain docs for emptiness and drift
+
+  Audit's Project Documentation Checks reconcile the three namespace domain
+  docs — personas.md, surfaces.md, glossary.md — against what the code actually
+  references, and report empty scaffolds. Detection is a deterministic bash
+  block in the skill; content judgment stays human-owned.
+
+  Each "When audit runs the domain-docs check" operates on an isolated fixture
+  project (its own namespace root and features/), never the live repo. The check
+  keys on real reference positions and ignores HTML-commented scaffold examples:
+  surface references come from Gherkin @surface tag lines in features/**; persona
+  references come from spec.md `**Persona:** … (CODE)` lines after HTML comments
+  are stripped; entry counts ignore `##` headings that sit inside a `<!-- … -->`
+  comment. A slug or code that appears only in prose or inside a comment is not a
+  reference.
+
+  @audit-domain-docs.TB1.R1 @surface.claude-code @surface.openai-codex @surface.cursor
+  Rule: audit-domain-docs.TB1.R1 — A surface referenced by a scenario tag but absent from the surfaces inventory is a drift error
+
+    @rejection
+    Scenario: Surface tag with no matching inventory entry is reported
+      Given a fixture feature file with a tag line "@surface.safeword-cli"
+      And the fixture surfaces.md is populated but has no entry whose heading slugifies to safeword-cli
+      When audit runs the domain-docs check
+      Then it reports an E008 surface-drift error naming safeword-cli
+
+    Scenario: Every referenced surface tag resolves, including multi-word headings
+      Given the fixture surfaces.md defines "## Claude Code on the Web" and "## Cursor"
+      And the fixture feature files tag only @surface.claude-code-on-the-web and @surface.cursor
+      When audit runs the domain-docs check
+      Then it reports no surface-drift error
+
+    Scenario: A surface defined in the inventory but referenced by no tag is not reported
+      Given the fixture surfaces.md defines a surface whose slug appears in no @surface tag
+      When audit runs the domain-docs check
+      Then it reports no surface-drift error for that surface
+
+    Scenario: A surface slug that appears only in prose is not treated as a reference
+      Given a fixture feature file that mentions "@surface.safeword-cli" only inside a step's prose, not on a tag line
+      And the fixture surfaces.md has no Safeword CLI entry
+      When audit runs the domain-docs check
+      Then it reports no surface-drift error
+
+  @audit-domain-docs.TB1.R2 @surface.claude-code @surface.openai-codex @surface.cursor
+  Rule: audit-domain-docs.TB1.R2 — A persona named in a spec but absent from the personas inventory is a drift error
+
+    @rejection
+    Scenario: Persona code named in a live spec Persona line but undefined is reported
+      Given a fixture ticket spec.md with an uncommented line "**Persona:** Growth Marketer (GM)"
+      And the fixture personas.md has no entry with code GM
+      When audit runs the domain-docs check
+      Then it reports an E009 persona-drift error naming GM
+
+    Scenario: Every persona code referenced in a live spec line resolves to an inventory entry
+      Given every uncommented spec.md **Persona:** code has a matching personas.md entry
+      When audit runs the domain-docs check
+      Then it reports no persona-drift error
+
+    Scenario: A persona code appearing only in a commented-out spec example is not reported
+      Given a fixture spec.md whose only "**Persona:** … (GM)" line sits inside an HTML comment
+      And the fixture personas.md has no entry with code GM
+      When audit runs the domain-docs check
+      Then it reports no persona-drift error
+
+  @audit-domain-docs.TB1.R3 @surface.claude-code @surface.openai-codex @surface.cursor
+  Rule: audit-domain-docs.TB1.R3 — A domain doc with no uncommented entries is reported empty with an offer to fill it from its template
+
+    @rejection
+    Scenario: A verbatim surfaces scaffold is reported empty
+      Given the fixture surfaces.md is the install scaffold, whose only "##" headings sit inside its HTML comment
+      When audit runs the domain-docs check
+      Then it reports a W008 empty-doc warning for surfaces.md
+      And the warning names the template packages/cli/templates/surfaces-template.md to fill from
+
+    @rejection
+    Scenario: A verbatim glossary scaffold is reported empty
+      Given the fixture glossary.md is the install scaffold, whose only "##" headings sit inside its HTML comment
+      When audit runs the domain-docs check
+      Then it reports a W008 empty-doc warning for glossary.md naming the template packages/cli/templates/glossary-template.md to fill from
+
+    Scenario: A populated domain doc is not reported empty
+      Given the fixture surfaces.md has one or more uncommented "##" entries
+      When audit runs the domain-docs check
+      Then it reports no empty-doc warning for surfaces.md
+
+    Scenario: An absent domain doc is skipped, not reported empty
+      Given the fixture namespace root has no surfaces.md file at all
+      When audit runs the domain-docs check
+      Then it reports no empty-doc warning for surfaces.md and does not error
+
+    Scenario: An empty domain doc suppresses its own drift codes
+      Given the fixture surfaces.md is an empty scaffold with no uncommented entries
+      And a fixture feature file carries a tag line "@surface.safeword-cli"
+      When audit runs the domain-docs check
+      Then it reports the W008 empty-doc warning for surfaces.md
+      And it reports no E008 surface-drift error
+
+  @audit-domain-docs.TB1.R4 @surface.claude-code @surface.openai-codex @surface.cursor
+  Rule: audit-domain-docs.TB1.R4 — Human-curated content is never reported as an error; content staleness is advisory only
+
+    Scenario: A fully-populated, in-sync docs set produces no domain-doc findings
+      Given the fixture personas.md, surfaces.md, and glossary.md are all populated
+      And every referenced surface slug and persona code resolves to an entry
+      When audit runs the domain-docs check
+      Then it reports no domain-doc error or warning
+
+    Scenario: Editing a curated definition changes no finding
+      Given a fixture that is the in-sync docs set with one glossary term's definition reworded
+      When audit runs the domain-docs check
+      Then it reports the same result as the in-sync set — no E-code or W-code for that term
+
+    Scenario: The skill instructs that glossary and description prose is advisory, never an error
+      Given the installed audit skill guidance
+      When a reader reaches the domain-docs check
+      Then it states that glossary term meaning and persona or surface descriptions are advisory-only and never emitted as an error code

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -451,6 +451,10 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 # same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
 # blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
 # as an unclosed range and wipe every following line to EOF.
+# Line-based limitation (accepted): a `## ` heading that shares its line with a
+# multi-line comment OPENER (`## Foo <!-- note` … `-->`) is deleted with the
+# comment — well-formed markdown keeps headings on their own line, so this never
+# bites the real docs; pinned by a test so any change to it stays conscious.
 strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -516,6 +516,12 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -g
 fi
 ```
 
+**Content is human-owned — advisory only, never an error.** This check judges _references_ (a slug/code that is or isn't defined) and _emptiness_ — observable facts. Whether a glossary term's meaning, or a persona/surface _description_, is still accurate is a human judgment: raise it as an advisory note at most, never as an error code. Only the three codes above (E008, E009, W008) are emitted here.
+
+**Empty-doc offer (W008):** report the empty doc and point the user to its template — do **not** draft entries or write the file during the audit pass (read-only). Filling it is a follow-up the user approves.
+
+**Coverage limitation:** the block reads the default namespace-root locations; per-file `paths.personas` / `paths.surfaces` / `paths.glossary` overrides are validated by `safeword check` (structure), not here. Persona drift reads spec `**Persona:**` lines only — feature lineage tags are not a reliable persona source.
+
 ---
 
 ## Report Format
@@ -531,6 +537,8 @@ Report findings by severity with codes:
 - [E005] Dependency gap: `@tanstack/query` is a major dependency but is not documented in ARCHITECTURE.md
 - [E006] Structural gap: module `billing` in `architecture.generated.md` is not documented in `ARCHITECTURE.md` (missing)
 - [E007] Drifted layer→dir: `ARCHITECTURE.md` maps `domain` → `src/core/` but no such module path is in `architecture.generated.md`
+- [E008] Surface drift: `@surface.safeword-cli` is referenced in `features/` but has no matching entry in `surfaces.md`
+- [E009] Persona drift: persona code `DEV` is named in a spec `**Persona:**` line but has no matching entry in `personas.md`
 
 ### Warnings (should review)
 
@@ -540,6 +548,7 @@ Report findings by severity with codes:
 - [W005] Stale config: `knip.json` — `lodash` can be removed from ignoreDependencies
 - [W006] Learning file missing Covers: — `<namespace-root>/learnings/foo.md` (absent from INDEX.md)
 - [W007] Stale .safeword/depcruise-config.cjs — run `safeword sync-config` to refresh and commit
+- [W008] Empty domain doc: `surfaces.md` has no uncommented entries — fill from its template (BDD intake references degrade until filled)
 
 ### Code Quality
 

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -449,10 +449,13 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
+# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
+# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
 # Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
 # substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -472,7 +475,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -492,9 +495,13 @@ personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
 dd_file="$personas_file"
 if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
-  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
-  # initials, single -> first two chars, uppercased).
-  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  # Defined codes: explicit trailing `## Name (CODE)` wins; else derived
+  # best-effort (multi-word -> initials, single -> first two chars, uppercased).
+  # Derivation is naive (particles/hyphens mis-derive, e.g. Site-Reliability
+  # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
+  # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
+  # writes, to avoid a spurious E009.
+  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
     if [ -n "$explicit" ]; then
@@ -510,7 +517,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -481,6 +481,39 @@ if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -g
     fi
   done
 fi
+
+# --- Persona drift (E009): spec **Persona:** code referenced but undefined ---
+# Spec lines only, comment-stripped (feature lineage tags carry ticket-ids, not
+# personas). Suppressed when personas.md is empty/absent.
+personas_file="$NS_ROOT/personas.md"
+tickets_dir="$NS_ROOT/tickets"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+  # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
+  # initials, single -> first two chars, uppercased).
+  defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+    name="${heading#\#\# }"
+    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    if [ -n "$explicit" ]; then
+      printf '%s\n' "$explicit"
+      continue
+    fi
+    base="${name%% (*}"
+    if [ "$(printf '%s' "$base" | wc -w | tr -d ' ')" -ge 2 ]; then
+      printf '%s' "$base" | awk '{s="";for(i=1;i<=NF;i++)s=s toupper(substr($i,1,1));print s}'
+    else
+      printf '%s' "$base" | cut -c1-2 | tr '[:lower:]' '[:upper:]'
+    fi
+  done)"
+  # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
+  referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
+    [ -f "$spec" ] && sed '/<!--/,/-->/d' "$spec"
+  done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
+  for code in $referenced_codes; do
+    if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then
+      echo "[E009] Persona drift: code $code referenced in a spec but no matching entry in personas.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -449,15 +449,17 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
 
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
 # live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
+# substitution clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+  sed '/<!--/,/-->/d' "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
 for doc in personas surfaces glossary; do
-  file="$NS_ROOT/$doc.md"
-  [ -f "$file" ] || continue
-  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+  dd_file="$NS_ROOT/$doc.md"
+  [ -f "$dd_file" ] || continue
+  if [ "$(domain_docs_entry_count)" -eq 0 ]; then
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
@@ -466,7 +468,8 @@ done
 # Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
 FEATURES_DIR="$PROJECT_DIR/features"
 surfaces_file="$NS_ROOT/surfaces.md"
-if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+dd_file="$surfaces_file"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
   defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
@@ -487,7 +490,8 @@ fi
 # personas). Suppressed when personas.md is empty/absent.
 personas_file="$NS_ROOT/personas.md"
 tickets_dir="$NS_ROOT/tickets"
-if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count "$personas_file")" -gt 0 ] && [ -d "$tickets_dir" ]; then
+dd_file="$personas_file"
+if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$tickets_dir" ]; then
   # Defined codes: explicit `## Name (CODE)`, else derived (multi-word ->
   # initials, single -> first two chars, uppercased).
   defined_codes="$(sed '/<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -461,6 +461,26 @@ for doc in personas surfaces glossary; do
     echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
   fi
 done
+
+# --- Surface drift (E008): @surface.<slug> tag referenced but undefined ---
+# Suppressed when surfaces.md is empty/absent — W008 already says "fill it".
+FEATURES_DIR="$PROJECT_DIR/features"
+surfaces_file="$NS_ROOT/surfaces.md"
+if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count "$surfaces_file")" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
+  # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
+  # `tr` — BSD/macOS sed lacks `\L`.
+  defined_slugs="$(sed '/<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+    | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
+  # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
+  # with @), so a slug mentioned in step prose is not a reference.
+  referenced_slugs="$(grep -rhE '^[[:space:]]*@' "$FEATURES_DIR" 2> /dev/null \
+    | grep -oE '@surface\.[a-z0-9-]+' | sed 's/^@surface\.//' | sort -u)"
+  for slug in $referenced_slugs; do
+    if ! printf '%s\n' $defined_slugs | grep -qxF "$slug"; then
+      echo "[E008] Surface drift: @surface.$slug referenced in features/ but no matching entry in surfaces.md"
+    fi
+  done
+fi
 ```
 
 ---

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -447,15 +447,18 @@ NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJEC
   if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
 }
 
+# Single-source the HTML-comment strip used by every check below. Strips
+# same-line comments FIRST (`s/<!--.*-->//g`) then deletes multi-line comment
+# blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a lone `<!-- x -->`
+# as an unclosed range and wipe every following line to EOF.
+strip_html_comments='s/<!--.*-->//g; /<!--/,/-->/d'
+
 # Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
-# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
-# The sed strips same-line comments FIRST (`s/<!--.*-->//g`) then deletes
-# multi-line comment blocks (`/<!--/,/-->/d`): a POSIX range alone would treat a
-# lone `<!-- x -->` as an unclosed range and wipe every following line to EOF.
-# Reads the named var `dd_file`, NOT positional `$1`: skill/command argument
-# substitution clobbers `$1` in the injected block body.
+# live inside its comment, so a verbatim scaffold counts as zero. Reads the
+# named var `dd_file`, NOT positional `$1`: skill/command argument substitution
+# clobbers `$1` in the injected block body.
 domain_docs_entry_count() {
-  sed 's/<!--.*-->//g; /<!--/,/-->/d' "$dd_file" | grep -cE '^## '
+  sed "$strip_html_comments" "$dd_file" | grep -cE '^## '
 }
 
 # --- Emptiness (W008): a domain doc with no uncommented entries ---
@@ -475,7 +478,7 @@ dd_file="$surfaces_file"
 if [ -f "$surfaces_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$FEATURES_DIR" ]; then
   # Defined slugs: slugify each uncommented `## ` heading. Portable casing via
   # `tr` — BSD/macOS sed lacks `\L`.
-  defined_slugs="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
+  defined_slugs="$(sed "$strip_html_comments" "$surfaces_file" | grep -E '^## ' | sed 's/^## //' \
     | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//')"
   # Referenced slugs: @surface.<slug> on Gherkin tag lines only (line starts
   # with @), so a slug mentioned in step prose is not a reference.
@@ -501,7 +504,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # Engineer -> SE not SRE), and codes are the project's `[A-Z][A-Z0-9]{1,5}`
   # (>=2 chars) — prefer the explicit `(CODE)` heading, which `safeword check`
   # writes, to avoid a spurious E009.
-  defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
+  defined_codes="$(sed "$strip_html_comments" "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
     # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
     # after a stripped inline comment left a trailing space; capture only the code.
@@ -519,7 +522,7 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   done)"
   # Referenced codes: (CODE) from spec **Persona:** lines, comments stripped.
   referenced_codes="$(for spec in "$tickets_dir"/*/spec.md; do
-    [ -f "$spec" ] && sed 's/<!--.*-->//g; /<!--/,/-->/d' "$spec"
+    [ -f "$spec" ] && sed "$strip_html_comments" "$spec"
   done 2> /dev/null | grep -E '^\*\*Persona:\*\*' | grep -oE '\([A-Z][A-Z0-9]{1,5}\)' | tr -d '()' | sort -u)"
   for code in $referenced_codes; do
     if ! printf '%s\n' $defined_codes | grep -qxF "$code"; then

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -503,7 +503,9 @@ if [ -f "$personas_file" ] && [ "$(domain_docs_entry_count)" -gt 0 ] && [ -d "$t
   # writes, to avoid a spurious E009.
   defined_codes="$(sed 's/<!--.*-->//g; /<!--/,/-->/d' "$personas_file" | grep -E '^## ' | while IFS= read -r heading; do
     name="${heading#\#\# }"
-    explicit="$(printf '%s' "$name" | grep -oE '\([A-Z][A-Z0-9]{1,5}\)$' | tr -d '()')"
+    # Trailing-whitespace-tolerant so `## Name (CODE)` still reads explicitly
+    # after a stripped inline comment left a trailing space; capture only the code.
+    explicit="$(printf '%s' "$name" | sed -nE 's/.*\(([A-Z][A-Z0-9]{1,5})\)[[:space:]]*$/\1/p')"
     if [ -n "$explicit" ]; then
       printf '%s\n' "$explicit"
       continue

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -430,6 +430,39 @@ Test Quality:
 
 Review recent commits (since last tag or last 20 commits). For each significantly changed area, check if related docs, readmes, or guides across the project need updating. Flag stale, missing, or contradictory impacted documentation as errors. Documentation drift is never a warning; only date-based staleness with no changed-code contradiction stays a warning.
 
+### 6. Namespace Domain Docs
+
+Reconcile the three namespace domain docs — `personas.md`, `surfaces.md`, `glossary.md` — against what the code actually references, and report empty scaffolds. These docs feed the BDD intake flow, so silent rot there degrades every downstream spec. This check is **read-only and class-2** (observable facts only): it reports and offers, it never rewrites a doc. **Run the block below verbatim, as ONE bash invocation.**
+
+```bash
+# domain-docs-check — read-only reconciliation of the namespace domain docs.
+# Class-2: observable facts only. Emits W008 (empty). Never writes the tree.
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}" || exit 1
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2> /dev/null || pwd)}"
+
+# Resolve the namespace root (honors config paths.projectRoot in real runs).
+# Fall back on directory existence — robust when the resolver hook is absent.
+NS_ROOT="$(bun "$PROJECT_DIR/.safeword/hooks/resolve-namespace-root.ts" "$PROJECT_DIR" 2> /dev/null)"
+[ -d "$NS_ROOT" ] || {
+  if [ -d "$PROJECT_DIR/.project" ]; then NS_ROOT="$PROJECT_DIR/.project"; else NS_ROOT="$PROJECT_DIR/.safeword-project"; fi
+}
+
+# Count `## ` entries OUTSIDE HTML comments — the scaffold's example headings
+# live inside its `<!-- ... -->` comment, so a verbatim scaffold counts as zero.
+domain_docs_entry_count() {
+  sed '/<!--/,/-->/d' "$1" | grep -cE '^## '
+}
+
+# --- Emptiness (W008): a domain doc with no uncommented entries ---
+for doc in personas surfaces glossary; do
+  file="$NS_ROOT/$doc.md"
+  [ -f "$file" ] || continue
+  if [ "$(domain_docs_entry_count "$file")" -eq 0 ]; then
+    echo "[W008] Empty domain doc: $doc.md — fill from packages/cli/templates/$doc-template.md (BDD intake references degrade until filled)"
+  fi
+done
+```
+
 ---
 
 ## Report Format

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -92,3 +92,59 @@ describe('audit domain-documentation emptiness (W008)', () => {
     expect(output).not.toContain('glossary.md');
   });
 });
+
+const MULTIWORD_SURFACES = `# Surfaces\n\n## Claude Code on the Web\n\n**Kind:** Agent runtime\n\n## Cursor\n\n**Kind:** Agent runtime\n`;
+
+function tagLineFeature(...tags: string[]): string {
+  return `Feature: fixture\n\n  ${tags.join(' ')}\n  Scenario: one\n    Given a thing\n    When it happens\n    Then it holds\n`;
+}
+
+describe('audit domain-documentation surface drift (E008)', () => {
+  it('reports a surface tag with no matching inventory entry', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': POPULATED_SURFACES,
+      'features/x.feature': tagLineFeature('@surface.safeword-cli'),
+    });
+
+    expect(output).toContain('[E008]');
+    expect(output).toContain('safeword-cli');
+  });
+
+  it('does not report drift when every tag resolves, including multi-word headings', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': MULTIWORD_SURFACES,
+      'features/x.feature': tagLineFeature('@surface.claude-code-on-the-web', '@surface.cursor'),
+    });
+
+    expect(output).not.toContain('[E008]');
+  });
+
+  it('does not report a surface defined but referenced by no tag', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': POPULATED_SURFACES,
+      'features/x.feature': tagLineFeature('@surface.claude-code'),
+    });
+
+    expect(output).not.toContain('[E008]');
+  });
+
+  it('does not treat a surface slug mentioned only in prose as a reference', () => {
+    const proseOnly = `Feature: fixture\n\n  Scenario: one\n    Given the @surface.safeword-cli tag is discussed in prose\n    When it happens\n    Then it holds\n`;
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': POPULATED_SURFACES,
+      'features/x.feature': proseOnly,
+    });
+
+    expect(output).not.toContain('[E008]');
+  });
+
+  it('suppresses surface drift when surfaces.md is an empty scaffold', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': SURFACES_SCAFFOLD,
+      'features/x.feature': tagLineFeature('@surface.safeword-cli'),
+    });
+
+    expect(output).toContain('[W008]');
+    expect(output).not.toContain('[E008]');
+  });
+});

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -148,3 +148,45 @@ describe('audit domain-documentation surface drift (E008)', () => {
     expect(output).not.toContain('[E008]');
   });
 });
+
+const PERSONAS_TB = `# Personas\n\n## Technical Builder (TB)\n\n**Role:** Runs the agent.\n`;
+
+describe('audit domain-documentation persona drift (E009)', () => {
+  it('reports a persona code named in a live spec line but undefined', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/personas.md': PERSONAS_TB,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Growth Marketer (GM)\n`,
+    });
+
+    expect(output).toContain('[E009]');
+    expect(output).toContain('GM');
+  });
+
+  it('does not report drift when every live spec persona code resolves', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/personas.md': PERSONAS_TB,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Technical Builder (TB)\n`,
+    });
+
+    expect(output).not.toContain('[E009]');
+  });
+
+  it('does not report a persona code that appears only in a commented-out spec example', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/personas.md': PERSONAS_TB,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n<!--\n**Persona:** Growth Marketer (GM)\n-->\n`,
+    });
+
+    expect(output).not.toContain('[E009]');
+  });
+
+  it('resolves a persona defined by name only via derived code', () => {
+    const { output } = runDomainDocumentationCheck({
+      // No explicit (PO) — derived from "Platform Operator" -> PO.
+      '.project/personas.md': `# Personas\n\n## Platform Operator\n\n**Role:** Owns infra.\n`,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Platform Operator (PO)\n`,
+    });
+
+    expect(output).not.toContain('[E009]');
+  });
+});

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -88,6 +88,17 @@ describe('audit domain-documentation emptiness (W008)', () => {
     expect(output).not.toContain('[W008]');
   });
 
+  it('documents the accepted limit: a heading sharing a multi-line-comment opener line is not counted', () => {
+    // Line-based stripping deletes the whole opener line, heading included. This
+    // is malformed markdown (headings belong on their own line); pinned so any
+    // change to the strip stays a conscious choice. Here only "## Kept" survives,
+    // so the doc is NOT empty — the surviving heading keeps it out of W008.
+    const openerOnHeadingLine = `# Surfaces\n## Swallowed <!-- opening note\nstill in comment\n-->\n## Kept\n\n**Kind:** x\n`;
+    const { output } = runDomainDocumentationCheck({ '.project/surfaces.md': openerOnHeadingLine });
+
+    expect(output).not.toContain('[W008]');
+  });
+
   it('skips absent domain docs without erroring', () => {
     const { output, status } = runDomainDocumentationCheck({
       '.project/surfaces.md': POPULATED_SURFACES,

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -19,7 +19,7 @@ function extractDomainDocumentationBlock(): string {
   const content = readSurface('packages/cli/templates/skills/audit/SKILL.md');
   const block = content
     .matchAll(/```bash\n([\s\S]*?)\n```/g)
-    .map(match => match[1])
+    .map(match => match[1] ?? '')
     .find(body => body.includes('domain-docs-check'));
   if (!block) throw new Error('domain-docs-check bash block not found in audit SKILL.md');
   return block;

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -190,3 +190,56 @@ describe('audit domain-documentation persona drift (E009)', () => {
     expect(output).not.toContain('[E009]');
   });
 });
+
+const IN_SYNC_FIXTURE: Record<string, string> = {
+  '.project/personas.md': PERSONAS_TB,
+  '.project/surfaces.md': POPULATED_SURFACES,
+  '.project/glossary.md': `# Glossary\n\n## Tool\n\n**Definition:** A callable capability.\n`,
+  '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Technical Builder (TB)\n`,
+  'features/x.feature': tagLineFeature('@surface.claude-code'),
+};
+
+describe('audit domain-documentation content is advisory only (R4)', () => {
+  it('produces no findings on a fully-populated, in-sync docs set', () => {
+    const { output } = runDomainDocumentationCheck(IN_SYNC_FIXTURE);
+
+    expect(output).not.toContain('[E008]');
+    expect(output).not.toContain('[E009]');
+    expect(output).not.toContain('[W008]');
+  });
+
+  it('emits the same result when a curated definition is reworded', () => {
+    const inSync = runDomainDocumentationCheck(IN_SYNC_FIXTURE);
+    const edited = runDomainDocumentationCheck({
+      ...IN_SYNC_FIXTURE,
+      '.project/glossary.md': `# Glossary\n\n## Tool\n\n**Definition:** A wholly different, arguably stale wording.\n`,
+    });
+
+    expect(edited.output).toBe(inSync.output);
+    expect(edited.output).not.toContain('[E');
+    expect(edited.output).not.toContain('[W');
+  });
+});
+
+const AUDIT_SURFACES = [
+  'packages/cli/templates/skills/audit/SKILL.md',
+  '.agents/skills/audit/SKILL.md',
+  '.claude/skills/audit/SKILL.md',
+];
+
+describe('audit domain-documentation skill guidance parity', () => {
+  it.each(AUDIT_SURFACES)('%s documents the domain-docs codes and advisory rule', relativePath => {
+    const content = readSurface(relativePath);
+
+    // The check exists and carries its sentinel + codes.
+    expect(content).toContain('domain-docs-check');
+    expect(content).toContain('Namespace Domain Docs');
+    // Codes appear in the Report Format legend, not only inline.
+    expect(content).toContain('[E008] Surface drift');
+    expect(content).toContain('[E009] Persona drift');
+    expect(content).toContain('[W008] Empty domain doc');
+    // R4: human-curated content is advisory-only, never an error.
+    expect(content).toContain('advisory');
+    expect(content).toMatch(/never (an? )?error/i);
+  });
+});

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -207,6 +207,17 @@ describe('audit domain-documentation persona drift (E009)', () => {
     expect(output).not.toContain('[W008]');
   });
 
+  it('reads an explicit code even when the heading has a trailing inline comment', () => {
+    // "Foo Bar" derives to FB, not XY — so this only resolves if the explicit
+    // (XY) is read despite the trailing space left by the stripped comment.
+    const { output } = runDomainDocumentationCheck({
+      '.project/personas.md': `# Personas\n\n## Foo Bar (XY) <!-- alias -->\n\n**Role:** x.\n`,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Foo Bar (XY)\n`,
+    });
+
+    expect(output).not.toContain('[E009]');
+  });
+
   it('resolves a persona defined by name only via derived code', () => {
     const { output } = runDomainDocumentationCheck({
       // No explicit (PO) — derived from "Platform Operator" -> PO.

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -81,6 +81,13 @@ describe('audit domain-documentation emptiness (W008)', () => {
     expect(output).not.toContain('[W008]');
   });
 
+  it('does not report a populated doc empty when it has a single-line HTML comment', () => {
+    const withInlineComment = `# Surfaces\n<!-- TODO: keep sorted -->\n## Claude Code\n\n**Kind:** Agent runtime\n`;
+    const { output } = runDomainDocumentationCheck({ '.project/surfaces.md': withInlineComment });
+
+    expect(output).not.toContain('[W008]');
+  });
+
   it('skips absent domain docs without erroring', () => {
     const { output, status } = runDomainDocumentationCheck({
       '.project/surfaces.md': POPULATED_SURFACES,
@@ -138,6 +145,16 @@ describe('audit domain-documentation surface drift (E008)', () => {
     expect(output).not.toContain('[E008]');
   });
 
+  it('does not false-flag a surface whose heading follows a single-line comment', () => {
+    const withInlineComment = `# Surfaces\n## Claude Code\n\n**Kind:** x\n<!-- keep sorted alphabetically -->\n## Cursor\n\n**Kind:** y\n`;
+    const { output } = runDomainDocumentationCheck({
+      '.project/surfaces.md': withInlineComment,
+      'features/x.feature': tagLineFeature('@surface.cursor'),
+    });
+
+    expect(output).not.toContain('[E008]');
+  });
+
   it('suppresses surface drift when surfaces.md is an empty scaffold', () => {
     const { output } = runDomainDocumentationCheck({
       '.project/surfaces.md': SURFACES_SCAFFOLD,
@@ -178,6 +195,16 @@ describe('audit domain-documentation persona drift (E009)', () => {
     });
 
     expect(output).not.toContain('[E009]');
+  });
+
+  it('resolves a persona whose heading follows a single-line comment', () => {
+    const { output } = runDomainDocumentationCheck({
+      '.project/personas.md': `# Personas\n<!-- roles below, keep in sync -->\n## Technical Builder (TB)\n\n**Role:** x.\n`,
+      '.project/tickets/T1-x/spec.md': `# Spec\n\n**Persona:** Technical Builder (TB)\n`,
+    });
+
+    expect(output).not.toContain('[E009]');
+    expect(output).not.toContain('[W008]');
   });
 
   it('resolves a persona defined by name only via derived code', () => {

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -242,4 +242,13 @@ describe('audit domain-documentation skill guidance parity', () => {
     expect(content).toContain('advisory');
     expect(content).toMatch(/never (an? )?error/i);
   });
+
+  it('does not use a positional $1 in the domain-docs block (clobbered by skill-arg substitution)', () => {
+    // Skill/command injection substitutes positional $1 in the block body, so a
+    // shell function reading "$1" breaks in a live session. Named vars survive.
+    const block = extractDomainDocumentationBlock();
+
+    expect(block).not.toContain('"$1"');
+    expect(block).toContain('"$dd_file"');
+  });
 });

--- a/packages/cli/tests/skills/audit-domain-documentation.test.ts
+++ b/packages/cli/tests/skills/audit-domain-documentation.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+
+function readSurface(relativePath: string): string {
+  return readFileSync(nodePath.join(ROOT, relativePath), 'utf8');
+}
+
+/**
+ * Extract the domain-docs bash block by its sentinel marker rather than by
+ * ordinal — robust to bash blocks added earlier in the skill.
+ */
+function extractDomainDocumentationBlock(): string {
+  const content = readSurface('packages/cli/templates/skills/audit/SKILL.md');
+  const block = content
+    .matchAll(/```bash\n([\s\S]*?)\n```/g)
+    .map(match => match[1])
+    .find(body => body.includes('domain-docs-check'));
+  if (!block) throw new Error('domain-docs-check bash block not found in audit SKILL.md');
+  return block;
+}
+
+/**
+ * Materialize a fixture project, run the extracted domain-docs block against it,
+ * and return combined stdout+stderr. `bun` is NOT stubbed: the block's
+ * `[ -d "$NS_ROOT" ]` fallback resolves the fixture's `.project/` even though
+ * the real resolver hook is absent in the temp dir.
+ */
+function runDomainDocumentationCheck(files: Record<string, string>): {
+  output: string;
+  status: number;
+} {
+  const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-domain-docs-'));
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const absolutePath = nodePath.join(projectDirectory, relativePath);
+      mkdirSync(nodePath.dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, content);
+    }
+    const result = spawnSync('bash', ['-c', extractDomainDocumentationBlock()], {
+      cwd: projectDirectory,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDirectory, PATH: process.env.PATH ?? '' },
+      encoding: 'utf8',
+    });
+    return { output: `${result.stdout ?? ''}${result.stderr ?? ''}`, status: result.status ?? 0 };
+  } finally {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  }
+}
+
+const SURFACES_SCAFFOLD = readSurface('packages/cli/templates/surfaces-template.md');
+const GLOSSARY_SCAFFOLD = readSurface('packages/cli/templates/glossary-template.md');
+
+const POPULATED_SURFACES = `# Surfaces\n\n## Claude Code\n\n**Kind:** Agent runtime\n**Description:** Local CLI.\n`;
+
+describe('audit domain-documentation emptiness (W008)', () => {
+  it('reports a verbatim surfaces scaffold as empty, naming its template', () => {
+    const { output } = runDomainDocumentationCheck({ '.project/surfaces.md': SURFACES_SCAFFOLD });
+
+    expect(output).toContain('[W008]');
+    expect(output).toContain('surfaces.md');
+    expect(output).toContain('packages/cli/templates/surfaces-template.md');
+  });
+
+  it('reports a verbatim glossary scaffold as empty, naming its template', () => {
+    const { output } = runDomainDocumentationCheck({ '.project/glossary.md': GLOSSARY_SCAFFOLD });
+
+    expect(output).toContain('[W008]');
+    expect(output).toContain('glossary.md');
+    expect(output).toContain('packages/cli/templates/glossary-template.md');
+  });
+
+  it('does not report a populated surfaces doc as empty', () => {
+    const { output } = runDomainDocumentationCheck({ '.project/surfaces.md': POPULATED_SURFACES });
+
+    expect(output).not.toContain('[W008]');
+  });
+
+  it('skips absent domain docs without erroring', () => {
+    const { output, status } = runDomainDocumentationCheck({
+      '.project/surfaces.md': POPULATED_SURFACES,
+    });
+
+    // personas.md and glossary.md are absent here — no W008 for them, no crash.
+    expect(status).toBe(0);
+    expect(output).not.toContain('personas.md');
+    expect(output).not.toContain('glossary.md');
+  });
+});


### PR DESCRIPTION
Closes #1027. Ticket N0W5KG.

## What

Adds `### 6. Namespace Domain Docs` to the `/audit` skill (3 byte-identical mirrors: template + Claude + Codex): a **read-only, class-2** bash block that reconciles the three namespace domain docs against what the code references, and reports empty scaffolds.

- **W008** — a `personas.md` / `surfaces.md` / `glossary.md` scaffold with no uncommented `##` entries → warn + offer to fill from its template (never writes during the pass).
- **E008** — an `@surface.<slug>` Gherkin tag line in `features/**` with no matching (portably-slugified) heading in `surfaces.md`.
- **E009** — a persona code in a comment-stripped `spec.md` `**Persona:** … (CODE)` line, absent from `personas.md`.
- **R4** — human-curated *content* (term meanings, descriptions) is advisory-only, never an error. Codes added to the skill's Report Format legend.

## Why

These docs feed the BDD intake flow; when they rot (empty on install, or a surface/persona referenced but never inventoried), every downstream spec references stale ground. Running the check on this repo surfaces two real, pre-existing drifts — `@surface.safeword-cli` and persona `DEV` — both routed to follow-up tasks.

## How it was built

Full BDD (ticket N0W5KG): `/figure-it-out` on approach + fill-offer depth → 15 scenarios → **two independent review rounds each** on scenarios and plan (the plan review empirically ran the extraction on the real repo and killed two bad assumptions before any code) → four TDD slices → `/verify` + `/audit` → `/quality-review` + `/refactor`.

Design: pure prose + bash in the skill, **no new CLI code** (structure is already validated by `safeword check`/`health.ts`). Mirrors the existing Section-3 W006 pattern.

## Notable bugs caught in-flight

- **Positional `$1` clobber** — skill/command argument-substitution rewrites `$1` in the injected block to empty; a shell function reading `"$1"` breaks in a live session. Caught dogfooding `/audit`; fixed with a named var + guard test.
- **POSIX `sed`-range on single-line comments** — a lone `<!-- x -->` opened the `/<!--/,/-->/` range and deleted to EOF (false empties/drifts, and *hid* real drift). Caught in `/quality-review`; fixed by collapsing same-line comments first.

## Tests

23 integration tests that extract the real bash block and run it via `spawnSync` against fixtures (genuine wiring, not content assertions) + content-parity assertions across the 3 mirrors. Portability verified for darwin (BSD) + Linux CI (`tr` not `sed \L`, comment-range handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
