### PR TITLE
docs: add Agent-Driven Developer (DEV) persona to personas.md

### DIFF
--- a/.project/personas.md
+++ b/.project/personas.md
@@ -13,6 +13,12 @@ packages/cli/templates/personas-template.md.
 
 **Context:** Stack-agnostic and harness-agnostic — safeword is a process layer, not a framework opinion, so this persona ships Next, Django, Gin, anything across Claude Code, Cursor, or Codex. Doesn't want to learn safeword's internals; expects it to feel like an experienced teammate that "just does things well." Guardrails fire only during agent sessions, never blocking their own hand-written commits. Drives the agent across many sessions and leans on tickets, gates, and BDD/TDD to stay oriented and to get unblocked when a gate fires. Can read the diff and unblock themselves with technical reasoning when a gate fires.
 
+## Agent-Driven Developer (DEV)
+
+**Role:** A developer driving an AI coding agent through safeword's workflow — tickets, dependency sequencing, BDD/TDD lanes, and the generated indices — across many interdependent pieces of work.
+
+**Context:** The established code for the technical-developer persona across safeword's own early specs (ticket-deps, gherkin lanes, discovery index, namespace migration, …). Same axis as **Technical Builder (TB)** — a code-reading developer driving an agent — and the honest read is that DEV and TB name the same person; DEV is retained because its `@<slug>.DEV<n>` lineage is numbering-locked into ~25 specs, ~65 `.feature` tags, and test names, where a rename would churn frozen done-work for no behavioral gain. **Prefer `TB` for new specs;** treat `DEV` as its entrenched historical alias, not a distinct audience. (Any real consolidation belongs in a deliberate follow-up, not a passing edit.)
+
 ## Non-Technical Builder (NTB)
 
 **Role:** Someone who ships software by directing an AI coding agent but doesn't read or write the code themselves — leans entirely on safeword's guardrails to keep the agent honest.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (414)
+## Tickets (416)
 
 ### 001
 
@@ -905,6 +905,10 @@
 - **Custom paths.projectRoot: wire formatter ignores + auto-upgrade staging (1QNPCF)** (done, epic: —)
   Make the namespace-root contribution to formatter ignore-lists and the auto-upgrade owned-paths prefixes follow the _resolved_ `paths.projectRoot`, not just the static `.project/`/`.safeword-project/`.
   → `.project/tickets/1QNPCF-custom-projectroot-wiring`
+- **Debug Codex retro runtime completion (24WR26)** (done, epic: —)
+  Identify the failing Codex retro runtime boundary and add focused smoke evidence for child launch and offset writes.
+  external issue: https://github.com/ArcadeAI/safeword/issues/960
+  → `.project/tickets/24WR26-codex-retro-runtime-completion`
 - **Reconcile ARCHITECTURE.md narrative with the generated module map (25TJAR)** (in_progress, epic: —)
   ARCHITECTURE.md documents all 13 real CLI modules, the test-plan module location, the plugin/ packaging note, and the cucumber runtime deps
   → `.project/tickets/25TJAR-architecture-narrative-reconcile`
@@ -1256,6 +1260,9 @@
 - **Epic: Make safeword legible to the Non-Technical Builder (K6CAJN)** (done, epic: —)
   Close the gaps where safeword speaks to the Non-Technical Builder (NTB) in raw jargon — across the CLI terminal, first-run runtime checks, gate blocks, and the framing rules that govern translation — so a user who can't read the diff always gets a plain-language explanation and a concrete next action.
   → `.project/tickets/K6CAJN-ntb-experience-epic`
+- **Add Agent-Driven Developer (DEV) persona to personas.md (KDS0P6)** (in_progress, epic: —)
+  Add the DEV persona block so the 25 specs / 65 feature tags using code DEV resolve, clearing the E009 drift the new audit check found
+  → `.project/tickets/KDS0P6-dev-persona-entry`
 - **Absorb the two remaining private shell tokenizers into shell-segments (KQ3MRV)** (done, epic: —)
   Migrate `cursor-run-identity.ts` and `branch-staleness.ts` — the two private shell tokenizers the EDDABK code review found outside the four Bash security gates — onto the shared `shell-segments.ts` tokenizer, so the "one tokenizer, one test surface" property holds repo-wide.
   → `.project/tickets/KQ3MRV-tokenizer-absorption`

--- a/.project/tickets/KDS0P6-dev-persona-entry/ticket.md
+++ b/.project/tickets/KDS0P6-dev-persona-entry/ticket.md
@@ -1,0 +1,20 @@
+---
+id: KDS0P6
+slug: dev-persona-entry
+type: task
+phase: done
+status: done
+created: 2026-07-13T22:05:58.989Z
+last_modified: 2026-07-13T22:05:58.989Z
+---
+
+# Add Agent-Driven Developer (DEV) persona to personas.md
+
+**Goal:** Add the DEV persona block so the 25 specs / 65 feature tags using code DEV resolve, clearing the E009 drift the new audit check found
+
+**Why:** DEV is an entrenched persona code (25 specs, 65 feature tags, test-name lineage) but was never in personas.md; migrating DEV->TB across frozen done-work is high-risk churn, so legitimize the established code with an honest TB cross-reference
+
+## Work Log
+
+- 2026-07-13T22:05:58.989Z Started: Created ticket KDS0P6
+- 2026-07-13T22:07:26.407Z Phase: intake → done


### PR DESCRIPTION
Task KDS0P6. Resolves the E009 persona-drift that the new `/audit` domain-docs check ([#1038](https://github.com/ArcadeAI/safeword/pull/1038)) surfaces.

`DEV` ("Agent-Driven Developer") is an entrenched persona code — **~25 specs, ~65 `.feature` tags, and test-name lineage** (`reconcile-namespace-root.test.ts` → `DEV1.AC1…`) — but was never defined in `.project/personas.md`.

**figure-it-out:** DEV and TB ("Technical Builder") name the same technical-developer axis, so consolidation would be "more correct" — but migrating `DEV`→`TB` across frozen done-work touches 25 specs / 65 tags / locked lineage IDs / green test names for **no behavioral gain and real regression risk**. Adding no-alias-support to personas.ts over-engineers a doc fix. So: legitimize the established code with an explicit `(DEV)` override and an honest note that DEV is TB's entrenched historical alias — **prefer TB for new specs**; leave any real consolidation to a deliberate follow-up.

`safeword check` keeps the explicit override (doesn't rewrite to the derived `ADD`); 84 persona/reconcile tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)