### PR TITLE
test: fail loudly instead of vacuously passing on unparseable shipped skill/command

### DIFF
--- a/packages/cli/tests/integration/skills-commands-validation.test.ts
+++ b/packages/cli/tests/integration/skills-commands-validation.test.ts
@@ -358,7 +358,7 @@ describe('Skills Validation (Claude Code Format)', () => {
       // File reference validation
       it('should have valid markdown file references in body', () => {
         if (!parsed?.body) {
-          return;
+          expect.fail('Shipped skill must have a body to validate its markdown links');
         }
 
         const brokenLinks = findBrokenMarkdownLinks(
@@ -428,7 +428,7 @@ describe('Commands Validation (Claude Code Format)', () => {
       it('should have description field for /help display', () => {
         // Safeword commands should have descriptions
         if (!parsed) {
-          return;
+          expect.fail('Shipped command must have valid frontmatter');
         }
 
         expect(
@@ -440,7 +440,7 @@ describe('Commands Validation (Claude Code Format)', () => {
 
       it('should have markdown body (not just frontmatter)', () => {
         if (!parsed) {
-          return;
+          expect.fail('Shipped command must have valid frontmatter, not just fail to parse');
         }
 
         expect(parsed.body, 'Command needs content after frontmatter').not.toBe('');
@@ -516,7 +516,7 @@ describe('Commands Validation (Claude Code Format)', () => {
       // File reference validation for commands
       it('should have valid markdown file references in body', () => {
         if (!parsed?.body) {
-          return;
+          expect.fail('Shipped command must have a body to validate its markdown links');
         }
 
         const brokenLinks = findBrokenMarkdownLinks(parsed.body, COMMANDS_DIR);


### PR DESCRIPTION
## What

`skills-commands-validation.test.ts` iterates safeword's **own shipped** skills and commands, which must all have valid frontmatter + body. Four per-aspect tests (markdown links ×2, body content, description) guarded with `if (!parsed) return;` — so a skill/command that failed to parse passed those tests **GREEN having asserted nothing**.

## Change

Each guard `if (!parsed…) return;` → `if (!parsed…) expect.fail('…');`. `expect.fail` is typed `never`, so it fails the test loudly **and** preserves the TS narrowing the early-return provided (typecheck stays green). Behavior is unchanged for all valid files (657/657 pass); a broken shipped file now fails these tests instead of silently passing.

## Why assert, not skip

`parseFrontmatter` returns `undefined` only when a file has no valid frontmatter. For safeword's own shipped files that is a **real defect**, never a legitimate absence — so the honest expression is fail, not `ctx.skip()`.

## Context

Follow-up to #1386, which disabled `sonarjs/explicit-test-skip` (newly promoted in sonarjs 4.2.0) that flagged these early-returns. Disabling the rule preset-wide was not an endorsement of the vacuous passes; this tightens the actual sites.

## Validation

- `skills-commands-validation.test.ts`: 657 passed
- typecheck clean (expect.fail narrows `parsed`)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)