### PR TITLE
fix(codex-plugin): name the remedy in catalogue drift errors

### DIFF
--- a/packages/cli/src/codex-plugin/catalogue.ts
+++ b/packages/cli/src/codex-plugin/catalogue.ts
@@ -328,6 +328,13 @@ function pluginAssetPaths(pluginDirectory: string): string[] {
   return markdownFiles(skillsDirectory).map(relativePath => nodePath.join('skills', relativePath));
 }
 
+// All three failures below mean the checked-in catalogue no longer matches its
+// canonical source, and share one remedy. The non-obvious trigger is a merge:
+// git combines an edit to templates/skills/ with an untouched generated plugin
+// cleanly, because they are different files — it has no notion that one derives
+// from the other.
+const REGENERATE_REMEDY = 'Regenerate it with `bun run --cwd packages/cli generate:codex-plugin`.';
+
 /** Ensure the checked-in plugin is the exact allowed transformation of canonical skills. */
 export function assertCodexPluginCatalogue(
   canonicalSkillsDirectory: string,
@@ -340,12 +347,12 @@ export function assertCodexPluginCatalogue(
   const actualPaths = pluginAssetPaths(pluginDirectory);
   const missingPath = [...expectedPaths].find(path => !actualPaths.includes(path));
   if (missingPath !== undefined) {
-    throw new Error(`Codex plugin is missing expected asset: ${missingPath}`);
+    throw new Error(`Codex plugin is missing expected asset: ${missingPath}\n${REGENERATE_REMEDY}`);
   }
 
   const unexpectedPath = actualPaths.find(path => !expectedPaths.has(path));
   if (unexpectedPath !== undefined) {
-    throw new Error(`Codex plugin has unexpected asset: ${unexpectedPath}`);
+    throw new Error(`Codex plugin has unexpected asset: ${unexpectedPath}\n${REGENERATE_REMEDY}`);
   }
 
   for (const asset of expectedAssets) {
@@ -353,7 +360,7 @@ export function assertCodexPluginCatalogue(
     const actualContent = readFileSync(actualPath, 'utf8');
     if (actualContent !== asset.content) {
       throw new Error(
-        `Codex plugin asset differs from the canonical transformation: ${asset.relativePath}`,
+        `Codex plugin asset differs from the canonical transformation: ${asset.relativePath}\n${REGENERATE_REMEDY}`,
       );
     }
   }


### PR DESCRIPTION
## Problem

All three `assertCodexPluginCatalogue` failures report *which* asset is wrong but not *what to do*:

```
Codex plugin asset differs from the canonical transformation: skills/quality-review/SKILL.md
```

The remedy (`generate:codex-plugin`) is documented in `README.md:548`, but you have to already know to look there. Hitting this cold costs a full investigation.

## Change

Appends a shared remedy line to the missing / unexpected / drifted errors:

```
Codex plugin asset differs from the canonical transformation: skills/quality-review/SKILL.md
Regenerate it with `bun run --cwd packages/cli generate:codex-plugin`.
```

The existing substring assertions — release tests (`.toThrow('missing expected asset')`) and the `give-codex-users-full-workflow` BDD steps — match on the original prefixes and are unaffected.

## Why the comment

It records the non-obvious trigger, which is what made the last occurrence hard to diagnose. A long-lived branch edited `templates/skills/` **before** the generated plugin existed on it, then merged main. Git combined the two sides cleanly — different files — leaving a stale generated copy with no conflict to signal it. Nobody skipped a regeneration step; there was no step to skip at the time.

## Scope

`assertCodexPluginCatalogue` has no caller in shipped CLI code (only tests and BDD steps), so naming a repo-developer command can't mislead an end user.

## Verification

- `bun run test:release` — 22/22 pass (7 files)
- `bunx cucumber-js` — 83 scenarios, 986 steps pass
- `bun run lint` — clean (eslint + gherkin + tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)