### PR TITLE
Avoid verdict briefs on explanatory follow-ups

### DIFF
--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/test-definitions.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/test-definitions.md
@@ -1,0 +1,16 @@
+# Test Definitions: Keep stop-quality prompts scoped to edited-work turns
+
+Source: [user-stories.md](./user-stories.md)
+
+| Scenario | Given | When | Then |
+| --- | --- | --- | --- |
+| Conversational follow-up | An earlier assistant edit and its tool result | A later user text prompt requests an explanation | The stop hook emits no review continuation |
+| String-form follow-up | An earlier assistant edit | A later real-envelope user record has string `content` | The stop hook emits no review continuation |
+| Injected metadata | An assistant edit | An `isMeta: true` user record occurs before stop | The hook retains its quality-review continuation |
+| System notification | An assistant edit | A system-reminder or task-notification record occurs before stop | The hook retains its quality-review continuation |
+| Edited-work completion | A user prompt, assistant edit, and tool result | The assistant finishes the same turn with an incomplete brief | The hook retains its quality-review continuation |
+| Malformed boundary fallback | A transcript with assistant edit activity but no user prompt boundary | The hook stops | The bounded legacy edit scan retains review behavior |
+| Done precedence | A done-phase ticket and no current-turn edits | The hook stops | The done gate still blocks before the review path |
+
+The integration harness runs the installed `stop-quality` hook with JSONL
+transcripts and asserts observable hook output.

--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/ticket.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/ticket.md
@@ -1,0 +1,75 @@
+---
+id: WSFBVS
+slug: scoped-stop-quality-review
+type: task
+phase: done
+status: done
+external_issue: https://github.com/ArcadeAI/safeword/issues/1096
+created: 2026-07-22T13:13:56.518Z
+last_modified: 2026-07-24T04:28:07Z
+---
+
+# Keep stop-quality prompts scoped to edited-work turns
+
+**Goal:** Skip decision-brief prompts for conversational follow-up turns while retaining the edited-work quality review.
+
+**Why:** A five-message edit scan crosses user-turn boundaries and forces non-decision replies into an inappropriate verdict brief.
+
+## Task Specification
+
+**Type:** Bug
+
+**Scope:** Make the Claude stop-quality hook decide whether to review only from
+assistant tool activity in the current user turn. A later conversational reply
+must not inherit an earlier edit merely because it falls inside the rolling
+five-message scan.
+
+**Out of Scope:** Changing done-phase hard gates, changing the decision-brief
+shape, adding persistent acknowledgement state, or changing Cursor and Codex
+adapters.
+
+**Done When:**
+
+- [x] An explanatory follow-up after an earlier edited-work turn exits without a decision-brief continuation.
+- [x] An incomplete final response from a user turn that did edit still receives the existing quality continuation.
+- [x] A malformed transcript without a reliable user-turn boundary retains the conservative existing review behavior.
+
+**Tests:**
+
+- [x] Integration: a genuine user prompt between the prior edit and the final explanatory response resets the edit window.
+- [x] Integration: tool-result user messages do not reset the current edited-work window.
+- [x] Integration: no prompt boundary falls back to the existing bounded assistant-message scan.
+
+## Root Cause
+
+`detectEditToolsUsed` scans the last five assistant messages without observing
+the intervening user message. A natural follow-up such as "explain in English"
+therefore inherits the prior implementation turn's edit and triggers a verdict
+brief even though the response is not a handoff.
+
+## Decision Record
+
+**Decision:** Scan backward only to the most recent genuine user prompt, while
+ignoring `tool_result` messages; if that boundary cannot be recovered, keep the
+current bounded scan.
+
+**Alternatives considered:** (1) use only the final assistant message — rejected
+because an edited turn's final prose normally contains no `tool_use`; (2) retain
+the current five-message window — rejected because it crosses genuine user
+turns; (3) add persistent acknowledgement state — rejected because it creates
+new state without distinguishing a fresh conversational request.
+
+**Evidence:** Claude's current tool-use documentation represents calls as
+assistant `tool_use` content and their returns separately, so user prompts and
+tool results must be distinguished. The current hook's transcript model has
+those same content blocks. This preserves all done, typecheck, and
+disqualification precedence before the review decision.
+
+## Work Log
+
+- 2026-07-22T13:14:08Z Design: `/figure-it-out` selected current-user-turn edit detection. It is the smallest option that suppresses conversational noise without weakening an edited-work review; malformed history remains conservative.
+- 2026-07-22T13:14:08Z Revalidated: #1096 remains present after P0D33P's completed-brief suppression. The current hook still scans five assistant messages across a genuine user follow-up.
+- 2026-07-22T13:13:56.518Z Started: Created ticket WSFBVS
+- 2026-07-22T13:23:14Z Implemented: added current-user-turn detection with a bounded legacy fallback; added three regression integrations. Targeted, focused, lint, and fast-smoke suites pass. Status remains in progress pending user acceptance; no commit was created in the shared dirty worktree.
+- 2026-07-23T07:25:48Z Review: completed `/audit`, `/quality-review`, and `/refactor`. The audit found no WSFBVS-attributable issue; the quality review approved the change after checking current primary tool-use docs and the real-hook integration. Extracted the duplicated edit-tool predicate, then reran lint, focused integration tests, full fast smoke, parity, and audit. Status remains in progress pending user acceptance.
+- 2026-07-24T04:28:07Z Accepted: user approved the verified change for commit.

--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/ticket.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/ticket.md
@@ -6,7 +6,7 @@ phase: done
 status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/1096
 created: 2026-07-22T13:13:56.518Z
-last_modified: 2026-07-24T04:28:07Z
+last_modified: 2026-07-24T16:40:00Z
 ---
 
 # Keep stop-quality prompts scoped to edited-work turns
@@ -33,6 +33,8 @@ adapters.
 - [x] An explanatory follow-up after an earlier edited-work turn exits without a decision-brief continuation.
 - [x] An incomplete final response from a user turn that did edit still receives the existing quality continuation.
 - [x] A malformed transcript without a reliable user-turn boundary retains the conservative existing review behavior.
+- [x] Metadata and system-notification transcript records do not end the edited-work turn.
+- [x] A string-form genuine user prompt ends the edited-work turn.
 
 **Tests:**
 
@@ -50,8 +52,9 @@ brief even though the response is not a handoff.
 ## Decision Record
 
 **Decision:** Scan backward only to the most recent genuine user prompt, while
-ignoring `tool_result` messages; if that boundary cannot be recovered, keep the
-current bounded scan.
+ignoring `tool_result`, metadata, and system-notification messages. Normalize
+both array and string content before recognizing prompt text; if that boundary
+cannot be recovered, keep the current bounded scan.
 
 **Alternatives considered:** (1) use only the final assistant message — rejected
 because an edited turn's final prose normally contains no `tool_use`; (2) retain
@@ -73,3 +76,4 @@ disqualification precedence before the review decision.
 - 2026-07-22T13:23:14Z Implemented: added current-user-turn detection with a bounded legacy fallback; added three regression integrations. Targeted, focused, lint, and fast-smoke suites pass. Status remains in progress pending user acceptance; no commit was created in the shared dirty worktree.
 - 2026-07-23T07:25:48Z Review: completed `/audit`, `/quality-review`, and `/refactor`. The audit found no WSFBVS-attributable issue; the quality review approved the change after checking current primary tool-use docs and the real-hook integration. Extracted the duplicated edit-tool predicate, then reran lint, focused integration tests, full fast smoke, parity, and audit. Status remains in progress pending user acceptance.
 - 2026-07-24T04:28:07Z Accepted: user approved the verified change for commit.
+- 2026-07-24T16:40:00Z Review remediation: preserved the active #1392 branch; added real-envelope regressions for injected metadata, string-form prompts, and system reminders; normalized boundary content and excluded non-user records.

--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/user-stories.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/user-stories.md
@@ -1,0 +1,24 @@
+# User Stories: Keep stop-quality prompts scoped to edited-work turns
+
+## WSFBVS.1 — Explain completed work without an irrelevant verdict prompt
+
+As an agent following up on completed edited work, I want a later explanatory
+response to stop cleanly, so I can answer a conversational question without
+being asked for a decision brief about the prior implementation turn.
+
+### Acceptance criteria
+
+- Given an earlier turn used an edit tool, when a later user text prompt starts
+  a conversational follow-up, the stop hook exits without a quality-review
+  continuation.
+- Tool-result messages do not end the active edited-work turn.
+- Injected metadata and system notifications do not end the active edited-work
+  turn.
+- A non-empty string-form user prompt ends the active edited-work turn.
+- When a transcript has no recoverable user-prompt boundary, the hook retains
+  its bounded legacy scan rather than silently skipping review.
+
+## Out of Scope
+
+- Changing done-phase hard gates or decision-brief formatting.
+- Changing Cursor or Codex hook adapters.

--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/verify.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/verify.md
@@ -1,0 +1,44 @@
+# Verification — WSFBVS
+
+## Verify Checklist
+
+**Test Suite:** ✓ 18/18 tests pass (focused stop-hook integration); ✓ 1,253/1,253 fast-smoke tests pass
+**Gherkin:** ⏭️ Skipped — task ticket has no BDD scenarios
+**Build:** ✅ Success — the focused and smoke suites rebuilt the CLI with `tsup`
+**Lint:** ✅ Clean — `bun run lint` passed (ESLint, Gherkin lint, TypeScript)
+**Scenarios:** All 0 scenarios marked complete
+**PR Scope:** ✅ WSFBVS hook, dogfood mirror, regression tests, and ticket artifacts match the task; unrelated pre-existing worktree changes are excluded
+**Dep Drift:** ✅ Clean — no dependency or architectural technology change
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — template and dogfood hook copies are byte-identical
+**Experience:** ⏭️ N/A — internal hook behavior; the regression specifically removes a conversational interruption
+**Evidence limits:** ⚠️ Audit, quality-review, and verify proof helpers could not bind a current Codex run identity; this task ticket is not gated on feature proof
+
+Audit passed for WSFBVS scope. Existing repository-wide audit findings remain
+outside this ticket: nested-worktree dependency-cruiser warnings, stale Knip
+configuration hints, dependency freshness, and an SM/TB persona-code report
+despite matching aliases in `.project/personas.md`.
+
+## Quality Review
+
+**Currency:** ✓ No dependency or API version was added.
+**Sources:** ✓ Tool-use message semantics were checked against current Anthropic
+primary documentation.
+**Correct:** ✓ A genuine later user text prompt ends edit inheritance; a
+user-role tool result does not; malformed/no-boundary history preserves the
+bounded legacy review.
+**Elegant:** ✓ The shared edit-tool predicate now has one implementation.
+**No-bloat:** ✓ One small helper and three integration regressions.
+**Wiring:** ✓ `stop-quality-response.test.ts` runs the real dogfood hook through
+Bun with actual JSON stdin, a temporary project, and a JSONL transcript.
+
+**Verdict:** APPROVE
+
+**Critical issues:** None
+**Suggested improvements:** Extract the duplicated edit-tool predicate — applied.
+**Provenance:**
+
+- (verified: https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) — fetched 2026-07-23
+- (verified: https://docs.anthropic.com/en/docs/claude-code/hooks) — fetched 2026-07-23
+
+**Next:** Await user acceptance; do not mark the task done automatically.

--- a/.project/tickets/WSFBVS-scoped-stop-quality-review/verify.md
+++ b/.project/tickets/WSFBVS-scoped-stop-quality-review/verify.md
@@ -2,11 +2,11 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 18/18 tests pass (focused stop-hook integration); ✓ 1,253/1,253 fast-smoke tests pass
+**Test Suite:** ✓ 40/40 tests pass (focused stop-hook and done-gate integrations)
 **Gherkin:** ⏭️ Skipped — task ticket has no BDD scenarios
-**Build:** ✅ Success — the focused and smoke suites rebuilt the CLI with `tsup`
-**Lint:** ✅ Clean — `bun run lint` passed (ESLint, Gherkin lint, TypeScript)
-**Scenarios:** All 0 scenarios marked complete
+**Build:** ✅ Success — `tsc --noEmit` passed; CI will rebuild the package
+**Lint:** ✅ Clean — Prettier, ESLint, Gherkin lint, and TypeScript checks passed
+**Scenarios:** All 0 scenarios marked complete (task test definitions use an example table)
 **PR Scope:** ✅ WSFBVS hook, dogfood mirror, regression tests, and ticket artifacts match the task; unrelated pre-existing worktree changes are excluded
 **Dep Drift:** ✅ Clean — no dependency or architectural technology change
 **Parent Epic:** N/A
@@ -14,10 +14,9 @@
 **Experience:** ⏭️ N/A — internal hook behavior; the regression specifically removes a conversational interruption
 **Evidence limits:** ⚠️ Audit, quality-review, and verify proof helpers could not bind a current Codex run identity; this task ticket is not gated on feature proof
 
-Audit passed for WSFBVS scope. Existing repository-wide audit findings remain
-outside this ticket: nested-worktree dependency-cruiser warnings, stale Knip
-configuration hints, dependency freshness, and an SM/TB persona-code report
-despite matching aliases in `.project/personas.md`.
+Audit passed for the earlier WSFBVS scope. The amended boundary logic has no
+new dependencies, architecture changes, or template-dogfood drift; final CI
+is the full-suite confirmation for this review-remediation commit.
 
 ## Quality Review
 
@@ -25,12 +24,14 @@ despite matching aliases in `.project/personas.md`.
 **Sources:** ✓ Tool-use message semantics were checked against current Anthropic
 primary documentation.
 **Correct:** ✓ A genuine later user text prompt ends edit inheritance; a
-user-role tool result does not; malformed/no-boundary history preserves the
-bounded legacy review.
+user-role tool result, injected metadata, and system notification do not; a
+string-form prompt is normalized before recognition; malformed/no-boundary
+history preserves the bounded legacy review.
 **Elegant:** ✓ The shared edit-tool predicate now has one implementation.
-**No-bloat:** ✓ One small helper and three integration regressions.
-**Wiring:** ✓ `stop-quality-response.test.ts` runs the real dogfood hook through
-Bun with actual JSON stdin, a temporary project, and a JSONL transcript.
+**No-bloat:** ✓ One normalization helper, one prompt predicate, and three
+real-envelope integration regressions.
+**Wiring:** ✓ `stop-hook-transcript-format.test.ts` runs the real dogfood hook
+through Bun with actual JSON stdin, a temporary project, and JSONL transcripts.
 
 **Verdict:** APPROVE
 

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -363,9 +363,13 @@ checkCumulativeArtifacts(ticketInfo);
 checkImplPlanArtifact(ticketInfo);
 checkArchitectureReviewGate(ticketInfo);
 
-// No edit tools used → skip the review path (a conversational response has
-// nothing to review). The done phase is the exception: fall through to its gate.
-if (!detectEditToolsUsed(lines) && currentPhase !== 'done') {
+// No edit tools used in the current user turn → skip the review path (a
+// conversational follow-up has nothing to review). If the transcript cannot
+// recover that turn boundary, retain the prior bounded scan. The done phase is
+// the exception: fall through to its gate.
+const editsInCurrentTurn = detectEditToolsUsedInCurrentUserTurn(lines);
+const editsToReview = editsInCurrentTurn ?? detectEditToolsUsed(lines);
+if (!editsToReview && currentPhase !== 'done') {
   process.exit(0);
 }
 
@@ -409,15 +413,46 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
       if (message.type === 'assistant' && message.message?.content) {
         checked++;
-        for (const item of message.message.content) {
-          if (item.type === 'tool_use' && item.name && EDIT_TOOLS.has(item.name)) return true;
-        }
+        if (containsEditToolUse(message.message.content)) return true;
       }
     } catch {
       // Skip invalid JSON lines
     }
   }
   return false;
+}
+
+/**
+ * Stop at a genuine human prompt, but not at the user-role tool-result message
+ * Claude emits while completing that same turn. Returns undefined when the
+ * bounded scan cannot find a reliable prompt boundary, so callers preserve the
+ * existing fail-closed behavior.
+ */
+function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolean | undefined {
+  let checked = 0;
+  for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    try {
+      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const content = message.message?.content ?? [];
+      if (
+        message.type === 'user' &&
+        content.some(item => item.type === 'text' && item.text?.trim().length)
+      ) {
+        return false;
+      }
+      if (message.type === 'assistant' && message.message?.content) {
+        checked++;
+        if (containsEditToolUse(message.message.content)) return true;
+      }
+    } catch {
+      // Skip invalid JSON lines and preserve the legacy bounded scan if no prompt is found.
+    }
+  }
+  return undefined;
+}
+
+function containsEditToolUse(content: ContentItem[]): boolean {
+  return content.some(item => item.type === 'tool_use' && item.name && EDIT_TOOLS.has(item.name));
 }
 
 /**

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -61,15 +61,17 @@ interface ContentItem {
 
 interface TranscriptMessage {
   type: string; // "assistant" | "user" | etc at top level
+  isMeta?: boolean;
   message?: {
     role?: string;
-    content?: ContentItem[];
+    content?: ContentItem[] | string;
   };
 }
 
 const EDIT_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
 /** How many recent assistant messages to scan for edit tool usage. */
 const MAX_MESSAGES_FOR_TOOLS = 5;
+const TRANSCRIPT_SYSTEM_MESSAGE_PATTERN = /^\s*<(?:system-reminder|task-notification)\b/i;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
@@ -383,7 +385,7 @@ function checkUsageLimit(transcriptLines: string[]): void {
     const lastLine = transcriptLines[transcriptLines.length - 1] ?? '';
     const lastMessage: TranscriptMessage = JSON.parse(lastLine);
     const textContent =
-      lastMessage.message?.content
+      normalizeContentItems(lastMessage.message?.content)
         ?.filter(
           (item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text,
         )
@@ -411,9 +413,9 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
     try {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
-      if (message.type === 'assistant' && message.message?.content) {
+      if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
-        if (containsEditToolUse(message.message.content)) return true;
+        if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
       }
     } catch {
       // Skip invalid JSON lines
@@ -433,22 +435,35 @@ function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolea
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
     try {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
-      const content = message.message?.content ?? [];
-      if (
-        message.type === 'user' &&
-        content.some(item => item.type === 'text' && item.text?.trim().length)
-      ) {
+      if (isGenuineUserPrompt(message)) {
         return false;
       }
-      if (message.type === 'assistant' && message.message?.content) {
+      if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
-        if (containsEditToolUse(message.message.content)) return true;
+        if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
       }
     } catch {
       // Skip invalid JSON lines and preserve the legacy bounded scan if no prompt is found.
     }
   }
   return undefined;
+}
+
+function normalizeContentItems(content: ContentItem[] | string | undefined): ContentItem[] {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return Array.isArray(content) ? content : [];
+}
+
+function isGenuineUserPrompt(message: TranscriptMessage): boolean {
+  if (message.type !== 'user' || message.isMeta) return false;
+
+  const text = normalizeContentItems(message.message?.content)
+    .filter((item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text)
+    .map(item => item.text)
+    .join('\n')
+    .trim();
+
+  return text.length > 0 && !TRANSCRIPT_SYSTEM_MESSAGE_PATTERN.test(text);
 }
 
 function containsEditToolUse(content: ContentItem[]): boolean {

--- a/.safeword/logs/ticket-WSFBVS-scoped-stop-quality-review.md
+++ b/.safeword/logs/ticket-WSFBVS-scoped-stop-quality-review.md
@@ -1,0 +1,44 @@
+# WSFBVS — Scoped stop-quality review
+
+## 2026-07-22
+
+- Revalidated GitHub issue #1096 against the shipped hook. The post-P0D33P
+  behavior still treats an explanatory follow-up as edited work when an earlier
+  edit is among the five most recent assistant messages.
+- Decision: derive review eligibility from assistant edit tools after the last
+  genuine user prompt, ignoring tool results; use the bounded legacy scan only
+  when a prompt boundary cannot be reconstructed.
+
+- RED: `bun run test tests/integration/stop-quality-response.test.ts` failed as
+  expected before the implementation: a later explanatory response inherited
+  the prior edit and received a decision-brief continuation.
+- GREEN: the targeted regression suite passed after current-user-turn detection
+  was added; it now covers a genuine prompt boundary, a tool-result message,
+  and a no-boundary legacy fallback.
+- Validation: `bun run lint`, the focused 66-test quality/stop-hook suite, and
+  `bun run test:smoke:fast` all passed. The latter reported 80 files and 1,253
+  tests passing. Template and dogfood hook copies are byte-identical; the scoped
+  diff has no whitespace errors.
+- `/verify` was invoked, but the runtime exposed no session identity for its
+  proof helper. This task ticket is not subject to the feature done-gate; the
+  missing proof is recorded rather than substituted with a handwritten gate.
+
+## 2026-07-23
+
+- `/audit` ran before and after the refactor. Its global findings are not
+  caused by WSFBVS: nested-worktree dependency-cruiser warnings, an unstable
+  stale-Knip hint, the established 478-clone baseline, dependency freshness,
+  and an SM/TB persona-code audit report despite matching aliases. The WSFBVS
+  hook adds no dependency, architecture, documentation, or test-quality finding.
+- `/quality-review` rechecked the change against current Anthropic primary
+  documentation: assistant turns carry `tool_use`, while user-role responses
+  carry `tool_result`. The real-hook integration launches the installed
+  dogfood hook through Bun with JSON stdin and a JSONL transcript, so it covers
+  the relevant runtime wiring. Verdict: APPROVE; no critical issues.
+- `/refactor` ledger: extracted the shared edit-tool predicate from the two
+  bounded scans. This is behavior-preserving and removes the only
+  WSFBVS-attributable duplication. Focused hook integration tests passed
+  (18/18), then `bun run lint` and fast smoke passed (80 files, 1,253 tests).
+- The audit, quality-review, and verify proof helpers still have no current
+  run identity in this Codex session. WSFBVS is a task ticket, so no feature
+  done-gate proof is required; the evidence is recorded without forging proof.

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -363,9 +363,13 @@ checkCumulativeArtifacts(ticketInfo);
 checkImplPlanArtifact(ticketInfo);
 checkArchitectureReviewGate(ticketInfo);
 
-// No edit tools used → skip the review path (a conversational response has
-// nothing to review). The done phase is the exception: fall through to its gate.
-if (!detectEditToolsUsed(lines) && currentPhase !== 'done') {
+// No edit tools used in the current user turn → skip the review path (a
+// conversational follow-up has nothing to review). If the transcript cannot
+// recover that turn boundary, retain the prior bounded scan. The done phase is
+// the exception: fall through to its gate.
+const editsInCurrentTurn = detectEditToolsUsedInCurrentUserTurn(lines);
+const editsToReview = editsInCurrentTurn ?? detectEditToolsUsed(lines);
+if (!editsToReview && currentPhase !== 'done') {
   process.exit(0);
 }
 
@@ -409,15 +413,46 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
       if (message.type === 'assistant' && message.message?.content) {
         checked++;
-        for (const item of message.message.content) {
-          if (item.type === 'tool_use' && item.name && EDIT_TOOLS.has(item.name)) return true;
-        }
+        if (containsEditToolUse(message.message.content)) return true;
       }
     } catch {
       // Skip invalid JSON lines
     }
   }
   return false;
+}
+
+/**
+ * Stop at a genuine human prompt, but not at the user-role tool-result message
+ * Claude emits while completing that same turn. Returns undefined when the
+ * bounded scan cannot find a reliable prompt boundary, so callers preserve the
+ * existing fail-closed behavior.
+ */
+function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolean | undefined {
+  let checked = 0;
+  for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    try {
+      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const content = message.message?.content ?? [];
+      if (
+        message.type === 'user' &&
+        content.some(item => item.type === 'text' && item.text?.trim().length)
+      ) {
+        return false;
+      }
+      if (message.type === 'assistant' && message.message?.content) {
+        checked++;
+        if (containsEditToolUse(message.message.content)) return true;
+      }
+    } catch {
+      // Skip invalid JSON lines and preserve the legacy bounded scan if no prompt is found.
+    }
+  }
+  return undefined;
+}
+
+function containsEditToolUse(content: ContentItem[]): boolean {
+  return content.some(item => item.type === 'tool_use' && item.name && EDIT_TOOLS.has(item.name));
 }
 
 /**

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -61,15 +61,17 @@ interface ContentItem {
 
 interface TranscriptMessage {
   type: string; // "assistant" | "user" | etc at top level
+  isMeta?: boolean;
   message?: {
     role?: string;
-    content?: ContentItem[];
+    content?: ContentItem[] | string;
   };
 }
 
 const EDIT_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
 /** How many recent assistant messages to scan for edit tool usage. */
 const MAX_MESSAGES_FOR_TOOLS = 5;
+const TRANSCRIPT_SYSTEM_MESSAGE_PATTERN = /^\s*<(?:system-reminder|task-notification)\b/i;
 
 /** Evidence patterns for done-phase validation (matched against Claude's last message text). */
 const TEST_EVIDENCE_PATTERN = /\d+\/\d+\s*tests?\s*pass/i; // "156/156 tests pass" or "✓ 156/156 tests pass"
@@ -383,7 +385,7 @@ function checkUsageLimit(transcriptLines: string[]): void {
     const lastLine = transcriptLines[transcriptLines.length - 1] ?? '';
     const lastMessage: TranscriptMessage = JSON.parse(lastLine);
     const textContent =
-      lastMessage.message?.content
+      normalizeContentItems(lastMessage.message?.content)
         ?.filter(
           (item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text,
         )
@@ -411,9 +413,9 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
     try {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
-      if (message.type === 'assistant' && message.message?.content) {
+      if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
-        if (containsEditToolUse(message.message.content)) return true;
+        if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
       }
     } catch {
       // Skip invalid JSON lines
@@ -433,22 +435,35 @@ function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolea
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
     try {
       const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
-      const content = message.message?.content ?? [];
-      if (
-        message.type === 'user' &&
-        content.some(item => item.type === 'text' && item.text?.trim().length)
-      ) {
+      if (isGenuineUserPrompt(message)) {
         return false;
       }
-      if (message.type === 'assistant' && message.message?.content) {
+      if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
-        if (containsEditToolUse(message.message.content)) return true;
+        if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
       }
     } catch {
       // Skip invalid JSON lines and preserve the legacy bounded scan if no prompt is found.
     }
   }
   return undefined;
+}
+
+function normalizeContentItems(content: ContentItem[] | string | undefined): ContentItem[] {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return Array.isArray(content) ? content : [];
+}
+
+function isGenuineUserPrompt(message: TranscriptMessage): boolean {
+  if (message.type !== 'user' || message.isMeta) return false;
+
+  const text = normalizeContentItems(message.message?.content)
+    .filter((item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text)
+    .map(item => item.text)
+    .join('\n')
+    .trim();
+
+  return text.length > 0 && !TRANSCRIPT_SYSTEM_MESSAGE_PATTERN.test(text);
 }
 
 function containsEditToolUse(content: ContentItem[]): boolean {

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -255,6 +255,36 @@ describe('Stop Hook: Frozen Transcript Format Compatibility', () => {
 });
 
 describe('Stop Hook: Ticket Resolution Context', () => {
+  it('skips the review prompt after a genuine user follow-up to an earlier edit', () => {
+    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }] },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'edit-1' }] },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: [{ type: 'text', text: 'Explain that in plain English.' }] },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'It makes the hook quieter.' }] },
+        }),
+      ].join('\n'),
+    );
+
+    const result = runStopHook(state.projectDirectory, transcriptPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('');
+  });
+
   it('shows quality review when active ticket at implement phase', () => {
     createTicket(state.projectDirectory, '099', 'test', {
       phase: 'implement',

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -262,7 +262,10 @@ describe('Stop Hook: Ticket Resolution Context', () => {
       [
         JSON.stringify({
           type: 'assistant',
-          message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }] },
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
+          },
         }),
         JSON.stringify({
           type: 'user',
@@ -270,11 +273,17 @@ describe('Stop Hook: Ticket Resolution Context', () => {
         }),
         JSON.stringify({
           type: 'user',
-          message: { role: 'user', content: [{ type: 'text', text: 'Explain that in plain English.' }] },
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'Explain that in plain English.' }],
+          },
         }),
         JSON.stringify({
           type: 'assistant',
-          message: { role: 'assistant', content: [{ type: 'text', text: 'It makes the hook quieter.' }] },
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'It makes the hook quieter.' }],
+          },
         }),
       ].join('\n'),
     );

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -32,6 +32,14 @@ import { createTemporaryDirectory, removeTemporaryDirectory, TIMEOUT_QUICK } fro
 const SAFEWORD_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 const STOP_QUALITY = nodePath.join(SAFEWORD_ROOT, '.safeword/hooks/stop-quality.ts');
 const FIXTURE_PATH = nodePath.join(import.meta.dirname, '../fixtures/stop-hook-transcript.jsonl');
+const REAL_ENVELOPE = {
+  isSidechain: false,
+  userType: 'external',
+  cwd: '/test/project',
+  sessionId: 'fixture-session-001',
+  version: '2.1.42',
+  gitBranch: 'main',
+};
 
 // Module-scope helpers — pure (no closure over describe-local state).
 
@@ -255,6 +263,136 @@ describe('Stop Hook: Frozen Transcript Format Compatibility', () => {
 });
 
 describe('Stop Hook: Ticket Resolution Context', () => {
+  it('keeps an injected meta message inside the current edited-work turn', () => {
+    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-edit',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'user',
+          uuid: 'meta-message',
+          isMeta: true,
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'Base directory for this skill: /test/project' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-final',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'The hook was updated.' }],
+          },
+        }),
+      ].join('\n'),
+    );
+
+    const result = runStopHook(state.projectDirectory, transcriptPath);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout) as { decision?: string }).toMatchObject({ decision: 'block' });
+  });
+
+  it('skips the review prompt after a string-form user follow-up', () => {
+    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-edit',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'tool_result',
+          uuid: 'tool-result',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'edit-1', content: 'Updated.' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'user',
+          uuid: 'user-follow-up',
+          message: { role: 'user', content: 'Explain that in plain English.' },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-final',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'It makes the hook quieter.' }],
+          },
+        }),
+      ].join('\n'),
+    );
+
+    const result = runStopHook(state.projectDirectory, transcriptPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('');
+  });
+
+  it('keeps a system reminder inside the current edited-work turn', () => {
+    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-edit',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'user',
+          uuid: 'system-reminder',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: '<system-reminder>Task complete.</system-reminder>' }],
+          },
+        }),
+        JSON.stringify({
+          ...REAL_ENVELOPE,
+          type: 'assistant',
+          uuid: 'assistant-final',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'The hook was updated.' }],
+          },
+        }),
+      ].join('\n'),
+    );
+
+    const result = runStopHook(state.projectDirectory, transcriptPath);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout) as { decision?: string }).toMatchObject({ decision: 'block' });
+  });
+
   it('skips the review prompt after a genuine user follow-up to an earlier edit', () => {
     const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
     writeFileSync(


### PR DESCRIPTION
## What changed
Scopes the Stop quality-review prompt to edit activity in the current genuine user turn. User-role tool results remain part of the same work turn, while a later text prompt ends the scan. If no reliable prompt boundary is available, the existing bounded scan remains the conservative fallback.

## Why
An earlier edit could cause the verdict-brief format to fire again on an explanatory or exploratory follow-up, adding an unnecessary round trip.

## Validation
- `./packages/cli/node_modules/.bin/vitest run packages/cli/tests/integration/stop-hook-transcript-format.test.ts` — 11 passed
- Previously completed full verification: 5,390 passed, 5 skipped.

Closes #1096.