### PR TITLE
feat(pre-commit): auto-heal template→mirror drift at commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -54,6 +54,32 @@ fi
 # explicit path has no PATH dependency.
 node_modules/.bin/lint-staged
 
+# Template->mirror auto-heal (#768/#1146): lint-staged's `prettier --write` above
+# reformats packages/cli/templates/** but NOT the .claude/.agents/.safeword/.cursor
+# mirrors (they are prettier-ignored), silently desyncing the pair. Re-sync the
+# mirrors from the just-formatted templates and stage them — the same
+# auto-fix-and-restage model lint-staged already uses for eslint/prettier. Only
+# runs when a template is staged; parity:fix touches schema-registered pairs
+# only (repo-local skills like versioning have no template and are untouched).
+# Bypassable with --no-verify.
+PARITY_MIRROR_DIRS=".claude .agents .cursor .safeword packages/cli/codex-plugin"
+if git diff --cached --name-only | grep -q '^packages/cli/templates/'; then
+  if [ -n "$(git diff --name-only -- $PARITY_MIRROR_DIRS)" ]; then
+    # Pre-existing UNSTAGED mirror edits: auto-staging could sweep them into this
+    # commit. Skip the auto-sync and tell the committer to resolve it explicitly.
+    echo "pre-commit: unstaged mirror changes present — skipping parity auto-sync." >&2
+    echo "  Run \`bun scripts/parity-check.ts --fix\` and stage the result if a pair drifted." >&2
+  else
+    bun scripts/parity-check.ts --fix > /dev/null 2>&1 || true
+    PARITY_HEALED=$(git diff --name-only -- $PARITY_MIRROR_DIRS)
+    if [ -n "$PARITY_HEALED" ]; then
+      echo "→ parity: re-synced mirror(s) from templates —"
+      echo "$PARITY_HEALED" | sed 's/^/    /'
+      git add -- $PARITY_MIRROR_DIRS
+    fi
+  fi
+fi
+
 # Boundary reconciliation gate (CDRJTW, #810 slice 1): warn-and-record over
 # staged ticket artifacts. Exits 0 by contract — `|| true` is belt-and-braces
 # so a broken bun/CLI can never block a commit.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -63,19 +63,44 @@ node_modules/.bin/lint-staged
 # only (repo-local skills like versioning have no template and are untouched).
 # Bypassable with --no-verify.
 PARITY_MIRROR_DIRS=".claude .agents .cursor .safeword packages/cli/codex-plugin"
+
+# Pre-existing working-tree changes in the mirror dirs — unstaged tracked edits
+# PLUS untracked (non-ignored) files. If present, running parity:fix could
+# overwrite a hand-edited mirror, so we skip and let the committer resolve it.
+# (`git diff` omits untracked; `ls-files --others` covers new files. Staged
+# changes are intentionally excluded — a normal template+mirror trio-edit has the
+# mirror already staged and must NOT trip the skip.)
+mirror_worktree_changes() {
+  git diff --name-only -- $PARITY_MIRROR_DIRS
+  git ls-files --others --exclude-standard -- $PARITY_MIRROR_DIRS
+}
+
+# Template->mirror auto-heal (#768/#1146): lint-staged's `prettier --write` above
+# reformats packages/cli/templates/** but NOT the .claude/.agents/.safeword/.cursor
+# mirrors (they are prettier-ignored), silently desyncing the pair. Re-sync the
+# mirrors from the just-formatted templates and stage them — the same
+# auto-fix-and-restage model lint-staged already uses for eslint/prettier. Only
+# runs when a template is staged; parity:fix touches schema-registered pairs
+# only (repo-local skills like versioning have no template and are untouched).
+# Bypassable with --no-verify.
 if git diff --cached --name-only | grep -q '^packages/cli/templates/'; then
-  if [ -n "$(git diff --name-only -- $PARITY_MIRROR_DIRS)" ]; then
-    # Pre-existing UNSTAGED mirror edits: auto-staging could sweep them into this
-    # commit. Skip the auto-sync and tell the committer to resolve it explicitly.
-    echo "pre-commit: unstaged mirror changes present — skipping parity auto-sync." >&2
+  if [ -n "$(mirror_worktree_changes)" ]; then
+    echo "pre-commit: unstaged/untracked mirror changes present — skipping parity auto-sync." >&2
     echo "  Run \`bun scripts/parity-check.ts --fix\` and stage the result if a pair drifted." >&2
   else
-    bun scripts/parity-check.ts --fix > /dev/null 2>&1 || true
-    PARITY_HEALED=$(git diff --name-only -- $PARITY_MIRROR_DIRS)
+    # Stage exactly the paths parity:fix reports syncing (lines like "  - <path>").
+    # Using its own output — not `git diff` — so a FIRST-TIME pair, whose mirror
+    # parity:fix CREATES as an untracked file, is still detected and staged
+    # (git diff omits untracked; #1415 review). Wording-coupled, but fail-safe:
+    # if extraction ever misses a path, the drift falls through to CI's parity gate.
+    PARITY_HEALED=$(bun scripts/parity-check.ts --fix 2> /dev/null | sed -n 's/^  - //p') || true
     if [ -n "$PARITY_HEALED" ]; then
       echo "→ parity: re-synced mirror(s) from templates —"
-      echo "$PARITY_HEALED" | sed 's/^/    /'
-      git add -- $PARITY_MIRROR_DIRS
+      printf '%s\n' "$PARITY_HEALED" | while IFS= read -r healed_path; do
+        [ -n "$healed_path" ] || continue
+        echo "    $healed_path"
+        git add -- "$healed_path"
+      done
     fi
   fi
 fi


### PR DESCRIPTION
## What

Adds a pre-commit step (after lint-staged) that re-syncs the `.claude`/`.agents`/`.safeword`/`.cursor`/`codex-plugin` mirrors from `packages/cli/templates/**` via the existing `parity:fix`, and re-stages the healed files — the same **auto-fix-and-restage** model lint-staged already uses for eslint/prettier/markdownlint.

## Why

`lint-staged.config.mjs` runs `prettier --write` on `*.md`, which reformats the **template** copy but not the mirrors (they're `.prettierignore`d). Editing a pair and committing silently desyncs it — caught only later by CI's `test:release` dogfood-parity gate (#1146). Pre-commit today runs `parity-check --mode=contracts-only` with the note *"Pairs are NOT enforced here."* This closes that gap at the point the drift is created, and removes the manual-`cp` toil (#1098).

Chosen over a **blocking** check (fail-and-fix-by-hand) via `/figure-it-out`: the drift path is common (~19 of the last 40 commits touch a template markdown), and blocking on it would be the lone pre-commit gate that *doesn't* auto-fix — training `--no-verify`. Full reasoning on #768.

## Safety

- **Runs only when a template is staged** — no-op otherwise.
- **Schema-scoped:** `parity:fix` syncs registered pairs only, so repo-local skills like `versioning` (no template) are never touched. Confirmed `parity:fix` is a clean no-op on current `main` (CI keeps registered pairs in sync, so there's no latent drift to sweep).
- **No-sweep valve:** if the mirror dirs have *pre-existing unstaged* changes, it skips auto-staging and tells the committer to resolve manually — it can never fold an unrelated edit into the commit.
- Prints every mirror it heals (never silent). Bypassable with `--no-verify`.

## Validation (end-to-end, real commits)

1. **Heals + folds in:** edit a template so a pair drifts → commit → mirror is re-synced and **both sides land in the same commit**; the drift never reaches CI.
2. **No-op:** a commit with no staged template produces no parity activity.
3. **Safety valve:** a staged template + a pre-existing *unstaged* mirror edit → auto-sync is skipped with an actionable message; nothing unrelated is swept in.

Note: `.husky/pre-commit` has no `.sh` extension so CI's shellcheck doesn't cover it; the unquoted `$PARITY_MIRROR_DIRS` word-splitting is intentional (5 path args, no spaces).

Refs #768, #1146, #1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)