### PR TITLE
Prevent phase anchors from accepting foreign artifacts

### DIFF
--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -4,7 +4,7 @@ Scope: issue #904 hardening diff from `50abb9bef`.
 
 - [x] Reuse `shapeValidImplPlan()` in the two duplicated boundary fixtures.
 - [x] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
-- [ ] Give enforcing callers a required-scope API while preserving the format-only predicate.
+- [x] Give enforcing callers a required-scope API while preserving the format-only predicate.
 - [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`492b4cd39`, `1186488e3`).
 - [x] Require ticket identity and feature roots at the boundary engine seam (`5a3b22d67`, `511ea43be`).
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -1,11 +1,11 @@
 # Refactor Ledger
 
-Scope: issue #904 hardening diff from `50abb9bef`.
+Scope: issue #904 hardening commits rebased onto `63e8bfa23`.
 
 - [x] Reuse `shapeValidImplPlan()` in the two duplicated boundary fixtures.
 - [x] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
 - [x] Give enforcing callers a required-scope API while preserving the format-only predicate.
-- [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`492b4cd39`, `1186488e3`).
-- [x] Require ticket identity and feature roots at the boundary engine seam (`5a3b22d67`, `511ea43be`).
+- [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`4dd71218c`, `fcb6d78ce`).
+- [x] Require ticket identity and feature roots at the boundary engine seam (`bdcb3cb47`, `6a179bc2b`).
 
 No scout findings were truncated or deferred.

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -1,0 +1,11 @@
+# Refactor Ledger
+
+Scope: issue #904 hardening diff from `50abb9bef`.
+
+- [x] Reuse `shapeValidImplPlan()` in the two duplicated boundary fixtures.
+- [ ] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
+- [ ] Give enforcing callers a required-scope API while preserving the format-only predicate.
+- [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`492b4cd39`, `1186488e3`).
+- [x] Require ticket identity and feature roots at the boundary engine seam (`5a3b22d67`, `511ea43be`).
+
+No scout findings were truncated or deferred.

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -4,7 +4,7 @@ Scope: issue #904 hardening commits rebased onto `63e8bfa23`.
 
 - [x] Reuse `shapeValidImplPlan()` in the two duplicated boundary fixtures.
 - [x] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
-- [x] Give enforcing callers a required-scope API while preserving the format-only predicate.
+- [x] Make ownership scope mandatory on both public detectors and remove the redundant scoped wrappers; format-only mode now omits only the tree reader.
 - [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`4dd71218c`, `fcb6d78ce`).
 - [x] Require ticket identity and feature roots at the boundary engine seam (`bdcb3cb47`, `6a179bc2b`).
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -3,7 +3,7 @@
 Scope: issue #904 hardening diff from `50abb9bef`.
 
 - [x] Reuse `shapeValidImplPlan()` in the two duplicated boundary fixtures.
-- [ ] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
+- [x] Extract the shared committed anchored-advance setup used by amend and rebase scenarios.
 - [ ] Give enforcing callers a required-scope API while preserving the format-only predicate.
 - [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`492b4cd39`, `1186488e3`).
 - [x] Require ticket identity and feature roots at the boundary engine seam (`5a3b22d67`, `511ea43be`).

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/refactor-ledger.md
@@ -7,5 +7,13 @@ Scope: issue #904 hardening commits rebased onto `63e8bfa23`.
 - [x] Make ownership scope mandatory on both public detectors and remove the redundant scoped wrappers; format-only mode now omits only the tree reader.
 - [x] Centralize configured repository-path normalization in `toRepoDirectory()` (`4dd71218c`, `fcb6d78ce`).
 - [x] Require ticket identity and feature roots at the boundary engine seam (`bdcb3cb47`, `6a179bc2b`).
+- [x] Replace the remaining acceptance-runner workspace-root literal with the dependency-free production constant (`4b00163e4`).
+- [x] Replace the phase-anchor and boundary-engine unit-fixture workspace-root literals with the same production constant (`437d9844d`, `7390c5441`).
 
 No scout findings were truncated or deferred.
+
+## Quality-review remediation
+
+- [x] Restore `.project`-over-`.safeword-project` precedence from the staged index at commit boundaries and `HEAD` at push boundaries (`af26407e6`).
+- [x] Cover both authoritative-root precedence and legacy-only fallback with real commit/push CLI repositories (`af26407e6`, `9dfa14b2c`).
+- [x] Strengthen unit ownership assertions to identify the exact `outside this ticket` branch (`7fb4d23ae`).

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
@@ -82,11 +82,13 @@ hashes.
   last-wins-on-re-advance all carry over.
 - **Canonical per-phase artifact** (phase entered ← exit artifact of phase
   left): define-behavior ← `spec.md` · scenario-gate ← the feature source
-  (`features/<slug>.feature` or configured path) · implement ← `impl-plan.md` ·
-  verify ← `test-definitions.md` (the R/G/R ledger) · done ← `verify.md`. The
-  explicit path (rather than a derived map) pins per-ticket ambiguity —
-  configurable features dir, legacy AC-path tickets — and keeps the traversal
-  trail the shipped birth check already reads (`engine.ts:198`).
+  (`features/<slug>.feature`, a direct workspace's `features/` lane, or the
+  configured feature lane; same-named `.feature` files elsewhere are not
+  executable evidence) · implement ← `impl-plan.md` · verify ←
+  `test-definitions.md` (the R/G/R ledger) · done ← `verify.md`. The explicit
+  path (rather than a derived map) pins per-ticket ambiguity — configurable
+  features dir, legacy AC-path tickets — and keeps the traversal trail the
+  shipped birth check already reads (`engine.ts:198`).
 - **Boundary verification (#810):** for the entered phase of a transition in
   the change — the anchored artifact exists in the shipped tree and passes the
   artifact's existing shape predicate (`parseImplPlan`, `checkVerifyArtifact`,

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
@@ -212,7 +212,7 @@ Unaffected:
 ## Vocabulary
 
 - **Artifact-content anchor** — a `phase_anchors` entry tying an entered phase
-  to the exit artifact of the phase being left, as `<relpath>@<content-hash>`;
+  to the exit artifact of the phase being left, as a bare repo-relative path;
   verified against the final tree, never against git history.
 - **Final-tree verification** — checking anchors in the tree being
   committed/pushed/PR'd, requiring no history and therefore surviving

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/spec.md
@@ -266,6 +266,13 @@ hex-shaped anchor for its entered phase draws the migrate-to-path remediation.
 resolution, and done-gate validation exactly as shipped — the redesign removes
 the phase-anchor dependency on git history, not the ledger's.
 
+#### artifact-content-phase-anchors.SM1.R6 — Ownership and configured lanes are resolved from canonical staged paths
+
+An anchor belongs to the ticket being advanced and, for feature sources, to an
+executable or configured feature lane. Ticket-root discovery, path
+normalization, and ownership checks use the staged tree's configuration and
+paths rather than unstaged worktree state.
+
 ## Rave Moment
 
 skip: table-stakes — evidence-substrate plumbing; the persona-facing moment

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -139,7 +139,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: A ticket cannot reuse another ticket's feature source
 
-- [ ] RED
+- [x] RED b612e91
 - [ ] GREEN
 - [ ] REFACTOR
 
@@ -151,7 +151,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: OS-native ticket paths are normalized to the anchor grammar
 
-- [ ] RED
+- [x] RED b612e91
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -71,9 +71,9 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: A rebased commit does not disturb a recorded anchor
 
-- [x] RED 4b546cd
-- [x] GREEN ca68343
-- [x] REFACTOR f78c62e
+- [x] RED 2cd0ef5
+- [x] GREEN 356c4ee
+- [x] REFACTOR a611f69
 
 ### Scenario: A shallow clone's anchor check passes with no unreachable-history hedging
 
@@ -133,63 +133,63 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: A ticket cannot reuse another ticket's same-kind artifact
 
-- [x] RED 4b546cd
-- [x] GREEN ca68343
-- [x] REFACTOR 6751bcf
+- [x] RED 2cd0ef5
+- [x] GREEN 356c4ee
+- [x] REFACTOR a0e95de
 
 ### Scenario: A ticket cannot reuse another ticket's feature source
 
-- [x] RED b612e91
-- [x] GREEN 5a3b22d
-- [x] REFACTOR 93bf3fe
+- [x] RED b5ed264
+- [x] GREEN bdcb3cb
+- [x] REFACTOR da20049
 
 ### Scenario: A Git index-stage prefix cannot alias a different artifact path
 
-- [x] RED 4b546cd
-- [x] GREEN ca68343
-- [x] REFACTOR 6751bcf
+- [x] RED 2cd0ef5
+- [x] GREEN 356c4ee
+- [x] REFACTOR a0e95de
 
 ### Scenario: OS-native ticket paths are normalized to the anchor grammar
 
-- [x] RED b612e91
-- [x] GREEN 5a3b22d
-- [x] REFACTOR 93bf3fe
+- [x] RED b5ed264
+- [x] GREEN bdcb3cb
+- [x] REFACTOR da20049
 
 ### Scenario: Canonical feature ownership is independent of unstaged worktree state
 
-- [x] RED 713d352
-- [x] GREEN 511ea43
-- [x] REFACTOR 93bf3fe
+- [x] RED ae77c9d
+- [x] GREEN 6a179bc
+- [x] REFACTOR da20049
 
 ### Scenario: Feature anchors must live in an executable or configured feature lane
 
-- [x] RED 8c8c4ca
-- [x] GREEN 8eee17d
-- [x] REFACTOR 93bf3fe
+- [x] RED 4f1475d
+- [x] GREEN eb7ef1e
+- [x] REFACTOR da20049
 
 ### Scenario: Ticket discovery uses the staged project-root configuration
 
-- [x] RED caa410f
-- [x] GREEN 430a493
-- [x] REFACTOR 93bf3fe
+- [x] RED dfec6ce
+- [x] GREEN 27ba49d
+- [x] REFACTOR da20049
 
 ### Scenario: Configured project roots normalize dot and separator segments
 
-- [x] RED 32ead6b
-- [x] GREEN 492b4cd
-- [x] REFACTOR 93bf3fe
+- [x] RED ccc5783
+- [x] GREEN 4dd7121
+- [x] REFACTOR da20049
 
 ### Scenario: Repository-root ticket and feature lanes remain enforceable
 
-- [x] RED 23278c9
-- [x] GREEN 1186488
-- [x] REFACTOR 93bf3fe
+- [x] RED 1f9fce8
+- [x] GREEN fcb6d78
+- [x] REFACTOR da20049
 
 ### Scenario: A configured project root outside the repository warns instead of failing open
 
-- [x] RED 23278c9
-- [x] GREEN 1186488
-- [x] REFACTOR 93bf3fe
+- [x] RED 1f9fce8
+- [x] GREEN fcb6d78
+- [x] REFACTOR da20049
 
 ### Scenario: A backward phase move is not flagged
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -181,13 +181,13 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: Repository-root ticket and feature lanes remain enforceable
 
-- [ ] RED
+- [x] RED 23278c9
 - [ ] GREEN
 - [ ] REFACTOR
 
 ### Scenario: A configured project root outside the repository warns instead of failing open
 
-- [ ] RED
+- [x] RED 23278c9
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -169,7 +169,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: Ticket discovery uses the staged project-root configuration
 
-- [ ] RED
+- [x] RED caa410f
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -131,6 +131,44 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [x] GREEN 73b9759
 - [x] REFACTOR 5bd56ea
 
+### Scenario: A backward phase move is not flagged
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+### Scenario: Re-declaring the same phase is not flagged
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+### Scenario: A non-feature ticket advancing is not flagged
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+### Scenario: A ticket becoming a feature past intake is not flagged
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+### Scenario: An edit that leaves the phase unchanged is not flagged
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+### Scenario: The at-rest advisory nudges a missing anchor with the path grammar
+
+- [x] RED e90eb07
+- [x] GREEN 73b9759
+- [x] REFACTOR 5bd56ea
+
+## Rule: Ownership and configured lanes are resolved from canonical staged paths
+
 ### Scenario: A ticket cannot reuse another ticket's same-kind artifact
 
 - [x] RED 2cd0ef5
@@ -190,42 +228,6 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [x] RED 1f9fce8
 - [x] GREEN fcb6d78
 - [x] REFACTOR da20049
-
-### Scenario: A backward phase move is not flagged
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
-
-### Scenario: Re-declaring the same phase is not flagged
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
-
-### Scenario: A non-feature ticket advancing is not flagged
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
-
-### Scenario: A ticket becoming a feature past intake is not flagged
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
-
-### Scenario: An edit that leaves the phase unchanged is not flagged
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
-
-### Scenario: The at-rest advisory nudges a missing anchor with the path grammar
-
-- [x] RED e90eb07
-- [x] GREEN 73b9759
-- [x] REFACTOR 5bd56ea
 
 ## Rule: Legacy SHA anchors neither warn at rest nor block new work
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -167,6 +167,12 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Ticket discovery uses the staged project-root configuration
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A backward phase move is not flagged
 
 - [x] RED e90eb07

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -12,10 +12,10 @@ green.
 
 Deliberate coverage notes (from the independent scenario review, applied
 2026-07-08): per-kind shape partitions for spec.md / feature source / ledger /
-verify.md are unit-lane only (dimensions.md test-layers note); the post-rebase
-history partition is subsumed by the squash scenario (a strictly harsher
-rewrite); done-gate ledger isolation is carried by the existing regression
-suites.
+verify.md are unit-lane only (dimensions.md test-layers note); done-gate ledger
+isolation is carried by the existing regression suites. The 2026-07-25 quality
+review added explicit rebase coverage and adversarial ticket/path binding
+partitions after real CLI probes found two anchor-substitution gaps.
 
 ## Rule: A forward advance anchors the entered phase to the exited phase's artifact
 
@@ -68,6 +68,12 @@ suites.
 - [x] RED 73b9759
 - [x] GREEN ea8bcf6
 - [x] REFACTOR 5bd56ea
+
+### Scenario: A rebased commit does not disturb a recorded anchor
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
 
 ### Scenario: A shallow clone's anchor check passes with no unreachable-history hedging
 
@@ -124,6 +130,18 @@ suites.
 - [x] RED e90eb07
 - [x] GREEN 73b9759
 - [x] REFACTOR 5bd56ea
+
+### Scenario: A ticket cannot reuse another ticket's same-kind artifact
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A Git index-stage prefix cannot alias a different artifact path
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
 
 ### Scenario: A backward phase move is not flagged
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -161,6 +161,12 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Feature anchors must live in an executable or configured feature lane
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A backward phase move is not flagged
 
 - [x] RED e90eb07

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -72,8 +72,8 @@ partitions after real CLI probes found two anchor-substitution gaps.
 ### Scenario: A rebased commit does not disturb a recorded anchor
 
 - [x] RED 4b546cd
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN ca68343
+- [x] REFACTOR f78c62e
 
 ### Scenario: A shallow clone's anchor check passes with no unreachable-history hedging
 
@@ -134,62 +134,62 @@ partitions after real CLI probes found two anchor-substitution gaps.
 ### Scenario: A ticket cannot reuse another ticket's same-kind artifact
 
 - [x] RED 4b546cd
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN ca68343
+- [x] REFACTOR 6751bcf
 
 ### Scenario: A ticket cannot reuse another ticket's feature source
 
 - [x] RED b612e91
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 5a3b22d
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: A Git index-stage prefix cannot alias a different artifact path
 
 - [x] RED 4b546cd
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN ca68343
+- [x] REFACTOR 6751bcf
 
 ### Scenario: OS-native ticket paths are normalized to the anchor grammar
 
 - [x] RED b612e91
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 5a3b22d
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: Canonical feature ownership is independent of unstaged worktree state
 
 - [x] RED 713d352
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 511ea43
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: Feature anchors must live in an executable or configured feature lane
 
 - [x] RED 8c8c4ca
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 8eee17d
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: Ticket discovery uses the staged project-root configuration
 
 - [x] RED caa410f
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 430a493
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: Configured project roots normalize dot and separator segments
 
 - [x] RED 32ead6b
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 492b4cd
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: Repository-root ticket and feature lanes remain enforceable
 
 - [x] RED 23278c9
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 1186488
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: A configured project root outside the repository warns instead of failing open
 
 - [x] RED 23278c9
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] GREEN 1186488
+- [x] REFACTOR 93bf3fe
 
 ### Scenario: A backward phase move is not flagged
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -157,7 +157,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: Canonical feature ownership is independent of unstaged worktree state
 
-- [ ] RED
+- [x] RED 713d352
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -155,6 +155,12 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Canonical feature ownership is independent of unstaged worktree state
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A backward phase move is not flagged
 
 - [x] RED e90eb07

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -175,7 +175,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: Configured project roots normalize dot and separator segments
 
-- [ ] RED
+- [x] RED 32ead6b
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -71,7 +71,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: A rebased commit does not disturb a recorded anchor
 
-- [ ] RED
+- [x] RED 4b546cd
 - [ ] GREEN
 - [ ] REFACTOR
 
@@ -133,13 +133,13 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: A ticket cannot reuse another ticket's same-kind artifact
 
-- [ ] RED
+- [x] RED 4b546cd
 - [ ] GREEN
 - [ ] REFACTOR
 
 ### Scenario: A Git index-stage prefix cannot alias a different artifact path
 
-- [ ] RED
+- [x] RED 4b546cd
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -179,6 +179,18 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Repository-root ticket and feature lanes remain enforceable
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A configured project root outside the repository warns instead of failing open
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A backward phase move is not flagged
 
 - [x] RED e90eb07

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -163,7 +163,7 @@ partitions after real CLI probes found two anchor-substitution gaps.
 
 ### Scenario: Feature anchors must live in an executable or configured feature lane
 
-- [ ] RED
+- [x] RED 8c8c4ca
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -137,9 +137,21 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: A ticket cannot reuse another ticket's feature source
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A Git index-stage prefix cannot alias a different artifact path
 
 - [x] RED 4b546cd
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: OS-native ticket paths are normalized to the anchor grammar
+
+- [ ] RED
 - [ ] GREEN
 - [ ] REFACTOR
 

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/test-definitions.md
@@ -173,6 +173,12 @@ partitions after real CLI probes found two anchor-substitution gaps.
 - [ ] GREEN
 - [ ] REFACTOR
 
+### Scenario: Configured project roots normalize dot and separator segments
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
 ### Scenario: A backward phase move is not flagged
 
 - [x] RED e90eb07

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
@@ -77,7 +77,8 @@ Evidence after addressing all nine unresolved PR review threads:
   upstream Astro preset expectation (`astro/no-omitted-end-tags` is `"error"`
   under the installed eslint-plugin-astro 3.0.1 while the test expects it to be
   absent). The Astro preset, test, manifests, and lockfile are unchanged from
-  `origin/main`; Node 22 and Node 24 CI passed on remediation head `a36e0d027`.
+  `origin/main`; Node 22 and Node 24 CI passed on the remediation branch after
+  all runtime changes.
 - Audit: 0 change-scoped errors; config parity clean; dependency-cruiser 0
   violations across 662 modules / 2,166 dependencies; Knip clean; dependencies
   current; domain and learning checks clean. Clones improved from 490 to 455

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
@@ -77,11 +77,36 @@ Evidence after addressing all nine unresolved PR review threads:
   upstream Astro preset expectation (`astro/no-omitted-end-tags` is `"error"`
   under the installed eslint-plugin-astro 3.0.1 while the test expects it to be
   absent). The Astro preset, test, manifests, and lockfile are unchanged from
-  `origin/main`; Node 22 and Node 24 CI were green on the prior PR head and will
-  rerun on this remediation.
+  `origin/main`; Node 22 and Node 24 CI passed on remediation head `a36e0d027`.
 - Audit: 0 change-scoped errors; config parity clean; dependency-cruiser 0
   violations across 662 modules / 2,166 dependencies; Knip clean; dependencies
   current; domain and learning checks clean. Clones improved from 490 to 455
   (8.37%) at the same `repo minus .safeword,.project` scope. Existing Python
   experiment import-linter/dead-code tool coverage remains a reported
   limitation.
+
+## Final full-skill pass — 2026-07-26
+
+- Full refactor scout completed with no truncated or deferred findings. Three
+  isolated commits removed every remaining fixture copy of `WORKSPACE_ROOTS`;
+  each passed its focused unit or acceptance lane before commit.
+- Three independent quality-review passes used current official Git and Node
+  documentation. The first reproduced a namespace-precedence regression; the
+  staged-index/`HEAD` fix and real commit/push regressions landed in
+  `af26407e6`. Follow-up passes approved with no critical issues or remaining
+  suggestions after legacy-only fallback coverage and stronger ownership
+  assertions landed.
+- Full generated verification ran on the final production code: 5,496 Vitest
+  tests passed, 5 skipped, and the sole failure remained the unchanged local
+  Astro preset expectation above. The full Gherkin lane passed 505/508
+  scenarios with 3 skips and 15,645/15,645 executed steps; build, ESLint,
+  formatting, Gherkin lint, and `tsc --noEmit` passed. The final assertion-only
+  refinement then passed its complete 51-test detector suite.
+- Final audit found no change-scoped architecture, dead-code, dependency,
+  domain-doc, learning, documentation, or test-quality errors: config sync and
+  Knip were clean; dependency-cruiser reported 0 violations across 662 modules
+  and 2,169 dependencies; JavaScript and Go dependencies were current; the Go
+  checker passed. The final jscpd run reported 456 clones (8.37%) at the same
+  `repo minus .safeword,.project` scope, effectively flat against the prior
+  455-clone record. The existing Python experiment still lacks import-linter
+  contracts and a dead-code executable.

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
@@ -27,3 +27,33 @@ fixture; cli-test and steps lanes each share theirs); outdated: knip 6.24.0→6.
 (dev, minor, Low — safe to update, not this ticket); learnings Covers-lines clean;
 no documentation drift (anchor convention documented in ticket-system skill + glossary,
 both updated in this ticket).
+
+## Issue #904 hardening verification — 2026-07-25
+
+Evidence from the repository-generated test plan after the complete audit,
+independent quality review, and refactor ledger.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5492/5492 tests pass (366 files; 5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (495/498 scenarios; 3 skipped; 15345/15345 executed steps pass)
+**Build:** ✅ Success (tsup + DTS)
+**Lint:** ✅ Clean (ESLint + Gherkin lint + `tsc --noEmit`)
+**Scenarios:** All 37 scenarios marked complete (112/112 R/G/R cells)
+**PR Scope:** ✅ Diff matches issue #904 hardening scope: canonical artifact ownership, staged-tree configuration authority, repository-root handling, adversarial path grammar, regression evidence, and behavior-preserving test-fixture/enforcement-seam refactors
+**Dep Drift:** ✅ Clean (no dependencies added or removed)
+**Parent Epic:** N/A (external epic #808; no local parent ticket)
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal boundary-enforcement hardening, not persona-facing
+**Evidence limits:** ✅ None
+
+Audit passed with warnings — 0 errors. Config parity is clean; dependency-cruiser
+reports 0 violations across 653 modules and 2124 dependencies; Knip and outdated
+dependency checks are clean; Go modules are current; learning and namespace-domain
+checks are clean; changed-test quality and configured documentation sources
+(`README.md`, website docs) show no drift. Clones: 490 (10.55% overall / 3.65%
+TypeScript) [repo minus `.safeword`, `.project`] versus the 2026-07-08 baseline
+of 423; the broader repository grew substantially and its shipped template/install
+mirrors are intentional, while this pass removed duplicated boundary and history
+fixtures. Coverage warnings are limited to the pre-existing Python experiment,
+which has no import-linter or dead-code executable installed.

--- a/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
+++ b/.project/tickets/HGYGND-artifact-content-phase-anchors/verify.md
@@ -28,10 +28,11 @@ fixture; cli-test and steps lanes each share theirs); outdated: knip 6.24.0→6.
 no documentation drift (anchor convention documented in ticket-system skill + glossary,
 both updated in this ticket).
 
-## Issue #904 hardening verification — 2026-07-25
+## Issue #904 hardening verification — 2026-07-25 (pre-rebase baseline)
 
 Evidence from the repository-generated test plan after the complete audit,
-independent quality review, and refactor ledger.
+independent quality review, and refactor ledger, before rebasing this follow-up
+onto the current `main`.
 
 ## Verify Checklist
 
@@ -57,3 +58,30 @@ of 423; the broader repository grew substantially and its shipped template/insta
 mirrors are intentional, while this pass removed duplicated boundary and history
 fixtures. Coverage warnings are limited to the pre-existing Python experiment,
 which has no import-linter or dead-code executable installed.
+
+## PR review remediation — 2026-07-26
+
+Evidence after addressing all nine unresolved PR review threads:
+
+- The two original public detectors require `PhaseAnchorScope`; the redundant
+  scoped wrappers and their fail-open unscoped path are gone.
+- All 37 ledger scenarios now have executable Gherkin coverage, including the
+  ten ownership/configuration scenarios previously present only in lower lanes.
+- Focused Vitest: 76/76 pass across the phase-anchor, boundary engine, real CLI,
+  and repository-path suites.
+- Full Cucumber: 505/508 scenarios pass, 3 skip; 15,645/15,645 executed steps
+  pass. The issue-focused lane is 40/40 scenarios and 1,210/1,210 steps.
+- Build succeeds; ESLint, Gherkin lint, `tsc --noEmit`, diff hygiene, and
+  template/dogfood parity are clean.
+- Full local Vitest: 5,492 pass, 5 skip, with one failure in the untouched
+  upstream Astro preset expectation (`astro/no-omitted-end-tags` is `"error"`
+  under the installed eslint-plugin-astro 3.0.1 while the test expects it to be
+  absent). The Astro preset, test, manifests, and lockfile are unchanged from
+  `origin/main`; Node 22 and Node 24 CI were green on the prior PR head and will
+  rerun on this remediation.
+- Audit: 0 change-scoped errors; config parity clean; dependency-cruiser 0
+  violations across 662 modules / 2,166 dependencies; Knip clean; dependencies
+  current; domain and learning checks clean. Clones improved from 490 to 455
+  (8.37%) at the same `repo minus .safeword,.project` scope. Existing Python
+  experiment import-linter/dead-code tool coverage remains a reported
+  limitation.

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -445,6 +445,14 @@ export type PhaseAnchorVerdict =
   | { kind: 'anchored' }
   | { kind: 'unanchored'; phase: string; reason: string };
 
+/** Canonical artifact ownership for the ticket being checked. */
+export interface PhaseAnchorScope {
+  /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
+  ticketPath: string;
+  /** Exact canonical feature source, when the ticket has one. */
+  featurePath?: string;
+}
+
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
 
 /**
@@ -466,7 +474,7 @@ export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -492,7 +500,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact, expectedTicketPath);
+  return validateAnchor(proposed, proposedPhase, readArtifact, scope);
 }
 
 /**
@@ -506,7 +514,7 @@ function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -538,14 +546,15 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // Feature sources are repository-level artifacts. Every other accepted kind
-  // is ticket-local and must be the changed ticket's own output, not a
-  // same-basename artifact borrowed from another ticket.
-  if (
-    expectedTicketPath !== undefined &&
-    !isFeatureSource(anchor) &&
-    dirnameOf(anchor) !== expectedTicketPath
-  ) {
+  // A feature source must be this ticket's canonical source. Every other
+  // accepted kind is ticket-local and must be this ticket's own output, not a
+  // same-kind artifact borrowed from elsewhere.
+  const isOwnedArtifact =
+    scope === undefined ||
+    (isFeatureSource(anchor)
+      ? anchor === scope.featurePath
+      : dirnameOf(anchor) === scope.ticketPath);
+  if (!isOwnedArtifact) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
     );
@@ -580,7 +589,7 @@ function validateAnchor(
 export function detectUnanchoredPhaseState(
   content: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -594,5 +603,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact, expectedTicketPath);
+  return validateAnchor(meta, phase, readArtifact, scope);
 }

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -422,8 +422,8 @@ const ANCHOR_KINDS = {
 
 /**
  * A plausible repo-relative path: non-empty, forward-slashed, not absolute
- * (POSIX or Windows), free of `..` traversal, and free of git pathspec
- * magic/glob characters — a value opening with `(` or `:` would activate
+ * (POSIX or Windows), free of empty, `.` or `..` segments, and free of git
+ * pathspec magic/glob characters — a value opening with `(` or `:` would activate
  * pathspec magic inside a `git show :<path>` read (`:(top)x` exits 0 with
  * commit text, a false "anchored"), and glob characters are never a single
  * artifact's path. Deliberately permissive beyond that — existence and kind
@@ -437,7 +437,7 @@ function isPlausibleRepoPath(value: string): boolean {
   // commit-tier reader prepends its own colon.
   if (/^[0-3]:/.test(value)) return false;
   if (/^[(:!^]/.test(value) || /[*?[\]]/.test(value)) return false;
-  return !value.split('/').includes('..');
+  return !value.split('/').some(segment => segment === '' || segment === '.' || segment === '..');
 }
 
 export type PhaseAnchorVerdict =

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -449,8 +449,6 @@ export type PhaseAnchorVerdict =
 export interface PhaseAnchorScope {
   /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
   ticketPath: string;
-  /** Exact canonical feature source, when the ticket has one. */
-  featurePath?: string;
 }
 
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
@@ -546,13 +544,17 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // A feature source must be this ticket's canonical source. Every other
-  // accepted kind is ticket-local and must be this ticket's own output, not a
-  // same-kind artifact borrowed from elsewhere.
+  // Feature source identity follows the repository convention
+  // `<any configured feature lane>/<ticket slug>.feature`; deriving the
+  // basename from the ticket path keeps ownership independent of unstaged
+  // worktree state. Every other kind must live in this ticket's own folder.
+  const ticketFolder = basenameOf(scope?.ticketPath ?? '');
+  const slugSeparator = ticketFolder.indexOf('-');
+  const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const isOwnedArtifact =
     scope === undefined ||
     (isFeatureSource(anchor)
-      ? anchor === scope.featurePath
+      ? basenameOf(anchor) === `${ticketSlug}.feature`
       : dirnameOf(anchor) === scope.ticketPath);
   if (!isOwnedArtifact) {
     return unanchored(

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -461,9 +461,10 @@ const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
  * Detect whether a feature ticket's forward phase advance carries a valid
  * artifact-path anchor for the phase it enters (HGYGND). Pure — the tree is
  * read through an injected ArtifactReader, so the predicate touches neither
- * filesystem nor git: the boundary gate supplies a staged-index or HEAD-tree
- * reader, `safeword check` a filesystem reader; a caller with no tree at hand
- * passes none (format-only).
+ * filesystem nor git: every caller supplies canonical ownership scope; the
+ * boundary gate also supplies a staged-index or HEAD-tree reader, `safeword
+ * check` a filesystem reader, and a caller with no tree at hand omits only
+ * the reader (format-only).
  *
  * Returns `anchored` / `unanchored` only for the policed act — a feature→feature
  * FORWARD phase change. Everything else is `not-applicable`: a creation/birth, a
@@ -475,8 +476,8 @@ const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
 export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -502,17 +503,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact, scope);
-}
-
-/** Enforcement entry point: ownership scope is required, tree reading remains optional. */
-export function detectScopedUnanchoredPhaseTransition(
-  priorContent: string | undefined,
-  proposedContent: string,
-  scope: PhaseAnchorScope,
-  readArtifact?: ArtifactReader,
-): PhaseAnchorVerdict {
-  return detectUnanchoredPhaseTransition(priorContent, proposedContent, readArtifact, scope);
+  return validateAnchor(proposed, proposedPhase, scope, readArtifact);
 }
 
 /**
@@ -525,8 +516,8 @@ export function detectScopedUnanchoredPhaseTransition(
 function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -561,23 +552,22 @@ function validateAnchor(
   // Feature source identity follows the executable-lane convention plus
   // `<ticket slug>.feature`; callers supply roots from the same tree as the
   // artifact reader. Every other kind must live in this ticket's own folder.
-  const ticketFolder = basenameOf(scope?.ticketPath ?? '');
+  const ticketFolder = basenameOf(scope.ticketPath);
   const slugSeparator = ticketFolder.indexOf('-');
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const anchorSegments = anchor.split('/');
-  const isConfiguredOrDefaultFeature =
-    scope?.featureRoots.some(root => root === '' || anchor.startsWith(`${root}/`)) ?? false;
+  const isConfiguredOrDefaultFeature = scope.featureRoots.some(
+    root => root === '' || anchor.startsWith(`${root}/`),
+  );
   const isWorkspaceFeature =
     anchorSegments.length >= 4 &&
-    (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&
+    scope.workspaceRoots.includes(anchorSegments[0] ?? '') &&
     anchorSegments[1] !== '' &&
     anchorSegments[2] === 'features';
-  const isOwnedArtifact =
-    scope === undefined ||
-    (isFeatureSource(anchor)
-      ? basenameOf(anchor) === `${ticketSlug}.feature` &&
-        (isConfiguredOrDefaultFeature || isWorkspaceFeature)
-      : dirnameOf(anchor) === scope.ticketPath);
+  const isOwnedArtifact = isFeatureSource(anchor)
+    ? basenameOf(anchor) === `${ticketSlug}.feature` &&
+      (isConfiguredOrDefaultFeature || isWorkspaceFeature)
+    : dirnameOf(anchor) === scope.ticketPath;
   if (!isOwnedArtifact) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
@@ -612,8 +602,8 @@ function validateAnchor(
  */
 export function detectUnanchoredPhaseState(
   content: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -627,14 +617,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact, scope);
-}
-
-/** At-rest enforcement entry point with required canonical ownership scope. */
-export function detectScopedUnanchoredPhaseState(
-  content: string,
-  scope: PhaseAnchorScope,
-  readArtifact?: ArtifactReader,
-): PhaseAnchorVerdict {
-  return detectUnanchoredPhaseState(content, readArtifact, scope);
+  return validateAnchor(meta, phase, scope, readArtifact);
 }

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -505,6 +505,16 @@ export function detectUnanchoredPhaseTransition(
   return validateAnchor(proposed, proposedPhase, readArtifact, scope);
 }
 
+/** Enforcement entry point: ownership scope is required, tree reading remains optional. */
+export function detectScopedUnanchoredPhaseTransition(
+  priorContent: string | undefined,
+  proposedContent: string,
+  scope: PhaseAnchorScope,
+  readArtifact?: ArtifactReader,
+): PhaseAnchorVerdict {
+  return detectUnanchoredPhaseTransition(priorContent, proposedContent, readArtifact, scope);
+}
+
 /**
  * Shared anchor validation ladder: entry present → path-shaped (hex is the
  * legacy branch) → expected kind for the phase → (with a reader) present in
@@ -618,4 +628,13 @@ export function detectUnanchoredPhaseState(
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
   return validateAnchor(meta, phase, readArtifact, scope);
+}
+
+/** At-rest enforcement entry point with required canonical ownership scope. */
+export function detectScopedUnanchoredPhaseState(
+  content: string,
+  scope: PhaseAnchorScope,
+  readArtifact?: ArtifactReader,
+): PhaseAnchorVerdict {
+  return detectUnanchoredPhaseState(content, readArtifact, scope);
 }

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -361,6 +361,7 @@ interface AnchorKind {
 }
 
 const basenameOf = (relpath: string): string => relpath.split('/').at(-1) ?? '';
+const dirnameOf = (relpath: string): string => relpath.split('/').slice(0, -1).join('/');
 
 /** A Gherkin source: any .feature path with at least one scenario. */
 const isFeatureSource = (relpath: string): boolean => relpath.endsWith('.feature');
@@ -431,6 +432,10 @@ const ANCHOR_KINDS = {
 function isPlausibleRepoPath(value: string): boolean {
   if (value === '' || value.includes('\\')) return false;
   if (value.startsWith('/') || /^[a-zA-Z]:/.test(value)) return false;
+  // `git show :0:path` addresses stage zero of `path` in the index. Without
+  // this guard, recording `0:path` aliases a different artifact when the
+  // commit-tier reader prepends its own colon.
+  if (/^[0-3]:/.test(value)) return false;
   if (/^[(:!^]/.test(value) || /[*?[\]]/.test(value)) return false;
   return !value.split('/').includes('..');
 }
@@ -461,6 +466,7 @@ export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -486,7 +492,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact);
+  return validateAnchor(proposed, proposedPhase, readArtifact, expectedTicketPath);
 }
 
 /**
@@ -500,6 +506,7 @@ function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -529,6 +536,18 @@ function validateAnchor(
   if (!kind.matches(anchor)) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
+    );
+  }
+  // Feature sources are repository-level artifacts. Every other accepted kind
+  // is ticket-local and must be the changed ticket's own output, not a
+  // same-basename artifact borrowed from another ticket.
+  if (
+    expectedTicketPath !== undefined &&
+    !isFeatureSource(anchor) &&
+    dirnameOf(anchor) !== expectedTicketPath
+  ) {
+    return unanchored(
+      `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
     );
   }
   if (readArtifact === undefined) return { kind: 'anchored' };
@@ -561,6 +580,7 @@ function validateAnchor(
 export function detectUnanchoredPhaseState(
   content: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -574,5 +594,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact);
+  return validateAnchor(meta, phase, readArtifact, expectedTicketPath);
 }

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -449,6 +449,10 @@ export type PhaseAnchorVerdict =
 export interface PhaseAnchorScope {
   /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
   ticketPath: string;
+  /** Concrete repo-relative feature-lane roots (default + configured). */
+  featureRoots: readonly string[];
+  /** Conventional roots whose direct members may own a features/ lane. */
+  workspaceRoots: readonly string[];
 }
 
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
@@ -544,17 +548,25 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // Feature source identity follows the repository convention
-  // `<any configured feature lane>/<ticket slug>.feature`; deriving the
-  // basename from the ticket path keeps ownership independent of unstaged
-  // worktree state. Every other kind must live in this ticket's own folder.
+  // Feature source identity follows the executable-lane convention plus
+  // `<ticket slug>.feature`; callers supply roots from the same tree as the
+  // artifact reader. Every other kind must live in this ticket's own folder.
   const ticketFolder = basenameOf(scope?.ticketPath ?? '');
   const slugSeparator = ticketFolder.indexOf('-');
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
+  const anchorSegments = anchor.split('/');
+  const isConfiguredOrDefaultFeature =
+    scope?.featureRoots.some(root => anchor.startsWith(`${root}/`)) ?? false;
+  const isWorkspaceFeature =
+    anchorSegments.length >= 4 &&
+    (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&
+    anchorSegments[1] !== '' &&
+    anchorSegments[2] === 'features';
   const isOwnedArtifact =
     scope === undefined ||
     (isFeatureSource(anchor)
-      ? basenameOf(anchor) === `${ticketSlug}.feature`
+      ? basenameOf(anchor) === `${ticketSlug}.feature` &&
+        (isConfiguredOrDefaultFeature || isWorkspaceFeature)
       : dirnameOf(anchor) === scope.ticketPath);
   if (!isOwnedArtifact) {
     return unanchored(

--- a/.safeword/hooks/lib/phase-provenance.ts
+++ b/.safeword/hooks/lib/phase-provenance.ts
@@ -556,7 +556,7 @@ function validateAnchor(
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const anchorSegments = anchor.split('/');
   const isConfiguredOrDefaultFeature =
-    scope?.featureRoots.some(root => anchor.startsWith(`${root}/`)) ?? false;
+    scope?.featureRoots.some(root => root === '' || anchor.startsWith(`${root}/`)) ?? false;
   const isWorkspaceFeature =
     anchorSegments.length >= 4 &&
     (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&

--- a/features/artifact-content-phase-anchors.feature
+++ b/features/artifact-content-phase-anchors.feature
@@ -91,6 +91,68 @@ Feature: Artifact-content phase anchors — a phase advance is evidenced by the 
       When the boundary command runs at the commit boundary
       Then it exits zero and warns that the anchored artifact is missing from the staged tree
 
+  Rule: Ownership and configured lanes are resolved from canonical staged paths
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: A ticket cannot reuse another ticket's same-kind artifact
+      Given a staged advance anchored to another ticket's shape-valid impl-plan
+      When the boundary command runs at the commit boundary
+      Then it exits zero and warns that the anchor is outside this ticket
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: A ticket cannot reuse another ticket's feature source
+      Given a staged advance anchored to another ticket's feature source
+      When the boundary command runs at the commit boundary
+      Then it exits zero and warns that the anchor is outside this ticket
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: A Git index-stage prefix cannot alias a different artifact path
+      Given a staged advance whose anchor uses a Git index-stage prefix
+      When the boundary command runs at the commit boundary
+      Then it exits zero and warns that the anchor is not repo-relative
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: OS-native ticket paths are normalized to the anchor grammar
+      Given an OS-native ticket directory path
+      When the path is normalized for an anchor
+      Then it uses the forward-slashed anchor grammar
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: Canonical feature ownership is independent of unstaged worktree state
+      Given a staged owned feature source that is then removed from the worktree
+      When the boundary command runs at the commit boundary
+      Then it exits zero with no anchor warning
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: Feature anchors must live in an executable or configured feature lane
+      Given a staged advance anchored to a correctly named feature outside every feature lane
+      When the boundary command runs at the commit boundary
+      Then it exits zero and warns about the phase anchor
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: Ticket discovery uses the staged project-root configuration
+      Given a staged project-root configuration and a ticket in that configured root
+      When the boundary command runs at the commit boundary
+      Then it exits zero and reports the configured ticket's malformed plan
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: Configured project roots normalize dot and separator segments
+      Given a staged project root containing dot and duplicate separator segments
+      When the boundary command runs at the commit boundary
+      Then it exits zero and reports the configured ticket's malformed plan
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: Repository-root ticket and feature lanes remain enforceable
+      Given staged repository-root ticket and feature lanes with a valid owned anchor
+      When the boundary command runs at the commit boundary
+      Then it exits zero with no anchor warning
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: A configured project root outside the repository warns instead of failing open
+      Given a staged project-root configuration outside the repository
+      When the boundary command runs at the commit boundary
+      Then it exits zero and warns that the project root is outside the repository
+
   Rule: A forward advance without a real artifact behind it is detectable as unanchored
 
     @artifact-content-phase-anchors.SM1.R3

--- a/features/artifact-content-phase-anchors.feature
+++ b/features/artifact-content-phase-anchors.feature
@@ -69,6 +69,14 @@ Feature: Artifact-content phase anchors — a phase advance is evidenced by the 
       Given a project whose ticket recorded a path anchor in a commit that was then amended
       When the boundary command runs at the push boundary
       Then it exits zero with no anchor warning
+      And the audit entry records a passing phase-anchor verdict
+
+    @artifact-content-phase-anchors.SM1.R2
+    Scenario: A rebased commit does not disturb a recorded anchor
+      Given a project whose ticket recorded a path anchor in a commit that was then rebased
+      When the boundary command runs at the push boundary
+      Then it exits zero with no anchor warning
+      And the audit entry records a passing phase-anchor verdict
 
     @artifact-content-phase-anchors.SM1.R2
     Scenario: A shallow clone's anchor check passes with no unreachable-history hedging

--- a/features/artifact-content-phase-anchors.feature
+++ b/features/artifact-content-phase-anchors.feature
@@ -93,61 +93,61 @@ Feature: Artifact-content phase anchors — a phase advance is evidenced by the 
 
   Rule: Ownership and configured lanes are resolved from canonical staged paths
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: A ticket cannot reuse another ticket's same-kind artifact
       Given a staged advance anchored to another ticket's shape-valid impl-plan
       When the boundary command runs at the commit boundary
       Then it exits zero and warns that the anchor is outside this ticket
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: A ticket cannot reuse another ticket's feature source
       Given a staged advance anchored to another ticket's feature source
       When the boundary command runs at the commit boundary
       Then it exits zero and warns that the anchor is outside this ticket
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: A Git index-stage prefix cannot alias a different artifact path
       Given a staged advance whose anchor uses a Git index-stage prefix
       When the boundary command runs at the commit boundary
       Then it exits zero and warns that the anchor is not repo-relative
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: OS-native ticket paths are normalized to the anchor grammar
       Given an OS-native ticket directory path
       When the path is normalized for an anchor
       Then it uses the forward-slashed anchor grammar
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: Canonical feature ownership is independent of unstaged worktree state
       Given a staged owned feature source that is then removed from the worktree
       When the boundary command runs at the commit boundary
       Then it exits zero with no anchor warning
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: Feature anchors must live in an executable or configured feature lane
       Given a staged advance anchored to a correctly named feature outside every feature lane
       When the boundary command runs at the commit boundary
       Then it exits zero and warns about the phase anchor
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: Ticket discovery uses the staged project-root configuration
       Given a staged project-root configuration and a ticket in that configured root
       When the boundary command runs at the commit boundary
       Then it exits zero and reports the configured ticket's malformed plan
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: Configured project roots normalize dot and separator segments
       Given a staged project root containing dot and duplicate separator segments
       When the boundary command runs at the commit boundary
       Then it exits zero and reports the configured ticket's malformed plan
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: Repository-root ticket and feature lanes remain enforceable
       Given staged repository-root ticket and feature lanes with a valid owned anchor
       When the boundary command runs at the commit boundary
       Then it exits zero with no anchor warning
 
-    @artifact-content-phase-anchors.SM1.R2
+    @artifact-content-phase-anchors.SM1.R6
     Scenario: A configured project root outside the repository warns instead of failing open
       Given a staged project-root configuration outside the repository
       When the boundary command runs at the commit boundary

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -53,6 +53,10 @@ export interface TicketChange {
   ticketFolder: string;
   /** Repo-relative path of this ticket's folder, for ticket-local anchors. */
   ticketPath: string;
+  /** Concrete repo-relative feature-lane roots (default + configured). */
+  featureRoots: readonly string[];
+  /** Conventional roots whose direct members may own a features/ lane. */
+  workspaceRoots: readonly string[];
   artifacts: ChangedArtifact[];
   /** ticket.md as it stands after the change (staged version, else on-disk). */
   ticketCurrent?: string;
@@ -309,7 +313,11 @@ function reconcileTicket(
   readArtifact?: ArtifactReader,
 ): CheckVerdict[] {
   const ticketFile = change.artifacts.find(a => a.artifact === 'ticket.md');
-  const scope = { ticketPath: change.ticketPath };
+  const scope = {
+    ticketPath: change.ticketPath,
+    featureRoots: change.featureRoots,
+    workspaceRoots: change.workspaceRoots,
+  };
   return [
     ...(ticketFile ? ticketFileChecks(ticketFile, readArtifact, scope, change.legalitySteps) : []),
     ...atRestBirthCheck(change),

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -14,7 +14,7 @@ import { parseImplPlan } from '../../templates/hooks/lib/impl-plan.js';
 import { type ShaResolver, validateLedger } from '../../templates/hooks/lib/ledger-validation.js';
 import {
   type ArtifactReader,
-  detectUnanchoredPhaseTransition,
+  detectScopedUnanchoredPhaseTransition,
   evaluateTicketWrite,
   frontmatterOf as parseTicketFrontmatter,
   type PhaseAnchorScope,
@@ -155,15 +155,15 @@ function legalityVerdict(
  */
 function phaseAnchorVerdict(
   ticketFile: ChangedArtifact,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): CheckVerdict {
   try {
-    const anchor = detectUnanchoredPhaseTransition(
+    const anchor = detectScopedUnanchoredPhaseTransition(
       ticketFile.prior,
       ticketFile.proposed ?? '',
-      readArtifact,
       scope,
+      readArtifact,
     );
     return anchor.kind === 'unanchored'
       ? warnVerdict('phase-anchor', anchor.reason)
@@ -179,8 +179,8 @@ function phaseAnchorVerdict(
 /** Transition checks over a staged/changed ticket.md. */
 function ticketFileChecks(
   ticketFile: ChangedArtifact,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
   legalitySteps?: LegalityStep[],
 ): CheckVerdict[] {
   if (ticketFile.proposed === undefined) return [];
@@ -197,7 +197,7 @@ function ticketFileChecks(
 
   checks.push(
     legalityVerdict(ticketFile, legalitySteps),
-    phaseAnchorVerdict(ticketFile, readArtifact, scope),
+    phaseAnchorVerdict(ticketFile, scope, readArtifact),
   );
 
   return checks;
@@ -319,7 +319,7 @@ function reconcileTicket(
     workspaceRoots: change.workspaceRoots,
   };
   return [
-    ...(ticketFile ? ticketFileChecks(ticketFile, readArtifact, scope, change.legalitySteps) : []),
+    ...(ticketFile ? ticketFileChecks(ticketFile, scope, readArtifact, change.legalitySteps) : []),
     ...atRestBirthCheck(change),
     ...ledgerChecks(change, resolveSha),
     ...artifactShapeChecks(change),

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -53,8 +53,6 @@ export interface TicketChange {
   ticketFolder: string;
   /** Repo-relative path of this ticket's folder, for ticket-local anchors. */
   ticketPath: string;
-  /** Exact canonical feature source path, when this ticket has one. */
-  featurePath?: string;
   artifacts: ChangedArtifact[];
   /** ticket.md as it stands after the change (staged version, else on-disk). */
   ticketCurrent?: string;
@@ -311,7 +309,7 @@ function reconcileTicket(
   readArtifact?: ArtifactReader,
 ): CheckVerdict[] {
   const ticketFile = change.artifacts.find(a => a.artifact === 'ticket.md');
-  const scope = { ticketPath: change.ticketPath, featurePath: change.featurePath };
+  const scope = { ticketPath: change.ticketPath };
   return [
     ...(ticketFile ? ticketFileChecks(ticketFile, readArtifact, scope, change.legalitySteps) : []),
     ...atRestBirthCheck(change),

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -50,6 +50,8 @@ export interface LegalityStep {
 export interface TicketChange {
   /** Ticket folder name, e.g. `BND001-clean`. */
   ticketFolder: string;
+  /** Repo-relative path of this ticket's folder, for ticket-local anchors. */
+  ticketPath?: string;
   artifacts: ChangedArtifact[];
   /** ticket.md as it stands after the change (staged version, else on-disk). */
   ticketCurrent?: string;
@@ -149,12 +151,14 @@ function legalityVerdict(
 function phaseAnchorVerdict(
   ticketFile: ChangedArtifact,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): CheckVerdict {
   try {
     const anchor = detectUnanchoredPhaseTransition(
       ticketFile.prior,
       ticketFile.proposed ?? '',
       readArtifact,
+      expectedTicketPath,
     );
     return anchor.kind === 'unanchored'
       ? warnVerdict('phase-anchor', anchor.reason)
@@ -171,6 +175,7 @@ function phaseAnchorVerdict(
 function ticketFileChecks(
   ticketFile: ChangedArtifact,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
   legalitySteps?: LegalityStep[],
 ): CheckVerdict[] {
   if (ticketFile.proposed === undefined) return [];
@@ -187,7 +192,7 @@ function ticketFileChecks(
 
   checks.push(
     legalityVerdict(ticketFile, legalitySteps),
-    phaseAnchorVerdict(ticketFile, readArtifact),
+    phaseAnchorVerdict(ticketFile, readArtifact, expectedTicketPath),
   );
 
   return checks;
@@ -304,7 +309,9 @@ function reconcileTicket(
 ): CheckVerdict[] {
   const ticketFile = change.artifacts.find(a => a.artifact === 'ticket.md');
   return [
-    ...(ticketFile ? ticketFileChecks(ticketFile, readArtifact, change.legalitySteps) : []),
+    ...(ticketFile
+      ? ticketFileChecks(ticketFile, readArtifact, change.ticketPath, change.legalitySteps)
+      : []),
     ...atRestBirthCheck(change),
     ...ledgerChecks(change, resolveSha),
     ...artifactShapeChecks(change),

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -14,7 +14,7 @@ import { parseImplPlan } from '../../templates/hooks/lib/impl-plan.js';
 import { type ShaResolver, validateLedger } from '../../templates/hooks/lib/ledger-validation.js';
 import {
   type ArtifactReader,
-  detectScopedUnanchoredPhaseTransition,
+  detectUnanchoredPhaseTransition,
   evaluateTicketWrite,
   frontmatterOf as parseTicketFrontmatter,
   type PhaseAnchorScope,
@@ -49,14 +49,8 @@ export interface LegalityStep {
 
 /** One touched ticket: its changed artifacts plus at-rest context. */
 export interface TicketChange {
-  /** Ticket folder name, e.g. `BND001-clean`. */
-  ticketFolder: string;
-  /** Repo-relative path of this ticket's folder, for ticket-local anchors. */
-  ticketPath: string;
-  /** Concrete repo-relative feature-lane roots (default + configured). */
-  featureRoots: readonly string[];
-  /** Conventional roots whose direct members may own a features/ lane. */
-  workspaceRoots: readonly string[];
+  /** Canonical ticket ownership and executable-feature-lane scope. */
+  anchorScope: PhaseAnchorScope;
   artifacts: ChangedArtifact[];
   /** ticket.md as it stands after the change (staged version, else on-disk). */
   ticketCurrent?: string;
@@ -159,7 +153,7 @@ function phaseAnchorVerdict(
   readArtifact?: ArtifactReader,
 ): CheckVerdict {
   try {
-    const anchor = detectScopedUnanchoredPhaseTransition(
+    const anchor = detectUnanchoredPhaseTransition(
       ticketFile.prior,
       ticketFile.proposed ?? '',
       scope,
@@ -313,13 +307,10 @@ function reconcileTicket(
   readArtifact?: ArtifactReader,
 ): CheckVerdict[] {
   const ticketFile = change.artifacts.find(a => a.artifact === 'ticket.md');
-  const scope = {
-    ticketPath: change.ticketPath,
-    featureRoots: change.featureRoots,
-    workspaceRoots: change.workspaceRoots,
-  };
   return [
-    ...(ticketFile ? ticketFileChecks(ticketFile, scope, readArtifact, change.legalitySteps) : []),
+    ...(ticketFile
+      ? ticketFileChecks(ticketFile, change.anchorScope, readArtifact, change.legalitySteps)
+      : []),
     ...atRestBirthCheck(change),
     ...ledgerChecks(change, resolveSha),
     ...artifactShapeChecks(change),
@@ -341,7 +332,7 @@ export function reconcileChange(
   readArtifact?: ArtifactReader,
 ): TicketReconciliation[] {
   return changes.map(change => ({
-    ticket: change.ticketFolder,
+    ticket: change.anchorScope.ticketPath.split('/').at(-1) ?? change.anchorScope.ticketPath,
     checks: reconcileTicket(change, resolveSha, readArtifact),
   }));
 }

--- a/packages/cli/src/boundary/engine.ts
+++ b/packages/cli/src/boundary/engine.ts
@@ -17,6 +17,7 @@ import {
   detectUnanchoredPhaseTransition,
   evaluateTicketWrite,
   frontmatterOf as parseTicketFrontmatter,
+  type PhaseAnchorScope,
   scalar,
 } from '../../templates/hooks/lib/phase-provenance.js';
 
@@ -51,7 +52,9 @@ export interface TicketChange {
   /** Ticket folder name, e.g. `BND001-clean`. */
   ticketFolder: string;
   /** Repo-relative path of this ticket's folder, for ticket-local anchors. */
-  ticketPath?: string;
+  ticketPath: string;
+  /** Exact canonical feature source path, when this ticket has one. */
+  featurePath?: string;
   artifacts: ChangedArtifact[];
   /** ticket.md as it stands after the change (staged version, else on-disk). */
   ticketCurrent?: string;
@@ -151,14 +154,14 @@ function legalityVerdict(
 function phaseAnchorVerdict(
   ticketFile: ChangedArtifact,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): CheckVerdict {
   try {
     const anchor = detectUnanchoredPhaseTransition(
       ticketFile.prior,
       ticketFile.proposed ?? '',
       readArtifact,
-      expectedTicketPath,
+      scope,
     );
     return anchor.kind === 'unanchored'
       ? warnVerdict('phase-anchor', anchor.reason)
@@ -175,7 +178,7 @@ function phaseAnchorVerdict(
 function ticketFileChecks(
   ticketFile: ChangedArtifact,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
   legalitySteps?: LegalityStep[],
 ): CheckVerdict[] {
   if (ticketFile.proposed === undefined) return [];
@@ -192,7 +195,7 @@ function ticketFileChecks(
 
   checks.push(
     legalityVerdict(ticketFile, legalitySteps),
-    phaseAnchorVerdict(ticketFile, readArtifact, expectedTicketPath),
+    phaseAnchorVerdict(ticketFile, readArtifact, scope),
   );
 
   return checks;
@@ -308,10 +311,9 @@ function reconcileTicket(
   readArtifact?: ArtifactReader,
 ): CheckVerdict[] {
   const ticketFile = change.artifacts.find(a => a.artifact === 'ticket.md');
+  const scope = { ticketPath: change.ticketPath, featurePath: change.featurePath };
   return [
-    ...(ticketFile
-      ? ticketFileChecks(ticketFile, readArtifact, change.ticketPath, change.legalitySteps)
-      : []),
+    ...(ticketFile ? ticketFileChecks(ticketFile, readArtifact, scope, change.legalitySteps) : []),
     ...atRestBirthCheck(change),
     ...ledgerChecks(change, resolveSha),
     ...artifactShapeChecks(change),

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -210,8 +210,23 @@ function appendAudit(cwd: string, entry: object): void {
   appendFileSync(auditPath, `${JSON.stringify(entry)}\n`);
 }
 
-function resolveBoundaryTicketDirectories(cwd: string, configuredProjectRoot?: string): string[] {
-  const directories = ticketDirectoriesForConfiguredRoot(cwd, configuredProjectRoot);
+function treeContainsPath(cwd: string, at: Boundary, repoRelativeRoot: string): boolean {
+  const args =
+    at === 'commit'
+      ? ['ls-files', '--cached', '--', `${repoRelativeRoot}/`]
+      : ['ls-tree', '-r', '--name-only', 'HEAD', '--', `${repoRelativeRoot}/`];
+  const listing = tryGit(cwd, args);
+  return (listing?.trim().length ?? 0) > 0;
+}
+
+function resolveBoundaryTicketDirectories(
+  cwd: string,
+  at: Boundary,
+  configuredProjectRoot?: string,
+): string[] {
+  const directories = ticketDirectoriesForConfiguredRoot(cwd, configuredProjectRoot, root =>
+    treeContainsPath(cwd, at, root),
+  );
   if (configuredProjectRoot !== undefined && directories.length === 0) {
     warn(`Configured project root "${configuredProjectRoot}" is outside the repository.`);
   }
@@ -235,7 +250,7 @@ function reconcileBoundary(cwd: string, at: Boundary): void {
   const configContent = readTreeArtifact(CONFIG_REPO_PATH);
   const configuredFeatures = readConfiguredPathFromContent(configContent, 'features');
   const configuredProjectRoot = readConfiguredPathFromContent(configContent, 'projectRoot');
-  const ticketsDirectories = resolveBoundaryTicketDirectories(cwd, configuredProjectRoot);
+  const ticketsDirectories = resolveBoundaryTicketDirectories(cwd, at, configuredProjectRoot);
   const changes = collectChanges(cwd, range, at, ticketsDirectories, configuredFeatures);
   if (changes.length === 0) return;
 

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -25,8 +25,10 @@ import {
   type TicketChange,
 } from '../boundary/engine.js';
 import { resolveTicketsDirectory } from '../utils/configured-paths.js';
+import { findRepoFeatureSourcePath } from '../utils/feature-source.js';
 import { readFileSafe } from '../utils/fs.js';
 import { warn } from '../utils/output.js';
+import { toRepoRelativePath } from '../utils/repo-path.js';
 
 export interface BoundaryOptions {
   at: string;
@@ -130,7 +132,7 @@ function parseTicketPath(
 
 /** Map changed paths to per-ticket changes with prior/proposed + at-rest context. */
 function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): TicketChange[] {
-  const ticketsDirectory = nodePath.relative(cwd, resolveTicketsDirectory(cwd));
+  const ticketsDirectory = toRepoRelativePath(cwd, resolveTicketsDirectory(cwd));
   const prefix = `${ticketsDirectory}/`;
   const byTicket = new Map<string, TicketChange>();
 
@@ -140,6 +142,7 @@ function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): Ticket
     const change = byTicket.get(parsed.ticketFolder) ?? {
       ticketFolder: parsed.ticketFolder,
       ticketPath: `${ticketsDirectory}/${parsed.ticketFolder}`,
+      featurePath: findRepoFeatureSourcePath(cwd, parsed.ticketFolder),
       artifacts: [],
       hasLedger: false,
     };

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -24,7 +24,11 @@ import {
   TICKET_ARTIFACTS,
   type TicketChange,
 } from '../boundary/engine.js';
-import { resolveTicketsDirectory } from '../utils/configured-paths.js';
+import {
+  readConfiguredPathFromContent,
+  resolveTicketsDirectory,
+} from '../utils/configured-paths.js';
+import { createPhaseAnchorScope } from '../utils/feature-source.js';
 import { readFileSafe } from '../utils/fs.js';
 import { warn } from '../utils/output.js';
 import { toRepoRelativePath } from '../utils/repo-path.js';
@@ -36,6 +40,7 @@ export interface BoundaryOptions {
 type Boundary = 'commit' | 'push';
 
 const AUDIT_RELATIVE_PATH = nodePath.join('.safeword', 'boundary-audit.jsonl');
+const CONFIG_REPO_PATH = '.safeword/config.json';
 
 /** Run git, returning stdout or undefined on any failure (never throws). */
 function tryGit(cwd: string, args: string[]): string | undefined {
@@ -130,7 +135,12 @@ function parseTicketPath(
 }
 
 /** Map changed paths to per-ticket changes with prior/proposed + at-rest context. */
-function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): TicketChange[] {
+function collectChanges(
+  cwd: string,
+  range: BoundaryRange,
+  at: Boundary,
+  configuredFeatures?: string,
+): TicketChange[] {
   const ticketsDirectory = toRepoRelativePath(cwd, resolveTicketsDirectory(cwd));
   const prefix = `${ticketsDirectory}/`;
   const byTicket = new Map<string, TicketChange>();
@@ -138,9 +148,10 @@ function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): Ticket
   for (const path of range.paths) {
     const parsed = parseTicketPath(path, prefix);
     if (parsed === undefined) continue;
+    const ticketPath = `${ticketsDirectory}/${parsed.ticketFolder}`;
     const change = byTicket.get(parsed.ticketFolder) ?? {
       ticketFolder: parsed.ticketFolder,
-      ticketPath: `${ticketsDirectory}/${parsed.ticketFolder}`,
+      ...createPhaseAnchorScope(cwd, ticketPath, configuredFeatures),
       artifacts: [],
       hasLedger: false,
     };
@@ -196,9 +207,6 @@ function reconcileBoundary(cwd: string, at: Boundary): void {
   const range = boundaryRange(cwd, at);
   if (range === undefined || range.paths.length === 0) return;
 
-  const changes = collectChanges(cwd, range, at);
-  if (changes.length === 0) return;
-
   // The push tier verifies LEDGER SHAs against real history; the commit tier
   // stays content-only for SHAs (sub-second budget — no history walks).
   // Anchors are tree-only at both tiers: the reader serves the exact tree the
@@ -208,6 +216,13 @@ function reconcileBoundary(cwd: string, at: Boundary): void {
   const resolveSha = at === 'push' ? createLedgerShaResolver(cwd) : undefined;
   const readTreeArtifact = (relpath: string): string | undefined =>
     contentAt(cwd, at === 'commit' ? `:${relpath}` : `HEAD:${relpath}`);
+  const configuredFeatures = readConfiguredPathFromContent(
+    readTreeArtifact(CONFIG_REPO_PATH),
+    'features',
+  );
+  const changes = collectChanges(cwd, range, at, configuredFeatures);
+  if (changes.length === 0) return;
+
   const reconciliations = reconcileChange(changes, resolveSha, readTreeArtifact);
   for (const finding of findings(reconciliations)) {
     warn(

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -139,6 +139,7 @@ function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): Ticket
     if (parsed === undefined) continue;
     const change = byTicket.get(parsed.ticketFolder) ?? {
       ticketFolder: parsed.ticketFolder,
+      ticketPath: `${ticketsDirectory}/${parsed.ticketFolder}`,
       artifacts: [],
       hasLedger: false,
     };

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -159,8 +159,7 @@ function collectChanges(
     if (parsed === undefined) continue;
     const ticketPath = `${parsed.ticketsDirectory}/${parsed.ticketFolder}`;
     const change = byTicket.get(ticketPath) ?? {
-      ticketFolder: parsed.ticketFolder,
-      ...createPhaseAnchorScope(cwd, ticketPath, configuredFeatures),
+      anchorScope: createPhaseAnchorScope(cwd, ticketPath, configuredFeatures),
       artifacts: [],
       hasLedger: false,
     };
@@ -171,7 +170,7 @@ function collectChanges(
   // At-rest context per touched ticket: ticket.md as it stands after the
   // change (staged version wins over disk) and whether a ledger exists.
   for (const change of byTicket.values()) {
-    const folder = nodePath.join(cwd, change.ticketPath);
+    const folder = nodePath.join(cwd, change.anchorScope.ticketPath);
     const staged = change.artifacts.find(a => a.artifact === 'ticket.md')?.proposed;
     change.ticketCurrent = staged ?? readFileSafe(nodePath.join(folder, 'ticket.md'));
     change.hasLedger =
@@ -182,7 +181,7 @@ function collectChanges(
     // endpoints (N76NQ0 — a range that traversed phases one legal step at a
     // time must not read as a skip).
     if (at === 'push' && change.artifacts.some(a => a.artifact === 'ticket.md')) {
-      const path = `${change.ticketPath}/ticket.md`;
+      const path = `${change.anchorScope.ticketPath}/ticket.md`;
       change.legalitySteps = legalityStepsFor(cwd, path, range.priorRef);
     }
   }
@@ -211,6 +210,14 @@ function appendAudit(cwd: string, entry: object): void {
   appendFileSync(auditPath, `${JSON.stringify(entry)}\n`);
 }
 
+function resolveBoundaryTicketDirectories(cwd: string, configuredProjectRoot?: string): string[] {
+  const directories = ticketDirectoriesForConfiguredRoot(cwd, configuredProjectRoot);
+  if (configuredProjectRoot !== undefined && directories.length === 0) {
+    warn(`Configured project root "${configuredProjectRoot}" is outside the repository.`);
+  }
+  return directories;
+}
+
 /** The reconciliation body — separated so the entry point stays a trivial guard. */
 function reconcileBoundary(cwd: string, at: Boundary): void {
   const range = boundaryRange(cwd, at);
@@ -228,7 +235,7 @@ function reconcileBoundary(cwd: string, at: Boundary): void {
   const configContent = readTreeArtifact(CONFIG_REPO_PATH);
   const configuredFeatures = readConfiguredPathFromContent(configContent, 'features');
   const configuredProjectRoot = readConfiguredPathFromContent(configContent, 'projectRoot');
-  const ticketsDirectories = ticketDirectoriesForConfiguredRoot(cwd, configuredProjectRoot);
+  const ticketsDirectories = resolveBoundaryTicketDirectories(cwd, configuredProjectRoot);
   const changes = collectChanges(cwd, range, at, ticketsDirectories, configuredFeatures);
   if (changes.length === 0) return;
 

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -25,7 +25,6 @@ import {
   type TicketChange,
 } from '../boundary/engine.js';
 import { resolveTicketsDirectory } from '../utils/configured-paths.js';
-import { findRepoFeatureSourcePath } from '../utils/feature-source.js';
 import { readFileSafe } from '../utils/fs.js';
 import { warn } from '../utils/output.js';
 import { toRepoRelativePath } from '../utils/repo-path.js';
@@ -142,7 +141,6 @@ function collectChanges(cwd: string, range: BoundaryRange, at: Boundary): Ticket
     const change = byTicket.get(parsed.ticketFolder) ?? {
       ticketFolder: parsed.ticketFolder,
       ticketPath: `${ticketsDirectory}/${parsed.ticketFolder}`,
-      featurePath: findRepoFeatureSourcePath(cwd, parsed.ticketFolder),
       artifacts: [],
       hasLedger: false,
     };

--- a/packages/cli/src/commands/boundary.ts
+++ b/packages/cli/src/commands/boundary.ts
@@ -26,12 +26,11 @@ import {
 } from '../boundary/engine.js';
 import {
   readConfiguredPathFromContent,
-  resolveTicketsDirectory,
+  ticketDirectoriesForConfiguredRoot,
 } from '../utils/configured-paths.js';
 import { createPhaseAnchorScope } from '../utils/feature-source.js';
 import { readFileSafe } from '../utils/fs.js';
 import { warn } from '../utils/output.js';
-import { toRepoRelativePath } from '../utils/repo-path.js';
 
 export interface BoundaryOptions {
   at: string;
@@ -134,35 +133,45 @@ function parseTicketPath(
   return { ticketFolder, basename };
 }
 
+function findChangedTicket(
+  path: string,
+  ticketsDirectories: string[],
+): { ticketFolder: string; basename: string; ticketsDirectory: string } | undefined {
+  for (const ticketsDirectory of ticketsDirectories) {
+    const parsed = parseTicketPath(path, `${ticketsDirectory}/`);
+    if (parsed !== undefined) return { ...parsed, ticketsDirectory };
+  }
+  return undefined;
+}
+
 /** Map changed paths to per-ticket changes with prior/proposed + at-rest context. */
 function collectChanges(
   cwd: string,
   range: BoundaryRange,
   at: Boundary,
+  ticketsDirectories: string[],
   configuredFeatures?: string,
 ): TicketChange[] {
-  const ticketsDirectory = toRepoRelativePath(cwd, resolveTicketsDirectory(cwd));
-  const prefix = `${ticketsDirectory}/`;
   const byTicket = new Map<string, TicketChange>();
 
   for (const path of range.paths) {
-    const parsed = parseTicketPath(path, prefix);
+    const parsed = findChangedTicket(path, ticketsDirectories);
     if (parsed === undefined) continue;
-    const ticketPath = `${ticketsDirectory}/${parsed.ticketFolder}`;
-    const change = byTicket.get(parsed.ticketFolder) ?? {
+    const ticketPath = `${parsed.ticketsDirectory}/${parsed.ticketFolder}`;
+    const change = byTicket.get(ticketPath) ?? {
       ticketFolder: parsed.ticketFolder,
       ...createPhaseAnchorScope(cwd, ticketPath, configuredFeatures),
       artifacts: [],
       hasLedger: false,
     };
     change.artifacts.push(readChangedArtifact(cwd, path, parsed.basename, range, at));
-    byTicket.set(parsed.ticketFolder, change);
+    byTicket.set(ticketPath, change);
   }
 
   // At-rest context per touched ticket: ticket.md as it stands after the
   // change (staged version wins over disk) and whether a ledger exists.
   for (const change of byTicket.values()) {
-    const folder = nodePath.join(cwd, ticketsDirectory, change.ticketFolder);
+    const folder = nodePath.join(cwd, change.ticketPath);
     const staged = change.artifacts.find(a => a.artifact === 'ticket.md')?.proposed;
     change.ticketCurrent = staged ?? readFileSafe(nodePath.join(folder, 'ticket.md'));
     change.hasLedger =
@@ -173,7 +182,7 @@ function collectChanges(
     // endpoints (N76NQ0 — a range that traversed phases one legal step at a
     // time must not read as a skip).
     if (at === 'push' && change.artifacts.some(a => a.artifact === 'ticket.md')) {
-      const path = `${prefix}${change.ticketFolder}/ticket.md`;
+      const path = `${change.ticketPath}/ticket.md`;
       change.legalitySteps = legalityStepsFor(cwd, path, range.priorRef);
     }
   }
@@ -216,11 +225,11 @@ function reconcileBoundary(cwd: string, at: Boundary): void {
   const resolveSha = at === 'push' ? createLedgerShaResolver(cwd) : undefined;
   const readTreeArtifact = (relpath: string): string | undefined =>
     contentAt(cwd, at === 'commit' ? `:${relpath}` : `HEAD:${relpath}`);
-  const configuredFeatures = readConfiguredPathFromContent(
-    readTreeArtifact(CONFIG_REPO_PATH),
-    'features',
-  );
-  const changes = collectChanges(cwd, range, at, configuredFeatures);
+  const configContent = readTreeArtifact(CONFIG_REPO_PATH);
+  const configuredFeatures = readConfiguredPathFromContent(configContent, 'features');
+  const configuredProjectRoot = readConfiguredPathFromContent(configContent, 'projectRoot');
+  const ticketsDirectories = ticketDirectoriesForConfiguredRoot(cwd, configuredProjectRoot);
+  const changes = collectChanges(cwd, range, at, ticketsDirectories, configuredFeatures);
   if (changes.length === 0) return;
 
   const reconciliations = reconcileChange(changes, resolveSha, readTreeArtifact);

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -14,7 +14,10 @@
 import { readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { detectScopedUnanchoredPhaseState } from '../templates/hooks/lib/phase-provenance.js';
+import {
+  detectUnanchoredPhaseState,
+  type PhaseAnchorScope,
+} from '../templates/hooks/lib/phase-provenance.js';
 import { getMissingPacks } from './packs/registry.js';
 import type { ProjectType } from './packs/types.js';
 import { typescriptPackages } from './packs/typescript/files.js';
@@ -31,7 +34,7 @@ import {
 } from './utils/configured-paths.js';
 import { createProjectContext } from './utils/context.js';
 import {
-  createPhaseAnchorScope,
+  createPhaseAnchorEnvironment,
   findFeatureSourcePath,
   hasDefaultExecutableFeatureFiles,
 } from './utils/feature-source.js';
@@ -330,11 +333,18 @@ function emptyCoverageDiagnostics(): CoverageDiagnostics {
 function findCoverageDiagnostics(cwd: string): CoverageDiagnostics {
   const ticketsRoot = resolveTicketsDirectory(cwd);
   const all = emptyCoverageDiagnostics();
+  const configuredFeatures = readConfiguredPath(cwd, 'features');
+  const anchorEnvironment = createPhaseAnchorEnvironment(cwd, configuredFeatures);
   for (const ticketId of listTicketIds(ticketsRoot)) {
     const ticketDiagnostics = coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId);
     all.issues.push(...ticketDiagnostics.issues);
     all.advisories.push(...ticketDiagnostics.advisories);
-    const anchorAdvisory = phaseAnchorAdvisoryForTicket(cwd, ticketsRoot, ticketId);
+    const anchorAdvisory = phaseAnchorAdvisoryForTicket(
+      cwd,
+      ticketsRoot,
+      ticketId,
+      anchorEnvironment,
+    );
     if (anchorAdvisory !== undefined) all.advisories.push(anchorAdvisory);
   }
   return all;
@@ -353,14 +363,14 @@ function phaseAnchorAdvisoryForTicket(
   cwd: string,
   ticketsRoot: string,
   ticketId: string,
+  anchorEnvironment: Omit<PhaseAnchorScope, 'ticketPath'>,
 ): string | undefined {
   const content = readFileSafe(nodePath.join(ticketsRoot, ticketId, 'ticket.md'));
   if (content === undefined || !isInProgress(content)) return undefined;
   const ticketDirectory = nodePath.join(ticketsRoot, ticketId);
   const ticketPath = toRepoRelativePath(cwd, ticketDirectory);
-  const configuredFeatures = readConfiguredPath(cwd, 'features');
-  const scope = createPhaseAnchorScope(cwd, ticketPath, configuredFeatures);
-  const verdict = detectScopedUnanchoredPhaseState(content, scope, relpath =>
+  const scope = { ticketPath, ...anchorEnvironment };
+  const verdict = detectUnanchoredPhaseState(content, scope, relpath =>
     readFileSafe(nodePath.join(cwd, relpath)),
   );
   if (verdict.kind !== 'unanchored') return undefined;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -14,7 +14,7 @@
 import { readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { detectUnanchoredPhaseState } from '../templates/hooks/lib/phase-provenance.js';
+import { detectScopedUnanchoredPhaseState } from '../templates/hooks/lib/phase-provenance.js';
 import { getMissingPacks } from './packs/registry.js';
 import type { ProjectType } from './packs/types.js';
 import { typescriptPackages } from './packs/typescript/files.js';
@@ -360,10 +360,8 @@ function phaseAnchorAdvisoryForTicket(
   const ticketPath = toRepoRelativePath(cwd, ticketDirectory);
   const configuredFeatures = readConfiguredPath(cwd, 'features');
   const scope = createPhaseAnchorScope(cwd, ticketPath, configuredFeatures);
-  const verdict = detectUnanchoredPhaseState(
-    content,
-    relpath => readFileSafe(nodePath.join(cwd, relpath)),
-    scope,
+  const verdict = detectScopedUnanchoredPhaseState(content, scope, relpath =>
+    readFileSafe(nodePath.join(cwd, relpath)),
   );
   if (verdict.kind !== 'unanchored') return undefined;
   return `${formatCoverageTicketLabel(ticketId)}: ${verdict.reason} The anchor is the exited phase's artifact — boundary checks verify it against the tree.`;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -30,11 +30,7 @@ import {
   resolveTicketsDirectory,
 } from './utils/configured-paths.js';
 import { createProjectContext } from './utils/context.js';
-import {
-  findFeatureSourcePath,
-  findRepoFeatureSourcePath,
-  hasDefaultExecutableFeatureFiles,
-} from './utils/feature-source.js';
+import { findFeatureSourcePath, hasDefaultExecutableFeatureFiles } from './utils/feature-source.js';
 import { exists, isDirectory, readFileSafe, readJson } from './utils/fs.js';
 import { FeatureParseError, findFeatureLineageIssues } from './utils/gherkin-feature.js';
 import { parseGlossary, validateGlossary } from './utils/glossary.js';
@@ -361,7 +357,6 @@ function phaseAnchorAdvisoryForTicket(
     relpath => readFileSafe(nodePath.join(cwd, relpath)),
     {
       ticketPath: toRepoRelativePath(cwd, nodePath.join(ticketsRoot, ticketId)),
-      featurePath: findRepoFeatureSourcePath(cwd, ticketId),
     },
   );
   if (verdict.kind !== 'unanchored') return undefined;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -30,7 +30,11 @@ import {
   resolveTicketsDirectory,
 } from './utils/configured-paths.js';
 import { createProjectContext } from './utils/context.js';
-import { findFeatureSourcePath, hasDefaultExecutableFeatureFiles } from './utils/feature-source.js';
+import {
+  createPhaseAnchorScope,
+  findFeatureSourcePath,
+  hasDefaultExecutableFeatureFiles,
+} from './utils/feature-source.js';
 import { exists, isDirectory, readFileSafe, readJson } from './utils/fs.js';
 import { FeatureParseError, findFeatureLineageIssues } from './utils/gherkin-feature.js';
 import { parseGlossary, validateGlossary } from './utils/glossary.js';
@@ -352,12 +356,14 @@ function phaseAnchorAdvisoryForTicket(
 ): string | undefined {
   const content = readFileSafe(nodePath.join(ticketsRoot, ticketId, 'ticket.md'));
   if (content === undefined || !isInProgress(content)) return undefined;
+  const ticketDirectory = nodePath.join(ticketsRoot, ticketId);
+  const ticketPath = toRepoRelativePath(cwd, ticketDirectory);
+  const configuredFeatures = readConfiguredPath(cwd, 'features');
+  const scope = createPhaseAnchorScope(cwd, ticketPath, configuredFeatures);
   const verdict = detectUnanchoredPhaseState(
     content,
     relpath => readFileSafe(nodePath.join(cwd, relpath)),
-    {
-      ticketPath: toRepoRelativePath(cwd, nodePath.join(ticketsRoot, ticketId)),
-    },
+    scope,
   );
   if (verdict.kind !== 'unanchored') return undefined;
   return `${formatCoverageTicketLabel(ticketId)}: ${verdict.reason} The anchor is the exited phase's artifact — boundary checks verify it against the tree.`;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -30,12 +30,17 @@ import {
   resolveTicketsDirectory,
 } from './utils/configured-paths.js';
 import { createProjectContext } from './utils/context.js';
-import { findFeatureSourcePath, hasDefaultExecutableFeatureFiles } from './utils/feature-source.js';
+import {
+  findFeatureSourcePath,
+  findRepoFeatureSourcePath,
+  hasDefaultExecutableFeatureFiles,
+} from './utils/feature-source.js';
 import { exists, isDirectory, readFileSafe, readJson } from './utils/fs.js';
 import { FeatureParseError, findFeatureLineageIssues } from './utils/gherkin-feature.js';
 import { parseGlossary, validateGlossary } from './utils/glossary.js';
 import { header, info, listItem, success, warn } from './utils/output.js';
 import { parsePersonas, validatePersonas } from './utils/personas.js';
+import { toRepoRelativePath } from './utils/repo-path.js';
 import {
   buildCoverageReport,
   buildCoverageReportFromFeature,
@@ -354,7 +359,10 @@ function phaseAnchorAdvisoryForTicket(
   const verdict = detectUnanchoredPhaseState(
     content,
     relpath => readFileSafe(nodePath.join(cwd, relpath)),
-    nodePath.relative(cwd, nodePath.join(ticketsRoot, ticketId)),
+    {
+      ticketPath: toRepoRelativePath(cwd, nodePath.join(ticketsRoot, ticketId)),
+      featurePath: findRepoFeatureSourcePath(cwd, ticketId),
+    },
   );
   if (verdict.kind !== 'unanchored') return undefined;
   return `${formatCoverageTicketLabel(ticketId)}: ${verdict.reason} The anchor is the exited phase's artifact — boundary checks verify it against the tree.`;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -351,8 +351,10 @@ function phaseAnchorAdvisoryForTicket(
 ): string | undefined {
   const content = readFileSafe(nodePath.join(ticketsRoot, ticketId, 'ticket.md'));
   if (content === undefined || !isInProgress(content)) return undefined;
-  const verdict = detectUnanchoredPhaseState(content, relpath =>
-    readFileSafe(nodePath.join(cwd, relpath)),
+  const verdict = detectUnanchoredPhaseState(
+    content,
+    relpath => readFileSafe(nodePath.join(cwd, relpath)),
+    nodePath.relative(cwd, nodePath.join(ticketsRoot, ticketId)),
   );
   if (verdict.kind !== 'unanchored') return undefined;
   return `${formatCoverageTicketLabel(ticketId)}: ${verdict.reason} The anchor is the exited phase's artifact — boundary checks verify it against the tree.`;

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -19,6 +19,7 @@
 import nodePath from 'node:path';
 
 import { isDirectory, readFileSafe } from './fs.js';
+import { toRepoDirectory } from './repo-path.js';
 
 /** Logical project-knowledge keys safeword knows how to override via `paths.*`. */
 export type ConfiguredPathKey = 'personas' | 'glossary' | 'surfaces' | 'architecture';
@@ -249,6 +250,25 @@ export function resolveNamespaceRoot(cwd: string): string {
 /** Absolute tickets directory under the resolved namespace root. */
 export function resolveTicketsDirectory(cwd: string): string {
   return nodePath.join(resolveNamespaceRoot(cwd), 'tickets');
+}
+
+/**
+ * Repo-relative ticket directories for a caller-supplied project-root config.
+ * With no explicit root, both supported conventional roots are candidates;
+ * the changed-tree path determines which one is present.
+ */
+export function ticketDirectoriesForConfiguredRoot(
+  cwd: string,
+  configuredProjectRoot?: string,
+): string[] {
+  if (configuredProjectRoot === undefined) {
+    return [
+      nodePath.posix.join(NAMESPACE_ROOT_DEFAULT, 'tickets'),
+      nodePath.posix.join(NAMESPACE_ROOT_LEGACY, 'tickets'),
+    ];
+  }
+  const projectRoot = toRepoDirectory(cwd, configuredProjectRoot);
+  return projectRoot === undefined ? [] : [nodePath.posix.join(projectRoot, 'tickets')];
 }
 
 /** Absolute learnings directory under the resolved namespace root. */

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -64,8 +64,10 @@ export const NAMESPACE_ROOT_LEGACY = '.safeword-project';
 function readSafewordConfig(cwd: string): SafewordConfigShape | undefined {
   const configPath = nodePath.join(cwd, ...CONFIG_SUBPATH);
   const content = readFileSafe(configPath);
-  if (content === undefined) return undefined;
+  return content === undefined ? undefined : parseSafewordConfig(content);
+}
 
+function parseSafewordConfig(content: string): SafewordConfigShape | undefined {
   try {
     return JSON.parse(content) as SafewordConfigShape;
   } catch {
@@ -123,6 +125,16 @@ export function readConfiguredPath(
   const raw = parsed?.paths?.[key];
   if (!nonEmptyString(raw)) return undefined;
   return raw;
+}
+
+/** Read a configured path from caller-supplied config content (e.g. a Git tree). */
+export function readConfiguredPathFromContent(
+  content: string | undefined,
+  key: ConfiguredPathKey | ConfiguredDirectoryKey,
+): string | undefined {
+  if (content === undefined) return undefined;
+  const raw = parseSafewordConfig(content)?.paths?.[key];
+  return nonEmptyString(raw) ? raw : undefined;
 }
 
 /**

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -254,18 +254,20 @@ export function resolveTicketsDirectory(cwd: string): string {
 
 /**
  * Repo-relative ticket directories for a caller-supplied project-root config.
- * With no explicit root, both supported conventional roots are candidates;
- * the changed-tree path determines which one is present.
+ * With no explicit root, preserve namespace precedence: `.project` wins over
+ * legacy `.safeword-project`, and a fresh project defaults to `.project`.
  */
 export function ticketDirectoriesForConfiguredRoot(
   cwd: string,
   configuredProjectRoot?: string,
+  rootExists: (repoRelativeRoot: string) => boolean = root => isDirectory(nodePath.join(cwd, root)),
 ): string[] {
   if (configuredProjectRoot === undefined) {
-    return [
-      nodePath.posix.join(NAMESPACE_ROOT_DEFAULT, 'tickets'),
-      nodePath.posix.join(NAMESPACE_ROOT_LEGACY, 'tickets'),
-    ];
+    let projectRoot = NAMESPACE_ROOT_DEFAULT;
+    if (!rootExists(projectRoot) && rootExists(NAMESPACE_ROOT_LEGACY)) {
+      projectRoot = NAMESPACE_ROOT_LEGACY;
+    }
+    return [nodePath.posix.join(projectRoot, 'tickets')];
   }
   const projectRoot = toRepoDirectory(cwd, configuredProjectRoot);
   if (projectRoot === undefined) return [];

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -268,7 +268,12 @@ export function ticketDirectoriesForConfiguredRoot(
     ];
   }
   const projectRoot = toRepoDirectory(cwd, configuredProjectRoot);
-  return projectRoot === undefined ? [] : [nodePath.posix.join(projectRoot, 'tickets')];
+  if (projectRoot === undefined) {
+    throw new Error(
+      `Configured project root "${configuredProjectRoot}" is outside the repository.`,
+    );
+  }
+  return [nodePath.posix.join(projectRoot, 'tickets')];
 }
 
 /** Absolute learnings directory under the resolved namespace root. */

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -259,8 +259,8 @@ export function resolveTicketsDirectory(cwd: string): string {
  */
 export function ticketDirectoriesForConfiguredRoot(
   cwd: string,
-  configuredProjectRoot?: string,
-  rootExists: (repoRelativeRoot: string) => boolean = root => isDirectory(nodePath.join(cwd, root)),
+  configuredProjectRoot: string | undefined,
+  rootExists: (repoRelativeRoot: string) => boolean,
 ): string[] {
   if (configuredProjectRoot === undefined) {
     let projectRoot = NAMESPACE_ROOT_DEFAULT;

--- a/packages/cli/src/utils/configured-paths.ts
+++ b/packages/cli/src/utils/configured-paths.ts
@@ -268,11 +268,7 @@ export function ticketDirectoriesForConfiguredRoot(
     ];
   }
   const projectRoot = toRepoDirectory(cwd, configuredProjectRoot);
-  if (projectRoot === undefined) {
-    throw new Error(
-      `Configured project root "${configuredProjectRoot}" is outside the repository.`,
-    );
-  }
+  if (projectRoot === undefined) return [];
   return [nodePath.posix.join(projectRoot, 'tickets')];
 }
 

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
+import { toRepoRelativePath } from './repo-path.js';
 import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
@@ -18,6 +19,12 @@ function slugFromTicketFolder(ticketFolder: string): string {
 export function findFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
   const fileName = `${slugFromTicketFolder(ticketFolder)}.feature`;
   return collectExecutableFeatureFiles(cwd, fileName)[0];
+}
+
+/** Find a ticket's canonical feature source in Git's repo-relative path grammar. */
+export function findRepoFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
+  const absolutePath = findFeatureSourcePath(cwd, ticketFolder);
+  return absolutePath === undefined ? undefined : toRepoRelativePath(cwd, absolutePath);
 }
 
 export function collectExecutableFeatureFiles(cwd: string, fileName?: string): string[] {

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -3,7 +3,7 @@ import nodePath from 'node:path';
 
 import type { PhaseAnchorScope } from '../../templates/hooks/lib/phase-provenance.js';
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
-import { toRepoDirectory } from './repo-path.js';
+import { toRepoDirectory, toRepoPath } from './repo-path.js';
 import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
@@ -22,12 +22,11 @@ export function findFeatureSourcePath(cwd: string, ticketFolder: string): string
   return collectExecutableFeatureFiles(cwd, fileName)[0];
 }
 
-/** Build feature ownership policy without consulting feature-file existence. */
-export function createPhaseAnchorScope(
+/** Build the ticket-invariant feature ownership policy once per tree/config. */
+export function createPhaseAnchorEnvironment(
   cwd: string,
-  ticketPath: string,
   configuredFeatures?: string,
-): PhaseAnchorScope {
+): Omit<PhaseAnchorScope, 'ticketPath'> {
   const featureRoots = ['features'];
   if (configuredFeatures !== undefined) {
     const configuredRoot = toRepoDirectory(cwd, configuredFeatures);
@@ -35,7 +34,19 @@ export function createPhaseAnchorScope(
       featureRoots.push(configuredRoot);
     }
   }
-  return { ticketPath, featureRoots, workspaceRoots: [...WORKSPACE_ROOTS] };
+  return { featureRoots, workspaceRoots: [...WORKSPACE_ROOTS] };
+}
+
+/** Build feature ownership policy without consulting feature-file existence. */
+export function createPhaseAnchorScope(
+  cwd: string,
+  ticketPath: string,
+  configuredFeatures?: string,
+): PhaseAnchorScope {
+  return {
+    ticketPath: toRepoPath(ticketPath),
+    ...createPhaseAnchorEnvironment(cwd, configuredFeatures),
+  };
 }
 
 export function collectExecutableFeatureFiles(cwd: string, fileName?: string): string[] {

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -1,7 +1,9 @@
 import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
+import type { PhaseAnchorScope } from '../../templates/hooks/lib/phase-provenance.js';
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
+import { toRepoPath, toRepoRelativePath } from './repo-path.js';
 import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
@@ -18,6 +20,32 @@ function slugFromTicketFolder(ticketFolder: string): string {
 export function findFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
   const fileName = `${slugFromTicketFolder(ticketFolder)}.feature`;
   return collectExecutableFeatureFiles(cwd, fileName)[0];
+}
+
+/** Build feature ownership policy without consulting feature-file existence. */
+export function createPhaseAnchorScope(
+  cwd: string,
+  ticketPath: string,
+  configuredFeatures?: string,
+): PhaseAnchorScope {
+  const featureRoots = ['features'];
+  if (configuredFeatures !== undefined) {
+    const configuredRoot = nodePath.isAbsolute(configuredFeatures)
+      ? toRepoRelativePath(cwd, configuredFeatures)
+      : toRepoPath(configuredFeatures);
+    let normalizedRoot = configuredRoot.startsWith('./') ? configuredRoot.slice(2) : configuredRoot;
+    while (normalizedRoot.endsWith('/')) normalizedRoot = normalizedRoot.slice(0, -1);
+    if (
+      normalizedRoot !== '' &&
+      normalizedRoot !== '.' &&
+      normalizedRoot !== '..' &&
+      !normalizedRoot.startsWith('../') &&
+      !featureRoots.includes(normalizedRoot)
+    ) {
+      featureRoots.push(normalizedRoot);
+    }
+  }
+  return { ticketPath, featureRoots, workspaceRoots: [...WORKSPACE_ROOTS] };
 }
 
 export function collectExecutableFeatureFiles(cwd: string, fileName?: string): string[] {

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -2,7 +2,6 @@ import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
-import { toRepoRelativePath } from './repo-path.js';
 import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
@@ -19,12 +18,6 @@ function slugFromTicketFolder(ticketFolder: string): string {
 export function findFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
   const fileName = `${slugFromTicketFolder(ticketFolder)}.feature`;
   return collectExecutableFeatureFiles(cwd, fileName)[0];
-}
-
-/** Find a ticket's canonical feature source in Git's repo-relative path grammar. */
-export function findRepoFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
-  const absolutePath = findFeatureSourcePath(cwd, ticketFolder);
-  return absolutePath === undefined ? undefined : toRepoRelativePath(cwd, absolutePath);
 }
 
 export function collectExecutableFeatureFiles(cwd: string, fileName?: string): string[] {

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -3,7 +3,7 @@ import nodePath from 'node:path';
 
 import type { PhaseAnchorScope } from '../../templates/hooks/lib/phase-provenance.js';
 import { resolveConfiguredLaneDirectory } from './configured-paths.js';
-import { toRepoPath, toRepoRelativePath } from './repo-path.js';
+import { toRepoDirectory } from './repo-path.js';
 import { WORKSPACE_ROOTS } from './workspaces.js';
 
 /** Ticket folder `ID-slug` -> `slug`; legacy `ID` -> `ID`. */
@@ -30,19 +30,9 @@ export function createPhaseAnchorScope(
 ): PhaseAnchorScope {
   const featureRoots = ['features'];
   if (configuredFeatures !== undefined) {
-    const configuredRoot = nodePath.isAbsolute(configuredFeatures)
-      ? toRepoRelativePath(cwd, configuredFeatures)
-      : toRepoPath(configuredFeatures);
-    let normalizedRoot = configuredRoot.startsWith('./') ? configuredRoot.slice(2) : configuredRoot;
-    while (normalizedRoot.endsWith('/')) normalizedRoot = normalizedRoot.slice(0, -1);
-    if (
-      normalizedRoot !== '' &&
-      normalizedRoot !== '.' &&
-      normalizedRoot !== '..' &&
-      !normalizedRoot.startsWith('../') &&
-      !featureRoots.includes(normalizedRoot)
-    ) {
-      featureRoots.push(normalizedRoot);
+    const configuredRoot = toRepoDirectory(cwd, configuredFeatures);
+    if (configuredRoot !== undefined && !featureRoots.includes(configuredRoot)) {
+      featureRoots.push(configuredRoot);
     }
   }
   return { ticketPath, featureRoots, workspaceRoots: [...WORKSPACE_ROOTS] };

--- a/packages/cli/src/utils/repo-path.test.ts
+++ b/packages/cli/src/utils/repo-path.test.ts
@@ -16,4 +16,9 @@ describe('toRepoDirectory', () => {
   it('normalizes dot segments and duplicate separators before Git path matching', () => {
     expect(toRepoDirectory('/repo', 'shadow/../.project//')).toBe('.project');
   });
+
+  it('represents the repository root as an empty Git path prefix', () => {
+    expect(toRepoDirectory('/repo', '.')).toBe('');
+    expect(toRepoDirectory('/repo', '/repo')).toBe('');
+  });
 });

--- a/packages/cli/src/utils/repo-path.test.ts
+++ b/packages/cli/src/utils/repo-path.test.ts
@@ -2,12 +2,18 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { toRepoPath } from './repo-path.js';
+import { toRepoDirectory, toRepoPath } from './repo-path.js';
 
 describe('toRepoPath', () => {
   it('normalizes a Windows-relative path to the forward-slashed anchor grammar', () => {
     const windowsPath = nodePath.win32.join('.project', 'tickets', 'ZZTEST-fixture');
 
     expect(toRepoPath(windowsPath)).toBe('.project/tickets/ZZTEST-fixture');
+  });
+});
+
+describe('toRepoDirectory', () => {
+  it('normalizes dot segments and duplicate separators before Git path matching', () => {
+    expect(toRepoDirectory('/repo', 'shadow/../.project//')).toBe('.project');
   });
 });

--- a/packages/cli/src/utils/repo-path.test.ts
+++ b/packages/cli/src/utils/repo-path.test.ts
@@ -1,0 +1,13 @@
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { toRepoPath } from './repo-path.js';
+
+describe('toRepoPath', () => {
+  it('normalizes a Windows-relative path to the forward-slashed anchor grammar', () => {
+    const windowsPath = nodePath.win32.join('.project', 'tickets', 'ZZTEST-fixture');
+
+    expect(toRepoPath(windowsPath)).toBe('.project/tickets/ZZTEST-fixture');
+  });
+});

--- a/packages/cli/src/utils/repo-path.ts
+++ b/packages/cli/src/utils/repo-path.ts
@@ -9,3 +9,18 @@ export function toRepoPath(value: string): string {
 export function toRepoRelativePath(cwd: string, absolutePath: string): string {
   return toRepoPath(nodePath.relative(cwd, absolutePath));
 }
+
+/** Normalize a configured directory that must remain inside the repository. */
+export function toRepoDirectory(cwd: string, configuredPath: string): string | undefined {
+  const repoPath = nodePath.isAbsolute(configuredPath)
+    ? toRepoRelativePath(cwd, configuredPath)
+    : toRepoPath(configuredPath);
+  let normalized = repoPath.startsWith('./') ? repoPath.slice(2) : repoPath;
+  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+  return normalized !== '' &&
+    normalized !== '.' &&
+    normalized !== '..' &&
+    !normalized.startsWith('../')
+    ? normalized
+    : undefined;
+}

--- a/packages/cli/src/utils/repo-path.ts
+++ b/packages/cli/src/utils/repo-path.ts
@@ -1,0 +1,4 @@
+/** Preserve a repository-relative path. Normalization is added in GREEN. */
+export function toRepoPath(value: string): string {
+  return value;
+}

--- a/packages/cli/src/utils/repo-path.ts
+++ b/packages/cli/src/utils/repo-path.ts
@@ -12,15 +12,12 @@ export function toRepoRelativePath(cwd: string, absolutePath: string): string {
 
 /** Normalize a configured directory that must remain inside the repository. */
 export function toRepoDirectory(cwd: string, configuredPath: string): string | undefined {
+  if (configuredPath === '') return undefined;
   const repoPath = nodePath.isAbsolute(configuredPath)
     ? toRepoRelativePath(cwd, configuredPath)
     : toRepoPath(configuredPath);
   const canonical = nodePath.posix.normalize(repoPath);
   const normalized = canonical.endsWith('/') ? canonical.slice(0, -1) : canonical;
-  return normalized !== '' &&
-    normalized !== '.' &&
-    normalized !== '..' &&
-    !normalized.startsWith('../')
-    ? normalized
-    : undefined;
+  if (normalized === '' || normalized === '.') return '';
+  return normalized !== '..' && !normalized.startsWith('../') ? normalized : undefined;
 }

--- a/packages/cli/src/utils/repo-path.ts
+++ b/packages/cli/src/utils/repo-path.ts
@@ -1,4 +1,11 @@
-/** Preserve a repository-relative path. Normalization is added in GREEN. */
+import nodePath from 'node:path';
+
+/** Normalize an OS-native relative path to Git's forward-slashed path grammar. */
 export function toRepoPath(value: string): string {
-  return value;
+  return value.split(nodePath.win32.sep).join(nodePath.posix.sep);
+}
+
+/** Return an absolute path relative to the repository in Git path grammar. */
+export function toRepoRelativePath(cwd: string, absolutePath: string): string {
+  return toRepoPath(nodePath.relative(cwd, absolutePath));
 }

--- a/packages/cli/src/utils/repo-path.ts
+++ b/packages/cli/src/utils/repo-path.ts
@@ -15,8 +15,8 @@ export function toRepoDirectory(cwd: string, configuredPath: string): string | u
   const repoPath = nodePath.isAbsolute(configuredPath)
     ? toRepoRelativePath(cwd, configuredPath)
     : toRepoPath(configuredPath);
-  let normalized = repoPath.startsWith('./') ? repoPath.slice(2) : repoPath;
-  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+  const canonical = nodePath.posix.normalize(repoPath);
+  const normalized = canonical.endsWith('/') ? canonical.slice(0, -1) : canonical;
   return normalized !== '' &&
     normalized !== '.' &&
     normalized !== '..' &&

--- a/packages/cli/src/utils/workspace-roots.ts
+++ b/packages/cli/src/utils/workspace-roots.ts
@@ -1,0 +1,7 @@
+/**
+ * Conventional monorepo package-root directories.
+ *
+ * Kept dependency-free so acceptance fixtures can import the production
+ * constant without loading filesystem-backed workspace discovery.
+ */
+export const WORKSPACE_ROOTS = ['packages', 'apps', 'libs', 'modules'] as const;

--- a/packages/cli/src/utils/workspace-roots.ts
+++ b/packages/cli/src/utils/workspace-roots.ts
@@ -1,6 +1,9 @@
 /**
  * Conventional monorepo package-root directories.
  *
+ * Shared so the scanners that walk them — workspace-member, BDD feature-source,
+ * and cucumber-harness detection — cannot drift when a root is added.
+ *
  * Kept dependency-free so acceptance fixtures can import the production
  * constant without loading filesystem-backed workspace discovery.
  */

--- a/packages/cli/src/utils/workspaces.ts
+++ b/packages/cli/src/utils/workspaces.ts
@@ -11,12 +11,6 @@ import { exists, readJson } from './fs.js';
 
 export { WORKSPACE_ROOTS } from './workspace-roots.js';
 
-/**
- * The conventional monorepo package-root directories. Shared so the scanners
- * that walk them — workspace-member, BDD feature-source, and cucumber-harness
- * detection — cannot drift (a root added in one place but not another silently
- * breaks detection or discovery).
- */
 interface PackageJson {
   name?: string;
   workspaces?: string[] | { packages?: string[] };

--- a/packages/cli/src/utils/workspaces.ts
+++ b/packages/cli/src/utils/workspaces.ts
@@ -9,14 +9,14 @@ import nodePath from 'node:path';
 
 import { exists, readJson } from './fs.js';
 
+export { WORKSPACE_ROOTS } from './workspace-roots.js';
+
 /**
  * The conventional monorepo package-root directories. Shared so the scanners
  * that walk them — workspace-member, BDD feature-source, and cucumber-harness
  * detection — cannot drift (a root added in one place but not another silently
  * breaks detection or discovery).
  */
-export const WORKSPACE_ROOTS = ['packages', 'apps', 'libs', 'modules'] as const;
-
 interface PackageJson {
   name?: string;
   workspaces?: string[] | { packages?: string[] };

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -445,6 +445,14 @@ export type PhaseAnchorVerdict =
   | { kind: 'anchored' }
   | { kind: 'unanchored'; phase: string; reason: string };
 
+/** Canonical artifact ownership for the ticket being checked. */
+export interface PhaseAnchorScope {
+  /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
+  ticketPath: string;
+  /** Exact canonical feature source, when the ticket has one. */
+  featurePath?: string;
+}
+
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
 
 /**
@@ -466,7 +474,7 @@ export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -492,7 +500,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact, expectedTicketPath);
+  return validateAnchor(proposed, proposedPhase, readArtifact, scope);
 }
 
 /**
@@ -506,7 +514,7 @@ function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -538,14 +546,15 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // Feature sources are repository-level artifacts. Every other accepted kind
-  // is ticket-local and must be the changed ticket's own output, not a
-  // same-basename artifact borrowed from another ticket.
-  if (
-    expectedTicketPath !== undefined &&
-    !isFeatureSource(anchor) &&
-    dirnameOf(anchor) !== expectedTicketPath
-  ) {
+  // A feature source must be this ticket's canonical source. Every other
+  // accepted kind is ticket-local and must be this ticket's own output, not a
+  // same-kind artifact borrowed from elsewhere.
+  const isOwnedArtifact =
+    scope === undefined ||
+    (isFeatureSource(anchor)
+      ? anchor === scope.featurePath
+      : dirnameOf(anchor) === scope.ticketPath);
+  if (!isOwnedArtifact) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
     );
@@ -580,7 +589,7 @@ function validateAnchor(
 export function detectUnanchoredPhaseState(
   content: string,
   readArtifact?: ArtifactReader,
-  expectedTicketPath?: string,
+  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -594,5 +603,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact, expectedTicketPath);
+  return validateAnchor(meta, phase, readArtifact, scope);
 }

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -422,8 +422,8 @@ const ANCHOR_KINDS = {
 
 /**
  * A plausible repo-relative path: non-empty, forward-slashed, not absolute
- * (POSIX or Windows), free of `..` traversal, and free of git pathspec
- * magic/glob characters — a value opening with `(` or `:` would activate
+ * (POSIX or Windows), free of empty, `.` or `..` segments, and free of git
+ * pathspec magic/glob characters — a value opening with `(` or `:` would activate
  * pathspec magic inside a `git show :<path>` read (`:(top)x` exits 0 with
  * commit text, a false "anchored"), and glob characters are never a single
  * artifact's path. Deliberately permissive beyond that — existence and kind
@@ -437,7 +437,7 @@ function isPlausibleRepoPath(value: string): boolean {
   // commit-tier reader prepends its own colon.
   if (/^[0-3]:/.test(value)) return false;
   if (/^[(:!^]/.test(value) || /[*?[\]]/.test(value)) return false;
-  return !value.split('/').includes('..');
+  return !value.split('/').some(segment => segment === '' || segment === '.' || segment === '..');
 }
 
 export type PhaseAnchorVerdict =

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -449,8 +449,6 @@ export type PhaseAnchorVerdict =
 export interface PhaseAnchorScope {
   /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
   ticketPath: string;
-  /** Exact canonical feature source, when the ticket has one. */
-  featurePath?: string;
 }
 
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
@@ -546,13 +544,17 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // A feature source must be this ticket's canonical source. Every other
-  // accepted kind is ticket-local and must be this ticket's own output, not a
-  // same-kind artifact borrowed from elsewhere.
+  // Feature source identity follows the repository convention
+  // `<any configured feature lane>/<ticket slug>.feature`; deriving the
+  // basename from the ticket path keeps ownership independent of unstaged
+  // worktree state. Every other kind must live in this ticket's own folder.
+  const ticketFolder = basenameOf(scope?.ticketPath ?? '');
+  const slugSeparator = ticketFolder.indexOf('-');
+  const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const isOwnedArtifact =
     scope === undefined ||
     (isFeatureSource(anchor)
-      ? anchor === scope.featurePath
+      ? basenameOf(anchor) === `${ticketSlug}.feature`
       : dirnameOf(anchor) === scope.ticketPath);
   if (!isOwnedArtifact) {
     return unanchored(

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -461,9 +461,10 @@ const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
  * Detect whether a feature ticket's forward phase advance carries a valid
  * artifact-path anchor for the phase it enters (HGYGND). Pure — the tree is
  * read through an injected ArtifactReader, so the predicate touches neither
- * filesystem nor git: the boundary gate supplies a staged-index or HEAD-tree
- * reader, `safeword check` a filesystem reader; a caller with no tree at hand
- * passes none (format-only).
+ * filesystem nor git: every caller supplies canonical ownership scope; the
+ * boundary gate also supplies a staged-index or HEAD-tree reader, `safeword
+ * check` a filesystem reader, and a caller with no tree at hand omits only
+ * the reader (format-only).
  *
  * Returns `anchored` / `unanchored` only for the policed act — a feature→feature
  * FORWARD phase change. Everything else is `not-applicable`: a creation/birth, a
@@ -475,8 +476,8 @@ const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
 export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -502,17 +503,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact, scope);
-}
-
-/** Enforcement entry point: ownership scope is required, tree reading remains optional. */
-export function detectScopedUnanchoredPhaseTransition(
-  priorContent: string | undefined,
-  proposedContent: string,
-  scope: PhaseAnchorScope,
-  readArtifact?: ArtifactReader,
-): PhaseAnchorVerdict {
-  return detectUnanchoredPhaseTransition(priorContent, proposedContent, readArtifact, scope);
+  return validateAnchor(proposed, proposedPhase, scope, readArtifact);
 }
 
 /**
@@ -525,8 +516,8 @@ export function detectScopedUnanchoredPhaseTransition(
 function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -561,23 +552,22 @@ function validateAnchor(
   // Feature source identity follows the executable-lane convention plus
   // `<ticket slug>.feature`; callers supply roots from the same tree as the
   // artifact reader. Every other kind must live in this ticket's own folder.
-  const ticketFolder = basenameOf(scope?.ticketPath ?? '');
+  const ticketFolder = basenameOf(scope.ticketPath);
   const slugSeparator = ticketFolder.indexOf('-');
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const anchorSegments = anchor.split('/');
-  const isConfiguredOrDefaultFeature =
-    scope?.featureRoots.some(root => root === '' || anchor.startsWith(`${root}/`)) ?? false;
+  const isConfiguredOrDefaultFeature = scope.featureRoots.some(
+    root => root === '' || anchor.startsWith(`${root}/`),
+  );
   const isWorkspaceFeature =
     anchorSegments.length >= 4 &&
-    (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&
+    scope.workspaceRoots.includes(anchorSegments[0] ?? '') &&
     anchorSegments[1] !== '' &&
     anchorSegments[2] === 'features';
-  const isOwnedArtifact =
-    scope === undefined ||
-    (isFeatureSource(anchor)
-      ? basenameOf(anchor) === `${ticketSlug}.feature` &&
-        (isConfiguredOrDefaultFeature || isWorkspaceFeature)
-      : dirnameOf(anchor) === scope.ticketPath);
+  const isOwnedArtifact = isFeatureSource(anchor)
+    ? basenameOf(anchor) === `${ticketSlug}.feature` &&
+      (isConfiguredOrDefaultFeature || isWorkspaceFeature)
+    : dirnameOf(anchor) === scope.ticketPath;
   if (!isOwnedArtifact) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
@@ -612,8 +602,8 @@ function validateAnchor(
  */
 export function detectUnanchoredPhaseState(
   content: string,
+  scope: PhaseAnchorScope,
   readArtifact?: ArtifactReader,
-  scope?: PhaseAnchorScope,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -627,14 +617,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact, scope);
-}
-
-/** At-rest enforcement entry point with required canonical ownership scope. */
-export function detectScopedUnanchoredPhaseState(
-  content: string,
-  scope: PhaseAnchorScope,
-  readArtifact?: ArtifactReader,
-): PhaseAnchorVerdict {
-  return detectUnanchoredPhaseState(content, readArtifact, scope);
+  return validateAnchor(meta, phase, scope, readArtifact);
 }

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -505,6 +505,16 @@ export function detectUnanchoredPhaseTransition(
   return validateAnchor(proposed, proposedPhase, readArtifact, scope);
 }
 
+/** Enforcement entry point: ownership scope is required, tree reading remains optional. */
+export function detectScopedUnanchoredPhaseTransition(
+  priorContent: string | undefined,
+  proposedContent: string,
+  scope: PhaseAnchorScope,
+  readArtifact?: ArtifactReader,
+): PhaseAnchorVerdict {
+  return detectUnanchoredPhaseTransition(priorContent, proposedContent, readArtifact, scope);
+}
+
 /**
  * Shared anchor validation ladder: entry present → path-shaped (hex is the
  * legacy branch) → expected kind for the phase → (with a reader) present in
@@ -618,4 +628,13 @@ export function detectUnanchoredPhaseState(
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
   return validateAnchor(meta, phase, readArtifact, scope);
+}
+
+/** At-rest enforcement entry point with required canonical ownership scope. */
+export function detectScopedUnanchoredPhaseState(
+  content: string,
+  scope: PhaseAnchorScope,
+  readArtifact?: ArtifactReader,
+): PhaseAnchorVerdict {
+  return detectUnanchoredPhaseState(content, readArtifact, scope);
 }

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -361,6 +361,7 @@ interface AnchorKind {
 }
 
 const basenameOf = (relpath: string): string => relpath.split('/').at(-1) ?? '';
+const dirnameOf = (relpath: string): string => relpath.split('/').slice(0, -1).join('/');
 
 /** A Gherkin source: any .feature path with at least one scenario. */
 const isFeatureSource = (relpath: string): boolean => relpath.endsWith('.feature');
@@ -431,6 +432,10 @@ const ANCHOR_KINDS = {
 function isPlausibleRepoPath(value: string): boolean {
   if (value === '' || value.includes('\\')) return false;
   if (value.startsWith('/') || /^[a-zA-Z]:/.test(value)) return false;
+  // `git show :0:path` addresses stage zero of `path` in the index. Without
+  // this guard, recording `0:path` aliases a different artifact when the
+  // commit-tier reader prepends its own colon.
+  if (/^[0-3]:/.test(value)) return false;
   if (/^[(:!^]/.test(value) || /[*?[\]]/.test(value)) return false;
   return !value.split('/').includes('..');
 }
@@ -461,6 +466,7 @@ export function detectUnanchoredPhaseTransition(
   priorContent: string | undefined,
   proposedContent: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   // A creation is a birth, not a transition.
   if (priorContent === undefined) return NOT_APPLICABLE;
@@ -486,7 +492,7 @@ export function detectUnanchoredPhaseTransition(
   if (toIndex <= canonicalIndex(effectivePrior)) return NOT_APPLICABLE; // backward or lateral
 
   // Policed: a forward feature advance must carry a valid anchor for the phase entered.
-  return validateAnchor(proposed, proposedPhase, readArtifact);
+  return validateAnchor(proposed, proposedPhase, readArtifact, expectedTicketPath);
 }
 
 /**
@@ -500,6 +506,7 @@ function validateAnchor(
   meta: Record<string, string | string[]>,
   phase: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   const kind = (ANCHOR_KINDS as Record<string, AnchorKind | undefined>)[phase];
   if (kind === undefined) return NOT_APPLICABLE; // intake/off-enum — nothing enterable to anchor
@@ -529,6 +536,18 @@ function validateAnchor(
   if (!kind.matches(anchor)) {
     return unanchored(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
+    );
+  }
+  // Feature sources are repository-level artifacts. Every other accepted kind
+  // is ticket-local and must be the changed ticket's own output, not a
+  // same-basename artifact borrowed from another ticket.
+  if (
+    expectedTicketPath !== undefined &&
+    !isFeatureSource(anchor) &&
+    dirnameOf(anchor) !== expectedTicketPath
+  ) {
+    return unanchored(
+      `phase_anchors entry for "${phase}" is "${anchor}", an artifact outside this ticket — record this ticket's own artifact, e.g. ${expectedLine}.`,
     );
   }
   if (readArtifact === undefined) return { kind: 'anchored' };
@@ -561,6 +580,7 @@ function validateAnchor(
 export function detectUnanchoredPhaseState(
   content: string,
   readArtifact?: ArtifactReader,
+  expectedTicketPath?: string,
 ): PhaseAnchorVerdict {
   const meta = frontmatterOf(normalizeNewlines(content));
   if (meta === undefined) return NOT_APPLICABLE;
@@ -574,5 +594,5 @@ export function detectUnanchoredPhaseState(
   const anchor = parseAnchors(meta).get(phase);
   if (anchor !== undefined && isValidSha(anchor)) return NOT_APPLICABLE;
 
-  return validateAnchor(meta, phase, readArtifact);
+  return validateAnchor(meta, phase, readArtifact, expectedTicketPath);
 }

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -449,6 +449,10 @@ export type PhaseAnchorVerdict =
 export interface PhaseAnchorScope {
   /** Repo-relative ticket folder, using Git's forward-slashed path grammar. */
   ticketPath: string;
+  /** Concrete repo-relative feature-lane roots (default + configured). */
+  featureRoots: readonly string[];
+  /** Conventional roots whose direct members may own a features/ lane. */
+  workspaceRoots: readonly string[];
 }
 
 const NOT_APPLICABLE: PhaseAnchorVerdict = { kind: 'not-applicable' };
@@ -544,17 +548,25 @@ function validateAnchor(
       `phase_anchors entry for "${phase}" is "${anchor}", not the expected artifact kind — "${phase}" expects ${kind.label}, e.g. ${expectedLine}.`,
     );
   }
-  // Feature source identity follows the repository convention
-  // `<any configured feature lane>/<ticket slug>.feature`; deriving the
-  // basename from the ticket path keeps ownership independent of unstaged
-  // worktree state. Every other kind must live in this ticket's own folder.
+  // Feature source identity follows the executable-lane convention plus
+  // `<ticket slug>.feature`; callers supply roots from the same tree as the
+  // artifact reader. Every other kind must live in this ticket's own folder.
   const ticketFolder = basenameOf(scope?.ticketPath ?? '');
   const slugSeparator = ticketFolder.indexOf('-');
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
+  const anchorSegments = anchor.split('/');
+  const isConfiguredOrDefaultFeature =
+    scope?.featureRoots.some(root => anchor.startsWith(`${root}/`)) ?? false;
+  const isWorkspaceFeature =
+    anchorSegments.length >= 4 &&
+    (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&
+    anchorSegments[1] !== '' &&
+    anchorSegments[2] === 'features';
   const isOwnedArtifact =
     scope === undefined ||
     (isFeatureSource(anchor)
-      ? basenameOf(anchor) === `${ticketSlug}.feature`
+      ? basenameOf(anchor) === `${ticketSlug}.feature` &&
+        (isConfiguredOrDefaultFeature || isWorkspaceFeature)
       : dirnameOf(anchor) === scope.ticketPath);
   if (!isOwnedArtifact) {
     return unanchored(

--- a/packages/cli/templates/hooks/lib/phase-provenance.ts
+++ b/packages/cli/templates/hooks/lib/phase-provenance.ts
@@ -556,7 +556,7 @@ function validateAnchor(
   const ticketSlug = slugSeparator === -1 ? ticketFolder : ticketFolder.slice(slugSeparator + 1);
   const anchorSegments = anchor.split('/');
   const isConfiguredOrDefaultFeature =
-    scope?.featureRoots.some(root => anchor.startsWith(`${root}/`)) ?? false;
+    scope?.featureRoots.some(root => root === '' || anchor.startsWith(`${root}/`)) ?? false;
   const isWorkspaceFeature =
     anchorSegments.length >= 4 &&
     (scope?.workspaceRoots.includes(anchorSegments[0] ?? '') ?? false) &&

--- a/packages/cli/tests/commands/boundary-engine.test.ts
+++ b/packages/cli/tests/commands/boundary-engine.test.ts
@@ -20,10 +20,11 @@ function ticketContent(phase: string, anchors?: string[]): string {
 
 function advanceChange(anchors: string[] | undefined): TicketChange {
   return {
-    ticketFolder: 'ENG001-fixture',
-    ticketPath: '.project/tickets/ENG001-fixture',
-    featureRoots: FEATURE_ROOTS,
-    workspaceRoots: WORKSPACE_ROOTS,
+    anchorScope: {
+      ticketPath: '.project/tickets/ENG001-fixture',
+      featureRoots: FEATURE_ROOTS,
+      workspaceRoots: WORKSPACE_ROOTS,
+    },
     artifacts: [
       {
         artifact: 'ticket.md',
@@ -69,10 +70,11 @@ describe('boundary engine — reader/resolver failure degrades to indeterminate'
       '',
     ].join('\n');
     const change: TicketChange = {
-      ticketFolder: 'ENG002-fixture',
-      ticketPath: '.project/tickets/ENG002-fixture',
-      featureRoots: FEATURE_ROOTS,
-      workspaceRoots: WORKSPACE_ROOTS,
+      anchorScope: {
+        ticketPath: '.project/tickets/ENG002-fixture',
+        featureRoots: FEATURE_ROOTS,
+        workspaceRoots: WORKSPACE_ROOTS,
+      },
       artifacts: [{ artifact: 'test-definitions.md', proposed: ledger }],
       ticketCurrent: ticketContent('implement', [`implement: ${IMPL_PLAN}`]),
       hasLedger: true,

--- a/packages/cli/tests/commands/boundary-engine.test.ts
+++ b/packages/cli/tests/commands/boundary-engine.test.ts
@@ -11,6 +11,8 @@ import { reconcileChange, type TicketChange } from '../../src/boundary/engine.js
 import { boundaryTicketContent, shapeValidImplPlan } from './boundary-helpers';
 
 const IMPL_PLAN = '.project/tickets/ENG001-fixture/impl-plan.md';
+const FEATURE_ROOTS = ['features'];
+const WORKSPACE_ROOTS = ['packages', 'apps', 'libs', 'modules'];
 
 function ticketContent(phase: string, anchors?: string[]): string {
   return boundaryTicketContent({ id: 'ZZENG', phase, anchors });
@@ -20,6 +22,8 @@ function advanceChange(anchors: string[] | undefined): TicketChange {
   return {
     ticketFolder: 'ENG001-fixture',
     ticketPath: '.project/tickets/ENG001-fixture',
+    featureRoots: FEATURE_ROOTS,
+    workspaceRoots: WORKSPACE_ROOTS,
     artifacts: [
       {
         artifact: 'ticket.md',
@@ -67,6 +71,8 @@ describe('boundary engine — reader/resolver failure degrades to indeterminate'
     const change: TicketChange = {
       ticketFolder: 'ENG002-fixture',
       ticketPath: '.project/tickets/ENG002-fixture',
+      featureRoots: FEATURE_ROOTS,
+      workspaceRoots: WORKSPACE_ROOTS,
       artifacts: [{ artifact: 'test-definitions.md', proposed: ledger }],
       ticketCurrent: ticketContent('implement', [`implement: ${IMPL_PLAN}`]),
       hasLedger: true,

--- a/packages/cli/tests/commands/boundary-engine.test.ts
+++ b/packages/cli/tests/commands/boundary-engine.test.ts
@@ -19,6 +19,7 @@ function ticketContent(phase: string, anchors?: string[]): string {
 function advanceChange(anchors: string[] | undefined): TicketChange {
   return {
     ticketFolder: 'ENG001-fixture',
+    ticketPath: '.project/tickets/ENG001-fixture',
     artifacts: [
       {
         artifact: 'ticket.md',
@@ -65,6 +66,7 @@ describe('boundary engine — reader/resolver failure degrades to indeterminate'
     ].join('\n');
     const change: TicketChange = {
       ticketFolder: 'ENG002-fixture',
+      ticketPath: '.project/tickets/ENG002-fixture',
       artifacts: [{ artifact: 'test-definitions.md', proposed: ledger }],
       ticketCurrent: ticketContent('implement', [`implement: ${IMPL_PLAN}`]),
       hasLedger: true,

--- a/packages/cli/tests/commands/boundary-engine.test.ts
+++ b/packages/cli/tests/commands/boundary-engine.test.ts
@@ -8,11 +8,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { reconcileChange, type TicketChange } from '../../src/boundary/engine.js';
+import { WORKSPACE_ROOTS } from '../../src/utils/workspace-roots.js';
 import { boundaryTicketContent, shapeValidImplPlan } from './boundary-helpers';
 
 const IMPL_PLAN = '.project/tickets/ENG001-fixture/impl-plan.md';
 const FEATURE_ROOTS = ['features'];
-const WORKSPACE_ROOTS = ['packages', 'apps', 'libs', 'modules'];
 
 function ticketContent(phase: string, anchors?: string[]): string {
   return boundaryTicketContent({ id: 'ZZENG', phase, anchors });

--- a/packages/cli/tests/commands/boundary-push.test.ts
+++ b/packages/cli/tests/commands/boundary-push.test.ts
@@ -148,6 +148,26 @@ describe('safeword boundary (push tier: artifact-content anchors)', () => {
 
     expect(result.exitCode).toBe(0);
     expect(combinedOutput(result)).not.toMatch(/phase-anchor|unreachable|not reachable/i);
+    expect(lastAuditEntry(dir)).toMatch(/phase-anchor.*pass|pass.*phase-anchor/);
+  });
+
+  it('a rebased commit does not disturb a recorded anchor (SM1.R2)', async () => {
+    const branch = git(dir, 'branch --show-current').trim();
+    commitAnchoredAdvance();
+    const beforeRebase = git(dir, 'rev-parse HEAD').trim();
+    git(dir, 'checkout --quiet -b rewritten-base @{u}');
+    writeTestFile(dir, 'README.md', '# rewritten base\n');
+    git(dir, 'add README.md');
+    git(dir, 'commit -m upstream-base --quiet');
+    git(dir, `checkout --quiet ${branch}`);
+    git(dir, 'rebase rewritten-base --quiet');
+    expect(git(dir, 'rev-parse HEAD').trim()).not.toBe(beforeRebase);
+
+    const result = await runCli(['boundary', '--at', 'push'], { cwd: dir });
+
+    expect(result.exitCode).toBe(0);
+    expect(combinedOutput(result)).not.toMatch(/phase-anchor|unreachable|not reachable/i);
+    expect(lastAuditEntry(dir)).toMatch(/phase-anchor.*pass|pass.*phase-anchor/);
   });
 
   it('a squash-merged history still verifies at the next boundary (SM1.R2/R4)', async () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -385,7 +385,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
 
       expect(result.exitCode).toBe(0);
-      expect(`${result.stdout}\n${result.stderr}`).toMatch(/phase-anchor.*shape/is);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/impl-plan-shape.*missing/is);
     });
   });
 

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -354,6 +354,59 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/impl-plan-shape.*missing/is);
     });
 
+    it('ignores legacy tickets when the staged tree contains the authoritative .project root', async () => {
+      writeIntakeFeatureTicket(dir, 'BND020-authoritative');
+      const legacyTicket = '.safeword-project/tickets/BND020-legacy/ticket.md';
+      writeTestFile(
+        dir,
+        legacyTicket,
+        boundaryTicketContent({ id: 'BND020', phase: 'scenario-gate' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(dir, legacyTicket, boundaryTicketContent({ id: 'BND020', phase: 'implement' }));
+      git(dir, `add ${legacyTicket}`);
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`.trim()).toBe('');
+      expect(readAudit(dir)).toHaveLength(0);
+    });
+
+    it('ignores legacy tickets when the pushed tree contains the authoritative .project root', async () => {
+      const remote = createTemporaryDirectory();
+      try {
+        execSync('git init --bare --quiet', { cwd: remote, stdio: 'pipe' });
+        writeIntakeFeatureTicket(dir, 'BND021-authoritative');
+        const legacyTicket = '.safeword-project/tickets/BND021-legacy/ticket.md';
+        writeTestFile(
+          dir,
+          legacyTicket,
+          boundaryTicketContent({ id: 'BND021', phase: 'scenario-gate' }),
+        );
+        git(dir, 'add -A');
+        git(dir, 'commit -m seed --quiet');
+        git(dir, `remote add origin ${remote}`);
+        git(dir, 'push -u origin HEAD --quiet');
+        writeTestFile(
+          dir,
+          legacyTicket,
+          boundaryTicketContent({ id: 'BND021', phase: 'implement' }),
+        );
+        git(dir, `add ${legacyTicket}`);
+        git(dir, 'commit -m legacy-only --quiet');
+
+        const result = await runCli(['boundary', '--at', 'push'], { cwd: dir });
+
+        expect(result.exitCode).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`.trim()).toBe('');
+        expect(readAudit(dir)).toHaveLength(0);
+      } finally {
+        removeTemporaryDirectory(remote);
+      }
+    });
+
     it('accepts a root-level configured feature lane from the staged config', async () => {
       const ticket = '.project/tickets/BND019-owner';
       const feature = 'docs/owner.feature';

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -387,6 +387,81 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/impl-plan-shape.*missing/is);
     });
+
+    it('discovers root-level tickets when staged projectRoot is the repository root', async () => {
+      const ticket = 'tickets/BND018-owner';
+      const config = '.safeword/config.json';
+      writeTestFile(dir, config, JSON.stringify({ paths: { projectRoot: '.' } }, undefined, 2));
+      writeTestFile(dir, `${ticket}/impl-plan.md`, '# hollow plan\n');
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND018',
+          phase: 'implement',
+          anchors: [`implement: ${ticket}/impl-plan.md`],
+        }),
+      );
+      git(dir, 'add -A');
+      writeTestFile(dir, config, '{}\n');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/impl-plan-shape.*missing/is);
+    });
+
+    it('accepts a root-level configured feature lane from the staged config', async () => {
+      const ticket = '.project/tickets/BND019-owner';
+      const feature = 'docs/owner.feature';
+      const config = '.safeword/config.json';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND019', phase: 'define-behavior' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(dir, config, JSON.stringify({ paths: { features: '.' } }, undefined, 2));
+      writeTestFile(
+        dir,
+        feature,
+        ['Feature: owner', '', '  Scenario: root lane', '    Then it exists', ''].join('\n'),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND019',
+          phase: 'scenario-gate',
+          anchors: [`scenario-gate: ${feature}`],
+        }),
+      );
+      git(dir, 'add -A');
+      unlinkSync(nodePath.join(dir, config));
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/phase-anchor/i);
+    });
+
+    it('warns instead of silently skipping a project root outside the repository', async () => {
+      const config = '.safeword/config.json';
+      writeTestFile(
+        dir,
+        config,
+        JSON.stringify({ paths: { projectRoot: '../outside' } }, undefined, 2),
+      );
+      git(dir, 'add -A');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(
+        /outside.*repository|repository.*outside/i,
+      );
+    });
   });
 
   describe('CDRJTW.TB1.AC1: silence for changes touching no ticket artifacts', () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -407,6 +407,57 @@ describe('safeword boundary (slice 1: engine core)', () => {
       }
     });
 
+    it('falls back to legacy tickets when the staged tree has no .project root', async () => {
+      const legacyTicket = '.safeword-project/tickets/BND022-legacy/ticket.md';
+      git(dir, 'rm -r .project --quiet');
+      writeTestFile(
+        dir,
+        legacyTicket,
+        boundaryTicketContent({ id: 'BND022', phase: 'scenario-gate' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m legacy-baseline --quiet');
+      writeTestFile(dir, legacyTicket, boundaryTicketContent({ id: 'BND022', phase: 'implement' }));
+      git(dir, `add ${legacyTicket}`);
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/BND022-legacy.*phase-anchor/is);
+    });
+
+    it('falls back to legacy tickets when the pushed tree has no .project root', async () => {
+      const remote = createTemporaryDirectory();
+      try {
+        execSync('git init --bare --quiet', { cwd: remote, stdio: 'pipe' });
+        const legacyTicket = '.safeword-project/tickets/BND023-legacy/ticket.md';
+        git(dir, 'rm -r .project --quiet');
+        writeTestFile(
+          dir,
+          legacyTicket,
+          boundaryTicketContent({ id: 'BND023', phase: 'scenario-gate' }),
+        );
+        git(dir, 'add -A');
+        git(dir, 'commit -m legacy-baseline --quiet');
+        git(dir, `remote add origin ${remote}`);
+        git(dir, 'push -u origin HEAD --quiet');
+        writeTestFile(
+          dir,
+          legacyTicket,
+          boundaryTicketContent({ id: 'BND023', phase: 'implement' }),
+        );
+        git(dir, `add ${legacyTicket}`);
+        git(dir, 'commit -m legacy-advance --quiet');
+
+        const result = await runCli(['boundary', '--at', 'push'], { cwd: dir });
+
+        expect(result.exitCode).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`).toMatch(/BND023-legacy.*phase-anchor/is);
+      } finally {
+        removeTemporaryDirectory(remote);
+      }
+    });
+
     it('accepts a root-level configured feature lane from the staged config', async () => {
       const ticket = '.project/tickets/BND019-owner';
       const feature = 'docs/owner.feature';

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -25,6 +25,7 @@ import {
   createBoundaryProject,
   git,
   readAudit,
+  shapeValidImplPlan,
 } from './boundary-helpers';
 
 function writeIntakeFeatureTicket(dir: string, folder: string): void {
@@ -103,36 +104,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       writeTestFile(dir, `${foreignTicket}/impl-plan.md`, '# foreign plan\n');
       git(dir, 'add -A');
       git(dir, 'commit -m seed --quiet');
-      writeTestFile(
-        dir,
-        `${foreignTicket}/impl-plan.md`,
-        [
-          '# Impl Plan: foreign',
-          '',
-          '**Status:** planned',
-          '',
-          '## Approach',
-          '',
-          'Foreign evidence.',
-          '',
-          '## Decisions',
-          '',
-          'skip: fixture',
-          '',
-          '## Arch alignment',
-          '',
-          'skip: fixture',
-          '',
-          '## Known deviations',
-          '',
-          'skip: fixture',
-          '',
-          '## Assessment triggers',
-          '',
-          'skip: fixture',
-          '',
-        ].join('\n'),
-      );
+      writeTestFile(dir, `${foreignTicket}/impl-plan.md`, shapeValidImplPlan());
       writeTestFile(
         dir,
         `${ticket}/ticket.md`,
@@ -159,36 +131,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       );
       git(dir, 'add -A');
       git(dir, 'commit -m seed --quiet');
-      writeTestFile(
-        dir,
-        `${ticket}/impl-plan.md`,
-        [
-          '# Impl Plan: owner',
-          '',
-          '**Status:** planned',
-          '',
-          '## Approach',
-          '',
-          'Real evidence.',
-          '',
-          '## Decisions',
-          '',
-          'skip: fixture',
-          '',
-          '## Arch alignment',
-          '',
-          'skip: fixture',
-          '',
-          '## Known deviations',
-          '',
-          'skip: fixture',
-          '',
-          '## Assessment triggers',
-          '',
-          'skip: fixture',
-          '',
-        ].join('\n'),
-      );
+      writeTestFile(dir, `${ticket}/impl-plan.md`, shapeValidImplPlan());
       writeTestFile(
         dir,
         `${ticket}/ticket.md`,

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -351,6 +351,42 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/phase-anchor/i);
     });
+
+    it('discovers tickets from a project root recorded only in the staged config', async () => {
+      const oldTicket = '.project/tickets/BND017-owner/ticket.md';
+      const ticket = 'custom/tickets/BND017-owner';
+      const config = '.safeword/config.json';
+      writeTestFile(
+        dir,
+        oldTicket,
+        boundaryTicketContent({ id: 'BND017', phase: 'scenario-gate' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      unlinkSync(nodePath.join(dir, oldTicket));
+      writeTestFile(
+        dir,
+        config,
+        JSON.stringify({ paths: { projectRoot: 'custom' } }, undefined, 2),
+      );
+      writeTestFile(dir, `${ticket}/impl-plan.md`, '# hollow plan\n');
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND017',
+          phase: 'implement',
+          anchors: [`implement: ${ticket}/impl-plan.md`],
+        }),
+      );
+      git(dir, 'add -A');
+      writeTestFile(dir, config, '{}\n');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/phase-anchor.*shape/is);
+    });
   });
 
   describe('CDRJTW.TB1.AC1: silence for changes touching no ticket artifacts', () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -119,7 +119,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
 
       expect(result.exitCode).toBe(0);
-      expect(`${result.stdout}\n${result.stderr}`).toMatch(/ticket.*artifact|artifact.*ticket/i);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/outside this ticket/i);
     });
 
     it('warns when an index-stage prefix aliases an existing staged artifact', async () => {
@@ -184,7 +184,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
 
       expect(result.exitCode).toBe(0);
-      expect(`${result.stdout}\n${result.stderr}`).toMatch(/ticket/i);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/outside this ticket/i);
     });
 
     it('uses the staged tree, not an unstaged removal, to identify the canonical feature', async () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -205,6 +205,44 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/repo-relative/i);
     });
+
+    it("warns when a ticket reuses another ticket's feature source", async () => {
+      const ticket = '.project/tickets/BND013-owner';
+      const foreignFeature = 'features/another-ticket.feature';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND013', phase: 'define-behavior' }),
+      );
+      writeTestFile(
+        dir,
+        foreignFeature,
+        [
+          'Feature: another ticket',
+          '',
+          '  Scenario: foreign evidence',
+          '    Then it exists',
+          '',
+        ].join('\n'),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND013',
+          phase: 'scenario-gate',
+          anchors: [`scenario-gate: ${foreignFeature}`],
+        }),
+      );
+      git(dir, 'add -A');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/ticket/i);
+    });
   });
 
   describe('CDRJTW.TB1.AC1: silence for changes touching no ticket artifacts', () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -91,6 +91,120 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/missing/i);
     });
+
+    it("warns when a ticket reuses another ticket's same-kind artifact", async () => {
+      const ticket = '.project/tickets/BND010-owner';
+      const foreignTicket = '.project/tickets/BND011-foreign';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND010', phase: 'scenario-gate' }),
+      );
+      writeTestFile(dir, `${foreignTicket}/impl-plan.md`, '# foreign plan\n');
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        `${foreignTicket}/impl-plan.md`,
+        [
+          '# Impl Plan: foreign',
+          '',
+          '**Status:** planned',
+          '',
+          '## Approach',
+          '',
+          'Foreign evidence.',
+          '',
+          '## Decisions',
+          '',
+          'skip: fixture',
+          '',
+          '## Arch alignment',
+          '',
+          'skip: fixture',
+          '',
+          '## Known deviations',
+          '',
+          'skip: fixture',
+          '',
+          '## Assessment triggers',
+          '',
+          'skip: fixture',
+          '',
+        ].join('\n'),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND010',
+          phase: 'implement',
+          anchors: [`implement: ${foreignTicket}/impl-plan.md`],
+        }),
+      );
+      git(dir, 'add -A');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/ticket.*artifact|artifact.*ticket/i);
+    });
+
+    it('warns when an index-stage prefix aliases an existing staged artifact', async () => {
+      const ticket = '.project/tickets/BND012-stage-alias';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND012', phase: 'scenario-gate' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        `${ticket}/impl-plan.md`,
+        [
+          '# Impl Plan: owner',
+          '',
+          '**Status:** planned',
+          '',
+          '## Approach',
+          '',
+          'Real evidence.',
+          '',
+          '## Decisions',
+          '',
+          'skip: fixture',
+          '',
+          '## Arch alignment',
+          '',
+          'skip: fixture',
+          '',
+          '## Known deviations',
+          '',
+          'skip: fixture',
+          '',
+          '## Assessment triggers',
+          '',
+          'skip: fixture',
+          '',
+        ].join('\n'),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND012',
+          phase: 'implement',
+          anchors: [`implement: 0:${ticket}/impl-plan.md`],
+        }),
+      );
+      git(dir, 'add -A');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/repo-relative/i);
+    });
   });
 
   describe('CDRJTW.TB1.AC1: silence for changes touching no ticket artifacts', () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -367,7 +367,7 @@ describe('safeword boundary (slice 1: engine core)', () => {
       writeTestFile(
         dir,
         config,
-        JSON.stringify({ paths: { projectRoot: 'custom' } }, undefined, 2),
+        JSON.stringify({ paths: { projectRoot: 'shadow/../custom//' } }, undefined, 2),
       );
       writeTestFile(dir, `${ticket}/impl-plan.md`, '# hollow plan\n');
       writeTestFile(

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -276,6 +276,81 @@ describe('safeword boundary (slice 1: engine core)', () => {
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/phase-anchor/i);
     });
+
+    it('rejects a correctly named feature outside every executable feature lane', async () => {
+      const ticket = '.project/tickets/BND015-owner';
+      const lookalike = 'docs/owner.feature';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND015', phase: 'define-behavior' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        lookalike,
+        ['Feature: lookalike', '', '  Scenario: not executable', '    Then it exists', ''].join(
+          '\n',
+        ),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND015',
+          phase: 'scenario-gate',
+          anchors: [`scenario-gate: ${lookalike}`],
+        }),
+      );
+      git(dir, 'add -A');
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/phase-anchor/i);
+    });
+
+    it('accepts a configured feature lane recorded only in the staged config', async () => {
+      const ticket = '.project/tickets/BND016-owner';
+      const feature = 'tests/behaviors/owner.feature';
+      const config = '.safeword/config.json';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND016', phase: 'define-behavior' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        config,
+        JSON.stringify({ paths: { features: 'tests/behaviors' } }, undefined, 2),
+      );
+      writeTestFile(
+        dir,
+        feature,
+        ['Feature: owner', '', '  Scenario: configured evidence', '    Then it exists', ''].join(
+          '\n',
+        ),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND016',
+          phase: 'scenario-gate',
+          anchors: [`scenario-gate: ${feature}`],
+        }),
+      );
+      git(dir, 'add -A');
+      unlinkSync(nodePath.join(dir, config));
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/phase-anchor/i);
+    });
   });
 
   describe('CDRJTW.TB1.AC1: silence for changes touching no ticket artifacts', () => {

--- a/packages/cli/tests/commands/boundary.test.ts
+++ b/packages/cli/tests/commands/boundary.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, unlinkSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -242,6 +242,39 @@ describe('safeword boundary (slice 1: engine core)', () => {
 
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(/ticket/i);
+    });
+
+    it('uses the staged tree, not an unstaged removal, to identify the canonical feature', async () => {
+      const ticket = '.project/tickets/BND014-owner';
+      const feature = 'features/owner.feature';
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({ id: 'BND014', phase: 'define-behavior' }),
+      );
+      git(dir, 'add -A');
+      git(dir, 'commit -m seed --quiet');
+      writeTestFile(
+        dir,
+        feature,
+        ['Feature: owner', '', '  Scenario: owned evidence', '    Then it exists', ''].join('\n'),
+      );
+      writeTestFile(
+        dir,
+        `${ticket}/ticket.md`,
+        boundaryTicketContent({
+          id: 'BND014',
+          phase: 'scenario-gate',
+          anchors: [`scenario-gate: ${feature}`],
+        }),
+      );
+      git(dir, 'add -A');
+      unlinkSync(nodePath.join(dir, feature));
+
+      const result = await runCli(['boundary', '--at', 'commit'], { cwd: dir });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/phase-anchor/i);
     });
   });
 

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -1225,6 +1225,27 @@ describe('Test Suite 8: Health Check', () => {
       expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/ANC006/);
     });
 
+    it("reports a feature-source anchor that belongs to another ticket's slug", async () => {
+      await createConfiguredProject(temporaryDirectory);
+      writeTestFile(
+        temporaryDirectory,
+        'features/another-ticket.feature',
+        ['Feature: another ticket', '', '  Scenario: foreign', '    Then it exists', ''].join('\n'),
+      );
+      writeAnchorTicket('ANC008-demo', [
+        'type: feature',
+        'phase: scenario-gate',
+        'status: in_progress',
+        'phase_anchors:',
+        '  - scenario-gate: features/another-ticket.feature',
+      ]);
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/ANC008.*outside this ticket/is);
+    });
+
     it('reports a path anchor whose artifact is missing from disk', async () => {
       await createConfiguredProject(temporaryDirectory);
       writeAnchorTicket('ANC007-demo', [

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -25,6 +25,11 @@ const SPEC_PATH = `${TICKET_DIR}/spec.md`;
 const LEDGER_PATH = `${TICKET_DIR}/test-definitions.md`;
 const VERIFY_PATH = `${TICKET_DIR}/verify.md`;
 const FEATURE_PATH = 'features/fixture.feature';
+const ANCHOR_SCOPE = {
+  ticketPath: TICKET_DIR,
+  featureRoots: ['features'],
+  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
+};
 
 const SHAPE_VALID_IMPL_PLAN = [
   '# Impl Plan: fixture',
@@ -346,7 +351,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       ticket({ type: 'feature', phase: 'scenario-gate' }),
       ticket({ type: 'feature', phase: 'implement', anchors: [`implement: ${foreignPlan}`] }),
       readerFor({ [foreignPlan]: SHAPE_VALID_IMPL_PLAN }),
-      { ticketPath: TICKET_DIR },
+      ANCHOR_SCOPE,
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
@@ -362,7 +367,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
         anchors: [`scenario-gate: ${foreignFeature}`],
       }),
       readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
-      { ticketPath: TICKET_DIR },
+      ANCHOR_SCOPE,
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import { WORKSPACE_ROOTS } from '../../src/utils/workspace-roots.js';
 import type {
   ArtifactReader,
   PhaseAnchorScope,
@@ -31,7 +32,7 @@ const FEATURE_PATH = 'features/fixture.feature';
 const ANCHOR_SCOPE = {
   ticketPath: TICKET_DIR,
   featureRoots: ['features'],
-  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
+  workspaceRoots: [...WORKSPACE_ROOTS],
 };
 
 it('requires ownership scope at the detector API boundary', () => {

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -315,6 +315,8 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
     '!bang/impl-plan.md',
     '^caret/impl-plan.md',
     'glob/*/impl-plan.md',
+    'ticket/./impl-plan.md',
+    'ticket//impl-plan.md',
   ])('an implausible path value %s is unanchored', value => {
     const verdict = detectUnanchoredPhaseTransition(
       ticket({ type: 'feature', phase: 'scenario-gate' }),
@@ -322,6 +324,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       readTree,
     );
     expect(verdict.kind).toBe('unanchored');
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/repo-relative/i);
   });
 
   it('an empty (readable but blank) artifact fails its shape check rather than reading as missing', () => {

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -362,7 +362,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
         anchors: [`scenario-gate: ${foreignFeature}`],
       }),
       readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
-      { ticketPath: TICKET_DIR, featurePath: FEATURE_PATH },
+      { ticketPath: TICKET_DIR },
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -346,7 +346,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       ticket({ type: 'feature', phase: 'scenario-gate' }),
       ticket({ type: 'feature', phase: 'implement', anchors: [`implement: ${foreignPlan}`] }),
       readerFor({ [foreignPlan]: SHAPE_VALID_IMPL_PLAN }),
-      TICKET_DIR,
+      { ticketPath: TICKET_DIR },
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
@@ -362,7 +362,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
         anchors: [`scenario-gate: ${foreignFeature}`],
       }),
       readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
-      TICKET_DIR,
+      { ticketPath: TICKET_DIR, featurePath: FEATURE_PATH },
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -329,6 +329,29 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/shape/i);
   });
 
+  it('a Git index-stage prefix cannot alias a different artifact path', () => {
+    const stagedAlias = `0:${IMPL_PLAN_PATH}`;
+    const verdict = detectUnanchoredPhaseTransition(
+      ticket({ type: 'feature', phase: 'scenario-gate' }),
+      ticket({ type: 'feature', phase: 'implement', anchors: [`implement: ${stagedAlias}`] }),
+      readerFor({ [stagedAlias]: SHAPE_VALID_IMPL_PLAN }),
+    );
+    expect(verdict.kind).toBe('unanchored');
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/repo-relative/i);
+  });
+
+  it("a ticket cannot reuse another ticket's same-kind artifact", () => {
+    const foreignPlan = '.project/tickets/OTHER-fixture/impl-plan.md';
+    const verdict = detectUnanchoredPhaseTransition(
+      ticket({ type: 'feature', phase: 'scenario-gate' }),
+      ticket({ type: 'feature', phase: 'implement', anchors: [`implement: ${foreignPlan}`] }),
+      readerFor({ [foreignPlan]: SHAPE_VALID_IMPL_PLAN }),
+      TICKET_DIR,
+    );
+    expect(verdict.kind).toBe('unanchored');
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
+  });
+
   it('a path absent from the tree is unanchored, saying it is missing', () => {
     const verdict = detectUnanchoredPhaseTransition(
       ticket({ type: 'feature', phase: 'scenario-gate' }),

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -377,7 +377,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       readerFor({ [foreignPlan]: SHAPE_VALID_IMPL_PLAN }),
     );
     expect(verdict.kind).toBe('unanchored');
-    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/outside this ticket/i);
   });
 
   it("a ticket cannot reuse another ticket's feature source", () => {
@@ -392,7 +392,7 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
     );
     expect(verdict.kind).toBe('unanchored');
-    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/outside this ticket/i);
   });
 
   it('a path absent from the tree is unanchored, saying it is missing', () => {

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -352,6 +352,22 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
   });
 
+  it("a ticket cannot reuse another ticket's feature source", () => {
+    const foreignFeature = 'features/another-ticket.feature';
+    const verdict = detectUnanchoredPhaseTransition(
+      ticket({ type: 'feature', phase: 'define-behavior' }),
+      ticket({
+        type: 'feature',
+        phase: 'scenario-gate',
+        anchors: [`scenario-gate: ${foreignFeature}`],
+      }),
+      readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
+      TICKET_DIR,
+    );
+    expect(verdict.kind).toBe('unanchored');
+    if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
+  });
+
   it('a path absent from the tree is unanchored, saying it is missing', () => {
     const verdict = detectUnanchoredPhaseTransition(
       ticket({ type: 'feature', phase: 'scenario-gate' }),

--- a/packages/cli/tests/hooks/phase-anchor.test.ts
+++ b/packages/cli/tests/hooks/phase-anchor.test.ts
@@ -8,12 +8,15 @@
  * the tier/history partitions.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import type { ArtifactReader } from '../../templates/hooks/lib/phase-provenance.js';
+import type {
+  ArtifactReader,
+  PhaseAnchorScope,
+} from '../../templates/hooks/lib/phase-provenance.js';
 import {
-  detectUnanchoredPhaseState,
-  detectUnanchoredPhaseTransition,
+  detectUnanchoredPhaseState as detectPhaseState,
+  detectUnanchoredPhaseTransition as detectPhaseTransition,
 } from '../../templates/hooks/lib/phase-provenance.js';
 
 /** A well-formed 7-hex abbreviated SHA — the legacy grammar. */
@@ -30,6 +33,23 @@ const ANCHOR_SCOPE = {
   featureRoots: ['features'],
   workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
 };
+
+it('requires ownership scope at the detector API boundary', () => {
+  expectTypeOf(detectPhaseTransition).parameter(2).toEqualTypeOf<PhaseAnchorScope>();
+  expectTypeOf(detectPhaseState).parameter(1).toEqualTypeOf<PhaseAnchorScope>();
+});
+
+function detectUnanchoredPhaseTransition(
+  priorContent: string | undefined,
+  proposedContent: string,
+  readArtifact?: ArtifactReader,
+) {
+  return detectPhaseTransition(priorContent, proposedContent, ANCHOR_SCOPE, readArtifact);
+}
+
+function detectUnanchoredPhaseState(content: string, readArtifact?: ArtifactReader) {
+  return detectPhaseState(content, ANCHOR_SCOPE, readArtifact);
+}
 
 const SHAPE_VALID_IMPL_PLAN = [
   '# Impl Plan: fixture',
@@ -354,7 +374,6 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       ticket({ type: 'feature', phase: 'scenario-gate' }),
       ticket({ type: 'feature', phase: 'implement', anchors: [`implement: ${foreignPlan}`] }),
       readerFor({ [foreignPlan]: SHAPE_VALID_IMPL_PLAN }),
-      ANCHOR_SCOPE,
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
@@ -370,7 +389,6 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
         anchors: [`scenario-gate: ${foreignFeature}`],
       }),
       readerFor({ [foreignFeature]: SHAPE_VALID_FEATURE }),
-      ANCHOR_SCOPE,
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/ticket/i);
@@ -382,9 +400,9 @@ describe('detectUnanchoredPhaseTransition — no real artifact behind the advanc
       ticket({
         type: 'feature',
         phase: 'implement',
-        anchors: [`implement: ${TICKET_DIR}/gone/impl-plan.md`],
+        anchors: [`implement: ${IMPL_PLAN_PATH}`],
       }),
-      readTree,
+      readerFor({}),
     );
     expect(verdict.kind).toBe('unanchored');
     if (verdict.kind === 'unanchored') expect(verdict.reason).toMatch(/missing/i);

--- a/steps/artifact-content-phase-anchors.steps.ts
+++ b/steps/artifact-content-phase-anchors.steps.ts
@@ -21,6 +21,7 @@ import { pathToFileURL } from 'node:url';
 import { Given, Then, When } from '@cucumber/cucumber';
 
 import { toRepoPath } from '../packages/cli/src/utils/repo-path.ts';
+import { WORKSPACE_ROOTS } from '../packages/cli/src/utils/workspace-roots.ts';
 import { git, implPlanContent, readAuditEntries, writeFileAt } from './support/repo-fixtures.ts';
 import type { SafewordWorld } from './world.js';
 
@@ -121,7 +122,7 @@ const { readFileSync } = await import('node:fs');
 const scope = {
   ticketPath: ${JSON.stringify(TICKET_DIR)},
   featureRoots: ['features'],
-  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
+  workspaceRoots: ${JSON.stringify(WORKSPACE_ROOTS)},
 };
 const read = tree === null ? undefined
   : tree === 'fs' ? (p) => { try { return readFileSync(p, 'utf8'); } catch { return undefined; } }

--- a/steps/artifact-content-phase-anchors.steps.ts
+++ b/steps/artifact-content-phase-anchors.steps.ts
@@ -501,6 +501,22 @@ function lastAuditEntry(dir: string): string {
   return entry === undefined ? '' : JSON.stringify(entry);
 }
 
+function createCommittedAnchoredAdvance(world: AnchorWorld): { dir: string; branch: string } {
+  const dir = createProject(world);
+  writeFileAt(dir, `${TICKET_DIR}/ticket.md`, ticketContent('feature', 'scenario-gate'));
+  addPushedBaseline(world);
+  const branch = git(dir, 'branch --show-current').trim();
+  writeFileAt(dir, IMPL_PLAN, SHAPE_VALID_IMPL_PLAN);
+  writeFileAt(
+    dir,
+    `${TICKET_DIR}/ticket.md`,
+    ticketContent('feature', 'implement', [`implement: ${IMPL_PLAN}`]),
+  );
+  git(dir, 'add -A');
+  git(dir, 'commit -m advance --quiet');
+  return { dir, branch };
+}
+
 Given(
   'a project whose ticket advanced phases across several commits — an earlier phase anchored by a legacy hex SHA — that were then squash-merged into one',
   function (this: AnchorWorld) {
@@ -561,17 +577,7 @@ When(
 Given(
   'a project whose ticket recorded a path anchor in a commit that was then amended',
   function (this: AnchorWorld) {
-    const dir = createProject(this);
-    writeFileAt(dir, `${TICKET_DIR}/ticket.md`, ticketContent('feature', 'scenario-gate'));
-    addPushedBaseline(this);
-    writeFileAt(dir, IMPL_PLAN, SHAPE_VALID_IMPL_PLAN);
-    writeFileAt(
-      dir,
-      `${TICKET_DIR}/ticket.md`,
-      ticketContent('feature', 'implement', [`implement: ${IMPL_PLAN}`]),
-    );
-    git(dir, 'add -A');
-    git(dir, 'commit -m advance --quiet');
+    const { dir } = createCommittedAnchoredAdvance(this);
     git(dir, 'commit --amend --quiet -m amended-advance');
   },
 );
@@ -579,18 +585,7 @@ Given(
 Given(
   'a project whose ticket recorded a path anchor in a commit that was then rebased',
   function (this: AnchorWorld) {
-    const dir = createProject(this);
-    writeFileAt(dir, `${TICKET_DIR}/ticket.md`, ticketContent('feature', 'scenario-gate'));
-    addPushedBaseline(this);
-    const branch = git(dir, 'branch --show-current').trim();
-    writeFileAt(dir, IMPL_PLAN, SHAPE_VALID_IMPL_PLAN);
-    writeFileAt(
-      dir,
-      `${TICKET_DIR}/ticket.md`,
-      ticketContent('feature', 'implement', [`implement: ${IMPL_PLAN}`]),
-    );
-    git(dir, 'add -A');
-    git(dir, 'commit -m advance --quiet');
+    const { branch, dir } = createCommittedAnchoredAdvance(this);
     git(dir, 'checkout --quiet -b rewritten-base @{u}');
     writeFileAt(dir, 'README.md', '# rewritten base\n');
     git(dir, 'add README.md');

--- a/steps/artifact-content-phase-anchors.steps.ts
+++ b/steps/artifact-content-phase-anchors.steps.ts
@@ -13,13 +13,14 @@
 
 import { strict as assert } from 'node:assert';
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, unlinkSync, writeFileSync } from 'node:fs';
 import nodeOs from 'node:os';
 import nodePath from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { Given, Then, When } from '@cucumber/cucumber';
 
+import { toRepoPath } from '../packages/cli/src/utils/repo-path.ts';
 import { git, implPlanContent, readAuditEntries, writeFileAt } from './support/repo-fixtures.ts';
 import type { SafewordWorld } from './world.js';
 
@@ -83,6 +84,8 @@ interface AnchorWorld extends SafewordWorld {
   dir?: string;
   remote?: string;
   cli?: { exitCode: number; output: string };
+  nativePath?: string;
+  normalizedPath?: string;
 }
 
 function ticketContent(
@@ -115,12 +118,17 @@ const RUNNER = `
 const { detectUnanchoredPhaseTransition, detectUnanchoredPhaseState } = await import(${JSON.stringify(LIB_URL)});
 const { prior, proposed, tree, mode } = JSON.parse(await new Response(Bun.stdin).text());
 const { readFileSync } = await import('node:fs');
+const scope = {
+  ticketPath: ${JSON.stringify(TICKET_DIR)},
+  featureRoots: ['features'],
+  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
+};
 const read = tree === null ? undefined
   : tree === 'fs' ? (p) => { try { return readFileSync(p, 'utf8'); } catch { return undefined; } }
   : (p) => (Object.hasOwn(tree, p) ? tree[p] : undefined);
 const verdict = mode === 'state'
-  ? detectUnanchoredPhaseState(proposed, read)
-  : detectUnanchoredPhaseTransition(prior, proposed, read);
+  ? detectUnanchoredPhaseState(proposed, scope, read)
+  : detectUnanchoredPhaseTransition(prior, proposed, scope, read);
 console.log(JSON.stringify(verdict));
 `;
 
@@ -351,7 +359,7 @@ When(
 );
 
 When('it advances to implement recording that path for implement', function (this: AnchorWorld) {
-  advance(this, { phase: 'implement', anchors: [`implement: ${GONE}`] });
+  advance(this, { phase: 'implement', anchors: [`implement: ${IMPL_PLAN}`] });
 });
 
 When(
@@ -516,6 +524,165 @@ function createCommittedAnchoredAdvance(world: AnchorWorld): { dir: string; bran
   git(dir, 'commit -m advance --quiet');
   return { dir, branch };
 }
+
+function seedTicket(world: AnchorWorld, ticketPath: string, phase: string): string {
+  const dir = createProject(world);
+  writeFileAt(dir, `${ticketPath}/ticket.md`, ticketContent('feature', phase));
+  git(dir, 'add -A');
+  git(dir, 'commit -m seed --quiet');
+  return dir;
+}
+
+Given(
+  "a staged advance anchored to another ticket's shape-valid impl-plan",
+  function (this: AnchorWorld) {
+    const foreignTicket = '.project/tickets/ACA002-foreign';
+    const foreignPlan = `${foreignTicket}/impl-plan.md`;
+    const dir = seedTicket(this, TICKET_DIR, 'scenario-gate');
+    writeFileAt(dir, foreignPlan, SHAPE_VALID_IMPL_PLAN);
+    writeFileAt(
+      dir,
+      `${TICKET_DIR}/ticket.md`,
+      ticketContent('feature', 'implement', [`implement: ${foreignPlan}`]),
+    );
+    git(dir, 'add -A');
+  },
+);
+
+Given("a staged advance anchored to another ticket's feature source", function (this: AnchorWorld) {
+  const foreignFeature = 'features/another-ticket.feature';
+  const dir = seedTicket(this, TICKET_DIR, 'define-behavior');
+  writeFileAt(dir, foreignFeature, FEATURE_CONTENT);
+  writeFileAt(
+    dir,
+    `${TICKET_DIR}/ticket.md`,
+    ticketContent('feature', 'scenario-gate', [`scenario-gate: ${foreignFeature}`]),
+  );
+  git(dir, 'add -A');
+});
+
+Given('a staged advance whose anchor uses a Git index-stage prefix', function (this: AnchorWorld) {
+  const stagedAlias = `0:${IMPL_PLAN}`;
+  const dir = seedTicket(this, TICKET_DIR, 'scenario-gate');
+  writeFileAt(dir, IMPL_PLAN, SHAPE_VALID_IMPL_PLAN);
+  writeFileAt(
+    dir,
+    `${TICKET_DIR}/ticket.md`,
+    ticketContent('feature', 'implement', [`implement: ${stagedAlias}`]),
+  );
+  git(dir, 'add -A');
+});
+
+Given('an OS-native ticket directory path', function (this: AnchorWorld) {
+  this.nativePath = nodePath.win32.join('.project', 'tickets', 'ACA001-fixture');
+});
+
+When('the path is normalized for an anchor', function (this: AnchorWorld) {
+  this.normalizedPath = toRepoPath(this.nativePath ?? '');
+});
+
+Then('it uses the forward-slashed anchor grammar', function (this: AnchorWorld) {
+  assert.equal(this.normalizedPath, TICKET_DIR);
+});
+
+Given(
+  'a staged owned feature source that is then removed from the worktree',
+  function (this: AnchorWorld) {
+    const dir = seedTicket(this, TICKET_DIR, 'define-behavior');
+    writeFileAt(dir, FEATURE_SRC, FEATURE_CONTENT);
+    writeFileAt(
+      dir,
+      `${TICKET_DIR}/ticket.md`,
+      ticketContent('feature', 'scenario-gate', [`scenario-gate: ${FEATURE_SRC}`]),
+    );
+    git(dir, 'add -A');
+    unlinkSync(nodePath.join(dir, FEATURE_SRC));
+  },
+);
+
+Given(
+  'a staged advance anchored to a correctly named feature outside every feature lane',
+  function (this: AnchorWorld) {
+    const lookalike = 'docs/fixture.feature';
+    const dir = seedTicket(this, TICKET_DIR, 'define-behavior');
+    writeFileAt(dir, lookalike, FEATURE_CONTENT);
+    writeFileAt(
+      dir,
+      `${TICKET_DIR}/ticket.md`,
+      ticketContent('feature', 'scenario-gate', [`scenario-gate: ${lookalike}`]),
+    );
+    git(dir, 'add -A');
+  },
+);
+
+function stageConfiguredTicket(
+  world: AnchorWorld,
+  configuredProjectRoot: string,
+  ticketRoot = 'custom',
+): void {
+  const ticketPath = `${ticketRoot}/tickets/ACA001-fixture`;
+  const dir = seedTicket(world, ticketPath, 'scenario-gate');
+  writeFileAt(
+    dir,
+    '.safeword/config.json',
+    JSON.stringify({ paths: { projectRoot: configuredProjectRoot } }, undefined, 2),
+  );
+  writeFileAt(dir, `${ticketPath}/impl-plan.md`, '# hollow plan\n');
+  writeFileAt(
+    dir,
+    `${ticketPath}/ticket.md`,
+    ticketContent('feature', 'implement', [`implement: ${ticketPath}/impl-plan.md`]),
+  );
+  git(dir, 'add -A');
+}
+
+Given(
+  'a staged project-root configuration and a ticket in that configured root',
+  function (this: AnchorWorld) {
+    stageConfiguredTicket(this, 'custom');
+  },
+);
+
+Given(
+  'a staged project root containing dot and duplicate separator segments',
+  function (this: AnchorWorld) {
+    stageConfiguredTicket(this, 'shadow/../custom//');
+  },
+);
+
+Given(
+  'staged repository-root ticket and feature lanes with a valid owned anchor',
+  function (this: AnchorWorld) {
+    const rootTicket = 'tickets/ACA001-fixture';
+    const rootFeature = 'fixture.feature';
+    const dir = createProject(this);
+    writeFileAt(
+      dir,
+      '.safeword/config.json',
+      JSON.stringify({ paths: { projectRoot: '.', features: '.' } }, undefined, 2),
+    );
+    writeFileAt(dir, `${rootTicket}/ticket.md`, ticketContent('feature', 'define-behavior'));
+    git(dir, 'add -A');
+    git(dir, 'commit -m seed --quiet');
+    writeFileAt(dir, rootFeature, FEATURE_CONTENT);
+    writeFileAt(
+      dir,
+      `${rootTicket}/ticket.md`,
+      ticketContent('feature', 'scenario-gate', [`scenario-gate: ${rootFeature}`]),
+    );
+    git(dir, 'add -A');
+  },
+);
+
+Given('a staged project-root configuration outside the repository', function (this: AnchorWorld) {
+  const dir = createProject(this);
+  writeFileAt(
+    dir,
+    '.safeword/config.json',
+    JSON.stringify({ paths: { projectRoot: '../outside' } }, undefined, 2),
+  );
+  git(dir, 'add -A');
+});
 
 Given(
   'a project whose ticket advanced phases across several commits — an earlier phase anchored by a legacy hex SHA — that were then squash-merged into one',
@@ -700,3 +867,37 @@ Then('the anchor check passes', function (this: AnchorWorld) {
 Then('the ledger check still warns about the unreachable tick SHA', function (this: AnchorWorld) {
   assert.match(this.cli?.output ?? '', /deadbee|ledger/i);
 });
+
+Then(
+  'it exits zero and warns that the anchor is outside this ticket',
+  function (this: AnchorWorld) {
+    assert.equal(this.cli?.exitCode, 0);
+    assert.match(this.cli?.output ?? '', /outside this ticket/i);
+  },
+);
+
+Then('it exits zero and warns that the anchor is not repo-relative', function (this: AnchorWorld) {
+  assert.equal(this.cli?.exitCode, 0);
+  assert.match(this.cli?.output ?? '', /repo-relative/i);
+});
+
+Then('it exits zero and warns about the phase anchor', function (this: AnchorWorld) {
+  assert.equal(this.cli?.exitCode, 0);
+  assert.match(this.cli?.output ?? '', /phase-anchor/i);
+});
+
+Then(
+  "it exits zero and reports the configured ticket's malformed plan",
+  function (this: AnchorWorld) {
+    assert.equal(this.cli?.exitCode, 0);
+    assert.match(this.cli?.output ?? '', /impl-plan-shape.*missing/is);
+  },
+);
+
+Then(
+  'it exits zero and warns that the project root is outside the repository',
+  function (this: AnchorWorld) {
+    assert.equal(this.cli?.exitCode, 0);
+    assert.match(this.cli?.output ?? '', /outside.*repository|repository.*outside/i);
+  },
+);

--- a/steps/artifact-content-phase-anchors.steps.ts
+++ b/steps/artifact-content-phase-anchors.steps.ts
@@ -577,6 +577,30 @@ Given(
 );
 
 Given(
+  'a project whose ticket recorded a path anchor in a commit that was then rebased',
+  function (this: AnchorWorld) {
+    const dir = createProject(this);
+    writeFileAt(dir, `${TICKET_DIR}/ticket.md`, ticketContent('feature', 'scenario-gate'));
+    addPushedBaseline(this);
+    const branch = git(dir, 'branch --show-current').trim();
+    writeFileAt(dir, IMPL_PLAN, SHAPE_VALID_IMPL_PLAN);
+    writeFileAt(
+      dir,
+      `${TICKET_DIR}/ticket.md`,
+      ticketContent('feature', 'implement', [`implement: ${IMPL_PLAN}`]),
+    );
+    git(dir, 'add -A');
+    git(dir, 'commit -m advance --quiet');
+    git(dir, 'checkout --quiet -b rewritten-base @{u}');
+    writeFileAt(dir, 'README.md', '# rewritten base\n');
+    git(dir, 'add README.md');
+    git(dir, 'commit -m upstream-base --quiet');
+    git(dir, `checkout --quiet ${branch}`);
+    git(dir, 'rebase rewritten-base --quiet');
+  },
+);
+
+Given(
   'a shallow single-depth clone of a project with an anchored feature ticket in the outgoing range',
   function (this: AnchorWorld) {
     const dir = createProject(this);

--- a/steps/boundary-reconciliation-gate.steps.ts
+++ b/steps/boundary-reconciliation-gate.steps.ts
@@ -18,6 +18,7 @@ import nodePath from 'node:path';
 
 import { After, Given, Then, When } from '@cucumber/cucumber';
 
+import { WORKSPACE_ROOTS } from '../packages/cli/src/utils/workspace-roots.ts';
 import {
   AUDIT_PATH,
   git,
@@ -463,10 +464,11 @@ const { reconcileChange } = await import(${JSON.stringify(
 const ticket = (phase, anchors) => ['---','id: BGT','type: feature','phase: '+phase,'status: in_progress', ...(anchors ? ['phase_anchors:', ...anchors.map(a=>'  - '+a)] : []), '---',''].join('\\n');
 const anchor = 'implement: .project/tickets/BGT001-fixture/impl-plan.md';
 const verdicts = reconcileChange([{
-  ticketFolder: 'BGT001-fixture',
-  ticketPath: '.project/tickets/BGT001-fixture',
-  featureRoots: ['features'],
-  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
+  anchorScope: {
+    ticketPath: '.project/tickets/BGT001-fixture',
+    featureRoots: ['features'],
+    workspaceRoots: ${JSON.stringify(WORKSPACE_ROOTS)},
+  },
   artifacts: [{ artifact: 'ticket.md', prior: ticket('define-behavior'), proposed: ticket('implement', [anchor]) }],
   ticketCurrent: ticket('implement', [anchor]),
   hasLedger: true,

--- a/steps/boundary-reconciliation-gate.steps.ts
+++ b/steps/boundary-reconciliation-gate.steps.ts
@@ -465,6 +465,8 @@ const anchor = 'implement: .project/tickets/BGT001-fixture/impl-plan.md';
 const verdicts = reconcileChange([{
   ticketFolder: 'BGT001-fixture',
   ticketPath: '.project/tickets/BGT001-fixture',
+  featureRoots: ['features'],
+  workspaceRoots: ['packages', 'apps', 'libs', 'modules'],
   artifacts: [{ artifact: 'ticket.md', prior: ticket('define-behavior'), proposed: ticket('implement', [anchor]) }],
   ticketCurrent: ticket('implement', [anchor]),
   hasLedger: true,

--- a/steps/boundary-reconciliation-gate.steps.ts
+++ b/steps/boundary-reconciliation-gate.steps.ts
@@ -464,6 +464,7 @@ const ticket = (phase, anchors) => ['---','id: BGT','type: feature','phase: '+ph
 const anchor = 'implement: .project/tickets/BGT001-fixture/impl-plan.md';
 const verdicts = reconcileChange([{
   ticketFolder: 'BGT001-fixture',
+  ticketPath: '.project/tickets/BGT001-fixture',
   artifacts: [{ artifact: 'ticket.md', prior: ticket('define-behavior'), proposed: ticket('implement', [anchor]) }],
   ticketCurrent: ticket('implement', [anchor]),
   hasLedger: true,


### PR DESCRIPTION
## Summary

- bind ticket-scoped phase anchors to the owning ticket instead of accepting any same-kind artifact
- bind feature-source anchors to the ticket slug and an executable/default/configured feature lane
- require ownership scope on both public detectors and remove the redundant fail-open scoped wrappers
- read project and feature roots from the same staged/HEAD tree being validated, including repository-root configurations
- reject Git index-stage aliases, traversal, duplicate separators, and other noncanonical anchor paths
- add all 37 ledger behaviors to executable Gherkin coverage, including the ten ownership/configuration cases previously covered only below the acceptance lane
- consolidate the boundary scope model, shared workspace-root constant, health config reads, and test fixtures

## Why

PR #964 made issue #904 amend-safe by replacing commit-SHA anchors with artifact paths. The remaining implementation accepted artifact kind and shape without fully binding the path to its ticket/configuration authority, allowing foreign-artifact substitution and staged/worktree configuration mismatches. This follow-up hardens that substrate without changing the warn-and-record boundary policy.

Follow-up to #904 and #964; it does not re-close the already closed issue.

## Validation

- CI on the remediation head: Dogfood parity, lint, Node 22, and Node 24 all pass
- focused Vitest: 4 files, 76 tests passed
- Cucumber: 505 passed, 3 skipped; 15,645 executed steps passed
- issue-focused Cucumber: 40 scenarios and 1,210 steps passed
- build, ESLint, Gherkin lint, `tsc --noEmit`, diff hygiene, and dogfood parity: clean
- audit: 0 change-scoped errors; dependency-cruiser 0 violations across 662 modules / 2,166 dependencies; Knip clean; dependencies current; clone count improved from 490 to 455 at the same scope
- independent quality review and post-refactor review: PASS

## Local environment note

- Full local Vitest: 5,492 passed, 5 skipped, with one failure in untouched upstream Astro preset files: `astro/no-omitted-end-tags` is `"error"` under the locally installed eslint-plugin-astro 3.0.1 while `astro.test.ts` expects it to be absent. The preset, test, manifests, and lockfile are unchanged from `origin/main`, and both Node 22 and Node 24 CI pass on this remediation head, so this does not reproduce in the clean branch environment.
- The push boundary emits warn-only ledger reachability advisories for historical HGYGND RED/GREEN/REFACTOR SHAs that were squash-merged before this follow-up. New hardening evidence references resolve on this branch.
