### PR TITLE
chore(deps): adopt eslint-plugin-sonarjs 4.2.0, curate its two new test rules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
         "eslint-plugin-regexp": "3.1.1",
         "eslint-plugin-security": "4.0.1",
         "eslint-plugin-simple-import-sort": "^14.0.0",
-        "eslint-plugin-sonarjs": "4.1.0",
+        "eslint-plugin-sonarjs": "4.2.0",
         "eslint-plugin-storybook": "10.5.0",
         "eslint-plugin-turbo": "2.10.4",
         "eslint-plugin-unicorn": "71.1.0",
@@ -1363,7 +1363,7 @@
 
     "eslint-plugin-simple-import-sort": ["eslint-plugin-simple-import-sort@14.0.0", "", { "peerDependencies": { "eslint": ">=5.0.0" } }, "sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ=="],
 
-    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.1.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.6.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.5", "scslre": "^0.3.0", "semver": "^7.8.4", "ts-api-utils": "^2.5.0", "typescript": ">=5", "yaml": "^2.9.0" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw=="],
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.2.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.7.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.5", "scslre": "^0.3.0", "semver": "^7.8.5", "ts-api-utils": "^2.5.0", "typescript": ">=5 <6.1.0", "yaml": "^2.9.0" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg=="],
 
     "eslint-plugin-storybook": ["eslint-plugin-storybook@10.5.0", "", { "dependencies": { "@typescript-eslint/types": "^8.48.0", "@typescript-eslint/utils": "^8.48.0" }, "peerDependencies": { "eslint": ">=8", "storybook": "^10.5.0" } }, "sha512-UyhbK11baKAYqzyDUHlwDlm1aP/wxPMR0vFmsxA5984BGaPwarhoXUWng1Xa0cd9BdPbQ+zr/y8ADk6XxtwkYg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-regexp": "3.1.1",
     "eslint-plugin-security": "4.0.1",
     "eslint-plugin-simple-import-sort": "^14.0.0",
-    "eslint-plugin-sonarjs": "4.1.0",
+    "eslint-plugin-sonarjs": "4.2.0",
     "eslint-plugin-storybook": "10.5.0",
     "eslint-plugin-turbo": "2.10.4",
     "eslint-plugin-unicorn": "71.1.0",

--- a/packages/cli/src/presets/typescript/eslint-configs/__tests__/plugins.test.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/__tests__/plugins.test.ts
@@ -62,13 +62,14 @@ describe('vitestConfig', () => {
     );
   });
 
-  // Twelve rules were promoted into the preset from the project-local
+  // Fourteen rules were promoted into the preset from the project-local
   // cli-tests-override block. They target test-code patterns (throwaway
   // fixtures, regex-heavy assertions, describe-block helpers) where the
   // rule's intent doesn't apply. If the preset is reorganized, these
   // turn-offs need to survive — table-driven so each rule gets its own
   // test case (failure isolation: if 3 rules regress, you see all 3 at
-  // once instead of just the first).
+  // once instead of just the first). The last two arrived with sonarjs
+  // 4.2.0, which promoted them into its recommended set (see vitest.ts).
   it.each([
     'sonarjs/no-unused-vars',
     'sonarjs/no-dead-store',
@@ -82,6 +83,8 @@ describe('vitestConfig', () => {
     'unicorn/no-array-callback-reference',
     'sonarjs/publicly-writable-directories',
     'sonarjs/no-alphabetical-sort',
+    'sonarjs/parameterized-tests',
+    'sonarjs/explicit-test-skip',
   ])('disables %s for test files', rule => {
     expect(getSeverityNumber(getRuleConfig(vitestConfig, rule))).toBe(0);
   });

--- a/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
+++ b/packages/cli/src/presets/typescript/eslint-configs/vitest.ts
@@ -153,6 +153,24 @@ export const vitestConfig: any[] = [
       // ordering (expect(files.sort()).toEqual(...)) — not a code-smell
       // in test contexts.
       'sonarjs/no-alphabetical-sort': 'off',
+      //
+      // parameterized-tests (new in sonarjs 4.2.0's recommended set): demands
+      // repetitive similar cases collapse into one it.each table. That is a
+      // readability *preference*, not a correctness rule — explicit separate
+      // cases keep a failure pointing at the exact scenario, which we value over
+      // table density. Enforcing it at error-level would force a large,
+      // mechanical rewrite of customer test suites for no correctness gain.
+      'sonarjs/parameterized-tests': 'off',
+      //
+      // explicit-test-skip (new in sonarjs 4.2.0's recommended set): flags a
+      // guard that `return`s early instead of calling ctx.skip(). Our
+      // data-driven validation tests use `if (!precondition) return` for
+      // conditional applicability; whether that reads better as ctx.skip() is a
+      // style call, not a test-quality gate we impose on customer suites. (The
+      // handful of internal early-return guards are tracked for a separate
+      // assert-or-skip tightening pass — off here is not an endorsement of
+      // vacuous passes.)
+      'sonarjs/explicit-test-skip': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Summary

Adopts `eslint-plugin-sonarjs` 4.1.0 → **4.2.0** (npm-latest) and curates the two rules it promotes into its recommended set (which `base.ts` spreads). Both fire **only on test files**:

| rule | sites | disposition |
| --- | --- | --- |
| `sonarjs/parameterized-tests` | 36 | **off** — readability preference (collapse repetitive cases into `it.each`); explicit cases keep a failure pointing at the exact scenario. Refactoring 36 tests is disproportionate to a lint bump. |
| `sonarjs/explicit-test-skip` | 4 | **off** — flags `if (!precondition) return` guards, wanting `ctx.skip()`. Conditional-applicability in our data-driven validation tests; a style call, not a gate we impose on customer suites. |

Both join the existing 12 curated sonarjs/unicorn test-rule opt-outs in `vitest.ts`, each with a documented rationale. Extends the failure-isolated `it.each` guard test in `plugins.test.ts` so a future bump/refactor can't silently re-enable them.

## Why disable, not refactor

Both are opinionated **test-structure** rules newly promoted in 4.2.0 — readability judgments, not correctness. safeword ships this preset at error-level into customers' test suites, so imposing either would force churn downstream for no correctness gain. This matches how the preset already curates `consistent-boolean-name`, `prefer-error-is-error`, and 12 test-scoped sonarjs/unicorn rules.

## Follow-up (tracked separately)

`explicit-test-skip` points at ~5 internal early-return test guards (e.g. `skills-commands-validation.test.ts`) where `if (!parsed) return` passes green having asserted nothing. Disabling the rule is **not** an endorsement of vacuous passes — those sites are flagged for an assert-or-skip tightening pass.

## Validation

- `eslint .` clean (all 40 violations gone, none new)
- preset guard tests (plugins + configs): 100 passed
- typecheck clean

Supersedes the sonarjs portion of the #1373 dependabot group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)