### PR TITLE
Close the override regression ticket

### DIFF
--- a/.project/tickets/5KHSQB-keep-override-regressions-fast/ticket.md
+++ b/.project/tickets/5KHSQB-keep-override-regressions-fast/ticket.md
@@ -2,10 +2,11 @@
 id: 5KHSQB
 slug: keep-override-regressions-fast
 type: task
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-07-26T14:35:33.508Z
-last_modified: 2026-07-27T03:00:41Z
+last_modified: 2026-07-27T06:22:22Z
+external_prs: [https://github.com/ArcadeAI/safeword/pull/1478]
 ---
 
 # Keep override regressions fast for maintainers
@@ -41,6 +42,9 @@ and make hook-launch failures explicit.
 
 ## Work Log
 
+- 2026-07-27T06:22:22Z Closed: PR #1478 admin-squash-merged as
+  `060813804fea791618143040f24daae8ae1c552a`; local verification and all four
+  GitHub CI checks passed.
 - 2026-07-27T03:00:41Z Final verification: merged current `origin/main`;
   full suite passed 5,503 tests across 371 files with 5 skipped; 494/494
   runnable Gherkin scenarios passed; build, lint, typecheck, audit, and


### PR DESCRIPTION
## Summary

- mark ticket 5KHSQB as `phase: done` and `status: done`
- link merged PR #1478 and record its squash-merge commit
- preserve the completed verification artifact and work log

## Why

PR #1478 merged with all local and GitHub checks green, but its project ticket remained open on `main`. This follow-up closes that bookkeeping gap.

## Validation

- Prettier check passed
- markdownlint passed
- `safeword check` accepted the done transition; unrelated existing advisories remain unchanged
- diff is limited to the ticket file

## Quality Review

**Verdict: APPROVE** — no critical issues. Full review in the [review thread](https://github.com/ArcadeAI/safeword/pull/1525#pullrequestreview-4787963469). Verified against live GitHub/git state:

- Merge commit `060813804fea791618143040f24daae8ae1c552a` is exactly the squash-merge of #1478 on `main`
- #1478 state `MERGED`, `mergedAt` 2026-07-27T06:18:16Z — 4m06s before this ticket's `last_modified` of 06:22:22Z
- `external_prs` matches the single-line list form used by the six other tickets carrying the field, and the shape `packages/cli/src/ticket-sync/index.ts:164` parses via `parseStringList`
- `phase: done` + `status: done` is the dominant pairing (229 done tickets); no orphan `phase: verify` left behind
- Done-gate artifacts all present: `verify.md`, `test-definitions.md`, `impl-plan.md`, `user-stories.md`

### Known gaps (both non-blocking, deliberately out of scope here)

1. **`INDEX.md` was not regenerated.** `5KHSQB` appears in neither `.project/tickets/INDEX.md` nor `INDEX-completed.md`. The closest precedent for this same close-a-merged-ticket pattern, #1403 for `KCFH00`, updated `INDEX.md` in the same commit. Left out on purpose: the index is systemically stale — 20 of 454 ticket directories are absent, last regenerated 2026-07-24 in `7f150cbb`, two days before this ticket existed — so a `sync-tickets` run here would drag 19 unrelated tickets into a bookkeeping diff. No CI gate enforces index freshness. Better as its own sync pass.
2. **"all four GitHub CI checks passed" is slightly imprecise.** #1478's check rollup shows `lint` concluding `FAILURE` on one run before a green re-run; the other three were green first time. Final state at merge was four-for-four green, so the closure decision is sound — the log line just reads cleaner than the run history was.
