### PR TITLE
fix(hooks): check the configs that actually cover the changed files

### DIFF
--- a/.safeword/hooks/lib/typecheck-gate.ts
+++ b/.safeword/hooks/lib/typecheck-gate.ts
@@ -37,6 +37,17 @@ export interface TypecheckGateInput {
 }
 
 /**
+ * A `node_modules` path is a dependency's code, never the developer's change.
+ * A project whose `.gitignore` misses `node_modules` reports vendored files as
+ * changed; find-up from one lands on that dependency's own `tsconfig.json`, and
+ * typechecking that reports errors the developer does not own and cannot fix
+ * (missing peer `@types`, unresolved `extends`).
+ */
+function isVendored(file: string): boolean {
+  return file.split(/[/\\]/u).includes('node_modules');
+}
+
+/**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
  * Returns every distinct tsconfig the changed files resolve to, or
  * { run: false } to skip entirely.
@@ -48,7 +59,7 @@ export interface TypecheckGateInput {
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
 
-  const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file));
+  const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file) && !isVendored(file));
   if (tsFiles.length === 0) return { run: false };
 
   const tsconfigPaths: string[] = [];

--- a/.safeword/hooks/lib/typecheck-gate.ts
+++ b/.safeword/hooks/lib/typecheck-gate.ts
@@ -2,8 +2,12 @@
 //
 // Pure decision: given the project dir, files changed this session, and the
 // current ticket phase, decide whether to spawn `tsc --noEmit` and which
-// `tsconfig.json` to use. Uses find-up from each changed TS file so monorepos
-// with package-level tsconfigs (no root one) work.
+// `tsconfig.json` files to use. Uses find-up from each changed TS file so
+// monorepos with package-level tsconfigs (no root one) work.
+//
+// Find-up alone is proximity, not relevance — the nearest config may include a
+// different tree entirely. Coverage is therefore checked separately, behind the
+// `ConfigCoverageResolver` seam, by asking tsc which files a config resolves to.
 //
 // The actual tsc spawn + output capture lives separately (I/O); this module
 // stays pure so the decision logic can be unit-tested without a temp project.
@@ -20,7 +24,7 @@ const TYPECHECK_TIMEOUT_MS = 60_000;
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 const DONE_PHASE = 'done';
 
-export type TypecheckTarget = { run: false } | { run: true; tsconfigPath: string };
+export type TypecheckTarget = { run: false } | { run: true; tsconfigPaths: string[] };
 
 export interface TypecheckGateInput {
   /** Absolute project root (where to start find-up bounds). */
@@ -34,7 +38,12 @@ export interface TypecheckGateInput {
 
 /**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
- * Returns the tsconfig to use, or { run: false } to skip entirely.
+ * Returns every distinct tsconfig the changed files resolve to, or
+ * { run: false } to skip entirely.
+ *
+ * Every config, not the first: returning on the first match meant a change
+ * spanning two packages only ever typechecked one of them, and the other's
+ * silence read as "clean".
  */
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
@@ -42,11 +51,13 @@ export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file));
   if (tsFiles.length === 0) return { run: false };
 
+  const tsconfigPaths: string[] = [];
   for (const file of tsFiles) {
     const tsconfig = findTsconfigUp(input.projectDirectory, file);
-    if (tsconfig !== null) return { run: true, tsconfigPath: tsconfig };
+    if (tsconfig !== null && !tsconfigPaths.includes(tsconfig)) tsconfigPaths.push(tsconfig);
   }
-  return { run: false };
+  if (tsconfigPaths.length === 0) return { run: false };
+  return { run: true, tsconfigPaths };
 }
 
 function isTypeScriptFile(file: string): boolean {
@@ -106,6 +117,61 @@ function findTscBin(projectDirectory: string, tsconfigPath: string): string | nu
 }
 
 /**
+ * Does this tsconfig's resolved file set contain any of the changed files?
+ * `undefined` when that cannot be determined.
+ *
+ * Proximity is not coverage: find-up returns the nearest config, which may
+ * `include` a completely different tree. A change under `.safeword/hooks/`
+ * resolves to the repo-root config whose include is `packages/*&#47;src/**`,
+ * so typechecking it reported errors in ~30 untouched files while checking
+ * none of the changed ones.
+ */
+export type ConfigCoverageResolver = (
+  projectDirectory: string,
+  tsconfigPath: string,
+  changedFiles: string[],
+) => boolean | undefined;
+
+/**
+ * Real resolver: ask tsc itself. `--showConfig` resolves `extends`, `include`,
+ * `exclude`, and the default-extension rules exactly as a real run would, so
+ * coverage never depends on us reimplementing tsconfig glob semantics.
+ */
+export function resolveConfigCoverage(
+  projectDirectory: string,
+  tsconfigPath: string,
+  changedFiles: string[],
+): boolean | undefined {
+  const tscBin = findTscBin(projectDirectory, tsconfigPath);
+  if (tscBin === null) return undefined;
+
+  const result = spawnSync(tscBin, ['--showConfig', '--project', tsconfigPath], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: TYPECHECK_TIMEOUT_MS,
+  });
+  if (result.error || result.status !== 0) return undefined;
+
+  let files: unknown;
+  try {
+    files = (JSON.parse(result.stdout) as { files?: unknown }).files;
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(files)) return undefined;
+
+  // `--showConfig` emits paths relative to the tsconfig's own directory, which
+  // is not necessarily the project root — resolve both sides before comparing.
+  const configDirectory = nodePath.dirname(nodePath.resolve(tsconfigPath));
+  const covered = new Set(
+    files
+      .filter((file): file is string => typeof file === 'string')
+      .map(file => nodePath.resolve(configDirectory, file)),
+  );
+  return changedFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
+}
+
+/**
  * Incremental-cache path in the OS temp dir, keyed by the tsconfig's absolute
  * path. Keeps the `.tsbuildinfo` OUT of the user's repo (no stray artifact, no
  * gitignore management) while staying warm across stops within a session.
@@ -156,17 +222,30 @@ export function runIncrementalTypecheck(
 export function evaluateImplementStopTypecheck(
   input: TypecheckGateInput,
   runner: TypecheckRunner = runIncrementalTypecheck,
+  coversChangedFiles: ConfigCoverageResolver = resolveConfigCoverage,
 ): { advice: string | null } {
   const gate = shouldRunTypecheck(input);
   if (!gate.run) return { advice: null };
 
-  const result = runner(input.projectDirectory, gate.tsconfigPath);
-  if (!result.available || result.ok) return { advice: null };
-  // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
-  // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
-  // diagnostic — that's not a type error in the change, so stay silent.
-  if (!hasFileLevelTypeError(result.output)) return { advice: null };
-  return { advice: result.output };
+  const advice: string[] = [];
+  for (const tsconfigPath of gate.tsconfigPaths) {
+    // Skip only on a definite "covers nothing you touched". Unknown coverage
+    // degrades to the previous behaviour and still runs: this filter is the new
+    // part, so when it cannot do its job it must not hide what tsc already found.
+    if (coversChangedFiles(input.projectDirectory, tsconfigPath, input.changedFiles) === false) {
+      continue;
+    }
+
+    const result = runner(input.projectDirectory, tsconfigPath);
+    if (!result.available || result.ok) continue;
+    // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
+    // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
+    // diagnostic — that's not a type error in the change, so stay silent.
+    if (!hasFileLevelTypeError(result.output)) continue;
+    advice.push(result.output);
+  }
+
+  return { advice: advice.length > 0 ? advice.join('\n\n') : null };
 }
 
 /** True iff tsc output has a file-level diagnostic, not just a config-level error. */

--- a/packages/cli/templates/hooks/lib/typecheck-gate.ts
+++ b/packages/cli/templates/hooks/lib/typecheck-gate.ts
@@ -37,6 +37,17 @@ export interface TypecheckGateInput {
 }
 
 /**
+ * A `node_modules` path is a dependency's code, never the developer's change.
+ * A project whose `.gitignore` misses `node_modules` reports vendored files as
+ * changed; find-up from one lands on that dependency's own `tsconfig.json`, and
+ * typechecking that reports errors the developer does not own and cannot fix
+ * (missing peer `@types`, unresolved `extends`).
+ */
+function isVendored(file: string): boolean {
+  return file.split(/[/\\]/u).includes('node_modules');
+}
+
+/**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
  * Returns every distinct tsconfig the changed files resolve to, or
  * { run: false } to skip entirely.
@@ -48,7 +59,7 @@ export interface TypecheckGateInput {
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
 
-  const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file));
+  const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file) && !isVendored(file));
   if (tsFiles.length === 0) return { run: false };
 
   const tsconfigPaths: string[] = [];

--- a/packages/cli/templates/hooks/lib/typecheck-gate.ts
+++ b/packages/cli/templates/hooks/lib/typecheck-gate.ts
@@ -2,8 +2,12 @@
 //
 // Pure decision: given the project dir, files changed this session, and the
 // current ticket phase, decide whether to spawn `tsc --noEmit` and which
-// `tsconfig.json` to use. Uses find-up from each changed TS file so monorepos
-// with package-level tsconfigs (no root one) work.
+// `tsconfig.json` files to use. Uses find-up from each changed TS file so
+// monorepos with package-level tsconfigs (no root one) work.
+//
+// Find-up alone is proximity, not relevance — the nearest config may include a
+// different tree entirely. Coverage is therefore checked separately, behind the
+// `ConfigCoverageResolver` seam, by asking tsc which files a config resolves to.
 //
 // The actual tsc spawn + output capture lives separately (I/O); this module
 // stays pure so the decision logic can be unit-tested without a temp project.
@@ -20,7 +24,7 @@ const TYPECHECK_TIMEOUT_MS = 60_000;
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 const DONE_PHASE = 'done';
 
-export type TypecheckTarget = { run: false } | { run: true; tsconfigPath: string };
+export type TypecheckTarget = { run: false } | { run: true; tsconfigPaths: string[] };
 
 export interface TypecheckGateInput {
   /** Absolute project root (where to start find-up bounds). */
@@ -34,7 +38,12 @@ export interface TypecheckGateInput {
 
 /**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
- * Returns the tsconfig to use, or { run: false } to skip entirely.
+ * Returns every distinct tsconfig the changed files resolve to, or
+ * { run: false } to skip entirely.
+ *
+ * Every config, not the first: returning on the first match meant a change
+ * spanning two packages only ever typechecked one of them, and the other's
+ * silence read as "clean".
  */
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
@@ -42,11 +51,13 @@ export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file));
   if (tsFiles.length === 0) return { run: false };
 
+  const tsconfigPaths: string[] = [];
   for (const file of tsFiles) {
     const tsconfig = findTsconfigUp(input.projectDirectory, file);
-    if (tsconfig !== null) return { run: true, tsconfigPath: tsconfig };
+    if (tsconfig !== null && !tsconfigPaths.includes(tsconfig)) tsconfigPaths.push(tsconfig);
   }
-  return { run: false };
+  if (tsconfigPaths.length === 0) return { run: false };
+  return { run: true, tsconfigPaths };
 }
 
 function isTypeScriptFile(file: string): boolean {
@@ -106,6 +117,61 @@ function findTscBin(projectDirectory: string, tsconfigPath: string): string | nu
 }
 
 /**
+ * Does this tsconfig's resolved file set contain any of the changed files?
+ * `undefined` when that cannot be determined.
+ *
+ * Proximity is not coverage: find-up returns the nearest config, which may
+ * `include` a completely different tree. A change under `.safeword/hooks/`
+ * resolves to the repo-root config whose include is `packages/*&#47;src/**`,
+ * so typechecking it reported errors in ~30 untouched files while checking
+ * none of the changed ones.
+ */
+export type ConfigCoverageResolver = (
+  projectDirectory: string,
+  tsconfigPath: string,
+  changedFiles: string[],
+) => boolean | undefined;
+
+/**
+ * Real resolver: ask tsc itself. `--showConfig` resolves `extends`, `include`,
+ * `exclude`, and the default-extension rules exactly as a real run would, so
+ * coverage never depends on us reimplementing tsconfig glob semantics.
+ */
+export function resolveConfigCoverage(
+  projectDirectory: string,
+  tsconfigPath: string,
+  changedFiles: string[],
+): boolean | undefined {
+  const tscBin = findTscBin(projectDirectory, tsconfigPath);
+  if (tscBin === null) return undefined;
+
+  const result = spawnSync(tscBin, ['--showConfig', '--project', tsconfigPath], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: TYPECHECK_TIMEOUT_MS,
+  });
+  if (result.error || result.status !== 0) return undefined;
+
+  let files: unknown;
+  try {
+    files = (JSON.parse(result.stdout) as { files?: unknown }).files;
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(files)) return undefined;
+
+  // `--showConfig` emits paths relative to the tsconfig's own directory, which
+  // is not necessarily the project root — resolve both sides before comparing.
+  const configDirectory = nodePath.dirname(nodePath.resolve(tsconfigPath));
+  const covered = new Set(
+    files
+      .filter((file): file is string => typeof file === 'string')
+      .map(file => nodePath.resolve(configDirectory, file)),
+  );
+  return changedFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
+}
+
+/**
  * Incremental-cache path in the OS temp dir, keyed by the tsconfig's absolute
  * path. Keeps the `.tsbuildinfo` OUT of the user's repo (no stray artifact, no
  * gitignore management) while staying warm across stops within a session.
@@ -156,17 +222,30 @@ export function runIncrementalTypecheck(
 export function evaluateImplementStopTypecheck(
   input: TypecheckGateInput,
   runner: TypecheckRunner = runIncrementalTypecheck,
+  coversChangedFiles: ConfigCoverageResolver = resolveConfigCoverage,
 ): { advice: string | null } {
   const gate = shouldRunTypecheck(input);
   if (!gate.run) return { advice: null };
 
-  const result = runner(input.projectDirectory, gate.tsconfigPath);
-  if (!result.available || result.ok) return { advice: null };
-  // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
-  // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
-  // diagnostic — that's not a type error in the change, so stay silent.
-  if (!hasFileLevelTypeError(result.output)) return { advice: null };
-  return { advice: result.output };
+  const advice: string[] = [];
+  for (const tsconfigPath of gate.tsconfigPaths) {
+    // Skip only on a definite "covers nothing you touched". Unknown coverage
+    // degrades to the previous behaviour and still runs: this filter is the new
+    // part, so when it cannot do its job it must not hide what tsc already found.
+    if (coversChangedFiles(input.projectDirectory, tsconfigPath, input.changedFiles) === false) {
+      continue;
+    }
+
+    const result = runner(input.projectDirectory, tsconfigPath);
+    if (!result.available || result.ok) continue;
+    // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
+    // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
+    // diagnostic — that's not a type error in the change, so stay silent.
+    if (!hasFileLevelTypeError(result.output)) continue;
+    advice.push(result.output);
+  }
+
+  return { advice: advice.length > 0 ? advice.join('\n\n') : null };
 }
 
 /** True iff tsc output has a file-level diagnostic, not just a config-level error. */

--- a/packages/cli/tests/hooks/typecheck-gate.test.ts
+++ b/packages/cli/tests/hooks/typecheck-gate.test.ts
@@ -138,6 +138,41 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
     }
   });
 
+  it('ignores changed files inside node_modules', () => {
+    // A project whose .gitignore misses node_modules reports vendored files as
+    // changed. They are a dependency's code, never the developer's change — and
+    // find-up from one lands on that dependency's own tsconfig.
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+
+    const result = shouldRunTypecheck({
+      projectDirectory,
+      changedFiles: ['node_modules/@cucumber/gherkin/src/index.ts'],
+      phase: 'implement',
+    });
+
+    expect(result.run).toBe(false);
+  });
+
+  it('never returns a tsconfig that lives inside node_modules', () => {
+    // Typechecking a dependency's config reports errors in code the developer
+    // does not own and cannot fix (missing peer @types, unresolved `extends`).
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'node_modules/@cucumber/gherkin/tsconfig.json'));
+
+    const result = shouldRunTypecheck({
+      projectDirectory,
+      changedFiles: ['src/mine.ts', 'node_modules/@cucumber/gherkin/src/index.ts'],
+      phase: 'implement',
+    });
+
+    expect(result.run).toBe(true);
+    if (result.run) {
+      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
+    }
+  });
+
   it('deduplicates when several changed files resolve to the same config', () => {
     const projectDirectory = makeProject();
     touch(nodePath.join(projectDirectory, 'tsconfig.json'));

--- a/packages/cli/tests/hooks/typecheck-gate.test.ts
+++ b/packages/cli/tests/hooks/typecheck-gate.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, it } from 'vitest';
 import {
   changedFilesSinceHead,
   evaluateImplementStopTypecheck,
+  resolveConfigCoverage,
   runIncrementalTypecheck,
   shouldRunTypecheck,
   type TypecheckRunResult,
@@ -65,7 +66,7 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPath).toBe(nodePath.join(projectDirectory, 'tsconfig.json'));
+      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
     }
   });
 
@@ -108,9 +109,48 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPath).toBe(
+      expect(result.tsconfigPaths).toEqual([
         nodePath.join(projectDirectory, 'packages/cli/tsconfig.json'),
-      );
+      ]);
+    }
+  });
+
+  it('returns a config for every package that changed, not just the first', () => {
+    // Regression: the gate used to return on the first changed file that found
+    // any tsconfig, so a second package's types were never checked at all — a
+    // silent pass, which reads as "clean".
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'packages/alpha/tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'packages/beta/tsconfig.json'));
+
+    const result = shouldRunTypecheck({
+      projectDirectory,
+      changedFiles: ['packages/alpha/src/a.ts', 'packages/beta/src/b.ts'],
+      phase: 'implement',
+    });
+
+    expect(result.run).toBe(true);
+    if (result.run) {
+      expect(result.tsconfigPaths).toEqual([
+        nodePath.join(projectDirectory, 'packages/alpha/tsconfig.json'),
+        nodePath.join(projectDirectory, 'packages/beta/tsconfig.json'),
+      ]);
+    }
+  });
+
+  it('deduplicates when several changed files resolve to the same config', () => {
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+
+    const result = shouldRunTypecheck({
+      projectDirectory,
+      changedFiles: ['src/a.ts', 'src/nested/b.ts', 'other/c.ts'],
+      phase: 'implement',
+    });
+
+    expect(result.run).toBe(true);
+    if (result.run) {
+      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
     }
   });
 
@@ -203,6 +243,134 @@ describe('evaluateImplementStopTypecheck (Rules 2 + 4 — surface as advice)', (
     });
 
     expect(evaluateImplementStopTypecheck(gatePassingInput(), runner).advice).toBeNull();
+  });
+});
+
+describe('evaluateImplementStopTypecheck — config coverage', () => {
+  const failingRunner = (): TypecheckRunResult => ({
+    available: true,
+    ok: false,
+    output: 'packages/cli/src/other.ts(1,7): error TS2322: Type error in an untouched file.',
+  });
+
+  /** Safeword's own shape: a root config whose `include` misses the changed file. */
+  function hookChangeInput(): { projectDirectory: string; changedFiles: string[]; phase: string } {
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+    return {
+      projectDirectory,
+      changedFiles: ['.safeword/hooks/lib/changed.ts'],
+      phase: 'implement',
+    };
+  }
+
+  it('does not run a config that covers none of the changed files', () => {
+    // The real failure: a change under .safeword/hooks finds the root tsconfig,
+    // whose include is packages/*/src/**/*. Typechecking it reported errors in
+    // ~30 untouched files and checked none of the changed ones.
+    let isRan = false;
+    const runner = (): TypecheckRunResult => {
+      isRan = true;
+      return failingRunner();
+    };
+
+    const { advice } = evaluateImplementStopTypecheck(hookChangeInput(), runner, () => false);
+
+    expect(advice).toBeNull();
+    expect(isRan).toBe(false);
+  });
+
+  it('runs a config that does cover a changed file', () => {
+    const { advice } = evaluateImplementStopTypecheck(hookChangeInput(), failingRunner, () => true);
+
+    expect(advice).toContain('error TS2322');
+  });
+
+  it('runs when coverage cannot be determined, degrading to the prior behavior', () => {
+    // Unknown coverage must not suppress the check: the filter is the new part,
+    // so when it cannot do its job it should never hide what tsc already found.
+    const coverageUnknown: boolean | undefined = undefined;
+
+    const { advice } = evaluateImplementStopTypecheck(
+      hookChangeInput(),
+      failingRunner,
+      () => coverageUnknown,
+    );
+
+    expect(advice).toContain('error TS2322');
+  });
+
+  it('surfaces advice from every covered config, not just the first', () => {
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'packages/alpha/tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'packages/beta/tsconfig.json'));
+    const runner = (_projectDirectory: string, tsconfigPath: string): TypecheckRunResult => ({
+      available: true,
+      ok: false,
+      output: tsconfigPath.includes('alpha')
+        ? 'packages/alpha/src/a.ts(1,7): error TS1111: alpha broke.'
+        : 'packages/beta/src/b.ts(1,7): error TS2222: beta broke.',
+    });
+
+    const { advice } = evaluateImplementStopTypecheck(
+      {
+        projectDirectory,
+        changedFiles: ['packages/alpha/src/a.ts', 'packages/beta/src/b.ts'],
+        phase: 'implement',
+      },
+      runner,
+      () => true,
+    );
+
+    expect(advice).toContain('alpha broke');
+    expect(advice).toContain('beta broke');
+  });
+});
+
+describe('resolveConfigCoverage (real tsc — integration)', () => {
+  /** Root config that only includes packages/*, mirroring safeword's own layout. */
+  function projectWithNarrowRootConfig(): string {
+    const cliTsc = nodePath.resolve(import.meta.dirname, '../../node_modules/.bin/tsc');
+    expect(existsSync(cliTsc)).toBe(true);
+    const project = mkdtempSync(nodePath.join(tmpdir(), 'tccov-'));
+    mkdirSync(nodePath.join(project, 'node_modules/.bin'), { recursive: true });
+    symlinkSync(realpathSync(cliTsc), nodePath.join(project, 'node_modules/.bin/tsc'));
+    writeFileSync(
+      nodePath.join(project, 'tsconfig.json'),
+      JSON.stringify({ include: ['packages/*/src/**/*'] }),
+    );
+    touch(nodePath.join(project, 'packages/cli/src/real.ts'));
+    touch(nodePath.join(project, '.safeword/hooks/lib/changed.ts'));
+    return project;
+  }
+
+  it('reports uncovered for a changed file outside the config include', () => {
+    const project = projectWithNarrowRootConfig();
+
+    const covered = resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), [
+      '.safeword/hooks/lib/changed.ts',
+    ]);
+
+    expect(covered).toBe(false);
+  });
+
+  it('reports covered for a changed file inside the config include', () => {
+    const project = projectWithNarrowRootConfig();
+
+    const covered = resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), [
+      'packages/cli/src/real.ts',
+    ]);
+
+    expect(covered).toBe(true);
+  });
+
+  it('returns undefined when no tsc binary exists to resolve the config', () => {
+    const project = makeProject();
+    touch(nodePath.join(project, 'tsconfig.json'));
+
+    expect(
+      resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), ['src/foo.ts']),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes the follow-up filed from #1225. That PR made the symptom quiet by fixing the root tsconfig's `lib`; this fixes the gate that surfaced it.

## Two defects, one root cause

`findTsconfigUp` returns the nearest `tsconfig.json` at or above a changed file. Nothing asked whether that config **covers** the file it started from, or whether other changed files needed other configs.

### It typechecked the wrong tree

A change under `.safeword/hooks/` finds no nearer config and lands on the repo root, whose `include` is `packages/*/src/**/*` — which doesn't cover `.safeword/hooks/` at all.

The gate reported errors across ~30 untouched files in `packages/cli` and typechecked **none** of the three files that triggered it, under a header claiming "TypeScript errors in your changed files".

### It silently skipped packages

```ts
for (const file of tsFiles) {
  const tsconfig = findTsconfigUp(input.projectDirectory, file);
  if (tsconfig !== null) return { run: true, tsconfigPath: tsconfig };   // ← first wins
}
```

A change spanning two packages only ever checked one. This repo has three tsconfigs, and `changedFilesSinceHead` yields tracked files first in git order — so `packages/cli` wins and **`packages/website` was never typechecked** when both changed.

This is the more dangerous of the two. It produces silence, and silence reads as clean.

## The fix

Coverage decides relevance, not proximity.

- `shouldRunTypecheck` stays pure and returns **every distinct** config.
- A new `ConfigCoverageResolver` seam — mirroring the existing `TypecheckRunner` seam — drops configs covering none of the changed files **before** anything is spawned.
- Coverage is resolved by asking tsc: `--showConfig` resolves `extends`, `include`, `exclude`, and default-extension rules exactly as a real run would, so this never depends on reimplementing tsconfig glob semantics. Its paths are relative to the tsconfig's own directory, not the project root, so both sides are resolved before comparison.

**Unknown coverage runs the check rather than skipping it.** Filtering is the new behavior; when it can't do its job it must not hide what tsc already found. The failure mode is the previous behavior, never new silence.

## Considered and rejected

**Filter diagnostics down to the changed files.** It makes the advisory's claim literally true in ~5 lines — and it would hide the gate's most valuable catch: you narrow an exported type, your own file is clean, and the error surfaces in an unchanged consumer. Coverage-based relevance keeps that visible.

## Verification

End-to-end against real tsc on safeword's own layout, with a genuine type error planted in `packages/cli/src`:

```
THE REAL CASE — changed .safeword/hooks/lib/changed.ts
  advice: null — SILENT ✓
CONTROL — changed packages/cli/src/broken.ts (covered)
  advice: reports the error ✓
```

- 28/28 gate tests (9 written failing first, covering both defects)
- 1158 tests across the hook + schema suites
- `bun run lint` clean, `parity-check --mode=all` 190 pairs + 8 contracts
- `test:release` 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)