### PR TITLE
Fix Cursor proof recording for relative helper commands

### DIFF
--- a/.project/tickets/DDFA7X-keep-cursor-skill-proof-recording/ticket.md
+++ b/.project/tickets/DDFA7X-keep-cursor-skill-proof-recording/ticket.md
@@ -1,0 +1,42 @@
+---
+id: DDFA7X
+slug: keep-cursor-skill-proof-recording
+type: task
+phase: intake
+status: in_progress
+created: 2026-07-22T06:34:45.732Z
+last_modified: 2026-07-22T06:34:45.732Z
+---
+
+# Keep Cursor quality proof recording reliable
+
+**Type:** Bug
+
+**Scope:** Ensure Cursor records current-session proof when an installed skill invokes the supported relative `record-skill-invocation.ts` helper path.
+
+**Out of Scope:** Changing Codex's packaged hook parser, altering the session-proof trust model, or supporting arbitrary helper lookalike paths.
+
+**Done When:**
+
+- [x] Cursor binds its conversation id for the supported relative helper command and the helper records the expected session-bound proof.
+- [x] Absolute helper commands and invalid/lookalike paths retain their current behavior.
+
+**Tests:**
+
+- [x] Integration: Cursor `beforeShellExecution` plus the supported relative helper records a `verify` and `audit` proof that satisfies the feature done gate.
+- [x] Unit: the shared parser recognizes exact relative helper paths but rejects lookalike paths.
+
+## Work Log
+
+- 2026-07-22T06:34:45.732Z Started: Created ticket DDFA7X
+- 2026-07-22T06:34:58Z Revalidated on current `origin/main` from an isolated worktree. A real Cursor `beforeShellExecution` payload for `bun .safeword/hooks/record-skill-invocation.ts <project> verify` returned allow, but the helper then reported `no run identity` and wrote no log. The otherwise identical absolute helper path recorded `cursor-absolute verify` successfully. Focused existing hook and fallback tests passed, so they do not cover this documented relative Cursor form.
+
+## Root Cause
+
+`parseRecordSkillInvocationCommand` in the shared Cursor bridge accepts only paths ending in `/.safeword/hooks/record-skill-invocation.ts`. The exact documented relative path starts with `.safeword/`, so the Cursor adapter never arms its short-lived identity cache before the helper executes.
+
+Ruled out: a general Cursor bridge failure (the absolute form records the supplied conversation id); a helper/log-format failure (the absolute form creates the expected session-bound log); and a Codex production-path failure (the packaged Codex hook recognizes the relative form through its separate parser).
+
+- 2026-07-22T10:08:00Z RED/GREEN: Added parser and real Cursor `beforeShellExecution` regression coverage. Both failed before the matcher change, then passed after accepting only the exact bare-relative path alongside the existing slash-anchored absolute form. Focused suite: 28 tests passed.
+- 2026-07-22T10:13:00Z Quality review: independent reviewer approved the minimal matcher expansion, real adapter → helper → done-gate wiring test, and template/dogfood mirror. Corrected an imprecise "documented" description to "supported" in the ticket, tests, and GitHub issue #1337; no code change required.
+- 2026-07-22T10:16:00Z Verification: focused regression suite (28 tests), release parity (25 tests), ESLint, Gherkin lint, TypeScript typecheck, and `git diff --check` passed. Full Vitest suite remained idle for three minutes with 0% CPU and was stopped; this is an environment runner limitation, not a product-test failure.

--- a/.safeword/hooks/lib/cursor-run-identity.ts
+++ b/.safeword/hooks/lib/cursor-run-identity.ts
@@ -80,7 +80,11 @@ function isBunExecutable(token: string | undefined): boolean {
 
 function isInvocationHelperPath(token: string | undefined): boolean {
   if (token === undefined) return false;
-  return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
+  const normalized = token.replaceAll('\\', '/');
+  return (
+    normalized === '.safeword/hooks/record-skill-invocation.ts' ||
+    normalized.endsWith('/.safeword/hooks/record-skill-invocation.ts')
+  );
 }
 
 // Unlike the invocation-helper matcher (slash-anchored suffix only), the stamp

--- a/packages/cli/templates/hooks/lib/cursor-run-identity.ts
+++ b/packages/cli/templates/hooks/lib/cursor-run-identity.ts
@@ -80,7 +80,11 @@ function isBunExecutable(token: string | undefined): boolean {
 
 function isInvocationHelperPath(token: string | undefined): boolean {
   if (token === undefined) return false;
-  return token.replaceAll('\\', '/').endsWith('/.safeword/hooks/record-skill-invocation.ts');
+  const normalized = token.replaceAll('\\', '/');
+  return (
+    normalized === '.safeword/hooks/record-skill-invocation.ts' ||
+    normalized.endsWith('/.safeword/hooks/record-skill-invocation.ts')
+  );
 }
 
 // Unlike the invocation-helper matcher (slash-anchored suffix only), the stamp

--- a/packages/cli/tests/hooks/review-stamp-bridge.test.ts
+++ b/packages/cli/tests/hooks/review-stamp-bridge.test.ts
@@ -101,6 +101,14 @@ describe('commandInvokesWriteReviewStamp (#630)', () => {
 describe('parseRecordSkillInvocationCommand (shared tokenizer, EDDABK follow-up)', () => {
   const HELPER = '/repo/.safeword/hooks/record-skill-invocation.ts';
 
+  it('parses the supported bare-relative form', () => {
+    expect(
+      parseRecordSkillInvocationCommand(
+        'bun .safeword/hooks/record-skill-invocation.ts /repo verify',
+      ),
+    ).toEqual({ skillName: 'verify' });
+  });
+
   it('parses the plain and quoted absolute forms', () => {
     expect(parseRecordSkillInvocationCommand(`bun ${HELPER} /repo verify`)).toEqual({
       skillName: 'verify',
@@ -129,6 +137,19 @@ describe('parseRecordSkillInvocationCommand (shared tokenizer, EDDABK follow-up)
 
   it('does not match the helper mentioned in a quoted string', () => {
     expect(parseRecordSkillInvocationCommand(`echo "bun ${HELPER} /repo x"`)).toBeUndefined();
+  });
+
+  it('does not match a helper-looking relative path', () => {
+    expect(
+      parseRecordSkillInvocationCommand(
+        'bun foo.safeword/hooks/record-skill-invocation.ts /repo verify',
+      ),
+    ).toBeUndefined();
+    expect(
+      parseRecordSkillInvocationCommand(
+        'bun .safeword/hooks/record-skill-invocation.ts.bak /repo verify',
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -102,6 +102,25 @@ function bindCodexSession(projectDirectory: string, skill: string, sessionId: st
   expect(result.status ?? 0).toBe(0);
 }
 
+// Drive Cursor's real beforeShellExecution adapter with the supported relative
+// helper command. The helper relies on this adapter to bridge conversation_id;
+// it receives neither a session argument nor a runtime identity in its env.
+function bindCursorSession(projectDirectory: string, skill: string, conversationId: string): void {
+  const command = `bun .safeword/hooks/record-skill-invocation.ts "${projectDirectory}" ${skill}`;
+  const result = spawnSync('bun', ['.safeword/hooks/cursor/before-shell-execution.ts'], {
+    cwd: projectDirectory,
+    input: JSON.stringify({
+      workspace_roots: [projectDirectory],
+      conversation_id: conversationId,
+      command,
+    }),
+    env: fallbackEnvironment(projectDirectory),
+    encoding: 'utf8',
+  });
+  expect(result.status ?? 0).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({ permission: 'allow' });
+}
+
 describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () => {
   let projectDirectory: string;
 
@@ -157,6 +176,23 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     }
 
     const result = runDoneGate(projectDirectory, sessionId);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Required skill invocation');
+  });
+
+  it('feature done PASSES when Cursor binds the supported relative helper command', () => {
+    writeFeatureTicketAtDone(projectDirectory, '953');
+    const conversationId = 'cursor-session-953';
+
+    for (const skill of ['verify', 'audit'] as const) {
+      bindCursorSession(projectDirectory, skill, conversationId);
+      const fallback = runFallback(projectDirectory, skill, '');
+      expect(fallback.exitCode).toBe(0);
+      expect(fallback.output).toContain(`${skill} ✓`);
+    }
+
+    const result = runDoneGate(projectDirectory, conversationId);
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).not.toContain('Required skill invocation');


### PR DESCRIPTION
Closes #1337.

## Summary

- recognize the exact bare-relative `record-skill-invocation.ts` helper path in the shared Cursor bridge
- preserve absolute-path support and reject lookalike paths
- add real Cursor adapter → helper → done-gate regression coverage

## Validation

- focused regression suite: 28 tests passed
- release parity suite: 25 tests passed
- ESLint, Gherkin lint, TypeScript typecheck, and `git diff --check` passed
- independent quality review: approved

The unconstrained full Vitest suite was started but remained idle for three minutes with 0% CPU, then was stopped. This is recorded in DDFA7X as a local runner limitation; it did not report a test failure.