### PR TITLE
docs: correct host toolchain closeout status

### DIFF
--- a/.project/tickets/13E3EN-honor-host-toolchains/verify.md
+++ b/.project/tickets/13E3EN-honor-host-toolchains/verify.md
@@ -21,5 +21,3 @@
 **Quality review:** APPROVE. Fresh independent review confirmed canonical owner selection, local-only binaries, environment isolation, containment, no-fallback behavior, and real Codex wiring.
 
 **Refactor:** Complete. The persisted ledger records the two completed behavior-preserving changes and one explicitly deferred marginal extraction.
-
-The ticket remains `status: in_progress` in verify phase pending explicit user confirmation to complete it.


### PR DESCRIPTION
## Summary

- remove the stale sentence claiming ticket `13E3EN` is still in progress
- align the verification record with its merged `phase: done` and `status: done` metadata

## Validation

- `bunx prettier --check .project/tickets/13E3EN-honor-host-toolchains/verify.md`
- `git diff --check`