### PR TITLE
Guard unbound Codex Stop sessions, and bind spec invariants to scenarios

### DIFF
--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -67,7 +67,7 @@ One lens to always run — **negative-case coverage**: for each happy-path scena
 
 ## Cross-cutting checks
 
-Six lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
+Eight lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
 
 - **Conflict** — do two scenarios contradict (one allows X, another rejects it) with no distinguishing precondition?
 - **Boundary** — zero / one / max / empty / null covered where they apply?
@@ -75,6 +75,7 @@ Six lenses across the whole scenario set (not per scenario) — each asks "what'
 - **Security** — authn/authz failures and abuse vectors covered?
 - **Persona consistency** — is each scenario's triggering persona clear, and would another persona experience it differently?
 - **Surface coverage** — if `spec.md` lists affected surfaces, does each affected surface have a matching `@surface.<slug>` scenario tag or an explicit `skip:` reason, and are any `@surface.*` tags stale?
+- **Invariant binding** — for each normative clause in `spec.md` (never / must not / always / only), name the scenario whose failure would falsify it **and** the condition under which it fails; a bare scenario reference is not a binding, it's a pointer that survives the invariant being violated. An invariant no scenario would catch is a **must-fix** — cheapest to write now, while no code exists to work around. Worse than a gap is the scenario whose title names the invariant while its `Given` establishes a weaker precondition: it reads as coverage and proves nothing, so report it as a vacuous pass, not a missing scenario. Found live in QRX2DN — the spec forbade an unbound session mutating ticket state, every row named `never_uses_a_fallback_for` bound a session id, and the no-identity case the invariant actually named shipped as a defect (#1425).
 - **Wiring** — for each behavior that crosses a module/command boundary, is there a scenario exercised end-to-end through the real entry point (real config → real collaborators, mocking only the process boundary), not only via injected internals? A path reachable solely through a `provider: none`-style short circuit has no wiring coverage (see `testing/SKILL.md` → Wiring Tests).
 
 ## Findings format

--- a/.claude/skills/review-spec/SKILL.md
+++ b/.claude/skills/review-spec/SKILL.md
@@ -67,7 +67,7 @@ One lens to always run — **negative-case coverage**: for each happy-path scena
 
 ## Cross-cutting checks
 
-Six lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
+Eight lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
 
 - **Conflict** — do two scenarios contradict (one allows X, another rejects it) with no distinguishing precondition?
 - **Boundary** — zero / one / max / empty / null covered where they apply?
@@ -75,6 +75,7 @@ Six lenses across the whole scenario set (not per scenario) — each asks "what'
 - **Security** — authn/authz failures and abuse vectors covered?
 - **Persona consistency** — is each scenario's triggering persona clear, and would another persona experience it differently?
 - **Surface coverage** — if `spec.md` lists affected surfaces, does each affected surface have a matching `@surface.<slug>` scenario tag or an explicit `skip:` reason, and are any `@surface.*` tags stale?
+- **Invariant binding** — for each normative clause in `spec.md` (never / must not / always / only), name the scenario whose failure would falsify it **and** the condition under which it fails; a bare scenario reference is not a binding, it's a pointer that survives the invariant being violated. An invariant no scenario would catch is a **must-fix** — cheapest to write now, while no code exists to work around. Worse than a gap is the scenario whose title names the invariant while its `Given` establishes a weaker precondition: it reads as coverage and proves nothing, so report it as a vacuous pass, not a missing scenario. Found live in QRX2DN — the spec forbade an unbound session mutating ticket state, every row named `never_uses_a_fallback_for` bound a session id, and the no-identity case the invariant actually named shipped as a defect (#1425).
 - **Wiring** — for each behavior that crosses a module/command boundary, is there a scenario exercised end-to-end through the real entry point (real config → real collaborators, mocking only the process boundary), not only via injected internals? A path reachable solely through a `provider: none`-style short circuit has no wiring coverage (see `testing/SKILL.md` → Wiring Tests).
 
 ## Findings format

--- a/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/spec.md
+++ b/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/spec.md
@@ -1,0 +1,112 @@
+# Spec: Bind spec invariants to falsifying scenarios
+
+## Intent
+
+A spec can assert "the hook must never X" and ship with nothing that would fail
+if the hook did X. QRX2DN did exactly that: its `spec.md` SWM1.R1 said an
+unbound Codex session "must never become a lifecycle-mutation fallback," the
+ledger carried rows named `never_uses_a_fallback_for`, and every one of those
+rows bound a session id — so the no-identity case the invariant actually
+forbade went untested and a live defect shipped (issue #1425). The gap is
+structural, not a lapse of attention: `self-review` reads `spec.md`,
+`review-spec` reads the scenarios, and nothing compares the two.
+
+## Intake Brief
+
+- **Requested by:** Review of PR #1404 — the class-fix decision behind issue #1425.
+- **Cost of inaction:** Any invariant stated in absolute terms can ship unenforced while appearing covered, because a scenario named after the rule reads as proof of it. The done-gate keeps advertising a guarantee the code doesn't make.
+- **Reversibility:** Two-way door — delete the lens bullet, regenerate mirrors. No data, format, or public API change.
+
+## References
+
+- Issue #1425 — the instance defect this generalizes.
+- `.project/tickets/QRX2DN-codex-done-gate-auto-transition/spec.md` — SWM1.R1, the unbound invariant.
+- `packages/cli/templates/skills/review-spec/SKILL.md` — cross-cutting checks; the **Surface coverage** lens is the precedent for review-spec reading `spec.md`.
+- `packages/cli/tests/hooks/feature-source-documentation.test.ts` — the mirror-drift test pattern this follows.
+
+## Personas
+
+- Safeword Maintainer (SWM)
+- Technical Builder (TBU)
+
+## Surfaces
+
+Affected:
+
+- Claude Code — `.claude/skills/review-spec/SKILL.md`
+- OpenAI Codex — `packages/cli/codex-plugin/skills/review-spec/SKILL.md`
+- Cursor — `.agents/skills/review-spec/SKILL.md`
+
+skip: the lens is identical prose on every surface; the generated mirrors carry
+no surface-specific behavior, so per-surface scenarios would assert the same
+string three times rather than three distinct behaviors. Drift across all four
+surfaces is covered by one test.
+
+## Vocabulary
+
+- **Normative clause** — a `spec.md` sentence stating a prohibition or absolute: never, must not, always, only.
+- **Binding** — a scenario paired with the condition under which it fails, such that the failure would falsify a named normative clause.
+- **Named-but-unbound** — a scenario whose title matches an invariant while its `Given` establishes a weaker precondition. Reads as coverage; proves nothing.
+
+## Jobs To Be Done
+
+### invariant-binding.SWM1 — Catch an unenforced invariant before code exists
+
+**Persona:** Safeword Maintainer (SWM)
+
+> When I write a spec that forbids something absolutely, I want the scenario
+> gate to refuse the ticket until some scenario would fail if that thing
+> happened, so I can stop shipping guarantees nothing enforces.
+
+#### invariant-binding.SWM1.R1 — Every normative clause names a falsifying scenario
+
+For each clause stating a prohibition or absolute, the scenario set contains
+one whose failure would falsify it. An invariant with no such scenario is a
+must-fix at the scenario-gate, while no code exists and the fix is cheap.
+
+#### invariant-binding.SWM1.R2 — A weaker precondition does not bind an invariant
+
+A scenario whose title names the invariant while its setup establishes a weaker
+precondition does not bind it. The mismatch between the scenario's `Given` and
+the invariant's actual condition is reported as a vacuous pass.
+
+### invariant-binding.TBU1 — Get a finding worth acting on
+
+**Persona:** Technical Builder (TBU)
+
+> When the gate tells me an invariant is unbound, I want it to name the
+> condition that would falsify it, so I can write the missing scenario instead
+> of guessing what would satisfy the reviewer.
+
+#### invariant-binding.TBU1.R1 — A binding states its falsifying condition
+
+A binding is recorded as scenario plus the condition under which it fails,
+never a bare scenario reference. A reference alone degenerates into keyword
+matching — every "never" acquires a rubber-stamp pointer and the lens passes
+vacuously, reproducing one level up the defect it exists to catch.
+
+## Outcomes
+
+- A spec invariant with no falsifying scenario is caught at the scenario-gate, not at review of the merged PR.
+- A scenario that names an invariant without exercising it is reported rather than credited.
+- All four review-spec surfaces carry the lens, and drift fails a test.
+
+## Evidence limits
+
+This lens is agent-run prose, like every other review-spec check, so its
+scenarios cover surface presence and drift — observable and falsifiable: remove
+the lens from a surface and the test fails. They do not cover the quality of a
+reviewer's judgment in applying it. That is validated once, manually, against a
+known positive: QRX2DN's `never_uses_a_fallback_for` rows, which a reviewer
+running the lens must flag as named-but-unbound.
+
+Writing a scenario asserting "the reviewer applies the lens correctly" would
+pass with the lens deleted — the exact vacuous pattern this ticket exists to
+prevent. Stating the limit is the honest alternative.
+
+## Open Questions
+
+Resolved: the lens belongs in `review-spec`, not `self-review`. `review-spec`
+already reads `spec.md` for the **Surface coverage** lens, so a cross-artifact
+check is established there. `self-review` runs before scenarios exist and could
+not compare an invariant against a scenario set not yet written.

--- a/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/ticket.md
+++ b/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/ticket.md
@@ -2,8 +2,8 @@
 id: Y9P3ZC
 slug: invariant-scenario-binding-lens
 type: task
-phase: verify
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/1425
 scope:
   - Add an invariant-binding lens to review-spec's cross-cutting checks that pairs each normative spec.md clause with a scenario whose failure would falsify it.
@@ -46,3 +46,5 @@ review-spec-vs-self-review question and the evidence-limits reasoning.
 
 - 2026-07-25T21:57:19.992Z Started: Created ticket Y9P3ZC
 - 2026-07-25T22:06:16.916Z Phase: intake → verify
+- 2026-07-25T22:50:31.946Z Phase: verify → done
+- 2026-07-25T22:50:31.946Z Done: CI run 30177280263 green on lint, Dogfood parity, and the full suite on Node 22.22.3 + Node 24, supplying the full-suite evidence the authoring container could not (uid 0 bypasses the `0o555` assertion in an unrelated self-report test). Evidence in verify.md; PR #1433.

--- a/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/ticket.md
+++ b/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/ticket.md
@@ -1,0 +1,48 @@
+---
+id: Y9P3ZC
+slug: invariant-scenario-binding-lens
+type: task
+phase: verify
+status: in_progress
+external_issue: https://github.com/ArcadeAI/safeword/issues/1425
+scope:
+  - Add an invariant-binding lens to review-spec's cross-cutting checks that pairs each normative spec.md clause with a scenario whose failure would falsify it.
+  - Name the named-but-weaker binding as the defect it is — a scenario whose title matches the rule while its Given exercises a weaker precondition.
+  - Regenerate the dogfood and Codex-plugin mirrors from the canonical template.
+  - Cover the lens with a mirror-drift regression test in the shipped-skill documentation family.
+out_of_scope:
+  - Code-enforced extraction of normative clauses from spec.md; this lens is agent-run prose, like every other review-spec check.
+  - Changing self-review's ownership of spec.md JTBD/criteria/persona framing.
+  - Re-reviewing or amending closed tickets whose invariants are already unbound.
+done_when:
+  - review-spec's cross-cutting checks include an invariant-binding lens that requires a named falsifying condition, not just a scenario reference.
+  - The lens states the named-but-weaker failure mode concretely enough that a reviewer would have caught QRX2DN's fallback rows.
+  - All four review-spec surfaces (templates, .claude, .agents, codex-plugin) carry the lens and parity reports no drift.
+  - A regression test fails if any surface loses the lens.
+created: 2026-07-25T21:57:19.992Z
+last_modified: 2026-07-25T21:57:19.992Z
+---
+
+# Bind spec invariants to falsifying scenarios
+
+**Goal:** Stop a spec's "must never" from shipping with no scenario that would fail if it were violated.
+
+**Why:** QRX2DN asserted an invariant, carried scenarios named after it that
+exercised a weaker case, and shipped the defect the invariant forbade (#1425).
+Nothing compares `spec.md`'s normative clauses against the scenario set —
+`self-review` reads one, `review-spec` reads the other.
+
+**Type note:** filed as `feature`, reclassified to `task`. The deliverable is
+one cross-cutting lens in a skill plus its regenerated mirrors; the only honest
+scenarios are surface-presence and drift, which a vitest drift test covers
+directly. Cucumber steps asserting a string appears in four files would add
+ceremony, not signal — and would be the vacuous shape this lens exists to
+catch. `spec.md` is retained as the design record: it holds the resolved
+review-spec-vs-self-review question and the evidence-limits reasoning.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-07-25T21:57:19.992Z Started: Created ticket Y9P3ZC
+- 2026-07-25T22:06:16.916Z Phase: intake → verify

--- a/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/verify.md
+++ b/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/verify.md
@@ -1,0 +1,60 @@
+# Verify: Bind spec invariants to falsifying scenarios
+
+## Verify Checklist
+
+**Test Suite:** ⚠️ Targeted suites green (132 passed across 13 files); the full
+suite is not claimable in this environment — see Evidence limits.
+**Build:** ✅ Success (tsup ESM + DTS via the vitest build lock)
+**Lint:** ✅ Clean (eslint, lint-gherkin, tsc --noEmit)
+**Format:** ✅ Prettier clean
+**Parity:** ✅ 193 pairs and 8 contracts in sync
+**Scenarios:** N/A — task, no scenario ledger (see ticket.md Type note)
+**PR Scope:** ✅ Diff matches ticket scope. No piggybacked changes.
+**Dep Drift:** ✅ None — no dependency change
+**Parent Epic:** N/A
+**Reconcile:** ✅ Follows the existing mirror-drift test pattern
+(`feature-source-documentation.test.ts`) and the cross-cutting lens format
+already used by Surface coverage and Wiring.
+**Experience:** ⏭️ N/A — agent-facing review prose
+
+## Evidence
+
+- `bun run lint` — eslint, gherkin lint, and typecheck pass.
+- `bun run format:check` — clean.
+- `bun scripts/parity-check.ts --mode=all` — 193 pairs, 8 contracts in sync.
+- `bun run generate:codex-plugin` — 26 assets regenerated; catalogue release test green.
+- `tests/skills` + `feature-source-documentation` + `codex-plugin-catalogue.release` — 132 passed.
+
+## Negative control
+
+The drift test was verified to bind, not merely pass: removing the lens from
+`.agents/skills/review-spec/SKILL.md` failed
+`review-spec-invariant-binding.test.ts` on exactly that surface (1 failed, 33
+passed); restoring it returned the suite to green. A test that passes both with
+and without the change under test is the vacuous shape this ticket exists to
+catch, so it was checked rather than assumed.
+
+## Calibration against a known positive
+
+The lens was validated against the case that motivated it. QRX2DN's `spec.md`
+line 64 states the invariant ("must never become a lifecycle-mutation
+fallback"); its ledger row 11 names it ("never selects a fallback for unbound,
+non-done, or already-done state"); every scenario behind that row binds a
+session id, so the no-identity precondition the invariant names went
+unexercised. Applying the lens to that pair yields a must-fix under the
+named-but-weaker clause — the defect that shipped as issue #1425.
+
+## Evidence limits
+
+The full package suite is not green in this container and this is not claimed
+as passing. `tests/hooks/self-report.test.ts:410` chmods a directory to `0o555`
+and asserts the write fails; the session runs as uid 0, and root bypasses
+permission bits — verified directly, not assumed. It is unrelated to this
+change (self-report spool markers) and passes in CI, which runs non-root. The
+suites this change can affect were run and are green.
+
+Because the full suite cannot be shown green here, this ticket is left at
+`phase: verify` / `status: in_progress` rather than being marked done. The
+done-gate's test requirement is not satisfiable in this environment, and
+writing a done stamp around it would be exactly the evidence-shaped-hole this
+ticket is about.

--- a/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/verify.md
+++ b/.project/tickets/Y9P3ZC-invariant-scenario-binding-lens/verify.md
@@ -2,8 +2,9 @@
 
 ## Verify Checklist
 
-**Test Suite:** ⚠️ Targeted suites green (132 passed across 13 files); the full
-suite is not claimable in this environment — see Evidence limits.
+**Test Suite:** ✅ Full suite green in CI on Node 22.22.3 and Node 24 —
+[run 30177280263](https://github.com/ArcadeAI/safeword/actions/runs/30177280263).
+Targeted suites also green locally (132 passed across 13 files).
 **Build:** ✅ Success (tsup ESM + DTS via the vitest build lock)
 **Lint:** ✅ Clean (eslint, lint-gherkin, tsc --noEmit)
 **Format:** ✅ Prettier clean
@@ -46,15 +47,14 @@ named-but-weaker clause — the defect that shipped as issue #1425.
 
 ## Evidence limits
 
-The full package suite is not green in this container and this is not claimed
-as passing. `tests/hooks/self-report.test.ts:410` chmods a directory to `0o555`
-and asserts the write fails; the session runs as uid 0, and root bypasses
-permission bits — verified directly, not assumed. It is unrelated to this
-change (self-report spool markers) and passes in CI, which runs non-root. The
-suites this change can affect were run and are green.
+The full package suite could not be run green in the authoring container:
+`tests/hooks/self-report.test.ts:410` chmods a directory to `0o555` and asserts
+the write fails, but the session runs as uid 0 and root bypasses permission
+bits — verified directly, not assumed. The diagnosis was confirmed rather than
+assumed: the same test passes in CI on both Node lanes, which run non-root.
 
-Because the full suite cannot be shown green here, this ticket is left at
-`phase: verify` / `status: in_progress` rather than being marked done. The
-done-gate's test requirement is not satisfiable in this environment, and
-writing a done stamp around it would be exactly the evidence-shaped-hole this
-ticket is about.
+That limit is now closed by CI rather than argued around. Run 30177280263
+executed lint, Dogfood parity, and the full suite on Node 22.22.3 and Node 24,
+all green, against the merge of this branch with `main` at 45a304a — so the
+result also covers integration with #1422, which landed after this branch was
+cut and touches none of these files.

--- a/.safeword/hooks/codex/stop.ts
+++ b/.safeword/hooks/codex/stop.ts
@@ -83,6 +83,15 @@ function completeSessionDoneTicket(
   input: CodexStopInput,
 ): DoneTransitionResult {
   const runIdentity = resolveRunIdentity(input, { runtime: 'codex' });
+  // No session id and no CODEX_THREAD_ID means no identity at all, and the state
+  // path would collapse to the unscoped `quality-state-undefined.json` every
+  // id-less hook run shares — whatever ticket it names belongs to some other
+  // session. Stop before the read: an unbound session keeps the architecture
+  // advisory's global fallback (isDonePhaseWork, above) but is never a
+  // lifecycle-mutation fallback. Issue #1425; spec SWM1.R1.
+  if (runIdentity.sessionKey === null) {
+    return { completed: false, architectureAdvisory: null };
+  }
   const ticket = readSessionActiveTicket(projectDirectory, runIdentity);
   if (!ticket?.folder || ticket.status !== 'in_progress' || ticket.phase !== 'done') {
     return { completed: false, architectureAdvisory: null };

--- a/packages/cli/codex-plugin/skills/review-spec/SKILL.md
+++ b/packages/cli/codex-plugin/skills/review-spec/SKILL.md
@@ -70,7 +70,7 @@ One lens to always run — **negative-case coverage**: for each happy-path scena
 
 ## Cross-cutting checks
 
-Six lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
+Eight lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
 
 - **Conflict** — do two scenarios contradict (one allows X, another rejects it) with no distinguishing precondition?
 - **Boundary** — zero / one / max / empty / null covered where they apply?
@@ -78,6 +78,7 @@ Six lenses across the whole scenario set (not per scenario) — each asks "what'
 - **Security** — authn/authz failures and abuse vectors covered?
 - **Persona consistency** — is each scenario's triggering persona clear, and would another persona experience it differently?
 - **Surface coverage** — if `spec.md` lists affected surfaces, does each affected surface have a matching `@surface.<slug>` scenario tag or an explicit `skip:` reason, and are any `@surface.*` tags stale?
+- **Invariant binding** — for each normative clause in `spec.md` (never / must not / always / only), name the scenario whose failure would falsify it **and** the condition under which it fails; a bare scenario reference is not a binding, it's a pointer that survives the invariant being violated. An invariant no scenario would catch is a **must-fix** — cheapest to write now, while no code exists to work around. Worse than a gap is the scenario whose title names the invariant while its `Given` establishes a weaker precondition: it reads as coverage and proves nothing, so report it as a vacuous pass, not a missing scenario. Found live in QRX2DN — the spec forbade an unbound session mutating ticket state, every row named `never_uses_a_fallback_for` bound a session id, and the no-identity case the invariant actually named shipped as a defect (#1425).
 - **Wiring** — for each behavior that crosses a module/command boundary, is there a scenario exercised end-to-end through the real entry point (real config → real collaborators, mocking only the process boundary), not only via injected internals? A path reachable solely through a `provider: none`-style short circuit has no wiring coverage (see `testing/SKILL.md` → Wiring Tests).
 
 ## Findings format

--- a/packages/cli/templates/hooks/codex/stop.ts
+++ b/packages/cli/templates/hooks/codex/stop.ts
@@ -83,6 +83,15 @@ function completeSessionDoneTicket(
   input: CodexStopInput,
 ): DoneTransitionResult {
   const runIdentity = resolveRunIdentity(input, { runtime: 'codex' });
+  // No session id and no CODEX_THREAD_ID means no identity at all, and the state
+  // path would collapse to the unscoped `quality-state-undefined.json` every
+  // id-less hook run shares — whatever ticket it names belongs to some other
+  // session. Stop before the read: an unbound session keeps the architecture
+  // advisory's global fallback (isDonePhaseWork, above) but is never a
+  // lifecycle-mutation fallback. Issue #1425; spec SWM1.R1.
+  if (runIdentity.sessionKey === null) {
+    return { completed: false, architectureAdvisory: null };
+  }
   const ticket = readSessionActiveTicket(projectDirectory, runIdentity);
   if (!ticket?.folder || ticket.status !== 'in_progress' || ticket.phase !== 'done') {
     return { completed: false, architectureAdvisory: null };

--- a/packages/cli/templates/skills/review-spec/SKILL.md
+++ b/packages/cli/templates/skills/review-spec/SKILL.md
@@ -67,7 +67,7 @@ One lens to always run — **negative-case coverage**: for each happy-path scena
 
 ## Cross-cutting checks
 
-Six lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
+Eight lenses across the whole scenario set (not per scenario) — each asks "what's missing?":
 
 - **Conflict** — do two scenarios contradict (one allows X, another rejects it) with no distinguishing precondition?
 - **Boundary** — zero / one / max / empty / null covered where they apply?
@@ -75,6 +75,7 @@ Six lenses across the whole scenario set (not per scenario) — each asks "what'
 - **Security** — authn/authz failures and abuse vectors covered?
 - **Persona consistency** — is each scenario's triggering persona clear, and would another persona experience it differently?
 - **Surface coverage** — if `spec.md` lists affected surfaces, does each affected surface have a matching `@surface.<slug>` scenario tag or an explicit `skip:` reason, and are any `@surface.*` tags stale?
+- **Invariant binding** — for each normative clause in `spec.md` (never / must not / always / only), name the scenario whose failure would falsify it **and** the condition under which it fails; a bare scenario reference is not a binding, it's a pointer that survives the invariant being violated. An invariant no scenario would catch is a **must-fix** — cheapest to write now, while no code exists to work around. Worse than a gap is the scenario whose title names the invariant while its `Given` establishes a weaker precondition: it reads as coverage and proves nothing, so report it as a vacuous pass, not a missing scenario. Found live in QRX2DN — the spec forbade an unbound session mutating ticket state, every row named `never_uses_a_fallback_for` bound a session id, and the no-identity case the invariant actually named shipped as a defect (#1425).
 - **Wiring** — for each behavior that crosses a module/command boundary, is there a scenario exercised end-to-end through the real entry point (real config → real collaborators, mocking only the process boundary), not only via injected internals? A path reachable solely through a `provider: none`-style short circuit has no wiring coverage (see `testing/SKILL.md` → Wiring Tests).
 
 ## Findings format

--- a/packages/cli/tests/integration/codex-stop-retro.test.ts
+++ b/packages/cli/tests/integration/codex-stop-retro.test.ts
@@ -712,6 +712,37 @@ describe('codex/stop.ts retro adapter (CDX602)', () => {
       }
     });
 
+    // The rows above all carry a session id, so their "unbound" means "no state
+    // for THIS id". A Codex payload with neither `session_id` nor
+    // CODEX_THREAD_ID has no identity at all: `getRunStorageKey` returns null
+    // and the state path collapses to the unscoped `quality-state-undefined.json`
+    // bucket every id-less hook run shares. Reading another session's active
+    // ticket from there and closing it is the lifecycle-mutation fallback
+    // spec SWM1.R1 forbids (issue #1425).
+    it('codex-done-gate.TBU1.R1.never_mutates_from_the_unscoped_state_bucket', () => {
+      writeConfig(dir, { surface: false, file: false });
+      const ticket = writeTicket(dir, 'FOREIGN');
+      writeFileSync(
+        nodePath.join(dir, '.project', 'quality-state-undefined.json'),
+        JSON.stringify({
+          locSinceCommit: 0,
+          lastCommitHash: '',
+          activeTicket: 'FOREIGN',
+          recentFailures: [],
+          incrementedPatterns: [],
+        }),
+      );
+
+      const result = runHook(dir, { cwd: dir }, { CODEX_THREAD_ID: undefined });
+
+      expect(result.status).toBe(0);
+      expectNoContinuation(result);
+      expect(readFileSync(nodePath.join(ticket, 'ticket.md'), 'utf8')).toMatch(
+        /^status: in_progress$/m,
+      );
+      expect(readFileSync(nodePath.join(ticket, 'ticket.md'), 'utf8')).toMatch(/^phase: done$/m);
+    });
+
     it('codex-done-gate.SWM1.R1.keeps_evidence_failure_ahead_of_architecture_and_filing', () => {
       writeConfig(dir, { surface: true, file: true });
       const sessionId = freshSession('done-priority');

--- a/packages/cli/tests/skills/review-spec-invariant-binding.test.ts
+++ b/packages/cli/tests/skills/review-spec-invariant-binding.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
+
+/**
+ * Every surface that ships review-spec. `.agents/skills` is included
+ * deliberately: it is git-tracked and byte-identical to the template for every
+ * other skill, but `parity:fix` does not sync it, so it is the copy that drifts
+ * silently.
+ */
+const surfaces = [
+  'packages/cli/templates/skills/review-spec/SKILL.md',
+  '.claude/skills/review-spec/SKILL.md',
+  '.agents/skills/review-spec/SKILL.md',
+  'packages/cli/codex-plugin/skills/review-spec/SKILL.md',
+].map(relative => nodePath.join(repoRoot, relative));
+
+const canonical = nodePath.join(repoRoot, 'packages/cli/templates/skills/review-spec/SKILL.md');
+
+describe('review-spec invariant-binding lens (Y9P3ZC)', () => {
+  it.each(surfaces)('%s carries the invariant-binding lens', file => {
+    const content = readFileSync(file, 'utf8');
+
+    expect(content).toContain('**Invariant binding**');
+    // A bare scenario reference is the degenerate form the lens exists to
+    // reject — it survives the invariant being violated, so demanding the
+    // falsifying condition is the load-bearing half of the check.
+    expect(content).toContain('the condition under which it fails');
+    // The named-but-weaker shape is what made QRX2DN read as covered; a lens
+    // that only asks "is there a scenario?" would have passed it.
+    expect(content).toContain('weaker precondition');
+  });
+
+  it('counts its cross-cutting lenses correctly', () => {
+    const content = readFileSync(canonical, 'utf8');
+    const section = content.slice(content.indexOf('## Cross-cutting checks'));
+    const declared = /^(?<count>\w+) lenses across the whole scenario set/m.exec(section)?.groups
+      ?.count;
+    const bullets = section.slice(0, section.indexOf('\n## ', 1)).match(/^- \*\*/gm)?.length;
+
+    expect(declared).toBe('Eight');
+    expect(bullets).toBe(8);
+  });
+});


### PR DESCRIPTION
Two commits from the post-merge review of #1404: the instance fix, and the class fix.

## 1. `fix(codex)`: never complete a ticket from an unbound Stop session

Closes #1425.

`completeSessionDoneTicket` resolved a run identity but never checked it carried a `sessionKey`. A Codex Stop payload with neither `session_id` nor `CODEX_THREAD_ID` has no identity at all, so `getRunStorageKey` returns `null` and the state path collapses to the unscoped `quality-state-undefined.json` bucket every id-less hook run shares — letting Stop read another session's active ticket and transition it to done.

QRX2DN's `spec.md` SWM1.R1 requires the opposite: an unbound session keeps the architecture advisory's global fallback but must never become a lifecycle-mutation fallback.

**This was not theoretical.** The test was written first and closed a foreign ticket on its first run — `status: done` on a ticket the session never touched.

The guard covers the mutating path only. `isDonePhaseWork` reads the same state for the advisory; that read is deliberately retained for unbound sessions, and guarding it too would have silently changed advisory behavior the spec wants.

## 2. `feat(review-spec)`: invariant-binding lens

Refs #1425. Ticket Y9P3ZC.

The gap that produced the above is structural, not a lapse of attention: `self-review` reads `spec.md`, `review-spec` reads the scenarios, and nothing compares the two. QRX2DN's ledger carried rows named `never_uses_a_fallback_for`, and every scenario behind them bound a session id — the no-identity case the invariant named went untested while reading as covered.

This adds an eighth cross-cutting lens: pair each normative clause with the scenario whose failure would falsify it **and** the condition under which it fails. A bare scenario reference is rejected as a binding — it survives the invariant being violated, which is how a rubber-stamp pointer would reproduce this defect one level up. A scenario whose title names the invariant while its `Given` establishes a weaker precondition is reported as a vacuous pass rather than a missing scenario.

The lens lives in `review-spec` rather than `self-review` because `review-spec` already reads `spec.md` for the **Surface coverage** lens, and `self-review` runs before a scenario set exists to compare against.

## Validation

- `bun run lint` — eslint, gherkin lint, typecheck clean
- `bun run format:check` — clean
- `bun scripts/parity-check.ts --mode=all` — 193 pairs, 8 contracts in sync
- `bun run generate:codex-plugin` — 26 assets regenerated
- Codex Stop suite: 61 passed. `tests/skills` + catalogue + doc-drift: 132 passed.
- **Negative control:** the drift test was verified to bind, not merely pass — removing the lens from one surface fails that surface's case; restoring it returns to green.
- **Calibration:** applying the lens to QRX2DN yields a must-fix on the ledger row that names the fallback while binding a session id — the defect that shipped as #1425.

## Why draft

The full package suite is not green in the authoring container and is not claimed as passing. `tests/hooks/self-report.test.ts:410` chmods a directory to `0o555` and asserts the write fails; that session runs as uid 0, and root bypasses permission bits (verified directly, not assumed). It is unrelated to these changes and passes in CI, which runs non-root. This PR is open as a draft so CI can supply the verification the container can't, and because Y9P3ZC is honestly still `phase: verify` / `status: in_progress` — marking it done around an unrunnable gate would be the evidence-shaped hole the second commit exists to prevent.

Ready for review once CI is green; the ticket closure would ride a follow-up push, not this description.

## Notes for the reviewer

`.agents/skills/` is git-tracked and byte-identical to the templates for every other skill, but `parity:fix` does not sync it — it had to be copied by hand here. The new drift test covers that surface, but the parity gap itself is untouched and may be the same class as #1428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmDAjEPLZfUyt73AqbBTSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmDAjEPLZfUyt73AqbBTSS)_