### PR TITLE
fix(hooks): judge each tsconfig by the files that selected it

### DIFF
--- a/.safeword/hooks/lib/typecheck-gate.ts
+++ b/.safeword/hooks/lib/typecheck-gate.ts
@@ -21,10 +21,35 @@ import nodePath from 'node:path';
 /** Hard cap on a single tsc run so a pathological project can't hang the stop. */
 const TYPECHECK_TIMEOUT_MS = 60_000;
 
+/**
+ * Total budget for typechecking across every config in one stop, divided among
+ * them. A per-spawn cap alone turns N configs into N × the cap, and the Stop
+ * hook declares no timeout of its own — so the harness default would kill the
+ * whole hook rather than just the typecheck step.
+ */
+export const TYPECHECK_BUDGET_MS = 60_000;
+
+/** Floor so a wide change still gives each config a usable slice. */
+const MIN_CONFIG_TIMEOUT_MS = 5_000;
+
+/**
+ * `--showConfig` output runs ~52 bytes per file; the 1 MB spawnSync default
+ * overflows near 19k files, which is exactly where the per-config cost is
+ * worst. Overflow degrades to "unknown", so the filter would go inert on the
+ * largest configs without this.
+ */
+const SHOW_CONFIG_MAX_BUFFER = 64 * 1024 * 1024;
+
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 const DONE_PHASE = 'done';
 
-export type TypecheckTarget = { run: false } | { run: true; tsconfigPaths: string[] };
+export interface TypecheckConfigTarget {
+  tsconfigPath: string;
+  /** The changed files that selected this config via find-up. */
+  selectingFiles: string[];
+}
+
+export type TypecheckTarget = { run: false } | { run: true; targets: TypecheckConfigTarget[] };
 
 export interface TypecheckGateInput {
   /** Absolute project root (where to start find-up bounds). */
@@ -49,12 +74,17 @@ function isVendored(file: string): boolean {
 
 /**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
- * Returns every distinct tsconfig the changed files resolve to, or
- * { run: false } to skip entirely.
+ * Returns every distinct tsconfig the changed files resolve to — each paired
+ * with the files that selected it — or { run: false } to skip entirely.
  *
  * Every config, not the first: returning on the first match meant a change
  * spanning two packages only ever typechecked one of them, and the other's
  * silence read as "clean".
+ *
+ * Each config carries its own selecting files because relevance is per-config.
+ * Asking "does this config cover anything that changed anywhere" let a root
+ * config ride in on a file that had already selected a nearer config, which is
+ * how the original symptom (errors in an untouched tree) survived the fix.
  */
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
@@ -62,13 +92,23 @@ export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file) && !isVendored(file));
   if (tsFiles.length === 0) return { run: false };
 
-  const tsconfigPaths: string[] = [];
+  const targets = new Map<string, string[]>();
   for (const file of tsFiles) {
     const tsconfig = findTsconfigUp(input.projectDirectory, file);
-    if (tsconfig !== null && !tsconfigPaths.includes(tsconfig)) tsconfigPaths.push(tsconfig);
+    if (tsconfig === null) continue;
+    const selecting = targets.get(tsconfig);
+    if (selecting === undefined) targets.set(tsconfig, [file]);
+    else selecting.push(file);
   }
-  if (tsconfigPaths.length === 0) return { run: false };
-  return { run: true, tsconfigPaths };
+  if (targets.size === 0) return { run: false };
+
+  return {
+    run: true,
+    targets: [...targets].map(([tsconfigPath, selectingFiles]) => ({
+      tsconfigPath,
+      selectingFiles,
+    })),
+  };
 }
 
 function isTypeScriptFile(file: string): boolean {
@@ -111,6 +151,7 @@ export interface TypecheckRunResult {
 export type TypecheckRunner = (
   projectDirectory: string,
   tsconfigPath: string,
+  timeoutMs?: number,
 ) => TypecheckRunResult;
 
 /** Locate a `tsc` binary by walking up from the tsconfig's dir to projectDirectory. */
@@ -145,8 +186,18 @@ export type ConfigCoverageResolver = (
 
 /**
  * Real resolver: ask tsc itself. `--showConfig` resolves `extends`, `include`,
- * `exclude`, and the default-extension rules exactly as a real run would, so
- * coverage never depends on us reimplementing tsconfig glob semantics.
+ * `exclude`, and the default-extension rules as a real run would, so coverage
+ * never depends on us reimplementing tsconfig glob semantics.
+ *
+ * Two shapes return `undefined` rather than an answer, and both degrade to
+ * running the check:
+ *
+ * - Configs that resolve to no `files` key — `${configDir}` templates and bases
+ *   pulled from `node_modules` (astro, `@tsconfig/*`, expo) emit absolute
+ *   include specs instead. Such projects get no benefit from this filter.
+ * - Changed files that no longer exist on disk. `--showConfig` lists what is
+ *   there, so a deletion could never be "covered" — and deleting an exported
+ *   module is exactly when its consumers break.
  */
 export function resolveConfigCoverage(
   projectDirectory: string,
@@ -156,10 +207,18 @@ export function resolveConfigCoverage(
   const tscBin = findTscBin(projectDirectory, tsconfigPath);
   if (tscBin === null) return undefined;
 
+  // A deleted file can never appear in the resolved set; judging coverage on
+  // what remains would turn a deletion into silence.
+  const presentFiles = changedFiles.filter(file =>
+    existsSync(nodePath.resolve(projectDirectory, file)),
+  );
+  if (presentFiles.length === 0) return undefined;
+
   const result = spawnSync(tscBin, ['--showConfig', '--project', tsconfigPath], {
     cwd: projectDirectory,
     encoding: 'utf8',
     timeout: TYPECHECK_TIMEOUT_MS,
+    maxBuffer: SHOW_CONFIG_MAX_BUFFER,
   });
   if (result.error || result.status !== 0) return undefined;
 
@@ -179,7 +238,7 @@ export function resolveConfigCoverage(
       .filter((file): file is string => typeof file === 'string')
       .map(file => nodePath.resolve(configDirectory, file)),
   );
-  return changedFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
+  return presentFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
 }
 
 /**
@@ -198,6 +257,7 @@ function tsBuildInfoPath(tsconfigPath: string): string {
 export function runIncrementalTypecheck(
   projectDirectory: string,
   tsconfigPath: string,
+  timeoutMs: number = TYPECHECK_TIMEOUT_MS,
 ): TypecheckRunResult {
   const tscBin = findTscBin(projectDirectory, tsconfigPath);
   if (tscBin === null) return { available: false, ok: false, output: '' };
@@ -214,7 +274,7 @@ export function runIncrementalTypecheck(
       '--project',
       tsconfigPath,
     ],
-    { cwd: projectDirectory, encoding: 'utf8', timeout: TYPECHECK_TIMEOUT_MS },
+    { cwd: projectDirectory, encoding: 'utf8', timeout: timeoutMs },
   );
 
   // Timed out or failed to spawn → stay silent (can't trust partial output).
@@ -238,25 +298,44 @@ export function evaluateImplementStopTypecheck(
   const gate = shouldRunTypecheck(input);
   if (!gate.run) return { advice: null };
 
+  const timeoutMs = Math.max(
+    MIN_CONFIG_TIMEOUT_MS,
+    Math.floor(TYPECHECK_BUDGET_MS / gate.targets.length),
+  );
+
   const advice: string[] = [];
-  for (const tsconfigPath of gate.tsconfigPaths) {
+  for (const { tsconfigPath, selectingFiles } of gate.targets) {
+    // Coverage is judged against this config's own selecting files, never the
+    // whole changed set — otherwise a config runs on the strength of a file
+    // that already had a nearer config of its own.
+    //
     // Skip only on a definite "covers nothing you touched". Unknown coverage
     // degrades to the previous behaviour and still runs: this filter is the new
     // part, so when it cannot do its job it must not hide what tsc already found.
-    if (coversChangedFiles(input.projectDirectory, tsconfigPath, input.changedFiles) === false) {
+    if (coversChangedFiles(input.projectDirectory, tsconfigPath, selectingFiles) === false) {
       continue;
     }
 
-    const result = runner(input.projectDirectory, tsconfigPath);
+    const result = runner(input.projectDirectory, tsconfigPath, timeoutMs);
     if (!result.available || result.ok) continue;
     // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
     // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
     // diagnostic — that's not a type error in the change, so stay silent.
     if (!hasFileLevelTypeError(result.output)) continue;
-    advice.push(result.output);
+    advice.push(`${describeConfig(input.projectDirectory, tsconfigPath)}\n${result.output}`);
   }
 
   return { advice: advice.length > 0 ? advice.join('\n\n') : null };
+}
+
+/**
+ * Label a config's diagnostics. Overlapping configs can report the same file
+ * with different `module`/`lib`, so an unlabelled block leaves no way to tell
+ * why the same line appears twice.
+ */
+function describeConfig(projectDirectory: string, tsconfigPath: string): string {
+  const relative = nodePath.relative(nodePath.resolve(projectDirectory), tsconfigPath);
+  return `[${relative === '' ? tsconfigPath : relative}]`;
 }
 
 /** True iff tsc output has a file-level diagnostic, not just a config-level error. */

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -666,8 +666,12 @@ const typecheckAdvice = evaluateImplementStopTypecheck({
   phase: currentPhase,
 });
 if (typecheckAdvice.advice !== null) {
+  // "reported by" rather than "in your changed files": the gate guarantees the
+  // config covers something you touched, not that every diagnostic sits in it.
+  // A narrowed export surfaces in an unchanged consumer, and that is the catch
+  // worth keeping — so the header says what it actually means.
   softBlock(
-    `TypeScript errors in your changed files — advisory, not a block (fix now, or stop and address later). The done gate still requires a clean typecheck.\n\n${typecheckAdvice.advice}`,
+    `TypeScript errors reported by the configs covering your changes — advisory, not a block (fix now, or stop and address later). Some may sit in files you did not touch. The done gate still requires a clean typecheck.\n\n${typecheckAdvice.advice}`,
   );
 }
 

--- a/packages/cli/templates/hooks/lib/typecheck-gate.ts
+++ b/packages/cli/templates/hooks/lib/typecheck-gate.ts
@@ -21,10 +21,35 @@ import nodePath from 'node:path';
 /** Hard cap on a single tsc run so a pathological project can't hang the stop. */
 const TYPECHECK_TIMEOUT_MS = 60_000;
 
+/**
+ * Total budget for typechecking across every config in one stop, divided among
+ * them. A per-spawn cap alone turns N configs into N × the cap, and the Stop
+ * hook declares no timeout of its own — so the harness default would kill the
+ * whole hook rather than just the typecheck step.
+ */
+export const TYPECHECK_BUDGET_MS = 60_000;
+
+/** Floor so a wide change still gives each config a usable slice. */
+const MIN_CONFIG_TIMEOUT_MS = 5_000;
+
+/**
+ * `--showConfig` output runs ~52 bytes per file; the 1 MB spawnSync default
+ * overflows near 19k files, which is exactly where the per-config cost is
+ * worst. Overflow degrades to "unknown", so the filter would go inert on the
+ * largest configs without this.
+ */
+const SHOW_CONFIG_MAX_BUFFER = 64 * 1024 * 1024;
+
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 const DONE_PHASE = 'done';
 
-export type TypecheckTarget = { run: false } | { run: true; tsconfigPaths: string[] };
+export interface TypecheckConfigTarget {
+  tsconfigPath: string;
+  /** The changed files that selected this config via find-up. */
+  selectingFiles: string[];
+}
+
+export type TypecheckTarget = { run: false } | { run: true; targets: TypecheckConfigTarget[] };
 
 export interface TypecheckGateInput {
   /** Absolute project root (where to start find-up bounds). */
@@ -49,12 +74,17 @@ function isVendored(file: string): boolean {
 
 /**
  * Decide whether the implement-phase stop should run `tsc --noEmit`.
- * Returns every distinct tsconfig the changed files resolve to, or
- * { run: false } to skip entirely.
+ * Returns every distinct tsconfig the changed files resolve to — each paired
+ * with the files that selected it — or { run: false } to skip entirely.
  *
  * Every config, not the first: returning on the first match meant a change
  * spanning two packages only ever typechecked one of them, and the other's
  * silence read as "clean".
+ *
+ * Each config carries its own selecting files because relevance is per-config.
+ * Asking "does this config cover anything that changed anywhere" let a root
+ * config ride in on a file that had already selected a nearer config, which is
+ * how the original symptom (errors in an untouched tree) survived the fix.
  */
 export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   if (input.phase === DONE_PHASE) return { run: false };
@@ -62,13 +92,23 @@ export function shouldRunTypecheck(input: TypecheckGateInput): TypecheckTarget {
   const tsFiles = input.changedFiles.filter(file => isTypeScriptFile(file) && !isVendored(file));
   if (tsFiles.length === 0) return { run: false };
 
-  const tsconfigPaths: string[] = [];
+  const targets = new Map<string, string[]>();
   for (const file of tsFiles) {
     const tsconfig = findTsconfigUp(input.projectDirectory, file);
-    if (tsconfig !== null && !tsconfigPaths.includes(tsconfig)) tsconfigPaths.push(tsconfig);
+    if (tsconfig === null) continue;
+    const selecting = targets.get(tsconfig);
+    if (selecting === undefined) targets.set(tsconfig, [file]);
+    else selecting.push(file);
   }
-  if (tsconfigPaths.length === 0) return { run: false };
-  return { run: true, tsconfigPaths };
+  if (targets.size === 0) return { run: false };
+
+  return {
+    run: true,
+    targets: [...targets].map(([tsconfigPath, selectingFiles]) => ({
+      tsconfigPath,
+      selectingFiles,
+    })),
+  };
 }
 
 function isTypeScriptFile(file: string): boolean {
@@ -111,6 +151,7 @@ export interface TypecheckRunResult {
 export type TypecheckRunner = (
   projectDirectory: string,
   tsconfigPath: string,
+  timeoutMs?: number,
 ) => TypecheckRunResult;
 
 /** Locate a `tsc` binary by walking up from the tsconfig's dir to projectDirectory. */
@@ -145,8 +186,18 @@ export type ConfigCoverageResolver = (
 
 /**
  * Real resolver: ask tsc itself. `--showConfig` resolves `extends`, `include`,
- * `exclude`, and the default-extension rules exactly as a real run would, so
- * coverage never depends on us reimplementing tsconfig glob semantics.
+ * `exclude`, and the default-extension rules as a real run would, so coverage
+ * never depends on us reimplementing tsconfig glob semantics.
+ *
+ * Two shapes return `undefined` rather than an answer, and both degrade to
+ * running the check:
+ *
+ * - Configs that resolve to no `files` key — `${configDir}` templates and bases
+ *   pulled from `node_modules` (astro, `@tsconfig/*`, expo) emit absolute
+ *   include specs instead. Such projects get no benefit from this filter.
+ * - Changed files that no longer exist on disk. `--showConfig` lists what is
+ *   there, so a deletion could never be "covered" — and deleting an exported
+ *   module is exactly when its consumers break.
  */
 export function resolveConfigCoverage(
   projectDirectory: string,
@@ -156,10 +207,18 @@ export function resolveConfigCoverage(
   const tscBin = findTscBin(projectDirectory, tsconfigPath);
   if (tscBin === null) return undefined;
 
+  // A deleted file can never appear in the resolved set; judging coverage on
+  // what remains would turn a deletion into silence.
+  const presentFiles = changedFiles.filter(file =>
+    existsSync(nodePath.resolve(projectDirectory, file)),
+  );
+  if (presentFiles.length === 0) return undefined;
+
   const result = spawnSync(tscBin, ['--showConfig', '--project', tsconfigPath], {
     cwd: projectDirectory,
     encoding: 'utf8',
     timeout: TYPECHECK_TIMEOUT_MS,
+    maxBuffer: SHOW_CONFIG_MAX_BUFFER,
   });
   if (result.error || result.status !== 0) return undefined;
 
@@ -179,7 +238,7 @@ export function resolveConfigCoverage(
       .filter((file): file is string => typeof file === 'string')
       .map(file => nodePath.resolve(configDirectory, file)),
   );
-  return changedFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
+  return presentFiles.some(file => covered.has(nodePath.resolve(projectDirectory, file)));
 }
 
 /**
@@ -198,6 +257,7 @@ function tsBuildInfoPath(tsconfigPath: string): string {
 export function runIncrementalTypecheck(
   projectDirectory: string,
   tsconfigPath: string,
+  timeoutMs: number = TYPECHECK_TIMEOUT_MS,
 ): TypecheckRunResult {
   const tscBin = findTscBin(projectDirectory, tsconfigPath);
   if (tscBin === null) return { available: false, ok: false, output: '' };
@@ -214,7 +274,7 @@ export function runIncrementalTypecheck(
       '--project',
       tsconfigPath,
     ],
-    { cwd: projectDirectory, encoding: 'utf8', timeout: TYPECHECK_TIMEOUT_MS },
+    { cwd: projectDirectory, encoding: 'utf8', timeout: timeoutMs },
   );
 
   // Timed out or failed to spawn → stay silent (can't trust partial output).
@@ -238,25 +298,44 @@ export function evaluateImplementStopTypecheck(
   const gate = shouldRunTypecheck(input);
   if (!gate.run) return { advice: null };
 
+  const timeoutMs = Math.max(
+    MIN_CONFIG_TIMEOUT_MS,
+    Math.floor(TYPECHECK_BUDGET_MS / gate.targets.length),
+  );
+
   const advice: string[] = [];
-  for (const tsconfigPath of gate.tsconfigPaths) {
+  for (const { tsconfigPath, selectingFiles } of gate.targets) {
+    // Coverage is judged against this config's own selecting files, never the
+    // whole changed set — otherwise a config runs on the strength of a file
+    // that already had a nearer config of its own.
+    //
     // Skip only on a definite "covers nothing you touched". Unknown coverage
     // degrades to the previous behaviour and still runs: this filter is the new
     // part, so when it cannot do its job it must not hide what tsc already found.
-    if (coversChangedFiles(input.projectDirectory, tsconfigPath, input.changedFiles) === false) {
+    if (coversChangedFiles(input.projectDirectory, tsconfigPath, selectingFiles) === false) {
       continue;
     }
 
-    const result = runner(input.projectDirectory, tsconfigPath);
+    const result = runner(input.projectDirectory, tsconfigPath, timeoutMs);
     if (!result.available || result.ok) continue;
     // Only surface real type errors in code (`file(line,col): error TS…`). tsc can
     // also fail for config reasons (e.g. TS18003 "no inputs found") with no file
     // diagnostic — that's not a type error in the change, so stay silent.
     if (!hasFileLevelTypeError(result.output)) continue;
-    advice.push(result.output);
+    advice.push(`${describeConfig(input.projectDirectory, tsconfigPath)}\n${result.output}`);
   }
 
   return { advice: advice.length > 0 ? advice.join('\n\n') : null };
+}
+
+/**
+ * Label a config's diagnostics. Overlapping configs can report the same file
+ * with different `module`/`lib`, so an unlabelled block leaves no way to tell
+ * why the same line appears twice.
+ */
+function describeConfig(projectDirectory: string, tsconfigPath: string): string {
+  const relative = nodePath.relative(nodePath.resolve(projectDirectory), tsconfigPath);
+  return `[${relative === '' ? tsconfigPath : relative}]`;
 }
 
 /** True iff tsc output has a file-level diagnostic, not just a config-level error. */

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -666,8 +666,12 @@ const typecheckAdvice = evaluateImplementStopTypecheck({
   phase: currentPhase,
 });
 if (typecheckAdvice.advice !== null) {
+  // "reported by" rather than "in your changed files": the gate guarantees the
+  // config covers something you touched, not that every diagnostic sits in it.
+  // A narrowed export surfaces in an unchanged consumer, and that is the catch
+  // worth keeping — so the header says what it actually means.
   softBlock(
-    `TypeScript errors in your changed files — advisory, not a block (fix now, or stop and address later). The done gate still requires a clean typecheck.\n\n${typecheckAdvice.advice}`,
+    `TypeScript errors reported by the configs covering your changes — advisory, not a block (fix now, or stop and address later). Some may sit in files you did not touch. The done gate still requires a clean typecheck.\n\n${typecheckAdvice.advice}`,
   );
 }
 

--- a/packages/cli/tests/hooks/typecheck-gate.test.ts
+++ b/packages/cli/tests/hooks/typecheck-gate.test.ts
@@ -26,6 +26,7 @@ import {
   resolveConfigCoverage,
   runIncrementalTypecheck,
   shouldRunTypecheck,
+  TYPECHECK_BUDGET_MS,
   type TypecheckRunResult,
 } from '../../templates/hooks/lib/typecheck-gate.js';
 
@@ -66,7 +67,9 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
+      expect(result.targets.map(target => target.tsconfigPath)).toEqual([
+        nodePath.join(projectDirectory, 'tsconfig.json'),
+      ]);
     }
   });
 
@@ -109,7 +112,7 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPaths).toEqual([
+      expect(result.targets.map(target => target.tsconfigPath)).toEqual([
         nodePath.join(projectDirectory, 'packages/cli/tsconfig.json'),
       ]);
     }
@@ -131,7 +134,7 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPaths).toEqual([
+      expect(result.targets.map(target => target.tsconfigPath)).toEqual([
         nodePath.join(projectDirectory, 'packages/alpha/tsconfig.json'),
         nodePath.join(projectDirectory, 'packages/beta/tsconfig.json'),
       ]);
@@ -169,7 +172,9 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
+      expect(result.targets.map(target => target.tsconfigPath)).toEqual([
+        nodePath.join(projectDirectory, 'tsconfig.json'),
+      ]);
     }
   });
 
@@ -185,7 +190,9 @@ describe('shouldRunTypecheck (Rule 1 — run-gate)', () => {
 
     expect(result.run).toBe(true);
     if (result.run) {
-      expect(result.tsconfigPaths).toEqual([nodePath.join(projectDirectory, 'tsconfig.json')]);
+      expect(result.targets.map(target => target.tsconfigPath)).toEqual([
+        nodePath.join(projectDirectory, 'tsconfig.json'),
+      ]);
     }
   });
 
@@ -281,6 +288,63 @@ describe('evaluateImplementStopTypecheck (Rules 2 + 4 — surface as advice)', (
   });
 });
 
+describe('evaluateImplementStopTypecheck — coverage attribution (#1284)', () => {
+  const cleanRunner = (): TypecheckRunResult => ({ available: true, ok: true, output: '' });
+
+  /** A mixed session: a hook change and a packages/cli change, two configs. */
+  function mixedSession(): { projectDirectory: string; changedFiles: string[]; phase: string } {
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'packages/cli/tsconfig.json'));
+    return {
+      projectDirectory,
+      changedFiles: ['.safeword/hooks/lib/a.ts', 'packages/cli/src/b.ts'],
+      phase: 'implement',
+    };
+  }
+
+  it('checks each config against only the files that selected it', () => {
+    const input = mixedSession();
+    const seen = new Map<string, string[]>();
+
+    evaluateImplementStopTypecheck(input, cleanRunner, (_project, tsconfigPath, files) => {
+      seen.set(tsconfigPath, files);
+      return true;
+    });
+
+    expect(seen.get(nodePath.join(input.projectDirectory, 'tsconfig.json'))).toEqual([
+      '.safeword/hooks/lib/a.ts',
+    ]);
+    expect(seen.get(nodePath.join(input.projectDirectory, 'packages/cli/tsconfig.json'))).toEqual([
+      'packages/cli/src/b.ts',
+    ]);
+  });
+
+  it('skips a config whose own selecting file is uncovered, even in a mixed session', () => {
+    // The #1225 symptom returning: the root config covers packages/cli/src/**,
+    // so passing every changed file made it "covered" and it ran anyway —
+    // reporting errors across a tree the developer had not touched.
+    const input = mixedSession();
+    const coversPackagesOnly = (
+      _project: string,
+      _tsconfigPath: string,
+      files: string[],
+    ): boolean => files.some(file => file.startsWith('packages/cli/'));
+    const runner = (_project: string, tsconfigPath: string): TypecheckRunResult => ({
+      available: true,
+      ok: false,
+      output: tsconfigPath.includes('packages/cli')
+        ? 'packages/cli/src/b.ts(1,7): error TS2222: real error in a touched file.'
+        : 'packages/cli/src/untouched.ts(1,7): error TS1111: noise from the root config.',
+    });
+
+    const { advice } = evaluateImplementStopTypecheck(input, runner, coversPackagesOnly);
+
+    expect(advice).toContain('real error in a touched file');
+    expect(advice).not.toContain('noise from the root config');
+  });
+});
+
 describe('evaluateImplementStopTypecheck — config coverage', () => {
   const failingRunner = (): TypecheckRunResult => ({
     available: true,
@@ -333,6 +397,67 @@ describe('evaluateImplementStopTypecheck — config coverage', () => {
     );
 
     expect(advice).toContain('error TS2322');
+  });
+
+  it('labels each block with the config that produced it', () => {
+    // The root and packages/cli configs overlap on packages/cli/src/** with
+    // different module/lib, so the same file can be reported twice with
+    // divergent diagnostics. Without a marker there is no way to tell why.
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'packages/cli/tsconfig.json'));
+    const runner = (_projectDirectory: string, tsconfigPath: string): TypecheckRunResult => ({
+      available: true,
+      ok: false,
+      output: `x.ts(1,7): error TS2322: from ${nodePath.basename(nodePath.dirname(tsconfigPath))}.`,
+    });
+
+    const { advice } = evaluateImplementStopTypecheck(
+      {
+        projectDirectory,
+        changedFiles: ['src/a.ts', 'packages/cli/src/b.ts'],
+        phase: 'implement',
+      },
+      runner,
+      () => true,
+    );
+
+    expect(advice).toContain('tsconfig.json');
+    expect(advice).toContain('packages/cli/tsconfig.json');
+  });
+
+  it('divides one timeout budget across the configs it runs', () => {
+    // Per-spawn timeouts turn N configs into N × the budget, and the Stop hook
+    // has no timeout of its own — so a wide monorepo change gets the whole hook
+    // killed rather than just the typecheck step.
+    const projectDirectory = makeProject();
+    touch(nodePath.join(projectDirectory, 'packages/alpha/tsconfig.json'));
+    touch(nodePath.join(projectDirectory, 'packages/beta/tsconfig.json'));
+    const timeouts: (number | undefined)[] = [];
+    const runner = (
+      _projectDirectory: string,
+      _tsconfigPath: string,
+      timeoutMs?: number,
+    ): TypecheckRunResult => {
+      timeouts.push(timeoutMs);
+      return { available: true, ok: true, output: '' };
+    };
+
+    evaluateImplementStopTypecheck(
+      {
+        projectDirectory,
+        changedFiles: ['packages/alpha/src/a.ts', 'packages/beta/src/b.ts'],
+        phase: 'implement',
+      },
+      runner,
+      () => true,
+    );
+
+    expect(timeouts).toHaveLength(2);
+    expect(timeouts[0]).toBe(Math.floor(TYPECHECK_BUDGET_MS / 2));
+    expect(timeouts.reduce((sum, ms) => (sum ?? 0) + (ms ?? 0), 0)).toBeLessThanOrEqual(
+      TYPECHECK_BUDGET_MS,
+    );
   });
 
   it('surfaces advice from every covered config, not just the first', () => {
@@ -393,6 +518,31 @@ describe('resolveConfigCoverage (real tsc — integration)', () => {
     const project = projectWithNarrowRootConfig();
 
     const covered = resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), [
+      'packages/cli/src/real.ts',
+    ]);
+
+    expect(covered).toBe(true);
+  });
+
+  it('returns undefined for a deleted file rather than reporting it uncovered', () => {
+    // `--showConfig` lists on-disk files, so a deleted path is never "covered".
+    // Deleting an exported module is exactly when consumers break — treating
+    // that as "skip" would be new silence in a gate whose thesis is that
+    // silence reads as clean.
+    const project = projectWithNarrowRootConfig();
+
+    const covered = resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), [
+      'packages/cli/src/deleted.ts',
+    ]);
+
+    expect(covered).toBeUndefined();
+  });
+
+  it('still reports coverage from the surviving files when only some were deleted', () => {
+    const project = projectWithNarrowRootConfig();
+
+    const covered = resolveConfigCoverage(project, nodePath.join(project, 'tsconfig.json'), [
+      'packages/cli/src/deleted.ts',
       'packages/cli/src/real.ts',
     ]);
 

--- a/packages/cli/tests/integration/stop-typecheck-gate.test.ts
+++ b/packages/cli/tests/integration/stop-typecheck-gate.test.ts
@@ -21,7 +21,7 @@ import {
 
 const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 const STOP_QUALITY = nodePath.join(SAFEWORD_ROOT, '.safeword/hooks/stop-quality.ts');
-const ADVICE_MARKER = 'TypeScript errors in your changed files';
+const ADVICE_MARKER = 'TypeScript errors reported by the configs covering your changes';
 
 interface HookRun {
   status: number | null;


### PR DESCRIPTION
Closes #1284 (findings 1–8). Follow-ups from the independent review of #1260.

## 1. Coverage was attributed to every changed file, not the selecting ones

The load-bearing one. A config ran if it covered **any** changed file — not the file that selected it. So a session touching both `.safeword/hooks/` and `packages/cli/` let the root config ride in on the packages/cli file and report errors across a tree the developer never touched.

Defect (a) from #1260 was therefore only fixed when the uncovered change was the *sole* change in the session. And since `bun run lint` delegates typecheck to `packages/cli`, CI never typechecks the root config — so that path stays live.

`shouldRunTypecheck` now returns `config → selectingFiles`, and coverage is judged per config against its own selectors. Proven on a fixture with this repo's layout:

```
tsconfig.json              selected by [.safeword/hooks/lib/a.ts]
                           vs ALL changed = true    (old)
                           vs SELECTING   = false   (new)  => SKIPPED ✓

packages/cli/tsconfig.json selected by [packages/cli/src/b.ts]
                           vs SELECTING   = true           => runs
```

That `true → false` is the #1225 symptom actually dying.

Closes **finding 8** for free — selecting files are already TS and non-vendored, so the resolver can no longer be handed a `.json` or a vendored path.

## 2. Deleted files went silent

`--showConfig` lists what's on disk, so a deleted path could never be "covered" and its config was skipped. **Deleting an exported module is exactly when consumers break.**

Changed files that no longer exist are excluded from the coverage judgement; a wholly-deleted selector set returns unknown, which runs. #1260 argued "no new silence" and then shipped some — this removes it.

## 3–7

- **5** — one `TYPECHECK_BUDGET_MS` divided across configs. A per-spawn cap made N configs `N ×` the cap, and the Stop hook declares no timeout of its own, so the harness would kill the whole hook rather than the typecheck step.
- **4** — `maxBuffer` raised so `--showConfig` can't overflow on large configs, which is where the filter matters most.
- **7** — per-block `[tsconfig.json]` labels. Root and `packages/cli` overlap on `packages/cli/src/**` with different `module`/`lib`, so the same file could appear twice with divergent diagnostics and no way to tell why.
- **3** — the doc comment no longer claims the resolver works everywhere. `${configDir}` templates and `node_modules`-extends bases (astro, `@tsconfig/*`, expo) emit no `files` key and get no benefit.
- **6** — the header said "TypeScript errors in your changed files" when coverage only guarantees the config covers one. Now: *"reported by the configs covering your changes … some may sit in files you did not touch."* The honest claim, and it keeps the narrowed-export catch that filtering diagnostics would have hidden.

Finding 6 had a live tripwire: `tests/integration/stop-typecheck-gate.test.ts` asserts that header string. Updated in the same commit.

## Reported, not fixed

`findTscBin` walks up from the **tsconfig's own directory**, so the root config resolves a `tsc` only where root `node_modules` exists. The primary checkout has one; git worktrees don't — making the filter inert *and* leaving the root config unchecked entirely there.

This is a distinct defect from the eight filed. I'm not fixing it here on purpose: widening the lookup would let the root config start running where it never has, which wants to land together with this PR's suppression rather than before it.

## Verification

- **full suite: 355 files, 5258 passed, 0 failed**
- 36/36 gate unit tests — 6 new, all written failing first
- `stop-typecheck-gate` integration 3/3
- lint clean, parity 190 pairs + 8 contracts, `test:release` 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)