### PR TITLE
Keep Codex Desktop proof session-bound

### DIFF
--- a/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/test-definitions.md
+++ b/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/test-definitions.md
@@ -1,0 +1,29 @@
+# Test definitions — S2CWBE
+
+## Guarded Codex Desktop session fallback
+
+- [x] RED: the shared run-identity resolver initially left `sessionKey` null
+  despite a non-empty `CODEX_THREAD_ID`.
+- [x] GREEN: the shared run-identity resolver recognizes a non-empty
+  `CODEX_THREAD_ID` as a Codex session only when no input `session_id` is
+  available, and never uses `turn_id` as that session.
+- [x] REFACTOR: preserve explicit-runtime behavior so Claude and Cursor do not
+  adopt the Codex environment variable.
+
+## Proof bridge precedence
+
+- [x] RED: the real installed invocation helper reported `no run identity` when
+  its cache was absent even though `CODEX_THREAD_ID` was present; review-stamp
+  also incorrectly chose that fallback ahead of a fresh Codex cache identity.
+- [x] GREEN: the helper records a proof with `CODEX_THREAD_ID` after cache
+  miss, and a fresh Codex cache identity wins when both are available.
+- [x] REFACTOR: retain the existing ordered cache queue and its expired,
+  out-of-order, foreign-path, and no-identity rejection coverage.
+
+## Stop-state consistency
+
+- [x] RED: a real Codex Stop invocation with no payload `session_id` left its
+  thread-bound ticket in progress despite `CODEX_THREAD_ID`.
+- [x] GREEN: the same invocation resolves only that thread-bound session and
+  preserves existing Stop behavior.
+- [x] REFACTOR: template and dogfood surfaces remain byte-aligned.

--- a/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/ticket.md
+++ b/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/ticket.md
@@ -1,0 +1,64 @@
+---
+id: S2CWBE
+slug: codex-desktop-session-proof-fallback
+type: task
+phase: implement
+status: in_progress
+scope:
+  - Restore current-session proof recording in Codex Desktop code-mode when its PreToolUse cache bridge did not arm.
+  - Use the runtime-provided CODEX_THREAD_ID only as a Codex session-identity fallback after explicit and fresh bridged identities are unavailable.
+  - Keep Codex Stop able to resolve the same session binding when its payload omits session_id.
+out_of_scope:
+  - Changing the Codex PreToolUse matcher, weakening the done gate, or treating turn_id as a durable session identity.
+  - Inventing a fixed session id, accepting CODEX_THREAD_ID for Claude or Cursor, or changing existing cache expiry and ordering semantics.
+  - Repairing the Codex Desktop hook dispatcher; its missing bridge delivery remains an upstream runtime observation.
+done_when:
+  - Codex Desktop proof helpers log CODEX_THREAD_ID only when explicit and fresh bridge identities are absent.
+  - A fresh Codex bridge identity remains authoritative over CODEX_THREAD_ID.
+  - Codex Stop resolves the same thread identity when a Stop payload lacks session_id.
+  - Template and dogfood hook copies remain synchronized, with focused behavioral regression evidence.
+created: 2026-07-24T23:01:29.838Z
+last_modified: 2026-07-25T00:12:00Z
+---
+
+# Keep Codex Desktop proof session-bound
+
+**Goal:** Let Codex Desktop record quality proof when its PreToolUse cache bridge is unavailable.
+
+**Why:** Desktop code-mode exposes CODEX_THREAD_ID while the documented cache bridge does not arm, leaving verified work without session-scoped proof.
+
+## User Story
+
+See [user-stories.md](./user-stories.md) for the user-visible behavior and acceptance criteria.
+
+## Test Definitions
+
+See [test-definitions.md](./test-definitions.md) for the RED/GREEN/REFACTOR ledger.
+
+## Figure-It-Out Decision
+
+**Frame:** Bind Safeword feature-skill proof in Codex Desktop code-mode when the
+documented PreToolUse cache bridge does not arm.
+
+**Decision:** Keep the cache bridge as the preferred path. After explicit
+arguments, Claude identity, and fresh Codex/Cursor bridge entries have all
+failed, let the shared run-identity resolver use a non-empty
+`CODEX_THREAD_ID` as a Codex session key. It must never use `turn_id` as the
+fallback, and callers that explicitly select Claude or Cursor keep their own
+identity rules.
+
+**Why:** The live Desktop environment exposes `CODEX_THREAD_ID`, and Safeword
+already treats it as session-stable for Codex retro state. The fallback restores
+proof and session-bound Stop behavior without pretending the cache bridge
+delivered an identity.
+
+## Work Log
+
+- 2026-07-24T23:01:29.838Z Started: Created ticket S2CWBE
+- 2026-07-24T23:02:31Z Revalidated: the earlier Codex bridge ticket covers the documented hook-to-helper cache path, but this Desktop code-mode run produces no cache while exposing CODEX_THREAD_ID. The missing bridge delivery is still relevant.
+- 2026-07-24T23:02:31Z Scoped: selected a cache-last CODEX_THREAD_ID fallback, constrained to the Codex runtime and the shared resolver so recorder, review stamp, and Codex Stop agree on one session key.
+- 2026-07-24T23:07:21Z RED: focused resolver, real invocation-helper, review-stamp, and Codex Stop tests failed as expected. Each currently sees no durable identity when only CODEX_THREAD_ID is available; Stop leaves the bound ticket in progress.
+- 2026-07-24T23:20:22Z RED: quality review found review-stamp let CODEX_THREAD_ID override a fresh Codex bridge cache identity.
+- 2026-07-24T23:20:49Z GREEN: made the bridge authoritative over the environment fallback while retaining Claude's direct identity precedence; the two Codex Desktop review-stamp regressions pass.
+- 2026-07-24T23:25:00Z Validated: focused resolver, proof-helper, review-stamp, and Stop tests pass; lint, typecheck, build, parity, and diff checks pass. Fresh quality review approved the corrected precedence.
+- 2026-07-25T00:12:00Z REFACTOR evidence: the full existing ordered proof-bridge cache suites pass (28 invocation-helper and 34 review-stamp bridge tests), covering expiry, ordering, foreign paths, and missing identity. The complete S2CWBE ledger is now green.

--- a/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/user-stories.md
+++ b/.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/user-stories.md
@@ -1,0 +1,21 @@
+# User stories — S2CWBE
+
+## Keep Codex Desktop proof attached to the current thread
+
+As a Safeword maintainer working in Codex Desktop code-mode, I want quality
+skills to record proof against my current Desktop thread when hook delivery does
+not create a bridge receipt, so that a completed feature is not blocked by a
+false missing-proof error.
+
+### Acceptance criteria
+
+- Given no explicit identity, no Claude identity, and no fresh Codex or Cursor
+  bridge entry, when the helper runs with a non-empty `CODEX_THREAD_ID`, then it
+  records proof under that thread id as a Codex session.
+- Given a fresh Codex bridge entry and `CODEX_THREAD_ID`, when the helper runs,
+  then it records proof under the bridge entry, not the environment fallback.
+- Given a Codex Stop payload without `session_id` and the same
+  `CODEX_THREAD_ID`, when Stop checks the active ticket, then it uses the
+  session binding for that thread only.
+- Given no usable identity, then no proof record is written and no unknown or
+  turn-derived session is invented.

--- a/.safeword/hooks/lib/run-identity.ts
+++ b/.safeword/hooks/lib/run-identity.ts
@@ -74,6 +74,12 @@ function detectRuntime(
   ) {
     return 'claude';
   }
+  // Codex Desktop code-mode can omit a hook payload while exposing a stable
+  // thread id to its helper process. Keep this after Claude detection so an
+  // explicit Claude environment never adopts a Codex runtime accidentally.
+  if (nonEmptyString(env.CODEX_THREAD_ID) !== null) {
+    return 'codex';
+  }
   return 'unknown';
 }
 
@@ -96,7 +102,12 @@ export function resolveRunIdentity(
   }
 
   if (runtime === 'codex') {
-    const session = firstString('input.session_id', input.session_id);
+    const session = firstString(
+      'input.session_id',
+      input.session_id,
+      'CODEX_THREAD_ID',
+      env.CODEX_THREAD_ID,
+    );
     return {
       runtime,
       sessionKey: session?.value ?? null,

--- a/.safeword/hooks/write-review-stamp.ts
+++ b/.safeword/hooks/write-review-stamp.ts
@@ -72,9 +72,12 @@ function readBridgedRunIdentity(): RunIdentity | undefined {
 
 const environmentIdentity = resolveRunIdentity({}, { env: process.env });
 const runIdentity =
-  environmentIdentity.sessionKey === null
-    ? (readBridgedRunIdentity() ?? environmentIdentity)
-    : environmentIdentity;
+  // Claude exposes its session to this helper directly. Codex Desktop's
+  // CODEX_THREAD_ID is a cache-miss fallback, so a fresh pre-tool bridge must
+  // still win when one is available.
+  environmentIdentity.runtime === 'claude' && environmentIdentity.sessionKey !== null
+    ? environmentIdentity
+    : (readBridgedRunIdentity() ?? environmentIdentity);
 const sessionId = runIdentity.sessionKey ?? fail('missing run identity for review stamp');
 
 // Collapse all whitespace (incl. newlines) to single spaces. The log is one

--- a/.safeword/logs/ticket-S2CWBE-codex-desktop-session-proof-fallback.md
+++ b/.safeword/logs/ticket-S2CWBE-codex-desktop-session-proof-fallback.md
@@ -1,0 +1,26 @@
+# Work Log: Keep Codex Desktop proof session-bound
+
+**Anchored to:** `.project/tickets/S2CWBE-codex-desktop-session-proof-fallback/ticket.md`
+
+## Session: 2026-07-24
+
+- [23:01] Revalidated the live failure: this Desktop code-mode process has a
+  stable `CODEX_THREAD_ID`, but no Codex identity cache is written before
+  `/quality-review`, `/verify`, or `/audit` invokes the proof helper.
+- [23:02] Ruled out the configured matcher: the project matches `Bash`, which
+  is the documented mapping for shell execution. Existing bridge tests cover a
+  simulated hook payload; they do not prove this Desktop wrapper delivers one.
+- [23:02] Decision: preserve the cache as authoritative, then use only
+  `CODEX_THREAD_ID` as a guarded Codex fallback. Keep `turn_id` excluded.
+- [23:07] RED: the resolver returns `sessionKey: null`; the real helper reports
+  `no run identity`; the real review stamp exits with missing identity; and
+  Codex Stop leaves the matching desktop-thread ticket in progress.
+- [23:20] Quality review found that review-stamp read CODEX_THREAD_ID before a
+  fresh bridge cache. Added a regression, watched it fail, then made fresh
+  bridge identity win while Claude's directly exposed identity remains first.
+- [23:25] Focused resolver, invocation-helper, review-stamp, and Stop tests
+  pass. Parity, ESLint, Gherkin lint, TypeScript typecheck, package build, and
+  diff checks pass. Fresh quality review approved the corrected precedence.
+- [00:12] Confirmed the existing cache hardening remains intact: the complete
+  invocation-helper (28) and review-stamp bridge (34) suites pass, including
+  expired, out-of-order, foreign-path, and no-identity cases.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -533,6 +533,15 @@ Published files: `dist/` + `templates/` (bundled for setup/upgrade) + `codex-plu
 
 **Cross-agent Stop delivery (JN403D/P30CRP):** Claude Code keeps the hard done-gate/review behavior in `stop-quality.ts`. Cursor uses a lighter local Stop adapter for continuation nudges (`cursor/stop.ts` appends `followup_message`). Codex uses the profile-scoped Safe Word plugin, whose hook manifest calls the packaged, version-pinned `bunx --bun safeword@<version> hook codex stop` entrypoint. It emits Codex continuation output (`decision: "block"`, `reason`) from queued project context. Codex Stop delivery is advisory continuation, not hard done-gate enforcement.
 
+**Codex Desktop session identity (S2CWBE):** Hook payload `session_id` and a
+fresh Codex proof-bridge cache remain the preferred sources. When Codex Desktop
+code-mode does not deliver the documented PreToolUse bridge, the shared
+run-identity resolver may use non-empty `CODEX_THREAD_ID` as a Codex-only,
+session-stable fallback. This comes after explicit and cached identities, never
+uses `turn_id`, and is unavailable to explicit Claude and Cursor callers. The
+single resolver is shared by invocation proof, review-stamp session binding,
+and Codex Stop so all three address the same state key.
+
 **Gate clearing:** All gates clear automatically when `git rev-parse --short HEAD` changes (i.e., a commit happened). No manual intervention needed. TDD gates have priority over LOC gate (LOC gate cannot overwrite an active TDD gate).
 
 ### Frozen Transcript Fixture Testing

--- a/packages/cli/templates/hooks/lib/run-identity.ts
+++ b/packages/cli/templates/hooks/lib/run-identity.ts
@@ -74,6 +74,12 @@ function detectRuntime(
   ) {
     return 'claude';
   }
+  // Codex Desktop code-mode can omit a hook payload while exposing a stable
+  // thread id to its helper process. Keep this after Claude detection so an
+  // explicit Claude environment never adopts a Codex runtime accidentally.
+  if (nonEmptyString(env.CODEX_THREAD_ID) !== null) {
+    return 'codex';
+  }
   return 'unknown';
 }
 
@@ -96,7 +102,12 @@ export function resolveRunIdentity(
   }
 
   if (runtime === 'codex') {
-    const session = firstString('input.session_id', input.session_id);
+    const session = firstString(
+      'input.session_id',
+      input.session_id,
+      'CODEX_THREAD_ID',
+      env.CODEX_THREAD_ID,
+    );
     return {
       runtime,
       sessionKey: session?.value ?? null,

--- a/packages/cli/templates/hooks/write-review-stamp.ts
+++ b/packages/cli/templates/hooks/write-review-stamp.ts
@@ -72,9 +72,12 @@ function readBridgedRunIdentity(): RunIdentity | undefined {
 
 const environmentIdentity = resolveRunIdentity({}, { env: process.env });
 const runIdentity =
-  environmentIdentity.sessionKey === null
-    ? (readBridgedRunIdentity() ?? environmentIdentity)
-    : environmentIdentity;
+  // Claude exposes its session to this helper directly. Codex Desktop's
+  // CODEX_THREAD_ID is a cache-miss fallback, so a fresh pre-tool bridge must
+  // still win when one is available.
+  environmentIdentity.runtime === 'claude' && environmentIdentity.sessionKey !== null
+    ? environmentIdentity
+    : (readBridgedRunIdentity() ?? environmentIdentity);
 const sessionId = runIdentity.sessionKey ?? fail('missing run identity for review stamp');
 
 // Collapse all whitespace (incl. newlines) to single spaces. The log is one

--- a/packages/cli/tests/hooks/run-identity.test.ts
+++ b/packages/cli/tests/hooks/run-identity.test.ts
@@ -31,6 +31,63 @@ describe('run identity normalization (WHFTDK)', () => {
     expect(getRunStorageKey(identity)).toBe('codex-codex-session');
   });
 
+  it('falls back to CODEX_THREAD_ID as a Codex session when the payload omits session_id', () => {
+    const identity = resolveRunIdentity(
+      { turn_id: 'per-turn-id' },
+      { runtime: 'codex', env: { CODEX_THREAD_ID: 'desktop-thread' } },
+    );
+
+    expect(identity).toEqual({
+      runtime: 'codex',
+      sessionKey: 'desktop-thread',
+      turnKey: 'per-turn-id',
+      source: 'CODEX_THREAD_ID',
+    });
+    expect(getRunStorageKey(identity)).toBe('codex-desktop-thread');
+  });
+
+  it('keeps a Codex payload session_id ahead of CODEX_THREAD_ID', () => {
+    const identity = resolveRunIdentity(
+      { session_id: 'hook-session' },
+      { runtime: 'codex', env: { CODEX_THREAD_ID: 'desktop-thread' } },
+    );
+
+    expect(identity.sessionKey).toBe('hook-session');
+    expect(identity.source).toBe('input.session_id');
+  });
+
+  it('does not treat a Codex turn id as a session when no durable identity is available', () => {
+    const identity = resolveRunIdentity({ turn_id: 'per-turn-id' }, { runtime: 'codex', env: {} });
+
+    expect(identity.sessionKey).toBeNull();
+    expect(identity.turnKey).toBe('per-turn-id');
+    expect(identity.source).toBe('missing');
+  });
+
+  it('does not let CODEX_THREAD_ID override an explicitly selected non-Codex runtime', () => {
+    const identity = resolveRunIdentity(
+      {},
+      { runtime: 'claude', env: { CODEX_THREAD_ID: 'desktop-thread' } },
+    );
+
+    expect(identity.runtime).toBe('claude');
+    expect(identity.sessionKey).toBeNull();
+    expect(identity.turnKey).toBeNull();
+    expect(identity.source).toBe('missing');
+  });
+
+  it('keeps a detected Claude environment ahead of CODEX_THREAD_ID', () => {
+    const identity = resolveRunIdentity(
+      {},
+      {
+        env: { CLAUDE_SESSION_ID: 'claude-session', CODEX_THREAD_ID: 'desktop-thread' },
+      },
+    );
+
+    expect(identity.runtime).toBe('claude');
+    expect(identity.sessionKey).toBe('claude-session');
+  });
+
   it('normalizes Cursor conversation_id and generation_id into durable and turn keys', () => {
     const identity = resolveRunIdentity({
       conversation_id: 'cursor-conversation',

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -181,6 +181,34 @@ describe('Codex/Cursor skill-invocation fallback → done-gate E2E (#295)', () =
     expect(result.stdout).not.toContain('Required skill invocation');
   });
 
+  it('records proof from CODEX_THREAD_ID when Codex Desktop did not create a bridge cache (S2CWBE)', () => {
+    const sessionId = 'codex-desktop-thread-no-cache';
+    const before = logContents(projectDirectory);
+
+    const result = runFallback(projectDirectory, 'verify', '', { CODEX_THREAD_ID: sessionId });
+
+    expect(result.exitCode, result.output).toBe(0);
+    expect(result.output).toContain('verify ✓');
+    const after = logContents(projectDirectory);
+    expect(after.startsWith(before)).toBe(true);
+    expect(after).toContain(`${sessionId} verify`);
+  });
+
+  it('keeps a fresh Codex bridge identity ahead of CODEX_THREAD_ID (S2CWBE)', () => {
+    const bridgeSessionId = 'codex-bridge-wins';
+    const environmentSessionId = 'codex-desktop-thread-loses';
+    bindCodexSession(projectDirectory, 'audit', bridgeSessionId);
+
+    const result = runFallback(projectDirectory, 'audit', '', {
+      CODEX_THREAD_ID: environmentSessionId,
+    });
+
+    expect(result.exitCode, result.output).toBe(0);
+    expect(result.output).toContain('audit ✓');
+    expect(logContents(projectDirectory)).toContain(`${bridgeSessionId} audit`);
+    expect(logContents(projectDirectory)).not.toContain(`${environmentSessionId} audit`);
+  });
+
   it('feature done PASSES when Cursor binds the supported relative helper command', () => {
     writeFeatureTicketAtDone(projectDirectory, '953');
     const conversationId = 'cursor-session-953';

--- a/packages/cli/tests/integration/review-stamp.test.ts
+++ b/packages/cli/tests/integration/review-stamp.test.ts
@@ -26,6 +26,10 @@ const CURSOR_BEFORE_SHELL_PATH = nodePath.resolve(
   __dirname,
   '../../templates/hooks/cursor/before-shell-execution.ts',
 );
+const CODEX_PRE_TOOL_PATH = nodePath.resolve(
+  __dirname,
+  '../../templates/hooks/codex/pre-tool-quality.ts',
+);
 const TICKET_ID = 'ABC123';
 
 const TICKET_FRONTMATTER = [
@@ -79,6 +83,20 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
     delete env.CLAUDE_SESSION_ID;
     delete env.CLAUDE_CODE_SESSION_ID;
     delete env.CODEX_THREAD_ID;
+
+    const result = spawnSync('bun', [STAMP_PATH, ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  function runStampWithCodexDesktopThread(threadId: string, ...args: string[]): HookResult {
+    const env: NodeJS.ProcessEnv = { ...process.env, CLAUDE_PROJECT_DIR: projectRoot };
+    delete env.CLAUDE_SESSION_ID;
+    delete env.CLAUDE_CODE_SESSION_ID;
+    env.CODEX_THREAD_ID = threadId;
 
     const result = spawnSync('bun', [STAMP_PATH, ...args], {
       encoding: 'utf8',
@@ -442,10 +460,25 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
       });
     }
 
-    function bindRuntimeSessionTicket(storageKey: string): void {
+    function runCodexPreTool(sessionId: string): void {
+      const result = spawnSync('bun', [CODEX_PRE_TOOL_PATH], {
+        cwd: projectRoot,
+        input: JSON.stringify({
+          session_id: sessionId,
+          tool_name: 'Bash',
+          tool_input: { command: STAMP_COMMAND },
+        }),
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_PROJECT_DIR: projectRoot },
+      });
+      expect(result.status).toBe(0);
+    }
+
+    function bindRuntimeSessionTicket(storageKey: string, ticketId: string = TICKET_ID): void {
       writeFileSync(
         nodePath.join(projectRoot, '.safeword-project', `quality-state-${storageKey}.json`),
-        JSON.stringify({ activeTicket: TICKET_ID }),
+        JSON.stringify({ activeTicket: ticketId }),
       );
     }
 
@@ -455,6 +488,31 @@ describe('NMSD94 stamp-earning step (write-review-stamp.ts)', () => {
 
       runCursorBeforeShell('conv-1');
       const stamp = runStampWithoutRuntimeIdentity('spec');
+
+      expect(stamp.status).toBe(0);
+      expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+    });
+
+    it('Codex Desktop: CODEX_THREAD_ID resolves the Codex-bound session ticket without a bridge cache (S2CWBE)', () => {
+      createSecondTicket();
+      const threadId = 'desktop-thread';
+      bindRuntimeSessionTicket(`codex-${threadId}`);
+
+      const stamp = runStampWithCodexDesktopThread(threadId, 'spec');
+
+      expect(stamp.status).toBe(0);
+      expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);
+    });
+
+    it('Codex Desktop: a fresh bridge identity wins over CODEX_THREAD_ID (S2CWBE)', () => {
+      createSecondTicket();
+      const bridgeSessionId = 'bridge-session';
+      const environmentThreadId = 'desktop-thread';
+      bindRuntimeSessionTicket(`codex-${bridgeSessionId}`);
+      bindRuntimeSessionTicket(`codex-${environmentThreadId}`, 'XYZ789');
+
+      runCodexPreTool(bridgeSessionId);
+      const stamp = runStampWithCodexDesktopThread(environmentThreadId, 'spec');
 
       expect(stamp.status).toBe(0);
       expect(readLog()).toContain(`review:${reviewScope(TICKET_ID, 'spec', hashArtifact(SPEC))}`);


### PR DESCRIPTION
## What changed

Adds a guarded Codex Desktop fallback to `CODEX_THREAD_ID` when hook payload and fresh proof-bridge identity are unavailable. Fresh bridge identity and direct Claude identity remain authoritative; `turn_id` is never promoted to a session identity.

## Why

Desktop code-mode exposes a stable thread ID while its documented PreToolUse cache bridge can be absent, leaving real quality work without session-scoped proof.

## Validation

- `bun run lint`
- `bun run test tests/hooks/run-identity.test.ts tests/hooks/review-stamp-bridge.test.ts tests/integration/codex-cursor-skill-fallback.test.ts tests/integration/review-stamp.test.ts` (69 passed)
- `bun scripts/parity-check.ts --check`

## Scope

S2CWBE only; QRX2DN remains in its existing draft PR #1404.