### PR TITLE
test(setup): guard shell detection against vendored .sh files

### DIFF
--- a/packages/cli/tests/utils/shell-detection.test.ts
+++ b/packages/cli/tests/utils/shell-detection.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { detectProjectType } from '../../src/utils/project-detector';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  const directories = [...temporaryDirectories];
+  temporaryDirectories.length = 0;
+  for (const dir of directories) rmSync(dir, { force: true, recursive: true });
+});
+
+function makeRepo(files: Record<string, string>): string {
+  const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shell-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const abs = nodePath.join(root, relativePath);
+    mkdirSync(nodePath.dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return root;
+}
+
+describe('project shell detection', () => {
+  it('is true when the USER has a shell script in their own source tree', () => {
+    const root = makeRepo({ 'scripts/deploy.sh': '#!/bin/sh\necho hi\n' });
+    expect(detectProjectType({}, root).shell).toBe(true);
+  });
+
+  it('is false when the only .sh files live in safeword-owned dirs', () => {
+    // A fresh Rust project whose only .sh files were installed by safeword and
+    // the auto-installed language skill. These are NOT the user's scripts, so
+    // shell detection must ignore them — otherwise the post-setup health check
+    // expects a prettier-plugin-sh that setup never installed and
+    // `setup --yes` exits 1 (the rust-golden-path CI regression).
+    const root = makeRepo({
+      'Cargo.toml': '[package]\nname = "x"\nversion = "0.1.0"\nedition = "2021"\n',
+      '.safeword/scripts/cleanup-zombies.sh': '#!/bin/sh\n',
+      '.claude/skills/rust-skills/checks/check.sh': '#!/bin/sh\n',
+      '.agents/skills/rust-skills/checks/check.sh': '#!/bin/sh\n',
+    });
+    expect(detectProjectType({}, root).shell).toBe(false);
+  });
+
+  it('is false for a project with no shell scripts at all', () => {
+    const root = makeRepo({ 'src/main.rs': 'fn main() {}\n' });
+    expect(detectProjectType({}, root).shell).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

A **test-only** addition. The underlying bug — `safeword setup --yes` exiting 1 on non-JS projects because vendored `.sh` files (safeword's own scripts + auto-installed language skills under `.claude`/`.agents`) flip `hasShellScripts` true only *after* package install — was already fixed on main by **#993**. This PR touches **no source**; it adds the unit guard that main still lacks.

## Why (not redundant with the E2E)

`rust-golden-path.test.ts` already catches a regression of this end-to-end — that's how the bug surfaced — but only **slowly** (~5 min), **network-gated** (it installs the rust skill via `npx`), toolchain-gated, and as a coarse `setupOrThrow` cascade three layers from the cause. This test pins the detector contract directly (`detectProjectType().shell`): a regression localizes **fast and offline**, at the unit level. Test-pyramid discipline — guard the subtle rule where it lives.

## The guard

- User `.sh` in their own tree → `shell: true`.
- Only vendored `.sh` under safeword-owned dirs (`.safeword`, `.claude`, `.agents`) → `shell: false`.
- No `.sh` at all → `shell: false`.

Implementation-agnostic (asserts behavior, not the exclude list), so it passes against #993's fix as-is and stays valid if that list is later refactored.

## Scope note

I originally also refactored the exclude list to reuse `SAFEWORD_IGNORE_DIRS` (single-source; also covers namespace roots the hardcoded list omits). Dropped it — that's a drive-by edit of #993's just-merged code for a marginal gain; if wanted, it's a separate follow-up. This PR is only the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)