### PR TITLE
fix(skills): drop dangling PRINCIPLES.md citations from shipped skills

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
+**Reviewer class:** _class-2 — independent observation_: every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
 
 ## Invocation log
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
+**Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
 ## Invocation log
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
+**Reviewer class:** _class-2 — independent observation_: every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
 
 ## Invocation log
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
+**Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
 ## Invocation log
 

--- a/packages/cli/codex-plugin/skills/audit/SKILL.md
+++ b/packages/cli/codex-plugin/skills/audit/SKILL.md
@@ -9,7 +9,7 @@ description: Run comprehensive code audit for architecture, dead code, and test
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
+**Reviewer class:** _class-2 — independent observation_: every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
 
 ## Invocation log
 

--- a/packages/cli/codex-plugin/skills/verify/SKILL.md
+++ b/packages/cli/codex-plugin/skills/verify/SKILL.md
@@ -9,7 +9,7 @@ description: Verify ticket completion criteria — use when finishing a ticket,
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
+**Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
 ## Invocation log
 

--- a/packages/cli/templates/skills/audit/SKILL.md
+++ b/packages/cli/templates/skills/audit/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Run a comprehensive code audit. Execute checks and report results by severity.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
+**Reviewer class:** _class-2 — independent observation_: every check confirms an observable fact, so no cross-model reviewer applies. Judging whether the architecture is _sound_ is not audit's job — that lives in the Architecture Review Gate (`ARCHITECTURE.md`) and `quality-review`.
 
 ## Invocation log
 

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: '*'
 
 Prove a ticket meets its criteria. Works with or without an active ticket.
 
-**Reviewer class:** _class-2 — independent observation_ (PRINCIPLES.md §1): the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
+**Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
 ## Invocation log
 


### PR DESCRIPTION
## Problem

`PRINCIPLES.md` lives only at the safeword repo root. It is **not** in `templates/`, has no entry in `ConfiguredPathKey` (`personas | glossary | surfaces | architecture`), and is never installed into a customer project.

So `(PRINCIPLES.md §1)` in `audit/` and `verify/` pointed customers at a file they don't have.

## Why it's worth fixing rather than ignoring

The citation is **directive-shaped, not decorative** — a file path with a section anchor, sitting in a corpus where `ARCHITECTURE.md` references look identical and *do* resolve (via `paths.architecture`, defaulting to the host's own root file, existence explicitly not guaranteed).

Two visually identical reference forms behaving differently is the actual defect, and it's invisible from inside this repo, where both resolve.

## Why removal, not rewording

Both sentences already name the principle inline — "class-2 — independent observation". The parenthetical was redundant with the text it annotated, so removing it costs zero provenance and a maintainer can still grep the named phrase against `PRINCIPLES.md`.

The `ARCHITECTURE.md` reference in `audit/` is deliberately preserved. It resolves.

## Considered and rejected

**Ship `PRINCIPLES.md`.** It addresses safeword's own maintainers — *"when evaluating a new feature, ticket approach, or design trade-off, check it against these principles"* — not customers evaluating their own work. It would also add a 191st parity pair plus per-project context cost, against evidence that context files can reduce task success while raising inference cost.

**Add a `principles` config key** alongside `architecture`. Builds resolution machinery for a document customers don't have and safeword never creates.

## Scope

Main carries two instances. `review-spec` and `tdd-review` carry the same citation on `safeword-pr-review-server-0a3852` and should get the same treatment when that branch lands.

`.agents/` copies are updated for tree consistency, though that surface is deprecated (schema `deprecatedFiles`; Codex moved to the packaged plugin in #993) and `parity-check` doesn't enforce it.

## Verification

- 170 tests across the 6 suites that read these files — pass
- `test:release` — 22/22
- `parity-check --mode=all` — 190 pairs + 8 contracts in sync
- Codex catalogue regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)