### PR TITLE
Keep zombie cleanup inside the current project

### DIFF
--- a/.claude/skills/cleanup-zombies/SKILL.md
+++ b/.claude/skills/cleanup-zombies/SKILL.md
@@ -28,9 +28,9 @@ If the preview looks correct, confirm the kill with `--yes`:
 ## What It Does
 
 1. **Auto-detects framework** - Finds port from vite.config.ts, next.config.js, etc. (checks root, `packages/*/`, `apps/*/` for monorepos)
-2. **Kills by port** - Dev server port AND test port (port + 1000)
-3. **Kills test processes** - Playwright, Chromium, Electron (scoped to this project)
-4. **Multi-project safe** - Only kills processes matching this project's directory
+2. **Checks project-owned port processes** - Inspects the dev port and in-range test port (port + 1000), reporting owners it skips when project ownership cannot be verified
+3. **Checks project-owned test processes** - Inspects Playwright, Chromium, and Electron matches whose working directory is inside this project
+4. **Revalidates before signaling** - Only kills processes whose current working directory still belongs to this project
 
 ## Manual Override
 

--- a/.cursor/commands/cleanup-zombies.md
+++ b/.cursor/commands/cleanup-zombies.md
@@ -24,9 +24,9 @@ If the preview looks correct, confirm the kill with `--yes`:
 ## What It Does
 
 1. **Auto-detects framework** - Finds port from vite.config.ts, next.config.js, etc. (checks root, `packages/*/`, `apps/*/` for monorepos)
-2. **Kills by port** - Dev server port AND test port (port + 1000)
-3. **Kills test processes** - Playwright, Chromium, Electron (scoped to this project)
-4. **Multi-project safe** - Only kills processes matching this project's directory
+2. **Checks project-owned port processes** - Inspects the dev port and in-range test port (port + 1000), reporting owners it skips when project ownership cannot be verified
+3. **Checks project-owned test processes** - Inspects Playwright, Chromium, and Electron matches whose working directory is inside this project
+4. **Revalidates before signaling** - Only kills processes whose current working directory still belongs to this project
 
 ## Manual Override
 

--- a/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
@@ -1,0 +1,44 @@
+---
+id: "1451"
+slug: cleanup-zombies-project-safety
+type: task
+phase: done
+status: done
+created: 2026-07-25
+last_modified: 2026-07-26
+external_issue: https://github.com/ArcadeAI/safeword/issues/1451
+---
+
+# Task: Keep zombie cleanup inside the current project
+
+**Type:** Bug
+
+**Scope:** Restrict processes found through auto-detected dev and test ports to
+the current project before previewing or killing them.
+
+**Out of Scope:** Changing framework detection, port conventions, pattern-based
+cleanup, or the explicit consent flow.
+
+**Done When:**
+
+- [x] A process from another project is omitted from the cleanup preview when it
+      owns this project's auto-detected port.
+- [x] A process owned by the current project remains eligible for cleanup by its
+      auto-detected port.
+- [x] Port ownership checks deny by default when project ownership cannot be
+      established.
+
+**Tests:**
+
+- [x] Integration: an unrelated project's process on an auto-detected port is
+      excluded from the preview.
+- [x] Integration: the current project's process on an auto-detected port is
+      included in the preview.
+- [x] Integration: kill mode passes a verified current-project port owner, but
+      never an unrelated owner, to `kill`.
+- [x] Integration: newline-containing paths cannot be truncated into false
+      ownership.
+- [x] Integration: descendants of the project root remain eligible.
+- [x] Integration: kill mode revalidates ownership immediately before signaling.
+- [x] Integration: multiple verified PIDs are signaled individually rather than
+      after a batched ownership check.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: done
 status: done
 created: 2026-07-25
-last_modified: 2026-07-26
+last_modified: 2026-07-27
 external_issue: https://github.com/ArcadeAI/safeword/issues/1451
 ---
 
@@ -15,7 +15,9 @@ external_issue: https://github.com/ArcadeAI/safeword/issues/1451
 
 **Scope:** Restrict processes found through auto-detected ports or command
 patterns to the current project before previewing or killing them. Report
-unverified candidates and failed signals accurately.
+unverified detected-port owners and failed signals accurately. Pattern matches
+whose working directory is outside the project remain silently ineligible so
+broad built-in patterns do not produce machine-wide skip noise.
 
 **Out of Scope:** Changing framework detection, port conventions, or the
 explicit consent flow.
@@ -30,8 +32,8 @@ explicit consent flow.
       established.
 - [x] Pattern ownership uses the same working-directory boundary as port
       ownership.
-- [x] The summary distinguishes a clean project from candidates that were
-      skipped or could not be killed.
+- [x] The summary distinguishes a clean project from detected-port candidates
+      that were skipped or eligible candidates that could not be killed.
 
 **Tests:**
 

--- a/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/ticket.md
@@ -13,11 +13,12 @@ external_issue: https://github.com/ArcadeAI/safeword/issues/1451
 
 **Type:** Bug
 
-**Scope:** Restrict processes found through auto-detected dev and test ports to
-the current project before previewing or killing them.
+**Scope:** Restrict processes found through auto-detected ports or command
+patterns to the current project before previewing or killing them. Report
+unverified candidates and failed signals accurately.
 
-**Out of Scope:** Changing framework detection, port conventions, pattern-based
-cleanup, or the explicit consent flow.
+**Out of Scope:** Changing framework detection, port conventions, or the
+explicit consent flow.
 
 **Done When:**
 
@@ -27,6 +28,10 @@ cleanup, or the explicit consent flow.
       auto-detected port.
 - [x] Port ownership checks deny by default when project ownership cannot be
       established.
+- [x] Pattern ownership uses the same working-directory boundary as port
+      ownership.
+- [x] The summary distinguishes a clean project from candidates that were
+      skipped or could not be killed.
 
 **Tests:**
 
@@ -42,3 +47,8 @@ cleanup, or the explicit consent flow.
 - [x] Integration: kill mode revalidates ownership immediately before signaling.
 - [x] Integration: multiple verified PIDs are signaled individually rather than
       after a batched ownership check.
+- [x] Integration: a foreign pattern match is excluded even when its argv names
+      the current project.
+- [x] Integration: project paths are not interpolated into `pgrep` regular
+      expressions.
+- [x] Integration: failed signals are not counted as successful kills.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -2,7 +2,7 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,505/5,505 tests pass; 5 skipped
+**Test Suite:** ✓ 5,506/5,506 tests pass; 5 skipped
 **Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
 **Build:** ✅ Success
 **Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean
@@ -27,3 +27,7 @@ The PR review findings were incorporated into dependency handling, project
 ownership, signal accounting, recovery messaging, performance, tests, and
 documentation. The final independent quality re-review approved the result with
 no critical issues or suggested improvements.
+
+The latest PR follow-up is also resolved: port-range behavior is documented,
+and a `pgrep` discovery error now preserves the summary for already-completed
+work before returning the original nonzero status.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -2,16 +2,16 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,473/5,473 tests pass; 5 skipped
+**Test Suite:** ✓ 5,487/5,487 tests pass; 5 skipped
 **Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
 **Build:** ✅ Success
 **Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean
-**Scenarios:** All 10 scenarios marked complete
+**Scenarios:** All 15 scenarios marked complete
 **PR Scope:** ✅ Diff matches ticket scope
 **Dep Drift:** ✅ Clean; no dependency changes
 **Parent Epic:** N/A
 **Reconcile:** ✅ Template and dogfood copies match; no pattern deviation
-**Experience:** ⏭️ N/A — internal cleanup safety behavior
+**Experience:** ✅ Preview, skipped-owner, and failed-signal output exercised by integration tests
 **Evidence limits:** ✅ None
 
 Audit passed for issue #1451 scope. The full-repository audit also reported
@@ -19,5 +19,6 @@ pre-existing orphan warnings in hidden worktrees, unavailable Python audit
 tools for experimental projects, and repository-wide duplication outside this
 ticket's files; the changed files have no detected clones.
 
-Independent quality review: APPROVE, with no critical issues or suggested
-improvements remaining.
+The PR reviewer approved the original fix after live-process verification. Its
+four non-blocking suggestions were then incorporated into the project ownership
+rule, signal accounting, recovery messaging, tests, and documentation.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -2,7 +2,7 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,487/5,487 tests pass; 5 skipped
+**Test Suite:** ✓ 5,502/5,502 tests pass; 5 skipped
 **Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
 **Build:** ✅ Success
 **Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean
@@ -14,11 +14,13 @@
 **Experience:** ✅ Preview, skipped-owner, and failed-signal output exercised by integration tests
 **Evidence limits:** ✅ None
 
-Audit passed for issue #1451 scope. The full-repository audit also reported
-pre-existing orphan warnings in hidden worktrees, unavailable Python audit
-tools for experimental projects, and repository-wide duplication outside this
-ticket's files; the changed files have no detected clones.
+Audit passed with warnings for issue #1451 scope. The full-repository audit
+reported pre-existing orphan warnings in hidden worktrees, unavailable Python
+audit tools for experimental projects, one low-risk dev dependency update, and
+the repository-wide 461-clone baseline outside this ticket's files. The changed
+script and test have no detected clones.
 
-The PR reviewer approved the original fix after live-process verification. Its
-four non-blocking suggestions were then incorporated into the project ownership
-rule, signal accounting, recovery messaging, tests, and documentation.
+The PR review findings were incorporated into dependency handling, project
+ownership, signal accounting, recovery messaging, performance, tests, and
+documentation. A fresh independent quality re-review found no critical issues
+or remaining suggestions.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -1,0 +1,23 @@
+# Verification: Keep zombie cleanup inside the current project
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5,473/5,473 tests pass; 5 skipped
+**Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
+**Build:** ✅ Success
+**Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean
+**Scenarios:** All 10 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean; no dependency changes
+**Parent Epic:** N/A
+**Reconcile:** ✅ Template and dogfood copies match; no pattern deviation
+**Experience:** ⏭️ N/A — internal cleanup safety behavior
+**Evidence limits:** ✅ None
+
+Audit passed for issue #1451 scope. The full-repository audit also reported
+pre-existing orphan warnings in hidden worktrees, unavailable Python audit
+tools for experimental projects, and repository-wide duplication outside this
+ticket's files; the changed files have no detected clones.
+
+Independent quality review: APPROVE, with no critical issues or suggested
+improvements remaining.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -14,13 +14,16 @@
 **Experience:** ✅ Preview, skipped-owner, and failed-signal output exercised by integration tests
 **Evidence limits:** ✅ None
 
-Audit passed with warnings for issue #1451 scope. The full-repository audit
-reported pre-existing orphan warnings in hidden worktrees, unavailable Python
-audit tools for experimental projects, one low-risk dev dependency update, and
-the repository-wide 461-clone baseline outside this ticket's files. The changed
-script and test have no detected clones.
+Audit passed with warnings for issue #1451 scope. Knip's only changed-scope
+finding, the test fixture's externally provided `pgrep` binary, is now
+registered and Knip is clean. Changed-scope duplication is 0%. The
+full-repository audit also reported pre-existing orphan warnings and unavailable
+Python audit tools in transient hidden worktrees, low-risk patch updates for dev
+dependencies, and 506 repository-wide clones outside this ticket's files; that
+global count is inflated by hidden worktree copies and is not a comparable
+changed-scope signal.
 
 The PR review findings were incorporated into dependency handling, project
 ownership, signal accounting, recovery messaging, performance, tests, and
-documentation. A fresh independent quality re-review found no critical issues
-or remaining suggestions.
+documentation. The final independent quality re-review approved the result with
+no critical issues or suggested improvements.

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -2,7 +2,7 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,502/5,502 tests pass; 5 skipped
+**Test Suite:** ✓ 5,505/5,505 tests pass; 5 skipped
 **Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
 **Build:** ✅ Success
 **Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean

--- a/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
+++ b/.project/tickets/1451-cleanup-zombies-project-safety/verify.md
@@ -2,7 +2,7 @@
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,506/5,506 tests pass; 5 skipped
+**Test Suite:** ✓ 5,513/5,513 tests pass; 5 skipped
 **Gherkin:** ✅ 494/494 acceptance scenarios and 15,313/15,313 steps pass; 3 scenarios and 4 steps skipped
 **Build:** ✅ Success
 **Lint:** ✅ ESLint, Gherkin lint, TypeScript, Bash syntax, and ShellCheck clean
@@ -14,13 +14,13 @@
 **Experience:** ✅ Preview, skipped-owner, and failed-signal output exercised by integration tests
 **Evidence limits:** ✅ None
 
-Audit passed with warnings for issue #1451 scope. Knip's only changed-scope
-finding, the test fixture's externally provided `pgrep` binary, is now
-registered and Knip is clean. Changed-scope duplication is 0%. The
-full-repository audit also reported pre-existing orphan warnings and unavailable
-Python audit tools in transient hidden worktrees, low-risk patch updates for dev
-dependencies, and 506 repository-wide clones outside this ticket's files; that
-global count is inflated by hidden worktree copies and is not a comparable
+Audit passed with warnings for issue #1451 scope. Config sync, Knip, learning
+metadata, namespace domain docs, and the changed-scope duplication check are
+clean; the changed production script, integration test, and guide have 0 clones.
+The full-repository audit also reported pre-existing orphan warnings and
+unavailable Python audit tools in transient hidden worktrees, low-risk patch
+updates for two dev dependencies, and 509 repository-wide clones. That global
+count is inflated by hidden worktree copies and is not a comparable
 changed-scope signal.
 
 The PR review findings were incorporated into dependency handling, project
@@ -28,6 +28,8 @@ ownership, signal accounting, recovery messaging, performance, tests, and
 documentation. The final independent quality re-review approved the result with
 no critical issues or suggested improvements.
 
-The latest PR follow-up is also resolved: port-range behavior is documented,
-and a `pgrep` discovery error now preserves the summary for already-completed
-work before returning the original nonzero status.
+The latest review follow-ups are also resolved: port-range behavior is
+validated, a `pgrep` discovery error preserves the summary for already-completed
+work before returning the original nonzero status, leading-dash patterns are
+passed after an option terminator, and generated Codex plugin assets match the
+canonical cleanup skill.

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -84,8 +84,10 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 ./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
-The script requires `lsof` to verify process working directories. If `lsof` is
-unavailable, it exits without signaling anything and explains how to recover.
+The script requires `lsof`, `pgrep`, and `ps` to discover processes, verify
+working directories, and exclude its invoking process tree. If any is
+unavailable, it exits without inspecting or signaling processes and explains
+how to recover.
 
 **Features:**
 

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -35,9 +35,11 @@ Broad kills by bare runtime name (`killall node`, `pkill -9 node`) hit ALL proje
 
 ---
 
-## Port-Based Cleanup (Safest for Multi-Project)
+## Port-Based Cleanup
 
-**Prerequisite:** Each project must use a different port (e.g., Project A: 3000, Project B: 3001)
+**Recommended:** Give each project a different port (for example, Project A:
+3000 and Project B: 3001). The built-in script still verifies process ownership
+when ports overlap.
 
 **Port convention:** Dev and test instances use different ports within the same project:
 
@@ -46,27 +48,21 @@ Broad kills by bare runtime name (`killall node`, `pkill -9 node`) hit ALL proje
 
 See `development-workflow.md` → "E2E Testing with Persistent Dev Servers" for full port isolation strategy.
 
-**Decision rule:** If unsure which cleanup method to use → port-based first (safest), then project script, then tmux.
+**Decision rule:** Use the built-in project script first. Use raw port or pattern
+commands only after inspecting their matches.
 
-**Recommended cleanup pattern** (replace ports with your project's ports):
+**Manual cleanup** (replace ports with your project's ports):
 
 ```bash
-# Kill both dev server AND test server ports
-# Example: Next.js (3000/4000), Vite (5173/6173), or your project's ports
-lsof -ti:3000 -ti:4000 | xargs kill -9 2> /dev/null
+# Inspect both dev server AND test server ports
+lsof -i:3000 -i:4000
 
-# Kill Playwright processes launched from THIS directory
-pkill -f "playwright.*$(pwd)" 2> /dev/null
-
-# Wait for cleanup
-sleep 2
+# Inspect Playwright command lines before signaling anything
+pgrep -af "playwright"
 ```
 
-**Why this works:**
-
-- ✅ Dev + test ports are unique to this project → safe to kill
-- ✅ `$(pwd)` ensures only THIS project's tests are killed
-- ✅ Other projects completely untouched
+Raw `lsof | xargs kill` and `pkill -f` commands are machine-wide. A command line
+that mentions this project does not prove that the process belongs to it.
 
 ---
 
@@ -93,7 +89,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 - Auto-detects port from config files (vite.config.ts, next.config.js, etc.)
 - Checks dev port AND test port (port + 1000), then keeps only processes whose
   working directory belongs to the current project
-- Scopes all pattern matching to current project directory
+- Finds pattern candidates by command line, then applies the same working-directory
+  ownership check
+- Reports port owners it skipped because project ownership could not be verified
 - `--dry-run` shows what would be killed without killing
 
 **Supported frameworks:** Vite, Next.js, Nuxt, SvelteKit, Astro, Angular
@@ -200,16 +198,16 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 ## Quick Reference
 
-| Situation                                | Command                                                          |
-| ---------------------------------------- | ---------------------------------------------------------------- |
-| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`                         |
-| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`                   |
-| Kill dev + test servers (use your ports) | `lsof -ti:$DEV_PORT -ti:$TEST_PORT \| xargs kill -9 2>/dev/null` |
-| Kill Playwright (this project)           | `pkill -f "playwright.*$(pwd)"`                                  |
-| Check what's on port                     | `lsof -i:3000`                                                   |
-| Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"`               |
-| Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill)               |
-| Kill by process ID                       | `kill -9 <PID>`                                                  |
+| Situation                                | Command                                            |
+| ---------------------------------------- | -------------------------------------------------- |
+| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`           |
+| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`     |
+| Inspect dev + test servers               | `lsof -i:$DEV_PORT -i:$TEST_PORT`                  |
+| Inspect Playwright commands              | `pgrep -af "playwright"`                           |
+| Check what's on port                     | `lsof -i:3000`                                     |
+| Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"` |
+| Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill) |
+| Kill by process ID                       | `kill -9 <PID>`                                    |
 
 ---
 

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -91,7 +91,8 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 **Features:**
 
 - Auto-detects port from config files (vite.config.ts, next.config.js, etc.)
-- Kills dev port AND test port (port + 1000)
+- Checks dev port AND test port (port + 1000), then keeps only processes whose
+  working directory belongs to the current project
 - Scopes all pattern matching to current project directory
 - `--dry-run` shows what would be killed without killing
 

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -87,7 +87,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 The script requires `lsof`, `pgrep`, and `ps` to discover processes, verify
 working directories, and exclude its invoking process tree. If any is
 unavailable, it exits without inspecting or signaling processes and explains
-how to recover.
+how to recover. Kill mode also uses PATH-resolved `xargs` and `kill`; if either
+cannot signal a selected process, the summary reports a failed signal instead
+of claiming a successful kill.
 
 **Features:**
 
@@ -108,38 +110,32 @@ how to recover.
 ### Next.js Projects
 
 ```bash
-# Kill Next.js dev server (port 3000)
-lsof -ti:3000 | xargs kill -9 2> /dev/null
-
-# Kill Next.js build processes for this project
-ps aux | grep "next dev" | grep "$(pwd)" | grep -v grep | awk '{print $2}' | xargs kill -9 2> /dev/null
+# Preview project-owned Next.js processes (auto-detects port 3000)
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### Playwright E2E Tests
 
 ```bash
-# Kill Playwright browsers and test runners
-pkill -f "playwright.*$(pwd)" 2> /dev/null
-
-# Or more specific (by project name)
-pkill -f "playwright.*my-project-name" 2> /dev/null
+# Preview project-owned Playwright browsers and test runners
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### Vite Projects
 
 ```bash
-# Kill Vite dev server (typically port 5173)
-lsof -ti:5173 | xargs kill -9 2> /dev/null
+# Preview project-owned Vite processes (auto-detects port 5173)
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### React Native / Expo
 
 ```bash
-# Kill Metro bundler (port 8081)
-lsof -ti:8081 | xargs kill -9 2> /dev/null
+# Preview a project-owned Metro bundler on port 8081
+./.safeword/scripts/cleanup-zombies.sh 8081 "metro"
 
-# Kill Expo dev tools (port 19000-19006)
-lsof -ti:19000-19006 | xargs kill -9 2> /dev/null
+# Preview project-owned Expo tools on a known port
+./.safeword/scripts/cleanup-zombies.sh 19000 "expo"
 ```
 
 ---

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -138,6 +138,10 @@ of claiming a successful kill.
 ./.safeword/scripts/cleanup-zombies.sh 19000 "expo"
 ```
 
+Port ranges are not supported. To inspect ports `19000` through `19006`, run
+the command once per port; a value such as `19000-19006` is treated as a
+process pattern, not a port.
+
 ---
 
 ## Alternative: tmux/Screen Sessions

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -188,8 +188,10 @@ lsof -i:3000 -P -n
 # List all node processes
 ps aux | grep -E "(node|playwright|chromium)"
 
-# More detailed (with working directory)
-lsof -p $(pgrep node) | grep cwd
+# Print each Node process working directory (safe for zero or many matches)
+while IFS= read -r pid; do
+  lsof -a -p "$pid" -d cwd -Fn
+done < <(pgrep node)
 ```
 
 ### Find Processes by Project Directory

--- a/.safeword/guides/zombie-process-cleanup.md
+++ b/.safeword/guides/zombie-process-cleanup.md
@@ -57,8 +57,8 @@ commands only after inspecting their matches.
 # Inspect both dev server AND test server ports
 lsof -i:3000 -i:4000
 
-# Inspect Playwright command lines before signaling anything
-pgrep -af "playwright"
+# Inspect matching Playwright processes before signaling anything
+pgrep -l -f "playwright"
 ```
 
 Raw `lsof | xargs kill` and `pkill -f` commands are machine-wide. A command line
@@ -83,6 +83,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 # Port + additional pattern
 ./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
+
+The script requires `lsof` to verify process working directories. If `lsof` is
+unavailable, it exits without signaling anything and explains how to recover.
 
 **Features:**
 
@@ -203,7 +206,7 @@ ps aux | grep "/Users/alex/projects/my-project"
 | Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`           |
 | Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`     |
 | Inspect dev + test servers               | `lsof -i:$DEV_PORT -i:$TEST_PORT`                  |
-| Inspect Playwright commands              | `pgrep -af "playwright"`                           |
+| Inspect Playwright processes             | `pgrep -l -f "playwright"`                         |
 | Check what's on port                     | `lsof -i:3000`                                     |
 | Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"` |
 | Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill) |

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -130,11 +130,13 @@ fi
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
-if ! command -v lsof > /dev/null 2>&1; then
-  echo "Error: lsof is required to verify project ownership; no processes were inspected or signaled." >&2
-  echo "Install lsof and retry." >&2
-  exit 1
-fi
+for required_tool in lsof pgrep ps; do
+  if ! command -v "$required_tool" > /dev/null 2>&1; then
+    echo "Error: $required_tool is required for safe project-scoped cleanup; no processes were inspected or signaled." >&2
+    echo "Install $required_tool and retry." >&2
+    exit 1
+  fi
+done
 
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
@@ -157,7 +159,8 @@ collect_cleanup_ancestors() {
   local parent_pid
 
   while [[ "$current_pid" =~ ^[0-9]+$ ]] && [ "$current_pid" -gt 1 ]; do
-    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null | tr -d '[:space:]')
+    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null)
+    parent_pid=${parent_pid//[[:space:]]/}
     if ! [[ "$parent_pid" =~ ^[0-9]+$ ]] || [ "$parent_pid" -le 1 ] || [ "$parent_pid" = "$current_pid" ]; then
       break
     fi
@@ -191,22 +194,11 @@ path_belongs_to_project() {
 # establish ownership.
 process_belongs_to_project() {
   local pid=$1
-  local field
-  local process_cwd
+  local owned_pid
 
-  process_cwd=""
-  while IFS= read -r -d '' field; do
-    case "$field" in
-      n*)
-        process_cwd=${field#n}
-        break
-        ;;
-    esac
-  done < <(lsof -a -p "$pid" -d cwd -Fn0 2> /dev/null || true)
-
-  if [ -n "$process_cwd" ] && path_belongs_to_project "$process_cwd"; then
-    return 0
-  fi
+  while IFS= read -r owned_pid; do
+    [ "$owned_pid" = "$pid" ] && return 0
+  done < <(project_owned_pids "$pid")
   return 1
 }
 
@@ -298,9 +290,20 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
+  local pgrep_status
   local candidate_pids=()
   local project_pids=()
-  pids=$(pgrep -f "$pattern" 2> /dev/null || true)
+  if pids=$(pgrep -f "$pattern" 2> /dev/null); then
+    :
+  else
+    pgrep_status=$?
+    if [ "$pgrep_status" -eq 1 ]; then
+      pids=""
+    else
+      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled." >&2
+      exit "$pgrep_status"
+    fi
+  fi
 
   for pid in $pids; do
     if process_is_cleanup_ancestor "$pid"; then

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -150,6 +150,7 @@ FOUND_COUNT=0
 KILLED_COUNT=0
 FAILED_KILL_COUNT=0
 SKIPPED_PORT_COUNT=0
+DISCOVERY_ERROR_STATUS=0
 
 # A user-supplied pattern can appear in the argv of the cleanup process and any
 # shell or task runner that invoked it. Exclude the whole ancestor chain.
@@ -293,6 +294,13 @@ cleanup_pattern() {
   local pgrep_status
   local candidate_pids=()
   local project_pids=()
+
+  # A previous pattern-discovery error makes later sweeps unsafe. Preserve any
+  # work already completed, then report it before exiting nonzero.
+  if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+    return 0
+  fi
+
   if pids=$(pgrep -f "$pattern" 2> /dev/null); then
     :
   else
@@ -300,8 +308,9 @@ cleanup_pattern() {
     if [ "$pgrep_status" -eq 1 ]; then
       pids=""
     else
-      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled." >&2
-      exit "$pgrep_status"
+      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled for this pattern." >&2
+      DISCOVERY_ERROR_STATUS=$pgrep_status
+      return 0
     fi
   fi
 
@@ -372,7 +381,10 @@ fi
 # 5. Summary
 echo ""
 if [ "$FOUND_COUNT" -eq 0 ]; then
-  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+  if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+    echo -e "${YELLOW}Cleanup incomplete: process discovery failed before any project-owned zombies were found${NC}"
+    report_skipped_processes
+  elif [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
     echo -e "${YELLOW}No project-owned zombie processes found${NC}"
     report_skipped_processes
   else
@@ -398,4 +410,8 @@ else
       echo "   Port $PORT is now free"
     fi
   fi
+fi
+
+if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+  exit "$DISCOVERY_ERROR_STATUS"
 fi

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -266,6 +266,15 @@ signal_process() {
   printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null
 }
 
+print_process_details() {
+  local pid
+  local cmd
+  for pid in "$@"; do
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+}
+
 signal_project_processes() {
   local count_skipped_port_owners=$1
   shift
@@ -307,11 +316,7 @@ cleanup_port() {
   FOUND_COUNT=$((FOUND_COUNT + count))
 
   echo "Port $port: $count process(es)"
-  for pid in "${project_pids[@]}"; do
-    local cmd
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-    echo "  PID $pid: $cmd"
-  done
+  print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
     signal_project_processes true "${project_pids[@]}"
@@ -367,11 +372,7 @@ cleanup_pattern() {
   FOUND_COUNT=$((FOUND_COUNT + count))
 
   echo "Pattern '$pattern' (project-scoped): $count process(es)"
-  for pid in "${project_pids[@]}"; do
-    local cmd
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-    echo "  PID $pid: $cmd"
-  done
+  print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
     signal_project_processes false "${project_pids[@]}"

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -270,7 +270,8 @@ print_process_details() {
   local pid
   local cmd
   for pid in "$@"; do
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80)
+    [ -n "$cmd" ] || cmd="unknown"
     echo "  PID $pid: $cmd"
   done
 }

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -276,7 +276,7 @@ print_process_details() {
 }
 
 signal_project_processes() {
-  local count_skipped_port_owners=$1
+  local cleanup_source=$1
   shift
   local pid
   for pid in "$@"; do
@@ -286,7 +286,7 @@ signal_project_processes() {
       else
         FAILED_KILL_COUNT=$((FAILED_KILL_COUNT + 1))
       fi
-    elif [ "$count_skipped_port_owners" = true ]; then
+    elif [ "$cleanup_source" = "port" ]; then
       SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
     fi
   done
@@ -319,7 +319,7 @@ cleanup_port() {
   print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
-    signal_project_processes true "${project_pids[@]}"
+    signal_project_processes "port" "${project_pids[@]}"
   fi
 }
 
@@ -375,7 +375,7 @@ cleanup_pattern() {
   print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
-    signal_project_processes false "${project_pids[@]}"
+    signal_project_processes "pattern" "${project_pids[@]}"
   fi
 }
 

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -128,13 +128,6 @@ if [ -z "$PATTERN" ]; then
 fi
 
 PROJECT_DIR="$(pwd -P)"
-# macOS exposes its temporary directory through both /var and /private/var.
-# A process may carry either spelling in its argv, so keep the equivalent alias
-# for the project-scoped match without broadening the directory boundary.
-PROJECT_DIR_ALIASES=("$PROJECT_DIR")
-if [[ "$PROJECT_DIR" == /private/var/* ]]; then
-  PROJECT_DIR_ALIASES+=("/var/${PROJECT_DIR#/private/var/}")
-fi
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
 echo "Cleanup zombies for: $PROJECT_NAME"
@@ -147,22 +140,21 @@ echo ""
 # Track what we find/kill
 FOUND_COUNT=0
 KILLED_COUNT=0
+FAILED_KILL_COUNT=0
+SKIPPED_PORT_COUNT=0
 
 # Return success only when a path is the project root or one of its descendants.
 path_belongs_to_project() {
   local candidate=$1
-  local project_dir
-  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
-    case "$candidate" in
-      "$project_dir" | "$project_dir"/*) return 0 ;;
-    esac
-  done
-  return 1
+  case "$candidate" in
+    "$PROJECT_DIR" | "$PROJECT_DIR"/*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-# Port ownership is machine-wide, so verify each matching process belongs to this
-# project before presenting it as a cleanup candidate. Deny by default when
-# its working directory does not establish ownership.
+# Verify each matching process belongs to this project before presenting it as a
+# cleanup candidate. Deny by default when its working directory does not
+# establish ownership.
 process_belongs_to_project() {
   local pid=$1
   local field
@@ -184,6 +176,30 @@ process_belongs_to_project() {
   return 1
 }
 
+# Use xargs so kill is PATH-resolved instead of invoking Bash's kill builtin.
+# Besides being portable, this preserves the subprocess seam used by tests.
+signal_process() {
+  local pid=$1
+  printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null
+}
+
+signal_project_processes() {
+  local count_skipped_port_owners=$1
+  shift
+  local pid
+  for pid in "$@"; do
+    if process_belongs_to_project "$pid"; then
+      if signal_process "$pid"; then
+        KILLED_COUNT=$((KILLED_COUNT + 1))
+      else
+        FAILED_KILL_COUNT=$((FAILED_KILL_COUNT + 1))
+      fi
+    elif [ "$count_skipped_port_owners" = true ]; then
+      SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
+    fi
+  done
+}
+
 # Function to find and optionally kill processes by port
 cleanup_port() {
   local port=$1
@@ -194,6 +210,8 @@ cleanup_port() {
   for pid in $pids; do
     if process_belongs_to_project "$pid"; then
       project_pids+=("$pid")
+    else
+      SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
     fi
   done
 
@@ -213,12 +231,7 @@ cleanup_port() {
   done
 
   if [ "$DRY_RUN" = false ]; then
-    for pid in "${project_pids[@]}"; do
-      if process_belongs_to_project "$pid"; then
-        printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null || true
-        KILLED_COUNT=$((KILLED_COUNT + 1))
-      fi
-    done
+    signal_project_processes true "${project_pids[@]}"
   fi
 }
 
@@ -226,29 +239,43 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
-  local project_dir
-  # Match pattern AND project directory for safety
-  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
-    pids=$(pgrep -f "$pattern.*$project_dir" 2> /dev/null || pgrep -f "$project_dir.*$pattern" 2> /dev/null || true)
-    [ -n "$pids" ] && break
+  local project_pids=()
+  pids=$(pgrep -f "$pattern" 2> /dev/null || true)
+
+  for pid in $pids; do
+    # Explicit patterns can appear in the cleanup command's own argv.
+    if [ "$pid" = "$$" ] || [ "$pid" = "$PPID" ]; then
+      continue
+    fi
+    if process_belongs_to_project "$pid"; then
+      project_pids+=("$pid")
+    fi
   done
 
-  if [ -n "$pids" ]; then
-    local count
-    count=$(echo "$pids" | wc -l | tr -d ' ')
-    FOUND_COUNT=$((FOUND_COUNT + count))
+  if [ "${#project_pids[@]}" -eq 0 ]; then
+    return
+  fi
 
-    echo "Pattern '$pattern' (project-scoped): $count process(es)"
-    for pid in $pids; do
-      local cmd
-      cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-      echo "  PID $pid: $cmd"
-    done
+  local count
+  count=${#project_pids[@]}
+  FOUND_COUNT=$((FOUND_COUNT + count))
 
-    if [ "$DRY_RUN" = false ]; then
-      echo "$pids" | xargs kill -9 2> /dev/null || true
-      KILLED_COUNT=$((KILLED_COUNT + count))
-    fi
+  echo "Pattern '$pattern' (project-scoped): $count process(es)"
+  for pid in "${project_pids[@]}"; do
+    local cmd
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+
+  if [ "$DRY_RUN" = false ]; then
+    signal_project_processes false "${project_pids[@]}"
+  fi
+}
+
+report_skipped_processes() {
+  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}Skipped $SKIPPED_PORT_COUNT process(es) on detected ports; ownership was not verified for this project${NC}"
+    echo "   A detected port may still be in use by another project"
   fi
 }
 
@@ -279,12 +306,22 @@ fi
 # 5. Summary
 echo ""
 if [ "$FOUND_COUNT" -eq 0 ]; then
-  echo -e "${GREEN}No zombie processes found - already clean!${NC}"
+  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}No project-owned zombie processes found${NC}"
+    report_skipped_processes
+  else
+    echo -e "${GREEN}No zombie processes found - already clean!${NC}"
+  fi
 elif [ "$DRY_RUN" = true ]; then
   echo -e "${YELLOW}Found $FOUND_COUNT process(es) that would be killed${NC}"
   echo "   Re-run with --yes to kill them"
+  report_skipped_processes
 else
   echo -e "${GREEN}Killed $KILLED_COUNT process(es)${NC}"
+  if [ "$FAILED_KILL_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}Failed to kill $FAILED_KILL_COUNT process(es)${NC}"
+  fi
+  report_skipped_processes
 
   # Verify port is free
   if [ -n "$PORT" ]; then

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -403,9 +403,10 @@ cleanup_pattern "chromium"
 cleanup_pattern "electron"
 
 # 3. Kill framework-specific processes scoped to this project
-if [ -n "$PATTERN" ]; then
-  cleanup_pattern "$PATTERN"
-fi
+case "$PATTERN" in
+  "" | playwright | chromium | electron) ;;
+  *) cleanup_pattern "$PATTERN" ;;
+esac
 
 # 4. Wait for cleanup
 if [ "$DRY_RUN" = false ] && [ "$KILLED_COUNT" -gt 0 ]; then

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -338,7 +338,7 @@ cleanup_pattern() {
     return 0
   fi
 
-  if pids=$(pgrep -f "$pattern" 2> /dev/null); then
+  if pids=$(pgrep -f -- "$pattern" 2> /dev/null); then
     :
   else
     pgrep_status=$?

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -130,6 +130,12 @@ fi
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
+if ! command -v lsof > /dev/null 2>&1; then
+  echo "Error: lsof is required to verify project ownership; no processes were inspected or signaled." >&2
+  echo "Install lsof and retry." >&2
+  exit 1
+fi
+
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
 [ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
@@ -142,6 +148,34 @@ FOUND_COUNT=0
 KILLED_COUNT=0
 FAILED_KILL_COUNT=0
 SKIPPED_PORT_COUNT=0
+
+# A user-supplied pattern can appear in the argv of the cleanup process and any
+# shell or task runner that invoked it. Exclude the whole ancestor chain.
+CLEANUP_ANCESTOR_PIDS=("$$" "$PPID")
+collect_cleanup_ancestors() {
+  local current_pid=$PPID
+  local parent_pid
+
+  while [[ "$current_pid" =~ ^[0-9]+$ ]] && [ "$current_pid" -gt 1 ]; do
+    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null | tr -d '[:space:]')
+    if ! [[ "$parent_pid" =~ ^[0-9]+$ ]] || [ "$parent_pid" -le 1 ] || [ "$parent_pid" = "$current_pid" ]; then
+      break
+    fi
+    CLEANUP_ANCESTOR_PIDS+=("$parent_pid")
+    current_pid=$parent_pid
+  done
+}
+
+process_is_cleanup_ancestor() {
+  local candidate=$1
+  local ancestor_pid
+  for ancestor_pid in "${CLEANUP_ANCESTOR_PIDS[@]}"; do
+    [ "$candidate" = "$ancestor_pid" ] && return 0
+  done
+  return 1
+}
+
+collect_cleanup_ancestors
 
 # Return success only when a path is the project root or one of its descendants.
 path_belongs_to_project() {
@@ -174,6 +208,31 @@ process_belongs_to_project() {
     return 0
   fi
   return 1
+}
+
+# Print the project-owned subset of a PID list, one PID per line. Batch the cwd
+# lookup so broad patterns such as "chrome" do not fork lsof once per match.
+project_owned_pids() {
+  [ "$#" -gt 0 ] || return
+
+  local current_pid=""
+  local field
+  local pid_list
+  local IFS=,
+  pid_list="$*"
+
+  while IFS= read -r -d '' field; do
+    # lsof terminates each process field set with a newline even in NUL mode.
+    field=${field#$'\n'}
+    case "$field" in
+      p*) current_pid=${field#p} ;;
+      n*)
+        if [ -n "$current_pid" ] && path_belongs_to_project "${field#n}"; then
+          printf '%s\n' "$current_pid"
+        fi
+        ;;
+    esac
+  done < <(lsof -a -p "$pid_list" -d cwd -Fpn0 2> /dev/null || true)
 }
 
 # Use xargs so kill is PATH-resolved instead of invoking Bash's kill builtin.
@@ -239,18 +298,22 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
+  local candidate_pids=()
   local project_pids=()
   pids=$(pgrep -f "$pattern" 2> /dev/null || true)
 
   for pid in $pids; do
-    # Explicit patterns can appear in the cleanup command's own argv.
-    if [ "$pid" = "$$" ] || [ "$pid" = "$PPID" ]; then
+    if process_is_cleanup_ancestor "$pid"; then
       continue
     fi
-    if process_belongs_to_project "$pid"; then
-      project_pids+=("$pid")
-    fi
+    candidate_pids+=("$pid")
   done
+
+  if [ "${#candidate_pids[@]}" -gt 0 ]; then
+    while IFS= read -r pid; do
+      [ -n "$pid" ] && project_pids+=("$pid")
+    done < <(project_owned_pids "${candidate_pids[@]}")
+  fi
 
   if [ "${#project_pids[@]}" -eq 0 ]; then
     return

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -127,6 +127,33 @@ if [ -z "$PATTERN" ]; then
   PATTERN=$(detect_pattern)
 fi
 
+normalize_port() {
+  local normalized=$1
+
+  while [[ "$normalized" == 0* ]] && [ "${#normalized}" -gt 1 ]; do
+    normalized=${normalized#0}
+  done
+
+  if [ "$normalized" = "0" ] \
+    || [ "${#normalized}" -gt 5 ] \
+    || [ "$normalized" -gt 65535 ]; then
+    echo "Error: port must be between 1 and 65535." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$normalized"
+}
+
+TEST_PORT=""
+if [ -n "$PORT" ]; then
+  if ! PORT=$(normalize_port "$PORT"); then
+    exit 2
+  fi
+  if [ "$PORT" -le 64535 ]; then
+    TEST_PORT=$((PORT + 1000))
+  fi
+fi
+
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
@@ -140,7 +167,11 @@ done
 
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
-[ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
+if [ -n "$TEST_PORT" ]; then
+  echo "   Port: $PORT (+ test port $TEST_PORT)"
+elif [ -n "$PORT" ]; then
+  echo "   Port: $PORT"
+fi
 [ -n "$PATTERN" ] && echo "   Pattern: $PATTERN"
 $DRY_RUN && echo -e "   ${YELLOW}DRY RUN (default) - no processes will be killed; pass --yes to kill${NC}"
 echo ""
@@ -358,9 +389,10 @@ report_skipped_processes() {
 if [ -n "$PORT" ]; then
   cleanup_port "$PORT"
 
-  # Also kill test port (dev port + 1000, common convention)
-  TEST_PORT=$((PORT + 1000))
-  cleanup_port "$TEST_PORT"
+  # Also kill test port (dev port + 1000) when it remains in range.
+  if [ -n "$TEST_PORT" ]; then
+    cleanup_port "$TEST_PORT"
+  fi
 fi
 
 # 2. Kill Playwright/test processes scoped to this project

--- a/.safeword/scripts/cleanup-zombies.sh
+++ b/.safeword/scripts/cleanup-zombies.sh
@@ -148,28 +148,77 @@ echo ""
 FOUND_COUNT=0
 KILLED_COUNT=0
 
+# Return success only when a path is the project root or one of its descendants.
+path_belongs_to_project() {
+  local candidate=$1
+  local project_dir
+  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
+    case "$candidate" in
+      "$project_dir" | "$project_dir"/*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Port ownership is machine-wide, so verify each matching process belongs to this
+# project before presenting it as a cleanup candidate. Deny by default when
+# its working directory does not establish ownership.
+process_belongs_to_project() {
+  local pid=$1
+  local field
+  local process_cwd
+
+  process_cwd=""
+  while IFS= read -r -d '' field; do
+    case "$field" in
+      n*)
+        process_cwd=${field#n}
+        break
+        ;;
+    esac
+  done < <(lsof -a -p "$pid" -d cwd -Fn0 2> /dev/null || true)
+
+  if [ -n "$process_cwd" ] && path_belongs_to_project "$process_cwd"; then
+    return 0
+  fi
+  return 1
+}
+
 # Function to find and optionally kill processes by port
 cleanup_port() {
   local port=$1
   local pids
+  local project_pids=()
   pids=$(lsof -ti:"$port" 2> /dev/null || true)
 
-  if [ -n "$pids" ]; then
-    local count
-    count=$(echo "$pids" | wc -l | tr -d ' ')
-    FOUND_COUNT=$((FOUND_COUNT + count))
-
-    echo "Port $port: $count process(es)"
-    for pid in $pids; do
-      local cmd
-      cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-      echo "  PID $pid: $cmd"
-    done
-
-    if [ "$DRY_RUN" = false ]; then
-      echo "$pids" | xargs kill -9 2> /dev/null || true
-      KILLED_COUNT=$((KILLED_COUNT + count))
+  for pid in $pids; do
+    if process_belongs_to_project "$pid"; then
+      project_pids+=("$pid")
     fi
+  done
+
+  if [ "${#project_pids[@]}" -eq 0 ]; then
+    return
+  fi
+
+  local count
+  count=${#project_pids[@]}
+  FOUND_COUNT=$((FOUND_COUNT + count))
+
+  echo "Port $port: $count process(es)"
+  for pid in "${project_pids[@]}"; do
+    local cmd
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+
+  if [ "$DRY_RUN" = false ]; then
+    for pid in "${project_pids[@]}"; do
+      if process_belongs_to_project "$pid"; then
+        printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null || true
+        KILLED_COUNT=$((KILLED_COUNT + 1))
+      fi
+    done
   fi
 }
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ it never stages, commits, or opens a PR.
 
 - `/audit` - Run architecture and dead code analysis
 - `/bdd` - Force BDD flow for current task
-- `/cleanup-zombies` - Preview or kill current-project zombie processes on ports
+- `/cleanup-zombies` - Preview or kill current-project zombie processes
 - `/debug` - Four-phase debugging framework
 - `/explain` - Plain-English version of any safeword block, verdict, or your current state
 - `/lint` - Run linters and formatters

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ it never stages, commits, or opens a PR.
 
 - `/audit` - Run architecture and dead code analysis
 - `/bdd` - Force BDD flow for current task
-- `/cleanup-zombies` - Kill zombie processes on ports
+- `/cleanup-zombies` - Preview or kill current-project zombie processes on ports
 - `/debug` - Four-phase debugging framework
 - `/explain` - Plain-English version of any safeword block, verdict, or your current state
 - `/lint` - Run linters and formatters

--- a/knip.json
+++ b/knip.json
@@ -11,6 +11,7 @@
     "shfmt",
     "dot",
     "shellcheck",
+    "pgrep",
     "rustup",
     "ruff",
     "golangci-lint",

--- a/packages/cli/codex-plugin/skills/cleanup-zombies/SKILL.md
+++ b/packages/cli/codex-plugin/skills/cleanup-zombies/SKILL.md
@@ -26,9 +26,9 @@ If the preview looks correct, confirm the kill with `--yes`:
 ## What It Does
 
 1. **Auto-detects framework** - Finds port from vite.config.ts, next.config.js, etc. (checks root, `packages/*/`, `apps/*/` for monorepos)
-2. **Kills by port** - Dev server port AND test port (port + 1000)
-3. **Kills test processes** - Playwright, Chromium, Electron (scoped to this project)
-4. **Multi-project safe** - Only kills processes matching this project's directory
+2. **Checks project-owned port processes** - Inspects the dev port and in-range test port (port + 1000), reporting owners it skips when project ownership cannot be verified
+3. **Checks project-owned test processes** - Inspects Playwright, Chromium, and Electron matches whose working directory is inside this project
+4. **Revalidates before signaling** - Only kills processes whose current working directory still belongs to this project
 
 ## Manual Override
 

--- a/packages/cli/templates/commands/cleanup-zombies.md
+++ b/packages/cli/templates/commands/cleanup-zombies.md
@@ -24,9 +24,9 @@ If the preview looks correct, confirm the kill with `--yes`:
 ## What It Does
 
 1. **Auto-detects framework** - Finds port from vite.config.ts, next.config.js, etc. (checks root, `packages/*/`, `apps/*/` for monorepos)
-2. **Kills by port** - Dev server port AND test port (port + 1000)
-3. **Kills test processes** - Playwright, Chromium, Electron (scoped to this project)
-4. **Multi-project safe** - Only kills processes matching this project's directory
+2. **Checks project-owned port processes** - Inspects the dev port and in-range test port (port + 1000), reporting owners it skips when project ownership cannot be verified
+3. **Checks project-owned test processes** - Inspects Playwright, Chromium, and Electron matches whose working directory is inside this project
+4. **Revalidates before signaling** - Only kills processes whose current working directory still belongs to this project
 
 ## Manual Override
 

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -84,8 +84,10 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 ./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
 
-The script requires `lsof` to verify process working directories. If `lsof` is
-unavailable, it exits without signaling anything and explains how to recover.
+The script requires `lsof`, `pgrep`, and `ps` to discover processes, verify
+working directories, and exclude its invoking process tree. If any is
+unavailable, it exits without inspecting or signaling processes and explains
+how to recover.
 
 **Features:**
 

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -35,9 +35,11 @@ Broad kills by bare runtime name (`killall node`, `pkill -9 node`) hit ALL proje
 
 ---
 
-## Port-Based Cleanup (Safest for Multi-Project)
+## Port-Based Cleanup
 
-**Prerequisite:** Each project must use a different port (e.g., Project A: 3000, Project B: 3001)
+**Recommended:** Give each project a different port (for example, Project A:
+3000 and Project B: 3001). The built-in script still verifies process ownership
+when ports overlap.
 
 **Port convention:** Dev and test instances use different ports within the same project:
 
@@ -46,27 +48,21 @@ Broad kills by bare runtime name (`killall node`, `pkill -9 node`) hit ALL proje
 
 See `development-workflow.md` → "E2E Testing with Persistent Dev Servers" for full port isolation strategy.
 
-**Decision rule:** If unsure which cleanup method to use → port-based first (safest), then project script, then tmux.
+**Decision rule:** Use the built-in project script first. Use raw port or pattern
+commands only after inspecting their matches.
 
-**Recommended cleanup pattern** (replace ports with your project's ports):
+**Manual cleanup** (replace ports with your project's ports):
 
 ```bash
-# Kill both dev server AND test server ports
-# Example: Next.js (3000/4000), Vite (5173/6173), or your project's ports
-lsof -ti:3000 -ti:4000 | xargs kill -9 2> /dev/null
+# Inspect both dev server AND test server ports
+lsof -i:3000 -i:4000
 
-# Kill Playwright processes launched from THIS directory
-pkill -f "playwright.*$(pwd)" 2> /dev/null
-
-# Wait for cleanup
-sleep 2
+# Inspect Playwright command lines before signaling anything
+pgrep -af "playwright"
 ```
 
-**Why this works:**
-
-- ✅ Dev + test ports are unique to this project → safe to kill
-- ✅ `$(pwd)` ensures only THIS project's tests are killed
-- ✅ Other projects completely untouched
+Raw `lsof | xargs kill` and `pkill -f` commands are machine-wide. A command line
+that mentions this project does not prove that the process belongs to it.
 
 ---
 
@@ -93,7 +89,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 - Auto-detects port from config files (vite.config.ts, next.config.js, etc.)
 - Checks dev port AND test port (port + 1000), then keeps only processes whose
   working directory belongs to the current project
-- Scopes all pattern matching to current project directory
+- Finds pattern candidates by command line, then applies the same working-directory
+  ownership check
+- Reports port owners it skipped because project ownership could not be verified
 - `--dry-run` shows what would be killed without killing
 
 **Supported frameworks:** Vite, Next.js, Nuxt, SvelteKit, Astro, Angular
@@ -200,16 +198,16 @@ ps aux | grep "/Users/alex/projects/my-project"
 
 ## Quick Reference
 
-| Situation                                | Command                                                          |
-| ---------------------------------------- | ---------------------------------------------------------------- |
-| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`                         |
-| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`                   |
-| Kill dev + test servers (use your ports) | `lsof -ti:$DEV_PORT -ti:$TEST_PORT \| xargs kill -9 2>/dev/null` |
-| Kill Playwright (this project)           | `pkill -f "playwright.*$(pwd)"`                                  |
-| Check what's on port                     | `lsof -i:3000`                                                   |
-| Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"`               |
-| Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill)               |
-| Kill by process ID                       | `kill -9 <PID>`                                                  |
+| Situation                                | Command                                            |
+| ---------------------------------------- | -------------------------------------------------- |
+| Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`           |
+| Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`     |
+| Inspect dev + test servers               | `lsof -i:$DEV_PORT -i:$TEST_PORT`                  |
+| Inspect Playwright commands              | `pgrep -af "playwright"`                           |
+| Check what's on port                     | `lsof -i:3000`                                     |
+| Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"` |
+| Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill) |
+| Kill by process ID                       | `kill -9 <PID>`                                    |
 
 ---
 

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -91,7 +91,8 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 **Features:**
 
 - Auto-detects port from config files (vite.config.ts, next.config.js, etc.)
-- Kills dev port AND test port (port + 1000)
+- Checks dev port AND test port (port + 1000), then keeps only processes whose
+  working directory belongs to the current project
 - Scopes all pattern matching to current project directory
 - `--dry-run` shows what would be killed without killing
 

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -87,7 +87,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 The script requires `lsof`, `pgrep`, and `ps` to discover processes, verify
 working directories, and exclude its invoking process tree. If any is
 unavailable, it exits without inspecting or signaling processes and explains
-how to recover.
+how to recover. Kill mode also uses PATH-resolved `xargs` and `kill`; if either
+cannot signal a selected process, the summary reports a failed signal instead
+of claiming a successful kill.
 
 **Features:**
 
@@ -108,38 +110,32 @@ how to recover.
 ### Next.js Projects
 
 ```bash
-# Kill Next.js dev server (port 3000)
-lsof -ti:3000 | xargs kill -9 2> /dev/null
-
-# Kill Next.js build processes for this project
-ps aux | grep "next dev" | grep "$(pwd)" | grep -v grep | awk '{print $2}' | xargs kill -9 2> /dev/null
+# Preview project-owned Next.js processes (auto-detects port 3000)
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### Playwright E2E Tests
 
 ```bash
-# Kill Playwright browsers and test runners
-pkill -f "playwright.*$(pwd)" 2> /dev/null
-
-# Or more specific (by project name)
-pkill -f "playwright.*my-project-name" 2> /dev/null
+# Preview project-owned Playwright browsers and test runners
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### Vite Projects
 
 ```bash
-# Kill Vite dev server (typically port 5173)
-lsof -ti:5173 | xargs kill -9 2> /dev/null
+# Preview project-owned Vite processes (auto-detects port 5173)
+./.safeword/scripts/cleanup-zombies.sh
 ```
 
 ### React Native / Expo
 
 ```bash
-# Kill Metro bundler (port 8081)
-lsof -ti:8081 | xargs kill -9 2> /dev/null
+# Preview a project-owned Metro bundler on port 8081
+./.safeword/scripts/cleanup-zombies.sh 8081 "metro"
 
-# Kill Expo dev tools (port 19000-19006)
-lsof -ti:19000-19006 | xargs kill -9 2> /dev/null
+# Preview project-owned Expo tools on a known port
+./.safeword/scripts/cleanup-zombies.sh 19000 "expo"
 ```
 
 ---

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -138,6 +138,10 @@ of claiming a successful kill.
 ./.safeword/scripts/cleanup-zombies.sh 19000 "expo"
 ```
 
+Port ranges are not supported. To inspect ports `19000` through `19006`, run
+the command once per port; a value such as `19000-19006` is treated as a
+process pattern, not a port.
+
 ---
 
 ## Alternative: tmux/Screen Sessions

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -188,8 +188,10 @@ lsof -i:3000 -P -n
 # List all node processes
 ps aux | grep -E "(node|playwright|chromium)"
 
-# More detailed (with working directory)
-lsof -p $(pgrep node) | grep cwd
+# Print each Node process working directory (safe for zero or many matches)
+while IFS= read -r pid; do
+  lsof -a -p "$pid" -d cwd -Fn
+done < <(pgrep node)
 ```
 
 ### Find Processes by Project Directory

--- a/packages/cli/templates/guides/zombie-process-cleanup.md
+++ b/packages/cli/templates/guides/zombie-process-cleanup.md
@@ -57,8 +57,8 @@ commands only after inspecting their matches.
 # Inspect both dev server AND test server ports
 lsof -i:3000 -i:4000
 
-# Inspect Playwright command lines before signaling anything
-pgrep -af "playwright"
+# Inspect matching Playwright processes before signaling anything
+pgrep -l -f "playwright"
 ```
 
 Raw `lsof | xargs kill` and `pkill -f` commands are machine-wide. A command line
@@ -83,6 +83,9 @@ Safeword includes a cleanup script at `.safeword/scripts/cleanup-zombies.sh`:
 # Port + additional pattern
 ./.safeword/scripts/cleanup-zombies.sh --yes 5173 "electron"
 ```
+
+The script requires `lsof` to verify process working directories. If `lsof` is
+unavailable, it exits without signaling anything and explains how to recover.
 
 **Features:**
 
@@ -203,7 +206,7 @@ ps aux | grep "/Users/alex/projects/my-project"
 | Preview zombies (recommended first step) | `./.safeword/scripts/cleanup-zombies.sh`           |
 | Kill what the preview showed             | `./.safeword/scripts/cleanup-zombies.sh --yes`     |
 | Inspect dev + test servers               | `lsof -i:$DEV_PORT -i:$TEST_PORT`                  |
-| Inspect Playwright commands              | `pgrep -af "playwright"`                           |
+| Inspect Playwright processes             | `pgrep -l -f "playwright"`                         |
 | Check what's on port                     | `lsof -i:3000`                                     |
 | Find zombie processes                    | `ps aux \| grep -E "(node\|playwright\|chromium)"` |
 | Preview what `pkill -f` would kill       | `pgrep -f "pattern"` (verify before running pkill) |

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -130,11 +130,13 @@ fi
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
-if ! command -v lsof > /dev/null 2>&1; then
-  echo "Error: lsof is required to verify project ownership; no processes were inspected or signaled." >&2
-  echo "Install lsof and retry." >&2
-  exit 1
-fi
+for required_tool in lsof pgrep ps; do
+  if ! command -v "$required_tool" > /dev/null 2>&1; then
+    echo "Error: $required_tool is required for safe project-scoped cleanup; no processes were inspected or signaled." >&2
+    echo "Install $required_tool and retry." >&2
+    exit 1
+  fi
+done
 
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
@@ -157,7 +159,8 @@ collect_cleanup_ancestors() {
   local parent_pid
 
   while [[ "$current_pid" =~ ^[0-9]+$ ]] && [ "$current_pid" -gt 1 ]; do
-    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null | tr -d '[:space:]')
+    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null)
+    parent_pid=${parent_pid//[[:space:]]/}
     if ! [[ "$parent_pid" =~ ^[0-9]+$ ]] || [ "$parent_pid" -le 1 ] || [ "$parent_pid" = "$current_pid" ]; then
       break
     fi
@@ -191,22 +194,11 @@ path_belongs_to_project() {
 # establish ownership.
 process_belongs_to_project() {
   local pid=$1
-  local field
-  local process_cwd
+  local owned_pid
 
-  process_cwd=""
-  while IFS= read -r -d '' field; do
-    case "$field" in
-      n*)
-        process_cwd=${field#n}
-        break
-        ;;
-    esac
-  done < <(lsof -a -p "$pid" -d cwd -Fn0 2> /dev/null || true)
-
-  if [ -n "$process_cwd" ] && path_belongs_to_project "$process_cwd"; then
-    return 0
-  fi
+  while IFS= read -r owned_pid; do
+    [ "$owned_pid" = "$pid" ] && return 0
+  done < <(project_owned_pids "$pid")
   return 1
 }
 
@@ -298,9 +290,20 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
+  local pgrep_status
   local candidate_pids=()
   local project_pids=()
-  pids=$(pgrep -f "$pattern" 2> /dev/null || true)
+  if pids=$(pgrep -f "$pattern" 2> /dev/null); then
+    :
+  else
+    pgrep_status=$?
+    if [ "$pgrep_status" -eq 1 ]; then
+      pids=""
+    else
+      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled." >&2
+      exit "$pgrep_status"
+    fi
+  fi
 
   for pid in $pids; do
     if process_is_cleanup_ancestor "$pid"; then

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -150,6 +150,7 @@ FOUND_COUNT=0
 KILLED_COUNT=0
 FAILED_KILL_COUNT=0
 SKIPPED_PORT_COUNT=0
+DISCOVERY_ERROR_STATUS=0
 
 # A user-supplied pattern can appear in the argv of the cleanup process and any
 # shell or task runner that invoked it. Exclude the whole ancestor chain.
@@ -293,6 +294,13 @@ cleanup_pattern() {
   local pgrep_status
   local candidate_pids=()
   local project_pids=()
+
+  # A previous pattern-discovery error makes later sweeps unsafe. Preserve any
+  # work already completed, then report it before exiting nonzero.
+  if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+    return 0
+  fi
+
   if pids=$(pgrep -f "$pattern" 2> /dev/null); then
     :
   else
@@ -300,8 +308,9 @@ cleanup_pattern() {
     if [ "$pgrep_status" -eq 1 ]; then
       pids=""
     else
-      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled." >&2
-      exit "$pgrep_status"
+      echo "Error: pgrep failed for pattern '$pattern' (exit $pgrep_status); no matching processes were inspected or signaled for this pattern." >&2
+      DISCOVERY_ERROR_STATUS=$pgrep_status
+      return 0
     fi
   fi
 
@@ -372,7 +381,10 @@ fi
 # 5. Summary
 echo ""
 if [ "$FOUND_COUNT" -eq 0 ]; then
-  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+  if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+    echo -e "${YELLOW}Cleanup incomplete: process discovery failed before any project-owned zombies were found${NC}"
+    report_skipped_processes
+  elif [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
     echo -e "${YELLOW}No project-owned zombie processes found${NC}"
     report_skipped_processes
   else
@@ -398,4 +410,8 @@ else
       echo "   Port $PORT is now free"
     fi
   fi
+fi
+
+if [ "$DISCOVERY_ERROR_STATUS" -ne 0 ]; then
+  exit "$DISCOVERY_ERROR_STATUS"
 fi

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -266,6 +266,15 @@ signal_process() {
   printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null
 }
 
+print_process_details() {
+  local pid
+  local cmd
+  for pid in "$@"; do
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+}
+
 signal_project_processes() {
   local count_skipped_port_owners=$1
   shift
@@ -307,11 +316,7 @@ cleanup_port() {
   FOUND_COUNT=$((FOUND_COUNT + count))
 
   echo "Port $port: $count process(es)"
-  for pid in "${project_pids[@]}"; do
-    local cmd
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-    echo "  PID $pid: $cmd"
-  done
+  print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
     signal_project_processes true "${project_pids[@]}"
@@ -367,11 +372,7 @@ cleanup_pattern() {
   FOUND_COUNT=$((FOUND_COUNT + count))
 
   echo "Pattern '$pattern' (project-scoped): $count process(es)"
-  for pid in "${project_pids[@]}"; do
-    local cmd
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-    echo "  PID $pid: $cmd"
-  done
+  print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
     signal_project_processes false "${project_pids[@]}"

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -270,7 +270,8 @@ print_process_details() {
   local pid
   local cmd
   for pid in "$@"; do
-    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80)
+    [ -n "$cmd" ] || cmd="unknown"
     echo "  PID $pid: $cmd"
   done
 }

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -276,7 +276,7 @@ print_process_details() {
 }
 
 signal_project_processes() {
-  local count_skipped_port_owners=$1
+  local cleanup_source=$1
   shift
   local pid
   for pid in "$@"; do
@@ -286,7 +286,7 @@ signal_project_processes() {
       else
         FAILED_KILL_COUNT=$((FAILED_KILL_COUNT + 1))
       fi
-    elif [ "$count_skipped_port_owners" = true ]; then
+    elif [ "$cleanup_source" = "port" ]; then
       SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
     fi
   done
@@ -319,7 +319,7 @@ cleanup_port() {
   print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
-    signal_project_processes true "${project_pids[@]}"
+    signal_project_processes "port" "${project_pids[@]}"
   fi
 }
 
@@ -375,7 +375,7 @@ cleanup_pattern() {
   print_process_details "${project_pids[@]}"
 
   if [ "$DRY_RUN" = false ]; then
-    signal_project_processes false "${project_pids[@]}"
+    signal_project_processes "pattern" "${project_pids[@]}"
   fi
 }
 

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -128,13 +128,6 @@ if [ -z "$PATTERN" ]; then
 fi
 
 PROJECT_DIR="$(pwd -P)"
-# macOS exposes its temporary directory through both /var and /private/var.
-# A process may carry either spelling in its argv, so keep the equivalent alias
-# for the project-scoped match without broadening the directory boundary.
-PROJECT_DIR_ALIASES=("$PROJECT_DIR")
-if [[ "$PROJECT_DIR" == /private/var/* ]]; then
-  PROJECT_DIR_ALIASES+=("/var/${PROJECT_DIR#/private/var/}")
-fi
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
 echo "Cleanup zombies for: $PROJECT_NAME"
@@ -147,22 +140,21 @@ echo ""
 # Track what we find/kill
 FOUND_COUNT=0
 KILLED_COUNT=0
+FAILED_KILL_COUNT=0
+SKIPPED_PORT_COUNT=0
 
 # Return success only when a path is the project root or one of its descendants.
 path_belongs_to_project() {
   local candidate=$1
-  local project_dir
-  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
-    case "$candidate" in
-      "$project_dir" | "$project_dir"/*) return 0 ;;
-    esac
-  done
-  return 1
+  case "$candidate" in
+    "$PROJECT_DIR" | "$PROJECT_DIR"/*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-# Port ownership is machine-wide, so verify each matching process belongs to this
-# project before presenting it as a cleanup candidate. Deny by default when
-# its working directory does not establish ownership.
+# Verify each matching process belongs to this project before presenting it as a
+# cleanup candidate. Deny by default when its working directory does not
+# establish ownership.
 process_belongs_to_project() {
   local pid=$1
   local field
@@ -184,6 +176,30 @@ process_belongs_to_project() {
   return 1
 }
 
+# Use xargs so kill is PATH-resolved instead of invoking Bash's kill builtin.
+# Besides being portable, this preserves the subprocess seam used by tests.
+signal_process() {
+  local pid=$1
+  printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null
+}
+
+signal_project_processes() {
+  local count_skipped_port_owners=$1
+  shift
+  local pid
+  for pid in "$@"; do
+    if process_belongs_to_project "$pid"; then
+      if signal_process "$pid"; then
+        KILLED_COUNT=$((KILLED_COUNT + 1))
+      else
+        FAILED_KILL_COUNT=$((FAILED_KILL_COUNT + 1))
+      fi
+    elif [ "$count_skipped_port_owners" = true ]; then
+      SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
+    fi
+  done
+}
+
 # Function to find and optionally kill processes by port
 cleanup_port() {
   local port=$1
@@ -194,6 +210,8 @@ cleanup_port() {
   for pid in $pids; do
     if process_belongs_to_project "$pid"; then
       project_pids+=("$pid")
+    else
+      SKIPPED_PORT_COUNT=$((SKIPPED_PORT_COUNT + 1))
     fi
   done
 
@@ -213,12 +231,7 @@ cleanup_port() {
   done
 
   if [ "$DRY_RUN" = false ]; then
-    for pid in "${project_pids[@]}"; do
-      if process_belongs_to_project "$pid"; then
-        printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null || true
-        KILLED_COUNT=$((KILLED_COUNT + 1))
-      fi
-    done
+    signal_project_processes true "${project_pids[@]}"
   fi
 }
 
@@ -226,29 +239,43 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
-  local project_dir
-  # Match pattern AND project directory for safety
-  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
-    pids=$(pgrep -f "$pattern.*$project_dir" 2> /dev/null || pgrep -f "$project_dir.*$pattern" 2> /dev/null || true)
-    [ -n "$pids" ] && break
+  local project_pids=()
+  pids=$(pgrep -f "$pattern" 2> /dev/null || true)
+
+  for pid in $pids; do
+    # Explicit patterns can appear in the cleanup command's own argv.
+    if [ "$pid" = "$$" ] || [ "$pid" = "$PPID" ]; then
+      continue
+    fi
+    if process_belongs_to_project "$pid"; then
+      project_pids+=("$pid")
+    fi
   done
 
-  if [ -n "$pids" ]; then
-    local count
-    count=$(echo "$pids" | wc -l | tr -d ' ')
-    FOUND_COUNT=$((FOUND_COUNT + count))
+  if [ "${#project_pids[@]}" -eq 0 ]; then
+    return
+  fi
 
-    echo "Pattern '$pattern' (project-scoped): $count process(es)"
-    for pid in $pids; do
-      local cmd
-      cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-      echo "  PID $pid: $cmd"
-    done
+  local count
+  count=${#project_pids[@]}
+  FOUND_COUNT=$((FOUND_COUNT + count))
 
-    if [ "$DRY_RUN" = false ]; then
-      echo "$pids" | xargs kill -9 2> /dev/null || true
-      KILLED_COUNT=$((KILLED_COUNT + count))
-    fi
+  echo "Pattern '$pattern' (project-scoped): $count process(es)"
+  for pid in "${project_pids[@]}"; do
+    local cmd
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+
+  if [ "$DRY_RUN" = false ]; then
+    signal_project_processes false "${project_pids[@]}"
+  fi
+}
+
+report_skipped_processes() {
+  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}Skipped $SKIPPED_PORT_COUNT process(es) on detected ports; ownership was not verified for this project${NC}"
+    echo "   A detected port may still be in use by another project"
   fi
 }
 
@@ -279,12 +306,22 @@ fi
 # 5. Summary
 echo ""
 if [ "$FOUND_COUNT" -eq 0 ]; then
-  echo -e "${GREEN}No zombie processes found - already clean!${NC}"
+  if [ "$SKIPPED_PORT_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}No project-owned zombie processes found${NC}"
+    report_skipped_processes
+  else
+    echo -e "${GREEN}No zombie processes found - already clean!${NC}"
+  fi
 elif [ "$DRY_RUN" = true ]; then
   echo -e "${YELLOW}Found $FOUND_COUNT process(es) that would be killed${NC}"
   echo "   Re-run with --yes to kill them"
+  report_skipped_processes
 else
   echo -e "${GREEN}Killed $KILLED_COUNT process(es)${NC}"
+  if [ "$FAILED_KILL_COUNT" -gt 0 ]; then
+    echo -e "${YELLOW}Failed to kill $FAILED_KILL_COUNT process(es)${NC}"
+  fi
+  report_skipped_processes
 
   # Verify port is free
   if [ -n "$PORT" ]; then

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -403,9 +403,10 @@ cleanup_pattern "chromium"
 cleanup_pattern "electron"
 
 # 3. Kill framework-specific processes scoped to this project
-if [ -n "$PATTERN" ]; then
-  cleanup_pattern "$PATTERN"
-fi
+case "$PATTERN" in
+  "" | playwright | chromium | electron) ;;
+  *) cleanup_pattern "$PATTERN" ;;
+esac
 
 # 4. Wait for cleanup
 if [ "$DRY_RUN" = false ] && [ "$KILLED_COUNT" -gt 0 ]; then

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -338,7 +338,7 @@ cleanup_pattern() {
     return 0
   fi
 
-  if pids=$(pgrep -f "$pattern" 2> /dev/null); then
+  if pids=$(pgrep -f -- "$pattern" 2> /dev/null); then
     :
   else
     pgrep_status=$?

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -130,6 +130,12 @@ fi
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
+if ! command -v lsof > /dev/null 2>&1; then
+  echo "Error: lsof is required to verify project ownership; no processes were inspected or signaled." >&2
+  echo "Install lsof and retry." >&2
+  exit 1
+fi
+
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
 [ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
@@ -142,6 +148,34 @@ FOUND_COUNT=0
 KILLED_COUNT=0
 FAILED_KILL_COUNT=0
 SKIPPED_PORT_COUNT=0
+
+# A user-supplied pattern can appear in the argv of the cleanup process and any
+# shell or task runner that invoked it. Exclude the whole ancestor chain.
+CLEANUP_ANCESTOR_PIDS=("$$" "$PPID")
+collect_cleanup_ancestors() {
+  local current_pid=$PPID
+  local parent_pid
+
+  while [[ "$current_pid" =~ ^[0-9]+$ ]] && [ "$current_pid" -gt 1 ]; do
+    parent_pid=$(ps -p "$current_pid" -o ppid= 2> /dev/null | tr -d '[:space:]')
+    if ! [[ "$parent_pid" =~ ^[0-9]+$ ]] || [ "$parent_pid" -le 1 ] || [ "$parent_pid" = "$current_pid" ]; then
+      break
+    fi
+    CLEANUP_ANCESTOR_PIDS+=("$parent_pid")
+    current_pid=$parent_pid
+  done
+}
+
+process_is_cleanup_ancestor() {
+  local candidate=$1
+  local ancestor_pid
+  for ancestor_pid in "${CLEANUP_ANCESTOR_PIDS[@]}"; do
+    [ "$candidate" = "$ancestor_pid" ] && return 0
+  done
+  return 1
+}
+
+collect_cleanup_ancestors
 
 # Return success only when a path is the project root or one of its descendants.
 path_belongs_to_project() {
@@ -174,6 +208,31 @@ process_belongs_to_project() {
     return 0
   fi
   return 1
+}
+
+# Print the project-owned subset of a PID list, one PID per line. Batch the cwd
+# lookup so broad patterns such as "chrome" do not fork lsof once per match.
+project_owned_pids() {
+  [ "$#" -gt 0 ] || return
+
+  local current_pid=""
+  local field
+  local pid_list
+  local IFS=,
+  pid_list="$*"
+
+  while IFS= read -r -d '' field; do
+    # lsof terminates each process field set with a newline even in NUL mode.
+    field=${field#$'\n'}
+    case "$field" in
+      p*) current_pid=${field#p} ;;
+      n*)
+        if [ -n "$current_pid" ] && path_belongs_to_project "${field#n}"; then
+          printf '%s\n' "$current_pid"
+        fi
+        ;;
+    esac
+  done < <(lsof -a -p "$pid_list" -d cwd -Fpn0 2> /dev/null || true)
 }
 
 # Use xargs so kill is PATH-resolved instead of invoking Bash's kill builtin.
@@ -239,18 +298,22 @@ cleanup_port() {
 cleanup_pattern() {
   local pattern=$1
   local pids
+  local candidate_pids=()
   local project_pids=()
   pids=$(pgrep -f "$pattern" 2> /dev/null || true)
 
   for pid in $pids; do
-    # Explicit patterns can appear in the cleanup command's own argv.
-    if [ "$pid" = "$$" ] || [ "$pid" = "$PPID" ]; then
+    if process_is_cleanup_ancestor "$pid"; then
       continue
     fi
-    if process_belongs_to_project "$pid"; then
-      project_pids+=("$pid")
-    fi
+    candidate_pids+=("$pid")
   done
+
+  if [ "${#candidate_pids[@]}" -gt 0 ]; then
+    while IFS= read -r pid; do
+      [ -n "$pid" ] && project_pids+=("$pid")
+    done < <(project_owned_pids "${candidate_pids[@]}")
+  fi
 
   if [ "${#project_pids[@]}" -eq 0 ]; then
     return

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -127,6 +127,33 @@ if [ -z "$PATTERN" ]; then
   PATTERN=$(detect_pattern)
 fi
 
+normalize_port() {
+  local normalized=$1
+
+  while [[ "$normalized" == 0* ]] && [ "${#normalized}" -gt 1 ]; do
+    normalized=${normalized#0}
+  done
+
+  if [ "$normalized" = "0" ] \
+    || [ "${#normalized}" -gt 5 ] \
+    || [ "$normalized" -gt 65535 ]; then
+    echo "Error: port must be between 1 and 65535." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$normalized"
+}
+
+TEST_PORT=""
+if [ -n "$PORT" ]; then
+  if ! PORT=$(normalize_port "$PORT"); then
+    exit 2
+  fi
+  if [ "$PORT" -le 64535 ]; then
+    TEST_PORT=$((PORT + 1000))
+  fi
+fi
+
 PROJECT_DIR="$(pwd -P)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
@@ -140,7 +167,11 @@ done
 
 echo "Cleanup zombies for: $PROJECT_NAME"
 echo "   Directory: $PROJECT_DIR"
-[ -n "$PORT" ] && echo "   Port: $PORT (+ test port $((PORT + 1000)))"
+if [ -n "$TEST_PORT" ]; then
+  echo "   Port: $PORT (+ test port $TEST_PORT)"
+elif [ -n "$PORT" ]; then
+  echo "   Port: $PORT"
+fi
 [ -n "$PATTERN" ] && echo "   Pattern: $PATTERN"
 $DRY_RUN && echo -e "   ${YELLOW}DRY RUN (default) - no processes will be killed; pass --yes to kill${NC}"
 echo ""
@@ -358,9 +389,10 @@ report_skipped_processes() {
 if [ -n "$PORT" ]; then
   cleanup_port "$PORT"
 
-  # Also kill test port (dev port + 1000, common convention)
-  TEST_PORT=$((PORT + 1000))
-  cleanup_port "$TEST_PORT"
+  # Also kill test port (dev port + 1000) when it remains in range.
+  if [ -n "$TEST_PORT" ]; then
+    cleanup_port "$TEST_PORT"
+  fi
 fi
 
 # 2. Kill Playwright/test processes scoped to this project

--- a/packages/cli/templates/scripts/cleanup-zombies.sh
+++ b/packages/cli/templates/scripts/cleanup-zombies.sh
@@ -148,28 +148,77 @@ echo ""
 FOUND_COUNT=0
 KILLED_COUNT=0
 
+# Return success only when a path is the project root or one of its descendants.
+path_belongs_to_project() {
+  local candidate=$1
+  local project_dir
+  for project_dir in "${PROJECT_DIR_ALIASES[@]}"; do
+    case "$candidate" in
+      "$project_dir" | "$project_dir"/*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Port ownership is machine-wide, so verify each matching process belongs to this
+# project before presenting it as a cleanup candidate. Deny by default when
+# its working directory does not establish ownership.
+process_belongs_to_project() {
+  local pid=$1
+  local field
+  local process_cwd
+
+  process_cwd=""
+  while IFS= read -r -d '' field; do
+    case "$field" in
+      n*)
+        process_cwd=${field#n}
+        break
+        ;;
+    esac
+  done < <(lsof -a -p "$pid" -d cwd -Fn0 2> /dev/null || true)
+
+  if [ -n "$process_cwd" ] && path_belongs_to_project "$process_cwd"; then
+    return 0
+  fi
+  return 1
+}
+
 # Function to find and optionally kill processes by port
 cleanup_port() {
   local port=$1
   local pids
+  local project_pids=()
   pids=$(lsof -ti:"$port" 2> /dev/null || true)
 
-  if [ -n "$pids" ]; then
-    local count
-    count=$(echo "$pids" | wc -l | tr -d ' ')
-    FOUND_COUNT=$((FOUND_COUNT + count))
-
-    echo "Port $port: $count process(es)"
-    for pid in $pids; do
-      local cmd
-      cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
-      echo "  PID $pid: $cmd"
-    done
-
-    if [ "$DRY_RUN" = false ]; then
-      echo "$pids" | xargs kill -9 2> /dev/null || true
-      KILLED_COUNT=$((KILLED_COUNT + count))
+  for pid in $pids; do
+    if process_belongs_to_project "$pid"; then
+      project_pids+=("$pid")
     fi
+  done
+
+  if [ "${#project_pids[@]}" -eq 0 ]; then
+    return
+  fi
+
+  local count
+  count=${#project_pids[@]}
+  FOUND_COUNT=$((FOUND_COUNT + count))
+
+  echo "Port $port: $count process(es)"
+  for pid in "${project_pids[@]}"; do
+    local cmd
+    cmd=$(ps -p "$pid" -o command= 2> /dev/null | head -c 80 || echo "unknown")
+    echo "  PID $pid: $cmd"
+  done
+
+  if [ "$DRY_RUN" = false ]; then
+    for pid in "${project_pids[@]}"; do
+      if process_belongs_to_project "$pid"; then
+        printf '%s\n' "$pid" | xargs -n 1 kill -9 2> /dev/null || true
+        KILLED_COUNT=$((KILLED_COUNT + 1))
+      fi
+    done
   fi
 }
 

--- a/packages/cli/templates/skills/cleanup-zombies/SKILL.md
+++ b/packages/cli/templates/skills/cleanup-zombies/SKILL.md
@@ -28,9 +28,9 @@ If the preview looks correct, confirm the kill with `--yes`:
 ## What It Does
 
 1. **Auto-detects framework** - Finds port from vite.config.ts, next.config.js, etc. (checks root, `packages/*/`, `apps/*/` for monorepos)
-2. **Kills by port** - Dev server port AND test port (port + 1000)
-3. **Kills test processes** - Playwright, Chromium, Electron (scoped to this project)
-4. **Multi-project safe** - Only kills processes matching this project's directory
+2. **Checks project-owned port processes** - Inspects the dev port and in-range test port (port + 1000), reporting owners it skips when project ownership cannot be verified
+3. **Checks project-owned test processes** - Inspects Playwright, Chromium, and Electron matches whose working directory is inside this project
+4. **Revalidates before signaling** - Only kills processes whose current working directory still belongs to this project
 
 ## Manual Override
 

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -70,7 +70,11 @@ describe('cleanup-zombies.sh', () => {
     writeFileSync(fullPath, content);
   }
 
-  function mockLiveProcessOwnership(pid: number): NodeJS.ProcessEnv {
+  function mockLiveProcessOwnership(
+    pid: number,
+    pattern: string,
+    mockDiscovery = true,
+  ): NodeJS.ProcessEnv {
     const binaryDirectory = nodePath.join(temporaryDirectory, 'live-bin');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
     const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
@@ -84,19 +88,21 @@ if [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fn0" ]] ||
 fi
 `,
     );
-    writeFileSync(
-      pgrepPath,
-      String.raw`#!/usr/bin/env bash
+    if (mockDiscovery) {
+      writeFileSync(
+        pgrepPath,
+        String.raw`#!/usr/bin/env bash
 if [[ "$*" == "-f $MOCK_LIVE_PATTERN" ]]; then
   printf '%s\n' "$MOCK_LIVE_PID"
 fi
 `,
-    );
+      );
+      chmodSync(pgrepPath, 0o755);
+    }
     chmodSync(lsofPath, 0o755);
-    chmodSync(pgrepPath, 0o755);
     return {
       MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
-      MOCK_LIVE_PATTERN: 'swzombie',
+      MOCK_LIVE_PATTERN: pattern,
       MOCK_LIVE_PID: String(pid),
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
     };
@@ -162,7 +168,9 @@ elif { [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fn0" ]] ||
     printf '%s\n' "$((read_count + 1))" > "$MOCK_LSOF_CWD_COUNT"
   fi
   printf 'p${MOCK_PID}\0\nfcwd\0n%s\0\n' "$process_cwd"
-elif [[ "$*" == "-a -p ${MOCK_SECOND_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_SECOND_PROCESS_CWD" ]]; then
+elif { [[ "$*" == "-a -p ${MOCK_SECOND_PID} -d cwd -Fn0" ]] ||
+  [[ "$*" == "-a -p ${MOCK_SECOND_PID} -d cwd -Fpn0" ]]; } &&
+  [[ -n "$MOCK_SECOND_PROCESS_CWD" ]]; then
   printf 'p${MOCK_SECOND_PID}\0\nfcwd\0n%s\0\n' "$MOCK_SECOND_PROCESS_CWD"
 elif [[ "$*" == "-a -p ${MOCK_PID},${MOCK_SECOND_PID} -d cwd -Fpn0" ]]; then
   [[ -n "$MOCK_PROCESS_CWD" ]] &&
@@ -177,6 +185,9 @@ fi
       String.raw`#!/usr/bin/env bash
 if [[ -n "$MOCK_PGREP_LOG" ]]; then
   printf '%s\n' "$*" >> "$MOCK_PGREP_LOG"
+fi
+if [[ -n "$MOCK_PGREP_EXIT_CODE" ]] && [[ "$*" == *"$MOCK_PGREP_ERROR_PATTERN"* ]]; then
+  exit "$MOCK_PGREP_EXIT_CODE"
 fi
 if [[ -n "$MOCK_PATTERN" ]] && [[ "$*" == *"$MOCK_PATTERN"* ]]; then
   printf '%s\n' "$MOCK_PATTERN_PIDS"
@@ -306,27 +317,53 @@ fi
   });
 
   describe('required ownership tooling', () => {
-    it('refuses loudly instead of reporting success when lsof is unavailable', () => {
-      const missingLsofBin = nodePath.join(temporaryDirectory, 'missing-lsof-bin');
-      const basenamePath = nodePath.join(missingLsofBin, 'basename');
-      mkdirSync(missingLsofBin);
-      writeFileSync(
-        basenamePath,
-        String.raw`#!/bin/sh
+    for (const missingTool of ['lsof', 'pgrep', 'ps']) {
+      it(`refuses loudly instead of reporting success when ${missingTool} is unavailable`, () => {
+        const requiredToolBin = nodePath.join(temporaryDirectory, `missing-${missingTool}-bin`);
+        mkdirSync(requiredToolBin);
+
+        for (const tool of ['basename', 'lsof', 'pgrep', 'ps']) {
+          if (tool === missingTool) continue;
+          const toolPath = nodePath.join(requiredToolBin, tool);
+          const content =
+            tool === 'basename'
+              ? String.raw`#!/bin/sh
 value=\${1%/}
 printf '%s\n' "\${value##*/}"
-`,
-      );
-      chmodSync(basenamePath, 0o755);
+`
+              : '#!/bin/sh\nexit 1\n';
+          writeFileSync(toolPath, content);
+          chmodSync(toolPath, 0o755);
+        }
 
-      const result = spawnSync('/bin/bash', [SCRIPT_PATH], {
+        const result = spawnSync('/bin/bash', [SCRIPT_PATH], {
+          cwd: temporaryDirectory,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: requiredToolBin },
+        });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `${missingTool} is required for safe project-scoped cleanup`,
+        );
+        expect(result.stdout).not.toContain('already clean');
+      });
+    }
+
+    it('reports pgrep errors instead of treating them as no matches', () => {
+      const result = spawnSync('/bin/bash', [SCRIPT_PATH, '['], {
         cwd: temporaryDirectory,
         encoding: 'utf8',
-        env: { ...process.env, PATH: missingLsofBin },
+        env: {
+          ...process.env,
+          ...mockPortOwner(),
+          MOCK_PGREP_ERROR_PATTERN: '[',
+          MOCK_PGREP_EXIT_CODE: '2',
+        },
       });
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain('lsof is required to verify project ownership');
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("pgrep failed for pattern '['");
       expect(result.stdout).not.toContain('already clean');
     });
   });
@@ -433,19 +470,19 @@ printf '%s\n' "\${value##*/}"
       victim = undefined;
     });
 
-    function spawnVictim(): number {
-      // The fixture uses a real process so consent mode reaches kill(1).
-      // Discovery is mocked separately because Bash may replace itself with its
-      // final command on Linux, removing the script path from the process list.
-      const victimScript = nodePath.join(realpathSync(temporaryDirectory), 'swzombie-victim.sh');
-      writeFileSync(victimScript, '#!/usr/bin/env bash\nsleep 60\n');
-      victim = spawn('bash', [victimScript], {
+    function spawnVictim(): { marker: string; pid: number } {
+      // Keep a unique marker in the argv of a real long-lived process so the
+      // script's real pgrep discovery path is exercised on every platform.
+      const marker = `swzombie-${process.pid}-${Date.now()}`;
+      const victimScript = nodePath.join(realpathSync(temporaryDirectory), `${marker}.mjs`);
+      writeFileSync(victimScript, 'setInterval(() => {}, 60_000);\n');
+      victim = spawn(process.execPath, [victimScript], {
         cwd: temporaryDirectory,
         detached: true,
         stdio: 'ignore',
       });
       if (victim.pid === undefined) throw new Error('failed to spawn victim');
-      return victim.pid;
+      return { marker, pid: victim.pid };
     }
 
     function isAlive(pid: number): boolean {
@@ -458,16 +495,16 @@ printf '%s\n' "\${value##*/}"
     }
 
     it('Scenario: the victim survives a bare preview and dies under --yes', async () => {
-      const pid = spawnVictim();
+      const { marker, pid } = spawnVictim();
       await expect.poll(() => isAlive(pid)).toBe(true);
 
-      const liveProcessEnvironment = mockLiveProcessOwnership(pid);
-      const preview = runScriptRaw(['swzombie'], liveProcessEnvironment);
-      expect(preview).toContain('swzombie');
+      const liveProcessEnvironment = mockLiveProcessOwnership(pid, marker, false);
+      const preview = runScriptRaw([marker], liveProcessEnvironment);
+      expect(preview).toContain(marker);
       expect(preview).toContain('Re-run with --yes to kill them');
       expect(isAlive(pid)).toBe(true); // preview never kills
 
-      runScriptRaw(['--yes', 'swzombie'], liveProcessEnvironment);
+      runScriptRaw(['--yes', marker], liveProcessEnvironment);
       await expect.poll(() => isAlive(pid)).toBe(false); // consent kills
     });
   });

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -29,10 +29,12 @@ const UNRELATED_PROJECT_DIRECTORY = '/tmp/unrelated-project';
 
 describe('cleanup-zombies.sh', () => {
   let isolatedPath: string;
+  let projectDirectory: string;
   let temporaryDirectory: string;
 
   beforeEach(() => {
     temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'cleanup-zombies-test-'));
+    projectDirectory = realpathSync(temporaryDirectory);
     const isolatedBinaryDirectory = nodePath.join(temporaryDirectory, 'isolated-bin');
     mkdirSync(isolatedBinaryDirectory);
     for (const command of ['lsof', 'pgrep']) {
@@ -108,7 +110,7 @@ fi
       );
     }
     return {
-      MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
+      MOCK_LIVE_CWD: projectDirectory,
       MOCK_LIVE_PATTERN: pattern,
       MOCK_LIVE_PID: String(pid),
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
@@ -133,7 +135,7 @@ fi
 `,
     );
     return {
-      MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
+      MOCK_LIVE_CWD: projectDirectory,
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
     };
   }
@@ -380,7 +382,7 @@ printf '%s\n' "\${value##*/}"
         env: {
           ...process.env,
           ...mockCleanupEnvironment({
-            processDirectory: realpathSync(temporaryDirectory),
+            processDirectory: projectDirectory,
           }),
           MOCK_KILL_LOG: killLog,
           MOCK_PGREP_ERROR_PATTERN: 'playwright',
@@ -534,7 +536,7 @@ printf '%s\n' "\${value##*/}"
       // script's real pgrep discovery and batched ownership paths are exercised
       // on every platform.
       const marker = `swzombie-${process.pid}-${Date.now()}`;
-      const victimScript = nodePath.join(realpathSync(temporaryDirectory), `${marker}.mjs`);
+      const victimScript = nodePath.join(projectDirectory, `${marker}.mjs`);
       writeFileSync(victimScript, 'setInterval(() => {}, 60_000);\n');
       const ownedVictim = spawn(process.execPath, [victimScript], {
         cwd: temporaryDirectory,
@@ -606,7 +608,6 @@ printf '%s\n' "\${value##*/}"
 
   describe('Rule: pattern cleanup stays scoped to the current project', () => {
     it('Scenario: an unrelated pattern match whose argv references this project is excluded', () => {
-      const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
         ...mockCleanupEnvironment({
           processDirectory: UNRELATED_PROJECT_DIRECTORY,
@@ -626,7 +627,7 @@ printf '%s\n' "\${value##*/}"
     it("Scenario: the current project's pattern match remains eligible", () => {
       const environment = {
         ...mockCleanupEnvironment({
-          processDirectory: realpathSync(temporaryDirectory),
+          processDirectory: projectDirectory,
           processCommand: '/usr/bin/playwright test',
         }),
         MOCK_PATTERN: 'playwright',
@@ -653,7 +654,6 @@ printf '%s\n' "\${value##*/}"
 
     it('Scenario: pattern ownership is read in one lsof call per candidate set', () => {
       const lsofLog = nodePath.join(temporaryDirectory, 'lsof.log');
-      const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
         ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
         MOCK_LSOF_LOG: lsofLog,
@@ -711,7 +711,7 @@ printf '%s\n' "\${value##*/}"
     it("Scenario: the current project's process remains in the preview", () => {
       const output = runScriptRaw(
         [],
-        mockCleanupEnvironment({ processDirectory: realpathSync(temporaryDirectory) }),
+        mockCleanupEnvironment({ processDirectory: projectDirectory }),
       );
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
@@ -720,7 +720,7 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: a process beneath the current project's root remains in the preview", () => {
-      const projectChild = nodePath.join(realpathSync(temporaryDirectory), 'packages', 'app');
+      const projectChild = nodePath.join(projectDirectory, 'packages', 'app');
       const output = runScriptRaw([], mockCleanupEnvironment({ processDirectory: projectChild }));
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
@@ -736,7 +736,6 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: a similarly prefixed project's command is excluded", () => {
-      const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
         mockCleanupEnvironment({
@@ -751,7 +750,6 @@ printf '%s\n' "\${value##*/}"
     });
 
     it('Scenario: an unrelated command argument referencing this project is excluded', () => {
-      const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
         mockCleanupEnvironment({
@@ -766,7 +764,6 @@ printf '%s\n' "\${value##*/}"
     });
 
     it('Scenario: an unrelated cwd containing a newline is excluded', () => {
-      const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
         mockCleanupEnvironment({
@@ -796,7 +793,7 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
         ...mockCleanupEnvironment({
-          processDirectory: realpathSync(temporaryDirectory),
+          processDirectory: projectDirectory,
         }),
         MOCK_KILL_LOG: killLog,
       };
@@ -809,7 +806,6 @@ printf '%s\n' "\${value##*/}"
 
     it('Scenario: --yes revalidates each PID immediately before signaling it', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
-      const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
         ...mockCleanupEnvironment({
           processDirectory: projectDirectory,
@@ -828,7 +824,6 @@ printf '%s\n' "\${value##*/}"
 
     it('Scenario: --yes signals verified PIDs individually', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
-      const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
         ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
         MOCK_KILL_LOG: killLog,
@@ -846,7 +841,7 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
         ...mockCleanupEnvironment({
-          processDirectory: realpathSync(temporaryDirectory),
+          processDirectory: projectDirectory,
         }),
         MOCK_KILL_EXIT_CODE: '1',
         MOCK_KILL_LOG: killLog,

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -497,6 +497,12 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: the victim survives a bare preview and dies under --yes', async () => {
       const { marker, pid } = spawnVictim();
       await expect.poll(() => isAlive(pid)).toBe(true);
+      await expect
+        .poll(() => {
+          const result = spawnSync('pgrep', ['-f', marker], { encoding: 'utf8' });
+          return result.stdout.split(/\s+/).filter(Boolean).map(Number);
+        })
+        .toContain(pid);
 
       const liveProcessEnvironment = mockLiveProcessOwnership(pid, marker, false);
       const preview = runScriptRaw([marker], liveProcessEnvironment);

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -5,7 +5,7 @@
  * in temp directories with mock config files.
  */
 
-import { type ChildProcess, execSync, spawn, spawnSync } from 'node:child_process';
+import { type ChildProcess, execFileSync, spawn, spawnSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
@@ -47,8 +47,7 @@ describe('cleanup-zombies.sh', () => {
 
   /** Run the real script with the args exactly as given. */
   function runScriptRaw(args: string[] = [], environmentOverrides: NodeJS.ProcessEnv = {}): string {
-    const command = `bash "${SCRIPT_PATH}" ${args.join(' ')}`;
-    return execSync(command, {
+    return execFileSync('/bin/bash', [SCRIPT_PATH, ...args], {
       cwd: temporaryDirectory,
       encoding: 'utf8',
       env: { ...process.env, PATH: isolatedPath, ...environmentOverrides },

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -134,11 +134,15 @@ fi
     };
   }
 
-  function mockCleanupEnvironment(
-    processDirectory?: string,
-    processCommand?: string,
-    subsequentProcessDirectory?: string,
-  ): NodeJS.ProcessEnv {
+  function mockCleanupEnvironment({
+    processDirectory,
+    processCommand,
+    subsequentProcessDirectory,
+  }: {
+    processDirectory?: string;
+    processCommand?: string;
+    subsequentProcessDirectory?: string;
+  } = {}): NodeJS.ProcessEnv {
     const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
     const killPath = nodePath.join(binaryDirectory, 'kill');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
@@ -544,10 +548,10 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: an unrelated pattern match whose argv references this project is excluded', () => {
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockCleanupEnvironment(
-          '/tmp/unrelated-project',
-          `/usr/bin/playwright ${projectDirectory}/report`,
-        ),
+        ...mockCleanupEnvironment({
+          processDirectory: '/tmp/unrelated-project',
+          processCommand: `/usr/bin/playwright ${projectDirectory}/report`,
+        }),
         MOCK_PATTERN: 'playwright',
         MOCK_PATTERN_PIDS: String(MOCK_PID),
       };
@@ -561,7 +565,10 @@ printf '%s\n' "\${value##*/}"
 
     it("Scenario: the current project's pattern match remains eligible", () => {
       const environment = {
-        ...mockCleanupEnvironment(realpathSync(temporaryDirectory), '/usr/bin/playwright test'),
+        ...mockCleanupEnvironment({
+          processDirectory: realpathSync(temporaryDirectory),
+          processCommand: '/usr/bin/playwright test',
+        }),
         MOCK_PATTERN: 'playwright',
         MOCK_PATTERN_PIDS: String(MOCK_PID),
       };
@@ -588,7 +595,7 @@ printf '%s\n' "\${value##*/}"
       const lsofLog = nodePath.join(temporaryDirectory, 'lsof.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockCleanupEnvironment(projectDirectory),
+        ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
         MOCK_LSOF_LOG: lsofLog,
         MOCK_PATTERN: 'playwright',
         MOCK_PATTERN_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
@@ -628,7 +635,10 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: an unrelated project's process is excluded from the preview", () => {
-      const output = runScriptRaw([], mockCleanupEnvironment('/tmp/unrelated-project'));
+      const output = runScriptRaw(
+        [],
+        mockCleanupEnvironment({ processDirectory: '/tmp/unrelated-project' }),
+      );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
@@ -639,7 +649,10 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: the current project's process remains in the preview", () => {
-      const output = runScriptRaw([], mockCleanupEnvironment(realpathSync(temporaryDirectory)));
+      const output = runScriptRaw(
+        [],
+        mockCleanupEnvironment({ processDirectory: realpathSync(temporaryDirectory) }),
+      );
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
       expect(output).toContain(`PID ${MOCK_PID}`);
@@ -648,7 +661,7 @@ printf '%s\n' "\${value##*/}"
 
     it("Scenario: a process beneath the current project's root remains in the preview", () => {
       const projectChild = nodePath.join(realpathSync(temporaryDirectory), 'packages', 'app');
-      const output = runScriptRaw([], mockCleanupEnvironment(projectChild));
+      const output = runScriptRaw([], mockCleanupEnvironment({ processDirectory: projectChild }));
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
       expect(output).toContain(`PID ${MOCK_PID}`);
@@ -666,10 +679,10 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
-        mockCleanupEnvironment(
-          '/tmp/unrelated-project',
-          `${projectDirectory}-other/node_modules/.bin/vite`,
-        ),
+        mockCleanupEnvironment({
+          processDirectory: '/tmp/unrelated-project',
+          processCommand: `${projectDirectory}-other/node_modules/.bin/vite`,
+        }),
       );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
@@ -681,10 +694,10 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
-        mockCleanupEnvironment(
-          '/tmp/unrelated-project',
-          `/usr/bin/vite --log-file ${projectDirectory}/server.log`,
-        ),
+        mockCleanupEnvironment({
+          processDirectory: '/tmp/unrelated-project',
+          processCommand: `/usr/bin/vite --log-file ${projectDirectory}/server.log`,
+        }),
       );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
@@ -696,7 +709,9 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
-        mockCleanupEnvironment(`${projectDirectory}\nn${projectDirectory}`),
+        mockCleanupEnvironment({
+          processDirectory: `${projectDirectory}\nn${projectDirectory}`,
+        }),
       );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
@@ -707,7 +722,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: --yes never passes an unrelated port owner to kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockCleanupEnvironment('/tmp/unrelated-project'),
+        ...mockCleanupEnvironment({ processDirectory: '/tmp/unrelated-project' }),
         MOCK_KILL_LOG: killLog,
       };
 
@@ -720,7 +735,9 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: --yes passes a current-project port owner to kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockCleanupEnvironment(realpathSync(temporaryDirectory)),
+        ...mockCleanupEnvironment({
+          processDirectory: realpathSync(temporaryDirectory),
+        }),
         MOCK_KILL_LOG: killLog,
       };
 
@@ -734,7 +751,10 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockCleanupEnvironment(projectDirectory, undefined, '/tmp/unrelated-project'),
+        ...mockCleanupEnvironment({
+          processDirectory: projectDirectory,
+          subsequentProcessDirectory: '/tmp/unrelated-project',
+        }),
         MOCK_KILL_LOG: killLog,
         MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
         MOCK_SECOND_PROCESS_CWD: projectDirectory,
@@ -750,7 +770,7 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockCleanupEnvironment(projectDirectory),
+        ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
         MOCK_KILL_LOG: killLog,
         MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
         MOCK_SECOND_PROCESS_CWD: projectDirectory,
@@ -765,7 +785,9 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: a failed signal is not reported as a successful kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockCleanupEnvironment(realpathSync(temporaryDirectory)),
+        ...mockCleanupEnvironment({
+          processDirectory: realpathSync(temporaryDirectory),
+        }),
         MOCK_KILL_EXIT_CODE: '1',
         MOCK_KILL_LOG: killLog,
       };

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -27,10 +27,19 @@ const MOCK_PID = 4242;
 const MOCK_SECOND_PID = 4343;
 
 describe('cleanup-zombies.sh', () => {
+  let isolatedPath: string;
   let temporaryDirectory: string;
 
   beforeEach(() => {
     temporaryDirectory = mkdtempSync(nodePath.join(tmpdir(), 'cleanup-zombies-test-'));
+    const isolatedBinaryDirectory = nodePath.join(temporaryDirectory, 'isolated-bin');
+    mkdirSync(isolatedBinaryDirectory);
+    for (const command of ['lsof', 'pgrep']) {
+      const commandPath = nodePath.join(isolatedBinaryDirectory, command);
+      writeFileSync(commandPath, '#!/usr/bin/env bash\nexit 1\n');
+      chmodSync(commandPath, 0o755);
+    }
+    isolatedPath = `${isolatedBinaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`;
   });
 
   afterEach(() => {
@@ -43,7 +52,7 @@ describe('cleanup-zombies.sh', () => {
     return execSync(command, {
       cwd: temporaryDirectory,
       encoding: 'utf8',
-      env: { ...process.env, ...environmentOverrides },
+      env: { ...process.env, PATH: isolatedPath, ...environmentOverrides },
     });
   }
 
@@ -69,6 +78,7 @@ describe('cleanup-zombies.sh', () => {
     const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
     const killPath = nodePath.join(binaryDirectory, 'kill');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
+    const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
     const psPath = nodePath.join(binaryDirectory, 'ps');
     mkdirSync(binaryDirectory);
     writeFileSync(
@@ -97,6 +107,17 @@ fi
 `,
     );
     writeFileSync(
+      pgrepPath,
+      String.raw`#!/usr/bin/env bash
+if [[ -n "$MOCK_PGREP_LOG" ]]; then
+  printf '%s\n' "$*" >> "$MOCK_PGREP_LOG"
+fi
+if [[ -n "$MOCK_PATTERN" ]] && [[ "$*" == *"$MOCK_PATTERN"* ]]; then
+  printf '%s\n' "$MOCK_PATTERN_PIDS"
+fi
+`,
+    );
+    writeFileSync(
       psPath,
       String.raw`#!/usr/bin/env bash
 if [[ -n "$MOCK_PROCESS_COMMAND" ]]; then
@@ -108,10 +129,14 @@ fi
       killPath,
       String.raw`#!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
+if [[ "$MOCK_KILL_EXIT_CODE" == "1" ]]; then
+  exit 1
+fi
 `,
     );
     chmodSync(killPath, 0o755);
     chmodSync(lsofPath, 0o755);
+    chmodSync(pgrepPath, 0o755);
     chmodSync(psPath, 0o755);
     return {
       MOCK_LSOF_CWD_COUNT: nodePath.join(temporaryDirectory, 'lsof-cwd-count'),
@@ -323,6 +348,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
       const victimScript = nodePath.join(realpathSync(temporaryDirectory), 'swzombie-victim.sh');
       writeFileSync(victimScript, '#!/usr/bin/env bash\nsleep 60\n');
       victim = spawn('bash', [victimScript], {
+        cwd: temporaryDirectory,
         detached: true,
         stdio: 'ignore',
       });
@@ -343,12 +369,13 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
       const pid = spawnVictim();
       await expect.poll(() => isAlive(pid)).toBe(true);
 
-      const preview = runScriptRaw(['swzombie']);
+      const liveProcessEnvironment = { PATH: process.env.PATH ?? '' };
+      const preview = runScriptRaw(['swzombie'], liveProcessEnvironment);
       expect(preview).toContain('swzombie');
       expect(preview).toContain('Re-run with --yes to kill them');
       expect(isAlive(pid)).toBe(true); // preview never kills
 
-      runScriptRaw(['--yes', 'swzombie']);
+      runScriptRaw(['--yes', 'swzombie'], liveProcessEnvironment);
       await expect.poll(() => isAlive(pid)).toBe(false); // consent kills
     });
   });
@@ -365,6 +392,51 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
     });
   });
 
+  describe('Rule: pattern cleanup stays scoped to the current project', () => {
+    it('Scenario: an unrelated pattern match whose argv references this project is excluded', () => {
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const environment = {
+        ...mockPortOwner(
+          '/tmp/unrelated-project',
+          `/usr/bin/playwright ${projectDirectory}/report`,
+        ),
+        MOCK_PATTERN: 'playwright',
+        MOCK_PATTERN_PIDS: String(MOCK_PID),
+      };
+
+      const output = runScriptRaw([], environment);
+
+      expect(output).not.toContain("Pattern 'playwright' (project-scoped):");
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it("Scenario: the current project's pattern match remains eligible", () => {
+      const environment = {
+        ...mockPortOwner(realpathSync(temporaryDirectory), '/usr/bin/playwright test'),
+        MOCK_PATTERN: 'playwright',
+        MOCK_PATTERN_PIDS: String(MOCK_PID),
+      };
+
+      const output = runScriptRaw([], environment);
+
+      expect(output).toContain("Pattern 'playwright' (project-scoped): 1 process(es)");
+      expect(output).toContain(`PID ${MOCK_PID}`);
+    });
+
+    it('Scenario: project paths are not interpolated into pgrep regular expressions', () => {
+      const pgrepLog = nodePath.join(temporaryDirectory, 'pgrep.log');
+      const environment = {
+        ...mockPortOwner(),
+        MOCK_PGREP_LOG: pgrepLog,
+      };
+
+      runScriptRaw([], environment);
+
+      expect(readFileSync(pgrepLog, 'utf8').split('\n')).toContain('-f playwright');
+    });
+  });
+
   describe('Rule: port cleanup stays scoped to the current project', () => {
     beforeEach(() => {
       createFile('vite.config.ts');
@@ -375,7 +447,10 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
+      expect(output).toContain(
+        'Skipped 1 process(es) on detected ports; ownership was not verified for this project',
+      );
     });
 
     it("Scenario: the current project's process remains in the preview", () => {
@@ -399,7 +474,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
     });
 
     it("Scenario: a similarly prefixed project's command is excluded", () => {
@@ -411,7 +486,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
     });
 
     it('Scenario: an unrelated command argument referencing this project is excluded', () => {
@@ -426,7 +501,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
     });
 
     it('Scenario: an unrelated cwd containing a newline is excluded', () => {
@@ -435,7 +510,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
     });
 
     it('Scenario: --yes never passes an unrelated port owner to kill', () => {
@@ -447,7 +522,7 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       const output = runScriptRaw(['--yes'], environment);
 
-      expect(output).toContain('already clean');
+      expect(output).toContain('No project-owned zombie processes found');
       expect(existsSync(killLog)).toBe(false);
     });
 
@@ -494,6 +569,21 @@ printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
 
       expect(output).toContain('Killed 2 process(es)');
       expect(readFileSync(killLog, 'utf8')).toBe(`-9 ${MOCK_PID}\n-9 ${MOCK_SECOND_PID}\n`);
+    });
+
+    it('Scenario: a failed signal is not reported as a successful kill', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const environment = {
+        ...mockPortOwner(realpathSync(temporaryDirectory)),
+        MOCK_KILL_EXIT_CODE: '1',
+        MOCK_KILL_LOG: killLog,
+      };
+
+      const output = runScriptRaw(['--yes'], environment);
+
+      expect(output).toContain('Killed 0 process(es)');
+      expect(output).toContain('Failed to kill 1 process(es)');
+      expect(readFileSync(killLog, 'utf8')).toBe(`-9 ${MOCK_PID}\n`);
     });
   });
 });

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -134,7 +134,7 @@ fi
     };
   }
 
-  function mockPortOwner(
+  function mockCleanupEnvironment(
     processDirectory?: string,
     processCommand?: string,
     subsequentProcessDirectory?: string,
@@ -353,7 +353,7 @@ printf '%s\n' "\${value##*/}"
         encoding: 'utf8',
         env: {
           ...process.env,
-          ...mockPortOwner(),
+          ...mockCleanupEnvironment(),
           MOCK_PGREP_ERROR_PATTERN: '[',
           MOCK_PGREP_EXIT_CODE: '2',
         },
@@ -544,7 +544,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: an unrelated pattern match whose argv references this project is excluded', () => {
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockPortOwner(
+        ...mockCleanupEnvironment(
           '/tmp/unrelated-project',
           `/usr/bin/playwright ${projectDirectory}/report`,
         ),
@@ -561,7 +561,7 @@ printf '%s\n' "\${value##*/}"
 
     it("Scenario: the current project's pattern match remains eligible", () => {
       const environment = {
-        ...mockPortOwner(realpathSync(temporaryDirectory), '/usr/bin/playwright test'),
+        ...mockCleanupEnvironment(realpathSync(temporaryDirectory), '/usr/bin/playwright test'),
         MOCK_PATTERN: 'playwright',
         MOCK_PATTERN_PIDS: String(MOCK_PID),
       };
@@ -575,7 +575,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: project paths are not interpolated into pgrep regular expressions', () => {
       const pgrepLog = nodePath.join(temporaryDirectory, 'pgrep.log');
       const environment = {
-        ...mockPortOwner(),
+        ...mockCleanupEnvironment(),
         MOCK_PGREP_LOG: pgrepLog,
       };
 
@@ -588,7 +588,7 @@ printf '%s\n' "\${value##*/}"
       const lsofLog = nodePath.join(temporaryDirectory, 'lsof.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockPortOwner(projectDirectory),
+        ...mockCleanupEnvironment(projectDirectory),
         MOCK_LSOF_LOG: lsofLog,
         MOCK_PATTERN: 'playwright',
         MOCK_PATTERN_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
@@ -628,7 +628,7 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: an unrelated project's process is excluded from the preview", () => {
-      const output = runScriptRaw([], mockPortOwner('/tmp/unrelated-project'));
+      const output = runScriptRaw([], mockCleanupEnvironment('/tmp/unrelated-project'));
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
@@ -639,7 +639,7 @@ printf '%s\n' "\${value##*/}"
     });
 
     it("Scenario: the current project's process remains in the preview", () => {
-      const output = runScriptRaw([], mockPortOwner(realpathSync(temporaryDirectory)));
+      const output = runScriptRaw([], mockCleanupEnvironment(realpathSync(temporaryDirectory)));
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
       expect(output).toContain(`PID ${MOCK_PID}`);
@@ -648,14 +648,14 @@ printf '%s\n' "\${value##*/}"
 
     it("Scenario: a process beneath the current project's root remains in the preview", () => {
       const projectChild = nodePath.join(realpathSync(temporaryDirectory), 'packages', 'app');
-      const output = runScriptRaw([], mockPortOwner(projectChild));
+      const output = runScriptRaw([], mockCleanupEnvironment(projectChild));
 
       expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
       expect(output).toContain(`PID ${MOCK_PID}`);
     });
 
     it('Scenario: a process with unknown ownership is excluded from the preview', () => {
-      const output = runScriptRaw([], mockPortOwner());
+      const output = runScriptRaw([], mockCleanupEnvironment());
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
@@ -666,7 +666,10 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
-        mockPortOwner('/tmp/unrelated-project', `${projectDirectory}-other/node_modules/.bin/vite`),
+        mockCleanupEnvironment(
+          '/tmp/unrelated-project',
+          `${projectDirectory}-other/node_modules/.bin/vite`,
+        ),
       );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
@@ -678,7 +681,7 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const output = runScriptRaw(
         [],
-        mockPortOwner(
+        mockCleanupEnvironment(
           '/tmp/unrelated-project',
           `/usr/bin/vite --log-file ${projectDirectory}/server.log`,
         ),
@@ -691,7 +694,10 @@ printf '%s\n' "\${value##*/}"
 
     it('Scenario: an unrelated cwd containing a newline is excluded', () => {
       const projectDirectory = realpathSync(temporaryDirectory);
-      const output = runScriptRaw([], mockPortOwner(`${projectDirectory}\nn${projectDirectory}`));
+      const output = runScriptRaw(
+        [],
+        mockCleanupEnvironment(`${projectDirectory}\nn${projectDirectory}`),
+      );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
       expect(output).not.toContain(`PID ${MOCK_PID}`);
@@ -701,7 +707,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: --yes never passes an unrelated port owner to kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockPortOwner('/tmp/unrelated-project'),
+        ...mockCleanupEnvironment('/tmp/unrelated-project'),
         MOCK_KILL_LOG: killLog,
       };
 
@@ -714,7 +720,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: --yes passes a current-project port owner to kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockPortOwner(realpathSync(temporaryDirectory)),
+        ...mockCleanupEnvironment(realpathSync(temporaryDirectory)),
         MOCK_KILL_LOG: killLog,
       };
 
@@ -728,7 +734,7 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockPortOwner(projectDirectory, undefined, '/tmp/unrelated-project'),
+        ...mockCleanupEnvironment(projectDirectory, undefined, '/tmp/unrelated-project'),
         MOCK_KILL_LOG: killLog,
         MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
         MOCK_SECOND_PROCESS_CWD: projectDirectory,
@@ -744,7 +750,7 @@ printf '%s\n' "\${value##*/}"
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
-        ...mockPortOwner(projectDirectory),
+        ...mockCleanupEnvironment(projectDirectory),
         MOCK_KILL_LOG: killLog,
         MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
         MOCK_SECOND_PROCESS_CWD: projectDirectory,
@@ -759,7 +765,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: a failed signal is not reported as a successful kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockPortOwner(realpathSync(temporaryDirectory)),
+        ...mockCleanupEnvironment(realpathSync(temporaryDirectory)),
         MOCK_KILL_EXIT_CODE: '1',
         MOCK_KILL_LOG: killLog,
       };

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -36,8 +36,7 @@ describe('cleanup-zombies.sh', () => {
     mkdirSync(isolatedBinaryDirectory);
     for (const command of ['lsof', 'pgrep']) {
       const commandPath = nodePath.join(isolatedBinaryDirectory, command);
-      writeFileSync(commandPath, '#!/usr/bin/env bash\nexit 1\n');
-      chmodSync(commandPath, 0o755);
+      writeExecutable(commandPath, '#!/usr/bin/env bash\nexit 1\n');
     }
     isolatedPath = `${isolatedBinaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`;
   });
@@ -70,6 +69,11 @@ describe('cleanup-zombies.sh', () => {
     writeFileSync(fullPath, content);
   }
 
+  function writeExecutable(filePath: string, content: string): void {
+    writeFileSync(filePath, content);
+    chmodSync(filePath, 0o755);
+  }
+
   function mockLiveProcessOwnership(
     pid: number,
     pattern: string,
@@ -79,7 +83,7 @@ describe('cleanup-zombies.sh', () => {
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
     const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
     mkdirSync(binaryDirectory);
-    writeFileSync(
+    writeExecutable(
       lsofPath,
       String.raw`#!/usr/bin/env bash
 if [[ "$1" == "-a" ]] && [[ "$2" == "-p" ]] &&
@@ -90,7 +94,7 @@ fi
 `,
     );
     if (mockDiscovery) {
-      writeFileSync(
+      writeExecutable(
         pgrepPath,
         String.raw`#!/usr/bin/env bash
 if [[ "$*" == "-f $MOCK_LIVE_PATTERN" ]]; then
@@ -98,9 +102,7 @@ if [[ "$*" == "-f $MOCK_LIVE_PATTERN" ]]; then
 fi
 `,
       );
-      chmodSync(pgrepPath, 0o755);
     }
-    chmodSync(lsofPath, 0o755);
     return {
       MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
       MOCK_LIVE_PATTERN: pattern,
@@ -113,7 +115,7 @@ fi
     const binaryDirectory = nodePath.join(temporaryDirectory, 'all-live-bin');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
     mkdirSync(binaryDirectory);
-    writeFileSync(
+    writeExecutable(
       lsofPath,
       String.raw`#!/usr/bin/env bash
 if [[ "$1" == "-a" ]] && [[ "$2" == "-p" ]] && [[ "$4" == "-d" ]] &&
@@ -126,7 +128,6 @@ if [[ "$1" == "-a" ]] && [[ "$2" == "-p" ]] && [[ "$4" == "-d" ]] &&
 fi
 `,
     );
-    chmodSync(lsofPath, 0o755);
     return {
       MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
@@ -144,7 +145,7 @@ fi
     const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
     const psPath = nodePath.join(binaryDirectory, 'ps');
     mkdirSync(binaryDirectory);
-    writeFileSync(
+    writeExecutable(
       lsofPath,
       String.raw`#!/usr/bin/env bash
 if [[ -n "$MOCK_LSOF_LOG" ]]; then
@@ -181,7 +182,7 @@ elif [[ "$*" == "-a -p ${MOCK_PID},${MOCK_SECOND_PID} -d cwd -Fpn0" ]]; then
 fi
 `,
     );
-    writeFileSync(
+    writeExecutable(
       pgrepPath,
       String.raw`#!/usr/bin/env bash
 if [[ -n "$MOCK_PGREP_LOG" ]]; then
@@ -195,7 +196,7 @@ if [[ -n "$MOCK_PATTERN" ]] && [[ "$*" == *"$MOCK_PATTERN"* ]]; then
 fi
 `,
     );
-    writeFileSync(
+    writeExecutable(
       psPath,
       String.raw`#!/usr/bin/env bash
 if [[ -n "$MOCK_PROCESS_COMMAND" ]]; then
@@ -203,7 +204,7 @@ if [[ -n "$MOCK_PROCESS_COMMAND" ]]; then
 fi
 `,
     );
-    writeFileSync(
+    writeExecutable(
       killPath,
       String.raw`#!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
@@ -212,10 +213,6 @@ if [[ "$MOCK_KILL_EXIT_CODE" == "1" ]]; then
 fi
 `,
     );
-    chmodSync(killPath, 0o755);
-    chmodSync(lsofPath, 0o755);
-    chmodSync(pgrepPath, 0o755);
-    chmodSync(psPath, 0o755);
     return {
       MOCK_LSOF_CWD_COUNT: nodePath.join(temporaryDirectory, 'lsof-cwd-count'),
       MOCK_PROCESS_COMMAND: processCommand,
@@ -333,8 +330,7 @@ value=\${1%/}
 printf '%s\n' "\${value##*/}"
 `
               : '#!/bin/sh\nexit 1\n';
-          writeFileSync(toolPath, content);
-          chmodSync(toolPath, 0o755);
+          writeExecutable(toolPath, content);
         }
 
         const result = spawnSync('/bin/bash', [SCRIPT_PATH], {
@@ -611,10 +607,8 @@ printf '%s\n' "\${value##*/}"
       const marker = `swzombie-ancestor-${process.pid}`;
       const outerWrapper = nodePath.join(temporaryDirectory, `${marker}.sh`);
       const innerWrapper = nodePath.join(temporaryDirectory, 'inner-wrapper.sh');
-      writeFileSync(outerWrapper, `#!/usr/bin/env bash\nbash "${innerWrapper}"\n`);
-      writeFileSync(innerWrapper, `#!/usr/bin/env bash\nbash "${SCRIPT_PATH}" "${marker}"\n`);
-      chmodSync(outerWrapper, 0o755);
-      chmodSync(innerWrapper, 0o755);
+      writeExecutable(outerWrapper, `#!/usr/bin/env bash\nbash "${innerWrapper}"\n`);
+      writeExecutable(innerWrapper, `#!/usr/bin/env bash\nbash "${SCRIPT_PATH}" "${marker}"\n`);
 
       const result = spawnSync('bash', [outerWrapper], {
         cwd: temporaryDirectory,

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -367,6 +367,29 @@ printf '%s\n' "\${value##*/}"
       expect(result.stderr).toContain("pgrep failed for pattern '['");
       expect(result.stdout).not.toContain('already clean');
     });
+
+    it('reports completed kills before exiting after a later pgrep error', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const result = spawnSync('/bin/bash', [SCRIPT_PATH, '--yes', String(MOCK_PORT)], {
+        cwd: temporaryDirectory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...mockCleanupEnvironment({
+            processDirectory: realpathSync(temporaryDirectory),
+          }),
+          MOCK_KILL_LOG: killLog,
+          MOCK_PGREP_ERROR_PATTERN: 'playwright',
+          MOCK_PGREP_EXIT_CODE: '2',
+        },
+      });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("pgrep failed for pattern 'playwright'");
+      expect(result.stdout).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
+      expect(result.stdout).toContain('Killed 1 process(es)');
+      expect(readFileSync(killLog, 'utf8')).toBe(`-9 ${MOCK_PID}\n`);
+    });
   });
 
   describe('explicit port override', () => {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -82,8 +82,9 @@ describe('cleanup-zombies.sh', () => {
     writeFileSync(
       lsofPath,
       String.raw`#!/usr/bin/env bash
-if [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fn0" ]] ||
-  [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fpn0" ]]; then
+if [[ "$1" == "-a" ]] && [[ "$2" == "-p" ]] &&
+  [[ ",$3," == *",$MOCK_LIVE_PID,"* ]] &&
+  [[ "$4" == "-d" ]] && [[ "$5" == "cwd" ]] && [[ "$6" == "-Fpn0" ]]; then
   printf 'p%s\0\nfcwd\0n%s\0\n' "$MOCK_LIVE_PID" "$MOCK_LIVE_CWD"
 fi
 `,
@@ -457,32 +458,43 @@ printf '%s\n' "\${value##*/}"
   // bare preview and dies under --yes. Everything above proves messaging; this
   // proves the mode flip reaches kill(1).
   describe('Rule: --yes kills what the preview showed (behavioral pin)', () => {
-    let victim: ChildProcess | undefined;
+    let victims: ChildProcess[] = [];
 
     afterEach(() => {
-      if (victim?.pid && victim.exitCode === null) {
-        try {
-          process.kill(victim.pid, 'SIGKILL');
-        } catch {
-          // already dead — the desired end state
+      for (const victim of victims) {
+        if (victim.pid && victim.exitCode === null) {
+          try {
+            process.kill(victim.pid, 'SIGKILL');
+          } catch {
+            // already dead — the desired end state
+          }
         }
       }
-      victim = undefined;
+      victims = [];
     });
 
-    function spawnVictim(): { marker: string; pid: number } {
+    function spawnVictims(): { marker: string; ownedPid: number; unownedPid: number } {
       // Keep a unique marker in the argv of a real long-lived process so the
-      // script's real pgrep discovery path is exercised on every platform.
+      // script's real pgrep discovery and batched ownership paths are exercised
+      // on every platform.
       const marker = `swzombie-${process.pid}-${Date.now()}`;
       const victimScript = nodePath.join(realpathSync(temporaryDirectory), `${marker}.mjs`);
       writeFileSync(victimScript, 'setInterval(() => {}, 60_000);\n');
-      victim = spawn(process.execPath, [victimScript], {
+      const ownedVictim = spawn(process.execPath, [victimScript], {
         cwd: temporaryDirectory,
         detached: true,
         stdio: 'ignore',
       });
-      if (victim.pid === undefined) throw new Error('failed to spawn victim');
-      return { marker, pid: victim.pid };
+      const unownedVictim = spawn(process.execPath, [victimScript], {
+        cwd: tmpdir(),
+        detached: true,
+        stdio: 'ignore',
+      });
+      victims = [ownedVictim, unownedVictim];
+      if (ownedVictim.pid === undefined || unownedVictim.pid === undefined) {
+        throw new Error('failed to spawn victims');
+      }
+      return { marker, ownedPid: ownedVictim.pid, unownedPid: unownedVictim.pid };
     }
 
     function isAlive(pid: number): boolean {
@@ -495,23 +507,28 @@ printf '%s\n' "\${value##*/}"
     }
 
     it('Scenario: the victim survives a bare preview and dies under --yes', async () => {
-      const { marker, pid } = spawnVictim();
-      await expect.poll(() => isAlive(pid)).toBe(true);
+      const { marker, ownedPid, unownedPid } = spawnVictims();
+      await expect.poll(() => isAlive(ownedPid) && isAlive(unownedPid)).toBe(true);
       await expect
         .poll(() => {
           const result = spawnSync('pgrep', ['-f', marker], { encoding: 'utf8' });
-          return result.stdout.split(/\s+/).filter(Boolean).map(Number);
+          const discoveredPids = new Set(result.stdout.split(/\s+/).filter(Boolean).map(Number));
+          return discoveredPids.has(ownedPid) && discoveredPids.has(unownedPid);
         })
-        .toContain(pid);
+        .toBe(true);
 
-      const liveProcessEnvironment = mockLiveProcessOwnership(pid, marker, false);
+      const liveProcessEnvironment = mockLiveProcessOwnership(ownedPid, marker, false);
       const preview = runScriptRaw([marker], liveProcessEnvironment);
       expect(preview).toContain(marker);
+      expect(preview).toContain(`PID ${ownedPid}`);
+      expect(preview).not.toContain(`PID ${unownedPid}`);
       expect(preview).toContain('Re-run with --yes to kill them');
-      expect(isAlive(pid)).toBe(true); // preview never kills
+      expect(isAlive(ownedPid)).toBe(true); // preview never kills
+      expect(isAlive(unownedPid)).toBe(true);
 
       runScriptRaw(['--yes', marker], liveProcessEnvironment);
-      await expect.poll(() => isAlive(pid)).toBe(false); // consent kills
+      await expect.poll(() => isAlive(ownedPid)).toBe(false); // consent kills
+      expect(isAlive(unownedPid)).toBe(true); // unknown ownership fails closed
     });
   });
 

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -73,6 +73,7 @@ describe('cleanup-zombies.sh', () => {
   function mockLiveProcessOwnership(pid: number): NodeJS.ProcessEnv {
     const binaryDirectory = nodePath.join(temporaryDirectory, 'live-bin');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
+    const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
     mkdirSync(binaryDirectory);
     writeFileSync(
       lsofPath,
@@ -83,9 +84,19 @@ if [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fn0" ]] ||
 fi
 `,
     );
+    writeFileSync(
+      pgrepPath,
+      String.raw`#!/usr/bin/env bash
+if [[ "$*" == "-f $MOCK_LIVE_PATTERN" ]]; then
+  printf '%s\n' "$MOCK_LIVE_PID"
+fi
+`,
+    );
     chmodSync(lsofPath, 0o755);
+    chmodSync(pgrepPath, 0o755);
     return {
       MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
+      MOCK_LIVE_PATTERN: 'swzombie',
       MOCK_LIVE_PID: String(pid),
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
     };
@@ -423,9 +434,9 @@ printf '%s\n' "\${value##*/}"
     });
 
     function spawnVictim(): number {
-      // The script path gives pgrep a stable argv containing both the marker
-      // ("swzombie") and temp project path. A shell comment is not stable across
-      // process-list implementations.
+      // The fixture uses a real process so consent mode reaches kill(1).
+      // Discovery is mocked separately because Bash may replace itself with its
+      // final command on Linux, removing the script path from the process list.
       const victimScript = nodePath.join(realpathSync(temporaryDirectory), 'swzombie-victim.sh');
       writeFileSync(victimScript, '#!/usr/bin/env bash\nsleep 60\n');
       victim = spawn('bash', [victimScript], {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -73,11 +73,15 @@ describe('cleanup-zombies.sh', () => {
     chmodSync(filePath, 0o755);
   }
 
-  function mockLiveProcessOwnership(
-    pid: number,
-    pattern: string,
+  function mockLiveProcessOwnership({
+    pid,
+    pattern,
     mockDiscovery = true,
-  ): NodeJS.ProcessEnv {
+  }: {
+    pid: number;
+    pattern: string;
+    mockDiscovery?: boolean;
+  }): NodeJS.ProcessEnv {
     const binaryDirectory = nodePath.join(temporaryDirectory, 'live-bin');
     const lsofPath = nodePath.join(binaryDirectory, 'lsof');
     const pgrepPath = nodePath.join(binaryDirectory, 'pgrep');
@@ -568,7 +572,11 @@ printf '%s\n' "\${value##*/}"
         })
         .toBe(true);
 
-      const liveProcessEnvironment = mockLiveProcessOwnership(ownedPid, marker, false);
+      const liveProcessEnvironment = mockLiveProcessOwnership({
+        pid: ownedPid,
+        pattern: marker,
+        mockDiscovery: false,
+      });
       const preview = runScriptRaw([marker], liveProcessEnvironment);
       expect(preview).toContain(marker);
       expect(preview).toContain(`PID ${ownedPid}`);

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -5,7 +5,7 @@
  * in temp directories with mock config files.
  */
 
-import { type ChildProcess, execSync, spawn } from 'node:child_process';
+import { type ChildProcess, execSync, spawn, spawnSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
@@ -70,6 +70,51 @@ describe('cleanup-zombies.sh', () => {
     writeFileSync(fullPath, content);
   }
 
+  function mockLiveProcessOwnership(pid: number): NodeJS.ProcessEnv {
+    const binaryDirectory = nodePath.join(temporaryDirectory, 'live-bin');
+    const lsofPath = nodePath.join(binaryDirectory, 'lsof');
+    mkdirSync(binaryDirectory);
+    writeFileSync(
+      lsofPath,
+      String.raw`#!/usr/bin/env bash
+if [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fn0" ]] ||
+  [[ "$*" == "-a -p $MOCK_LIVE_PID -d cwd -Fpn0" ]]; then
+  printf 'p%s\0\nfcwd\0n%s\0\n' "$MOCK_LIVE_PID" "$MOCK_LIVE_CWD"
+fi
+`,
+    );
+    chmodSync(lsofPath, 0o755);
+    return {
+      MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
+      MOCK_LIVE_PID: String(pid),
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+    };
+  }
+
+  function mockAllLiveProcessOwnership(): NodeJS.ProcessEnv {
+    const binaryDirectory = nodePath.join(temporaryDirectory, 'all-live-bin');
+    const lsofPath = nodePath.join(binaryDirectory, 'lsof');
+    mkdirSync(binaryDirectory);
+    writeFileSync(
+      lsofPath,
+      String.raw`#!/usr/bin/env bash
+if [[ "$1" == "-a" ]] && [[ "$2" == "-p" ]] && [[ "$4" == "-d" ]] &&
+  [[ "$5" == "cwd" ]] && [[ "$6" == "-Fpn0" ]]; then
+  for pid in \${3//,/ }; do
+    if kill -0 "$pid" 2> /dev/null; then
+      printf 'p%s\0\nfcwd\0n%s\0\n' "$pid" "$MOCK_LIVE_CWD"
+    fi
+  done
+fi
+`,
+    );
+    chmodSync(lsofPath, 0o755);
+    return {
+      MOCK_LIVE_CWD: realpathSync(temporaryDirectory),
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+    };
+  }
+
   function mockPortOwner(
     processDirectory?: string,
     processCommand?: string,
@@ -84,13 +129,18 @@ describe('cleanup-zombies.sh', () => {
     writeFileSync(
       lsofPath,
       String.raw`#!/usr/bin/env bash
+if [[ -n "$MOCK_LSOF_LOG" ]]; then
+  printf '%s\n' "$*" >> "$MOCK_LSOF_LOG"
+fi
 if [[ "$*" == "-ti:${MOCK_PORT}" ]]; then
   if [[ -n "$MOCK_PORT_PIDS" ]]; then
     printf '%s\n' "$MOCK_PORT_PIDS"
   else
     echo ${MOCK_PID}
   fi
-elif [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_PROCESS_CWD" ]]; then
+elif { [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fn0" ]] ||
+  [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fpn0" ]]; } &&
+  [[ -n "$MOCK_PROCESS_CWD" ]]; then
   process_cwd="$MOCK_PROCESS_CWD"
   if [[ -n "$MOCK_PROCESS_CWD_AFTER_FIRST" ]]; then
     read_count=0
@@ -103,6 +153,11 @@ elif [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_PROCESS_CWD" 
   printf 'p${MOCK_PID}\0\nfcwd\0n%s\0\n' "$process_cwd"
 elif [[ "$*" == "-a -p ${MOCK_SECOND_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_SECOND_PROCESS_CWD" ]]; then
   printf 'p${MOCK_SECOND_PID}\0\nfcwd\0n%s\0\n' "$MOCK_SECOND_PROCESS_CWD"
+elif [[ "$*" == "-a -p ${MOCK_PID},${MOCK_SECOND_PID} -d cwd -Fpn0" ]]; then
+  [[ -n "$MOCK_PROCESS_CWD" ]] &&
+    printf 'p${MOCK_PID}\0\nfcwd\0n%s\0\n' "$MOCK_PROCESS_CWD"
+  [[ -n "$MOCK_SECOND_PROCESS_CWD" ]] &&
+    printf 'p${MOCK_SECOND_PID}\0\nfcwd\0n%s\0\n' "$MOCK_SECOND_PROCESS_CWD"
 fi
 `,
     );
@@ -239,6 +294,32 @@ fi
     });
   });
 
+  describe('required ownership tooling', () => {
+    it('refuses loudly instead of reporting success when lsof is unavailable', () => {
+      const missingLsofBin = nodePath.join(temporaryDirectory, 'missing-lsof-bin');
+      const basenamePath = nodePath.join(missingLsofBin, 'basename');
+      mkdirSync(missingLsofBin);
+      writeFileSync(
+        basenamePath,
+        String.raw`#!/bin/sh
+value=\${1%/}
+printf '%s\n' "\${value##*/}"
+`,
+      );
+      chmodSync(basenamePath, 0o755);
+
+      const result = spawnSync('/bin/bash', [SCRIPT_PATH], {
+        cwd: temporaryDirectory,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: missingLsofBin },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('lsof is required to verify project ownership');
+      expect(result.stdout).not.toContain('already clean');
+    });
+  });
+
   describe('explicit port override', () => {
     it('uses provided port instead of auto-detection', () => {
       createFile('vite.config.ts'); // Would normally detect 5173
@@ -369,7 +450,7 @@ fi
       const pid = spawnVictim();
       await expect.poll(() => isAlive(pid)).toBe(true);
 
-      const liveProcessEnvironment = { PATH: process.env.PATH ?? '' };
+      const liveProcessEnvironment = mockLiveProcessOwnership(pid);
       const preview = runScriptRaw(['swzombie'], liveProcessEnvironment);
       expect(preview).toContain('swzombie');
       expect(preview).toContain('Re-run with --yes to kill them');
@@ -434,6 +515,45 @@ fi
       runScriptRaw([], environment);
 
       expect(readFileSync(pgrepLog, 'utf8').split('\n')).toContain('-f playwright');
+    });
+
+    it('Scenario: pattern ownership is read in one lsof call per candidate set', () => {
+      const lsofLog = nodePath.join(temporaryDirectory, 'lsof.log');
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const environment = {
+        ...mockPortOwner(projectDirectory),
+        MOCK_LSOF_LOG: lsofLog,
+        MOCK_PATTERN: 'playwright',
+        MOCK_PATTERN_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
+        MOCK_SECOND_PROCESS_CWD: projectDirectory,
+      };
+
+      const output = runScriptRaw([], environment);
+
+      expect(output).toContain("Pattern 'playwright' (project-scoped): 2 process(es)");
+      expect(readFileSync(lsofLog, 'utf8').trim()).toBe(
+        `-a -p ${MOCK_PID},${MOCK_SECOND_PID} -d cwd -Fpn0`,
+      );
+    });
+
+    it('Scenario: a matching grandparent process is excluded from cleanup candidates', () => {
+      const marker = `swzombie-ancestor-${process.pid}`;
+      const outerWrapper = nodePath.join(temporaryDirectory, `${marker}.sh`);
+      const innerWrapper = nodePath.join(temporaryDirectory, 'inner-wrapper.sh');
+      writeFileSync(outerWrapper, `#!/usr/bin/env bash\nbash "${innerWrapper}"\n`);
+      writeFileSync(innerWrapper, `#!/usr/bin/env bash\nbash "${SCRIPT_PATH}" "${marker}"\n`);
+      chmodSync(outerWrapper, 0o755);
+      chmodSync(innerWrapper, 0o755);
+
+      const result = spawnSync('bash', [outerWrapper], {
+        cwd: temporaryDirectory,
+        encoding: 'utf8',
+        env: { ...process.env, ...mockAllLiveProcessOwnership() },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).not.toContain(`Pattern '${marker}' (project-scoped):`);
+      expect(result.stdout).toContain('already clean');
     });
   });
 

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -25,6 +25,7 @@ const SCRIPT_PATH = nodePath.join(__dirname, '../../templates/scripts/cleanup-zo
 const MOCK_PORT = 5173;
 const MOCK_PID = 4242;
 const MOCK_SECOND_PID = 4343;
+const UNRELATED_PROJECT_DIRECTORY = '/tmp/unrelated-project';
 
 describe('cleanup-zombies.sh', () => {
   let isolatedPath: string;
@@ -608,7 +609,7 @@ printf '%s\n' "\${value##*/}"
       const projectDirectory = realpathSync(temporaryDirectory);
       const environment = {
         ...mockCleanupEnvironment({
-          processDirectory: '/tmp/unrelated-project',
+          processDirectory: UNRELATED_PROJECT_DIRECTORY,
           processCommand: `/usr/bin/playwright ${projectDirectory}/report`,
         }),
         MOCK_PATTERN: 'playwright',
@@ -696,7 +697,7 @@ printf '%s\n' "\${value##*/}"
     it("Scenario: an unrelated project's process is excluded from the preview", () => {
       const output = runScriptRaw(
         [],
-        mockCleanupEnvironment({ processDirectory: '/tmp/unrelated-project' }),
+        mockCleanupEnvironment({ processDirectory: UNRELATED_PROJECT_DIRECTORY }),
       );
 
       expect(output).not.toContain(`Port ${MOCK_PORT}:`);
@@ -739,7 +740,7 @@ printf '%s\n' "\${value##*/}"
       const output = runScriptRaw(
         [],
         mockCleanupEnvironment({
-          processDirectory: '/tmp/unrelated-project',
+          processDirectory: UNRELATED_PROJECT_DIRECTORY,
           processCommand: `${projectDirectory}-other/node_modules/.bin/vite`,
         }),
       );
@@ -754,7 +755,7 @@ printf '%s\n' "\${value##*/}"
       const output = runScriptRaw(
         [],
         mockCleanupEnvironment({
-          processDirectory: '/tmp/unrelated-project',
+          processDirectory: UNRELATED_PROJECT_DIRECTORY,
           processCommand: `/usr/bin/vite --log-file ${projectDirectory}/server.log`,
         }),
       );
@@ -781,7 +782,7 @@ printf '%s\n' "\${value##*/}"
     it('Scenario: --yes never passes an unrelated port owner to kill', () => {
       const killLog = nodePath.join(temporaryDirectory, 'kill.log');
       const environment = {
-        ...mockCleanupEnvironment({ processDirectory: '/tmp/unrelated-project' }),
+        ...mockCleanupEnvironment({ processDirectory: UNRELATED_PROJECT_DIRECTORY }),
         MOCK_KILL_LOG: killLog,
       };
 
@@ -812,7 +813,7 @@ printf '%s\n' "\${value##*/}"
       const environment = {
         ...mockCleanupEnvironment({
           processDirectory: projectDirectory,
-          subsequentProcessDirectory: '/tmp/unrelated-project',
+          subsequentProcessDirectory: UNRELATED_PROJECT_DIRECTORY,
         }),
         MOCK_KILL_LOG: killLog,
         MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -599,10 +599,10 @@ printf '%s\n' "\${value##*/}"
       createFile('vite.config.ts');
 
       const output = runScript();
+      const expectedTestPort = MOCK_PORT + 1000;
 
-      // Output format: "Port: 5173 (+ test port 6173)"
-      expect(output).toContain('Port: 5173');
-      expect(output).toContain('test port 6173');
+      expect(output).toContain(`Port: ${MOCK_PORT}`);
+      expect(output).toContain(`test port ${expectedTestPort}`);
     });
   });
 

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -652,6 +652,19 @@ printf '%s\n' "\${value##*/}"
       expect(output).toContain(`PID ${MOCK_PID}: unknown`);
     });
 
+    it('Scenario: a custom pattern matching a built-in is inspected once', () => {
+      const environment = {
+        ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
+        MOCK_PATTERN: 'playwright',
+        MOCK_PATTERN_PIDS: String(MOCK_PID),
+      };
+
+      const output = runScriptRaw(['playwright'], environment);
+
+      expect(output.match(/Pattern 'playwright' \(project-scoped\)/g)).toHaveLength(1);
+      expect(output).toContain('Found 1 process(es) that would be killed');
+    });
+
     it('Scenario: project paths are not interpolated into pgrep regular expressions', () => {
       const pgrepLog = nodePath.join(temporaryDirectory, 'pgrep.log');
       const environment = {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -640,6 +640,18 @@ printf '%s\n' "\${value##*/}"
       expect(output).toContain(`PID ${MOCK_PID}`);
     });
 
+    it('Scenario: an unavailable process command is reported as unknown', () => {
+      const environment = {
+        ...mockCleanupEnvironment({ processDirectory: projectDirectory }),
+        MOCK_PATTERN: 'playwright',
+        MOCK_PATTERN_PIDS: String(MOCK_PID),
+      };
+
+      const output = runScriptRaw([], environment);
+
+      expect(output).toContain(`PID ${MOCK_PID}: unknown`);
+    });
+
     it('Scenario: project paths are not interpolated into pgrep regular expressions', () => {
       const pgrepLog = nodePath.join(temporaryDirectory, 'pgrep.log');
       const environment = {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -6,13 +6,25 @@
  */
 
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const SCRIPT_PATH = nodePath.join(__dirname, '../../templates/scripts/cleanup-zombies.sh');
+const MOCK_PORT = 5173;
+const MOCK_PID = 4242;
+const MOCK_SECOND_PID = 4343;
 
 describe('cleanup-zombies.sh', () => {
   let temporaryDirectory: string;
@@ -26,9 +38,13 @@ describe('cleanup-zombies.sh', () => {
   });
 
   /** Run the real script with the args exactly as given. */
-  function runScriptRaw(args: string[] = []): string {
+  function runScriptRaw(args: string[] = [], environmentOverrides: NodeJS.ProcessEnv = {}): string {
     const command = `bash "${SCRIPT_PATH}" ${args.join(' ')}`;
-    return execSync(command, { cwd: temporaryDirectory, encoding: 'utf8' });
+    return execSync(command, {
+      cwd: temporaryDirectory,
+      encoding: 'utf8',
+      env: { ...process.env, ...environmentOverrides },
+    });
   }
 
   /** Detection-suite default: always preview explicitly. */
@@ -43,6 +59,67 @@ describe('cleanup-zombies.sh', () => {
       mkdirSync(dir, { recursive: true });
     }
     writeFileSync(fullPath, content);
+  }
+
+  function mockPortOwner(
+    processDirectory?: string,
+    processCommand?: string,
+    subsequentProcessDirectory?: string,
+  ): NodeJS.ProcessEnv {
+    const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
+    const killPath = nodePath.join(binaryDirectory, 'kill');
+    const lsofPath = nodePath.join(binaryDirectory, 'lsof');
+    const psPath = nodePath.join(binaryDirectory, 'ps');
+    mkdirSync(binaryDirectory);
+    writeFileSync(
+      lsofPath,
+      String.raw`#!/usr/bin/env bash
+if [[ "$*" == "-ti:${MOCK_PORT}" ]]; then
+  if [[ -n "$MOCK_PORT_PIDS" ]]; then
+    printf '%s\n' "$MOCK_PORT_PIDS"
+  else
+    echo ${MOCK_PID}
+  fi
+elif [[ "$*" == "-a -p ${MOCK_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_PROCESS_CWD" ]]; then
+  process_cwd="$MOCK_PROCESS_CWD"
+  if [[ -n "$MOCK_PROCESS_CWD_AFTER_FIRST" ]]; then
+    read_count=0
+    [[ -f "$MOCK_LSOF_CWD_COUNT" ]] && read_count=$(<"$MOCK_LSOF_CWD_COUNT")
+    if [[ "$read_count" -gt 0 ]]; then
+      process_cwd="$MOCK_PROCESS_CWD_AFTER_FIRST"
+    fi
+    printf '%s\n' "$((read_count + 1))" > "$MOCK_LSOF_CWD_COUNT"
+  fi
+  printf 'p${MOCK_PID}\0\nfcwd\0n%s\0\n' "$process_cwd"
+elif [[ "$*" == "-a -p ${MOCK_SECOND_PID} -d cwd -Fn0" ]] && [[ -n "$MOCK_SECOND_PROCESS_CWD" ]]; then
+  printf 'p${MOCK_SECOND_PID}\0\nfcwd\0n%s\0\n' "$MOCK_SECOND_PROCESS_CWD"
+fi
+`,
+    );
+    writeFileSync(
+      psPath,
+      String.raw`#!/usr/bin/env bash
+if [[ -n "$MOCK_PROCESS_COMMAND" ]]; then
+  printf '%s\n' "$MOCK_PROCESS_COMMAND"
+fi
+`,
+    );
+    writeFileSync(
+      killPath,
+      String.raw`#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_KILL_LOG"
+`,
+    );
+    chmodSync(killPath, 0o755);
+    chmodSync(lsofPath, 0o755);
+    chmodSync(psPath, 0o755);
+    return {
+      MOCK_LSOF_CWD_COUNT: nodePath.join(temporaryDirectory, 'lsof-cwd-count'),
+      MOCK_PROCESS_COMMAND: processCommand,
+      MOCK_PROCESS_CWD: processDirectory,
+      MOCK_PROCESS_CWD_AFTER_FIRST: subsequentProcessDirectory,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+    };
   }
 
   describe('framework detection (root)', () => {
@@ -285,6 +362,138 @@ describe('cleanup-zombies.sh', () => {
       // Output format: "Port: 5173 (+ test port 6173)"
       expect(output).toContain('Port: 5173');
       expect(output).toContain('test port 6173');
+    });
+  });
+
+  describe('Rule: port cleanup stays scoped to the current project', () => {
+    beforeEach(() => {
+      createFile('vite.config.ts');
+    });
+
+    it("Scenario: an unrelated project's process is excluded from the preview", () => {
+      const output = runScriptRaw([], mockPortOwner('/tmp/unrelated-project'));
+
+      expect(output).not.toContain(`Port ${MOCK_PORT}:`);
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it("Scenario: the current project's process remains in the preview", () => {
+      const output = runScriptRaw([], mockPortOwner(realpathSync(temporaryDirectory)));
+
+      expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
+      expect(output).toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('Found 1 process(es) that would be killed');
+    });
+
+    it("Scenario: a process beneath the current project's root remains in the preview", () => {
+      const projectChild = nodePath.join(realpathSync(temporaryDirectory), 'packages', 'app');
+      const output = runScriptRaw([], mockPortOwner(projectChild));
+
+      expect(output).toContain(`Port ${MOCK_PORT}: 1 process(es)`);
+      expect(output).toContain(`PID ${MOCK_PID}`);
+    });
+
+    it('Scenario: a process with unknown ownership is excluded from the preview', () => {
+      const output = runScriptRaw([], mockPortOwner());
+
+      expect(output).not.toContain(`Port ${MOCK_PORT}:`);
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it("Scenario: a similarly prefixed project's command is excluded", () => {
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const output = runScriptRaw(
+        [],
+        mockPortOwner('/tmp/unrelated-project', `${projectDirectory}-other/node_modules/.bin/vite`),
+      );
+
+      expect(output).not.toContain(`Port ${MOCK_PORT}:`);
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it('Scenario: an unrelated command argument referencing this project is excluded', () => {
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const output = runScriptRaw(
+        [],
+        mockPortOwner(
+          '/tmp/unrelated-project',
+          `/usr/bin/vite --log-file ${projectDirectory}/server.log`,
+        ),
+      );
+
+      expect(output).not.toContain(`Port ${MOCK_PORT}:`);
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it('Scenario: an unrelated cwd containing a newline is excluded', () => {
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const output = runScriptRaw([], mockPortOwner(`${projectDirectory}\nn${projectDirectory}`));
+
+      expect(output).not.toContain(`Port ${MOCK_PORT}:`);
+      expect(output).not.toContain(`PID ${MOCK_PID}`);
+      expect(output).toContain('already clean');
+    });
+
+    it('Scenario: --yes never passes an unrelated port owner to kill', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const environment = {
+        ...mockPortOwner('/tmp/unrelated-project'),
+        MOCK_KILL_LOG: killLog,
+      };
+
+      const output = runScriptRaw(['--yes'], environment);
+
+      expect(output).toContain('already clean');
+      expect(existsSync(killLog)).toBe(false);
+    });
+
+    it('Scenario: --yes passes a current-project port owner to kill', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const environment = {
+        ...mockPortOwner(realpathSync(temporaryDirectory)),
+        MOCK_KILL_LOG: killLog,
+      };
+
+      const output = runScriptRaw(['--yes'], environment);
+
+      expect(output).toContain('Killed 1 process(es)');
+      expect(readFileSync(killLog, 'utf8')).toContain(`-9 ${MOCK_PID}`);
+    });
+
+    it('Scenario: --yes revalidates each PID immediately before signaling it', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const environment = {
+        ...mockPortOwner(projectDirectory, undefined, '/tmp/unrelated-project'),
+        MOCK_KILL_LOG: killLog,
+        MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
+        MOCK_SECOND_PROCESS_CWD: projectDirectory,
+      };
+
+      const output = runScriptRaw(['--yes'], environment);
+
+      expect(output).toContain('Killed 1 process(es)');
+      expect(readFileSync(killLog, 'utf8')).toBe(`-9 ${MOCK_SECOND_PID}\n`);
+    });
+
+    it('Scenario: --yes signals verified PIDs individually', () => {
+      const killLog = nodePath.join(temporaryDirectory, 'kill.log');
+      const projectDirectory = realpathSync(temporaryDirectory);
+      const environment = {
+        ...mockPortOwner(projectDirectory),
+        MOCK_KILL_LOG: killLog,
+        MOCK_PORT_PIDS: `${MOCK_PID}\n${MOCK_SECOND_PID}`,
+        MOCK_SECOND_PROCESS_CWD: projectDirectory,
+      };
+
+      const output = runScriptRaw(['--yes'], environment);
+
+      expect(output).toContain('Killed 2 process(es)');
+      expect(readFileSync(killLog, 'utf8')).toBe(`-9 ${MOCK_PID}\n-9 ${MOCK_SECOND_PID}\n`);
     });
   });
 });

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -674,7 +674,19 @@ printf '%s\n' "\${value##*/}"
 
       runScriptRaw([], environment);
 
-      expect(readFileSync(pgrepLog, 'utf8').split('\n')).toContain('-f playwright');
+      expect(readFileSync(pgrepLog, 'utf8').split('\n')).toContain('-f -- playwright');
+    });
+
+    it('Scenario: a leading-dash pattern is passed as an operand', () => {
+      const pgrepLog = nodePath.join(temporaryDirectory, 'pgrep.log');
+      const environment = {
+        ...mockCleanupEnvironment(),
+        MOCK_PGREP_LOG: pgrepLog,
+      };
+
+      runScriptRaw(['-custom'], environment);
+
+      expect(readFileSync(pgrepLog, 'utf8').split('\n')).toContain('-f -- -custom');
     });
 
     it('Scenario: pattern ownership is read in one lsof call per candidate set', () => {

--- a/packages/cli/tests/scripts/cleanup-zombies.test.ts
+++ b/packages/cli/tests/scripts/cleanup-zombies.test.ts
@@ -409,6 +409,35 @@ printf '%s\n' "\${value##*/}"
       expect(output).toContain('Port: 9000');
       expect(output).toContain('Pattern: custom');
     });
+
+    it('normalizes a leading-zero port as decimal', () => {
+      const output = runScript(['00080']);
+
+      expect(output).toContain('Port: 80');
+      expect(output).toContain('test port 1080');
+    });
+
+    it('does not derive a test port beyond the valid port range', () => {
+      const output = runScript(['65535']);
+
+      expect(output).toContain('Port: 65535');
+      expect(output).not.toContain('test port');
+      expect(output).not.toContain('66535');
+    });
+
+    for (const invalidPort of ['0', '65536']) {
+      it(`rejects invalid numeric port ${invalidPort}`, () => {
+        const result = spawnSync('/bin/bash', [SCRIPT_PATH, invalidPort], {
+          cwd: temporaryDirectory,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: isolatedPath },
+        });
+
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain('port must be between 1 and 65535');
+        expect(result.stdout).not.toContain('Cleanup zombies for:');
+      });
+    }
   });
 
   describe('--dry-run behavior', () => {

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -9,16 +9,16 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Quick actions you type in Claude Code or Cursor. Just type the command and hit enter. Codex uses plugin-scoped skills such as `safeword:bdd`, `safeword:verify`, and `safeword:explain`.
 
-| Command            | What it does                              |
-| ------------------ | ----------------------------------------- |
-| `/lint`            | Fix code style issues                     |
-| `/audit`           | Find dead code and architecture drift     |
-| `/quality-review`  | Deep review against latest research       |
-| `/cleanup-zombies` | Kill stuck processes hogging ports        |
-| `/bdd`             | Start BDD workflow (includes TDD)         |
-| `/debug`           | Start structured debugging workflow       |
-| `/refactor`        | Start safe refactoring workflow           |
-| `/verify`          | Run completion checklist for current task |
+| Command            | What it does                               |
+| ------------------ | ------------------------------------------ |
+| `/lint`            | Fix code style issues                      |
+| `/audit`           | Find dead code and architecture drift      |
+| `/quality-review`  | Deep review against latest research        |
+| `/cleanup-zombies` | Clean current-project processes from ports |
+| `/bdd`             | Start BDD workflow (includes TDD)          |
+| `/debug`           | Start structured debugging workflow        |
+| `/refactor`        | Start safe refactoring workflow            |
+| `/verify`          | Run completion checklist for current task  |
 
 ---
 

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -9,16 +9,16 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Quick actions you type in Claude Code or Cursor. Just type the command and hit enter. Codex uses plugin-scoped skills such as `safeword:bdd`, `safeword:verify`, and `safeword:explain`.
 
-| Command            | What it does                               |
-| ------------------ | ------------------------------------------ |
-| `/lint`            | Fix code style issues                      |
-| `/audit`           | Find dead code and architecture drift      |
-| `/quality-review`  | Deep review against latest research        |
-| `/cleanup-zombies` | Clean current-project processes from ports |
-| `/bdd`             | Start BDD workflow (includes TDD)          |
-| `/debug`           | Start structured debugging workflow        |
-| `/refactor`        | Start safe refactoring workflow            |
-| `/verify`          | Run completion checklist for current task  |
+| Command            | What it does                              |
+| ------------------ | ----------------------------------------- |
+| `/lint`            | Fix code style issues                     |
+| `/audit`           | Find dead code and architecture drift     |
+| `/quality-review`  | Deep review against latest research       |
+| `/cleanup-zombies` | Clean current-project zombie processes    |
+| `/bdd`             | Start BDD workflow (includes TDD)         |
+| `/debug`           | Start structured debugging workflow       |
+| `/refactor`        | Start safe refactoring workflow           |
+| `/verify`          | Run completion checklist for current task |
 
 ---
 


### PR DESCRIPTION
## What changed

- Apply one fail-closed working-directory ownership rule to both port and command-pattern candidates.
- Parse `lsof` field output safely with NUL delimiters, including paths containing newlines.
- Revalidate and signal each PID individually to narrow process-identity races.
- PATH-resolve `kill` through an explicit test seam and count only successful signals.
- Explain when foreign port owners were skipped instead of reporting the project as “already clean.”
- Fail loudly when required tools or `pgrep` discovery fail, while preserving summaries for earlier completed work.
- Validate explicit ports as decimal values in the 1–65535 range and derive the conventional test port only when it remains valid.
- Pass patterns after `pgrep`'s option terminator and avoid duplicate built-in/custom pattern sweeps.
- Add deterministic integration coverage for unrelated projects, descendants, unknown ownership, tricky pathnames, pattern candidates, failed signals, multi-PID behavior, port boundaries, and leading-dash patterns.
- Update the cleanup guide, README, website reference, generated Codex skill, and dogfood mirrors; raw machine-wide kill examples are no longer presented as project-safe.

## Why

Port and pattern discovery are machine-wide. Previously, a foreign process could be treated as project-owned when its argv mentioned this project, and filtered foreign port owners produced a misleading “already clean” result. Cleanup now uses the process working directory as the single ownership boundary and leaves anything unverified alone.

## Impact

Developers can run zombie cleanup without terminating another project that shares a port or whose command line references the current project. If a foreign process still occupies a detected port, the command explains that recovery condition. Failed signals are no longer counted as successful kills. Broad foreign pattern matches remain silently ineligible to avoid machine-wide skip noise.

## Decision evidence

A `$safeword:figure-it-out` pass compared a narrow polish, a unified ownership rule, and a split follow-up. The unified rule won because destructive cleanup should not change its definition of “this project” based on how it discovered the PID. The main tradeoff is that a legitimate child that changes working directory will be skipped; fail-closed behavior is intentional.

A fresh `$safeword:quality-review` and full `$safeword:refactor` pass resolved every valid finding, including port arithmetic, process-label fallback, duplicate pattern discovery, test-harness argument fidelity, generated plugin parity, and stale verification evidence. Risky Bash generalizations and framework-detection restructuring were deliberately deferred because they add complexity or fall outside issue #1451.

## Verification

- 369 test files passed: 5,513 tests passed; 5 skipped (5,518 total).
- 494/494 active Cucumber scenarios and 15,313/15,313 active steps passed; 3 scenarios and 4 steps skipped.
- Focused cleanup suite: 51/51 passed.
- Build, ESLint, Gherkin lint, TypeScript, Bash syntax, ShellCheck, formatting, config sync, mirror checks, generated Codex catalogue, and targeted Markdown checks passed.
- Changed production script, integration test, and guide duplication scan: 0 clones.
- Audit passed with warnings only for pre-existing/out-of-scope repository conditions: hidden-worktree scan noise, unavailable Python audit tools, and two dev-only patch updates.

Fixes #1451
