### PR TITLE
fix(hooks): stop the self-report Stop wake loop; stop counting safeword's own churn against the user

### DIFF
--- a/.safeword/guides/self-report-filing.md
+++ b/.safeword/guides/self-report-filing.md
@@ -111,6 +111,9 @@ with two differences:
 ```
 
 - `capture` (default `true`) — record signals to the local spool.
-- `surface` (default `true`) — mention captured signals at the end of a turn.
+- `surface` (default `true`) — mention captured signals at the end of a turn. Each
+  distinct signature is mentioned **once per session**: a turn that captured
+  nothing new stays silent, because Stop context re-wakes the agent and an
+  unconditional mention would loop forever (issue #1163).
 - `file` (default `true`) — file them autonomously per this playbook. Set `false`
   to keep an install watch-only (capture + surface, no GitHub issues).

--- a/.safeword/hooks/lib/jsonl-spool.ts
+++ b/.safeword/hooks/lib/jsonl-spool.ts
@@ -81,15 +81,34 @@ export function readJsonlRecords<T>(
  * break the host path that called it.
  */
 export function appendJsonlRecords(filePath: string, lines: readonly string[], cap: number): void {
+  tryAppendJsonlRecords(filePath, lines, cap);
+}
+
+/**
+ * {@link appendJsonlRecords}, but REPORTS whether every line was durably written:
+ * `false` when the write threw or the cap truncated it. Still never throws.
+ *
+ * Callers that must not act on an unrecorded write need this signal — the
+ * void-returning wrapper cannot distinguish "written" from "silently dropped",
+ * and re-reading the file to check introduces its own false-negative (a transient
+ * read failure after a good write). See the surfaced-signature marker (#1163).
+ */
+export function tryAppendJsonlRecords(
+  filePath: string,
+  lines: readonly string[],
+  cap: number,
+): boolean {
+  if (lines.length === 0) return true;
   try {
     const room = cap - countJsonlRecords(filePath);
-    if (room <= 0) return;
+    if (room <= 0) return false;
     const toWrite = lines.slice(0, room);
-    if (toWrite.length === 0) return;
     mkdirSync(nodePath.dirname(filePath), { recursive: true });
     appendFileSync(filePath, `${toWrite.join('\n')}\n`);
+    return toWrite.length === lines.length;
   } catch {
-    // Self-observation must never break the host. Swallow.
+    // Self-observation must never break the host. Swallow, but report failure.
+    return false;
   }
 }
 

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -23,9 +23,33 @@ export const ESCALATION_THRESHOLD = 3;
  */
 export const EXPLAIN_HINT = 'Run `/explain` for a plain-English version of this block.';
 
-/** Tooling/meta paths that are not application code.
- *  Used by pre-tool (skip blocking) and post-tool (skip LOC counting). */
-export const META_PATHS = ['.project/', '.safeword-project/', '.safeword/', '.claude/', '.cursor/'];
+/**
+ * Tooling/meta paths that are not application code.
+ * Used by pre-tool (skip blocking) and post-tool (skip LOC counting).
+ *
+ * Must stay the trailing-slash mirror of `SAFEWORD_IGNORE_DIRS` (src/owned-paths.ts) —
+ * the same "safeword owns this directory, it is never the customer's work product"
+ * set, enforced by a drift test. The hooks can't import from `src/`, so the list is
+ * restated here rather than shared.
+ *
+ * `.agents/` and `.codex/` were missing until issue #1163: session-auto-upgrade
+ * relocating skills out of `.agents/` counted ~3800 deletions of safeword's own
+ * churn against the 400-line gate, hard-blocking the agent's next edit over work
+ * neither it nor the user authored.
+ *
+ * Files safeword only MERGES INTO (package.json, eslint.config.mjs, …) are
+ * deliberately absent: those are shared with the customer, and excluding them
+ * would blind the gate to real work.
+ */
+export const META_PATHS = [
+  '.safeword/',
+  '.claude/',
+  '.cursor/',
+  '.codex/',
+  '.agents/',
+  '.project/',
+  '.safeword-project/',
+];
 
 export interface FailureEntry {
   pattern: string;

--- a/.safeword/hooks/lib/quality-state.ts
+++ b/.safeword/hooks/lib/quality-state.ts
@@ -51,6 +51,31 @@ export const META_PATHS = [
   '.safeword-project/',
 ];
 
+/**
+ * Is `filePath` a safeword-owned meta path *within this project*?
+ *
+ * Match the path RELATIVE to the project root, never a substring of the absolute
+ * path. A bare `absolutePath.includes('.claude/')` also matches every file in a
+ * checkout that merely LIVES under a directory of that name — safeword's own
+ * worktrees sit in `<repo>/.claude/worktrees/<name>/`, which silently disabled
+ * EVERY pre-tool gate (phase freeze, test-definitions, LOC) for every file in
+ * them. Found reviewing #1163, which widened the blast radius by adding
+ * `.codex/` and `.agents/` to the list.
+ *
+ * A path outside the project resolves to a `..` escape and stays exempt — the
+ * gates below reason about project code, and an out-of-tree edit was never
+ * theirs to block.
+ */
+export function isMetaPath(filePath: string, projectDirectory: string): boolean {
+  if (filePath.length === 0) return false;
+  const relative = nodePath.isAbsolute(filePath)
+    ? nodePath.relative(projectDirectory, filePath)
+    : filePath;
+  if (relative.startsWith('..')) return true; // outside the project — not ours to gate
+  const normalized = relative.split(nodePath.sep).join('/');
+  return META_PATHS.some(meta => normalized.startsWith(meta) || normalized === meta.slice(0, -1));
+}
+
 export interface FailureEntry {
   pattern: string;
   timestamp: string;

--- a/.safeword/hooks/lib/self-report.ts
+++ b/.safeword/hooks/lib/self-report.ts
@@ -472,10 +472,70 @@ export function formatIssueDrafts(records: SelfReportRecord[]): SelfReportIssueD
 }
 
 /**
+ * Absolute path of the per-session "already surfaced" marker (issue #1163).
+ *
+ * Deliberately a `surfaced/` SUBDIR of the spool dir, not a sibling file:
+ * `readReports` globs `*.jsonl` at the spool dir's top level, so a sibling
+ * marker would be parsed as if it held SelfReportRecords and would pollute
+ * every summary and issue draft. Derived from `spoolPath` so the FG6V57
+ * session-token rule stays in exactly one place.
+ */
+export function surfacedMarkerPath(projectDirectory: string, sessionId: string): string {
+  const spool = spoolPath(projectDirectory, sessionId);
+  return nodePath.join(nodePath.dirname(spool), 'surfaced', nodePath.basename(spool));
+}
+
+/** One persisted "this signature has been shown to the agent" marker. */
+interface SurfacedMarker {
+  ts: string;
+  signature: string;
+}
+
+/**
+ * The signatures already surfaced to the agent this session. Fail-open: an
+ * absent or unreadable marker yields an empty set, which costs at most one
+ * repeat surfacing — never a throw inside a Stop hook.
+ */
+export function readSurfacedSignatures(projectDirectory: string, sessionId: string): Set<string> {
+  return new Set(
+    readJsonlRecords(surfacedMarkerPath(projectDirectory, sessionId), value => {
+      const { signature } = value as Partial<SurfacedMarker>;
+      return typeof signature === 'string' && signature.length > 0 ? signature : undefined;
+    }),
+  );
+}
+
+/**
+ * Persist `signatures` as surfaced. BEST-EFFORT — a failed write risks one
+ * repeat surfacing, never a broken Stop. Shares MAX_RECORDS_PER_FILE with the
+ * spool it mirrors: a session can hold at most that many records, so it can
+ * never produce more distinct signatures than the marker has room for.
+ */
+export function markSignaturesSurfaced(
+  projectDirectory: string,
+  sessionId: string,
+  signatures: readonly string[],
+): void {
+  const ts = new Date().toISOString();
+  appendJsonlRecords(
+    surfacedMarkerPath(projectDirectory, sessionId),
+    signatures.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
+    MAX_RECORDS_PER_FILE,
+  );
+}
+
+/**
  * Build the Stop-time surfacing line for a session's records, or null when there
  * is nothing to surface. Phrased as a FACTUAL statement (no imperative / no
  * out-of-band command) so Claude treats it as context rather than tripping its
  * prompt-injection defenses (https://code.claude.com/docs/en/hooks).
+ *
+ * Pure formatter over the records it is HANDED — it has no idea what was already
+ * shown. The session spool never drains, so a caller that passes it every record
+ * on every Stop re-emits a byte-identical line forever; because Stop
+ * additionalContext wakes the agent as a fresh turn, that is an infinite wake
+ * loop, not just noise (issue #1163). Stop callers MUST filter by
+ * {@link readSurfacedSignatures} first and {@link markSignaturesSurfaced} after.
  */
 export function formatSelfReportSurfacing(
   records: SelfReportRecord[],

--- a/.safeword/hooks/lib/self-report.ts
+++ b/.safeword/hooks/lib/self-report.ts
@@ -18,7 +18,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { appendJsonlRecords, readJsonlRecords } from './jsonl-spool.js';
+import { appendJsonlRecords, readJsonlRecords, tryAppendJsonlRecords } from './jsonl-spool.js';
 
 /** The agent harness safeword is running under. */
 export type AgentId = 'claude' | 'cursor' | 'codex' | 'unknown';
@@ -506,20 +506,32 @@ export function readSurfacedSignatures(projectDirectory: string, sessionId: stri
 }
 
 /**
- * Persist `signatures` as surfaced. BEST-EFFORT — a failed write risks one
- * repeat surfacing, never a broken Stop. Shares MAX_RECORDS_PER_FILE with the
- * spool it mirrors: a session can hold at most that many records, so it can
- * never produce more distinct signatures than the marker has room for.
+ * Persist `signatures` as surfaced, returning whether the marker durably holds
+ * ALL of them. Never throws; a `false` tells the caller it has no durable record
+ * and so must not emit (emitting unrecorded is what loops).
+ *
+ * Self-deduping: signatures already in the marker are skipped, so the file holds
+ * at most one line per distinct signature. That is what keeps it under
+ * MAX_RECORDS_PER_FILE — the spool it mirrors caps at the same number of records,
+ * hence at most that many distinct signatures. Doing it HERE rather than relying
+ * on the caller's pre-filter matters because this is exported: a second caller,
+ * a future SubagentStop wiring, or two overlapping Stops would otherwise burn
+ * headroom and eventually silence real signals permanently.
  */
 export function markSignaturesSurfaced(
   projectDirectory: string,
   sessionId: string,
   signatures: readonly string[],
-): void {
+): boolean {
+  const already = readSurfacedSignatures(projectDirectory, sessionId);
+  const fresh = [...new Set(signatures)].filter(signature => !already.has(signature));
+  // Nothing fresh means every signature is already recorded (or none were asked
+  // for) — the marker already holds them all, so the caller may emit.
+  if (fresh.length === 0) return true;
   const ts = new Date().toISOString();
-  appendJsonlRecords(
+  return tryAppendJsonlRecords(
     surfacedMarkerPath(projectDirectory, sessionId),
-    signatures.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
+    fresh.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
     MAX_RECORDS_PER_FILE,
   );
 }

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -36,8 +36,8 @@ import {
 } from './lib/review-ledger.ts';
 import {
   EXPLAIN_HINT,
+  isMetaPath,
   LOC_THRESHOLD,
-  META_PATHS,
   readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
@@ -642,7 +642,8 @@ if (editedFile.endsWith('test-definitions.md') && isNamespacePath(editedFile, 't
 
 // Never block edits to tooling/meta files — these are not application code.
 // (After artifact prerequisite check, which targets files in .safeword-project/)
-if (META_PATHS.some(p => editedFile.includes(p))) {
+// Project-relative match, NOT a substring of the absolute path — see isMetaPath.
+if (isMetaPath(editedFile, projectDirectory)) {
   process.exit(0);
 }
 

--- a/.safeword/hooks/stop-self-report.ts
+++ b/.safeword/hooks/stop-self-report.ts
@@ -7,11 +7,22 @@
 // fact — never an imperative — because out-of-band/command phrasing trips
 // Claude's prompt-injection defenses and gets surfaced verbatim instead of acted
 // on (https://code.claude.com/docs/en/hooks). Best-effort: never blocks Stop.
+//
+// EMIT ONLY ON CHANGE (issue #1163). Stop additionalContext wakes the agent as a
+// fresh turn with no user message; the agent must say something to end that turn,
+// which fires Stop again. So an unconditional emit from a Stop hook is an
+// infinite wake-loop generator, and the session spool never drains — every Stop
+// would re-surface a byte-identical line. Each signature is therefore surfaced at
+// most once per session, tracked in the `surfaced/` marker; a Stop with nothing
+// new emits nothing at all.
 
 import {
   formatSelfReportSurfacing,
+  markSignaturesSurfaced,
   readSelfReportConfig,
   readSessionReports,
+  readSurfacedSignatures,
+  signatureOf,
 } from './lib/self-report.ts';
 
 interface HookInput {
@@ -33,11 +44,23 @@ async function main(): Promise<void> {
   const config = readSelfReportConfig(projectDirectory);
   if (!config.surface) return; // selfReport.surface = false → stay silent
 
-  const additionalContext = formatSelfReportSurfacing(
-    readSessionReports(projectDirectory, sessionId),
-    { file: config.file },
+  const surfaced = readSurfacedSignatures(projectDirectory, sessionId);
+  const fresh = readSessionReports(projectDirectory, sessionId).filter(
+    record => !surfaced.has(signatureOf(record)),
   );
+
+  const additionalContext = formatSelfReportSurfacing(fresh, { file: config.file });
   if (!additionalContext) return;
+
+  // Persist BEFORE emitting, and emit only once the marker has actually landed.
+  // The marker write is best-effort (it swallows I/O errors), so confirm it by
+  // reading back: with no durable marker the next Stop re-surfaces this same
+  // line, and Stop additionalContext re-wakes the agent — that is the infinite
+  // loop, not a cosmetic repeat. Silence is the safe failure here.
+  const signatures = [...new Set(fresh.map(record => signatureOf(record)))];
+  markSignaturesSurfaced(projectDirectory, sessionId, signatures);
+  const persisted = readSurfacedSignatures(projectDirectory, sessionId);
+  if (!signatures.every(signature => persisted.has(signature))) return;
 
   process.stdout.write(
     `${JSON.stringify({

--- a/.safeword/hooks/stop-self-report.ts
+++ b/.safeword/hooks/stop-self-report.ts
@@ -27,6 +27,7 @@ import {
 
 interface HookInput {
   session_id?: string;
+  stop_hook_active?: boolean;
 }
 
 async function main(): Promise<void> {
@@ -40,6 +41,15 @@ async function main(): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return;
 
+  // Belt to the marker's braces: never speak into a continuation a Stop hook
+  // already caused. The docs don't say whether this is set for an
+  // additionalContext-induced continuation (only for `decision:"block"`), so it
+  // is not load-bearing — but when it IS set it caps any residual loop, and the
+  // cost of a false positive is only DELAY: nothing is marked on this path, so
+  // the signal still surfaces at the next ordinary stop. The sibling
+  // stop-retro-filing.ts guards the same way.
+  if (input.stop_hook_active === true) return;
+
   const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
   const config = readSelfReportConfig(projectDirectory);
   if (!config.surface) return; // selfReport.surface = false → stay silent
@@ -52,15 +62,14 @@ async function main(): Promise<void> {
   const additionalContext = formatSelfReportSurfacing(fresh, { file: config.file });
   if (!additionalContext) return;
 
-  // Persist BEFORE emitting, and emit only once the marker has actually landed.
-  // The marker write is best-effort (it swallows I/O errors), so confirm it by
-  // reading back: with no durable marker the next Stop re-surfaces this same
+  // Persist BEFORE emitting, and emit only if the marker durably took ALL of
+  // these signatures. With no durable marker the next Stop re-surfaces this same
   // line, and Stop additionalContext re-wakes the agent — that is the infinite
-  // loop, not a cosmetic repeat. Silence is the safe failure here.
+  // loop, not a cosmetic repeat, so silence is the safe failure here. (Cost of
+  // that failure: the signal stays in the spool and `safeword self-report` still
+  // shows it; only the end-of-turn mention is skipped.)
   const signatures = [...new Set(fresh.map(record => signatureOf(record)))];
-  markSignaturesSurfaced(projectDirectory, sessionId, signatures);
-  const persisted = readSurfacedSignatures(projectDirectory, sessionId);
-  if (!signatures.every(signature => persisted.has(signature))) return;
+  if (!markSignaturesSurfaced(projectDirectory, sessionId, signatures)) return;
 
   process.stdout.write(
     `${JSON.stringify({

--- a/packages/cli/templates/guides/self-report-filing.md
+++ b/packages/cli/templates/guides/self-report-filing.md
@@ -111,6 +111,9 @@ with two differences:
 ```
 
 - `capture` (default `true`) — record signals to the local spool.
-- `surface` (default `true`) — mention captured signals at the end of a turn.
+- `surface` (default `true`) — mention captured signals at the end of a turn. Each
+  distinct signature is mentioned **once per session**: a turn that captured
+  nothing new stays silent, because Stop context re-wakes the agent and an
+  unconditional mention would loop forever (issue #1163).
 - `file` (default `true`) — file them autonomously per this playbook. Set `false`
   to keep an install watch-only (capture + surface, no GitHub issues).

--- a/packages/cli/templates/hooks/lib/jsonl-spool.ts
+++ b/packages/cli/templates/hooks/lib/jsonl-spool.ts
@@ -81,15 +81,34 @@ export function readJsonlRecords<T>(
  * break the host path that called it.
  */
 export function appendJsonlRecords(filePath: string, lines: readonly string[], cap: number): void {
+  tryAppendJsonlRecords(filePath, lines, cap);
+}
+
+/**
+ * {@link appendJsonlRecords}, but REPORTS whether every line was durably written:
+ * `false` when the write threw or the cap truncated it. Still never throws.
+ *
+ * Callers that must not act on an unrecorded write need this signal — the
+ * void-returning wrapper cannot distinguish "written" from "silently dropped",
+ * and re-reading the file to check introduces its own false-negative (a transient
+ * read failure after a good write). See the surfaced-signature marker (#1163).
+ */
+export function tryAppendJsonlRecords(
+  filePath: string,
+  lines: readonly string[],
+  cap: number,
+): boolean {
+  if (lines.length === 0) return true;
   try {
     const room = cap - countJsonlRecords(filePath);
-    if (room <= 0) return;
+    if (room <= 0) return false;
     const toWrite = lines.slice(0, room);
-    if (toWrite.length === 0) return;
     mkdirSync(nodePath.dirname(filePath), { recursive: true });
     appendFileSync(filePath, `${toWrite.join('\n')}\n`);
+    return toWrite.length === lines.length;
   } catch {
-    // Self-observation must never break the host. Swallow.
+    // Self-observation must never break the host. Swallow, but report failure.
+    return false;
   }
 }
 

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -23,9 +23,33 @@ export const ESCALATION_THRESHOLD = 3;
  */
 export const EXPLAIN_HINT = 'Run `/explain` for a plain-English version of this block.';
 
-/** Tooling/meta paths that are not application code.
- *  Used by pre-tool (skip blocking) and post-tool (skip LOC counting). */
-export const META_PATHS = ['.project/', '.safeword-project/', '.safeword/', '.claude/', '.cursor/'];
+/**
+ * Tooling/meta paths that are not application code.
+ * Used by pre-tool (skip blocking) and post-tool (skip LOC counting).
+ *
+ * Must stay the trailing-slash mirror of `SAFEWORD_IGNORE_DIRS` (src/owned-paths.ts) —
+ * the same "safeword owns this directory, it is never the customer's work product"
+ * set, enforced by a drift test. The hooks can't import from `src/`, so the list is
+ * restated here rather than shared.
+ *
+ * `.agents/` and `.codex/` were missing until issue #1163: session-auto-upgrade
+ * relocating skills out of `.agents/` counted ~3800 deletions of safeword's own
+ * churn against the 400-line gate, hard-blocking the agent's next edit over work
+ * neither it nor the user authored.
+ *
+ * Files safeword only MERGES INTO (package.json, eslint.config.mjs, …) are
+ * deliberately absent: those are shared with the customer, and excluding them
+ * would blind the gate to real work.
+ */
+export const META_PATHS = [
+  '.safeword/',
+  '.claude/',
+  '.cursor/',
+  '.codex/',
+  '.agents/',
+  '.project/',
+  '.safeword-project/',
+];
 
 export interface FailureEntry {
   pattern: string;

--- a/packages/cli/templates/hooks/lib/quality-state.ts
+++ b/packages/cli/templates/hooks/lib/quality-state.ts
@@ -51,6 +51,31 @@ export const META_PATHS = [
   '.safeword-project/',
 ];
 
+/**
+ * Is `filePath` a safeword-owned meta path *within this project*?
+ *
+ * Match the path RELATIVE to the project root, never a substring of the absolute
+ * path. A bare `absolutePath.includes('.claude/')` also matches every file in a
+ * checkout that merely LIVES under a directory of that name — safeword's own
+ * worktrees sit in `<repo>/.claude/worktrees/<name>/`, which silently disabled
+ * EVERY pre-tool gate (phase freeze, test-definitions, LOC) for every file in
+ * them. Found reviewing #1163, which widened the blast radius by adding
+ * `.codex/` and `.agents/` to the list.
+ *
+ * A path outside the project resolves to a `..` escape and stays exempt — the
+ * gates below reason about project code, and an out-of-tree edit was never
+ * theirs to block.
+ */
+export function isMetaPath(filePath: string, projectDirectory: string): boolean {
+  if (filePath.length === 0) return false;
+  const relative = nodePath.isAbsolute(filePath)
+    ? nodePath.relative(projectDirectory, filePath)
+    : filePath;
+  if (relative.startsWith('..')) return true; // outside the project — not ours to gate
+  const normalized = relative.split(nodePath.sep).join('/');
+  return META_PATHS.some(meta => normalized.startsWith(meta) || normalized === meta.slice(0, -1));
+}
+
 export interface FailureEntry {
   pattern: string;
   timestamp: string;

--- a/packages/cli/templates/hooks/lib/self-report.ts
+++ b/packages/cli/templates/hooks/lib/self-report.ts
@@ -472,10 +472,70 @@ export function formatIssueDrafts(records: SelfReportRecord[]): SelfReportIssueD
 }
 
 /**
+ * Absolute path of the per-session "already surfaced" marker (issue #1163).
+ *
+ * Deliberately a `surfaced/` SUBDIR of the spool dir, not a sibling file:
+ * `readReports` globs `*.jsonl` at the spool dir's top level, so a sibling
+ * marker would be parsed as if it held SelfReportRecords and would pollute
+ * every summary and issue draft. Derived from `spoolPath` so the FG6V57
+ * session-token rule stays in exactly one place.
+ */
+export function surfacedMarkerPath(projectDirectory: string, sessionId: string): string {
+  const spool = spoolPath(projectDirectory, sessionId);
+  return nodePath.join(nodePath.dirname(spool), 'surfaced', nodePath.basename(spool));
+}
+
+/** One persisted "this signature has been shown to the agent" marker. */
+interface SurfacedMarker {
+  ts: string;
+  signature: string;
+}
+
+/**
+ * The signatures already surfaced to the agent this session. Fail-open: an
+ * absent or unreadable marker yields an empty set, which costs at most one
+ * repeat surfacing — never a throw inside a Stop hook.
+ */
+export function readSurfacedSignatures(projectDirectory: string, sessionId: string): Set<string> {
+  return new Set(
+    readJsonlRecords(surfacedMarkerPath(projectDirectory, sessionId), value => {
+      const { signature } = value as Partial<SurfacedMarker>;
+      return typeof signature === 'string' && signature.length > 0 ? signature : undefined;
+    }),
+  );
+}
+
+/**
+ * Persist `signatures` as surfaced. BEST-EFFORT — a failed write risks one
+ * repeat surfacing, never a broken Stop. Shares MAX_RECORDS_PER_FILE with the
+ * spool it mirrors: a session can hold at most that many records, so it can
+ * never produce more distinct signatures than the marker has room for.
+ */
+export function markSignaturesSurfaced(
+  projectDirectory: string,
+  sessionId: string,
+  signatures: readonly string[],
+): void {
+  const ts = new Date().toISOString();
+  appendJsonlRecords(
+    surfacedMarkerPath(projectDirectory, sessionId),
+    signatures.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
+    MAX_RECORDS_PER_FILE,
+  );
+}
+
+/**
  * Build the Stop-time surfacing line for a session's records, or null when there
  * is nothing to surface. Phrased as a FACTUAL statement (no imperative / no
  * out-of-band command) so Claude treats it as context rather than tripping its
  * prompt-injection defenses (https://code.claude.com/docs/en/hooks).
+ *
+ * Pure formatter over the records it is HANDED — it has no idea what was already
+ * shown. The session spool never drains, so a caller that passes it every record
+ * on every Stop re-emits a byte-identical line forever; because Stop
+ * additionalContext wakes the agent as a fresh turn, that is an infinite wake
+ * loop, not just noise (issue #1163). Stop callers MUST filter by
+ * {@link readSurfacedSignatures} first and {@link markSignaturesSurfaced} after.
  */
 export function formatSelfReportSurfacing(
   records: SelfReportRecord[],

--- a/packages/cli/templates/hooks/lib/self-report.ts
+++ b/packages/cli/templates/hooks/lib/self-report.ts
@@ -18,7 +18,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { appendJsonlRecords, readJsonlRecords } from './jsonl-spool.js';
+import { appendJsonlRecords, readJsonlRecords, tryAppendJsonlRecords } from './jsonl-spool.js';
 
 /** The agent harness safeword is running under. */
 export type AgentId = 'claude' | 'cursor' | 'codex' | 'unknown';
@@ -506,20 +506,32 @@ export function readSurfacedSignatures(projectDirectory: string, sessionId: stri
 }
 
 /**
- * Persist `signatures` as surfaced. BEST-EFFORT — a failed write risks one
- * repeat surfacing, never a broken Stop. Shares MAX_RECORDS_PER_FILE with the
- * spool it mirrors: a session can hold at most that many records, so it can
- * never produce more distinct signatures than the marker has room for.
+ * Persist `signatures` as surfaced, returning whether the marker durably holds
+ * ALL of them. Never throws; a `false` tells the caller it has no durable record
+ * and so must not emit (emitting unrecorded is what loops).
+ *
+ * Self-deduping: signatures already in the marker are skipped, so the file holds
+ * at most one line per distinct signature. That is what keeps it under
+ * MAX_RECORDS_PER_FILE — the spool it mirrors caps at the same number of records,
+ * hence at most that many distinct signatures. Doing it HERE rather than relying
+ * on the caller's pre-filter matters because this is exported: a second caller,
+ * a future SubagentStop wiring, or two overlapping Stops would otherwise burn
+ * headroom and eventually silence real signals permanently.
  */
 export function markSignaturesSurfaced(
   projectDirectory: string,
   sessionId: string,
   signatures: readonly string[],
-): void {
+): boolean {
+  const already = readSurfacedSignatures(projectDirectory, sessionId);
+  const fresh = [...new Set(signatures)].filter(signature => !already.has(signature));
+  // Nothing fresh means every signature is already recorded (or none were asked
+  // for) — the marker already holds them all, so the caller may emit.
+  if (fresh.length === 0) return true;
   const ts = new Date().toISOString();
-  appendJsonlRecords(
+  return tryAppendJsonlRecords(
     surfacedMarkerPath(projectDirectory, sessionId),
-    signatures.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
+    fresh.map(signature => JSON.stringify({ ts, signature } satisfies SurfacedMarker)),
     MAX_RECORDS_PER_FILE,
   );
 }

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -36,8 +36,8 @@ import {
 } from './lib/review-ledger.ts';
 import {
   EXPLAIN_HINT,
+  isMetaPath,
   LOC_THRESHOLD,
-  META_PATHS,
   readSessionState,
   recordFailure,
 } from './lib/quality-state.ts';
@@ -642,7 +642,8 @@ if (editedFile.endsWith('test-definitions.md') && isNamespacePath(editedFile, 't
 
 // Never block edits to tooling/meta files — these are not application code.
 // (After artifact prerequisite check, which targets files in .safeword-project/)
-if (META_PATHS.some(p => editedFile.includes(p))) {
+// Project-relative match, NOT a substring of the absolute path — see isMetaPath.
+if (isMetaPath(editedFile, projectDirectory)) {
   process.exit(0);
 }
 

--- a/packages/cli/templates/hooks/stop-self-report.ts
+++ b/packages/cli/templates/hooks/stop-self-report.ts
@@ -7,11 +7,22 @@
 // fact — never an imperative — because out-of-band/command phrasing trips
 // Claude's prompt-injection defenses and gets surfaced verbatim instead of acted
 // on (https://code.claude.com/docs/en/hooks). Best-effort: never blocks Stop.
+//
+// EMIT ONLY ON CHANGE (issue #1163). Stop additionalContext wakes the agent as a
+// fresh turn with no user message; the agent must say something to end that turn,
+// which fires Stop again. So an unconditional emit from a Stop hook is an
+// infinite wake-loop generator, and the session spool never drains — every Stop
+// would re-surface a byte-identical line. Each signature is therefore surfaced at
+// most once per session, tracked in the `surfaced/` marker; a Stop with nothing
+// new emits nothing at all.
 
 import {
   formatSelfReportSurfacing,
+  markSignaturesSurfaced,
   readSelfReportConfig,
   readSessionReports,
+  readSurfacedSignatures,
+  signatureOf,
 } from './lib/self-report.ts';
 
 interface HookInput {
@@ -33,11 +44,23 @@ async function main(): Promise<void> {
   const config = readSelfReportConfig(projectDirectory);
   if (!config.surface) return; // selfReport.surface = false → stay silent
 
-  const additionalContext = formatSelfReportSurfacing(
-    readSessionReports(projectDirectory, sessionId),
-    { file: config.file },
+  const surfaced = readSurfacedSignatures(projectDirectory, sessionId);
+  const fresh = readSessionReports(projectDirectory, sessionId).filter(
+    record => !surfaced.has(signatureOf(record)),
   );
+
+  const additionalContext = formatSelfReportSurfacing(fresh, { file: config.file });
   if (!additionalContext) return;
+
+  // Persist BEFORE emitting, and emit only once the marker has actually landed.
+  // The marker write is best-effort (it swallows I/O errors), so confirm it by
+  // reading back: with no durable marker the next Stop re-surfaces this same
+  // line, and Stop additionalContext re-wakes the agent — that is the infinite
+  // loop, not a cosmetic repeat. Silence is the safe failure here.
+  const signatures = [...new Set(fresh.map(record => signatureOf(record)))];
+  markSignaturesSurfaced(projectDirectory, sessionId, signatures);
+  const persisted = readSurfacedSignatures(projectDirectory, sessionId);
+  if (!signatures.every(signature => persisted.has(signature))) return;
 
   process.stdout.write(
     `${JSON.stringify({

--- a/packages/cli/templates/hooks/stop-self-report.ts
+++ b/packages/cli/templates/hooks/stop-self-report.ts
@@ -27,6 +27,7 @@ import {
 
 interface HookInput {
   session_id?: string;
+  stop_hook_active?: boolean;
 }
 
 async function main(): Promise<void> {
@@ -40,6 +41,15 @@ async function main(): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return;
 
+  // Belt to the marker's braces: never speak into a continuation a Stop hook
+  // already caused. The docs don't say whether this is set for an
+  // additionalContext-induced continuation (only for `decision:"block"`), so it
+  // is not load-bearing — but when it IS set it caps any residual loop, and the
+  // cost of a false positive is only DELAY: nothing is marked on this path, so
+  // the signal still surfaces at the next ordinary stop. The sibling
+  // stop-retro-filing.ts guards the same way.
+  if (input.stop_hook_active === true) return;
+
   const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
   const config = readSelfReportConfig(projectDirectory);
   if (!config.surface) return; // selfReport.surface = false → stay silent
@@ -52,15 +62,14 @@ async function main(): Promise<void> {
   const additionalContext = formatSelfReportSurfacing(fresh, { file: config.file });
   if (!additionalContext) return;
 
-  // Persist BEFORE emitting, and emit only once the marker has actually landed.
-  // The marker write is best-effort (it swallows I/O errors), so confirm it by
-  // reading back: with no durable marker the next Stop re-surfaces this same
+  // Persist BEFORE emitting, and emit only if the marker durably took ALL of
+  // these signatures. With no durable marker the next Stop re-surfaces this same
   // line, and Stop additionalContext re-wakes the agent — that is the infinite
-  // loop, not a cosmetic repeat. Silence is the safe failure here.
+  // loop, not a cosmetic repeat, so silence is the safe failure here. (Cost of
+  // that failure: the signal stays in the spool and `safeword self-report` still
+  // shows it; only the end-of-turn mention is skipped.)
   const signatures = [...new Set(fresh.map(record => signatureOf(record)))];
-  markSignaturesSurfaced(projectDirectory, sessionId, signatures);
-  const persisted = readSurfacedSignatures(projectDirectory, sessionId);
-  if (!signatures.every(signature => persisted.has(signature))) return;
+  if (!markSignaturesSurfaced(projectDirectory, sessionId, signatures)) return;
 
   process.stdout.write(
     `${JSON.stringify({

--- a/packages/cli/tests/hooks/self-report.test.ts
+++ b/packages/cli/tests/hooks/self-report.test.ts
@@ -20,14 +20,18 @@ import {
   detectAgent,
   formatIssueDrafts,
   formatSelfReportSurfacing,
+  markSignaturesSurfaced,
   readReports,
   readSelfReportConfig,
   readSessionReports,
+  readSurfacedSignatures,
   recordSignal,
   sanitizeStackFrames,
   type SelfReportSignal,
+  signatureOf,
   spoolPath,
   summarizeReports,
+  surfacedMarkerPath,
 } from '../../templates/hooks/lib/self-report.js';
 
 describe('self-report capture (QYYC5Y)', () => {
@@ -353,6 +357,66 @@ describe('self-report capture (QYYC5Y)', () => {
       // Factual framing — no imperative "you must / file an issue" command.
       expect(line?.toLowerCase()).not.toContain('you must');
       expect(line?.toLowerCase()).not.toContain('file an issue');
+    });
+  });
+
+  describe('surfaced-signature marker (#1163)', () => {
+    it('round-trips surfaced signatures per session', () => {
+      expect(readSurfacedSignatures(projectDirectory, 's')).toEqual(new Set());
+
+      markSignaturesSurfaced(projectDirectory, 's', ['claude:GateEscalation@loc-exceeded']);
+      expect(readSurfacedSignatures(projectDirectory, 's')).toEqual(
+        new Set(['claude:GateEscalation@loc-exceeded']),
+      );
+
+      // Appends accumulate; a different session is unaffected.
+      markSignaturesSurfaced(projectDirectory, 's', ['claude:TypeError@post-tool-quality']);
+      expect(readSurfacedSignatures(projectDirectory, 's').size).toBe(2);
+      expect(readSurfacedSignatures(projectDirectory, 'other')).toEqual(new Set());
+    });
+
+    it('keys the marker by the same signature the spool records produce', () => {
+      recordSignal(
+        projectDirectory,
+        's',
+        { source: 'loc-exceeded', agent: 'claude', errorClass: 'GateEscalation' },
+        '0.68.0',
+      );
+      const signatures = readSessionReports(projectDirectory, 's').map(record =>
+        signatureOf(record),
+      );
+      expect(signatures).toEqual(['claude:GateEscalation@loc-exceeded']);
+
+      markSignaturesSurfaced(projectDirectory, 's', signatures);
+
+      // Mirrors the membership test the hook filters records by.
+      const surfaced = readSurfacedSignatures(projectDirectory, 's');
+      expect(signatures.every(signature => surfaced.has(signature))).toBe(true);
+    });
+
+    it('lives outside the spool glob so readReports never ingests it', () => {
+      recordSignal(projectDirectory, 's', { source: 'check', exitCode: 1 }, '0.68.0');
+      markSignaturesSurfaced(projectDirectory, 's', ['claude:exit1@check']);
+
+      // The marker is JSONL in a `surfaced/` SUBDIR; a sibling `*.jsonl` would be
+      // parsed as SelfReportRecords and inflate every summary and issue draft.
+      const spoolDirectory = nodePath.dirname(spoolPath(projectDirectory, 's'));
+      const markerDirectory = nodePath.dirname(surfacedMarkerPath(projectDirectory, 's'));
+      expect(markerDirectory).toBe(nodePath.join(spoolDirectory, 'surfaced'));
+      expect(readReports(projectDirectory)).toHaveLength(1);
+      expect(readSessionReports(projectDirectory, 's')).toHaveLength(1);
+    });
+
+    it('is fail-open on a torn marker line', () => {
+      mkdirSync(nodePath.dirname(surfacedMarkerPath(projectDirectory, 's')), { recursive: true });
+      writeFileSync(
+        surfacedMarkerPath(projectDirectory, 's'),
+        `{not json\n${JSON.stringify({ ts: 'now', signature: 'claude:exit1@check' })}\n`,
+      );
+
+      expect(readSurfacedSignatures(projectDirectory, 's')).toEqual(
+        new Set(['claude:exit1@check']),
+      );
     });
   });
 

--- a/packages/cli/tests/hooks/self-report.test.ts
+++ b/packages/cli/tests/hooks/self-report.test.ts
@@ -8,7 +8,7 @@
  * that strips the actionable frame must also fail).
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -405,6 +405,31 @@ describe('self-report capture (QYYC5Y)', () => {
       expect(markerDirectory).toBe(nodePath.join(spoolDirectory, 'surfaced'));
       expect(readReports(projectDirectory)).toHaveLength(1);
       expect(readSessionReports(projectDirectory, 's')).toHaveLength(1);
+    });
+
+    it('reports failure when the marker cannot be written, so the caller stays silent', () => {
+      // The loop guard proper: emitting without a durable marker is what loops.
+      // An unwritable spool dir must be reported, never silently swallowed.
+      const spoolDirectory = nodePath.dirname(spoolPath(projectDirectory, 's'));
+      mkdirSync(spoolDirectory, { recursive: true });
+      chmodSync(spoolDirectory, 0o555);
+      try {
+        expect(markSignaturesSurfaced(projectDirectory, 's', ['claude:exit1@check'])).toBe(false);
+      } finally {
+        chmodSync(spoolDirectory, 0o755);
+      }
+    });
+
+    it('does not burn marker headroom on a repeated signature', () => {
+      // Self-deduping: without it, a repeat append per stop fills the cap and
+      // permanently silences later, genuinely-new signals.
+      for (let index = 0; index < 5; index++) {
+        expect(markSignaturesSurfaced(projectDirectory, 's', ['claude:exit1@check'])).toBe(true);
+      }
+      const lines = readFileSync(surfacedMarkerPath(projectDirectory, 's'), 'utf8')
+        .split('\n')
+        .filter(line => line.trim().length > 0);
+      expect(lines).toHaveLength(1);
     });
 
     it('is fail-open on a torn marker line', () => {

--- a/packages/cli/tests/integration/stop-self-report.test.ts
+++ b/packages/cli/tests/integration/stop-self-report.test.ts
@@ -83,6 +83,90 @@ describe('stop-self-report hook (QYYC5Y)', () => {
     expect(result.stdout.trim()).toBe('');
   });
 
+  // -------------------------------------------------------------------------
+  // Issue #1163: the wake loop. Stop additionalContext wakes the agent as a
+  // fresh turn with no user message; ending that turn fires Stop again. The
+  // session spool never drains, so an unconditional emit re-surfaces a
+  // byte-identical line forever — observed live as ~1h40m of the agent
+  // replying "." to itself. These assert emit-only-on-change.
+  // -------------------------------------------------------------------------
+
+  it('surfaces a signature once, then stays silent on every later stop (#1163)', () => {
+    // The exact record shape that drove the observed loop.
+    recordSignal(
+      projectDirectory,
+      'sess-loop',
+      { source: 'loc-exceeded', agent: 'claude', errorClass: 'GateEscalation' },
+      '0.68.0',
+    );
+
+    const first = runHook(projectDirectory, 'sess-loop');
+    expect(first.status).toBe(0);
+    expect(first.stdout).toContain('GateEscalation@loc-exceeded');
+
+    // Nothing new landed, so every subsequent Stop must emit NOTHING. A repeat
+    // here is not cosmetic noise — it is an infinite agent wake loop.
+    for (let stop = 0; stop < 3; stop++) {
+      const later = runHook(projectDirectory, 'sess-loop');
+      expect(later.status).toBe(0);
+      expect(later.stdout.trim()).toBe('');
+    }
+  });
+
+  it('stays silent when an ALREADY-surfaced signature recurs (#1163)', () => {
+    const signal = {
+      source: 'loc-exceeded',
+      agent: 'claude',
+      errorClass: 'GateEscalation',
+    } as const;
+    recordSignal(projectDirectory, 'sess-repeat', signal, '0.68.0');
+    expect(runHook(projectDirectory, 'sess-repeat').stdout).toContain('GateEscalation');
+
+    // A second occurrence of the SAME signature is not new information — dedupe
+    // is by signature, not by record count, so a gate that keeps firing cannot
+    // wake the agent once per firing.
+    recordSignal(projectDirectory, 'sess-repeat', signal, '0.68.0');
+
+    expect(runHook(projectDirectory, 'sess-repeat').stdout.trim()).toBe('');
+  });
+
+  it('surfaces only the NEW signature when a different one lands later (#1163)', () => {
+    recordSignal(
+      projectDirectory,
+      'sess-new',
+      { source: 'loc-exceeded', agent: 'claude', errorClass: 'GateEscalation' },
+      '0.68.0',
+    );
+    expect(runHook(projectDirectory, 'sess-new').stdout).toContain('GateEscalation@loc-exceeded');
+
+    recordSignal(
+      projectDirectory,
+      'sess-new',
+      { source: 'post-tool-quality', agent: 'claude', errorClass: 'TypeError' },
+      '0.68.0',
+    );
+
+    const second = runHook(projectDirectory, 'sess-new');
+    expect(second.stdout).toContain('TypeError@post-tool-quality');
+    // The already-surfaced one must not ride along again.
+    expect(second.stdout).not.toContain('GateEscalation');
+  });
+
+  it('dedupes per session — a second session still gets its own surfacing (#1163)', () => {
+    const signal = {
+      source: 'loc-exceeded',
+      agent: 'claude',
+      errorClass: 'GateEscalation',
+    } as const;
+    recordSignal(projectDirectory, 'sess-a', signal, '0.68.0');
+    recordSignal(projectDirectory, 'sess-b', signal, '0.68.0');
+
+    expect(runHook(projectDirectory, 'sess-a').stdout).toContain('GateEscalation');
+    expect(runHook(projectDirectory, 'sess-a').stdout.trim()).toBe('');
+    // sess-b's marker is independent — the dedupe must not silence a fresh session.
+    expect(runHook(projectDirectory, 'sess-b').stdout).toContain('GateEscalation');
+  });
+
   it('appends the filing-guide pointer when selfReport.file is true (#353)', () => {
     recordSignal(projectDirectory, 'sess-3', { source: 'check', exitCode: 1 }, '1.0.0');
     writeSelfReportConfig(projectDirectory, { file: true });

--- a/packages/cli/tests/integration/stop-self-report.test.ts
+++ b/packages/cli/tests/integration/stop-self-report.test.ts
@@ -37,6 +37,13 @@ function runHook(directory: string, sessionId: string) {
   });
 }
 
+/** The exact record shape that drove the observed #1163 wake loop. */
+const LOOP_SIGNAL = {
+  source: 'loc-exceeded',
+  agent: 'claude',
+  errorClass: 'GateEscalation',
+} as const;
+
 describe('stop-self-report hook (QYYC5Y)', () => {
   let projectDirectory: string;
 
@@ -92,13 +99,7 @@ describe('stop-self-report hook (QYYC5Y)', () => {
   // -------------------------------------------------------------------------
 
   it('surfaces a signature once, then stays silent on every later stop (#1163)', () => {
-    // The exact record shape that drove the observed loop.
-    recordSignal(
-      projectDirectory,
-      'sess-loop',
-      { source: 'loc-exceeded', agent: 'claude', errorClass: 'GateEscalation' },
-      '0.68.0',
-    );
+    recordSignal(projectDirectory, 'sess-loop', LOOP_SIGNAL, '0.68.0');
 
     const first = runHook(projectDirectory, 'sess-loop');
     expect(first.status).toBe(0);
@@ -114,29 +115,19 @@ describe('stop-self-report hook (QYYC5Y)', () => {
   });
 
   it('stays silent when an ALREADY-surfaced signature recurs (#1163)', () => {
-    const signal = {
-      source: 'loc-exceeded',
-      agent: 'claude',
-      errorClass: 'GateEscalation',
-    } as const;
-    recordSignal(projectDirectory, 'sess-repeat', signal, '0.68.0');
+    recordSignal(projectDirectory, 'sess-repeat', LOOP_SIGNAL, '0.68.0');
     expect(runHook(projectDirectory, 'sess-repeat').stdout).toContain('GateEscalation');
 
     // A second occurrence of the SAME signature is not new information — dedupe
     // is by signature, not by record count, so a gate that keeps firing cannot
     // wake the agent once per firing.
-    recordSignal(projectDirectory, 'sess-repeat', signal, '0.68.0');
+    recordSignal(projectDirectory, 'sess-repeat', LOOP_SIGNAL, '0.68.0');
 
     expect(runHook(projectDirectory, 'sess-repeat').stdout.trim()).toBe('');
   });
 
   it('surfaces only the NEW signature when a different one lands later (#1163)', () => {
-    recordSignal(
-      projectDirectory,
-      'sess-new',
-      { source: 'loc-exceeded', agent: 'claude', errorClass: 'GateEscalation' },
-      '0.68.0',
-    );
+    recordSignal(projectDirectory, 'sess-new', LOOP_SIGNAL, '0.68.0');
     expect(runHook(projectDirectory, 'sess-new').stdout).toContain('GateEscalation@loc-exceeded');
 
     recordSignal(
@@ -153,13 +144,8 @@ describe('stop-self-report hook (QYYC5Y)', () => {
   });
 
   it('dedupes per session — a second session still gets its own surfacing (#1163)', () => {
-    const signal = {
-      source: 'loc-exceeded',
-      agent: 'claude',
-      errorClass: 'GateEscalation',
-    } as const;
-    recordSignal(projectDirectory, 'sess-a', signal, '0.68.0');
-    recordSignal(projectDirectory, 'sess-b', signal, '0.68.0');
+    recordSignal(projectDirectory, 'sess-a', LOOP_SIGNAL, '0.68.0');
+    recordSignal(projectDirectory, 'sess-b', LOOP_SIGNAL, '0.68.0');
 
     expect(runHook(projectDirectory, 'sess-a').stdout).toContain('GateEscalation');
     expect(runHook(projectDirectory, 'sess-a').stdout.trim()).toBe('');

--- a/packages/cli/tests/owned-paths.test.ts
+++ b/packages/cli/tests/owned-paths.test.ts
@@ -21,7 +21,7 @@ import {
 import type { ProjectContext } from '../src/packs/types.js';
 import type { SafewordSchema } from '../src/schema.js';
 import { SAFEWORD_SCHEMA } from '../src/schema.js';
-import { META_PATHS } from '../templates/hooks/lib/quality-state.js';
+import { isMetaPath, META_PATHS } from '../templates/hooks/lib/quality-state.js';
 
 // Minimal context for resolvedNamespaceDirectory: it only reads cwd + namespaceRoot.
 const ctxWith = (cwd: string, namespaceRoot?: string): ProjectContext =>
@@ -163,6 +163,22 @@ describe('META_PATHS ↔ SAFEWORD_IGNORE_DIRS drift (#1163)', () => {
     for (const directory of ['.safeword/', '.claude/', '.cursor/', '.codex/', '.agents/']) {
       expect(META_PATHS).toContain(directory);
     }
+  });
+
+  it('matches project-relative paths, not substrings of the absolute path', () => {
+    // The gate bypass: safeword's own worktrees live at `<repo>/.claude/worktrees/<n>/`,
+    // so a substring test against the ABSOLUTE path matched every file in them and
+    // silently disabled every pre-tool gate — phase freeze, test-definitions, LOC.
+    const project = '/home/u/code/.claude/worktrees/wt';
+    expect(isMetaPath(`${project}/src/app.ts`, project)).toBe(false);
+    expect(isMetaPath(`${project}/packages/cli/src/index.ts`, project)).toBe(false);
+    // Real in-project meta paths still exempt, absolute or relative.
+    expect(isMetaPath(`${project}/.claude/settings.json`, project)).toBe(true);
+    expect(isMetaPath(`${project}/.agents/skills/x.md`, project)).toBe(true);
+    expect(isMetaPath('.safeword/hooks/x.ts', project)).toBe(true);
+    // A directory whose name merely STARTS with a meta name is not a meta path.
+    expect(isMetaPath(`${project}/.clauderc/app.ts`, project)).toBe(false);
+    expect(isMetaPath(`${project}/src/.claude-notes/app.ts`, project)).toBe(false);
   });
 
   it('does not exclude config files safeword merely merges into', () => {

--- a/packages/cli/tests/owned-paths.test.ts
+++ b/packages/cli/tests/owned-paths.test.ts
@@ -21,6 +21,7 @@ import {
 import type { ProjectContext } from '../src/packs/types.js';
 import type { SafewordSchema } from '../src/schema.js';
 import { SAFEWORD_SCHEMA } from '../src/schema.js';
+import { META_PATHS } from '../templates/hooks/lib/quality-state.js';
 
 // Minimal context for resolvedNamespaceDirectory: it only reads cwd + namespaceRoot.
 const ctxWith = (cwd: string, namespaceRoot?: string): ProjectContext =>
@@ -138,6 +139,37 @@ describe('generateOwnedPathsModule', () => {
   it('emits a filterSafewordFiles helper for the auto-upgrade hook to consume', () => {
     const source = generateOwnedPathsModule(stubSchema({ ownedFiles: ['.safeword/x.ts'] }));
     expect(source).toContain('export function filterSafewordFiles');
+  });
+});
+
+describe('META_PATHS ↔ SAFEWORD_IGNORE_DIRS drift (#1163)', () => {
+  // The LOC gate measures `git diff HEAD` minus META_PATHS. Any safeword-owned
+  // directory missing from that list gets counted as the agent's uncommitted
+  // work, so safeword's own auto-upgrade churn can hard-block the next edit.
+  // That is exactly how #1163 fired: `.agents/` (3801 tracked LOC in the
+  // safeword repo) was absent, so relocating skills out of it counted ~3800
+  // deletions against a 400-line threshold.
+  //
+  // The hooks can't import from `src/`, so the list is restated in
+  // templates/hooks/lib/quality-state.ts. This test is the seam that keeps the
+  // two honest — adding an owned dir to one without the other fails here.
+  it('META_PATHS is the trailing-slash mirror of SAFEWORD_IGNORE_DIRS', () => {
+    expect(new Set(META_PATHS)).toEqual(new Set(SAFEWORD_IGNORE_DIRS.map(dir => `${dir}/`)));
+  });
+
+  it('covers the agent-harness dirs safeword rewrites during auto-upgrade', () => {
+    // Named explicitly so a future edit that drops one has to argue with a test
+    // rather than silently re-open the gate bug.
+    for (const directory of ['.safeword/', '.claude/', '.cursor/', '.codex/', '.agents/']) {
+      expect(META_PATHS).toContain(directory);
+    }
+  });
+
+  it('does not exclude config files safeword merely merges into', () => {
+    // package.json / eslint.config.mjs are shared with the customer — excluding
+    // them would blind the gate to real work. Only whole owned DIRS are exempt.
+    expect(META_PATHS.every(path => path.endsWith('/'))).toBe(true);
+    expect(META_PATHS).not.toContain('package.json');
   });
 });
 


### PR DESCRIPTION
Fixes two compounding bugs observed live on safeword 0.68.0 → 0.69.0, plus a third found while reviewing them.

The two originals compound: the LOC gate produced a signal that the self-report Stop hook then looped on for ~1h40m, the agent replying `.` to itself with no user input.

## 1. The Stop wake loop

`stop-self-report.ts` emitted `hookSpecificOutput.additionalContext` on **every** Stop. `formatSelfReportSurfacing`'s only guard was `records.length === 0`, the per-session spool never drains, and nothing recorded that a signal had already been shown — so every turn end emitted a byte-identical line.

That's not merely noisy. Per [the hooks docs](https://code.claude.com/docs/en/hooks), Stop `additionalContext` appears "at the end of the turn. **The conversation continues** so Claude can act on the feedback." The agent is woken with no user message, must emit something to end the turn, which fires Stop, which re-emits. **Any unconditional emit from a Stop hook is an infinite wake-loop generator.** The docs carry no warning about this and expose no mechanism to tell a hook it is re-entering from its own continuation, so a hook must guard itself.

Each signature is now surfaced **at most once per session**, tracked in `.safeword/self-reports/surfaced/<session>.jsonl`. A Stop with nothing new emits nothing.

- Dedupe is by **signature, not record count**, so a gate that keeps firing can't wake the agent once per firing.
- The hook emits only if the marker durably took every signature. `markSignaturesSurfaced` reports that outcome rather than the hook re-reading the file — a read-back had its own false negative, where a transient read failure after a good write suppressed the signal permanently for the session.
- The marker lives in a subdirectory because `readReports` globs `*.jsonl` at the spool dir's top level and would otherwise parse markers as records.
- `stop_hook_active` guard added to match sibling `stop-retro-filing`. Not load-bearing (docs define it only for `decision:"block"`), but it caps any residual loop, and a false positive costs only delay.

Audited the other Stop hooks: `stop-reentry` appends to a file, `stop-retro` emits nothing by design, `stop-retro-filing` and `stop-quality` are guarded. This was the only unconditional emitter, and Claude-only — the Cursor/Codex `stop.ts` read the config but never call the surfacer.

## 2. The LOC gate counted safeword's own churn

`session-auto-upgrade` rewrites safeword's own scaffolding mid-session. `META_PATHS` listed five safeword-owned dirs but omitted `.agents/` and `.codex/`, while `SAFEWORD_IGNORE_DIRS` — safeword's own "dirs a customer's formatter must skip" list — has all seven. `.agents/` holds **3801 tracked LOC** here, so relocating skills out of it counted ~3800 deletions against a 400-line threshold and hard-blocked the agent's next edit.

The two lists are now bound by a drift test. The hooks can't import from `src/`, so the restatement is unavoidable and the test is the only thing keeping them honest. Config files safeword merely *merges into* (`package.json`, `eslint.config.mjs`) stay counted — they're shared with the user, and exempting them would blind the gate to real work.

## 3. `META_PATHS` gate bypass (found while reviewing; pre-existing, widened by #2)

`pre-tool-quality` matched `META_PATHS` with `editedFile.includes(p)` against an **absolute** path. So a checkout that merely *lives* under a directory named `.claude/`, `.cursor/`, `.safeword/` — and, after #2, `.codex/` or `.agents/` — had **every pre-tool gate silently disabled for every file**: the plan-implementation code freeze, the implement-without-test-definitions gate, and the LOC gate.

safeword's own worktrees live at `<repo>/.claude/worktrees/<name>/`, so this was live in this repo.

Demonstrated with two identical throwaway projects holding 5000 LOC of pending change: under a normal parent the LOC gate denied; under a parent named `.codex` the hook exited silently. Both now deny, and a genuine in-project `.claude/settings.json` stays exempt.

Matching is now project-relative at a segment boundary. Paths resolving outside the project stay exempt — the gates reason about project code, and an out-of-tree edit was never theirs to block.

## Coverage

Every regression test was verified to **fail before its fix** — 6 red on the originals, and the bypass reproduced empirically before and after. The loop bug in particular produces no error, no failure, and no log line, so the key test drives the hook repeatedly against an unchanged spool and asserts silence on every stop after the first.

Also covered: new-signature-still-surfaces, per-session independence, unwritable-marker reports failure, repeated signature doesn't consume marker headroom, torn-line fail-open, `readReports` non-pollution, near-miss directories (`.clauderc/`, `src/.claude-notes/`) that must **not** be exempt.

## Verification

- Full suite: **5235 passed**. One failure was a 60s *timeout* (not an assertion) in `setup-hooks.test.ts` during a 19-minute contended run; it passes 37/37 in isolation and references none of the changed symbols.
- Acceptance lane: 487 scenarios, 484 passed / 3 skipped.
- Lint, typecheck, build clean. `/audit`: architecture clean (626 modules), knip clean, no dead refs, no domain-doc drift.
- Template ↔ dogfood hook parity verified byte-identical.

## Notes for the reviewer

- The self-report config guide described `surface` as mentioning signals "at the end of a turn" — the behavior this PR removes. Updated in both halves of the pair.
- Deliberately **not** included: a re-baseline of the LOC counter after auto-upgrade (it already commits its own churn, so the exclusion is sufficient), and four outdated dev dependencies (unrelated churn).
- Worth a follow-up, out of scope here: `/audit` treats the jscpd clone-count delta as a finding, but the metric varies **470–475 across runs on an identical tree**. Historical recorded deltas (`+12`, `+3`, flat) sit at or below that noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)