### PR TITLE
chore(release): v0.69.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.68.0 hook codex session-start",
+            "command": "bunx --bun safeword@0.69.0 hook codex session-start",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.68.0 hook codex pre-tool-use",
+            "command": "bunx --bun safeword@0.69.0 hook codex pre-tool-use",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.68.0 hook codex post-tool-use",
+            "command": "bunx --bun safeword@0.69.0 hook codex post-tool-use",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.68.0 hook codex user-prompt-submit",
+            "command": "bunx --bun safeword@0.69.0 hook codex user-prompt-submit",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.68.0 hook codex stop",
+            "command": "bunx --bun safeword@0.69.0 hook codex stop",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.69.0 (minor)

Cuts the release for the Codex packaged-plugin migration merged in #993 (`feat(codex): migrate Safe Word to packaged plugin hooks`).

**Version bump only** — all four release-tracked artifacts moved 0.68.0 → 0.69.0:
- `packages/cli/package.json`
- `.claude-plugin/marketplace.json` → `plugins[0].version`
- `packages/cli/codex-plugin/.codex-plugin/plugin.json`
- `packages/cli/codex-plugin/hooks.json` (all 5 pinned `bunx --bun safeword@0.69.0` commands)

`bun.lock` unchanged (pure version bump — no resolution change under bun 1.3.14). `scripts/check-version-sync.ts` passes.

### Semver: minor
New Codex plugin path is **additive / opt-in** — `safeword upgrade` preserves existing repo-local Codex hook runtime files so enforcement keeps working; users adopt the plugin explicitly via `safeword migrate codex-plugin`. Passes the "auto-upgrade at SessionStart — does anything break?" test in the negative.

### Release notes for existing Codex users
The repo-local Codex install is superseded by a packaged plugin + the `safeword hook codex` CLI. To adopt it: run `safeword migrate codex-plugin`, review the plugin hooks in Codex `/hooks`, then `safeword migrate codex-plugin --remove-legacy-hooks` to complete the handoff.

After merge: tag `v0.69.0` on the merge commit → `release.yml` publishes to npm via OIDC.