### PR TITLE
Fix flaky golden-path lint-hook fallback tests (python + rust)

### DIFF
--- a/packages/cli/tests/integration/python-golden-path.test.ts
+++ b/packages/cli/tests/integration/python-golden-path.test.ts
@@ -218,10 +218,25 @@ describe('E2E: Python Lint Hook Fallback', () => {
     writeTestFile(projectDirectory, 'src/fallback.py', 'x=1;y=2');
     const filePath = nodePath.join(projectDirectory, 'src/fallback.py');
 
-    // Hook should use fallback path (Ruff without --config)
-    runLintHook(projectDirectory, filePath);
+    // SAFEWORD_NO_AUTO_UPGRADE is load-bearing, not hygiene. Without it the hook sees
+    // the missing Python pack and shells `bunx safeword@latest upgrade`, which (a) is a
+    // live network install whose latency is unbounded — the 30s spawn cap then SIGKILLs
+    // it and the file is never touched, which is how this test flaked — and (b) RESTORES
+    // both configs, so the run lints via the normal configured path and the fallback
+    // this test is named for is never exercised at all.
+    const hook = runLintHook(projectDirectory, filePath, { SAFEWORD_NO_AUTO_UPGRADE: '1' });
 
-    // File should still be formatted by Ruff
+    // Assert the hook actually ran. Discarding this result is what let the flake surface
+    // as a baffling content mismatch instead of "the hook was killed". A set `signal`
+    // means the 30s cap killed it — asserted first so a timeout names itself.
+    expect(hook.signal ?? undefined).toBeUndefined();
+    expect(hook.status).toBe(0);
+
+    // The fallback path was genuinely taken: neither config came back.
+    expect(fileExists(projectDirectory, 'ruff.toml')).toBe(false);
+    expect(fileExists(projectDirectory, '.safeword/ruff.toml')).toBe(false);
+
+    // File should still be formatted by Ruff, using its own defaults.
     const result = readTestFile(projectDirectory, 'src/fallback.py');
     expect(result).toContain('x = 1');
   });

--- a/packages/cli/tests/integration/rust-golden-path.test.ts
+++ b/packages/cli/tests/integration/rust-golden-path.test.ts
@@ -584,10 +584,16 @@ describe('E2E: Rust Lint Hook Fallback', () => {
     initGitRepo(projectDirectory);
     // Run setup to get the hook infrastructure
     await setupOrThrow(projectDirectory);
-    // Delete .safeword/rustfmt.toml to test fallback path
-    const rustfmtConfig = nodePath.join(projectDirectory, '.safeword/rustfmt.toml');
-    if (fileExists(projectDirectory, '.safeword/rustfmt.toml')) {
-      unlinkSync(rustfmtConfig);
+    // Delete BOTH rustfmt configs to test the fallback path. Deleting only the
+    // .safeword copy is not enough: rustfmt searches the target file's directory and
+    // its PARENTS for a rustfmt.toml, so the project-root config setup wrote is still
+    // discovered and plain `rustfmt <file>` keeps running under safeword's settings.
+    // (Verified: a root `max_width = 40` visibly changes wrapping vs. the default.)
+    // See https://github.com/rust-lang/rustfmt#configuring-rustfmt
+    for (const config of ['.safeword/rustfmt.toml', 'rustfmt.toml']) {
+      if (fileExists(projectDirectory, config)) {
+        unlinkSync(nodePath.join(projectDirectory, config));
+      }
     }
   });
 
@@ -615,8 +621,11 @@ describe('E2E: Rust Lint Hook Fallback', () => {
     expect(hook.signal ?? undefined).toBeUndefined();
     expect(hook.status).toBe(0);
 
-    // The fallback path was genuinely taken: the config did not come back.
+    // The fallback path was genuinely taken: neither config came back. The ROOT one is
+    // load-bearing here — rustfmt's parent-directory search means a surviving
+    // rustfmt.toml at the project root silently keeps this on the configured path.
     expect(fileExists(projectDirectory, '.safeword/rustfmt.toml')).toBe(false);
+    expect(fileExists(projectDirectory, 'rustfmt.toml')).toBe(false);
 
     // File should still be formatted (rustfmt works without config)
     const result = readTestFile(projectDirectory, 'src/fallback-test.rs');

--- a/packages/cli/tests/integration/rust-golden-path.test.ts
+++ b/packages/cli/tests/integration/rust-golden-path.test.ts
@@ -601,8 +601,22 @@ describe('E2E: Rust Lint Hook Fallback', () => {
     const filePath = nodePath.join(projectDirectory, 'src/fallback-test.rs');
     writeTestFile(projectDirectory, 'src/fallback-test.rs', `fn fallback_test(){println!("test")}`);
 
-    // Run lint hook - should use plain rustfmt (no --config-path)
-    runLintHook(projectDirectory, filePath);
+    // SAFEWORD_NO_AUTO_UPGRADE is load-bearing, not hygiene. Without it the hook sees
+    // the missing Rust pack and shells `bunx safeword@latest upgrade`, which (a) is a
+    // live network install whose latency is unbounded — the 30s spawn cap then SIGKILLs
+    // it and the file is never touched, which is how this test flaked — and (b) RESTORES
+    // the config, so the run lints via the normal configured path and the fallback this
+    // test is named for is never exercised at all.
+    const hook = runLintHook(projectDirectory, filePath, { SAFEWORD_NO_AUTO_UPGRADE: '1' });
+
+    // Assert the hook actually ran. Discarding this result is what let the flake surface
+    // as a baffling content mismatch instead of "the hook was killed". A set `signal`
+    // means the 30s cap killed it — asserted first so a timeout names itself.
+    expect(hook.signal ?? undefined).toBeUndefined();
+    expect(hook.status).toBe(0);
+
+    // The fallback path was genuinely taken: the config did not come back.
+    expect(fileExists(projectDirectory, '.safeword/rustfmt.toml')).toBe(false);
 
     // File should still be formatted (rustfmt works without config)
     const result = readTestFile(projectDirectory, 'src/fallback-test.rs');


### PR DESCRIPTION
Two tests flaked locally:

- `tests/integration/python-golden-path.test.ts` › *lint hook formats files without safeword Ruff config*
- `tests/integration/rust-golden-path.test.ts` › *lint hook formats .rs files without safeword config*

They failed with `expected 'x=1;y=2' to contain 'x = 1'` — the file completely untouched — then passed on the next run of the same tree.

## Root cause

Both tests delete the linter configs in `beforeAll` to exercise the fallback path, then call the hook. With the pack config gone, `ensurePackInstalled` (`templates/hooks/lib/lint.ts:200`) shells `bunx safeword@latest upgrade`. That has two consequences:

1. **It is a live network install with unbounded latency.** `runLintHook` caps the spawn at 30s with `killSignal: 'SIGKILL'`, so a slow fetch kills the hook before it formats anything and the file is left exactly as written. That is the flake.
2. **On success it restores the deleted configs.** Verified directly — after one hook run, `ruff.toml` and `.safeword/ruff.toml` are both back. So when the upgrade *did* win the race, the run linted via the normal configured path and **the fallback branch these tests are named for was never exercised at all.**

So this was not only flaky, it was a test whose name claimed coverage its assertions never established — the same shape as #1463, one layer down.

Both tests also **discarded `runLintHook`'s return value**, so a SIGKILLed hook surfaced as a confusing content mismatch rather than naming its own cause.

Worth noting: `ensurePackInstalled` also gates on `process.env.CI`, so **CI never had this flake** — the upgrade is skipped there and the fallback path is already taken correctly. This only bit local and container runs. The fix makes local behavior match what CI was already doing.

## Fix

- Pass `SAFEWORD_NO_AUTO_UPGRADE: '1'` — the existing gate at `lint.ts:206`, already used this way by `golden-path.test.ts:305`. No network, no restore, fallback genuinely taken.
- Assert the hook was neither killed nor non-zero, with `signal` checked first so a timeout names itself instead of hiding behind a content assertion.
- Assert the configs are **still absent at assert time**, pinning that the fallback path was actually taken. Without this, a future change that re-restores configs would silently turn these back into non-fallback tests.

## Mutation evidence

Both new guards are load-bearing — each mutant applied, run isolated, then reverted:

| Mutant | Result |
|---|---|
| **M1** — remove the `SAFEWORD_NO_AUTO_UPGRADE` gate | `AssertionError: expected 'SIGKILL' to be undefined` — the original flake, now reproduced **by name** |
| **M2** — leave the configs in place (models a successful auto-upgrade restore) | `AssertionError: expected true to be false` — the config-absence guard fires |

M1 is the more interesting result: it reproduces the exact flake deterministically under vitest, and the new assertion converts it from "ruff mysteriously didn't format" into "the hook was killed".

## Verification

- **Full suite: 5459 pass**, 7 skipped, 369 files — **both golden-path tests pass in a full run**, the exact run type where python previously failed. That is the fix confirmed end-to-end, not just in isolation.
- 88 tests pass across the 6 affected files
- Full-repo lint (eslint + lint-gherkin + `tsc --noEmit`) clean
- Test-only diff; no production code touched

The one remaining local failure is `tests/hooks/self-report.test.ts`, unrelated and environmental: it `chmod 0o555`s a directory and expects the write to fail, but container **root bypasses permission bits**. It fails identically on clean `main`.

## Follow-up worth considering (not in this PR)

`ensurePackInstalled` shelling `bunx safeword@latest upgrade` from inside a lint hook is a live network install on a developer's edit path, gated off only by `CI` or the opt-out env var. It made these tests flaky; it can equally stall a real editing session on a slow network. That is product behavior rather than test behavior, so it is deliberately left alone here.

Kept separate from #1468 (the #1463 parity fix) deliberately — unrelated change, and folding it in would break that PR's scope check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PmDh9rxQNmfkVJLfjYdt7