### PR TITLE
docs(WNMCH1): add product-management + design role plugins (§8)

### DIFF
--- a/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/comparison.md
+++ b/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/comparison.md
@@ -266,8 +266,9 @@ Two kinds of follow-up: **net-new gaps to borrow** (capabilities we lack) and **
 | G4 | Dedicated agentic security tracer — cross-file taint tracing + vuln taxonomy | `security-guidance` | Deeper on security than our general Stop-gate | High |
 | G5 | Frontend/visual design skill — anti-templating, subject-derived design doctrine | `frontend-design` | Total gap; only matters if UI work is in scope | Med |
 | G6 | Teaching/pairing output modes — hand the human the load-bearing decisions | `learning-output-style` | No safeword equivalent; optional pedagogy mode | Low |
+| G7 | Connector-agnostic `~~category` placeholder pattern — skills reference `~~project tracker` / `~~design tool`, resolve to whatever MCP server is connected; "standalone always works, supercharged with tools, never nag to connect" | `product-management` / `design` role plugins | Decouples safeword skills from hardcoded tool assumptions; cleaner multi-tool story | Med |
 
-_Lower priority / narrow: plugin-authoring toolkit (`plugin-dev`), SDK scaffolder (`agent-sdk-dev`), model-migration helper, the Ralph iterate-until-true loop._
+_Lower priority / narrow: plugin-authoring toolkit (`plugin-dev`), SDK scaffolder (`agent-sdk-dev`), model-migration helper, the Ralph iterate-until-true loop, and the PM/design role playbooks themselves (`product-management`, `design`) — adjacent domains safeword doesn't cover; adopt only if safeword expands past code into PM/design work (see §8)._
 
 ### 7b. Overlap to sharpen (we have a counterpart; borrow the mechanic)
 
@@ -278,8 +279,54 @@ _Lower priority / narrow: plugin-authoring toolkit (`plugin-dev`), SDK scaffolde
 | S3 | Explicit **cheap-triage-first model ladder** (skip trivial diffs) + a distinct **validate-then-filter** stage before reporting findings | `quality-review` / `stop-quality` cross-model review | `code-review` | Better cost/signal on the Stop-gate | Med | Consider |
 | S4 | **Biased-parallel option generation** — fan out 2-3 sub-agents with different biases (minimal/clean/pragmatic), user picks | `figure-it-out` | `feature-dev` | Genuine independence for one-way-door decisions | Med | Consider (big decisions only) |
 | S5 | **Escalating-cost review tiers** (regex → single-shot LLM → agentic cross-file) for depth-on-demand | single-tier quality gate | `security-guidance` 3-layer | Depth only where warranted | High | Later |
+| S6 | Fold PM-spec rigor into the spec/self-review gate — **outcomes-not-outputs** goals, **non-goals as first-class scope defense**, INVEST user stories, "if everything is P0, nothing is P0" | `spec.md` / `self-review` | `product-management:write-spec` | Sharpens spec quality with proven PM discipline; fits our existing JTBD/Rules framing | Low–Med | Consider |
 
 **Recommendation:** pursue **S1 and S2** first (high value, low risk, no philosophy change), plus **G1** (cheap, clear gap). Everything else is "consider," gated on appetite.
+
+---
+
+## 8. Product & design role plugins (knowledge-work marketplace)
+
+Separate from the 13 `claude-code-plugins`, Anthropic also ships **role playbooks** in the open-source `anthropics/knowledge-work-plugins` marketplace (built for Cowork, run in Claude Code too). Two are directly product/design-relevant. Unlike everything in §1–§6, these carry **zero enforcement** — no hooks, gates, tickets, or state. They are pure **domain knowledge + MCP connector orchestration**: closest in kind to safeword's own *skills* (`brainstorm`, `elicit`, `figure-it-out`), pointed at PM/design work safeword doesn't cover at all.
+
+### 8a. `product-management` (v1.2.0 — 7 commands, 8 skills, 16 connectors)
+
+Pattern: **interview → pull from connectors → emit a structured document**, with embedded frameworks and honesty gates.
+
+| Skill | Encodes | Sharpest rule |
+|---|---|---|
+| `write-spec` | PRD (Problem→Goals→Non-Goals→Stories→Reqs→Metrics→Open Qs); INVEST, P0/P1/P2 + MoSCoW, Given/When/Then | "Goals are outcomes not outputs; if everything is P0, nothing is P0" |
+| `roadmap-update` | Now/Next/Later + OKR + themes; RICE/ICE/MoSCoW/Value×Effort; 70/20/10 capacity | "Roadmaps are zero-sum — adding something means asking what comes off" |
+| `synthesize-research` | 6-step thematic analysis, affinity mapping, triangulation, personas, opportunity sizing | "A finding from 2 interviews is a hypothesis; behavior > stated preference" |
+| `metrics-review` | North Star→L1→L2 hierarchy, AARRR, OKR scoring, cadences, dashboards | "If the review doesn't lead to an action, it wasn't useful" |
+| `stakeholder-update` | Audience templates, Green/Yellow/Red, ROAM risk, ADR | "Don't bury the lead; Yellow is not a failure" |
+| `competitive-brief` | Web-first research (incl. job postings), feature matrices, positioning, win/loss | "A comparison that always shows you winning is not credible" |
+| `sprint-planning` | Capacity table, P0/P1/P2, DoD | "Plan to 70-80% capacity, you will get interrupts" |
+| `product-brainstorming` | The outlier — conversational sparring partner, **anti-deliverable**; 4 modes + How Might We / JTBD / Opportunity Solution Trees / SCAMPER / OODA | "Your job is not to generate deliverables… be opinionated, push back" |
+
+Connectors: Slack, Linear/Asana/monday/ClickUp/Jira, Notion, Figma, Amplitude/Pendo, Intercom, Fireflies, Similarweb, Gmail/Calendar.
+
+### 8b. `design` (v1.2.0 — 6 commands, 7 skills, Figma-centric)
+
+Pattern: **artifact in → filled template out**; shorter skills, emoji severity (🔴🟡🟢), connectors as optional appendix.
+
+| Skill | Encodes | Sharpest rule |
+|---|---|---|
+| `accessibility-review` | **WCAG 2.1 AA** rubric by POUR; contrast ≥4.5:1, touch ≥44×44px; 5-step test approach | "Automated scan catches only ~30%; manual VoiceOver/NVDA catches what I can't" |
+| `design-critique` | 5-lens framework (First Impression 2s → Usability → Hierarchy → Consistency → A11y), mandated positives | Stage-matched feedback (exploration ≠ final polish) |
+| `design-handoff` | Spec sheet: tokens/states/breakpoints/edge-cases/motion | "Use tokens, not values — reference `spacing-md`, not `16px`" |
+| `design-system` | 3 modes (audit/document/extend); audit emits /100 + component-completeness X/10 | "If it's not documented, it doesn't exist" |
+| `research-synthesis` | Lighter twin; delegates method depth to `user-research` | "Separate observations from interpretations; quantify — '7 of 10' not 'most'" |
+| `user-research` | Pure methodology backbone (method table, interview-guide structure, JTBD) — no template, no connectors | — |
+| `ux-copy` | Formulas (error = what happened + why + how to fix; label buttons with the action), voice/tone matrix | "Consider the user's emotional state — errors need empathy" |
+
+Connectors: Figma, Slack, Linear/Asana/Jira, Notion, Intercom.
+
+### 8c. What these add to the borrow list
+
+- **G7 (new gap):** the **connector-agnostic `~~category` placeholder** contract — tool-agnostic workflows + "standalone always works, supercharged with connectors, never nag." A clean pattern safeword could adopt to decouple its skills from hardcoded tool assumptions.
+- **S6 (new sharpen):** fold `write-spec`'s PM rigor (outcomes-not-outputs, non-goals as first-class, INVEST, ruthless P0s) into safeword's `spec.md`/`self-review` gate — same JTBD/Rules spirit, sharper.
+- **Adjacency, not overlap:** `product-brainstorming` ≈ safeword's `brainstorm` (both anti-deliverable), and `synthesize-research` ≈ `elicit`+research. But safeword has **no** counterpart for specs-as-PM-artifacts, roadmaps, metrics, stakeholder comms, or any design work — these are genuinely new domains, worth adopting only if safeword expands past code.
 
 ---
 

--- a/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/ticket.md
+++ b/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/ticket.md
@@ -22,6 +22,7 @@ external_issue: 1166
 ## Sources
 
 - Anthropic marketplace `anthropics/claude-code` — 13 plugins, read from file contents (commands/agents/skills/hooks).
+- Anthropic marketplace `anthropics/knowledge-work-plugins` — `product-management` (8 skills) + `design` (7 skills) role playbooks, read from SKILL.md contents (§8).
 - Safeword v0.69.0 surface — ~20 skills, 40+ hooks, CLI, 5-phase workflow, read from `.claude/skills`, `.safeword/`, templates.
 
 ## Key findings
@@ -34,9 +35,9 @@ external_issue: 1166
 
 ## Action candidates (see comparison.md §7)
 
-**Gaps worth borrowing (net-new):** G1 commit/PR/cleanup commands incl. `clean_gone` (low) · G2 specialist review agents w/ per-axis rubrics (med) · G3 hookify-style user-authored guardrail DSL (med) · G4 agentic security tracer (high) · G5 frontend-design skill (med) · G6 teaching output modes (low).
+**Gaps worth borrowing (net-new):** G1 commit/PR/cleanup commands incl. `clean_gone` (low) · G2 specialist review agents w/ per-axis rubrics (med) · G3 hookify-style user-authored guardrail DSL (med) · G4 agentic security tracer (high) · G5 frontend-design skill (med) · G6 teaching output modes (low) · **G7 connector-agnostic `~~category` placeholder pattern** from the PM/design role plugins (med).
 
-**Overlap to sharpen (borrow the mechanic):** S1 scope Stop-review to this-session's diff via git-stash baseline (**pursue**) · S2 render each test with "the regression it prevents" (**pursue**) · S3 cheap-triage model ladder + validate-then-filter stage (consider) · S4 biased-parallel option generation in figure-it-out (consider) · S5 escalating-cost review tiers (later).
+**Overlap to sharpen (borrow the mechanic):** S1 scope Stop-review to this-session's diff via git-stash baseline (**pursue**) · S2 render each test with "the regression it prevents" (**pursue**) · S3 cheap-triage model ladder + validate-then-filter stage (consider) · S4 biased-parallel option generation in figure-it-out (consider) · S5 escalating-cost review tiers (later) · **S6 fold write-spec PM rigor (outcomes-not-outputs, non-goals, INVEST) into spec/self-review** (consider).
 
 **Recommended first moves:** S1, S2, and G1 — high value, low risk, no philosophy change.
 
@@ -55,3 +56,4 @@ Epic **#1166** `[Epic] Borrow & sharpen from Anthropic claude-code plugins [WNMC
 - 2026-07-19T16:06Z Filed comparison.md deliverable into ticket; research task complete (documentation artifact, no code change).
 - 2026-07-19T16:19Z Added §7 action candidates to comparison.md (gaps to borrow + overlap to sharpen) and summarized recommended first moves here.
 - 2026-07-19T17:03Z Filed epic #1166 + 11 sub-issues (#1167–#1177) on ArcadeAI/safeword; linked external_issue: 1166. Structure decided via /figure-it-out (epic + all 11, tiered).
+- 2026-07-21T03:48Z PR #1160 merged. Restarted branch from origin/main and added §8 (product-management + design role plugins from anthropics/knowledge-work-plugins) as follow-up; added borrow candidates G7 (connector-agnostic `~~category` pattern) and S6 (write-spec PM rigor → spec/self-review).

--- a/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/ticket.md
+++ b/.project/tickets/WNMCH1-anthropic-plugins-vs-safeword/ticket.md
@@ -47,8 +47,11 @@ Epic **#1166** `[Epic] Borrow & sharpen from Anthropic claude-code plugins [WNMC
 
 - Recommended: S1 #1167 · S2 #1168 · G1 #1169
 - Backlog: S3 #1170 · S4 #1171 · S5 #1172 · G2 #1173 · G3 #1174 · G4 #1175 · G5 #1176 · G6 #1177
+- §8 follow-up: G7 #1291 (connector-agnostic `~~category` pattern) · S6 #1292 (write-spec PM rigor → spec/self-review)
 
 (Adjacent: #1165 autonomous cross-vendor PR review — related to G2/S3, cross-linked not duplicated.)
+
+PRs: #1160 (§1–§7, merged) · #1290 (§8 follow-up).
 
 ## Work Log
 


### PR DESCRIPTION
Follow-up to the merged WNMCH1 comparison (#1160). Extends the analysis to Anthropic's two product/design **role playbooks** from `anthropics/knowledge-work-plugins`. Docs only; no code changes.

## What's added

- **New §8 in `comparison.md`** — per-skill teardown of `product-management` (8 skills) and `design` (7 skills), read from the actual SKILL.md bodies: frameworks, quality gates, connectors, and the sharpest rule of each.
- **Two new borrow candidates** in the §7 tables + ticket:
  - **G7** (gap) — the connector-agnostic `~~category` placeholder pattern ("standalone always works, supercharged with connectors, never nag to connect").
  - **S6** (sharpen) — fold `write-spec`'s PM rigor (outcomes-not-outputs, non-goals as first-class, INVEST, ruthless P0s) into safeword's `spec.md`/`self-review`.

## Key observation

These role plugins carry **zero enforcement** (no hooks/gates/state) — pure domain knowledge + MCP connector orchestration. They're the opposite end of the spectrum from safeword and cover PM/design domains safeword doesn't touch; `product-brainstorming` ≈ safeword's `brainstorm` and `synthesize-research` ≈ `elicit` are the only adjacencies.

Tracked as sub-issues G7/S6 under epic #1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkABNy1kurs3nAoX8PYCLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkABNy1kurs3nAoX8PYCLL)_