### PR TITLE
Surface reply format before Claude responds

### DIFF
--- a/.project/learnings/long-session-style-drift.md
+++ b/.project/learnings/long-session-style-drift.md
@@ -51,7 +51,11 @@ The lookup question when adding or moving a rule: "if the model goes 50 turns wi
 ## When NOT to apply
 
 - **Don't preemptively wrap every rule.** Preamble inflation is its own problem — see ticket QSNKBB-prompt-brevity-cut where 7 lines of philosophical preamble were cut precisely because they were re-injecting content already in SAFEWORD.md.
-- **Don't add per-turn UserPromptSubmit re-injection** for rules that have natural Stop-fire cadence. 50× the token cost of a Stop-hook pointer for no extra steering benefit.
+- **Don't add per-turn UserPromptSubmit re-injection** merely because a rule has
+  natural Stop-fire cadence. Add it only when evidence shows that Stop arrives
+  too late or is intentionally quiet for the relevant turn. Issue #1524 is the
+  counter-example for the compact reply-format rule: its reminder is gated to
+  lead-only during active TDD steps, preserving the Stop hook's quiet workflow.
 - **Don't add pointers to every skill output template.** Skill outputs aren't system reminders, so they don't bypass the dismissive wrapper anyway. High maintenance burden, no actual fix.
 
 ## Tickets where this pattern was established

--- a/.project/learnings/long-session-style-drift.md
+++ b/.project/learnings/long-session-style-drift.md
@@ -56,6 +56,10 @@ The lookup question when adding or moving a rule: "if the model goes 50 turns wi
   too late or is intentionally quiet for the relevant turn. Issue #1524 is the
   counter-example for the compact reply-format rule: its reminder is gated to
   lead-only during active TDD steps, preserving the Stop hook's quiet workflow.
+  Note the cost correction: this bullet once claimed "50× the token cost of a
+  Stop-hook pointer," which was wrong. Stop and UserPromptSubmit both fire
+  roughly once per turn, so a one-line pointer costs about the same either way
+  (~40 tokens per prompt). Weigh the two on **timing**, not cost.
 - **Don't add pointers to every skill output template.** Skill outputs aren't system reminders, so they don't bypass the dismissive wrapper anyway. High maintenance burden, no actual fix.
 
 ## Tickets where this pattern was established
@@ -63,6 +67,7 @@ The lookup question when adding or moving a rule: "if the model goes 50 turns wi
 - F14BG2-stop-hook-verdict-shape — reshaped the Stop-hook verdict to a scannable decision brief.
 - QSNKBB-prompt-brevity-cut — cut SAFEWORD.md-duplicated preamble from the same hook.
 - 68SRC8-long-session-rule-stickiness — applied the pattern (recency placement + hook pointer) and wrote this learning file.
+- K8D3M4-reply-format-proactive-reminder — hit 68SRC8's own revisit trigger (issue #1524) and narrowed the "When NOT to apply" bullet above: added the per-turn reminder for the reply-format rule only, gated off intentionally quiet TDD steps, with the shared wording owned by `hooks/lib/quality.ts`.
 
 ## Provenance of the claims here
 

--- a/.project/tickets/5ARWDG-lean-system-prompt-resilience/ticket.md
+++ b/.project/tickets/5ARWDG-lean-system-prompt-resilience/ticket.md
@@ -7,7 +7,7 @@ status: in_progress
 epic: cc-changelog-alignment
 relates_to: 8R54HV
 created: 2026-05-31T21:05:09.536Z
-last_modified: 2026-05-31T21:05:09.536Z
+last_modified: 2026-07-27T19:17:12Z
 ---
 
 # Verify per-turn reminders land under lean system prompt default
@@ -42,7 +42,18 @@ Opus 4.8 sessions get less baseline scaffolding. Project instructions (`CLAUDE.m
 
 - Rewriting SAFEWORD.md methodology; this is a verification spike, not a redesign.
 
+## Related resolution
+
+K8D3M4 resolves this spike's narrow reply-format question with direct evidence
+from issue #1524: a compact `UserPromptSubmit` reminder arrives before Claude
+drafts the response, while active implement/TDD steps receive only a lead-first
+cue so the intentionally quiet Stop workflow stays quiet. This does not answer
+whether lean prompts broadly weaken phase or propose-and-converge steering;
+5ARWDG remains open for that observation.
+
 ## Work Log
 
 - 2026-05-31T21:05:09.536Z Started: Created ticket 5ARWDG
 - 2026-05-31 Noted single-line per-turn anchor in prompt-questions.ts:36 as the main at-risk steering surface.
+- 2026-07-27T19:17:12Z K8D3M4 recorded the narrow reply-format resolution above;
+  retained this ticket for the broader lean-prompt evidence gap.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -6,7 +6,7 @@ phase: verify
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/1524
 created: 2026-07-27T16:11:23.968Z
-last_modified: 2026-07-27T17:26:02Z
+last_modified: 2026-07-27T19:46:34Z
 ---
 
 # Surface reply format before Claude responds
@@ -17,12 +17,15 @@ last_modified: 2026-07-27T17:26:02Z
 
 **Type:** Improvement
 
-**Scope:** Add a compact reply-format reminder to Claude's existing
+**Scope:** Add a compact, phase-aware reply-format reminder to Claude's existing
 `UserPromptSubmit` hook so it reaches the model beside each new user prompt.
-Keep the Stop hook's detailed validation as the post-response safety net.
+Keep the Stop hook's detailed validation as the post-response safety net. During
+an active implement/TDD step, retain only the lead-with-the-answer cue because
+the Stop hook intentionally keeps that workflow quiet.
 
 **Out of Scope:** Changing the verdict contract, modifying Cursor or Codex
-adapters, adding a new hook, or requiring decision-brief formatting for short
+adapters (tracked by [#1547](https://github.com/ArcadeAI/safeword/issues/1547)),
+adding a new hook, or requiring decision-brief formatting for short
 conversational replies.
 
 ## User story
@@ -31,21 +34,39 @@ As a Safeword user, I want the agent to receive the reply-format rule before it
 drafts a substantive work update, so the first response is useful without a
 post-hoc rewrite.
 
+As a builder in an active TDD step, I want the pre-prompt reminder to stay
+brief, so normal RED/GREEN/REFACTOR progress does not receive an unnecessary
+decision-brief demand.
+
 ## Decision
 
 Use the existing Claude `UserPromptSubmit` hook. Its compact factual reminder
 is injected beside the submitted prompt, unlike the Stop hook which runs only
 after the response. A session-start-only rule already exists in `SAFEWORD.md`;
-repeating the full Stop template would add unnecessary prompt overhead.
+repeating the full Stop template would add unnecessary prompt overhead. The
+reminder is sourced from `hooks/lib/quality.ts` so its vocabulary cannot fork
+from the Stop contract.
+
+This supersedes 68SRC8's Option-A rejection and the matching
+`long-session-style-drift` learning only for the reply-format rule: #1524 is
+the recorded revisit trigger, showing that post-response correction arrives too
+late. The prior cadence rationale does not apply when Stop is intentionally
+suppressed or unavailable. K8D3M4 also resolves the narrow per-turn
+reply-format decision in 5ARWDG; that ticket's broader lean-prompt spike remains
+open.
 
 ## Done When:
 
 - [x] Each Claude `UserPromptSubmit` invocation emits a compact reminder to lead
-      with the outcome and use the decision brief only for substantive work
+      with the answer and use the decision brief only for substantive work
       updates.
 - [x] The reminder retains `CONFIDENT`, `BLOCKED`, and `Next` as the load-bearing
       terms without copying the Stop hook's full template.
 - [x] Existing phase/readiness guidance and Stop-hook validation remain intact.
+- [x] Active implement/TDD steps receive only the lead-with-the-answer cue, not
+      the decision-brief demand that Stop deliberately suppresses on those turns.
+- [x] The compact reminder is exported from `hooks/lib/quality.ts` and uses the
+      same `answer` vocabulary as the Stop contract.
 
 ## Test Definitions:
 
@@ -53,17 +74,23 @@ repeating the full Stop template would add unnecessary prompt overhead.
 - [x] GREEN — Hook output includes the compact reminder for a Safeword project.
 - [x] REFACTOR — The reminder is named once, remains concise, and the focused
       hook and quality-message tests stay green.
+- [x] RED — An installed hook with an active implement/TDD ticket still emits
+      the full decision-brief demand.
+- [x] GREEN — That active TDD state emits only the shared lead-with-the-answer
+      pointer, while ordinary prompts retain the full compact reminder.
+- [x] REFACTOR — The shared quality module owns both forms; no local copy can
+      silently drift from the Stop contract.
 
 ## Refactor ledger
 
-- [x] Replace the inline reply-format behavioral literal in
-  `prompt-questions.ts` with `REPLY_FORMAT_REMINDER`, so the purpose of the
-  second hook line is explicit without changing its output. Verified by the
-  real-installed-hook suite (58/58), lint/typecheck, template parity, and a
-  follow-up audit.
-- Commit deferred: this cleanup touches the same template and dogfood files as
-  the uncommitted #1524 behavior fix, so it cannot form an honest standalone
-  refactor commit.
+- [x] Move both reply-format variants into `hooks/lib/quality.ts` so the prompt
+  hook and Stop contract share the same answer-first vocabulary. The full
+  reminder remains the ordinary case; active implement/TDD receives only the
+  shared lead pointer. Verified by installed-hook coverage, quality-contract
+  tests, lint/typecheck, template parity, and a follow-up audit.
+- The earlier local `REPLY_FORMAT_REMINDER` extraction was deliberately
+  superseded during PR review because it did not prevent cross-hook vocabulary
+  drift. This scoped cleanup stays in the same commit as the behavior change.
 
 ## Work Log
 
@@ -89,3 +116,12 @@ repeating the full Stop template would add unnecessary prompt overhead.
   `REPLY_FORMAT_REMINDER`; behavior is unchanged. Focused hook tests (58/58),
   lint/typecheck, parity, and the follow-up full audit passed. No further
   refactor candidates remain in this scoped hook change.
+- 2026-07-27T19:17:12Z PR #1540 review remediation: corrected the superseded
+  68SRC8 learning, recorded the narrow resolution in 5ARWDG, moved reply-format
+  text into `hooks/lib/quality.ts`, and added an installed-hook implement/TDD
+  negative contract. RED failed as expected; GREEN passed 102 focused tests.
+- 2026-07-27T19:46:34Z Quality re-review found and corrected only a punctuation
+  defect in the shared Stop-header interpolation; an exact regression assertion
+  now covers it. Full verification passed: Vitest 5,551 passed (5 skipped),
+  Cucumber 505 passed (3 skipped), lint, Gherkin lint, typecheck, template
+  parity, diff hygiene, and the follow-up audit all completed.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -6,7 +6,7 @@ phase: verify
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/1524
 created: 2026-07-27T16:11:23.968Z
-last_modified: 2026-07-27T20:05:46Z
+last_modified: 2026-07-28T00:33:10Z
 ---
 
 # Surface reply format before Claude responds
@@ -104,6 +104,10 @@ open.
 - [x] Scout disposition: retain the production hook's local line construction
   and phase state flow. A further extraction would add parameters without
   removing duplicated behavior or improving a tested boundary.
+- [x] Decouple the active-TDD negative contract from the styling of an
+  unrelated phase `Next:` hint. It now rejects the shared full
+  `REPLY_FORMAT_REMINDER` directly, so a future bolding change cannot create a
+  false regression while the decision-brief reminder remains suppressed.
 
 ## Work Log
 
@@ -158,3 +162,13 @@ open.
   installed-hook suites 104/104, schema/parity 61/61, `bun run lint`
   (eslint + Gherkin + typecheck) clean, `bun run parity:fix` re-synced both
   dogfood mirrors.
+- 2026-07-27T23:50:20Z Final review-nit cleanup: replaced the active-TDD
+  contract's indirect `**Next:**` absence check with an assertion against the
+  shared full `REPLY_FORMAT_REMINDER`, removing coupling to the styling of the
+  separate phase next-step hint.
+- 2026-07-28T00:33:10Z Final verification: hook plus quality suites passed
+  104/104; lint, Gherkin lint, typecheck, template parity (195 pairs and 8
+  contracts), and diff hygiene were clean. The first full-suite attempt hit a
+  transient connection refusal while installing React fixture dependencies;
+  its isolated 11-test suite passed on retry, then a clean full rerun passed
+  5,553 tests across all 373 files with 5 skipped.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -1,0 +1,91 @@
+---
+id: K8D3M4
+slug: reply-format-proactive-reminder
+type: task
+phase: verify
+status: in_progress
+external_issue: https://github.com/ArcadeAI/safeword/issues/1524
+created: 2026-07-27T16:11:23.968Z
+last_modified: 2026-07-27T17:26:02Z
+---
+
+# Surface reply format before Claude responds
+
+**Goal:** Keep substantive Claude work updates in Safeword’s concise decision-brief shape before they reach the user.
+
+**Why:** The current Stop hook can only correct a response after it has already been shown, causing repeated re-teaching and catch-up loops.
+
+**Type:** Improvement
+
+**Scope:** Add a compact reply-format reminder to Claude's existing
+`UserPromptSubmit` hook so it reaches the model beside each new user prompt.
+Keep the Stop hook's detailed validation as the post-response safety net.
+
+**Out of Scope:** Changing the verdict contract, modifying Cursor or Codex
+adapters, adding a new hook, or requiring decision-brief formatting for short
+conversational replies.
+
+## User story
+
+As a Safeword user, I want the agent to receive the reply-format rule before it
+drafts a substantive work update, so the first response is useful without a
+post-hoc rewrite.
+
+## Decision
+
+Use the existing Claude `UserPromptSubmit` hook. Its compact factual reminder
+is injected beside the submitted prompt, unlike the Stop hook which runs only
+after the response. A session-start-only rule already exists in `SAFEWORD.md`;
+repeating the full Stop template would add unnecessary prompt overhead.
+
+## Done When:
+
+- [x] Each Claude `UserPromptSubmit` invocation emits a compact reminder to lead
+      with the outcome and use the decision brief only for substantive work
+      updates.
+- [x] The reminder retains `CONFIDENT`, `BLOCKED`, and `Next` as the load-bearing
+      terms without copying the Stop hook's full template.
+- [x] Existing phase/readiness guidance and Stop-hook validation remain intact.
+
+## Test Definitions:
+
+- [x] RED — Hook output lacks the proactive reply-format reminder.
+- [x] GREEN — Hook output includes the compact reminder for a Safeword project.
+- [x] REFACTOR — The reminder is named once, remains concise, and the focused
+      hook and quality-message tests stay green.
+
+## Refactor ledger
+
+- [x] Replace the inline reply-format behavioral literal in
+  `prompt-questions.ts` with `REPLY_FORMAT_REMINDER`, so the purpose of the
+  second hook line is explicit without changing its output. Verified by the
+  real-installed-hook suite (58/58), lint/typecheck, template parity, and a
+  follow-up audit.
+- Commit deferred: this cleanup touches the same template and dogfood files as
+  the uncommitted #1524 behavior fix, so it cannot form an honest standalone
+  refactor commit.
+
+## Work Log
+
+- 2026-07-27T16:11:23.968Z Started: Created ticket K8D3M4
+- 2026-07-27T16:11:23.968Z Revalidated #1524 against fresh origin/main: the
+  Stop hook still injects the verbose format template only after a response.
+- 2026-07-27T16:11:23.968Z Decided: use the existing UserPromptSubmit hook for
+  a compact pre-response reminder; retain Stop as validation backstop.
+- 2026-07-27T16:43:53Z RED: confirmed the installed hook did not emit a
+  reply-format reminder. Added its integration contract before implementation.
+- 2026-07-27T16:43:53Z GREEN: added one concise output line to the existing
+  template hook and synchronized the dogfood mirror with `bun run parity:fix`.
+- 2026-07-27T16:43:53Z Verified: focused hook integration (58/58), full Vitest
+  (5,549 passed; 5 skipped), Gherkin (505 passed; 3 skipped), typecheck, Knip,
+  lint, and diff hygiene passed. Independent quality review approved.
+- 2026-07-27T16:43:53Z Audit note: `bun run deps:validate` reported only the
+  pre-existing `no-orphans` warning for `packages/cli/src/codex-plugin/hooks.ts`.
+- 2026-07-27T16:45:51Z Full audit: config sync, dependency-cruiser (0
+  violations), Knip, and Go checks passed. The audit recorded 506 baseline
+  clones and one low-risk dev-only `markdownlint-cli2` patch update; neither is
+  in this ticket's scope.
+- 2026-07-27T17:26:02Z Refactor pass: named the reply-format literal
+  `REPLY_FORMAT_REMINDER`; behavior is unchanged. Focused hook tests (58/58),
+  lint/typecheck, parity, and the follow-up full audit passed. No further
+  refactor candidates remain in this scoped hook change.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -6,7 +6,7 @@ phase: verify
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/1524
 created: 2026-07-27T16:11:23.968Z
-last_modified: 2026-07-27T19:46:34Z
+last_modified: 2026-07-27T20:05:46Z
 ---
 
 # Surface reply format before Claude responds
@@ -91,6 +91,13 @@ open.
 - The earlier local `REPLY_FORMAT_REMINDER` extraction was deliberately
   superseded during PR review because it did not prevent cross-hook vocabulary
   drift. This scoped cleanup stays in the same commit as the behavior change.
+- [x] Extract the repeated real installed `prompt-questions.ts` subprocess
+  setup in `packages/cli/tests/integration/hooks.test.ts` into one helper, so
+  the ordinary, TDD, and non-Safeword contracts cannot diverge in how they
+  invoke the hook.
+- [x] Scout disposition: retain the production hook's local line construction
+  and phase state flow. A further extraction would add parameters without
+  removing duplicated behavior or improving a tested boundary.
 
 ## Work Log
 
@@ -125,3 +132,8 @@ open.
   now covers it. Full verification passed: Vitest 5,551 passed (5 skipped),
   Cucumber 505 passed (3 skipped), lint, Gherkin lint, typecheck, template
   parity, diff hygiene, and the follow-up audit all completed.
+- 2026-07-27T20:05:46Z Quality-review follow-up approved the final implementation
+  and identified one stale verification summary, corrected separately. Refactor
+  scout then unified the three installed prompt-hook test launchers behind one
+  helper; the real integration suite passed 59/59 with unchanged stdin and
+  project-directory behavior.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -21,7 +21,9 @@ last_modified: 2026-07-27T20:05:46Z
 `UserPromptSubmit` hook so it reaches the model beside each new user prompt.
 Keep the Stop hook's detailed validation as the post-response safety net. During
 an active implement/TDD step, retain only the lead-with-the-answer cue because
-the Stop hook intentionally keeps that workflow quiet.
+the Stop hook intentionally keeps that workflow quiet. The pre-existing first
+anchor line also gains the `-` bullet prefix every other emitted line already
+carries, so the injected block is uniform now that it leads with two anchors.
 
 **Out of Scope:** Changing the verdict contract, modifying Cursor or Codex
 adapters (tracked by [#1547](https://github.com/ArcadeAI/safeword/issues/1547)),
@@ -67,6 +69,10 @@ open.
       the decision-brief demand that Stop deliberately suppresses on those turns.
 - [x] The compact reminder is exported from `hooks/lib/quality.ts` and uses the
       same `answer` vocabulary as the Stop contract.
+- [x] Both anchor lines lead the injected block in a fixed order, asserted by
+      position rather than presence, and both carry the `-` bullet prefix.
+- [x] The Stop pointer keeps its original one-sentence prose with the shared lead
+      rule inline, not appended as a trailing labelled sentence.
 
 ## Test Definitions:
 
@@ -137,3 +143,18 @@ open.
   scout then unified the three installed prompt-hook test launchers behind one
   helper; the real integration suite passed 59/59 with unchanged stdin and
   project-directory behavior.
+- 2026-07-27T23:30:00Z Second PR #1540 review pass, polish only (no behavior
+  change): replaced the positional `lines.splice(1, 0, …)` with a separate
+  `anchors` array concatenated at output, so no later push can displace an
+  anchor; restored the Stop pointer's original one-sentence prose by making
+  `REPLY_FORMAT_LEAD_RULE` a bare inline fragment (retiring the `answer.,`
+  comma-splice guard the interpolation had needed); declared the `-` prefix
+  change in Scope with a position-asserting test; refreshed the now-stale
+  `hooks/lib/quality.ts` header comment for its third consumer; pinned all three
+  pointer exports in the schema contract; normalized the lone `./lib/quality.js`
+  type specifier to the `.ts` form this file uses elsewhere; and added the
+  K8D3M4 entry plus the corrected token-cost note to the
+  `long-session-style-drift` learning. Targeted verification: quality +
+  installed-hook suites 104/104, schema/parity 61/61, `bun run lint`
+  (eslint + Gherkin + typecheck) clean, `bun run parity:fix` re-synced both
+  dogfood mirrors.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
@@ -1,12 +1,14 @@
 # Verify: Surface reply format before Claude responds (K8D3M4)
 
-Verified 2026-07-27 after revalidating GitHub issue #1524 and completing the
-task's RED → GREEN → REFACTOR cycle.
+Verified 2026-07-27 after revalidating GitHub issue #1524, completing the
+task's RED → GREEN → REFACTOR cycle, and addressing the shared-constant and
+active-TDD review remediation.
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,549 passed (373 files; 5 skipped). The new real-installed
-hook integration contract is included; its focused run passed 58/58 tests.
+**Test Suite:** ✓ 5,551 passed (373 files; 5 skipped). The real-installed hook
+integration and shared quality-contract tests are included; their focused run
+passed 163/163 tests.
 
 **Gherkin:** ✅ 505 passed, 3 skipped (15,645 passed steps; 4 skipped).
 
@@ -15,12 +17,14 @@ hook integration contract is included; its focused run passed 58/58 tests.
 **Lint:** ✅ `bun run lint`, `bun run typecheck`, `bun run knip`, and
 `git diff --check` passed.
 
-**Scenarios:** All three task test-definition rows are complete: the original
-hook output was shown absent, the installed hook now emits the concise reminder,
-and the formatting contract is covered without duplicating the Stop template.
+**Scenarios:** All six task test-definition rows are complete: the original
+hook output was shown absent; the installed hook now emits the concise reminder;
+the formatting contract is shared without duplicating the Stop template; and an
+active implement/TDD state keeps only the answer-first cue.
 
-**PR Scope:** ✅ Diff is limited to the prompt hook template and synced dogfood
-mirror, its integration contract, and this ticket's records.
+**PR Scope:** ✅ Diff is limited to the prompt hook and shared-quality template
+sources with their synced dogfood mirrors, schema and integration contracts,
+and this ticket's records.
 
 **Dep Drift:** ✅ No dependencies changed. `bun run deps:validate` reported one
 pre-existing `no-orphans` warning on `packages/cli/src/codex-plugin/hooks.ts`,
@@ -30,15 +34,15 @@ outside this ticket's diff.
 `bun run parity:fix`; existing Stop-hook validation and non-Claude adapters are
 unchanged.
 
-**Quality review:** ✅ Independent review approved. The chosen
-`UserPromptSubmit` timing is correct for #1524, the reminder remains compact,
-and the test executes the installed hook in a real temporary Safeword project.
+**Quality review:** ✅ Independent review approved after the remediation. The
+chosen `UserPromptSubmit` timing is correct for #1524; its active-TDD condition
+matches the Stop hook's quiet condition; and the test executes the installed
+hook in a real temporary Safeword project.
 
-**Refactor:** ✅ The dedicated refactor pass replaced the reply-format inline
-literal with the named `REPLY_FORMAT_REMINDER` constant. The real-installed-hook
-suite still passes 58/58, lint/typecheck and template parity are clean, and the
-one-item ledger is complete. Commit is deferred because this cleanup shares the
-uncommitted #1524 source files and cannot be isolated honestly.
+**Refactor:** ✅ The dedicated refactor pass moved both reply-format variants
+into `hooks/lib/quality.ts`, preventing vocabulary drift between the prompt and
+Stop hooks. The real-installed-hook suite passed 163/163, lint/typecheck and
+template parity are clean, and the one-item ledger is complete.
 
 **Audit:** ✅ Passed with non-blocking repository observations. Config sync,
 dependency-cruiser (0 violations across 666 modules and 2,179 dependencies),

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
@@ -1,0 +1,53 @@
+# Verify: Surface reply format before Claude responds (K8D3M4)
+
+Verified 2026-07-27 after revalidating GitHub issue #1524 and completing the
+task's RED → GREEN → REFACTOR cycle.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5,549 passed (373 files; 5 skipped). The new real-installed
+hook integration contract is included; its focused run passed 58/58 tests.
+
+**Gherkin:** ✅ 505 passed, 3 skipped (15,645 passed steps; 4 skipped).
+
+**Build:** ✅ tsup ESM and DTS build completed as part of the test run.
+
+**Lint:** ✅ `bun run lint`, `bun run typecheck`, `bun run knip`, and
+`git diff --check` passed.
+
+**Scenarios:** All three task test-definition rows are complete: the original
+hook output was shown absent, the installed hook now emits the concise reminder,
+and the formatting contract is covered without duplicating the Stop template.
+
+**PR Scope:** ✅ Diff is limited to the prompt hook template and synced dogfood
+mirror, its integration contract, and this ticket's records.
+
+**Dep Drift:** ✅ No dependencies changed. `bun run deps:validate` reported one
+pre-existing `no-orphans` warning on `packages/cli/src/codex-plugin/hooks.ts`,
+outside this ticket's diff.
+
+**Reconcile:** ✅ Template and dogfood hook copies were synchronized with
+`bun run parity:fix`; existing Stop-hook validation and non-Claude adapters are
+unchanged.
+
+**Quality review:** ✅ Independent review approved. The chosen
+`UserPromptSubmit` timing is correct for #1524, the reminder remains compact,
+and the test executes the installed hook in a real temporary Safeword project.
+
+**Refactor:** ✅ The dedicated refactor pass replaced the reply-format inline
+literal with the named `REPLY_FORMAT_REMINDER` constant. The real-installed-hook
+suite still passes 58/58, lint/typecheck and template parity are clean, and the
+one-item ledger is complete. Commit is deferred because this cleanup shares the
+uncommitted #1524 source files and cannot be isolated honestly.
+
+**Audit:** ✅ Passed with non-blocking repository observations. Config sync,
+dependency-cruiser (0 violations across 666 modules and 2,179 dependencies),
+Knip, and Go checks were clean. `jscpd` recorded 506 clones (8.92%) across the
+repository excluding generated and Safeword/ticket mirrors; the diff adds no
+new clone pattern. `bun outdated` found one low-risk dev-only patch update
+(`markdownlint-cli2` 0.23.1 → 0.23.2), deferred as out of scope. Python
+dead-code/import checks remain unavailable in an unrelated experiment because
+their tools are not installed.
+
+**Evidence limits:** ✅ None for this task. The ticket intentionally remains
+`in_progress` pending user confirmation before it is marked done.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
@@ -6,9 +6,9 @@ active-TDD review remediation.
 
 ## Verify Checklist
 
-**Test Suite:** ✓ 5,551 passed (373 files; 5 skipped). The real-installed hook
-integration and shared quality-contract tests are included; their focused run
-passed 163/163 tests.
+**Test Suite:** ✓ 5,553 passed (373 files; 5 skipped). The real-installed hook
+integration and shared quality-contract tests are included; their latest
+focused run passed 104/104 tests.
 
 **Gherkin:** ✅ 505 passed, 3 skipped (15,645 passed steps; 4 skipped).
 
@@ -42,8 +42,10 @@ hook in a real temporary Safeword project.
 
 **Refactor:** ✅ The dedicated refactor pass moved both reply-format variants
 into `hooks/lib/quality.ts`, preventing vocabulary drift between the prompt and
-Stop hooks. The real-installed-hook suite passed 163/163, lint/typecheck and
-template parity are clean, and the one-item ledger is complete.
+Stop hooks. The active-TDD negative contract now rejects the shared full
+reminder directly rather than depending on the styling of an unrelated phase
+hint. The hook plus quality suites passed 104/104, lint/typecheck and template
+parity are clean, and the ledger is complete.
 
 **Audit:** ✅ Passed with non-blocking repository observations. Config sync,
 dependency-cruiser (0 violations across 666 modules and 2,179 dependencies),

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
@@ -22,9 +22,10 @@ hook output was shown absent; the installed hook now emits the concise reminder;
 the formatting contract is shared without duplicating the Stop template; and an
 active implement/TDD state keeps only the answer-first cue.
 
-**PR Scope:** ✅ Diff is limited to the prompt hook and shared-quality template
-sources with their synced dogfood mirrors, schema and integration contracts,
-and this ticket's records.
+**PR Scope:** ✅ Diff is limited to the reply-format change: the prompt hook and
+shared-quality template sources with their synced dogfood mirrors, schema and
+integration contracts, the K8D3M4 ticket, the related long-session learning,
+and the narrow 5ARWDG coordination record.
 
 **Dep Drift:** ✅ No dependencies changed. `bun run deps:validate` reported one
 pre-existing `no-orphans` warning on `packages/cli/src/codex-plugin/hooks.ts`,

--- a/.safeword/hooks/lib/quality.ts
+++ b/.safeword/hooks/lib/quality.ts
@@ -1,5 +1,6 @@
-// Shared quality review message for Claude Code and Cursor hooks.
-// Used by: stop-quality.ts, cursor/stop.ts
+// Shared reply-shape vocabulary for Claude Code and Cursor hooks: the Stop
+// quality-review message plus the compact pre-response pointers.
+// Used by: stop-quality.ts, cursor/stop.ts, prompt-questions.ts (UserPromptSubmit).
 //
 // Contract: every Stop terminates in CONFIDENT or BLOCKED (binary terminal).
 // CONFIDENT carries a decision brief — Decided / Rejected (optional) / Open /
@@ -11,7 +12,8 @@
 // Bold-led sub-fields separated by blank lines render as a scannable stacked
 // column. Indent inside a paragraph is a no-op.
 //
-// Style discipline: this prompt is reinjected every Stop. Keep it terse and
+// Style discipline: this prompt is reinjected every Stop, and the compact
+// pointers below are reinjected every user prompt. Keep it terse and
 // load-bearing. Project philosophy (research-depth, critical-review,
 // investigate-on-uncertainty) lives in SAFEWORD.md which loads every
 // conversation — don't duplicate it here.
@@ -24,13 +26,20 @@ import type { CANONICAL_PHASES } from './phase-provenance.js';
 /** Derived from CANONICAL_PHASES so a new phase is a compile error here, not drift. */
 export type BddPhase = (typeof CANONICAL_PHASES)[number];
 
-/** Canonical compact reply-format pointer for pre-response hooks. */
-export const REPLY_FORMAT_LEAD = 'Reply format: lead with the answer.';
+/**
+ * The single wording of the lead-first rule. A bare mid-sentence fragment so the
+ * Stop header can keep it inline where it belongs, rather than appending it as a
+ * trailing labelled sentence.
+ */
+export const REPLY_FORMAT_LEAD_RULE = 'lead with the answer';
+
+/** Lead-only pre-response pointer: the sole cue during intentionally quiet TDD steps. */
+export const REPLY_FORMAT_LEAD = `Reply format: ${REPLY_FORMAT_LEAD_RULE}.`;
 
 /** Full pre-response pointer, used outside intentionally quiet TDD steps. */
 export const REPLY_FORMAT_REMINDER = `${REPLY_FORMAT_LEAD} For substantive work updates, use one **CONFIDENT**/**BLOCKED** decision brief and end with **Next:**.`;
 
-const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read; named structure only when it carries weight; end with **Next:**. ${REPLY_FORMAT_LEAD}
+const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read, ${REPLY_FORMAT_LEAD_RULE}, named structure only when it carries weight, end with **Next:**.
 
 End with one verdict as its own scannable decision brief — the reader is choosing whether to continue, redirect, or intervene with this block as their only context. Plain English; no jargon the reader hasn't seen this turn — make the CONFIDENT/BLOCKED line clear from the words after the dash, not the label alone (a non-coder may not know the labels). Reproduce the shape below exactly: bolded labels, blank line between each paragraph.
 

--- a/.safeword/hooks/lib/quality.ts
+++ b/.safeword/hooks/lib/quality.ts
@@ -24,7 +24,13 @@ import type { CANONICAL_PHASES } from './phase-provenance.js';
 /** Derived from CANONICAL_PHASES so a new phase is a compile error here, not drift. */
 export type BddPhase = (typeof CANONICAL_PHASES)[number];
 
-const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read, lead with the answer, named structure only when it carries weight, end with **Next:**.
+/** Canonical compact reply-format pointer for pre-response hooks. */
+export const REPLY_FORMAT_LEAD = 'Reply format: lead with the answer.';
+
+/** Full pre-response pointer, used outside intentionally quiet TDD steps. */
+export const REPLY_FORMAT_REMINDER = `${REPLY_FORMAT_LEAD} For substantive work updates, use one **CONFIDENT**/**BLOCKED** decision brief and end with **Next:**.`;
+
+const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read; named structure only when it carries weight; end with **Next:**. ${REPLY_FORMAT_LEAD}
 
 End with one verdict as its own scannable decision brief — the reader is choosing whether to continue, redirect, or intervene with this block as their only context. Plain English; no jargon the reader hasn't seen this turn — make the CONFIDENT/BLOCKED line clear from the words after the dash, not the label alone (a non-coder may not know the labels). Reproduce the shape below exactly: bolded labels, blank line between each paragraph.
 

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -12,6 +12,7 @@ import {
 } from './lib/active-ticket.ts';
 import { READINESS_POINTER, shouldSurfaceReadiness } from './lib/readiness-pointer.ts';
 import { evaluateReplan } from './lib/replan.ts';
+import { REPLY_FORMAT_LEAD, REPLY_FORMAT_REMINDER } from './lib/quality.ts';
 import {
   ESCALATION_THRESHOLD,
   type FailureEntry,
@@ -41,14 +42,9 @@ try {
   input = {};
 }
 
-// One behavioral anchor (SAFEWORD.md has the full methodology; this survives as a compressed reminder)
-const REPLY_FORMAT_REMINDER =
-  'Reply format: lead with the outcome. A substantive work update uses one **CONFIDENT**/**BLOCKED** decision brief and ends with **Next:**.';
-
-const lines = [
-  'Contribute before asking. Embed open questions in your contribution.',
-  REPLY_FORMAT_REMINDER,
-];
+// Compact behavioral anchors; SAFEWORD.md carries the full methodology.
+const lines = ['- Contribute before asking. Embed open questions in your contribution.'];
+let replyFormatReminder = REPLY_FORMAT_REMINDER;
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as
@@ -75,6 +71,13 @@ if (existsSync(stateFile)) {
           phase === 'implement' && ticketInfo.folder
             ? deriveTddStep(projectDirectory, ticketInfo.folder)
             : null;
+
+        // Stop reviews deliberately stay quiet inside an active TDD step. Keep
+        // only the lead-first cue here so the prompt hook does not reintroduce
+        // the decision-brief demand that Stop suppresses.
+        if (phase === 'implement' && tddStep !== null) {
+          replyFormatReminder = REPLY_FORMAT_LEAD;
+        }
 
         // Phase-specific one-liner
         // satisfies proves every canonical phase has a reminder (a missing key was
@@ -166,6 +169,8 @@ if (existsSync(stateFile)) {
     // State file corrupted or unreadable — skip reminder, keep core principles
   }
 }
+
+lines.splice(1, 0, `- ${replyFormatReminder}`);
 
 // Readiness pointer (TPP6Y2): compressed five-dimension self-test, surfaced
 // during Clarify (no active ticket or intake phase) and suppressed once a build

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -42,7 +42,13 @@ try {
 }
 
 // One behavioral anchor (SAFEWORD.md has the full methodology; this survives as a compressed reminder)
-const lines = ['Contribute before asking. Embed open questions in your contribution.'];
+const REPLY_FORMAT_REMINDER =
+  'Reply format: lead with the outcome. A substantive work update uses one **CONFIDENT**/**BLOCKED** decision brief and ends with **Next:**.';
+
+const lines = [
+  'Contribute before asking. Embed open questions in your contribution.',
+  REPLY_FORMAT_REMINDER,
+];
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -12,6 +12,7 @@ import {
 } from './lib/active-ticket.ts';
 import { READINESS_POINTER, shouldSurfaceReadiness } from './lib/readiness-pointer.ts';
 import { evaluateReplan } from './lib/replan.ts';
+import type { BddPhase } from './lib/quality.ts';
 import { REPLY_FORMAT_LEAD, REPLY_FORMAT_REMINDER } from './lib/quality.ts';
 import {
   ESCALATION_THRESHOLD,
@@ -42,9 +43,13 @@ try {
   input = {};
 }
 
-// Compact behavioral anchors; SAFEWORD.md carries the full methodology.
-const lines = ['- Contribute before asking. Embed open questions in your contribution.'];
+// Compact behavioral anchors; SAFEWORD.md carries the full methodology. These
+// always lead the block, so they live in their own array — `lines` below is the
+// situational tail, and the two are concatenated at output. Keeping them apart
+// means no push into `lines` can displace an anchor.
+const anchors = ['- Contribute before asking. Embed open questions in your contribution.'];
 let replyFormatReminder = REPLY_FORMAT_REMINDER;
+const lines: string[] = [];
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as
@@ -96,7 +101,7 @@ if (existsSync(stateFile)) {
             : 'Phase: implement.',
           verify: 'Phase: verify. Cross-scenario refactor if needed, then run /verify and /audit.',
           done: 'Phase: done. Close ticket (verify.md exists).',
-        } satisfies Record<import('./lib/quality.js').BddPhase, string> & Record<string, string>;
+        } satisfies Record<BddPhase, string> & Record<string, string>;
 
         // Name the active ticket slug-first (ZRXM6Q) so the per-turn reminder
         // reads in names, not the opaque ID — recognition over recall. The slug
@@ -170,7 +175,9 @@ if (existsSync(stateFile)) {
   }
 }
 
-lines.splice(1, 0, `- ${replyFormatReminder}`);
+// Resolved only after the state block above, which decides whether an active
+// TDD step reduces this to the lead-only cue.
+anchors.push(`- ${replyFormatReminder}`);
 
 // Readiness pointer (TPP6Y2): compressed five-dimension self-test, surfaced
 // during Clarify (no active ticket or intake phase) and suppressed once a build
@@ -205,7 +212,7 @@ try {
 }
 
 lines.push('- Avoid bloat.');
-console.log(lines.join('\n'));
+console.log([...anchors, ...lines].join('\n'));
 
 function tddNextStep(step: string): string {
   const next: Record<string, string> = {

--- a/.safeword/logs/ticket-K8D3M4-reply-format-proactive-reminder.md
+++ b/.safeword/logs/ticket-K8D3M4-reply-format-proactive-reminder.md
@@ -1,0 +1,35 @@
+# Work Log: Surface reply format before Claude responds
+
+**Anchored to:** `.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md`
+
+---
+
+## Session: 2026-07-27
+
+- [16:11] Revalidated GitHub issue #1524 against fresh `origin/main`.
+- [16:11] Found the full verdict template in `hooks/lib/quality.ts`; it is
+  delivered by the Stop hook after the response.
+- [16:11] Confirmed the existing `prompt-questions.ts` hook runs at
+  `UserPromptSubmit`, before Claude processes the user's prompt.
+- [16:11] Researched current Claude hook semantics: UserPromptSubmit context is
+  injected beside the user prompt; static project instructions should stay
+  concise and a per-prompt hook is appropriate for timing-sensitive reminders.
+- [16:11] Decision: add one compact factual reminder to the existing prompt
+  hook, retain the Stop hook as the detailed safety net, and keep non-Claude
+  adapters out of scope for this issue.
+- [16:43] RED: added the real-installed-hook contract and confirmed the
+  reminder was absent before changing the template.
+- [16:43] GREEN: added the concise outcome/decision-brief reminder and synced
+  the dogfood mirror with `bun run parity:fix`.
+- [16:43] Verification: focused 58/58 integration tests, complete Vitest
+  (5,549 passed; 5 skipped), Gherkin (505 passed; 3 skipped), lint, typecheck,
+  Knip, and diff hygiene passed. Independent quality review: APPROVE.
+- [16:45] Full audit: config sync, dependency-cruiser, Knip, and Go checks
+  passed. `jscpd` reported the existing repository baseline (506 clones);
+  `bun outdated` found only the out-of-scope, low-risk dev patch for
+  `markdownlint-cli2`.
+- [17:26] Dedicated refactor: replaced the inline reply-format literal with
+  `REPLY_FORMAT_REMINDER`. The real installed-hook test remains 58/58; lint,
+  typecheck, parity, and the follow-up audit pass. No second cleanup is
+  justified; the refactor cannot be committed separately from the uncommitted
+  #1524 change.

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1326,6 +1326,11 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       // free-form review.
       requires: [
         'QUALITY_REVIEW_MESSAGE',
+        // prompt-questions.ts imports all three pre-response pointers; the Stop
+        // header composes the bare rule inline. Removing any one forks the
+        // reply-shape vocabulary back across two hooks.
+        'REPLY_FORMAT_LEAD_RULE',
+        'REPLY_FORMAT_LEAD',
         'REPLY_FORMAT_REMINDER',
         'CONFIDENT',
         'BLOCKED',

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1324,7 +1324,14 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
       // BLOCKED, Tried:, Need:) define the binary-terminal shape from ticket 143.
       // Removing any of them would silently regress the prompt back to legacy
       // free-form review.
-      requires: ['QUALITY_REVIEW_MESSAGE', 'CONFIDENT', 'BLOCKED', 'Tried:', 'Need:'],
+      requires: [
+        'QUALITY_REVIEW_MESSAGE',
+        'REPLY_FORMAT_REMINDER',
+        'CONFIDENT',
+        'BLOCKED',
+        'Tried:',
+        'Need:',
+      ],
     },
     'packages/cli/templates/doc-templates/test-definitions-feature.md': {
       // Canonical test-definitions.md format. Rule grouping (Gherkin 6+

--- a/packages/cli/templates/hooks/lib/quality.ts
+++ b/packages/cli/templates/hooks/lib/quality.ts
@@ -1,5 +1,6 @@
-// Shared quality review message for Claude Code and Cursor hooks.
-// Used by: stop-quality.ts, cursor/stop.ts
+// Shared reply-shape vocabulary for Claude Code and Cursor hooks: the Stop
+// quality-review message plus the compact pre-response pointers.
+// Used by: stop-quality.ts, cursor/stop.ts, prompt-questions.ts (UserPromptSubmit).
 //
 // Contract: every Stop terminates in CONFIDENT or BLOCKED (binary terminal).
 // CONFIDENT carries a decision brief — Decided / Rejected (optional) / Open /
@@ -11,7 +12,8 @@
 // Bold-led sub-fields separated by blank lines render as a scannable stacked
 // column. Indent inside a paragraph is a no-op.
 //
-// Style discipline: this prompt is reinjected every Stop. Keep it terse and
+// Style discipline: this prompt is reinjected every Stop, and the compact
+// pointers below are reinjected every user prompt. Keep it terse and
 // load-bearing. Project philosophy (research-depth, critical-review,
 // investigate-on-uncertainty) lives in SAFEWORD.md which loads every
 // conversation — don't duplicate it here.
@@ -24,13 +26,20 @@ import type { CANONICAL_PHASES } from './phase-provenance.js';
 /** Derived from CANONICAL_PHASES so a new phase is a compile error here, not drift. */
 export type BddPhase = (typeof CANONICAL_PHASES)[number];
 
-/** Canonical compact reply-format pointer for pre-response hooks. */
-export const REPLY_FORMAT_LEAD = 'Reply format: lead with the answer.';
+/**
+ * The single wording of the lead-first rule. A bare mid-sentence fragment so the
+ * Stop header can keep it inline where it belongs, rather than appending it as a
+ * trailing labelled sentence.
+ */
+export const REPLY_FORMAT_LEAD_RULE = 'lead with the answer';
+
+/** Lead-only pre-response pointer: the sole cue during intentionally quiet TDD steps. */
+export const REPLY_FORMAT_LEAD = `Reply format: ${REPLY_FORMAT_LEAD_RULE}.`;
 
 /** Full pre-response pointer, used outside intentionally quiet TDD steps. */
 export const REPLY_FORMAT_REMINDER = `${REPLY_FORMAT_LEAD} For substantive work updates, use one **CONFIDENT**/**BLOCKED** decision brief and end with **Next:**.`;
 
-const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read; named structure only when it carries weight; end with **Next:**. ${REPLY_FORMAT_LEAD}
+const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read, ${REPLY_FORMAT_LEAD_RULE}, named structure only when it carries weight, end with **Next:**.
 
 End with one verdict as its own scannable decision brief — the reader is choosing whether to continue, redirect, or intervene with this block as their only context. Plain English; no jargon the reader hasn't seen this turn — make the CONFIDENT/BLOCKED line clear from the words after the dash, not the label alone (a non-coder may not know the labels). Reproduce the shape below exactly: bolded labels, blank line between each paragraph.
 

--- a/packages/cli/templates/hooks/lib/quality.ts
+++ b/packages/cli/templates/hooks/lib/quality.ts
@@ -24,7 +24,13 @@ import type { CANONICAL_PHASES } from './phase-provenance.js';
 /** Derived from CANONICAL_PHASES so a new phase is a compile error here, not drift. */
 export type BddPhase = (typeof CANONICAL_PHASES)[number];
 
-const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read, lead with the answer, named structure only when it carries weight, end with **Next:**.
+/** Canonical compact reply-format pointer for pre-response hooks. */
+export const REPLY_FORMAT_LEAD = 'Reply format: lead with the answer.';
+
+/** Full pre-response pointer, used outside intentionally quiet TDD steps. */
+export const REPLY_FORMAT_REMINDER = `${REPLY_FORMAT_LEAD} For substantive work updates, use one **CONFIDENT**/**BLOCKED** decision brief and end with **Next:**.`;
+
+const UNIVERSAL_HEADER = `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read; named structure only when it carries weight; end with **Next:**. ${REPLY_FORMAT_LEAD}
 
 End with one verdict as its own scannable decision brief — the reader is choosing whether to continue, redirect, or intervene with this block as their only context. Plain English; no jargon the reader hasn't seen this turn — make the CONFIDENT/BLOCKED line clear from the words after the dash, not the label alone (a non-coder may not know the labels). Reproduce the shape below exactly: bolded labels, blank line between each paragraph.
 

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -12,6 +12,7 @@ import {
 } from './lib/active-ticket.ts';
 import { READINESS_POINTER, shouldSurfaceReadiness } from './lib/readiness-pointer.ts';
 import { evaluateReplan } from './lib/replan.ts';
+import { REPLY_FORMAT_LEAD, REPLY_FORMAT_REMINDER } from './lib/quality.ts';
 import {
   ESCALATION_THRESHOLD,
   type FailureEntry,
@@ -41,14 +42,9 @@ try {
   input = {};
 }
 
-// One behavioral anchor (SAFEWORD.md has the full methodology; this survives as a compressed reminder)
-const REPLY_FORMAT_REMINDER =
-  'Reply format: lead with the outcome. A substantive work update uses one **CONFIDENT**/**BLOCKED** decision brief and ends with **Next:**.';
-
-const lines = [
-  'Contribute before asking. Embed open questions in your contribution.',
-  REPLY_FORMAT_REMINDER,
-];
+// Compact behavioral anchors; SAFEWORD.md carries the full methodology.
+const lines = ['- Contribute before asking. Embed open questions in your contribution.'];
+let replyFormatReminder = REPLY_FORMAT_REMINDER;
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as
@@ -75,6 +71,13 @@ if (existsSync(stateFile)) {
           phase === 'implement' && ticketInfo.folder
             ? deriveTddStep(projectDirectory, ticketInfo.folder)
             : null;
+
+        // Stop reviews deliberately stay quiet inside an active TDD step. Keep
+        // only the lead-first cue here so the prompt hook does not reintroduce
+        // the decision-brief demand that Stop suppresses.
+        if (phase === 'implement' && tddStep !== null) {
+          replyFormatReminder = REPLY_FORMAT_LEAD;
+        }
 
         // Phase-specific one-liner
         // satisfies proves every canonical phase has a reminder (a missing key was
@@ -166,6 +169,8 @@ if (existsSync(stateFile)) {
     // State file corrupted or unreadable — skip reminder, keep core principles
   }
 }
+
+lines.splice(1, 0, `- ${replyFormatReminder}`);
 
 // Readiness pointer (TPP6Y2): compressed five-dimension self-test, surfaced
 // during Clarify (no active ticket or intake phase) and suppressed once a build

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -42,7 +42,13 @@ try {
 }
 
 // One behavioral anchor (SAFEWORD.md has the full methodology; this survives as a compressed reminder)
-const lines = ['Contribute before asking. Embed open questions in your contribution.'];
+const REPLY_FORMAT_REMINDER =
+  'Reply format: lead with the outcome. A substantive work update uses one **CONFIDENT**/**BLOCKED** decision brief and ends with **Next:**.';
+
+const lines = [
+  'Contribute before asking. Embed open questions in your contribution.',
+  REPLY_FORMAT_REMINDER,
+];
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -12,6 +12,7 @@ import {
 } from './lib/active-ticket.ts';
 import { READINESS_POINTER, shouldSurfaceReadiness } from './lib/readiness-pointer.ts';
 import { evaluateReplan } from './lib/replan.ts';
+import type { BddPhase } from './lib/quality.ts';
 import { REPLY_FORMAT_LEAD, REPLY_FORMAT_REMINDER } from './lib/quality.ts';
 import {
   ESCALATION_THRESHOLD,
@@ -42,9 +43,13 @@ try {
   input = {};
 }
 
-// Compact behavioral anchors; SAFEWORD.md carries the full methodology.
-const lines = ['- Contribute before asking. Embed open questions in your contribution.'];
+// Compact behavioral anchors; SAFEWORD.md carries the full methodology. These
+// always lead the block, so they live in their own array — `lines` below is the
+// situational tail, and the two are concatenated at output. Keeping them apart
+// means no push into `lines` can displace an anchor.
+const anchors = ['- Contribute before asking. Embed open questions in your contribution.'];
 let replyFormatReminder = REPLY_FORMAT_REMINDER;
+const lines: string[] = [];
 
 // Effective Clarify phase: the active in-progress ticket's phase, else undefined
 // (no ticket, pre-classify, or a ticket that isn't in_progress — all treated as
@@ -96,7 +101,7 @@ if (existsSync(stateFile)) {
             : 'Phase: implement.',
           verify: 'Phase: verify. Cross-scenario refactor if needed, then run /verify and /audit.',
           done: 'Phase: done. Close ticket (verify.md exists).',
-        } satisfies Record<import('./lib/quality.js').BddPhase, string> & Record<string, string>;
+        } satisfies Record<BddPhase, string> & Record<string, string>;
 
         // Name the active ticket slug-first (ZRXM6Q) so the per-turn reminder
         // reads in names, not the opaque ID — recognition over recall. The slug
@@ -170,7 +175,9 @@ if (existsSync(stateFile)) {
   }
 }
 
-lines.splice(1, 0, `- ${replyFormatReminder}`);
+// Resolved only after the state block above, which decides whether an active
+// TDD step reduces this to the lead-only cue.
+anchors.push(`- ${replyFormatReminder}`);
 
 // Readiness pointer (TPP6Y2): compressed five-dimension self-test, surfaced
 // during Clarify (no active ticket or intake phase) and suppressed once a build
@@ -205,7 +212,7 @@ try {
 }
 
 lines.push('- Avoid bloat.');
-console.log(lines.join('\n'));
+console.log([...anchors, ...lines].join('\n'));
 
 function tddNextStep(step: string): string {
   const next: Record<string, string> = {

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -182,10 +182,13 @@ function runPromptQuestionsHook(
     env: { ...process.env, CLAUDE_PROJECT_DIR: claudeProjectDirectory },
     encoding: 'utf8',
   });
+  if (result.error) {
+    throw result.error;
+  }
   return {
     stdout: result.stdout ?? '',
     stderr: result.stderr ?? '',
-    exitCode: result.status ?? 0,
+    exitCode: result.status ?? 1,
   };
 }
 

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -170,6 +170,25 @@ function runStopHook(
   };
 }
 
+/** Run the installed UserPromptSubmit question hook. */
+function runPromptQuestionsHook(
+  targetDirectory: string,
+  input: string,
+  claudeProjectDirectory = targetDirectory,
+): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync('bun', ['.safeword/hooks/prompt-questions.ts'], {
+    input,
+    cwd: targetDirectory,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: claudeProjectDirectory },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 0,
+  };
+}
+
 /** Parse JSON output from stop hook */
 function parseStopOutput(result: { stdout: string }): {
   decision?: string;
@@ -438,33 +457,27 @@ describe('E2E: UserPromptSubmit Hooks', () => {
 
   describe('prompt-questions.ts', () => {
     it('outputs question guidance for prompts', () => {
-      const output = execSync(
-        'echo "Help me implement a new feature for user authentication" | bun .safeword/hooks/prompt-questions.ts',
-        {
-          cwd: shared.projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
-          encoding: 'utf8',
-        },
+      const result = runPromptQuestionsHook(
+        shared.projectDirectory,
+        'Help me implement a new feature for user authentication',
       );
 
-      expect(output).toContain('Contribute before asking');
-      expect(output.trim().split('\n').at(-1)).toBe('- Avoid bloat.');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Contribute before asking');
+      expect(result.stdout.trim().split('\n').at(-1)).toBe('- Avoid bloat.');
     });
 
     it('proactively reminds Claude how to format substantive work updates', () => {
-      const output = execSync(
-        'echo "Summarize the completed work" | bun .safeword/hooks/prompt-questions.ts',
-        {
-          cwd: shared.projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
-          encoding: 'utf8',
-        },
+      const result = runPromptQuestionsHook(
+        shared.projectDirectory,
+        'Summarize the completed work',
       );
 
-      expect(output).toContain('- Reply format: lead with the answer.');
-      expect(output).toContain('substantive work update');
-      expect(output).toContain('**CONFIDENT**/**BLOCKED**');
-      expect(output).toContain('**Next:**');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('- Reply format: lead with the answer.');
+      expect(result.stdout).toContain('substantive work update');
+      expect(result.stdout).toContain('**CONFIDENT**/**BLOCKED**');
+      expect(result.stdout).toContain('**Next:**');
     });
 
     it('keeps active implement/TDD prompts free of the decision-brief demand', () => {
@@ -491,14 +504,12 @@ describe('E2E: UserPromptSubmit Hooks', () => {
       );
 
       try {
-        const result = spawnSync('bun', ['.safeword/hooks/prompt-questions.ts'], {
-          input: JSON.stringify({ session_id: 'test-session', prompt: 'Continue implementation' }),
-          cwd: shared.projectDirectory,
-          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
-          encoding: 'utf8',
-        });
+        const result = runPromptQuestionsHook(
+          shared.projectDirectory,
+          JSON.stringify({ session_id: 'test-session', prompt: 'Continue implementation' }),
+        );
 
-        expect(result.status).toBe(0);
+        expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('- Reply format: lead with the answer.');
         expect(result.stdout).not.toContain('**CONFIDENT**/**BLOCKED**');
         expect(result.stdout).not.toContain('**Next:**');
@@ -513,16 +524,14 @@ describe('E2E: UserPromptSubmit Hooks', () => {
     it('exits silently for non-safeword project', () => {
       const nonSafewordDirectory = createTemporaryDirectory();
       try {
-        const output = execSync(
-          'echo "Help me implement a new feature for user authentication" | bun .safeword/hooks/prompt-questions.ts',
-          {
-            cwd: shared.projectDirectory,
-            env: { ...process.env, CLAUDE_PROJECT_DIR: nonSafewordDirectory },
-            encoding: 'utf8',
-          },
+        const result = runPromptQuestionsHook(
+          shared.projectDirectory,
+          'Help me implement a new feature for user authentication',
+          nonSafewordDirectory,
         );
 
-        expect(output.trim()).toBe('');
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('');
       } finally {
         removeTemporaryDirectory(nonSafewordDirectory);
       }

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -451,6 +451,22 @@ describe('E2E: UserPromptSubmit Hooks', () => {
       expect(output.trim().split('\n').at(-1)).toBe('- Avoid bloat.');
     });
 
+    it('proactively reminds Claude how to format substantive work updates', () => {
+      const output = execSync(
+        'echo "Summarize the completed work" | bun .safeword/hooks/prompt-questions.ts',
+        {
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
+          encoding: 'utf8',
+        },
+      );
+
+      expect(output).toContain('Reply format: lead with the outcome.');
+      expect(output).toContain('substantive work update');
+      expect(output).toContain('**CONFIDENT**/**BLOCKED**');
+      expect(output).toContain('**Next:**');
+    });
+
     it('exits silently for non-safeword project', () => {
       const nonSafewordDirectory = createTemporaryDirectory();
       try {

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -470,6 +470,18 @@ describe('E2E: UserPromptSubmit Hooks', () => {
       expect(result.stdout.trim().split('\n').at(-1)).toBe('- Avoid bloat.');
     });
 
+    it('leads with the two anchor bullets in a stable order', () => {
+      const result = runPromptQuestionsHook(shared.projectDirectory, 'Ship the auth fix');
+
+      // Position, not just presence: the anchors are assembled separately from the
+      // situational lines precisely so no later push can displace them.
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim().split('\n').slice(0, 2)).toEqual([
+        '- Contribute before asking. Embed open questions in your contribution.',
+        '- Reply format: lead with the answer. For substantive work updates, use one **CONFIDENT**/**BLOCKED** decision brief and end with **Next:**.',
+      ]);
+    });
+
     it('proactively reminds Claude how to format substantive work updates', () => {
       const result = runPromptQuestionsHook(
         shared.projectDirectory,

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -461,10 +461,53 @@ describe('E2E: UserPromptSubmit Hooks', () => {
         },
       );
 
-      expect(output).toContain('Reply format: lead with the outcome.');
+      expect(output).toContain('- Reply format: lead with the answer.');
       expect(output).toContain('substantive work update');
       expect(output).toContain('**CONFIDENT**/**BLOCKED**');
       expect(output).toContain('**Next:**');
+    });
+
+    it('keeps active implement/TDD prompts free of the decision-brief demand', () => {
+      setupIssuesDirectory(shared.projectDirectory, [
+        {
+          id: 'TDD123',
+          type: 'feature',
+          phase: 'implement',
+          status: 'in_progress',
+          lastModified: VERIFIED_AT,
+        },
+      ]);
+      writeTestFile(
+        shared.projectDirectory,
+        '.project/tickets/TDD123/test-definitions.md',
+        ['## Scenario: implement work', '- [x] RED', '- [ ] GREEN', '- [ ] REFACTOR', ''].join(
+          '\n',
+        ),
+      );
+      writeTestFile(
+        shared.projectDirectory,
+        '.project/quality-state-test-session.json',
+        JSON.stringify({ activeTicket: 'TDD123' }),
+      );
+
+      try {
+        const result = spawnSync('bun', ['.safeword/hooks/prompt-questions.ts'], {
+          input: JSON.stringify({ session_id: 'test-session', prompt: 'Continue implementation' }),
+          cwd: shared.projectDirectory,
+          env: { ...process.env, CLAUDE_PROJECT_DIR: shared.projectDirectory },
+          encoding: 'utf8',
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('- Reply format: lead with the answer.');
+        expect(result.stdout).not.toContain('**CONFIDENT**/**BLOCKED**');
+        expect(result.stdout).not.toContain('**Next:**');
+      } finally {
+        clearIssuesDirectory(shared.projectDirectory);
+        rmSync(`${shared.projectDirectory}/.project/quality-state-test-session.json`, {
+          force: true,
+        });
+      }
     });
 
     it('exits silently for non-safeword project', () => {

--- a/packages/cli/tests/integration/hooks.test.ts
+++ b/packages/cli/tests/integration/hooks.test.ts
@@ -23,6 +23,7 @@ import {
   AUTO_UPGRADE_LOCK_MESSAGE,
   releaseAutoUpgradeLock,
 } from '../../templates/hooks/lib/auto-upgrade-lock.js';
+import { REPLY_FORMAT_REMINDER } from '../../templates/hooks/lib/quality.js';
 import {
   createTemporaryDirectory,
   createTypeScriptPackageJson,
@@ -527,7 +528,7 @@ describe('E2E: UserPromptSubmit Hooks', () => {
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('- Reply format: lead with the answer.');
         expect(result.stdout).not.toContain('**CONFIDENT**/**BLOCKED**');
-        expect(result.stdout).not.toContain('**Next:**');
+        expect(result.stdout).not.toContain(REPLY_FORMAT_REMINDER);
       } finally {
         clearIssuesDirectory(shared.projectDirectory);
         rmSync(`${shared.projectDirectory}/.project/quality-state-test-session.json`, {

--- a/packages/cli/tests/quality.test.ts
+++ b/packages/cli/tests/quality.test.ts
@@ -5,9 +5,20 @@ import {
   getDisqualificationMessage,
   getQualityMessage,
   QUALITY_REVIEW_MESSAGE,
+  REPLY_FORMAT_LEAD,
+  REPLY_FORMAT_REMINDER,
 } from '../templates/hooks/lib/quality.js';
 
 describe('getQualityMessage — universal binary terminal (143 + F14BG2 + QSNKBB)', () => {
+  it('exports the compact reply-format pointers used by pre-response hooks', () => {
+    expect(REPLY_FORMAT_LEAD).toBe('Reply format: lead with the answer.');
+    expect(REPLY_FORMAT_REMINDER).toContain(REPLY_FORMAT_LEAD);
+    expect(REPLY_FORMAT_REMINDER).toContain('**CONFIDENT**/**BLOCKED**');
+    expect(REPLY_FORMAT_REMINDER).toContain('**Next:**');
+    expect(getQualityMessage('intake')).toContain(REPLY_FORMAT_LEAD);
+    expect(getQualityMessage('intake')).not.toContain('answer.,');
+  });
+
   describe('Rule: Every Stop emits the binary terminal across phases', () => {
     it('intake includes the universal header with bolded verdict tokens', () => {
       const message = getQualityMessage('intake');

--- a/packages/cli/tests/quality.test.ts
+++ b/packages/cli/tests/quality.test.ts
@@ -6,17 +6,27 @@ import {
   getQualityMessage,
   QUALITY_REVIEW_MESSAGE,
   REPLY_FORMAT_LEAD,
+  REPLY_FORMAT_LEAD_RULE,
   REPLY_FORMAT_REMINDER,
 } from '../templates/hooks/lib/quality.js';
 
 describe('getQualityMessage — universal binary terminal (143 + F14BG2 + QSNKBB)', () => {
   it('exports the compact reply-format pointers used by pre-response hooks', () => {
+    expect(REPLY_FORMAT_LEAD_RULE).toBe('lead with the answer');
     expect(REPLY_FORMAT_LEAD).toBe('Reply format: lead with the answer.');
     expect(REPLY_FORMAT_REMINDER).toContain(REPLY_FORMAT_LEAD);
     expect(REPLY_FORMAT_REMINDER).toContain('**CONFIDENT**/**BLOCKED**');
     expect(REPLY_FORMAT_REMINDER).toContain('**Next:**');
-    expect(getQualityMessage('intake')).toContain(REPLY_FORMAT_LEAD);
-    expect(getQualityMessage('intake')).not.toContain('answer.,');
+  });
+
+  it('keeps the lead rule inline in the Stop pointer sentence, not appended to it', () => {
+    // 68SRC8's pointer is one sentence listing the rules in priority order. The
+    // shared fragment must compose into it, not arrive as a trailing labelled
+    // afterthought — otherwise the most important rule reads as the least.
+    expect(getQualityMessage('intake')).toContain(
+      `Apply SAFEWORD.md "Talking to the user" rules to your reply: scan-not-read, ${REPLY_FORMAT_LEAD_RULE}, named structure only when it carries weight, end with **Next:**.`,
+    );
+    expect(getQualityMessage('intake')).not.toContain(REPLY_FORMAT_LEAD);
   });
 
   describe('Rule: Every Stop emits the binary terminal across phases', () => {


### PR DESCRIPTION
## Summary

- Remind Claude of Safeword's concise reply shape **before** it processes a substantive user prompt, via the existing `UserPromptSubmit` hook.
- Gate the reminder down to the lead-only cue during an active implement/TDD step, because the Stop hook deliberately keeps that workflow quiet (`stop-quality.ts` sets `fireReview = false` there).
- Own the wording in `hooks/lib/quality.ts` so the pre-response pointer and the Stop contract cannot fork; the schema contract pins all three exports.
- Keep the detailed Stop-hook format check as the post-response safety net.
- Cover the installed hook with real-subprocess contracts: ordinary prompt, active TDD prompt (negative), anchor ordering by position, and non-Safeword silence.

## Why

The reply-format template previously arrived only after Claude had written a response, causing avoidable re-teaching and rewrites.

This supersedes 68SRC8's rejection of a per-turn `UserPromptSubmit` nudge, but only for the reply-format rule. #1524 is the revisit trigger 68SRC8 itself named. Its stated reason — "50× the token cost for no extra steering benefit" — does not hold: Stop and UserPromptSubmit both fire about once per turn, so the two cost roughly the same and the real difference is timing. `.project/learnings/long-session-style-drift.md` is corrected accordingly, and 5ARWDG records that its narrow per-turn reply-format question is now answered while its broader lean-prompt spike stays open.

## Not in scope

Cursor and Codex do not get the pre-response reminder — tracked in #1547.

## Validation

On the behavior commits (`451ed938d`):

- Full Vitest — 5,551 passed, 5 skipped
- Gherkin — 505 passed, 3 skipped
- `bun run lint`, typecheck, template parity, and full audit passed

On the review-polish commit (`bd451952a`), which changes no emitted text:

- `tests/quality.test.ts` + `tests/integration/hooks.test.ts` — 104/104 passed
- `tests/schema.test.ts` + `tests/parity.test.ts` — 61/61 passed
- `bun run lint` (eslint + Gherkin lint + typecheck) clean
- `bun run parity:fix` re-synced both dogfood mirrors byte-identically
- Full suite and audit not re-run locally; CI covers this head

Fixes #1524
