### PR TITLE
docs: point GitHub links to ArcadeAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # SAFEWORD - AI Agent Configuration CLI
 
-[![CI](https://github.com/TheMostlyGreat/safeword/actions/workflows/ci.yml/badge.svg)](https://github.com/TheMostlyGreat/safeword/actions/workflows/ci.yml)
+[![CI](https://github.com/ArcadeAI/safeword/actions/workflows/ci.yml/badge.svg)](https://github.com/ArcadeAI/safeword/actions/workflows/ci.yml)
 
 **Problem**: AI agents write code without tests, skip design validation, and lack consistency across projects.
 
 **Solution**: Portable patterns and guides that enforce test-first development (BDD/TDD), quality standards, and best practices across all your projects.
 
-**Repository**: <https://github.com/TheMostlyGreat/safeword>
+**Repository**: <https://github.com/ArcadeAI/safeword>
 
 ---
 
@@ -555,4 +555,4 @@ The CLI installs matching workflow capabilities for Claude Code, Cursor, and Cod
 
 - **Claude Code docs**: <https://docs.claude.com/en/docs/claude-code>
 - **OpenAI Codex docs**: <https://developers.openai.com/codex>
-- **This repo**: <https://github.com/TheMostlyGreat/safeword>
+- **This repo**: <https://github.com/ArcadeAI/safeword>

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -65,7 +65,7 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/TheMostlyGreat/safeword',
+          href: 'https://github.com/ArcadeAI/safeword',
         },
       ],
       sidebar: [
@@ -83,7 +83,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: 'https://github.com/TheMostlyGreat/safeword/edit/main/packages/website/',
+        baseUrl: 'https://github.com/ArcadeAI/safeword/edit/main/packages/website/',
       },
     }),
   ],

--- a/packages/website/src/content/docs/getting-started/faq.mdx
+++ b/packages/website/src/content/docs/getting-started/faq.mdx
@@ -96,6 +96,6 @@ Safeword's hooks are configured in `.claude/settings.json` (Claude Code) and `.c
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/packages/website/src/content/docs/getting-started/quick-start.mdx
+++ b/packages/website/src/content/docs/getting-started/quick-start.mdx
@@ -125,6 +125,6 @@ Your customizations are preserved. Only the core files get updated.
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/packages/website/src/content/docs/getting-started/workflow.mdx
+++ b/packages/website/src/content/docs/getting-started/workflow.mdx
@@ -85,6 +85,6 @@ Safeword runs hooks every turn to track which phase the agent is in. Four of the
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/packages/website/src/content/docs/index.mdx
+++ b/packages/website/src/content/docs/index.mdx
@@ -86,7 +86,7 @@ bunx safeword@latest upgrade
 
 <footer class="splash-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © {new Date().getFullYear()}
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © {new Date().getFullYear()}
 
 </footer>
 

--- a/packages/website/src/content/docs/reference/cli.mdx
+++ b/packages/website/src/content/docs/reference/cli.mdx
@@ -147,6 +147,6 @@ Run `safeword diff` to see which files you've modified.
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -268,6 +268,6 @@ Credentials resolve from the OS keychain or an environment variable only — nev
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -140,7 +140,7 @@ When safeword sets up (or upgrades) a project, it installs a small third-party *
 
 Language coding-skills install into `.claude/skills/` and, where supported by the agent, `.agents/skills/` via the `npx skills` CLI. These are third-party language helpers, not Safe Word Codex workflow aliases. The install is **best-effort** — a missing network or installer error degrades to a warning and never blocks setup. It runs once; later upgrades skip it when the skill is already present.
 
-**What you see:** edit a `.go` / `.py` / `.ts` / `.tsx` / `.rs` file and, in Claude Code, a one-line reminder points your agent at the matching skill and surfaces the skill's own description. It fires once per scenario and stays silent for other file types. The Cursor adapter is built but dormant until Cursor fixes an upstream injection bug ([#534](https://github.com/TheMostlyGreat/safeword/issues/534)). Codex's Safe Word workflow guidance now comes from the Codex plugin rather than repo-local `.agents/skills/` aliases.
+**What you see:** edit a `.go` / `.py` / `.ts` / `.tsx` / `.rs` file and, in Claude Code, a one-line reminder points your agent at the matching skill and surfaces the skill's own description. It fires once per scenario and stays silent for other file types. The Cursor adapter is built but dormant until Cursor fixes an upstream injection bug ([#534](https://github.com/ArcadeAI/safeword/issues/534)). Codex's Safe Word workflow guidance now comes from the Codex plugin rather than repo-local `.agents/skills/` aliases.
 
 To skip the skill install, set `SAFEWORD_SKIP_SKILLS=1` (or `SAFEWORD_SKIP_INSTALL=1` to skip all network installs during setup).
 
@@ -211,6 +211,6 @@ Your agent will create a structured ticket folder with a spec, test definitions,
 
 <footer class="docs-footer">
 
-[GitHub](https://github.com/TheMostlyGreat/safeword) · MIT License · © 2026
+[GitHub](https://github.com/ArcadeAI/safeword) · MIT License · © 2026
 
 </footer>

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring. Start a new session to auto-install, or run /safeword:setup.",
   "author": { "name": "safeword" },
   "homepage": "https://safeword.dev",
-  "repository": "https://github.com/TheMostlyGreat/safeword",
+  "repository": "https://github.com/ArcadeAI/safeword",
   "license": "MIT",
   "keywords": ["bdd", "tdd", "linting", "quality-review", "debugging", "refactoring"]
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -23,7 +23,7 @@ Safeword configures AI coding agents with proven development workflows:
 ### From GitHub
 
 ```
-/plugin marketplace add TheMostlyGreat/safeword
+/plugin marketplace add ArcadeAI/safeword
 /plugin install safeword@safeword
 ```
 
@@ -58,5 +58,5 @@ Once setup completes, everything is installed locally in your project (`.safewor
 ## Learn more
 
 - [Website](https://safeword.dev)
-- [GitHub](https://github.com/TheMostlyGreat/safeword)
-- [CLI documentation](https://github.com/TheMostlyGreat/safeword/tree/main/packages/cli)
+- [GitHub](https://github.com/ArcadeAI/safeword)
+- [CLI documentation](https://github.com/ArcadeAI/safeword/tree/main/packages/cli)


### PR DESCRIPTION
## Summary

- point repository and marketplace links at `ArcadeAI/safeword`
- update website GitHub social and edit links
- correct all documentation footer and issue links

## Validation

- `bun run --cwd packages/website build`
