### PR TITLE
fix(test): wire 'Bun is unavailable' step to actually hide bun (flaky cucumber lane)

### DIFF
--- a/packages/cli/features/steps/migrate-codex-plugin.steps.ts
+++ b/packages/cli/features/steps/migrate-codex-plugin.steps.ts
@@ -51,6 +51,7 @@ command = "gh-mcp"
 interface MigrationWorld extends SafewordWorld {
   migrationDirectory?: string;
   migrationBin?: string;
+  bunUnavailable?: boolean;
   migrationResult?: { stdout: string; stderr: string; exitCode: number };
   originalCodexConfig?: string;
   customCodexConfiguration?: string;
@@ -121,7 +122,11 @@ esac
   world.migrationBin = bin;
 }
 
-function migrate(world: MigrationWorld, shouldRemoveLegacyHooks = false, withoutBun = false): void {
+function migrate(
+  world: MigrationWorld,
+  shouldRemoveLegacyHooks = false,
+  withoutBun = world.bunUnavailable ?? false,
+): void {
   const directory = worldDirectory(world);
   const arguments_ = ['migrate', 'codex-plugin'];
   if (shouldRemoveLegacyHooks) arguments_.push('--remove-legacy-hooks');
@@ -258,6 +263,11 @@ Given('Codex reports the Safe Word plugin is disabled', function (this: Migratio
 
 Given('Bun is unavailable', function (this: MigrationWorld) {
   this.migrationBin = undefined;
+  // Empty the migration's PATH so neither the stub nor a real bun on the
+  // developer/CI PATH is found — otherwise `bun --version` in the migration
+  // succeeds and the "migration fails" assertion is a no-op (the withoutBun
+  // switch existed but was never wired to this step).
+  this.bunUnavailable = true;
 });
 
 When('the builder upgrades Safe Word', function (this: MigrationWorld) {


### PR DESCRIPTION
## Problem

The `migrate-codex-to-plugin` cucumber harness has a `withoutBun` switch that empties the spawned migration's `PATH`, but **nothing ever sets it true** (0 callers). The `Bun is unavailable` step only nulls `migrationBin`, which leaves a real `bun` on `process.env.PATH` — so `bun --version` inside the migration succeeds and the **"Missing Bun retains legacy hooks"** scenario asserts a no-op.

Result: the scenario passes only on CI runners whose PATH happens to lack `bun`, and fails wherever `bun` is present (local dev, and runners with `setup-bun` on PATH). That's why #993's CI went green but later PRs branched off it go red on this lane — pure environment luck, not code.

## Fix

Wire the precondition explicitly: the `Bun is unavailable` step sets `world.bunUnavailable`, and `migrate()` defaults `withoutBun` to it, so the generic "migrates Codex to the plugin" step honors it. The flag is scoped to that one scenario, so no other migration scenario changes behavior.

## Verification

- `migrate-codex-to-plugin.feature` + `give-codex-users-full-workflow.feature`: **83/83** scenarios pass (was 82/83, deterministically, on a machine with bun on PATH).
- Test-harness only — no product code touched.

Context: surfaced while rebasing an unrelated skill PR onto main; this flaky lane blocks any PR built on a runner that has `bun` on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)