### PR TITLE
Correct dedup consistency wording

### DIFF
--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -158,7 +158,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
    * signature, which is why this read as flaky for so long.
    *
    * The listing endpoint returns raw bodies verbatim, so the marker check becomes
-   * a local string compare — exact, index-independent, and lag-free. No label
+   * a local string compare — exact and search-index-independent. No label
    * filter: this keeps the old query's recall, so a marker hand-copied into an
    * unlabeled issue (as happens when issues are merged) still dedups.
    *

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -162,6 +162,12 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
    * filter: this keeps the old query's recall, so a marker hand-copied into an
    * unlabeled issue (as happens when issues are merged) still dedups.
    *
+   * Reviewer: index-independent is not lag-free. GitHub documents no
+   * read-after-write guarantee on the listing endpoint, and API reads can be
+   * served from a replica, so an issue another run filed moments ago may not
+   * appear here. `createdThisRun` below closes the same-transport case; the
+   * cross-run one is #1479.
+   *
    * Cached because triage runs up to two lookups per encounter; a 12-finding
    * session would otherwise re-list 24 times.
    */


### PR DESCRIPTION
## What changed

- Correct the dedup listing comment to say the comparison is exact and search-index-independent.
- Remove the unsupported claim that the listing endpoint is lag-free.

## Why

PR #1465 removed search-index dependence, but that does not establish a broader replication-lag guarantee. This follow-up makes the source match the post-merge review correction.

The description on PR #1465 has also been amended separately so its amendment note accurately acknowledges the residual-risk and follow-on-pointer edits.

## Impact

Documentation-only correction. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- `prettier --check packages/cli/src/retro/github-rest.ts`
- pre-commit ESLint and Prettier hooks
