### PR TITLE
docs: add Safeword CLI surface to surfaces.md

### DIFF
--- a/.project/surfaces.md
+++ b/.project/surfaces.md
@@ -58,3 +58,12 @@ surfaces.md from packages/cli/templates/surfaces-template.md and then own it.
 **Examples:** `.cursor/environment.json` (cloud-only env config), Cursor Web (cursor.com/agents), Slack/GitHub/Linear `@cursor` mentions, `cursor/<task-slug>` branches (customizable prefix)
 **Coverage notes:** Tag feature scenarios with `@surface.cursor-cloud-agents` when behavior depends on the cloud VM lifecycle rather than local IDE mechanics. Project-level `.cursor/rules`, `.cursor/commands`, and command-based `.cursor/hooks.json` still apply; user-level hooks and IDE-only events do not.
 **Do not confuse with:** Cursor — runs in the IDE on the developer's machine with full local environment access.
+
+## Safeword CLI
+
+**Kind:** CLI
+**Description:** The `safeword` command-line tool itself — the harness-agnostic engine that installs and maintains the process layer. Runs setup/upgrade to scaffold and reconcile managed files (personas.md, surfaces.md, glossary.md, hooks, skills), and check/sync-config/test-plan/ticket to validate and drive the workflow. Operates on the project's real filesystem independent of which agent (if any) invokes it.
+**Audience:** Technical Builder (TB), Safeword Maintainer (SM)
+**Examples:** `safeword setup`, `safeword upgrade`, `safeword check`, `safeword sync-config`, `safeword test-plan`, `safeword ticket new`, the managed-file reconcile contract, generated `INDEX.md`
+**Coverage notes:** Tag feature scenarios with `@surface.safeword-cli` when the behavior is the CLI tool's own — file scaffolding/reconciliation, config validation, index generation — rather than something that must work through a specific agent runtime.
+**Do not confuse with:** Claude Code / OpenAI Codex / Cursor — the agent runtimes that *invoke* safeword during a session. `@surface.safeword-cli` marks behavior that must hold no matter which agent (or a plain terminal) runs the command.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (414)
+## Tickets (416)
 
 ### 001
 
@@ -905,6 +905,10 @@
 - **Custom paths.projectRoot: wire formatter ignores + auto-upgrade staging (1QNPCF)** (done, epic: —)
   Make the namespace-root contribution to formatter ignore-lists and the auto-upgrade owned-paths prefixes follow the _resolved_ `paths.projectRoot`, not just the static `.project/`/`.safeword-project/`.
   → `.project/tickets/1QNPCF-custom-projectroot-wiring`
+- **Debug Codex retro runtime completion (24WR26)** (done, epic: —)
+  Identify the failing Codex retro runtime boundary and add focused smoke evidence for child launch and offset writes.
+  external issue: https://github.com/ArcadeAI/safeword/issues/960
+  → `.project/tickets/24WR26-codex-retro-runtime-completion`
 - **Reconcile ARCHITECTURE.md narrative with the generated module map (25TJAR)** (in_progress, epic: —)
   ARCHITECTURE.md documents all 13 real CLI modules, the test-plan module location, the plugin/ packaging note, and the cucumber runtime deps
   → `.project/tickets/25TJAR-architecture-narrative-reconcile`
@@ -1303,6 +1307,9 @@
 - **Show complete reset removals for users (P95FN6)** (in_progress, epic: —)
   Make `ReconcileResult.removed` report every file removed during reset/uninstall, including cleanup side effects from unmerge and unpatch executors.
   → `.project/tickets/P95FN6-show-complete-reset-removals`
+- **Add Safeword CLI surface to surfaces.md (P9Z3P7)** (in_progress, epic: —)
+  Add a ## Safeword CLI entry so the @surface.safeword-cli tags in feature-surfaces-bdd.feature resolve, clearing the E008 drift the new audit check found
+  → `.project/tickets/P9Z3P7-safeword-cli-surface`
 - **Retro accepts process-level friction surfaces and reports egress drops (PNZM3B)** (done, epic: —)
   Let retro file process-level friction under a leak-proof `process/<slug>` surface and report every egress drop, so silence means clean instead of secretly lossy.
   → `.project/tickets/PNZM3B-retro-process-surface`

--- a/.project/tickets/P9Z3P7-safeword-cli-surface/ticket.md
+++ b/.project/tickets/P9Z3P7-safeword-cli-surface/ticket.md
@@ -1,0 +1,20 @@
+---
+id: P9Z3P7
+slug: safeword-cli-surface
+type: task
+phase: done
+status: done
+created: 2026-07-13T22:01:05.339Z
+last_modified: 2026-07-13T22:01:05.339Z
+---
+
+# Add Safeword CLI surface to surfaces.md
+
+**Goal:** Add a ## Safeword CLI entry so the @surface.safeword-cli tags in feature-surfaces-bdd.feature resolve, clearing the E008 drift the new audit check found
+
+**Why:** feature-surfaces-bdd tags @surface.safeword-cli on 3 tag lines but surfaces.md has no matching entry; the safeword CLI is a real, distinct surface (its own setup/upgrade/check behaviors), not an agent runtime
+
+## Work Log
+
+- 2026-07-13T22:01:05.339Z Started: Created ticket P9Z3P7
+- 2026-07-13T22:02:24.869Z Phase: intake → done


### PR DESCRIPTION
Task P9Z3P7. Resolves the E008 surface-drift that the new `/audit` domain-docs check ([#1038](https://github.com/ArcadeAI/safeword/pull/1038)) surfaces.

`feature-surfaces-bdd.feature` tags `@surface.safeword-cli` on 3 tag lines, but `.project/surfaces.md` had no matching entry. The `safeword` CLI is a genuinely distinct **CLI-kind** surface — its own setup/upgrade/check/reconcile behaviors, harness-agnostic — not one of the agent runtimes that *invoke* it (figure-it-out: retagging would mis-attribute CLI behavior to an agent runtime and lose coverage signal).

Added a `## Safeword CLI` entry in the house format; slug `safeword-cli` now resolves. 121 surface/persona tests green; `safeword check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)