### PR TITLE
Add skill-eval-optimization guide + review-spec reference README (XZFSZ5)

### DIFF
--- a/.project/tickets/7ZLTWB-eval-driven-skill-optimization/ticket.md
+++ b/.project/tickets/7ZLTWB-eval-driven-skill-optimization/ticket.md
@@ -1,0 +1,51 @@
+---
+id: 7ZLTWB
+slug: eval-driven-skill-optimization
+type: epic
+phase: intake
+status: in_progress
+epic: eval-driven-skill-optimization
+children: ['21RAT9', 'M3SI7T', 'XZFSZ5']
+scope:
+  - A reusable, skill-agnostic harness for measurably improving any skill prompt - seed known defects into a certified-clean corpus, score with a deterministic set-matching metric (no LLM judge), gate on a relative recall floor (majority-voted protected set), a multi-run consensus accept gate, and a Tier-2 real-harness gate (claude -p).
+  - The methodology as a durable asset - eval-first; GEPA-optional (the optimizer serves the eval, never replaces it); single-run adjudication is unreliable; the bare-model proxy oversells the gain, so Tier-2 is the honest ship gate.
+  - First application beyond review-spec - the pr-review skill (WAWQA6/G5337S) and its eval (WAWQA6/CWGYH0).
+out_of_scope:
+  - Shipping any specific skill change - that is each child ticket's job (M3SI7T ships review-spec).
+  - The pr-review product itself - WAWQA6 owns that; this epic owns the harness CWGYH0 consumes.
+done_when:
+  - The harness runs against a second skill (pr-review) with zero review-spec-specific code - corpus, skill path, fixtures, and protected manifest are all parameters.
+  - The methodology is documented so a new skill onboards without re-deriving the floor/consensus/Tier-2 design.
+  - review-spec's lean candidate is shipped (M3SI7T) - the epic's first end-to-end proof.
+created: 2026-07-24T04:13:44.000Z
+last_modified: 2026-07-24T04:13:44.000Z
+---
+
+# Eval-driven skill optimization — a reusable harness to measurably improve any skill prompt
+
+**Goal:** Turn the review-spec eval machinery (built in E2D8S5, hardened in 21RAT9) into a reusable, skill-agnostic harness — so a proposed prompt change to ANY skill is adjudicated by evidence, not taste, before it ships.
+
+**Origin:** The `/figure-it-out` that reshaped the +124% GEPA winner into a lean +32% candidate, which then passed the bare-model gate (−46% false alarms) AND the real-harness Tier-2 gate (−34%, floor clean) — plus the call to generalize the harness for reuse, pr-review next.
+
+## The methodology (the durable asset)
+
+1. **Certified-clean corpus + seeded defects** — one mutation per fixture; the mutation operator IS the label. No LLM judge (deterministic set-matching → dodges judge bias).
+2. **Relative recall floor** — reject only a miss of a seed the BASELINE reliably catches (majority-voted protected set, ⌈2k/3⌉). Systematically-missed seeds stay measured but unprotected (an absolute floor is unsatisfiable).
+3. **Multi-run consensus gate** — single runs are too noisy (even the baseline breaches a one-run floor ~⅓ of the time); gate on ⌈2N/3⌉ consensus.
+4. **Tier-2 real-harness gate** — run the finalist through `claude -p` (full CC system prompt + tools), because the bare-model proxy oversells the gain (measured: −46% → −34%).
+5. **GEPA is optional** — the optimizer serves the eval; a human-authored candidate beat the GEPA winner here.
+
+## Children
+
+- **21RAT9** review-spec-eval-hardening — **done**. The proving ground: hardened the eval, rejected the raw GEPA winner (it dropped a real 2nd defect ~⅓ of the time), salvaged then leaned a candidate that passes Tier-1 and Tier-2.
+- **M3SI7T** adopt-lean-review-spec — ship the validated lean candidate into the live review-spec skill across all harnesses.
+- **XZFSZ5** generalize-skill-eval-harness — parameterize the machinery so it drives any skill; first external application is pr-review (feeds CWGYH0).
+
+## Relation to WAWQA6 (autonomous-pr-review)
+
+This epic owns the reusable HARNESS; WAWQA6 owns the pr-review PRODUCT. XZFSZ5 delivers the harness that WAWQA6/CWGYH0 consumes — the two epics meet there.
+
+## Work Log
+
+- 2026-07-24 Epic created (user directive). Houses 21RAT9 (done) + adoption (M3SI7T) + generalization (XZFSZ5). The generalization's first target is pr-review, linking to WAWQA6/CWGYH0.
+- 2026-07-24 **/figure-it-out on code-bug corpus construction → the seeded-defect method does NOT cleanly transfer to pr-review; CWGYH0 already chose the right fit, and the research says why.** Investigated building a seeded code-bug corpus for pr-review (mirroring review-spec's one-mutation-per-fixture). Fresh evidence says don't: synthetic bugs are systematically EASIER than real (LLM detectors ~10.5% higher on synthetic Juliet than real-world; shortcut-learning leaks the label), "certified-clean" is far harder for a code diff than a BDD scenario (a latent pre-existing bug becomes false-alarm noise), the mutant→real-fault correlation is contested, and every 2026 code-review benchmark (SWR-Bench, entelligence) leans on golden-comments + a judge — not deterministic set-matching. **CWGYH0 independently landed on the right approach already** — real human-approved-zero-comment arcade PRs + human triage + a pre-registered bar — so NO new corpus ticket was cut (it would duplicate CWGYH0). **Thesis refinement:** the reusable, skill-agnostic asset is the GATING machinery — relative recall floor, multi-run ⌈2N/3⌉ consensus, Tier-2 real-harness gate, and the discipline (eval-first, GEPA-optional, never auto-adopt). "Seed defects into a certified-clean corpus + deterministic set-matching" is review-spec-SPECIFIC (BDD defects are cheap+exact to seed; code bugs are neither), NOT universal. So XZFSZ5 should generalize the FLOOR/CONSENSUS/Tier-2 seams — which CWGYH0's real-PR corpus CAN feed (human-triaged findings still support a floor + consensus + a pre-registered bar) — and drop the assumption that every skill gets a seeded corpus. Sources: synthetic-vs-real gap (arXiv 2512.22306), mutants-vs-faults (Just FSE'14), code-review benchmark survey (arXiv 2602.13377), GHRB contamination (arXiv 2310.13229).

--- a/.project/tickets/XZFSZ5-generalize-skill-eval-harness/ticket.md
+++ b/.project/tickets/XZFSZ5-generalize-skill-eval-harness/ticket.md
@@ -1,0 +1,37 @@
+---
+id: XZFSZ5
+slug: generalize-skill-eval-harness
+type: task
+phase: implement
+status: in_progress
+parent: 7ZLTWB
+depends_on: [21RAT9]
+scope:
+  - The METHODOLOGY as a durable, copyable asset — a playbook documenting the eval-driven discipline (eval-first; GEPA-optional; single-run adjudication is unreliable → multi-run consensus; relative recall FLOOR over baseline-reliable items, no composite headline; bare-model oversells → Tier-2 real-harness gate; never auto-adopt).
+  - review-spec's experiment (experiments/gepa-review-spec) as the REFERENCE IMPLEMENTATION a new seeded-corpus skill copies and adapts — concrete, with documented entry points, not prose.
+  - Extract shared CODE only at the THIRD seeded-corpus consumer (rule of three), and only the genuinely corpus-agnostic pieces (the Tier-2 `claude -p` runner shell is the first candidate).
+out_of_scope:
+  - Building a shared floor/consensus/scoring FRAMEWORK now — /figure-it-out 2026-07-24 (work log): at N=2 semantically-divergent evals that is the wrong abstraction. The floor's value is per-SEED (anti-gaming); it has no meaning on a corpus with no seeded item set, and genericizing it to aggregate-score regression degrades review-spec while misfitting pr-review.
+  - CWGYH0 as a harness consumer — pr-review's eval is a DIFFERENT shape (real human-approved-zero-comment PRs + human triage + a pre-registered bar, no seeding). It reuses the DISCIPLINE, not the seeded harness code.
+  - Building the pr-review corpus (CWGYH0's job). Re-optimizing review-spec (done in 21RAT9).
+done_when:
+  - A methodology playbook exists so a new skill onboards to the eval discipline without re-deriving the floor/consensus/Tier-2 design.
+  - review-spec's experiment is usable as a copyable reference implementation (documented entry points, not just source).
+  - The extraction trigger is recorded — at the third seeded-corpus skill, extract the shared seeded-gate then, not before.
+created: 2026-07-24T04:13:44.000Z
+last_modified: 2026-07-24T17:57:01.000Z
+---
+
+# Generalize the eval discipline for any skill — playbook + reference impl, not a premature framework
+
+**Goal:** Make the eval-driven-skill-optimization method reusable so any skill's prompt changes can be adjudicated by evidence — by capturing the METHODOLOGY (a playbook) and a copyable REFERENCE IMPLEMENTATION (review-spec's experiment), not by building a shared code framework two divergent evals would both fight.
+
+**Why this shape (reframed 2026-07-24, /figure-it-out):** the epic first assumed "parameterize the seeded harness so pr-review consumes it." But CWGYH0 (pr-review's eval) chose real-PR + human-triage, not seeding — a semantically different eval. The reusable asset across both is the DISCIPLINE, not the seeded floor/consensus code (whose per-seed anti-gaming value is intrinsically seeded-corpus-specific). Rule of three: extract shared code at the third seeded consumer, not the second. Duplication is cheaper than the wrong abstraction.
+
+**Riskiest assumption:** a documented playbook is enough to keep a future seeded-corpus skill from re-deriving (and drifting on) the floor/consensus lessons. Cheapest mitigation: ship review-spec's experiment as a concrete copyable reference with documented entry points, plus the explicit extract-at-three trigger.
+
+## Work Log
+
+- 2026-07-24 Created. The reusable-harness half of the eval-driven-skill-optimization epic. First consumer: pr-review (WAWQA6/CWGYH0).
+- 2026-07-24 **Reframed via /figure-it-out (B: playbook + reference impl, not a shared framework).** Evidence: eval frameworks (Braintrust/promptfoo) keep the regression gate at the abstract-score layer — exactly the layer where our per-SEED floor gives up its anti-gaming value; and rule-of-three / "duplication is cheaper than the wrong abstraction" (Metz) warns against abstracting N=2 semantically-divergent consumers. CWGYH0 uses real-PR + human-triage (no seeded set), so the floor/consensus has nothing to protect there — it is NOT a consumer of a shared seeded harness. Rewrote scope/done_when: deliver the methodology playbook + review-spec as a copyable reference impl; extract shared code only at the THIRD seeded-corpus skill (the Tier-2 runner the first candidate). Supersedes the original "parameterize the harness, zero review-spec-specific code" goal.
+- 2026-07-24T18:15:16.583Z Phase: intake → implement

--- a/.safeword/guides/llm-evals-guide.md
+++ b/.safeword/guides/llm-evals-guide.md
@@ -38,14 +38,15 @@ Agent chooses the right tool       → eval or trace eval
 The first matching row picks the approach (rows run cheapest/most-deterministic →
 most model-graded, which is also the tie-break order):
 
-| If…                                                                     | Approach                                          |
-| ----------------------------------------------------------------------- | ------------------------------------------------- |
-| a normal deterministic test can fully prove the behavior                | Use unit, integration, E2E, or migration coverage |
-| a deterministic eval assertion can prove part of the AI output contract | Add that assertion before any model-graded scorer |
-| there's a known correct output, label, or fact set                      | Reference-based evals                             |
-| comparing two outputs is easier than scoring one absolutely             | Pairwise evals                                    |
-| the desired quality is subjective but describable                       | Rubric-based LLM-as-judge evals                   |
-| the behavior involves multiple steps, tools, retrieval, or agents       | Trace or trajectory evals                         |
+| If…                                                                            | Approach                                                                                                   |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| a normal deterministic test can fully prove the behavior                       | Use unit, integration, E2E, or migration coverage                                                          |
+| a deterministic eval assertion can prove part of the AI output contract        | Add that assertion before any model-graded scorer                                                          |
+| there's a known correct output, label, or fact set                             | Reference-based evals                                                                                      |
+| you're optimizing a skill's _prompt_ and can seed one known defect per fixture | See `@.safeword/guides/skill-eval-optimization-guide.md` — relative recall floor + `⌈2N/3⌉` consensus gate |
+| comparing two outputs is easier than scoring one absolutely                    | Pairwise evals                                                                                             |
+| the desired quality is subjective but describable                              | Rubric-based LLM-as-judge evals                                                                            |
+| the behavior involves multiple steps, tools, retrieval, or agents              | Trace or trajectory evals                                                                                  |
 
 If none fit, write the missing acceptance criteria before creating the eval.
 Model-graded evals are powerful but add cost, latency, and grader failure modes.

--- a/.safeword/guides/skill-eval-optimization-guide.md
+++ b/.safeword/guides/skill-eval-optimization-guide.md
@@ -1,0 +1,130 @@
+# Skill-Eval Optimization Guide
+
+How to decide whether a change to a **skill's prompt** is actually better — by
+evidence, not taste. A seeded-defect corpus plus a regression gate adjudicate the
+change before it ships. Built and proven on `review-spec` (epic 7ZLTWB).
+
+**See:** `@.safeword/guides/llm-evals-guide.md` for evaluating AI features in
+general; **this** guide is the narrower method for optimizing a skill's _prompt_.
+`@.safeword/guides/llm-writing-guide.md` for prose principles.
+
+---
+
+## When to use this
+
+Reach for this method when all of these hold:
+
+- You want to change a skill's prompt (tighten, expand, compress, re-order) and
+  need to know the new version is better before shipping it to users.
+- The skill emits discrete **findings** (detections, flags, classifications) you
+  can seed known-good and known-bad cases for.
+- A defect can be **seeded deterministically** — take a clean input, introduce one
+  known flaw, and the mutation itself IS the label (no human or LLM judge needed).
+
+Do **not** use it when:
+
+- Quality is human-judgment-bound with **no seedable ground truth** — e.g. a PR
+  reviewer, where "is this a real defect worth a comment" needs a human. Seed
+  nothing; use a real corpus + human triage instead (see _When this doesn't fit_).
+- A normal deterministic test proves the behaviour faster (see the evals guide's
+  decision tree).
+
+---
+
+## The method (five parts)
+
+Each part answers a failure the one before it exposes.
+
+### 1. Certified-clean corpus + seeded defects
+
+Build fixtures from a **certified-clean** base (reviewed to contain zero real
+defects), introducing **one mutation per fixture** — the mutation operator IS the
+label. Score with **deterministic set-matching** (did the skill's findings match
+the seeded defect?), never an LLM judge — that sidesteps judge bias entirely. Keep
+two scores **decoupled** and never collapse them into one headline (an F1 is
+gameable): **recall** over seeded defects, and **false alarms** counted ONLY on
+certified-clean fixtures (precision over an under-labelled corpus is unidentifiable).
+
+### 2. Relative recall floor
+
+Don't require 100% recall — some defects the base model systematically misses, so
+an absolute floor is unsatisfiable. Protect only what the **baseline prompt reliably
+catches**: run the baseline k times, majority-vote (`⌈2k/3⌉`) the seeds it catches
+into a **protected set**, and reject a candidate only if it misses a protected seed.
+Systematically-missed seeds stay MEASURED but never gate. The floor is **per-seed**,
+not aggregate, on purpose — that is what stops a candidate trading real recall for a
+cleaner false-alarm number.
+
+### 3. Multi-run consensus gate
+
+A single run is too noisy to gate on — with no temperature set, default sampling
+makes even the baseline miss a protected seed ~⅓ of runs, so a one-run gate
+spuriously rejects good candidates. Run the candidate N times and require each
+protected seed caught on a **`⌈2N/3⌉` consensus** — the same supermajority that
+defined the floor.
+
+### 4. Tier-2 real-harness gate
+
+The bare-model API proxy **oversells** the gain — it runs the prompt in a clean,
+short context the real harness never has. Run the finalist through the real harness
+(`claude -p`, full system prompt + tools) as the honest ship gate. Measured on
+review-spec: a candidate's win shrank from −46% (proxy) to −34% (real harness) —
+still real, but the proxy inflated it.
+
+### 5. GEPA is optional
+
+A reflective prompt optimiser (GEPA) can PROPOSE candidates, but the eval is the
+gate, never the optimiser. On review-spec the raw GEPA winner was REJECTED — it
+dropped a real second defect ⅓ of the time to buy precision — and a
+**human-authored** candidate, informed by the eval's own findings, beat it. The
+optimiser serves the eval; it never replaces it.
+
+---
+
+## The discipline (what keeps it honest)
+
+- **Eval-first.** Build the eval before the prompt change — it is the source of
+  truth, not the logs and not the optimiser.
+- **Never auto-adopt a winner.** A passing candidate goes to a human before it
+  ships; inspect it for gaming (bloat, memorised fixtures, eval-shape exploits).
+- **No composite headline.** Report recall and false-alarms separately; a single
+  number is what an optimiser games.
+- **Read the log, not the exit code.** Wrapper and background exit codes lie; the
+  metric lives in the output.
+- **Certify every new fixture** (a paid run) before committing it — an
+  un-adjudicated "clean" base is a silent false-alarm source.
+
+---
+
+## When this method doesn't fit
+
+The floor and consensus gate need a **seeded item set** — a known list of defects to
+catch. A skill whose quality is human-judgment-bound (a PR reviewer: "is this worth a
+comment?") has no such set. There, seed nothing: use a corpus of **real,
+human-adjudicated** cases (e.g. PRs humans approved with zero comments), measure
+actionable-rate / coverage / false-certainty against a **bar recorded before triage**,
+and let humans — not the agent that built the skill — judge the findings. That is a
+different eval _shape_; it reuses this guide's **discipline** (decoupled metrics,
+pre-registered bar, never-auto-adopt), not its seeded machinery.
+
+---
+
+## Reference implementation
+
+`experiments/gepa-review-spec/` is the working review-spec eval — copy and adapt it
+for a new seeded-corpus skill. Its `README.md` documents the seams:
+
+- `src/dataset.ts` — load fixtures + train/test split
+- `src/task.ts` — run the skill prompt against one fixture (swap the vendor runner)
+- `src/evaluator.ts` — the deterministic set-matching metric
+- `src/protected.ts` — the relative floor + `⌈2N/3⌉` consensus
+- `validate-skill.ts` — the multi-run accept gate; `stability.ts` — variance probe
+- `compute-protected.ts` — build the protected-set manifest from k baseline runs
+
+## Reusing the code — rule of three
+
+Do **not** extract a shared framework for the second skill. Two seeded evals diverge
+(corpus, defect taxonomy, output contract), and a premature abstraction costs more
+than duplication. **Copy-adapt** the reference impl per skill; extract shared code
+only at the **third** seeded-corpus consumer. The Tier-2 `claude -p` runner is the
+first genuinely corpus-agnostic extraction candidate when that day comes.

--- a/experiments/gepa-review-spec/README.md
+++ b/experiments/gepa-review-spec/README.md
@@ -1,88 +1,58 @@
-# GEPA × `review-spec` — eval harness (research spike)
+# review-spec eval — reference implementation
 
-A behavioral eval for the `review-spec` skill, built so it can later drive a
-[GEPA](https://github.com/gepa-ai/gepa) prompt-optimization loop — and so it can
-later be lifted onto LangSmith or Arize Phoenix without a rewrite.
+The working eval that adjudicated review-spec's prompt (epic 7ZLTWB, hardened in
+21RAT9). This is the **copyable reference** for
+`.safeword/guides/skill-eval-optimization-guide.md`. To eval a new seeded-corpus
+skill, copy this directory and swap the corpus + defect taxonomy — do **not**
+extract a shared framework until a third skill needs one (rule of three).
 
-**Status:** Phases 1–5 run. 20 fixtures (12 train / 8 held-out) mutated from
-safeword's own `test-plan-resolver` and `formatter-aware-lint-hook` features. One
-GEPA run completed; its winner was **rejected** at review (it gamed the eval —
-see the ticket work log). Metric is decoupled recall vs false-alarms
-with **family-level** recall matching (see `evaluator.ts`). Baseline (Sonnet 4.6,
-temp 0): **family-recall 100%** on both splits; false alarms **1.50/clean-fixture**
-(train), **2.13/clean-fixture** (held-out) — so precision (over-flagging clean
-concrete-value Thens) is the sole GEPA target, behind a hard 100% recall floor.
-Phase 4 (the Python GEPA adapter) is next.
+**Isolation:** everything lives here under `experiments/`. No runtime dependency is
+added to `packages/cli`; the shipped skill is untouched. Delete this dir and nothing
+else changes.
 
-**Isolation:** everything lives here, under `experiments/`. No runtime
-dependency is added to `packages/cli`; the shipped `review-spec/SKILL.md` is
-untouched. Delete this directory and nothing else changes.
+## Seams (what to change per skill)
 
-## Why this exists
+| File / dir         | Role                                                                                             | Per-skill?                      |
+| ------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `fixtures/`        | `<name>.feature` + `<name>.expected.json` (32 pairs)                                             | **yes** — corpus                |
+| `src/types.ts`     | defect taxonomy (`DefectType`, `DEFAULT_SEVERITY`)                                               | **yes**                         |
+| `src/dataset.ts`   | load fixtures + train/test split                                                                 | mostly generic                  |
+| `src/task.ts`      | run the skill prompt over a fixture → `Detection[]`; vendor runners + the eval output contract   | generic (swap the contract)     |
+| `src/evaluator.ts` | deterministic set-matching metric — decoupled recall + false-alarms, family-level, no F1         | generic                         |
+| `src/protected.ts` | the relative recall floor + `⌈2N/3⌉` consensus                                                   | **generic — the reusable core** |
+| `src/harness.ts`   | composes dataset+task+evaluator, platform-agnostic; `src/adapters/` stubs LangSmith/Phoenix/GEPA | generic                         |
 
-GEPA optimizes text against a metric. Safeword has ~11,500 lines of prompts but
-no metric that scores prompt _behavior_. `review-spec` is the one skill whose
-output is objectively scoreable: seed a `.feature` file with known defects, then
-measure how many the skill catches. Ground truth is known because we injected
-it, so scoring is **deterministic set-matching — no LLM judge**, which dodges the
-judge-reliability problems that plague fuzzy evals.
-
-## The three seams
-
-The eval is split to match how LangSmith and Phoenix both model an eval
-(dataset + target/task + evaluator), so a platform adapter is a thin wrapper.
-
-| Seam          | File               | Role                                                                         |
-| ------------- | ------------------ | ---------------------------------------------------------------------------- |
-| **dataset**   | `src/dataset.ts`   | load `{ input: .feature, reference: labels }` fixtures + train/test split    |
-| **task**      | `src/task.ts`      | run a candidate prompt over a feature file → `Detection[]`                   |
-| **evaluator** | `src/evaluator.ts` | pure metric: family-level recall + false-alarm rate (no F1) + per-defect ASI |
-| harness       | `src/harness.ts`   | composes the three; platform-agnostic                                        |
-
-See `src/adapters/README.md` for how to drop in a LangSmith, Phoenix, or GEPA
-adapter against these seams.
-
-## Corpus
-
-`fixtures/<name>.feature` + `fixtures/<name>.expected.json`. Each defect is
-labeled with a `defectType` (mapped to a `review-spec` check), a `severity`, and
-a `scope` (`scenario` = pinned to one scenario; `fixture` = set-level, matched
-if reported anywhere in the file).
-
-20 fixtures, mostly built by the **certified-clean-base → single-mutation** pattern:
-excerpt a clean 3-scenario base from a real safeword `.feature`, then apply ONE
-semantic mutation operator (the operator IS the label). A fixture is
-`certifiedClean` when its base was adjudicated free of must-fix defects — only
-then does an unmatched must-fix detection count as a false alarm (on an ordinary
-positive it's `unlabeled`, never penalized, because the corpus isn't exhaustive).
-Recall is matched at the **defect-family** level so a defensible subtype swap
-(e.g. `vacuous-given-echo` for a `vacuous-trivially-true` seed) is a catch, not a
-double-penalty. The held-out (`test`) split uses a DISTINCT base
-(`formatter-aware-lint-hook`) GEPA never trains on.
-
-`rescore.ts <trace>` re-scores a saved `SAFEWORD_EVAL_TRACE=1` run with the
-current metric, token-free — handy for comparing GEPA candidates against a cached
-baseline without re-calling the API.
-
-## Running
-
-Unit tests (no API key, deterministic):
+## Entry points (all spend tokens — wrap with `op run`)
 
 ```bash
-npx vitest run --config experiments/gepa-review-spec/vitest.config.ts
+# Build the protected-set manifest from k baseline runs (once per model/corpus)
+SAFEWORD_EVAL_MODEL=claude-sonnet-5 bun compute-protected.ts 5 # → baseline-protected.json
+
+# Multi-run accept gate: seed vs candidate on the held-out split (the ship gate)
+bun validate-skill.ts gepa/candidate-lean.md 5 test # ACCEPT / REJECT (floor) + precision
+
+# Stability probe: per-fixture variance + which seeds flip (diagnosis, not a gate)
+bun stability.ts 3
+
+# GEPA optimizer (optional — proposes candidates; the gate decides)
+gepa/.venv/bin/python gepa/run.py --max-metric-calls 250
 ```
 
-Phase 3 baseline (spends tokens — scores the real skill):
+Unit tests (no key, deterministic): `npx vitest run` from this directory.
+`rescore.ts <trace>` re-scores a saved `SAFEWORD_EVAL_TRACE=1` run token-free.
 
-```bash
-ANTHROPIC_API_KEY=sk-... bun experiments/gepa-review-spec/src/baseline.ts
-```
+## Discipline (full list in the guide)
 
-## Next steps
+- The **eval is the gate**; GEPA only proposes. **Never auto-adopt a winner** —
+  review-spec's raw GEPA winner was REJECTED (it gamed the eval by dropping a real
+  second defect); a human-authored lean candidate beat it and shipped.
+- **Read the log, not the exit code** — wrapper/background exit codes lie.
+- **Certify every new fixture** (a paid run) before committing it.
+- Recall and false-alarms stay **decoupled** — no composite F1 headline.
 
-1. Run the baseline on the 3 seed fixtures; confirm auto-score matches a human
-   read. If parsing is noisy, tighten `EVAL_OUTPUT_CONTRACT` in `src/task.ts`
-   (the eval wrapper — never the shipped skill).
-2. Expand the corpus to ~20 fixtures, ideally via **mutation** of safeword's own
-   shipping `.feature` files (the mutation operator is the ground-truth label).
-3. Phase 4: a Python GEPA adapter that calls this harness as its metric.
+## Not for every skill
+
+The floor + consensus need a **seeded item set**. A human-judgment-bound skill (e.g.
+pr-review) has none — it uses a real-corpus + human-triage eval instead
+(WAWQA6/CWGYH0), a different _shape_ that reuses only the discipline, not this
+machinery.

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -873,6 +873,9 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     '.safeword/guides/planning-guide.md': {
       template: 'guides/planning-guide.md',
     },
+    '.safeword/guides/skill-eval-optimization-guide.md': {
+      template: 'guides/skill-eval-optimization-guide.md',
+    },
     '.safeword/guides/testing-guide.md': {
       template: 'guides/testing-guide.md',
     },

--- a/packages/cli/templates/guides/llm-evals-guide.md
+++ b/packages/cli/templates/guides/llm-evals-guide.md
@@ -38,14 +38,15 @@ Agent chooses the right tool       → eval or trace eval
 The first matching row picks the approach (rows run cheapest/most-deterministic →
 most model-graded, which is also the tie-break order):
 
-| If…                                                                     | Approach                                          |
-| ----------------------------------------------------------------------- | ------------------------------------------------- |
-| a normal deterministic test can fully prove the behavior                | Use unit, integration, E2E, or migration coverage |
-| a deterministic eval assertion can prove part of the AI output contract | Add that assertion before any model-graded scorer |
-| there's a known correct output, label, or fact set                      | Reference-based evals                             |
-| comparing two outputs is easier than scoring one absolutely             | Pairwise evals                                    |
-| the desired quality is subjective but describable                       | Rubric-based LLM-as-judge evals                   |
-| the behavior involves multiple steps, tools, retrieval, or agents       | Trace or trajectory evals                         |
+| If…                                                                            | Approach                                                                                                   |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| a normal deterministic test can fully prove the behavior                       | Use unit, integration, E2E, or migration coverage                                                          |
+| a deterministic eval assertion can prove part of the AI output contract        | Add that assertion before any model-graded scorer                                                          |
+| there's a known correct output, label, or fact set                             | Reference-based evals                                                                                      |
+| you're optimizing a skill's _prompt_ and can seed one known defect per fixture | See `@.safeword/guides/skill-eval-optimization-guide.md` — relative recall floor + `⌈2N/3⌉` consensus gate |
+| comparing two outputs is easier than scoring one absolutely                    | Pairwise evals                                                                                             |
+| the desired quality is subjective but describable                              | Rubric-based LLM-as-judge evals                                                                            |
+| the behavior involves multiple steps, tools, retrieval, or agents              | Trace or trajectory evals                                                                                  |
 
 If none fit, write the missing acceptance criteria before creating the eval.
 Model-graded evals are powerful but add cost, latency, and grader failure modes.

--- a/packages/cli/templates/guides/skill-eval-optimization-guide.md
+++ b/packages/cli/templates/guides/skill-eval-optimization-guide.md
@@ -1,0 +1,130 @@
+# Skill-Eval Optimization Guide
+
+How to decide whether a change to a **skill's prompt** is actually better — by
+evidence, not taste. A seeded-defect corpus plus a regression gate adjudicate the
+change before it ships. Built and proven on `review-spec` (epic 7ZLTWB).
+
+**See:** `@.safeword/guides/llm-evals-guide.md` for evaluating AI features in
+general; **this** guide is the narrower method for optimizing a skill's _prompt_.
+`@.safeword/guides/llm-writing-guide.md` for prose principles.
+
+---
+
+## When to use this
+
+Reach for this method when all of these hold:
+
+- You want to change a skill's prompt (tighten, expand, compress, re-order) and
+  need to know the new version is better before shipping it to users.
+- The skill emits discrete **findings** (detections, flags, classifications) you
+  can seed known-good and known-bad cases for.
+- A defect can be **seeded deterministically** — take a clean input, introduce one
+  known flaw, and the mutation itself IS the label (no human or LLM judge needed).
+
+Do **not** use it when:
+
+- Quality is human-judgment-bound with **no seedable ground truth** — e.g. a PR
+  reviewer, where "is this a real defect worth a comment" needs a human. Seed
+  nothing; use a real corpus + human triage instead (see _When this doesn't fit_).
+- A normal deterministic test proves the behaviour faster (see the evals guide's
+  decision tree).
+
+---
+
+## The method (five parts)
+
+Each part answers a failure the one before it exposes.
+
+### 1. Certified-clean corpus + seeded defects
+
+Build fixtures from a **certified-clean** base (reviewed to contain zero real
+defects), introducing **one mutation per fixture** — the mutation operator IS the
+label. Score with **deterministic set-matching** (did the skill's findings match
+the seeded defect?), never an LLM judge — that sidesteps judge bias entirely. Keep
+two scores **decoupled** and never collapse them into one headline (an F1 is
+gameable): **recall** over seeded defects, and **false alarms** counted ONLY on
+certified-clean fixtures (precision over an under-labelled corpus is unidentifiable).
+
+### 2. Relative recall floor
+
+Don't require 100% recall — some defects the base model systematically misses, so
+an absolute floor is unsatisfiable. Protect only what the **baseline prompt reliably
+catches**: run the baseline k times, majority-vote (`⌈2k/3⌉`) the seeds it catches
+into a **protected set**, and reject a candidate only if it misses a protected seed.
+Systematically-missed seeds stay MEASURED but never gate. The floor is **per-seed**,
+not aggregate, on purpose — that is what stops a candidate trading real recall for a
+cleaner false-alarm number.
+
+### 3. Multi-run consensus gate
+
+A single run is too noisy to gate on — with no temperature set, default sampling
+makes even the baseline miss a protected seed ~⅓ of runs, so a one-run gate
+spuriously rejects good candidates. Run the candidate N times and require each
+protected seed caught on a **`⌈2N/3⌉` consensus** — the same supermajority that
+defined the floor.
+
+### 4. Tier-2 real-harness gate
+
+The bare-model API proxy **oversells** the gain — it runs the prompt in a clean,
+short context the real harness never has. Run the finalist through the real harness
+(`claude -p`, full system prompt + tools) as the honest ship gate. Measured on
+review-spec: a candidate's win shrank from −46% (proxy) to −34% (real harness) —
+still real, but the proxy inflated it.
+
+### 5. GEPA is optional
+
+A reflective prompt optimiser (GEPA) can PROPOSE candidates, but the eval is the
+gate, never the optimiser. On review-spec the raw GEPA winner was REJECTED — it
+dropped a real second defect ⅓ of the time to buy precision — and a
+**human-authored** candidate, informed by the eval's own findings, beat it. The
+optimiser serves the eval; it never replaces it.
+
+---
+
+## The discipline (what keeps it honest)
+
+- **Eval-first.** Build the eval before the prompt change — it is the source of
+  truth, not the logs and not the optimiser.
+- **Never auto-adopt a winner.** A passing candidate goes to a human before it
+  ships; inspect it for gaming (bloat, memorised fixtures, eval-shape exploits).
+- **No composite headline.** Report recall and false-alarms separately; a single
+  number is what an optimiser games.
+- **Read the log, not the exit code.** Wrapper and background exit codes lie; the
+  metric lives in the output.
+- **Certify every new fixture** (a paid run) before committing it — an
+  un-adjudicated "clean" base is a silent false-alarm source.
+
+---
+
+## When this method doesn't fit
+
+The floor and consensus gate need a **seeded item set** — a known list of defects to
+catch. A skill whose quality is human-judgment-bound (a PR reviewer: "is this worth a
+comment?") has no such set. There, seed nothing: use a corpus of **real,
+human-adjudicated** cases (e.g. PRs humans approved with zero comments), measure
+actionable-rate / coverage / false-certainty against a **bar recorded before triage**,
+and let humans — not the agent that built the skill — judge the findings. That is a
+different eval _shape_; it reuses this guide's **discipline** (decoupled metrics,
+pre-registered bar, never-auto-adopt), not its seeded machinery.
+
+---
+
+## Reference implementation
+
+`experiments/gepa-review-spec/` is the working review-spec eval — copy and adapt it
+for a new seeded-corpus skill. Its `README.md` documents the seams:
+
+- `src/dataset.ts` — load fixtures + train/test split
+- `src/task.ts` — run the skill prompt against one fixture (swap the vendor runner)
+- `src/evaluator.ts` — the deterministic set-matching metric
+- `src/protected.ts` — the relative floor + `⌈2N/3⌉` consensus
+- `validate-skill.ts` — the multi-run accept gate; `stability.ts` — variance probe
+- `compute-protected.ts` — build the protected-set manifest from k baseline runs
+
+## Reusing the code — rule of three
+
+Do **not** extract a shared framework for the second skill. Two seeded evals diverge
+(corpus, defect taxonomy, output contract), and a premature abstraction costs more
+than duplication. **Copy-adapt** the reference impl per skill; extract shared code
+only at the **third** seeded-corpus consumer. The Tier-2 `claude -p` runner is the
+first genuinely corpus-agnostic extraction candidate when that day comes.


### PR DESCRIPTION
## What

Generalizes the eval-driven-skill-optimization method (epic 7ZLTWB, proven on review-spec in 21RAT9) as a **methodology playbook** — not a shared code framework.

- **New guide** `.safeword/guides/skill-eval-optimization-guide.md` (byte-parity template↔dogfood, schema-registered): the 5-part method — certified-clean seeded corpus, relative recall floor, ⌈2N/3⌉ multi-run consensus gate, Tier-2 real-harness gate, GEPA-optional — plus the discipline and **when it does NOT fit** (human-judgment-bound skills → real-corpus + human-triage eval).
- **Cross-linked** from `llm-evals-guide.md`'s decision tree.
- **`experiments/gepa-review-spec/README.md`** rewritten as the copyable reference implementation (the seams a new seeded-corpus skill swaps).
- Brings the **7ZLTWB epic + XZFSZ5 ticket** to main (fixes the orphan parent left on 21RAT9/M3SI7T by #1398).

## Why a playbook, not a framework

`/figure-it-out`: at N=2 semantically-divergent evals, duplication beats the wrong abstraction (rule of three). The floor/consensus need a *seeded item set*; pr-review's eval (CWGYH0) has none — it uses real human-approved PRs + human triage, a **distinct shape** that reuses only the discipline. Extract shared code at the *third* seeded consumer, not before.

## Verification

- Full suite: **5360 passed / 5 skipped**, build ✓, typecheck ✓.
- Independent `/quality-review`: **APPROVE, no criticals** — every claim (−46%/−34% proxy-vs-harness, ⌈2k/3⌉ thresholds, GEPA-winner-rejected) corroborated against code + ticket artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)