### PR TITLE
chore: 0.69 release hardening (verify/audit/refactor pass)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,6 +342,7 @@ CLI command
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `commander`                                       | CLI argument parsing                                                                       |
 | `yaml`                                            | YAML config parsing (failsafe mode)                                                        |
+| `smol-toml`                                       | TOML parse/validate for Codex config migration (`migrate-codex-plugin.ts`)                 |
 | `@secretlint/core`                                | Retro egress: in-process secret detection over a raw string (returns spans)                |
 | `@secretlint/secretlint-rule-preset-recommend`    | Retro egress: maintained provider-key rule-packs (28 formats) layered over the regex floor |
 | `@cucumber/gherkin`                               | Gherkin parse engine for `lint-gherkin` and `.feature` scenario-source validation          |
@@ -411,7 +412,7 @@ Published files: `dist/` + `templates/` (bundled for setup/upgrade) + `codex-plu
 ### Settled Decisions (2025-12)
 
 - **Graceful Linter Fallback:** Skip linter silently if not installed (`.nothrow().quiet()`). Hook should never block Claude's workflow. (`lint.ts`)
-- **TOML Parsing Without Dependencies:** Line-based extraction for pyproject.toml. Only need `[tool.poetry]`/`[tool.uv]` detection — no TOML parser dependency. (`project-detector.ts`)
+- **TOML Parsing — line-based for detection, `smol-toml` for Codex config:** pyproject.toml detection uses line-based extraction; it only needs `[tool.poetry]`/`[tool.uv]` and pulls in no TOML parser (`project-detector.ts`). Codex plugin migration is the one exception — it uses `smol-toml` to validate config parseability before its line-based hook surgery (`migrate-codex-plugin.ts`).
 - **Ruff in Hook, mypy in Command Only:** Ruff is ms/file (safe for hooks); mypy is seconds/project (only runs via `/lint` command).
 
 **Linter crash resilience:** `captureRemainingErrors()` reads stderr when stdout is empty on non-zero exit. This distinguishes "linter found no issues" from "linter crashed" (e.g., golangci-lint Go version mismatch). Crashes surface as warnings via the existing `warnings` array, not as lint errors. This prevents silent failures where a broken linter reports success.

--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,8 @@
     "mypy",
     "rustfmt",
     "which",
+    "claude",
+    "codex",
     "architecture",
     "boundary",
     "test-plan",
@@ -27,6 +29,7 @@
   ],
   "ignoreDependencies": [
     "safeword",
+    "@openai/codex",
     "tsx",
     "@next/eslint-plugin-next",
     "@tanstack/eslint-plugin-query",

--- a/packages/cli/features/steps/migrate-codex-plugin.steps.ts
+++ b/packages/cli/features/steps/migrate-codex-plugin.steps.ts
@@ -51,6 +51,7 @@ command = "gh-mcp"
 interface MigrationWorld extends SafewordWorld {
   migrationDirectory?: string;
   migrationBin?: string;
+  bunUnavailable?: boolean;
   migrationResult?: { stdout: string; stderr: string; exitCode: number };
   originalCodexConfig?: string;
   customCodexConfiguration?: string;
@@ -121,12 +122,15 @@ esac
   world.migrationBin = bin;
 }
 
-function migrate(world: MigrationWorld, shouldRemoveLegacyHooks = false, withoutBun = false): void {
+function migrate(world: MigrationWorld, shouldRemoveLegacyHooks = false): void {
   const directory = worldDirectory(world);
   const arguments_ = ['migrate', 'codex-plugin'];
   if (shouldRemoveLegacyHooks) arguments_.push('--remove-legacy-hooks');
   world.migrationResult = runCli(arguments_, directory, {
-    PATH: withoutBun ? '' : `${world.migrationBin}:${process.env.PATH ?? ''}`,
+    // Deterministically remove bun/codex for the "Bun is unavailable" scenario via an
+    // empty PATH, rather than relying on the ambient PATH happening to lack them (which
+    // made the scenario pass in CI but fail on a dev machine that has bun/codex on PATH).
+    PATH: world.bunUnavailable ? '' : `${world.migrationBin}:${process.env.PATH ?? ''}`,
   });
 }
 
@@ -257,7 +261,7 @@ Given('Codex reports the Safe Word plugin is disabled', function (this: Migratio
 });
 
 Given('Bun is unavailable', function (this: MigrationWorld) {
-  this.migrationBin = undefined;
+  this.bunUnavailable = true;
 });
 
 When('the builder upgrades Safe Word', function (this: MigrationWorld) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { Command } from 'commander';
 
 import { installCliCrashCapture } from './self-report-capture.js';
+import { error } from './utils/output.js';
 import { VERSION } from './version.js';
 
 // Self-observation (issues #345 / #720): capture safeword's own genuine crashes
@@ -322,5 +323,14 @@ if (process.argv.length === 2) {
   program.help();
 }
 
-// Parse arguments
-program.parse();
+// Parse arguments. parseAsync (not parse) so an error thrown by an async command
+// action rejects the returned promise and reliably sets a non-zero exit code on
+// every runtime. With sync parse(), an async action's rejection is only an
+// unhandledRejection — node surfaces that as a non-zero exit, but bun does not, so
+// `bunx safeword <cmd>` (e.g. the packaged Codex hooks) could exit 0 on a fatal error.
+try {
+  await program.parseAsync();
+} catch (parseError: unknown) {
+  error(parseError instanceof Error ? parseError.message : String(parseError));
+  process.exit(1);
+}


### PR DESCRIPTION
Hardening pass over the code landing in 0.69 (the #993 Codex packaged-plugin migration), run as verify → audit → refactor. Three focused, independently-committed changes; all CI-green locally (lint, knip, depcruise, targeted + release + BDD suites).

## Changes
1. **`docs(architecture)`** — #993 added `smol-toml` as a runtime dep (Codex config validation) but ARCHITECTURE.md still claimed "no TOML parser dependency". Documented the dep; scoped the line-based-parsing decision to pyproject detection. *(verify: dep-drift)*
2. **`fix(cli)` + knip hygiene** — `await program.parseAsync()` with a catch, so errors thrown by #993's async command actions (`migrate codex-plugin`, `hook codex`) print a clean message and reliably exit non-zero on every runtime (bun included) instead of a raw unhandled-rejection stack trace — which also stops the crash-capture from spooling deliberate CLI errors as `claude:Error@migrate` self-reports. Restored `claude`/`codex` to knip `ignoreBinaries` and added `@openai/codex` to `ignoreDependencies` (#993 had left `bunx knip` red; knip isn't a CI gate so it slipped through). *(audit)*
3. **`test(codex)`** — made the "Bun is unavailable" migration scenario deterministic. The `withoutBun` param was vestigial; the step relied on the ambient PATH lacking bun/codex, so it passed in CI but failed on a dev machine with them on PATH. Replaced with a `world.bunUnavailable` flag that empties PATH. *(refactor: test robustness)*

## Findings flagged as follow-ups (not auto-fixed)
- **E008 surface drift** — 7 `@surface.*` tags referenced in features but undefined in `surfaces.md` (2 from #993: `codex-plugin-hooks`, `safe-word-packaged-cli`; 5 pre-existing). Domain-doc content is human-owned per the audit skill, so filed as a follow-up rather than auto-written.
- Migrate error-message polish + a missing not-enabled test case (from prior review) — filed as a follow-up.

## Release ordering
This should merge to main **before** cutting the 0.69.0 tag so the release includes it. The bump PR #1124 (pure version bump) will then need a rebase onto the new main.