### PR TITLE
fix(codex-plugin): correct the drift remedy; pin out repo-only citations

### DIFF
--- a/packages/cli/src/codex-plugin/catalogue.ts
+++ b/packages/cli/src/codex-plugin/catalogue.ts
@@ -333,7 +333,11 @@ function pluginAssetPaths(pluginDirectory: string): string[] {
 // git combines an edit to templates/skills/ with an untouched generated plugin
 // cleanly, because they are different files — it has no notion that one derives
 // from the other.
-const REGENERATE_REMEDY = 'Regenerate it with `bun run --cwd packages/cli generate:codex-plugin`.';
+// Name the directory rather than using `--cwd packages/cli`: that flag resolves
+// against the caller's cwd, so it fails from packages/cli — which is exactly
+// where `bun run test:release` surfaces these errors.
+const REGENERATE_REMEDY =
+  'Regenerate the catalogue: `bun run generate:codex-plugin` from packages/cli.';
 
 /** Ensure the checked-in plugin is the exact allowed transformation of canonical skills. */
 export function assertCodexPluginCatalogue(

--- a/packages/cli/tests/skills/shipped-skill-document-references.test.ts
+++ b/packages/cli/tests/skills/shipped-skill-document-references.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const CLI_ROOT = nodePath.resolve(import.meta.dirname, '../..');
+const SHIPPED_SKILLS = nodePath.join(CLI_ROOT, 'templates/skills');
+
+/**
+ * `PRINCIPLES.md` lives only at the safeword repo root: it is not under
+ * `templates/`, has no `ConfiguredPathKey` entry, and is never installed into a
+ * customer project. `ARCHITECTURE.md` is the opposite — `resolveArchitectureNarrative`
+ * resolves `paths.architecture`, defaulting to the host's own root file — so
+ * referencing that one is legitimate and stays allowed.
+ *
+ * The two look identical in prose and both resolve from inside this repo, which
+ * is why the breakage is invisible here and only bites customers. PR #1210
+ * removed two instances; this pins them out for good.
+ */
+const REPO_ONLY_DOCUMENT = 'PRINCIPLES';
+
+function markdownFiles(directory: string, prefix = ''): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const relativePath = nodePath.join(prefix, entry.name);
+    const absolutePath = nodePath.join(directory, entry.name);
+    if (entry.isDirectory()) return markdownFiles(absolutePath, relativePath);
+    return entry.isFile() && entry.name.endsWith('.md') ? [relativePath] : [];
+  });
+}
+
+describe('shipped skills', () => {
+  it('never cite a document that is not installed into customer projects', () => {
+    const offenders = markdownFiles(SHIPPED_SKILLS).filter(relativePath =>
+      readFileSync(nodePath.join(SHIPPED_SKILLS, relativePath), 'utf8').includes(
+        REPO_ONLY_DOCUMENT,
+      ),
+    );
+
+    expect(
+      offenders,
+      `These shipped skills cite ${REPO_ONLY_DOCUMENT}.md, which customers never receive. ` +
+        `Name the principle inline instead — the prose already carries it, so the citation ` +
+        `only adds a file path that cannot resolve outside this repo.`,
+    ).toEqual([]);
+  });
+
+  it('still allows ARCHITECTURE.md, which resolves via paths.architecture', () => {
+    const citingArchitecture = markdownFiles(SHIPPED_SKILLS).filter(relativePath =>
+      readFileSync(nodePath.join(SHIPPED_SKILLS, relativePath), 'utf8').includes('ARCHITECTURE.md'),
+    );
+
+    // Guards the guard: if this ever empties, the check above stopped
+    // discriminating and would pass for the wrong reason.
+    expect(citingArchitecture.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Two follow-ups from the #1210 review. Thanks to the reviewer — the second item was flagged as a wording nit and turned out to be a real defect.

## 1. The remedy command was wrong where it's read

#1209 shipped:

```
bun run --cwd packages/cli generate:codex-plugin
```

`--cwd` resolves against the caller's cwd, so it works only from the repo root. From `packages/cli`:

```
ENOENT: Could not change directory to "packages/cli"
```

That's exactly where `CLAUDE.md` says to run `test:release`, and therefore where these errors surface. It fails loudly (exit 1), so confusing rather than dangerous — but it misdirected precisely the reader the message exists to help.

```diff
-Regenerate it with `bun run --cwd packages/cli generate:codex-plugin`.
+Regenerate the catalogue: `bun run generate:codex-plugin` from packages/cli.
```

Naming the directory is correct from anywhere. "Regenerate it" → "the catalogue" because regeneration rewrites the whole catalogue, not the single drifted asset the message just named.

## 2. The citation removal had no guard

#1210 removed `(PRINCIPLES.md §1)` from `audit` and `verify`. Nothing stops it returning — and `safeword-pr-review-server-0a3852` **already carries the identical citation** in `review-spec` and `tdd-review`. When that branch lands it silently undoes #1210 across its own parity surfaces.

A tracking note is the weakest response available. `PRINCIPLES §1` itself says structure enforces and instructions suggest, so this is a check, not a reminder someone has to hold in their head.

The guard asserts on `templates/skills/**` — the canonical source that both the `.claude` copies and the generated Codex catalogue derive from, so one assertion covers every surface.

**`ARCHITECTURE.md` stays legal**, and is pinned by a second case. That reference genuinely resolves via `paths.architecture` to the host's own file. If it ever stops appearing, the first check has stopped discriminating and would pass for the wrong reason.

## Proved non-vacuous

Injected the branch's real `tdd-review` citation and confirmed the guard goes red:

```
AssertionError: These shipped skills cite PRINCIPLES.md, which customers never receive.
  expected [ 'tdd-review/SKILL.md' ] to deeply equal []
```

Green once reverted.

## Verification

- `test:release` — 22/22
- `bun run lint` — clean
- `parity-check --mode=all` — 190 pairs + 8 contracts in sync
- Corrected command confirmed working from `packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)