### PR TITLE
fix(tsconfig): give the root config the lib settings its own include needs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2023", "ESNext.Iterator", "ESNext.Collection"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,


### PR DESCRIPTION
## Problem

`bunx tsc -p tsconfig.json` at the repo root reports **88 errors on a clean checkout**. Every one is a missing modern-lib member in files nobody touched:

- `toSorted` / `toReversed` → ES2023
- `Iterator.toArray` → ESNext.Iterator
- `Set.difference` → ESNext.Collection

## Cause

The root config declared `target: ES2022` and **no `lib`**, while `packages/cli/tsconfig.json` — the config that actually governs that code — declares `["ES2023", "ESNext.Iterator", "ESNext.Collection"]`.

The root config's `include` is `packages/*/src/**/*`, so it typechecked the entire CLI source tree under lib settings that source was never written against.

## Why it went unnoticed

Nothing exercises it. Both root scripts delegate:

```jsonc
"typecheck": "bun run --cwd packages/cli typecheck",
"lint":      "eslint . && bun run lint:gherkin && bun run --cwd packages/cli typecheck",
```

No script and no CI job runs tsc against the root project, so the drift was invisible.

## How it surfaced

The stop hook's typecheck gate find-ups from each changed file. A change under `.safeword/hooks/**` finds no nearer `tsconfig.json` and lands on this one — which doesn't even `include` the file that triggered it. The gate then reported 88 errors in untouched files while typechecking none of the changed ones.

That find-up behavior is a **separate defect** in `templates/hooks/lib/typecheck-gate.ts` (it should prefer a config that covers the file, or skip when none does). Filed separately — this PR only makes the config it lands on correct.

## Note

Worth a follow-up question: given nothing consumes the root config except this accidental find-up, it arguably should be a solution-style config with `references` rather than one that re-covers `packages/cli` badly. Left alone here to keep the fix minimal.

## Verification

- root `tsc -p tsconfig.json` — **88 → 0**
- root `eslint .` — clean (confirms no type-aware rule shifted)
- `packages/cli` `bun run lint` — clean
- `test:release` — 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)