### PR TITLE
fix(surfaces): rename Claude Code on the Web to Claude Code Cloud; clear E008 surface drift

### DIFF
--- a/.project/surfaces.md
+++ b/.project/surfaces.md
@@ -12,15 +12,15 @@ surfaces.md from packages/cli/templates/surfaces-template.md and then own it.
 **Audience:** Technical Builder (TBU), Non-Technical Builder (NTB), Safeword Maintainer (SWM)
 **Examples:** `.claude/skills`, `.claude/settings.json`, slash commands, Claude hooks, VS Code / JetBrains IDE extensions
 **Coverage notes:** Tag feature scenarios with `@surface.claude-code` when behavior must work through Claude Code's installed files or workflow on a developer's local machine.
-**Do not confuse with:** Claude Code on the Web — runs in an ephemeral cloud container instead of the developer's machine; local-only mechanics (e.g. `claude --resume`, an interactively-authenticated MCP server) don't carry over.
+**Do not confuse with:** Claude Code Cloud — runs in an ephemeral, Anthropic-managed cloud VM instead of the developer's machine; local-only mechanics (e.g. `claude --resume`, an interactively-authenticated MCP server) don't carry over.
 
-## Claude Code on the Web
+## Claude Code Cloud
 
 **Kind:** Agent runtime
-**Description:** Cloud-hosted Claude Code sessions launched from claude.ai/code, the Claude mobile/desktop app, a GitHub Action, or a scheduled Routine. Each session clones the repo into an ephemeral, isolated container governed by the environment's network policy, and is reclaimed when the session ends or after inactivity.
+**Description:** Cloud-hosted Claude Code sessions (officially "Claude Code on the web") launched from claude.ai/code, the Claude mobile/desktop app, `claude --cloud` from the terminal, or a scheduled Routine — plus Claude Code GitHub Actions, which runs Claude Code inside a GitHub-hosted CI runner rather than an Anthropic VM. Each cloud session clones the repo into an ephemeral, isolated Anthropic-managed VM governed by the environment's network policy, and is reclaimed when the session ends or after inactivity.
 **Audience:** Technical Builder (TBU), Non-Technical Builder (NTB), Safeword Maintainer (SWM)
-**Examples:** claude.ai/code web UI, Claude mobile app, GitHub Action integration, scheduled/event-driven Routines, `add_repo` for extra repo sources, per-environment network policy
-**Coverage notes:** Tag feature scenarios with `@surface.claude-code-on-the-web` when behavior depends on the cloud session lifecycle (ephemeral container, network policy, triggers) rather than a developer's local setup. Lifecycle hooks (`SessionStart`, `UserPromptSubmit`, etc.) do fire in cloud sessions, but interactively-authenticated MCP servers may be unavailable in headless runs.
+**Examples:** claude.ai/code web UI, Claude mobile app, `claude --cloud` / `--teleport`, scheduled/event-driven Routines, Claude Code GitHub Actions (`anthropics/claude-code-action`, `@claude` issue/PR triggers), the **+ → Add from GitHub** repo picker, per-environment network policy
+**Coverage notes:** Tag feature scenarios with `@surface.claude-code-cloud` when behavior depends on a cloud / off-machine lifecycle (ephemeral VM or CI runner, network policy, GitHub-event triggers) rather than a developer's local setup. Lifecycle hooks (`SessionStart`, `UserPromptSubmit`, etc.) do fire in cloud sessions, but interactively-authenticated MCP servers may be unavailable in headless runs.
 **Do not confuse with:** Claude Code — runs on the developer's own persistent machine, not a reclaimed container.
 
 ## OpenAI Codex

--- a/features/plan-implementation-phase.feature
+++ b/features/plan-implementation-phase.feature
@@ -272,7 +272,7 @@ Feature: plan-implementation phase before TDD
   @plan-implementation-phase.NTB2.R3
   Rule: plan-implementation-phase.NTB2.R3 — headless sessions record pending approval instead of blocking
 
-    @surface.claude-code-on-the-web @surface.openai-codex-cloud @surface.cursor-cloud-agents
+    @surface.claude-code-cloud @surface.openai-codex-cloud @surface.cursor-cloud-agents
     Scenario: Headless session with approval enabled surfaces the plan instead of stalling
       Given the shipped bdd skill documents
       When PLAN_IMPLEMENTATION.md is read
@@ -372,7 +372,7 @@ Feature: plan-implementation phase before TDD
   @plan-implementation-phase.SM1.R4
   Rule: plan-implementation-phase.SM1.R4 — the phase contract runs on current harnesses including cloud surfaces
 
-    @surface.claude-code @surface.openai-codex @surface.cursor @surface.claude-code-on-the-web @surface.openai-codex-cloud @surface.cursor-cloud-agents
+    @surface.claude-code @surface.openai-codex @surface.cursor @surface.claude-code-cloud @surface.openai-codex-cloud @surface.cursor-cloud-agents
     Scenario: The phase contract carries no interactive-only dependencies
       Given the shipped bdd skill documents
       When PLAN_IMPLEMENTATION.md is read

--- a/packages/cli/features/codex-plugin-hook-parity.feature
+++ b/packages/cli/features/codex-plugin-hook-parity.feature
@@ -7,20 +7,20 @@ Feature: Codex plugin hook parity
 
   Rule: PreToolUse preserves quality gates and proof bridges
 
-    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PreToolUse denies the same blocked edit as the legacy adapter
       Given a Codex project with an incomplete feature ticket
       When the packaged Codex PreToolUse command receives an apply_patch that creates that ticket's test definitions
       Then it denies the edit with the Safe Word intake gate reason
       And the denial explains the Codex `$explain` escape hatch
 
-    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PreToolUse records skill and review-stamp run identity
       Given a Codex session id and project namespace root
       When the packaged Codex PreToolUse command sees Safe Word proof commands
       Then it writes the Codex run identity bridge files expected by the proof helpers
 
-    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R1 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PreToolUse preserves the shared shell safety gate
       Given a Codex project with a dangerous broad process-kill command
       When the packaged Codex PreToolUse command receives that shell command
@@ -28,19 +28,19 @@ Feature: Codex plugin hook parity
 
   Rule: PostToolUse preserves quality state and language-skill nudges
 
-    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PostToolUse accumulates quality state through the shared hook
       Given a Codex project with an active implementation ticket
       When the packaged Codex PostToolUse command receives an apply_patch edit
       Then the shared quality state records the Codex edit under that session
 
-    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PostToolUse forwards language skill nudges
       Given a Codex edit that creates source code needing a language skill nudge
       When the packaged Codex PostToolUse command runs
       Then it emits Codex PostToolUse additionalContext from the shared skill nudge hook
 
-    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R2 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged PostToolUse stays quiet for edits without a language nudge
       Given a Codex edit that changes only markdown
       When the packaged Codex PostToolUse command runs
@@ -48,7 +48,7 @@ Feature: Codex plugin hook parity
 
   Rule: Stop preserves continuations retro work and fail-open behavior
 
-    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged Stop emits architecture continuation before filing continuation
       Given a Codex done-phase session with an architecture documentation nudge
       And retro drafts are also waiting to be filed
@@ -56,14 +56,14 @@ Feature: Codex plugin hook parity
       Then it blocks with the architecture continuation
       And it does not emit a second continuation
 
-    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged Stop runs retro extraction invisibly
       Given a substantial Codex Stop payload with a readable transcript
       When the packaged Codex Stop command runs
       Then it launches the Codex retro extraction path
       And it returns no conversation-visible output unless filing is required
 
-    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R3 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged Stop fails open with valid JSON
       Given malformed Codex Stop input
       When the packaged Codex Stop command runs
@@ -71,14 +71,14 @@ Feature: Codex plugin hook parity
 
   Rule: SessionStart preserves context and auto-upgrade behavior through one dispatcher
 
-    @codex-plugin-hook-parity.TB1.R4 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R4 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged SessionStart runs auto-upgrade before emitting package-owned SAFEWORD context
       Given a Codex project with no applicable Safe Word upgrade
       When the packaged Codex SessionStart command runs
       Then it invokes the shared auto-upgrade core
       And it emits SessionStart additionalContext containing package-owned SAFEWORD.md
 
-    @codex-plugin-hook-parity.TB1.R4 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R4 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged SessionStart includes upgrade notices without exit-code blocking
       Given the shared auto-upgrade core reports a visible notice
       When the packaged Codex SessionStart command runs
@@ -87,14 +87,14 @@ Feature: Codex plugin hook parity
 
   Rule: UserPromptSubmit preserves timestamp and queued prompt context
 
-    @codex-plugin-hook-parity.TB1.R5 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R5 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged UserPromptSubmit emits queued Safe Word prompt context
       Given queued Safe Word prompt context for a Codex project
       When the packaged Codex UserPromptSubmit command runs
       Then it emits Codex UserPromptSubmit additionalContext containing that queued context
       And the queued context remains project-owned data, not plugin implementation
 
-    @codex-plugin-hook-parity.TB1.R5 @surface.openai-codex @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.TB1.R5 @surface.openai-codex @surface.safeword-cli
     Scenario: Packaged UserPromptSubmit emits a current timestamp with no queued prompt context
       Given no queued Safe Word prompt context for a Codex project
       When the packaged Codex UserPromptSubmit command runs
@@ -102,7 +102,7 @@ Feature: Codex plugin hook parity
 
   Rule: Parity evidence is layered before live smoke
 
-    @codex-plugin-hook-parity.SM1.R1 @surface.openai-codex @surface.codex-plugin-hooks @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.SM1.R1 @surface.openai-codex @surface.safeword-cli
     Scenario: Event-by-event parity map covers every legacy adapter behavior
       Given the legacy Codex adapters and packaged hook command are inspected
       When the parity audit is generated
@@ -110,14 +110,14 @@ Feature: Codex plugin hook parity
       And every preserved behavior names a deterministic proof
       And every deferred behavior names the follow-up or explicit non-goal
 
-    @codex-plugin-hook-parity.SM1.R2 @surface.codex-plugin-hooks @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.SM1.R2 @surface.openai-codex @surface.safeword-cli
     Scenario: Plugin manifest commands all use the packaged hook command
       Given the Codex plugin hook manifest
       When hook commands are inspected
       Then every Safe Word hook command runs `safeword hook codex`
       And no command points at repo-local `.safeword/hooks/codex`
 
-    @codex-plugin-hook-parity.SM1.R2 @surface.safe-word-packaged-cli
+    @codex-plugin-hook-parity.SM1.R2 @surface.safeword-cli
     Scenario: Hidden compatibility alias preserves the packaged hook contract
       Given a legacy Safe Word Codex hook command invokes `safeword codex-hook pre-tool-use`
       When it receives the same blocked edit payload as `safeword hook codex pre-tool-use`

--- a/packages/cli/features/codex-retro-parity.feature
+++ b/packages/cli/features/codex-retro-parity.feature
@@ -13,7 +13,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
 
   Rule: Stop extraction is synchronous and invisible
 
-    @codex-retro-parity.TB1.AC1 @surface.codex-stop @surface.retro-pipeline
+    @codex-retro-parity.TB1.AC1 @surface.openai-codex @surface.safeword-cli
     Scenario: The Codex Stop hook runs child extraction with an inline digest
       Given a local Codex Stop payload whose transcript_path is readable
       When the Codex Stop hook runs
@@ -24,7 +24,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
       And the Stop hook waits for the child before returning
       And the Stop hook writes no conversation-visible output
 
-    @codex-retro-parity.TB1.AC2 @surface.codex-stop
+    @codex-retro-parity.TB1.AC2 @surface.openai-codex
     Scenario Outline: The Codex Stop hook fails open without a continuation
       Given the Codex Stop hook encounters <failure>
       When the Codex Stop hook runs
@@ -43,7 +43,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
         | an empty child output file      |
         | a schema-invalid child output   |
 
-    @codex-retro-parity.TB1.AC2 @surface.codex-stop
+    @codex-retro-parity.TB1.AC2 @surface.openai-codex
     Scenario: A retro child Stop does not spawn another extraction
       Given the environment has `SAFEWORD_RETRO_CHILD=1`
       When the Codex Stop hook runs
@@ -54,14 +54,14 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
 
   Rule: Codex and Claude resolve different retro model defaults
 
-    @codex-retro-parity.SM1.AC1 @surface.retro-model
+    @codex-retro-parity.SM1.AC1 @surface.safeword-cli
     Scenario: Codex and Claude resolve their agent-specific defaults
       Given no retro model override exists in `.safeword/config.json`
       When each agent resolves its retro extraction model
       Then Claude resolves `sonnet`
       And Codex resolves `gpt-5.5`
 
-    @codex-retro-parity.SM1.AC1 @surface.retro-model
+    @codex-retro-parity.SM1.AC1 @surface.safeword-cli
     Scenario: A configured retro model overrides both agent defaults
       Given `.safeword/config.json` configures `retro.model`
       When each agent resolves its retro extraction model
@@ -69,7 +69,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
 
   Rule: Codex uses the shared egress, spool, and filing path
 
-    @codex-retro-parity.SM1.AC2 @surface.codex-stop @surface.retro-pipeline
+    @codex-retro-parity.SM1.AC2 @surface.openai-codex @surface.safeword-cli
     Scenario: Codex child findings are spooled and filed through the existing retro pipeline
       Given child Codex extraction returns a valid safeword finding containing raw transcript text and the secret-like token "SW-LEAK-CANARY-602"
       And the local REST transport can authenticate
@@ -78,7 +78,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
       And the filed issue body contains neither the raw transcript text nor "SW-LEAK-CANARY-602"
       And no conversation-visible output contains the raw finding text
 
-    @codex-retro-parity.SM1.AC2 @codex-retro-parity.SM1.AC3 @surface.codex-stop @surface.retro-pipeline
+    @codex-retro-parity.SM1.AC2 @codex-retro-parity.SM1.AC3 @surface.openai-codex @surface.safeword-cli
     Scenario Outline: Unfiled Codex drafts remain spooled for the Lane-2 nudge
       Given child Codex extraction returns a valid safeword finding
       And the local REST transport <failure>
@@ -92,7 +92,7 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
         | returns a retryable server error|
         | times out before filing         |
 
-    @codex-retro-parity.SM1.AC2 @surface.codex-stop @surface.retro-pipeline
+    @codex-retro-parity.SM1.AC2 @surface.openai-codex @surface.safeword-cli
     Scenario: Empty Codex child findings stay silent and create no filing work
       Given child Codex extraction returns schema-valid output with no findings
       When the Codex Stop hook completes the retro path
@@ -102,13 +102,13 @@ Feature: Codex retro parity — invisible local extraction and Lane-2 filing
 
   Rule: UserPromptSubmit surfaces unfiled Codex drafts
 
-    @codex-retro-parity.SM1.AC3 @surface.codex-user-prompt-submit @surface.config-wiring
+    @codex-retro-parity.SM1.AC3 @surface.openai-codex @surface.safeword-cli
     Scenario: The generated Codex config wires the packaged UserPromptSubmit hook
       Given a project installed with Codex hooks
       When a new user prompt starts after retro drafts remain spooled
       Then the Codex UserPromptSubmit hook runs `safeword hook codex user-prompt-submit`
 
-    @codex-retro-parity.SM1.AC3 @surface.codex-user-prompt-submit
+    @codex-retro-parity.SM1.AC3 @surface.openai-codex
     Scenario: The Codex prompt nudge fires once per unfiled batch
       Given retro drafts remain spooled for a Codex session
       When a new user prompt starts

--- a/packages/cli/features/migrate-codex-to-plugin.feature
+++ b/packages/cli/features/migrate-codex-to-plugin.feature
@@ -15,7 +15,7 @@ Feature: Move Codex users to the Safe Word plugin
       When the builder sets up Safe Word
       Then the project has no Safe Word Codex hook configuration
 
-  @surface.safe-word-packaged-cli @migrate-codex-to-plugin.TB1.R2
+  @surface.safeword-cli @migrate-codex-to-plugin.TB1.R2
   Rule: migrate-codex-to-plugin.TB1.R2 - Explicit migration verifies the profile plugin and preserves Safe Word-owned project hooks until the reviewed handoff cleanup
 
     Scenario: Verified plugin migration preserves legacy hooks pending review


### PR DESCRIPTION
## What

Two related fixes to the surface taxonomy, surfaced while hardening the 0.69 release.

### 1. Rename the cloud surface (`a52fc1bd6`)

`Claude Code on the Web` → `Claude Code Cloud`. The surface now covers both Anthropic-hosted cloud sessions and Claude Code GitHub Actions, so "on the Web" no longer describes it. Two wrong terms in the entry are corrected at the same time:

- `add_repo` was never a real mechanism — the repo picker is **+ → Add from GitHub** (search or paste a repo URL)
- cloud sessions run in an **Anthropic-managed VM**, not a container

`--teleport` was checked against current docs and kept (`claude --teleport` / `/teleport` pulls a cloud session down to the terminal).

### 2. Clear E008 surface drift (`a26c0118d`)

Feature files referenced seven `@surface.*` slugs with no matching `surfaces.md` entry. Mapped onto the existing runtime taxonomy rather than minting a new surface per mechanism:

| Old slug | New surface |
|---|---|
| `codex-stop`, `codex-user-prompt-submit`, `codex-plugin-hooks` | `openai-codex` |
| `retro-pipeline`, `retro-model`, `config-wiring`, `safe-word-packaged-cli` | `safeword-cli` |

A single hook event isn't a runtime, so these belong to the runtime they run through, not to surfaces of their own.

## Why this shape

The rename and the retag are a **matched pair**: renaming the surface without retagging `plan-implementation-phase.feature` leaves a dangling `@surface.claude-code-on-the-web` and turns E008 red. They have to land together.

`PLAN_IMPLEMENTATION.md` prose deliberately keeps the official name "Claude Code on the web" — that line names the headless-session category using product names customers recognize, and the internal surface label doesn't need to bleed into shipped skill copy.

## Verification

- E008 clean in both `features/` (7 refs) and `packages/cli/features/` (4 refs), run under bash
- 78/78 tests pass — audit domain-docs suite (24, covers E008) plus all five other `surfaces.md`-touching suites (54)
- `bun ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)