### PR TITLE
Keep lint-hook edits free of Safeword upgrades

### DIFF
--- a/.project/tickets/1511-keep-lint-hook-off-network/ticket.md
+++ b/.project/tickets/1511-keep-lint-hook-off-network/ticket.md
@@ -4,8 +4,8 @@ slug: keep-lint-hook-off-network
 title: Keep lint-hook edits free of Safeword upgrades
 type: task
 subtype: bug
-phase: verify
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/1511
 scope:
   - Remove the lint hook's language-pack self-repair path.

--- a/.project/tickets/1511-keep-lint-hook-off-network/ticket.md
+++ b/.project/tickets/1511-keep-lint-hook-off-network/ticket.md
@@ -1,0 +1,66 @@
+---
+id: "1511"
+slug: keep-lint-hook-off-network
+title: Keep lint-hook edits free of Safeword upgrades
+type: task
+subtype: bug
+phase: verify
+status: in_progress
+external_issue: https://github.com/ArcadeAI/safeword/issues/1511
+scope:
+  - Remove the lint hook's language-pack self-repair path.
+  - Keep fallback linting active when a Safeword lint config is absent.
+  - Prevent lint-hook upgrade, staging, and commit side effects.
+out_of_scope:
+  - Session-start auto-upgrade behavior.
+  - Generic linter tool resolution.
+  - Language-pack detection or installation.
+done_when:
+  - A supported edit with a missing pack config never invokes a Safeword upgrade.
+  - The lint hook does not stage or commit repository changes.
+  - Fallback linting still runs without the missing Safeword config.
+created: 2026-07-26
+last_modified: 2026-07-26
+---
+
+# Task: Keep lint-hook edits free of Safeword upgrades
+
+**Type:** Bug
+
+**Scope:** Remove the lint hook's language-pack self-repair path. When a
+Safeword lint config is absent, the hook continues with the linter's defaults
+without running `safeword upgrade`, staging files, or creating a commit.
+
+**Out of Scope:** Session-start auto-upgrade behavior, generic linter tool
+resolution, and changes to language-pack detection or installation.
+
+**Done When:**
+
+- [x] Editing a supported file with a missing pack config never invokes a
+      Safeword upgrade from the lint hook.
+- [x] The lint hook does not stage or commit repository changes.
+- [x] Fallback linting still runs without the missing Safeword config.
+
+**Tests:**
+
+- [x] Integration: missing-config edits exercise TypeScript, Python, Go, Rust,
+      and SQL fallbacks without invoking Safeword or git.
+- [x] Integration: configured edits still pass the generated config to ESLint,
+      Ruff, golangci-lint, rustfmt, and SQLFluff.
+- [x] Integration: the shipped template and dogfood hook have the same
+      side-effect-free behavior across the full matrix.
+
+**Source:** [GitHub issue #1511](https://github.com/ArcadeAI/safeword/issues/1511)
+
+## Work Log
+
+- Removed the lint hook's duplicate language-pack repair path; session start
+  remains the sole owner of Safeword upgrades.
+- Preserved each linter's existing fallback behavior and generated-config
+  arguments when the config is present.
+- Added real subprocess coverage for both hook copies across missing and
+  configured TypeScript, Python, Go, Rust, and SQL cases.
+- Updated the public configuration reference with the fallback and side-effect
+  contract.
+- Ran the full refactor, quality-review, verify, and audit workflows; applied
+  every issue-scoped finding.

--- a/.project/tickets/1511-keep-lint-hook-off-network/verify.md
+++ b/.project/tickets/1511-keep-lint-hook-off-network/verify.md
@@ -1,0 +1,38 @@
+# Verify: Keep lint-hook edits free of Safeword upgrades (#1511)
+
+Verified on 2026-07-26 after rebasing onto `origin/main`.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5515/5515 tests pass (370 files; 5 pre-existing skips)
+**Gherkin:** ✅ Acceptance lane passes (494/497 scenarios; 3 expected skips)
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 0 scenarios marked complete — task ticket has no test-definitions.md
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ✅ No new friction — Walked a developer through editing a supported file with a missing generated config; worst step = JavaScript fallback tooling may still resolve through `bunx`; new steps vs before = 0, with the upgrade wait and implicit commit removed.
+**Evidence limits:** ✅ None
+
+Audit passed with warnings — no #1511-scoped errors remain. Config sync,
+dependency-cruiser (661 modules, 2,163 dependencies), Knip, package freshness,
+learning headers, domain docs, and the configured documentation inventory were
+clean. Duplication improved to 464 clones (8.54%) at the stable scope of the
+repository minus `.safeword` and `.project`, down from the prior 478-clone
+baseline. Pre-existing warnings remain for Python audit-tool coverage,
+agent-config structure/staleness, and four unrelated test-quality findings in
+the audit sample.
+
+## Issue evidence
+
+- The real-hook subprocess matrix passes for both shipped copies across missing
+  and configured TypeScript, Python, Go, Rust, and SQL paths (20/20 cases).
+- Missing configs never invoke `safeword`, `upgrade`, or git, and never create
+  `.safeword/`.
+- Configured paths retain ESLint, Ruff, golangci-lint, rustfmt, and SQLFluff
+  config arguments.
+- Two fresh-context quality-review passes approved the implementation; the
+  final pass found no correctness, security, scope, test, or documentation
+  issues.

--- a/.safeword/hooks/lib/lint-config.ts
+++ b/.safeword/hooks/lib/lint-config.ts
@@ -110,7 +110,7 @@ export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
  * declared check keeps this in step with the setup-side twin in
  * packs/sql/files.ts (kept in sync by hand — templates can't be imported from
  * src), so a declared-but-not-installed repo whose sqlfluff configs setup
- * suppressed doesn't fall through to the auto-upgrade path on every edit.
+ * suppressed still uses the host-owned formatting path.
  */
 export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
   if (existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'))) {

--- a/.safeword/hooks/lib/lint.ts
+++ b/.safeword/hooks/lib/lint.ts
@@ -4,9 +4,9 @@
 // Uses explicit --config flags pointing to .safeword/ configs for LLM enforcement.
 // This allows stricter rules for LLMs while humans use their normal project configs.
 //
-// Missing language-pack configs degrade to each linter's defaults. Upgrades are
-// owned by the session-start hook, so missing configs never trigger upgrade,
-// staging, or commit side effects from linting.
+// Missing language-pack configs never trigger upgrade, staging, or commit side
+// effects from linting. Version upgrades run at session start; pack repair is
+// manual, so fallback linting reports the missing config once per session.
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -218,6 +218,23 @@ function configArgs(configPath: string): string[] {
   return hasConfig(configPath) ? ['--config', configPath] : [];
 }
 
+/** Warn once per session when fallback linting cannot enforce Safeword rules. */
+function warnMissingSafewordConfig(
+  packName: string,
+  tool: string,
+  configPath: string,
+  warnings: string[],
+): void {
+  if (hasConfig(configPath)) return;
+  const warningKey = `pack:${packName}`;
+  if (toolWarnings.has(warningKey)) return;
+  toolWarnings.add(warningKey);
+  warnings.push(
+    `${packName} Safeword config is missing — linting with ${tool} defaults, not Safeword rules. ` +
+      'Run `safeword setup` or `safeword upgrade` to install it.',
+  );
+}
+
 /** Run prettier with safeword config if available */
 async function runPrettier(file: string): Promise<void> {
   // A non-Prettier formatter owns this repo — defer to it, don't restyle (V7GGJZ).
@@ -275,6 +292,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       };
     }
     if (host) return runHostToolchain(host);
+    warnMissingSafewordConfig('TypeScript', 'ESLint', SAFEWORD_ESLINT, warnings);
     const configArguments = configArgs(SAFEWORD_ESLINT);
     await $`bunx eslint ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await runPrettier(normalizedFile);
@@ -297,6 +315,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     ) {
       return { warnings };
     }
+    warnMissingSafewordConfig('Python', 'Ruff', SAFEWORD_RUFF, warnings);
     const configArguments = configArgs(SAFEWORD_RUFF);
     await $`ruff check ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await $`ruff format ${configArguments} ${normalizedFile}`.nothrow().quiet();
@@ -336,6 +355,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       }
       toolWarnings.add('golangci-lint-v2-ok');
     }
+    warnMissingSafewordConfig('Go', 'golangci-lint', SAFEWORD_GOLANGCI, warnings);
     const configArguments = configArgs(SAFEWORD_GOLANGCI);
     await $`golangci-lint run ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await $`golangci-lint fmt ${configArguments} ${normalizedFile}`.nothrow().quiet();
@@ -349,6 +369,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
   // Rust files - clippy for linting (package-level), rustfmt for formatting (file-level)
   if (RUST_EXTENSIONS.has(extension)) {
     const hasRustConfig = hasConfig(SAFEWORD_RUSTFMT);
+    warnMissingSafewordConfig('Rust', 'rustfmt', SAFEWORD_RUSTFMT, warnings);
 
     // Run clippy with package targeting for workspaces
     const packageName = detectRustPackage(normalizedFile);

--- a/.safeword/hooks/lib/lint.ts
+++ b/.safeword/hooks/lib/lint.ts
@@ -4,7 +4,9 @@
 // Uses explicit --config flags pointing to .safeword/ configs for LLM enforcement.
 // This allows stricter rules for LLMs while humans use their normal project configs.
 //
-// Auto-upgrades safeword if a language pack is missing.
+// Missing language-pack configs degrade to each linter's defaults. Upgrades are
+// owned by the session-start hook, so missing configs never trigger upgrade,
+// staging, or commit side effects from linting.
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -67,9 +69,6 @@ const SAFEWORD_PRETTIER = `${projectDir}/.safeword/.prettierrc`;
 // so it never restyles the customer's files into a competing style (ticket
 // V7GGJZ). ESLint still runs (security/complexity) — see lintFile.
 const REPO_OWNS_ALTERNATIVE_FORMATTER = projectOwnsAlternativeFormatter(projectDir);
-
-// Track if we've already tried upgrading (avoid repeated attempts in same process)
-let upgradeAttempted = false;
 
 // Track which tools we've already warned about (once per session)
 const toolWarnings = new Set<string>();
@@ -193,55 +192,6 @@ function detectRustPackage(filePath: string): string | undefined {
   return undefined;
 }
 
-/**
- * Run safeword upgrade and auto-commit .safeword/ changes.
- * Only runs once per process to avoid repeated slow upgrades.
- */
-async function ensurePackInstalled(packName: string, configPath: string): Promise<boolean> {
-  // Already have config
-  if (hasConfig(configPath)) return true;
-
-  // Match the project-wide auto-upgrade policy. The fallback linter below can
-  // still run with the host defaults when a user or CI opts out of repair.
-  if (process.env.SAFEWORD_NO_AUTO_UPGRADE || process.env.CI) return false;
-
-  // Already tried upgrading this session
-  if (upgradeAttempted) return false;
-  upgradeAttempted = true;
-
-  console.error(`${packName} pack missing, running upgrade...`);
-
-  const result = await $`bunx safeword@latest upgrade`.nothrow().quiet();
-  if (result.exitCode !== 0) {
-    console.error('Upgrade failed. Run manually: bunx safeword upgrade');
-    return false;
-  }
-
-  // If upgrade succeeded but config still missing, the language may be in
-  // a location safeword can't auto-detect.
-  if (!hasConfig(configPath)) {
-    console.error(
-      `${packName} config not created after upgrade. ` +
-        `Linting with ${packName} defaults (no strict safeword rules).`,
-    );
-  }
-
-  // Auto-commit .safeword/ (excluding learnings/ and logs/)
-  // Use -- .safeword/ to only commit safeword files, not other staged changes
-  await $`git add .safeword/ ':!.safeword/learnings/' ':!.safeword/logs/'`.nothrow().quiet();
-  const commitResult =
-    await $`git commit -m "chore: safeword auto-upgrade (${packName} pack)" -- .safeword/`
-      .nothrow()
-      .quiet();
-  if (commitResult.exitCode !== 0) {
-    console.error('Could not auto-commit .safeword/ changes (not a git repo or no changes)');
-  } else {
-    console.error('Upgrade complete and committed');
-  }
-
-  return hasConfig(configPath);
-}
-
 /** Run a linter in check-only mode and capture remaining errors after auto-fix.
  *  When a linter crashes (non-zero exit, empty stdout, stderr present), pushes
  *  an infrastructure warning instead of returning lint errors. */
@@ -264,8 +214,8 @@ async function captureRemainingErrors(
 }
 
 /** Build --config args if safeword config exists. */
-function configArgs(configPath: string, hasConfig_: boolean): string[] {
-  return hasConfig_ ? ['--config', configPath] : [];
+function configArgs(configPath: string): string[] {
+  return hasConfig(configPath) ? ['--config', configPath] : [];
 }
 
 /** Run prettier with safeword config if available */
@@ -298,7 +248,6 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
   const warnings: string[] = [];
 
   // JS/TS and framework files - ESLint first (fix code), then Prettier (format)
-  // Auto-upgrades safeword if TypeScript pack is missing
   if (JS_EXTENSIONS.has(extension)) {
     const canonicalRoot = normalizeExistingDirectory(_projectDir);
     const safewordDirectory = nodePath.join(canonicalRoot, '.safeword');
@@ -326,19 +275,17 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       };
     }
     if (host) return runHostToolchain(host);
-    const hasEslint = await ensurePackInstalled('TypeScript', SAFEWORD_ESLINT);
-    const cfg = configArgs(SAFEWORD_ESLINT, hasEslint);
-    await $`bunx eslint ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_ESLINT);
+    await $`bunx eslint ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await runPrettier(normalizedFile);
     const errors = await captureRemainingErrors(
-      ['bunx', 'eslint', ...cfg, normalizedFile],
+      ['bunx', 'eslint', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Python files - Ruff check (fix code), then Ruff format
-  // Auto-upgrades safeword if Python pack is missing
   if (PYTHON_EXTENSIONS.has(extension)) {
     if (
       !(await checkToolAvailable(
@@ -350,19 +297,17 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     ) {
       return { warnings };
     }
-    const hasRuff = await ensurePackInstalled('Python', SAFEWORD_RUFF);
-    const cfg = configArgs(SAFEWORD_RUFF, hasRuff);
-    await $`ruff check ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
-    await $`ruff format ${cfg} ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_RUFF);
+    await $`ruff check ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
+    await $`ruff format ${configArguments} ${normalizedFile}`.nothrow().quiet();
     const errors = await captureRemainingErrors(
-      ['ruff', 'check', ...cfg, normalizedFile],
+      ['ruff', 'check', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Go files - golangci-lint run (fix code), then golangci-lint fmt (format)
-  // Auto-upgrades safeword if Go pack is missing
   if (GO_EXTENSIONS.has(extension)) {
     if (
       !(await checkToolAvailable(
@@ -391,21 +336,19 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       }
       toolWarnings.add('golangci-lint-v2-ok');
     }
-    const hasGolangci = await ensurePackInstalled('Go', SAFEWORD_GOLANGCI);
-    const cfg = configArgs(SAFEWORD_GOLANGCI, hasGolangci);
-    await $`golangci-lint run ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
-    await $`golangci-lint fmt ${cfg} ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_GOLANGCI);
+    await $`golangci-lint run ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
+    await $`golangci-lint fmt ${configArguments} ${normalizedFile}`.nothrow().quiet();
     const errors = await captureRemainingErrors(
-      ['golangci-lint', 'run', ...cfg, normalizedFile],
+      ['golangci-lint', 'run', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Rust files - clippy for linting (package-level), rustfmt for formatting (file-level)
-  // Auto-upgrades safeword if Rust pack is missing
   if (RUST_EXTENSIONS.has(extension)) {
-    const hasRustConfig = await ensurePackInstalled('Rust', SAFEWORD_RUSTFMT);
+    const hasRustConfig = hasConfig(SAFEWORD_RUSTFMT);
 
     // Run clippy with package targeting for workspaces
     const packageName = detectRustPackage(normalizedFile);
@@ -454,16 +397,14 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       if (result.exitCode === 0) return { warnings };
       // Non-zero: the plugin is undeclared in the host config, or the edit
       // itself doesn't parse. Only fall through to sqlfluff when its config
-      // already exists — in a host-owned repo it's absent by design, and
-      // falling through would fire ensurePackInstalled's network upgrade on
-      // every failing edit. Surface prettier's stderr so the agent sees the
-      // parse error instead of silence.
+      // already exists — in a host-owned repo it's absent by design. Surface
+      // prettier's stderr so the agent sees the parse error instead of silence.
       if (!hasConfig(SAFEWORD_SQLFLUFF)) {
         const stderr = result.stderr.toString().trim();
         return { warnings, ...(stderr && { errors: stderr }) };
       }
     }
-    const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
+    const hasSqlfluff = hasConfig(SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {
       if (
         !(await checkToolAvailable(

--- a/packages/cli/templates/hooks/lib/lint-config.ts
+++ b/packages/cli/templates/hooks/lib/lint-config.ts
@@ -110,7 +110,7 @@ export function shouldWarnMissingPrettier(entries: readonly string[]): boolean {
  * declared check keeps this in step with the setup-side twin in
  * packs/sql/files.ts (kept in sync by hand — templates can't be imported from
  * src), so a declared-but-not-installed repo whose sqlfluff configs setup
- * suppressed doesn't fall through to the auto-upgrade path on every edit.
+ * suppressed still uses the host-owned formatting path.
  */
 export function hostFormatsSqlWithPrettier(projectDirectory: string): boolean {
   if (existsSync(nodePath.join(projectDirectory, 'node_modules', 'prettier-plugin-sql'))) {

--- a/packages/cli/templates/hooks/lib/lint.ts
+++ b/packages/cli/templates/hooks/lib/lint.ts
@@ -4,9 +4,9 @@
 // Uses explicit --config flags pointing to .safeword/ configs for LLM enforcement.
 // This allows stricter rules for LLMs while humans use their normal project configs.
 //
-// Missing language-pack configs degrade to each linter's defaults. Upgrades are
-// owned by the session-start hook, so missing configs never trigger upgrade,
-// staging, or commit side effects from linting.
+// Missing language-pack configs never trigger upgrade, staging, or commit side
+// effects from linting. Version upgrades run at session start; pack repair is
+// manual, so fallback linting reports the missing config once per session.
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -218,6 +218,23 @@ function configArgs(configPath: string): string[] {
   return hasConfig(configPath) ? ['--config', configPath] : [];
 }
 
+/** Warn once per session when fallback linting cannot enforce Safeword rules. */
+function warnMissingSafewordConfig(
+  packName: string,
+  tool: string,
+  configPath: string,
+  warnings: string[],
+): void {
+  if (hasConfig(configPath)) return;
+  const warningKey = `pack:${packName}`;
+  if (toolWarnings.has(warningKey)) return;
+  toolWarnings.add(warningKey);
+  warnings.push(
+    `${packName} Safeword config is missing — linting with ${tool} defaults, not Safeword rules. ` +
+      'Run `safeword setup` or `safeword upgrade` to install it.',
+  );
+}
+
 /** Run prettier with safeword config if available */
 async function runPrettier(file: string): Promise<void> {
   // A non-Prettier formatter owns this repo — defer to it, don't restyle (V7GGJZ).
@@ -275,6 +292,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       };
     }
     if (host) return runHostToolchain(host);
+    warnMissingSafewordConfig('TypeScript', 'ESLint', SAFEWORD_ESLINT, warnings);
     const configArguments = configArgs(SAFEWORD_ESLINT);
     await $`bunx eslint ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await runPrettier(normalizedFile);
@@ -297,6 +315,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     ) {
       return { warnings };
     }
+    warnMissingSafewordConfig('Python', 'Ruff', SAFEWORD_RUFF, warnings);
     const configArguments = configArgs(SAFEWORD_RUFF);
     await $`ruff check ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await $`ruff format ${configArguments} ${normalizedFile}`.nothrow().quiet();
@@ -336,6 +355,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       }
       toolWarnings.add('golangci-lint-v2-ok');
     }
+    warnMissingSafewordConfig('Go', 'golangci-lint', SAFEWORD_GOLANGCI, warnings);
     const configArguments = configArgs(SAFEWORD_GOLANGCI);
     await $`golangci-lint run ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await $`golangci-lint fmt ${configArguments} ${normalizedFile}`.nothrow().quiet();
@@ -349,6 +369,7 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
   // Rust files - clippy for linting (package-level), rustfmt for formatting (file-level)
   if (RUST_EXTENSIONS.has(extension)) {
     const hasRustConfig = hasConfig(SAFEWORD_RUSTFMT);
+    warnMissingSafewordConfig('Rust', 'rustfmt', SAFEWORD_RUSTFMT, warnings);
 
     // Run clippy with package targeting for workspaces
     const packageName = detectRustPackage(normalizedFile);

--- a/packages/cli/templates/hooks/lib/lint.ts
+++ b/packages/cli/templates/hooks/lib/lint.ts
@@ -4,7 +4,9 @@
 // Uses explicit --config flags pointing to .safeword/ configs for LLM enforcement.
 // This allows stricter rules for LLMs while humans use their normal project configs.
 //
-// Auto-upgrades safeword if a language pack is missing.
+// Missing language-pack configs degrade to each linter's defaults. Upgrades are
+// owned by the session-start hook, so missing configs never trigger upgrade,
+// staging, or commit side effects from linting.
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -67,9 +69,6 @@ const SAFEWORD_PRETTIER = `${projectDir}/.safeword/.prettierrc`;
 // so it never restyles the customer's files into a competing style (ticket
 // V7GGJZ). ESLint still runs (security/complexity) — see lintFile.
 const REPO_OWNS_ALTERNATIVE_FORMATTER = projectOwnsAlternativeFormatter(projectDir);
-
-// Track if we've already tried upgrading (avoid repeated attempts in same process)
-let upgradeAttempted = false;
 
 // Track which tools we've already warned about (once per session)
 const toolWarnings = new Set<string>();
@@ -193,55 +192,6 @@ function detectRustPackage(filePath: string): string | undefined {
   return undefined;
 }
 
-/**
- * Run safeword upgrade and auto-commit .safeword/ changes.
- * Only runs once per process to avoid repeated slow upgrades.
- */
-async function ensurePackInstalled(packName: string, configPath: string): Promise<boolean> {
-  // Already have config
-  if (hasConfig(configPath)) return true;
-
-  // Match the project-wide auto-upgrade policy. The fallback linter below can
-  // still run with the host defaults when a user or CI opts out of repair.
-  if (process.env.SAFEWORD_NO_AUTO_UPGRADE || process.env.CI) return false;
-
-  // Already tried upgrading this session
-  if (upgradeAttempted) return false;
-  upgradeAttempted = true;
-
-  console.error(`${packName} pack missing, running upgrade...`);
-
-  const result = await $`bunx safeword@latest upgrade`.nothrow().quiet();
-  if (result.exitCode !== 0) {
-    console.error('Upgrade failed. Run manually: bunx safeword upgrade');
-    return false;
-  }
-
-  // If upgrade succeeded but config still missing, the language may be in
-  // a location safeword can't auto-detect.
-  if (!hasConfig(configPath)) {
-    console.error(
-      `${packName} config not created after upgrade. ` +
-        `Linting with ${packName} defaults (no strict safeword rules).`,
-    );
-  }
-
-  // Auto-commit .safeword/ (excluding learnings/ and logs/)
-  // Use -- .safeword/ to only commit safeword files, not other staged changes
-  await $`git add .safeword/ ':!.safeword/learnings/' ':!.safeword/logs/'`.nothrow().quiet();
-  const commitResult =
-    await $`git commit -m "chore: safeword auto-upgrade (${packName} pack)" -- .safeword/`
-      .nothrow()
-      .quiet();
-  if (commitResult.exitCode !== 0) {
-    console.error('Could not auto-commit .safeword/ changes (not a git repo or no changes)');
-  } else {
-    console.error('Upgrade complete and committed');
-  }
-
-  return hasConfig(configPath);
-}
-
 /** Run a linter in check-only mode and capture remaining errors after auto-fix.
  *  When a linter crashes (non-zero exit, empty stdout, stderr present), pushes
  *  an infrastructure warning instead of returning lint errors. */
@@ -264,8 +214,8 @@ async function captureRemainingErrors(
 }
 
 /** Build --config args if safeword config exists. */
-function configArgs(configPath: string, hasConfig_: boolean): string[] {
-  return hasConfig_ ? ['--config', configPath] : [];
+function configArgs(configPath: string): string[] {
+  return hasConfig(configPath) ? ['--config', configPath] : [];
 }
 
 /** Run prettier with safeword config if available */
@@ -298,7 +248,6 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
   const warnings: string[] = [];
 
   // JS/TS and framework files - ESLint first (fix code), then Prettier (format)
-  // Auto-upgrades safeword if TypeScript pack is missing
   if (JS_EXTENSIONS.has(extension)) {
     const canonicalRoot = normalizeExistingDirectory(_projectDir);
     const safewordDirectory = nodePath.join(canonicalRoot, '.safeword');
@@ -326,19 +275,17 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       };
     }
     if (host) return runHostToolchain(host);
-    const hasEslint = await ensurePackInstalled('TypeScript', SAFEWORD_ESLINT);
-    const cfg = configArgs(SAFEWORD_ESLINT, hasEslint);
-    await $`bunx eslint ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_ESLINT);
+    await $`bunx eslint ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
     await runPrettier(normalizedFile);
     const errors = await captureRemainingErrors(
-      ['bunx', 'eslint', ...cfg, normalizedFile],
+      ['bunx', 'eslint', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Python files - Ruff check (fix code), then Ruff format
-  // Auto-upgrades safeword if Python pack is missing
   if (PYTHON_EXTENSIONS.has(extension)) {
     if (
       !(await checkToolAvailable(
@@ -350,19 +297,17 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
     ) {
       return { warnings };
     }
-    const hasRuff = await ensurePackInstalled('Python', SAFEWORD_RUFF);
-    const cfg = configArgs(SAFEWORD_RUFF, hasRuff);
-    await $`ruff check ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
-    await $`ruff format ${cfg} ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_RUFF);
+    await $`ruff check ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
+    await $`ruff format ${configArguments} ${normalizedFile}`.nothrow().quiet();
     const errors = await captureRemainingErrors(
-      ['ruff', 'check', ...cfg, normalizedFile],
+      ['ruff', 'check', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Go files - golangci-lint run (fix code), then golangci-lint fmt (format)
-  // Auto-upgrades safeword if Go pack is missing
   if (GO_EXTENSIONS.has(extension)) {
     if (
       !(await checkToolAvailable(
@@ -391,21 +336,19 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       }
       toolWarnings.add('golangci-lint-v2-ok');
     }
-    const hasGolangci = await ensurePackInstalled('Go', SAFEWORD_GOLANGCI);
-    const cfg = configArgs(SAFEWORD_GOLANGCI, hasGolangci);
-    await $`golangci-lint run ${cfg} --fix ${normalizedFile}`.nothrow().quiet();
-    await $`golangci-lint fmt ${cfg} ${normalizedFile}`.nothrow().quiet();
+    const configArguments = configArgs(SAFEWORD_GOLANGCI);
+    await $`golangci-lint run ${configArguments} --fix ${normalizedFile}`.nothrow().quiet();
+    await $`golangci-lint fmt ${configArguments} ${normalizedFile}`.nothrow().quiet();
     const errors = await captureRemainingErrors(
-      ['golangci-lint', 'run', ...cfg, normalizedFile],
+      ['golangci-lint', 'run', ...configArguments, normalizedFile],
       warnings,
     );
     return { warnings, ...(errors && { errors }) };
   }
 
   // Rust files - clippy for linting (package-level), rustfmt for formatting (file-level)
-  // Auto-upgrades safeword if Rust pack is missing
   if (RUST_EXTENSIONS.has(extension)) {
-    const hasRustConfig = await ensurePackInstalled('Rust', SAFEWORD_RUSTFMT);
+    const hasRustConfig = hasConfig(SAFEWORD_RUSTFMT);
 
     // Run clippy with package targeting for workspaces
     const packageName = detectRustPackage(normalizedFile);
@@ -454,16 +397,14 @@ export async function lintFile(file: string, _projectDir: string): Promise<LintR
       if (result.exitCode === 0) return { warnings };
       // Non-zero: the plugin is undeclared in the host config, or the edit
       // itself doesn't parse. Only fall through to sqlfluff when its config
-      // already exists — in a host-owned repo it's absent by design, and
-      // falling through would fire ensurePackInstalled's network upgrade on
-      // every failing edit. Surface prettier's stderr so the agent sees the
-      // parse error instead of silence.
+      // already exists — in a host-owned repo it's absent by design. Surface
+      // prettier's stderr so the agent sees the parse error instead of silence.
       if (!hasConfig(SAFEWORD_SQLFLUFF)) {
         const stderr = result.stderr.toString().trim();
         return { warnings, ...(stderr && { errors: stderr }) };
       }
     }
-    const hasSqlfluff = await ensurePackInstalled('sql', SAFEWORD_SQLFLUFF);
+    const hasSqlfluff = hasConfig(SAFEWORD_SQLFLUFF);
     if (hasSqlfluff) {
       if (
         !(await checkToolAvailable(

--- a/packages/cli/tests/hooks/lint-config-fallback.test.ts
+++ b/packages/cli/tests/hooks/lint-config-fallback.test.ts
@@ -32,6 +32,8 @@ const LANGUAGE_CASES = [
     languageName: 'TypeScript',
     extension: 'ts',
     configRelativePath: undefined,
+    expectedWarning:
+      'TypeScript Safeword config is missing — linting with ESLint defaults, not Safeword rules. Run `safeword setup` or `safeword upgrade` to install it.',
     forbidConfigArgument: true,
     stubCommands: [],
     expectedInvocations: [
@@ -44,6 +46,7 @@ const LANGUAGE_CASES = [
     languageName: 'configured TypeScript',
     extension: 'ts',
     configRelativePath: '.safeword/eslint.config.mjs',
+    expectedWarning: undefined,
     forbidConfigArgument: false,
     stubCommands: [],
     expectedInvocations: [
@@ -56,6 +59,8 @@ const LANGUAGE_CASES = [
     languageName: 'Python',
     extension: 'py',
     configRelativePath: undefined,
+    expectedWarning:
+      'Python Safeword config is missing — linting with Ruff defaults, not Safeword rules. Run `safeword setup` or `safeword upgrade` to install it.',
     forbidConfigArgument: true,
     stubCommands: ['ruff'],
     expectedInvocations: [
@@ -68,6 +73,7 @@ const LANGUAGE_CASES = [
     languageName: 'configured Python',
     extension: 'py',
     configRelativePath: '.safeword/ruff.toml',
+    expectedWarning: undefined,
     forbidConfigArgument: false,
     stubCommands: ['ruff'],
     expectedInvocations: [
@@ -80,6 +86,8 @@ const LANGUAGE_CASES = [
     languageName: 'Go',
     extension: 'go',
     configRelativePath: undefined,
+    expectedWarning:
+      'Go Safeword config is missing — linting with golangci-lint defaults, not Safeword rules. Run `safeword setup` or `safeword upgrade` to install it.',
     forbidConfigArgument: true,
     stubCommands: ['golangci-lint'],
     expectedInvocations: [
@@ -93,6 +101,7 @@ const LANGUAGE_CASES = [
     languageName: 'configured Go',
     extension: 'go',
     configRelativePath: '.safeword/.golangci.yml',
+    expectedWarning: undefined,
     forbidConfigArgument: false,
     stubCommands: ['golangci-lint'],
     expectedInvocations: [
@@ -106,6 +115,8 @@ const LANGUAGE_CASES = [
     languageName: 'Rust',
     extension: 'rs',
     configRelativePath: undefined,
+    expectedWarning:
+      'Rust Safeword config is missing — linting with rustfmt defaults, not Safeword rules. Run `safeword setup` or `safeword upgrade` to install it.',
     forbidConfigArgument: true,
     stubCommands: ['rustfmt'],
     expectedInvocations: [/^rustfmt .*source\.rs$/],
@@ -114,6 +125,7 @@ const LANGUAGE_CASES = [
     languageName: 'configured Rust',
     extension: 'rs',
     configRelativePath: '.safeword/rustfmt.toml',
+    expectedWarning: undefined,
     forbidConfigArgument: false,
     stubCommands: ['rustfmt'],
     expectedInvocations: [/^rustfmt --config-path .*\/\.safeword\/rustfmt\.toml .*source\.rs$/],
@@ -122,6 +134,7 @@ const LANGUAGE_CASES = [
     languageName: 'SQL',
     extension: 'sql',
     configRelativePath: undefined,
+    expectedWarning: undefined,
     forbidConfigArgument: true,
     stubCommands: [],
     expectedInvocations: [],
@@ -130,6 +143,7 @@ const LANGUAGE_CASES = [
     languageName: 'configured SQL',
     extension: 'sql',
     configRelativePath: '.safeword/sqlfluff.cfg',
+    expectedWarning: undefined,
     forbidConfigArgument: false,
     stubCommands: ['sqlfluff'],
     expectedInvocations: [/^sqlfluff lint --config .*\/\.safeword\/sqlfluff\.cfg .*source\.sql$/],
@@ -155,11 +169,12 @@ describe('lintFile language-pack config ownership', () => {
       configRelativePath,
       extension,
       expectedInvocations,
+      expectedWarning,
       forbidConfigArgument,
       modulePath,
       stubCommands,
     }) => {
-      const directory = mkdtempSync(path.join(tmpdir(), 'lint-no-auto-upgrade-'));
+      const directory = mkdtempSync(path.join(tmpdir(), 'lint-config-fallback-'));
       directories.push(directory);
       const sourceFile = path.join(directory, `source.${extension}`);
       const stubBin = path.join(directory, 'stub-bin');
@@ -187,8 +202,9 @@ describe('lintFile language-pack config ownership', () => {
 
       const script = `
         const { lintFile } = await import(${JSON.stringify(modulePath)});
-        const result = await lintFile(${JSON.stringify(sourceFile)}, ${JSON.stringify(directory)});
-        console.log(JSON.stringify(result));
+        const first = await lintFile(${JSON.stringify(sourceFile)}, ${JSON.stringify(directory)});
+        const second = await lintFile(${JSON.stringify(sourceFile)}, ${JSON.stringify(directory)});
+        console.log(JSON.stringify({ first, second }));
       `;
       const { stdout } = await execFileAsync('bun', ['-e', script], {
         cwd: REPO_ROOT,
@@ -200,13 +216,22 @@ describe('lintFile language-pack config ownership', () => {
         timeout: 30_000,
       });
 
-      expect(JSON.parse(stdout.trim())).toEqual({ warnings: [] });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        first: { warnings: expectedWarning ? [expectedWarning] : [] },
+        second: { warnings: [] },
+      });
       const invocations = existsSync(invocationLog)
         ? readFileSync(invocationLog, 'utf8').trim().split('\n')
         : [];
-      expect(invocations).toEqual(
-        expect.arrayContaining(expectedInvocations.map(pattern => expect.stringMatching(pattern))),
-      );
+      if (expectedInvocations.length === 0) {
+        expect(invocations).toEqual([]);
+      } else {
+        expect(invocations).toEqual(
+          expect.arrayContaining(
+            expectedInvocations.map(pattern => expect.stringMatching(pattern)),
+          ),
+        );
+      }
       const forbiddenSideEffect = [
         /^git /,
         /(?:^| )safeword(?:@| |$)/,

--- a/packages/cli/tests/hooks/lint-no-auto-upgrade.test.ts
+++ b/packages/cli/tests/hooks/lint-no-auto-upgrade.test.ts
@@ -1,0 +1,226 @@
+import { execFile } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const LINT_MODULES = [
+  {
+    moduleName: 'shipped template',
+    modulePath: path.resolve(__dirname, '../../templates/hooks/lib/lint.ts'),
+  },
+  {
+    moduleName: 'dogfood hook',
+    modulePath: path.resolve(REPO_ROOT, '.safeword/hooks/lib/lint.ts'),
+  },
+];
+const LANGUAGE_CASES = [
+  {
+    languageName: 'TypeScript',
+    extension: 'ts',
+    configRelativePath: undefined,
+    forbidConfigArgument: true,
+    stubCommands: [],
+    expectedInvocations: [
+      /^bunx eslint --fix .*source\.ts$/,
+      /^bunx eslint .*source\.ts$/,
+      /^bunx prettier --write .*source\.ts$/,
+    ],
+  },
+  {
+    languageName: 'configured TypeScript',
+    extension: 'ts',
+    configRelativePath: '.safeword/eslint.config.mjs',
+    forbidConfigArgument: false,
+    stubCommands: [],
+    expectedInvocations: [
+      /^bunx eslint --config .*\/\.safeword\/eslint\.config\.mjs --fix .*source\.ts$/,
+      /^bunx eslint --config .*\/\.safeword\/eslint\.config\.mjs .*source\.ts$/,
+      /^bunx prettier --write .*source\.ts$/,
+    ],
+  },
+  {
+    languageName: 'Python',
+    extension: 'py',
+    configRelativePath: undefined,
+    forbidConfigArgument: true,
+    stubCommands: ['ruff'],
+    expectedInvocations: [
+      /^ruff check --fix .*source\.py$/,
+      /^ruff format .*source\.py$/,
+      /^ruff check .*source\.py$/,
+    ],
+  },
+  {
+    languageName: 'configured Python',
+    extension: 'py',
+    configRelativePath: '.safeword/ruff.toml',
+    forbidConfigArgument: false,
+    stubCommands: ['ruff'],
+    expectedInvocations: [
+      /^ruff check --config .*\/\.safeword\/ruff\.toml --fix .*source\.py$/,
+      /^ruff format --config .*\/\.safeword\/ruff\.toml .*source\.py$/,
+      /^ruff check --config .*\/\.safeword\/ruff\.toml .*source\.py$/,
+    ],
+  },
+  {
+    languageName: 'Go',
+    extension: 'go',
+    configRelativePath: undefined,
+    forbidConfigArgument: true,
+    stubCommands: ['golangci-lint'],
+    expectedInvocations: [
+      /^golangci-lint version --short$/,
+      /^golangci-lint run --fix .*source\.go$/,
+      /^golangci-lint fmt .*source\.go$/,
+      /^golangci-lint run .*source\.go$/,
+    ],
+  },
+  {
+    languageName: 'configured Go',
+    extension: 'go',
+    configRelativePath: '.safeword/.golangci.yml',
+    forbidConfigArgument: false,
+    stubCommands: ['golangci-lint'],
+    expectedInvocations: [
+      /^golangci-lint version --short$/,
+      /^golangci-lint run --config .*\/\.safeword\/\.golangci\.yml --fix .*source\.go$/,
+      /^golangci-lint fmt --config .*\/\.safeword\/\.golangci\.yml .*source\.go$/,
+      /^golangci-lint run --config .*\/\.safeword\/\.golangci\.yml .*source\.go$/,
+    ],
+  },
+  {
+    languageName: 'Rust',
+    extension: 'rs',
+    configRelativePath: undefined,
+    forbidConfigArgument: true,
+    stubCommands: ['rustfmt'],
+    expectedInvocations: [/^rustfmt .*source\.rs$/],
+  },
+  {
+    languageName: 'configured Rust',
+    extension: 'rs',
+    configRelativePath: '.safeword/rustfmt.toml',
+    forbidConfigArgument: false,
+    stubCommands: ['rustfmt'],
+    expectedInvocations: [/^rustfmt --config-path .*\/\.safeword\/rustfmt\.toml .*source\.rs$/],
+  },
+  {
+    languageName: 'SQL',
+    extension: 'sql',
+    configRelativePath: undefined,
+    forbidConfigArgument: true,
+    stubCommands: [],
+    expectedInvocations: [],
+  },
+  {
+    languageName: 'configured SQL',
+    extension: 'sql',
+    configRelativePath: '.safeword/sqlfluff.cfg',
+    forbidConfigArgument: false,
+    stubCommands: ['sqlfluff'],
+    expectedInvocations: [/^sqlfluff lint --config .*\/\.safeword\/sqlfluff\.cfg .*source\.sql$/],
+  },
+];
+const LINT_CASES = LINT_MODULES.flatMap(lintModule =>
+  LANGUAGE_CASES.map(languageCase => ({ ...lintModule, ...languageCase })),
+);
+
+describe('lintFile language-pack config ownership', () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    directories.length = 0;
+  });
+
+  it.each(LINT_CASES)(
+    '$moduleName keeps $languageName upgrade and git side effects off the edit path',
+    async ({
+      configRelativePath,
+      extension,
+      expectedInvocations,
+      forbidConfigArgument,
+      modulePath,
+      stubCommands,
+    }) => {
+      const directory = mkdtempSync(path.join(tmpdir(), 'lint-no-auto-upgrade-'));
+      directories.push(directory);
+      const sourceFile = path.join(directory, `source.${extension}`);
+      const stubBin = path.join(directory, 'stub-bin');
+      const invocationLog = path.join(directory, 'invocations.log');
+      mkdirSync(stubBin);
+      writeFileSync(sourceFile, 'export const source = 1;\n');
+      if (configRelativePath) {
+        const configPath = path.join(directory, configRelativePath);
+        mkdirSync(path.dirname(configPath), { recursive: true });
+        writeFileSync(configPath, '');
+      }
+
+      for (const command of ['bunx', 'git', ...stubCommands]) {
+        const stub = path.join(stubBin, command);
+        const versionOutput =
+          command === 'golangci-lint'
+            ? 'if [ "$1 $2" = "version --short" ]; then printf "2.0.0\\n"; fi\n'
+            : '';
+        writeFileSync(
+          stub,
+          `#!/bin/sh\nprintf '%s %s\\n' ${JSON.stringify(command)} "$*" >> ${JSON.stringify(invocationLog)}\n${versionOutput}exit 0\n`,
+        );
+        chmodSync(stub, 0o755);
+      }
+
+      const script = `
+        const { lintFile } = await import(${JSON.stringify(modulePath)});
+        const result = await lintFile(${JSON.stringify(sourceFile)}, ${JSON.stringify(directory)});
+        console.log(JSON.stringify(result));
+      `;
+      const { stdout } = await execFileAsync('bun', ['-e', script], {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          CLAUDE_PROJECT_DIR: directory,
+          PATH: `${stubBin}${path.delimiter}${process.env.PATH ?? ''}`,
+        },
+        timeout: 30_000,
+      });
+
+      expect(JSON.parse(stdout.trim())).toEqual({ warnings: [] });
+      const invocations = existsSync(invocationLog)
+        ? readFileSync(invocationLog, 'utf8').trim().split('\n')
+        : [];
+      expect(invocations).toEqual(
+        expect.arrayContaining(expectedInvocations.map(pattern => expect.stringMatching(pattern))),
+      );
+      const forbiddenSideEffect = [
+        /^git /,
+        /(?:^| )safeword(?:@| |$)/,
+        /(?:^| )upgrade(?: |$)/,
+        ...(forbidConfigArgument ? [/(?:^| )--config(?: |$)/] : []),
+      ];
+      expect(
+        invocations.some(invocation =>
+          forbiddenSideEffect.some(pattern => pattern.test(invocation)),
+        ),
+      ).toBe(false);
+      if (!configRelativePath) {
+        expect(existsSync(path.join(directory, '.safeword'))).toBe(false);
+      }
+    },
+  );
+});

--- a/packages/cli/tests/hooks/lint-sql-branch.test.ts
+++ b/packages/cli/tests/hooks/lint-sql-branch.test.ts
@@ -3,8 +3,7 @@
  * (#636/#638): prettier-plugin-sql present, no .safeword/sqlfluff.cfg (setup
  * suppresses it by design). When the host prettier run fails, the hook must
  * surface prettier's error to the agent and return — NOT fall through to the
- * sqlfluff/auto-upgrade path, which would fire a network upgrade attempt on
- * every failing SQL edit.
+ * secondary sqlfluff formatter.
  *
  * lint.ts imports Bun's `$`, so it can't be imported under the node-based
  * vitest process — the hook runs in a `bun` subprocess instead, with cwd at
@@ -46,7 +45,7 @@ describe('lintFile SQL branch — host-owned prettier formatting', () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  it('surfaces the prettier error and does not fall through to the upgrade path when prettier fails', async () => {
+  it('surfaces the prettier error and does not fall through to sqlfluff when prettier fails', async () => {
     // Valid SQL, but the temp dir has no prettier config declaring the sql
     // plugin — prettier exits non-zero ("No parser could be inferred"), the
     // same failure shape as an unparseable agent edit.
@@ -67,8 +66,7 @@ describe('lintFile SQL branch — host-owned prettier formatting', () => {
     const result = JSON.parse(stdout.trim()) as { warnings: string[]; errors?: string };
     // The agent gets prettier's parse error instead of silence.
     expect(result.errors).toMatch(/parser/i);
-    // No fall-through side effects: ensurePackInstalled would have created or
-    // touched .safeword/ via `safeword upgrade` + git; the guard returns first.
+    // The guard returns before any secondary formatter can create state.
     expect(existsSync(path.join(directory, '.safeword'))).toBe(false);
   }, 90_000);
 });
@@ -85,7 +83,7 @@ describe('lintFile SQL branch — sqlfluff dispatch', () => {
 
   beforeAll(() => {
     directory = mkdtempSync(path.join(tmpdir(), 'lint-sql-dispatch-'));
-    // sqlfluff config present → ensurePackInstalled short-circuits, no upgrade.
+    // sqlfluff config present → dispatch directly to sqlfluff.
     mkdirSync(path.join(directory, '.safeword'), { recursive: true });
     writeFileSync(path.join(directory, '.safeword', 'sqlfluff.cfg'), '[sqlfluff]\n');
     writeFileSync(path.join(directory, 'query.sql'), 'select 1;\n');

--- a/packages/cli/tests/integration/invisible-extension.test.ts
+++ b/packages/cli/tests/integration/invisible-extension.test.ts
@@ -340,9 +340,9 @@ formatters:
         expect(lintHook).toContain('.safeword/ruff.toml');
         expect(lintHook).toContain('.safeword/.golangci.yml');
 
-        // Should use --config flag when safeword configs exist
+        // The generated hook carries explicit config support. Runtime selection
+        // with and without these files is covered by lint-no-auto-upgrade.test.ts.
         expect(lintHook).toContain('--config');
-        expect(lintHook).toContain('hasEslint');
       },
       SETUP_TIMEOUT,
     );

--- a/packages/cli/tests/integration/invisible-extension.test.ts
+++ b/packages/cli/tests/integration/invisible-extension.test.ts
@@ -341,7 +341,7 @@ formatters:
         expect(lintHook).toContain('.safeword/.golangci.yml');
 
         // The generated hook carries explicit config support. Runtime selection
-        // with and without these files is covered by lint-no-auto-upgrade.test.ts.
+        // with and without these files is covered by lint-config-fallback.test.ts.
         expect(lintHook).toContain('--config');
       },
       SETUP_TIMEOUT,

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -90,6 +90,8 @@ Safeword auto-detects your stack and configures linting accordingly:
 
 Detection is stored in `.safeword/config.json`. To force a refresh, delete that file and run `safeword setup` again.
 
+Edit-time linting uses the generated language-pack config when it exists. If that config is missing, linting falls back to the tool's defaults; the lint hook does not repair the pack, run `safeword upgrade`, stage files, or create a commit. Safeword updates remain the responsibility of the session-start auto-upgrade.
+
 ## Biome & Alternative Formatters
 
 If your project uses Biome, dprint, or Rome, Safeword detects it automatically and skips Prettier installation. Your formatter keeps running as-is.

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -90,7 +90,7 @@ Safeword auto-detects your stack and configures linting accordingly:
 
 Detection is stored in `.safeword/config.json`. To force a refresh, delete that file and run `safeword setup` again.
 
-Edit-time linting uses the generated language-pack config when it exists. For JavaScript/TypeScript, Python, Go, and Rust, a missing config falls back to the tool's defaults. SQLFluff runs only when its generated config exists. In either case, the lint hook does not repair the pack, run `safeword upgrade`, stage files, or create a commit. Safeword updates remain the responsibility of the session-start auto-upgrade.
+Edit-time linting uses the generated language-pack config when it exists. For JavaScript/TypeScript, Python, Go, and Rust, a missing config falls back to the tool's defaults and reports once per session that Safeword rules are not active. SQLFluff runs only when its generated config exists. The lint hook never repairs a pack, runs an upgrade, stages files, or creates a commit. Version upgrades remain the responsibility of the session-start auto-upgrade; to repair a missing pack manually, run `safeword setup` or `safeword upgrade`.
 
 ## Biome & Alternative Formatters
 

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -90,7 +90,7 @@ Safeword auto-detects your stack and configures linting accordingly:
 
 Detection is stored in `.safeword/config.json`. To force a refresh, delete that file and run `safeword setup` again.
 
-Edit-time linting uses the generated language-pack config when it exists. If that config is missing, linting falls back to the tool's defaults; the lint hook does not repair the pack, run `safeword upgrade`, stage files, or create a commit. Safeword updates remain the responsibility of the session-start auto-upgrade.
+Edit-time linting uses the generated language-pack config when it exists. For JavaScript/TypeScript, Python, Go, and Rust, a missing config falls back to the tool's defaults. SQLFluff runs only when its generated config exists. In either case, the lint hook does not repair the pack, run `safeword upgrade`, stage files, or create a commit. Safeword updates remain the responsibility of the session-start auto-upgrade.
 
 ## Biome & Alternative Formatters
 


### PR DESCRIPTION
## Summary

- remove the edit-time lint hook's duplicate language-pack repair path
- fall back to existing tool behavior when generated configs are absent, without running Safeword upgrade, staging, or commit commands
- preserve generated config arguments when configs exist across TypeScript, Python, Go, Rust, and SQL
- document the missing-config behavior and keep the shipped template and dogfood hook aligned

## Root cause

The lint hook treated a missing language-pack config as a repair trigger. That allowed an ordinary post-edit lint pass to run `safeword upgrade` and then stage and commit repository changes, duplicating the session-start upgrade owner and introducing network and git side effects into the edit path.

## Validation

- 5,515 Vitest tests passed; 5 skipped
- 494/497 Gherkin scenarios passed; 3 expected skips
- build, lint, and TypeScript typecheck passed
- real subprocess matrix covers configured and missing-config behavior for both hook copies across all five language branches
- final independent quality review approved with no correctness, security, scope, test, or documentation findings

Closes #1511