### PR TITLE
Prevent retro duplicates when issues close during pagination

### DIFF
--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/quality-review.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/quality-review.md
@@ -78,3 +78,48 @@ ESLint, Prettier, TypeScript, and diff hygiene passed.
 
 **Next:** Commit and push the reviewed fixes, close the ticket through the done
 gate, then reply to and resolve the PR threads.
+
+## Follow-up review
+
+The 2026-07-27 follow-up review approved the fixes and raised three
+nonblocking improvements. A fresh quality pass reproduced the 415-day
+flat-rate arithmetic and exact recent 30-day buckets of 18, 110, 365, and
+1,014 items.
+
+**Verdict:** APPROVE
+
+**Critical issues:** None.
+
+Corrections and decisions:
+
+- Describe 415 days as a flat-rate capacity horizon, not a forecast. The recent
+  buckets increased sharply, but four observations do not establish a durable
+  growth model.
+- Make the observable threshold #1552's first independent deliverable. It still
+  requires a signal-destination decision, but not the other four investigations.
+- Keep the production bound private. Test-local specification constants remove
+  ambiguous cap-derived literals while deliberately retaining an independent
+  value that makes accidental production drift fail the behavioral tests.
+
+**Premortem:** If this resolution fails, the test-local policy value drifts
+without detection; retain the full-bound and first-tail transport tests as the
+cross-check.
+
+**Next:** Refactor the cap tests around named specification constants, clarify
+the source comment, and reorder #1552.
+
+### Follow-up post-fix review
+
+**Verdict:** APPROVE
+
+**Critical issues:** None.
+**Suggested improvements:** None.
+
+The independent reviewer confirmed that the test constants remain deliberately
+independent from `MAX_DEDUP_PAGES`, the unrelated fixture is expressed as two
+pages plus one, the source calls 415 days a flat-rate capacity horizon, and
+Issue #1552 makes the observable threshold its first independent deliverable. All 41
+focused transport tests and Prettier passed.
+
+**Next:** Run final Safeword verification, commit, push, and answer the
+top-level review comment.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/quality-review.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/quality-review.md
@@ -1,0 +1,80 @@
+# Quality Review: Keep retro dedup stable during issue closure
+
+Evidence reviewed 2026-07-27 against PR #1541, current GitHub primary
+documentation, repository history, CI, and a live API census.
+
+## Feedback review
+
+**Currency:** ✓ Current as of 2026-07-27  
+**Sources:** ✓ Load-bearing claims verified against primary GitHub sources and
+live repository data  
+**Correct:** ⚠️ The cap and CI blockers were valid; several advisory claims
+needed narrower wording  
+**Elegant:** ✓ The required fixes were narrow  
+**No-bloat:** ⚠️ Link traversal and cross-run caching require separate design  
+**Wiring:** ✓ The real `createRestTransport` tests mock only the network boundary
+
+**Verdict:** REQUEST CHANGES
+
+Validated blockers:
+
+1. `MAX_DEDUP_PAGES = 30` was introduced for an open-only universe. The
+   all-state universe contained 1,550 items across 16 pages, leaving roughly
+   4.7–6.1 weeks before a deterministic, transport-latched filing outage at
+   measured trailing growth.
+2. CI correctly rejected completion evidence while the ticket remained
+   `verify` / `in_progress`.
+
+Corrections to the feedback:
+
+- A 150-page guard was reasonable but not “comfortably over a year”: it bought
+  about 303 days at the measured trailing-seven-day rate.
+- The test normalizer masked omitted issue state, but it did not affect
+  reconcile transport tests in this file.
+- ETags do not make request count O(new items), and an issue-number high-water
+  mark alone misses reopens.
+- Equal-creation-time ordering remains undocumented and therefore
+  nonblocking.
+
+## Figure-it-out decision
+
+Recommend **a 200-page fail-closed guard plus explicit issue states in fixtures**
+because it buys a measured one-year safety horizon without changing
+normal-path request count or widening the transport response contract.
+Following GitHub `Link` URLs is the documented pagination best practice, but it
+does not provide a documented snapshot guarantee and belongs with the caching,
+mutation, and ordering design tracked in
+[issue #1552](https://github.com/ArcadeAI/safeword/issues/1552).
+
+**Premortem:** If this fails within six months, tracker growth accelerated
+beyond the measured seven-day rate and no threshold-based follow-up landed
+before 20,000 items.
+
+## Post-fix review
+
+**Currency:** ✓ GitHub API contract current as of 2026-07-27  
+**Sources:** ✓ Primary GitHub docs and live census verified  
+**Correct:** ✓ Cap, filtering, and exact boundary behavior are correct  
+**Elegant:** ✓ Stale cap wording corrected  
+**No-bloat:** ✓ Minimal constant, test, and fixture changes  
+**Wiring:** ✓ Real transport with only `fetch` mocked
+
+**Verdict:** APPROVE
+
+**Critical issues:** None.
+
+The 200-page calculation is exact for the dated measurement:
+`(20,000 − 1,550) ÷ (311 ÷ 7) = 415.27 days`. Tests pin completion at exactly
+20,000 items and fail-closed behavior at 20,001. All 41 focused transport tests,
+ESLint, Prettier, TypeScript, and diff hygiene passed.
+
+## Provenance
+
+- [List repository issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues)
+- [Using pagination in the REST API](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api)
+- [REST API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api)
+- [REST API versions](https://docs.github.com/en/rest/about-the-rest-api/api-versions)
+- Live `ArcadeAI/safeword` all-state issue enumeration fetched 2026-07-27
+
+**Next:** Commit and push the reviewed fixes, close the ticket through the done
+gate, then reply to and resolve the PR threads.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
@@ -34,6 +34,12 @@
 - [x] GREEN
 - [x] REFACTOR
 
+### Scenario: The all-state guard retains a measured one-year safety horizon
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
 ## Task-level cross-scenario refactor
 
 - [x] cross-scenario 809d662b0

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
@@ -1,0 +1,40 @@
+# Test Definitions: Keep retro dedup stable during issue closure
+
+## Rule: State changes cannot create a false marker absence
+
+### Scenario: An earlier issue closes while a later marker is being paginated
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: A closed exact marker remains ineligible
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+## Rule: Enumeration retains its existing safety boundaries
+
+### Scenario: The dedup request enumerates all states in creation order
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: Pull requests remain ineligible marker matches
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+### Scenario: Enumeration fails closed when an unread tail may remain
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
+## Task-level cross-scenario refactor
+
+- [x] cross-scenario — removed the repeated-sweep state machine and centralized
+      realistic default issue states in the network fixture

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/test-definitions.md
@@ -36,5 +36,7 @@
 
 ## Task-level cross-scenario refactor
 
-- [x] cross-scenario — removed the repeated-sweep state machine and centralized
-      realistic default issue states in the network fixture
+- [x] cross-scenario 809d662b0
+
+Removed the repeated-sweep state machine and centralized realistic default
+issue states in the network fixture.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
@@ -1,0 +1,64 @@
+---
+id: GS2FGC
+slug: keep-retro-dedup-stable-during-issue-closure
+type: task
+phase: verify
+status: in_progress
+created: 2026-07-27T17:29:00.567Z
+last_modified: 2026-07-27T18:11:37Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1481
+scope: |
+  Enumerate the stable all-state repository issue universe in creation order,
+  then retain only open non-pull-request issues for exact retro marker matching.
+out_of_scope: |
+  GitHub cursor/Link-header plumbing, concurrent create idempotency, deleted
+  issue handling, and changing the existing closed-issue recurrence policy.
+done_when: |
+  Closing an earlier issue during pagination cannot hide a later still-open
+  marker match; closed issues and pull requests remain ineligible matches; the
+  bounded enumeration still fails closed on a genuine unread tail.
+---
+
+# Keep retro dedup stable during issue closure
+
+**Goal:** Prevent issue state changes during pagination from authorizing a duplicate retro issue.
+
+**Why:** A closing issue can shift page-number pagination and hide a still-open marker match.
+
+## Work Log
+
+- 2026-07-27T18:11:37Z VERIFY: Final generated gate passed on the exact tree: 5,549/5,549 Vitest tests, 505/508 acceptance scenarios (3 skipped), 15,645/15,645 executed steps, build, lint, formatting, typecheck, and diff hygiene. Independent quality/engineering review: APPROVE with no critical findings; final delta re-check unchanged.
+- 2026-07-27T17:58:00Z AUDIT: No change-scoped errors. Config, dependency boundaries, dead-code scan, learning/domain docs, changed-test quality, architecture, and configured docs were clean. Repository-wide warnings were limited to duplication growth, two patch-level dev-tool updates, and the pre-existing Python experiment coverage limitation.
+- 2026-07-27T17:43:00Z REFACTOR: Removed the 55-line repeated-sweep state machine, made open-state eligibility explicit, and kept one cached all-state enumeration. Focused transport suite: 41/41; Prettier clean.
+- 2026-07-27T17:40:00Z GREEN: Closed issues are retained in raw page membership but filtered from exact-marker candidates; the endpoint contract now pins `state=all&sort=created&direction=asc`.
+- 2026-07-27T17:39:00Z RED: An all-state response containing only a closed exact marker incorrectly matched it, proving local state filtering is required to preserve the existing closed-recurrence policy.
+- 2026-07-27T17:38:00Z GREEN: Switching the listing universe to `state=all` makes the repeated-close regression find #101 in the first real transport sweep.
+- 2026-07-27T17:37:00Z RED: A real-transport/network-boundary test repeats the same close-at-page-boundary shift in every open-only sweep; the lookup returned `[]` instead of the still-open marker on #101.
+- 2026-07-27T17:34:00Z Planned: Use `state=all` as the pagination universe and filter `state=open` locally. GitHub documents `open|closed|all`, creation-order sorting, item state, and issue/PR co-listing; the live repository currently needs 16 all-state pages versus 18 requests for the existing three-sweep miss path. Cursor pagination is more invasive and its mutation consistency is not documented; repeated open-state sweeps preserve the fragile proof that produced #1481.
+- 2026-07-27T17:31:00Z Researched: GitHub's REST pagination uses server-provided Link URLs and the issue listing supports `state=all`; permanent issue deletion remains a separate rare membership mutation. Sources: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues, https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api, https://docs.github.com/en/issues/tracking-your-work-with-issues/administering-issues/deleting-an-issue
+- 2026-07-27T17:29:00.567Z Started: Created ticket GS2FGC
+
+## Figure-it-out decision
+
+Recommend **all-state pagination with local open-state filtering** because it
+removes close/reopen transitions from pagination membership while preserving
+the existing open-only match policy. Repeated open-state sweeps were close on
+API compatibility but lose on correctness complexity; cursor plumbing was
+close on pagination mechanics but loses on scope and lacks a documented
+snapshot-consistency guarantee.
+
+**Premortem:** If this fails in six months, repository growth reaches the
+3,000-item fail-closed bound sooner because closed issues and pull requests now
+consume it; keep the explicit cap error and revisit the bound or cursor path
+before the live count approaches it.
+
+**Next:** Add the mutation regression in
+`packages/cli/src/retro/github-rest.test.ts`, prove RED, then change
+`fetchIssuePage` in `packages/cli/src/retro/github-rest.ts`.
+
+## Tests
+
+- [x] A close between page one and page two cannot hide a still-open exact marker.
+- [x] A closed issue carrying the exact marker remains ineligible.
+- [x] The request uses the documented all-state, creation-ascending listing.
+- [x] Existing truncation, pull-request filtering, and cache behavior remain green.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: done
 status: done
 created: 2026-07-27T17:29:00.567Z
-last_modified: 2026-07-27T20:19:54Z
+last_modified: 2026-07-27T23:48:49Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1481
 external_prs:
   - https://github.com/ArcadeAI/safeword/pull/1541
@@ -29,6 +29,12 @@ done_when: |
 
 ## Work Log
 
+- 2026-07-27T23:48:49Z DONE: Fresh-build Safeword verification passed: 5,549/5,549 Vitest tests, 505/508 acceptance scenarios (3 skipped), 15,645/15,645 executed steps, build, lint, formatting, typecheck, and diff hygiene. Independent post-fix quality review: APPROVE with no critical or suggested issues.
+- 2026-07-27T23:33:58Z REFACTOR: Replaced all nine cap-derived test literals with intentionally independent specification constants; expressed the unrelated two-pages-plus-one fixture semantically. Focused transport suite: 41/41; ESLint, Prettier, TypeScript, and diff hygiene clean.
+- 2026-07-27T23:33:11Z GREEN: Restored the test policy to the production contract (200 pages); the exact-bound behavior passed.
+- 2026-07-27T23:32:38Z RED: Set the independent test policy one page above production; the exact-bound behavior rejected at the production cap, proving the test specification detects drift rather than importing its own answer.
+- 2026-07-27T23:29:09Z FOLLOW-UP: Reordered #1552 so the observable guard threshold is its first independent deliverable, named the unresolved signal destination, and clarified that 415 days is a flat-rate capacity horizon rather than a forecast.
+- 2026-07-27T23:26:12Z FOLLOW-UP REVIEW: Reopened to resolve the approved nonblocking feedback. Independent re-measurement confirmed sharply increasing exact 30-day buckets (18 → 110 → 365 → 1,014), but corrected “plainly super-linear” to a capacity-horizon caveat. Figure-it-out chose test-local policy constants over exporting the production bound, preserving drift detection while removing ambiguous literals; #1552’s observable threshold will become its first independent deliverable.
 - 2026-07-27T20:19:54Z DONE: Fresh-build Safeword verification passed on the exact final tree: 5,549/5,549 Vitest tests, 505/508 acceptance scenarios (3 skipped), 15,645/15,645 executed steps, build, and TypeScript. Post-fix quality review approved with no critical findings.
 - 2026-07-27T19:50:18Z FOLLOW-UP: Filed #1552 to design Link traversal, safe cross-run caching, reopen/deletion/transfer handling, equal-timestamp ordering, and a guard-monitoring threshold together.
 - 2026-07-27T19:47:57Z REFACTOR: Removed `normalizeIssueStates`; every GitHub issue fixture now declares `state` explicitly. Updated all cap boundary, probe, and latch assertions to 20,000/20,001 items. Focused transport suite: 41/41.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md
@@ -2,11 +2,13 @@
 id: GS2FGC
 slug: keep-retro-dedup-stable-during-issue-closure
 type: task
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-07-27T17:29:00.567Z
-last_modified: 2026-07-27T18:11:37Z
+last_modified: 2026-07-27T20:19:54Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1481
+external_prs:
+  - https://github.com/ArcadeAI/safeword/pull/1541
 scope: |
   Enumerate the stable all-state repository issue universe in creation order,
   then retain only open non-pull-request issues for exact retro marker matching.
@@ -27,6 +29,12 @@ done_when: |
 
 ## Work Log
 
+- 2026-07-27T20:19:54Z DONE: Fresh-build Safeword verification passed on the exact final tree: 5,549/5,549 Vitest tests, 505/508 acceptance scenarios (3 skipped), 15,645/15,645 executed steps, build, and TypeScript. Post-fix quality review approved with no critical findings.
+- 2026-07-27T19:50:18Z FOLLOW-UP: Filed #1552 to design Link traversal, safe cross-run caching, reopen/deletion/transfer handling, equal-timestamp ordering, and a guard-monitoring threshold together.
+- 2026-07-27T19:47:57Z REFACTOR: Removed `normalizeIssueStates`; every GitHub issue fixture now declares `state` explicitly. Updated all cap boundary, probe, and latch assertions to 20,000/20,001 items. Focused transport suite: 41/41.
+- 2026-07-27T19:46:51Z GREEN: Raised the fail-closed guard to 200 pages and recorded the dated live census and safety-horizon calculation in the owning comment.
+- 2026-07-27T19:46:24Z RED: Changed the exact-bound behavior to accept 20,000 items; the 3,000-item implementation rejected it with `repository items exceed 3000`.
+- 2026-07-27T19:45:13Z REVIEW DECISION: Validated PR #1541 feedback against GitHub docs and a live 1,550-item census. The 3,000-item cap is blocking, but 150 pages buys only ~303 days at the trailing-7-day rate; chose 200 pages (~415 days) plus explicit-state fixtures. Link traversal and persistent incremental state remain a scoped follow-up because neither has a documented snapshot guarantee and both widen this fix.
 - 2026-07-27T18:11:37Z VERIFY: Final generated gate passed on the exact tree: 5,549/5,549 Vitest tests, 505/508 acceptance scenarios (3 skipped), 15,645/15,645 executed steps, build, lint, formatting, typecheck, and diff hygiene. Independent quality/engineering review: APPROVE with no critical findings; final delta re-check unchanged.
 - 2026-07-27T17:58:00Z AUDIT: No change-scoped errors. Config, dependency boundaries, dead-code scan, learning/domain docs, changed-test quality, architecture, and configured docs were clean. Repository-wide warnings were limited to duplication growth, two patch-level dev-tool updates, and the pre-existing Python experiment coverage limitation.
 - 2026-07-27T17:43:00Z REFACTOR: Removed the 55-line repeated-sweep state machine, made open-state eligibility explicit, and kept one cached all-state enumeration. Focused transport suite: 41/41; Prettier clean.
@@ -47,14 +55,34 @@ API compatibility but lose on correctness complexity; cursor plumbing was
 close on pagination mechanics but loses on scope and lacks a documented
 snapshot-consistency guarantee.
 
-**Premortem:** If this fails in six months, repository growth reaches the
-3,000-item fail-closed bound sooner because closed issues and pull requests now
-consume it; keep the explicit cap error and revisit the bound or cursor path
-before the live count approaches it.
+**Premortem:** If this fails in six months, repository growth accelerates beyond
+the measured rate and reaches the 20,000-item fail-closed bound sooner; keep the
+explicit cap error and land the monitoring/caching follow-up before the live
+count approaches it.
 
 **Next:** Add the mutation regression in
 `packages/cli/src/retro/github-rest.test.ts`, prove RED, then change
 `fetchIssuePage` in `packages/cli/src/retro/github-rest.ts`.
+
+## Review follow-up decision
+
+Recommend **a 200-page fail-closed guard plus explicit issue states in test
+fixtures** because it removes the verified near-term outage without changing
+normal-path requests or widening the transport contract. A 150-page guard was
+close on minimality but loses on its stated headroom: the 2026-07-27 live census
+was 1,550 items, with 1,020 created in 30 days and 311 in 7 days, so 150 pages
+buys about 303 days at the recent rate while 200 pages buys about 415. Following
+GitHub's `Link` header is documented best practice, but doing it here adds
+response-header plumbing without a documented snapshot-consistency gain; ETag
+or high-water persistence needs a separate state and invalidation design.
+
+**Premortem:** If the 200-page choice fails within six months, tracker growth
+accelerated beyond the measured seven-day rate and no threshold-based follow-up
+landed before the repository approached 20,000 items.
+
+**Next:** Change the bound behavior tests to 20,000/20,001 items, prove RED,
+then raise `MAX_DEDUP_PAGES` and replace implicit state normalization with
+explicit fixtures.
 
 ## Tests
 

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/user-stories.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/user-stories.md
@@ -1,0 +1,27 @@
+# User Story: Keep retro dedup stable during issue closure
+
+As a Safeword maintainer
+I want retro marker enumeration to remain complete while issues change state
+So that a recurrence cannot silently open a duplicate issue.
+
+## Acceptance Criteria
+
+- The enumerated page membership does not change when an issue closes or reopens.
+- Only open issues can satisfy an exact legacy or canonical marker lookup.
+- Pull requests cannot satisfy an issue marker lookup.
+- An unread tail still fails closed instead of authorizing creation.
+
+## Out of Scope
+
+- Atomic protection against simultaneous creators.
+- Changing how closed recurrences are handled.
+- Guaranteeing stability when an administrator permanently deletes an issue.
+
+## INVEST
+
+- Independent: limited to the REST dedup enumeration.
+- Negotiable: the implementation follows the smallest verified API contract.
+- Valuable: prevents silent duplicate tracker issues.
+- Estimable: one transport and its focused tests.
+- Small: no new dependency or entry point.
+- Testable: each acceptance criterion has an observable transport result.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
@@ -1,6 +1,6 @@
 # Verify: Keep retro dedup stable during issue closure (GS2FGC)
 
-Evidence captured 2026-07-27 after resolving the PR review feedback.
+Evidence captured 2026-07-27 after resolving the follow-up review feedback.
 
 ## Verify Checklist
 
@@ -31,13 +31,14 @@ experiment still lacks import-linter and dead-code executables.
 Quality verdict: **APPROVE** — the review correctly identified that the original
 3,000-item guard had inadequate headroom and that implicit fixture state obscured
 the contract. The final implementation uses a measured 20,000-item guard
-(approximately 415 days of headroom at the trailing-seven-day rate), declares
-fixture states explicitly, and retains the all-state, creation-ascending listing
-contract. The post-fix review found no critical issues. Link traversal, caching,
-and mutation-lifecycle hardening are tracked in #1552.
+(a 415-day flat-rate capacity horizon, not a forecast), declares fixture states
+explicitly, and retains the all-state, creation-ascending listing contract.
+Follow-up review resolution replaced ambiguous cap literals with independent
+test-policy constants and made observability #1552's first deliverable. The
+post-fix review found no critical or suggested issues.
 
 Engineering ratings: Security 5/5, Performance 4/5, Correctness 4.5/5,
 Maintainability 4.5/5.
 
-**Next:** Commit and push the verified review resolution, then resolve the PR
-threads and confirm CI.
+**Next:** Commit and push the verified follow-up resolution, answer the
+top-level review comment, and confirm CI.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
@@ -1,6 +1,6 @@
 # Verify: Keep retro dedup stable during issue closure (GS2FGC)
 
-Evidence captured 2026-07-27 after the final reviewer-driven test refinement.
+Evidence captured 2026-07-27 after resolving the PR review feedback.
 
 ## Verify Checklist
 
@@ -8,7 +8,7 @@ Evidence captured 2026-07-27 after the final reviewer-driven test refinement.
 **Gherkin:** ✅ Acceptance lane passes (505/508 scenarios; 3 skipped; 15645/15645 executed steps)
 **Build:** ✅ Success (tsup + DTS)
 **Lint:** ✅ Clean (ESLint, Prettier, TypeScript, and diff hygiene)
-**Scenarios:** All 16 scenarios marked complete
+**Scenarios:** All 19 scenario checks marked complete
 **PR Scope:** ✅ Diff matches ticket scope
 **Dep Drift:** ✅ Clean
 **Parent Epic:** N/A
@@ -28,13 +28,16 @@ experiment still lacks import-linter and dead-code executables.
 
 ## Independent review
 
-Quality verdict: **APPROVE** — current GitHub primary documentation supports the
-all-state, creation-ascending listing contract; closed issues and pull requests
-remain locally ineligible; one bounded cached enumeration replaces the repeated
-confirmation state machine. Final delta re-check found no critical or suggested
-issues.
+Quality verdict: **APPROVE** — the review correctly identified that the original
+3,000-item guard had inadequate headroom and that implicit fixture state obscured
+the contract. The final implementation uses a measured 20,000-item guard
+(approximately 415 days of headroom at the trailing-seven-day rate), declares
+fixture states explicitly, and retains the all-state, creation-ascending listing
+contract. The post-fix review found no critical issues. Link traversal, caching,
+and mutation-lifecycle hardening are tracked in #1552.
 
 Engineering ratings: Security 5/5, Performance 4/5, Correctness 4.5/5,
 Maintainability 4.5/5.
 
-**Next:** Commit the verified change and open the pull request linked to #1481.
+**Next:** Commit and push the verified review resolution, then resolve the PR
+threads and confirm CI.

--- a/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
+++ b/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/verify.md
@@ -1,0 +1,40 @@
+# Verify: Keep retro dedup stable during issue closure (GS2FGC)
+
+Evidence captured 2026-07-27 after the final reviewer-driven test refinement.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5549/5549 tests pass (5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (505/508 scenarios; 3 skipped; 15645/15645 executed steps)
+**Build:** ✅ Success (tsup + DTS)
+**Lint:** ✅ Clean (ESLint, Prettier, TypeScript, and diff hygiene)
+**Scenarios:** All 16 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal GitHub transport correctness fix
+**Evidence limits:** ✅ None
+
+Audit passed with warnings — 0 change-scoped errors. Config synchronization,
+dependency-cruiser (666 modules, 2,179 dependencies, 0 violations), Knip,
+learning/domain docs, changed-test quality, architecture reconciliation, and
+configured documentation sources (`README.md` and website docs) were clean.
+Clones: 514 (9.03%) [repo minus `.safeword`, `.project`], +58 versus the latest
+same-scope 456-clone record; this change is net -29 production lines and did not
+introduce the repository-wide growth. Low-risk updates remain for `@types/node`
+26.1.1→26.1.2 and `markdownlint-cli2` 0.23.1→0.23.2. The pre-existing Python
+experiment still lacks import-linter and dead-code executables.
+
+## Independent review
+
+Quality verdict: **APPROVE** — current GitHub primary documentation supports the
+all-state, creation-ascending listing contract; closed issues and pull requests
+remain locally ineligible; one bounded cached enumeration replaces the repeated
+confirmation state machine. Final delta re-check found no critical or suggested
+issues.
+
+Engineering ratings: Security 5/5, Performance 4/5, Correctness 4.5/5,
+Maintainability 4.5/5.
+
+**Next:** Commit the verified change and open the pull request linked to #1481.

--- a/.safeword/logs/ticket-GS2FGC-keep-retro-dedup-stable-during-issue-closure.md
+++ b/.safeword/logs/ticket-GS2FGC-keep-retro-dedup-stable-during-issue-closure.md
@@ -1,0 +1,31 @@
+# Work Log: Keep retro dedup stable during issue closure
+
+**Anchored to:** `.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/ticket.md`
+
+---
+
+## Session: 2026-07-27
+
+- [12:20] Started review-feedback resolution for PR #1541.
+- [12:21] Review claims to validate: all-state cap headroom, ticket done gate,
+  independent-review provenance, fixture realism, Link pagination, lifetime
+  enumeration cost, and creation-time tie ordering.
+- [12:22] Investigation domains: live repository growth, GitHub pagination
+  guarantees, failure/rate-limit economics, and minimal behavioral test design.
+- [12:38] Live census: 1,550 items / 16 pages; 1,020 created in 30 days and
+  311 in 7 days. Existing 3,000 cap reaches a deterministic latched outage in
+  roughly 4.7–6.1 weeks.
+- [12:41] Quality verdict on comments: REQUEST CHANGES is justified. Corrected
+  two overclaims: 150 pages is not comfortably over one year at recent growth,
+  and the fixture normalizer does not reach reconcile transport tests.
+- [12:45] Figure-it-out: chose 200 pages plus explicit fixture states now.
+  Rejected Link plumbing for this slice because it adds a response-header seam
+  without documented snapshot consistency; rejected ETag/high-water persistence
+  because its cross-run state and invalidation contract is underdesigned.
+- [12:46] RED: the 20,000-item exact-bound test failed at the old 3,000-item
+  guard.
+- [12:47] GREEN: the same test passed after raising the guard to 200 pages.
+- [12:48] REFACTOR: removed implicit state normalization, made every issue
+  fixture explicit, and kept all 41 transport tests green.
+- [12:50] Filed GitHub follow-up #1552 for Link traversal, safe cross-run
+  caching, state mutation handling, ordering, and guard observability.

--- a/.safeword/logs/ticket-GS2FGC-keep-retro-dedup-stable-during-issue-closure.md
+++ b/.safeword/logs/ticket-GS2FGC-keep-retro-dedup-stable-during-issue-closure.md
@@ -29,3 +29,29 @@
   fixture explicit, and kept all 41 transport tests green.
 - [12:50] Filed GitHub follow-up #1552 for Link traversal, safe cross-run
   caching, state mutation handling, ordering, and guard observability.
+
+## Session: 2026-07-27 follow-up
+
+- [16:17] Fetched the new top-level review: APPROVE, no unresolved inline
+  threads; three nonblocking suggestions concern forecast wording, #1552
+  sequencing, and cap-derived test literals.
+- [16:22] Re-measured 1,554 total items. Exact rolling 30-day buckets are
+  18 → 110 → 365 → 1,014; exact trailing seven days contain 303 items.
+- [16:24] Quality review: APPROVE with no critical issues. Correct “plainly
+  super-linear” to “sharply increasing recent buckets” and “land and close
+  independently” to “land independently.”
+- [16:26] Figure-it-out: keep `MAX_DEDUP_PAGES` private and introduce
+  test-local specification constants. Importing the production value was close
+  on convenience but would make the boundary expectations self-referential.
+- [16:29] Updated #1552: observable threshold is now the first independent
+  deliverable; signal destination remains the explicit first decision.
+- [16:32] RED: set the test policy to 201 pages. The exact-bound test rejected
+  at production's 200-page cap, proving independent drift detection.
+- [16:33] GREEN: restored the test policy to 200 pages; exact-bound behavior
+  passed.
+- [16:33] REFACTOR: derived all nine cap literals from named test policy
+  constants and expressed the unrelated fixture as two pages plus one. All 41
+  focused tests, ESLint, Prettier, TypeScript, and diff hygiene passed.
+- [16:48] VERIFY: fresh-build full gate passed — 5,549 Vitest tests, 505/508
+  acceptance scenarios, 15,645 executed steps, build, and TypeScript.
+  Independent post-fix review approved with no findings.

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -8,6 +8,14 @@ interface MockResponse {
   json: () => unknown;
 }
 
+const GITHUB_PAGE_SIZE = 100;
+// Deliberately independent from the production value: an accidental cap change
+// must fail the boundary contract instead of updating its own expectation.
+const EXPECTED_DEDUP_PAGE_BOUND = 200;
+const EXPECTED_DEDUP_PROBE_PAGE = EXPECTED_DEDUP_PAGE_BOUND + 1;
+const EXPECTED_DEDUP_ITEM_BOUND = EXPECTED_DEDUP_PAGE_BOUND * GITHUB_PAGE_SIZE;
+const PAGE_BOUNDARY_FIXTURE_SIZE = 2 * GITHUB_PAGE_SIZE + 1;
+
 function mockFetch(responder: (url: string) => MockResponse): string[] {
   const calls: string[] = [];
   vi.stubGlobal(
@@ -247,33 +255,33 @@ describe('createRestTransport', () => {
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    // 200 bound pages + the probe page, which was also full → a genuine tail.
-    expect(calls).toHaveLength(201);
+    // The configured bound pages + a full probe page → a genuine tail.
+    expect(calls).toHaveLength(EXPECTED_DEDUP_PROBE_PAGE);
   });
 
-  // The boundary the bound alone cannot distinguish: at exactly 200 full pages the
-  // enumeration is COMPLETE, and throwing there would halt every session's filing
-  // over a tail that does not exist.
+  // The boundary the bound alone cannot distinguish: at exactly the configured
+  // number of full pages the enumeration is COMPLETE, and throwing there would
+  // halt every session's filing over a tail that does not exist.
   it('#1453: completes rather than throwing at exactly the page bound', async () => {
-    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+    const fullPage = Array.from({ length: GITHUB_PAGE_SIZE }, (_, i) => ({
       number: i,
       title: `t${i}`,
       body: 'no marker',
       state: 'open',
     }));
     const calls = mockFetch(url => ({
-      json: () => (url.endsWith('page=201') ? [] : fullPage),
+      json: () => (url.endsWith(`page=${EXPECTED_DEDUP_PROBE_PAGE}`) ? [] : fullPage),
     }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([]);
-    expect(calls).toHaveLength(201);
+    expect(calls).toHaveLength(EXPECTED_DEDUP_PROBE_PAGE);
   });
 
-  // The cap has to mean what it says. Appending the probe page instead of rejecting
-  // on it would silently accept 20,001–20,099 items under a "20,000" bound.
-  it('#1453: trips the cap at 20001 items rather than quietly accepting the probe', async () => {
+  // The cap has to mean what it says. Appending the probe page instead of
+  // rejecting it would silently accept items beyond the configured bound.
+  it('#1453: trips the cap at the first item past the bound', async () => {
     const fullPage = Array.from({ length: 100 }, (_, i) => ({
       number: i,
       title: `t${i}`,
@@ -283,15 +291,15 @@ describe('createRestTransport', () => {
     const calls = mockFetch(url => ({
       // Exactly one item past the bound — the smallest genuine tail there is.
       json: () =>
-        url.endsWith('page=201')
-          ? [{ number: 20_001, title: 'tail', body: 'x', state: 'open' }]
+        url.endsWith(`page=${EXPECTED_DEDUP_PROBE_PAGE}`)
+          ? [{ number: EXPECTED_DEDUP_ITEM_BOUND + 1, title: 'tail', body: 'x', state: 'open' }]
           : fullPage,
     }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    expect(calls).toHaveLength(201);
+    expect(calls).toHaveLength(EXPECTED_DEDUP_PROBE_PAGE);
   });
 
   // Ascending creation order appends genuinely new issues to the last page,
@@ -326,7 +334,7 @@ describe('createRestTransport', () => {
 
   it('#1481: finds a still-open marker when an earlier issue closes at a page boundary', async () => {
     const marker = '<!-- safeword-retro-signature: retro:abc123def456 -->';
-    const settled = Array.from({ length: 201 }, (_, i) => ({
+    const settled = Array.from({ length: PAGE_BOUNDARY_FIXTURE_SIZE }, (_, i) => ({
       number: i + 1,
       title: `t${i + 1}`,
       body: i === 100 ? marker : 'no marker',
@@ -388,8 +396,8 @@ describe('createRestTransport', () => {
     expect(calls.length).toBeGreaterThan(1);
   });
 
-  // Truncation is deterministic: re-running it burns another 201 requests to reach
-  // the same answer. Only transient failures earn a retry.
+  // Truncation is deterministic: re-running it burns another full bounded sweep
+  // plus the probe to reach the same answer. Only transient failures earn a retry.
   it('#1453: does not re-run a terminal truncation for every later encounter', async () => {
     const fullPage = Array.from({ length: 100 }, (_, i) => ({
       number: i,
@@ -402,13 +410,13 @@ describe('createRestTransport', () => {
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    expect(calls).toHaveLength(201);
+    expect(calls).toHaveLength(EXPECTED_DEDUP_PROBE_PAGE);
 
     // The next encounter fails the same way, from the latch — no new requests.
     await expect(transport.searchByCanonical('canonical:abc123def456')).rejects.toThrow(
       /truncated/,
     );
-    expect(calls).toHaveLength(201);
+    expect(calls).toHaveLength(EXPECTED_DEDUP_PROBE_PAGE);
   });
 
   // The enumeration is a snapshot from before the first create, and

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -8,19 +8,6 @@ interface MockResponse {
   json: () => unknown;
 }
 
-function normalizeIssueStates(value: unknown): unknown {
-  if (!Array.isArray(value)) return value;
-  return value.map(item =>
-    typeof item === 'object' &&
-    item !== null &&
-    'number' in item &&
-    'title' in item &&
-    !('state' in item)
-      ? { state: 'open', ...item }
-      : item,
-  );
-}
-
 function mockFetch(responder: (url: string) => MockResponse): string[] {
   const calls: string[] = [];
   vi.stubGlobal(
@@ -31,7 +18,7 @@ function mockFetch(responder: (url: string) => MockResponse): string[] {
       return Promise.resolve({
         ok: r.ok ?? true,
         status: r.status ?? 200,
-        json: () => Promise.resolve(normalizeIssueStates(r.json())),
+        json: () => Promise.resolve(r.json()),
       });
     }),
   );
@@ -101,11 +88,13 @@ describe('createRestTransport', () => {
           number: 1,
           title: 'near miss',
           body: '<!-- safeword-retro-signature: retro:abc123def4567 -->',
+          state: 'open',
         },
         {
           number: 2,
           title: 'exact',
           body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+          state: 'open',
         },
       ],
     }));
@@ -120,11 +109,17 @@ describe('createRestTransport', () => {
   it('prevent-retro-duplicate-issues.SM1.R2.rejects a canonical hash token without its exact marker', async () => {
     mockFetch(() => ({
       json: () => [
-        { number: 1, title: 'near miss', body: 'contains canonical:abc123def456-suffix' },
+        {
+          number: 1,
+          title: 'near miss',
+          body: 'contains canonical:abc123def456-suffix',
+          state: 'open',
+        },
         {
           number: 2,
           title: 'exact',
           body: '<!-- safeword-retro-canonical: canonical:abc123def456 -->',
+          state: 'open',
         },
       ],
     }));
@@ -143,12 +138,14 @@ describe('createRestTransport', () => {
           number: 1,
           title: 'copied marker PR',
           body: '<!-- safeword-retro-canonical: canonical:abc123def456 -->',
+          state: 'open',
           pull_request: {},
         },
         {
           number: 2,
           title: 'canonical issue',
           body: '<!-- safeword-retro-canonical: canonical:abc123def456 -->',
+          state: 'open',
         },
       ],
     }));
@@ -186,6 +183,7 @@ describe('createRestTransport', () => {
           number: 1425,
           title: 'hand-merged issue',
           body: 'merged\n<!-- safeword-retro-signature: retro:9230b08d2fb3 -->',
+          state: 'open',
           labels: [],
         },
       ],
@@ -204,6 +202,7 @@ describe('createRestTransport', () => {
       number: i,
       title: `t${i}`,
       body: 'nothing here',
+      state: 'open',
     }));
     const calls = mockFetch(url => ({
       json: () =>
@@ -214,6 +213,7 @@ describe('createRestTransport', () => {
                 number: 999,
                 title: 'on page two',
                 body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+                state: 'open',
               },
             ],
     }));
@@ -240,17 +240,18 @@ describe('createRestTransport', () => {
       number: i,
       title: `t${i}`,
       body: 'no marker',
+      state: 'open',
     }));
     const calls = mockFetch(() => ({ json: () => fullPage }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    // 30 bound pages + the probe page, which was also full → a genuine tail.
-    expect(calls).toHaveLength(31);
+    // 200 bound pages + the probe page, which was also full → a genuine tail.
+    expect(calls).toHaveLength(201);
   });
 
-  // The boundary the bound alone cannot distinguish: at exactly 30 full pages the
+  // The boundary the bound alone cannot distinguish: at exactly 200 full pages the
   // enumeration is COMPLETE, and throwing there would halt every session's filing
   // over a tail that does not exist.
   it('#1453: completes rather than throwing at exactly the page bound', async () => {
@@ -258,35 +259,39 @@ describe('createRestTransport', () => {
       number: i,
       title: `t${i}`,
       body: 'no marker',
+      state: 'open',
     }));
     const calls = mockFetch(url => ({
-      json: () => (url.endsWith('page=31') ? [] : fullPage),
+      json: () => (url.endsWith('page=201') ? [] : fullPage),
     }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([]);
-    expect(calls).toHaveLength(31);
+    expect(calls).toHaveLength(201);
   });
 
-  // The cap has to mean what it says. Appending the probe page instead of
-  // rejecting on it would silently accept 3,001–3,099 items under a "3,000" bound.
-  it('#1453: trips the cap at 3001 items rather than quietly accepting the probe', async () => {
+  // The cap has to mean what it says. Appending the probe page instead of rejecting
+  // on it would silently accept 20,001–20,099 items under a "20,000" bound.
+  it('#1453: trips the cap at 20001 items rather than quietly accepting the probe', async () => {
     const fullPage = Array.from({ length: 100 }, (_, i) => ({
       number: i,
       title: `t${i}`,
       body: 'no marker',
+      state: 'open',
     }));
     const calls = mockFetch(url => ({
       // Exactly one item past the bound — the smallest genuine tail there is.
       json: () =>
-        url.endsWith('page=31') ? [{ number: 3001, title: 'tail', body: 'x' }] : fullPage,
+        url.endsWith('page=201')
+          ? [{ number: 20_001, title: 'tail', body: 'x', state: 'open' }]
+          : fullPage,
     }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    expect(calls).toHaveLength(31);
+    expect(calls).toHaveLength(201);
   });
 
   // Ascending creation order appends genuinely new issues to the last page,
@@ -296,6 +301,7 @@ describe('createRestTransport', () => {
       number: i + 1,
       title: `t${i + 1}`,
       body: 'no marker',
+      state: 'open',
     }));
     mockFetch(url => ({
       json: () =>
@@ -306,6 +312,7 @@ describe('createRestTransport', () => {
                 number: 5000,
                 title: 'brand new',
                 body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+                state: 'open',
               },
             ],
     }));
@@ -381,26 +388,27 @@ describe('createRestTransport', () => {
     expect(calls.length).toBeGreaterThan(1);
   });
 
-  // Truncation is deterministic: re-running it burns another 31 requests to reach
+  // Truncation is deterministic: re-running it burns another 201 requests to reach
   // the same answer. Only transient failures earn a retry.
   it('#1453: does not re-run a terminal truncation for every later encounter', async () => {
     const fullPage = Array.from({ length: 100 }, (_, i) => ({
       number: i,
       title: `t${i}`,
       body: 'no marker',
+      state: 'open',
     }));
     const calls = mockFetch(() => ({ json: () => fullPage }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(/truncated/);
-    expect(calls).toHaveLength(31);
+    expect(calls).toHaveLength(201);
 
     // The next encounter fails the same way, from the latch — no new requests.
     await expect(transport.searchByCanonical('canonical:abc123def456')).rejects.toThrow(
       /truncated/,
     );
-    expect(calls).toHaveLength(31);
+    expect(calls).toHaveLength(201);
   });
 
   // The enumeration is a snapshot from before the first create, and
@@ -440,6 +448,7 @@ describe('createRestTransport', () => {
                 number: 7,
                 title: 'found on retry',
                 body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+                state: 'open',
               },
             ],
           };

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -8,6 +8,19 @@ interface MockResponse {
   json: () => unknown;
 }
 
+function normalizeIssueStates(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  return value.map(item =>
+    typeof item === 'object' &&
+    item !== null &&
+    'number' in item &&
+    'title' in item &&
+    !('state' in item)
+      ? { state: 'open', ...item }
+      : item,
+  );
+}
+
 function mockFetch(responder: (url: string) => MockResponse): string[] {
   const calls: string[] = [];
   vi.stubGlobal(
@@ -18,7 +31,7 @@ function mockFetch(responder: (url: string) => MockResponse): string[] {
       return Promise.resolve({
         ok: r.ok ?? true,
         status: r.status ?? 200,
-        json: () => Promise.resolve(r.json()),
+        json: () => Promise.resolve(normalizeIssueStates(r.json())),
       });
     }),
   );
@@ -63,7 +76,7 @@ describe('createRestTransport', () => {
   // in an HTML comment, and an unindexed marker returns the same empty array as a
   // genuinely absent one, so triage cannot tell "no duplicate" from "could not
   // tell". These tests pin the listing endpoint as the source of truth.
-  it('C2: enumerates open issues via the listing endpoint, never the search index', async () => {
+  it('#1481: enumerates all issue states in creation order, never the search index', async () => {
     const calls = mockFetch(() => ({ json: () => [] }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
@@ -74,7 +87,7 @@ describe('createRestTransport', () => {
     expect(url).not.toContain('/search/');
     expect(url).toBe(
       'https://api.github.com/repos/ArcadeAI/safeword/issues' +
-        '?state=open&sort=created&direction=asc&per_page=100&page=1',
+        '?state=all&sort=created&direction=asc&per_page=100&page=1',
     );
   });
 
@@ -147,6 +160,23 @@ describe('createRestTransport', () => {
     ]);
   });
 
+  it('#1481: rejects an exact marker carried only by a closed issue', async () => {
+    mockFetch(() => ({
+      json: () => [
+        {
+          number: 1,
+          title: 'closed recurrence',
+          body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+          state: 'closed',
+        },
+      ],
+    }));
+    const transport = createRestTransport('tok');
+    if (!transport) throw new Error('expected a transport');
+
+    await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([]);
+  });
+
   // The marker can be hand-copied into an ordinary issue when two are merged
   // (#1453 documents exactly that on #1425), so dedup must not filter by label.
   it('#1453: matches a marker on an issue that carries no retro label', async () => {
@@ -193,16 +223,12 @@ describe('createRestTransport', () => {
     await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([
       { number: 999, title: 'on page two' },
     ]);
-    // A HIT costs one sweep and no confirmation — a page-boundary skip can hide
-    // an issue, never fabricate one, so a positive match needs no second look.
+    // One all-state sweep populates the transport cache.
     expect(calls).toHaveLength(2);
 
     // A second lookup reuses the enumeration — triage runs two per encounter.
-    // This one MISSES, so it pays for the one-time stability confirmation: two
-    // FRESH sweeps (2 pages each), so the window under test is those two calls
-    // rather than everything since the run began.
     await transport.searchByCanonical('canonical:abc123def456');
-    expect(calls).toHaveLength(6);
+    expect(calls).toHaveLength(2);
   });
 
   // The bug this replaces was invisible because a zero result was
@@ -240,9 +266,7 @@ describe('createRestTransport', () => {
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([]);
-    // 31 for the cached sweep, then two fresh 31-page sweeps to confirm the miss.
-    // All three see the same set, so the miss stands.
-    expect(calls).toHaveLength(93);
+    expect(calls).toHaveLength(31);
   });
 
   // The cap has to mean what it says. Appending the probe page instead of
@@ -265,68 +289,65 @@ describe('createRestTransport', () => {
     expect(calls).toHaveLength(31);
   });
 
-  // Ascending order appends genuinely new issues to the LAST page, where they
-  // displace nothing already read. Treating that as instability would fail closed
-  // on every session that files while a human is opening issues.
-  it('#1453: tolerates a genuinely new issue appearing between sweeps', async () => {
-    const settled = Array.from({ length: 60 }, (_, i) => ({
+  // Ascending creation order appends genuinely new issues to the last page,
+  // where they displace nothing already read.
+  it('#1481: includes a new marker appended on a later page', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
       number: i + 1,
       title: `t${i + 1}`,
       body: 'no marker',
     }));
-    const withNewcomer = [...settled, { number: 5000, title: 'brand new', body: 'no marker' }];
-    let sweep = 0;
-    mockFetch(url => {
-      if (!url.endsWith('page=1')) return { json: () => [] };
-      sweep += 1;
-      const page = sweep === 1 ? settled : withNewcomer;
-      return { json: () => page };
-    });
+    mockFetch(url => ({
+      json: () =>
+        url.endsWith('page=1')
+          ? firstPage
+          : [
+              {
+                number: 5000,
+                title: 'brand new',
+                body: '<!-- safeword-retro-signature: retro:abc123def456 -->',
+              },
+            ],
+    }));
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
-    await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([]);
+    await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([
+      { number: 5000, title: 'brand new' },
+    ]);
   });
 
-  // Instability is a one-off, unlike truncation: someone closed an issue. Latching
-  // it would defer the whole session's filing over one unlucky close — the very
-  // "nothing reaches the tracker" symptom #1453 reported. It must fail only its own
-  // encounter and let the next one re-confirm.
-  it('#1453: retries confirmation after instability instead of latching the run', async () => {
-    // Models the mechanic faithfully rather than just the set difference: three
-    // pages, and the close lands BETWEEN page 1 and page 2 of one sweep so the
-    // shift actually drops an item across the boundary.
-    //
-    // Settled: #1..#201. Sweep 3 reads page 1 (#1..#100), then #1 closes, so the
-    // list becomes #2..#201 and page 2 now returns #102..#201 — #101 is skipped,
-    // exactly the silent-duplicate mechanic. Page 1 stays FULL, so pagination
-    // continues past the boundary instead of stopping short of it.
+  it('#1481: finds a still-open marker when an earlier issue closes at a page boundary', async () => {
+    const marker = '<!-- safeword-retro-signature: retro:abc123def456 -->';
     const settled = Array.from({ length: 201 }, (_, i) => ({
       number: i + 1,
       title: `t${i + 1}`,
-      body: 'no marker',
+      body: i === 100 ? marker : 'no marker',
+      state: 'open',
     }));
     const pageOf = (list: typeof settled, page: number) => list.slice((page - 1) * 100, page * 100);
 
-    let sweep = 0;
     mockFetch(url => {
-      // Anchored: a bare /page=(\d+)/ matches `per_page=100` first.
       const page = Number(/&page=(\d+)$/.exec(url)?.[1] ?? '1');
-      if (page === 1) sweep += 1;
-      // Sweeps: 1 = cached snapshot, 2+3 = the first confirmation pair. Only
-      // sweep 3 sees the close, and only from page 2 onward.
-      const shifted = sweep === 3 && page > 1;
-      return { json: () => pageOf(shifted ? settled.slice(1) : settled, page) };
+      if (url.includes('state=all')) {
+        const allStates = settled.map(issue =>
+          issue.number === 1 && page > 1 ? { ...issue, state: 'closed' } : issue,
+        );
+        return { json: () => pageOf(allStates, page) };
+      }
+
+      // The current open-only strategy sees #1 on page one, then loses it before
+      // page two. Every repeated sweep suffers the same shift, so set comparison
+      // cannot distinguish three equally incomplete reads from a stable result.
+      const openAfterClose = settled.slice(1);
+      return { json: () => pageOf(page === 1 ? settled : openAfterClose, page) };
     });
     const transport = createRestTransport('tok');
     if (!transport) throw new Error('expected a transport');
 
-    await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow(
-      /closed mid-enumeration/,
-    );
-    // Not latched: the next encounter re-confirms against a settled tracker
-    // (sweeps 4 and 5) and gets a real answer.
-    await expect(transport.searchByCanonical('canonical:abc123def456')).resolves.toEqual([]);
+    await expect(transport.searchBySignature('retro:abc123def456')).resolves.toEqual([
+      { number: 101, title: 't101' },
+    ]);
   });
 
   // A wrong credential fails the same way every time. Retrying it once per
@@ -388,7 +409,7 @@ describe('createRestTransport', () => {
   // pre-create snapshot, misses, and files the duplicate this module prevents.
   it('#1453: a lookup matches an issue created earlier in the same run', async () => {
     mockFetch(url =>
-      url.includes('state=open')
+      url.includes('state=all')
         ? { json: () => [] }
         : { json: () => ({ number: 7, title: 'just filed' }) },
     );

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -37,8 +37,10 @@ const MAX_ISSUE_PAGES = 10;
 //
 // Measured 2026-07-27: 1,550 items (16 pages), with 1,020 created in the prior
 // 30 days and 311 in the prior 7. A 200-page guard leaves 18,450 items — about
-// 415 days even at the faster trailing-7-day rate — without adding a request to
-// the normal 16-page sweep. Revisit before the repository approaches 20,000.
+// 415 days at the faster trailing-7-day rate — without adding a request to the
+// normal 16-page sweep. That is a flat-rate capacity horizon, not a forecast:
+// recent rolling-window volume increased sharply. Issue #1552 makes an
+// observable revisit threshold its first independent deliverable.
 const MAX_DEDUP_PAGES = 200;
 
 /** Ask the `gh` CLI for the environment's GitHub token, or undefined if unavailable. */

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -28,17 +28,13 @@ const PER_PAGE = 100;
 const MAX_COMMENT_PAGES = 20;
 // Safety bound on issue-listing pagination for the reconcile sweep (→ 1000 issues).
 const MAX_ISSUE_PAGES = 10;
-// Safety bound on the dedup enumeration (→ 3000 open *items*: the listing
-// endpoint returns PRs alongside issues, and they are filtered after the fetch,
-// so open PRs consume this budget too). Deliberately looser than
+// Safety bound on the dedup enumeration (→ 3000 repository *items*: the stable
+// all-state listing includes closed issues and PRs, which are filtered after the
+// fetch, so both consume this budget). Deliberately looser than
 // MAX_ISSUE_PAGES: hitting this bound THROWS rather than truncating (see
 // listOpenIssues), so it halts filing entirely — it needs real headroom above
-// the repo's open count, not just enough for one sweep.
+// the repo's total issue/PR count, not just enough for one sweep.
 const MAX_DEDUP_PAGES = 30;
-// How many times a run will re-take the two confirmation sweeps before giving up.
-// Instability is a one-off (someone closed an issue), so retrying usually works —
-// but a genuinely churning tracker must not spin the whole session on it.
-const MAX_CONFIRMATION_ATTEMPTS = 3;
 
 /** Ask the `gh` CLI for the environment's GitHub token, or undefined if unavailable. */
 function ghAuthToken(): string | undefined {
@@ -149,7 +145,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   const call = buildCall(token);
 
   /**
-   * Every open issue body, fetched once per transport (#1453).
+   * Every open issue body, fetched once per transport (#1453, #1481).
    *
    * Dedup used to ask `/search/issues` for the signature's hash token and filter
    * the hits. That made the search INDEX the arbiter of "already filed", and the
@@ -161,9 +157,15 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
    * signature, which is why this read as flaky for so long.
    *
    * The listing endpoint returns raw bodies verbatim, so the marker check becomes
-   * a local string compare — exact, index-independent, and lag-free. No label
-   * filter: this keeps the old query's recall, so a marker hand-copied into an
-   * unlabeled issue (as happens when issues are merged) still dedups.
+   * a local string compare — exact and index-independent. The pagination universe
+   * is `state=all`: closing or reopening an issue changes its state but not its
+   * membership or creation-order position, so it cannot shift a later open marker
+   * across a page boundary. Closed issues are filtered locally and remain
+   * ineligible matches. No label filter: this keeps the old query's recall, so a
+   * marker hand-copied into an unlabeled issue (as happens when issues are merged)
+   * still dedups. Deletion or transfer can still remove an item from this
+   * repository-wide universe; those administrative mutations remain outside the
+   * close/reopen race addressed here.
    *
    * Cached because triage runs up to two lookups per encounter; a 12-finding
    * session would otherwise re-list 24 times.
@@ -171,14 +173,12 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   let openIssues: Promise<OpenIssue[]> | undefined;
   /**
    * A failure the enumeration cannot recover from by trying again — the bound was
-   * exceeded, or the tracker mutated underneath it. Unlike a transient 5xx, these
-   * are deterministic, so re-running costs a full 31-request sweep to reach the
-   * same answer. Latched for the transport's life and rethrown to every later
-   * encounter (each still lands as its own isolated `failed` in triage).
+   * exceeded. Unlike a transient 5xx, this is deterministic, so re-running costs
+   * a full 31-request sweep to reach the same answer. Latched for the transport's
+   * life and rethrown to every later encounter (each still lands as its own
+   * isolated `failed` in triage).
    */
   let terminalFailure: Error | undefined;
-  let stabilityConfirmed = false;
-  let confirmationAttempts = 0;
 
   function latchTerminal(message: string): Error {
     terminalFailure = new Error(message);
@@ -186,24 +186,30 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   }
 
   /**
-   * One page of open issues. `rawLength` is the page size BEFORE pull requests are
-   * filtered out — a full page that happened to be all PRs still means "there is
-   * more", so the last-page test has to read the raw count, not the kept count.
+   * One page from the all-state issue/PR universe. `rawLength` is the page size
+   * BEFORE closed issues and pull requests are filtered out — a full page with no
+   * eligible issue still means "there is more", so the last-page test has to read
+   * the raw count, not the kept count.
    */
   async function fetchIssuePage(page: number): Promise<{ issues: OpenIssue[]; rawLength: number }> {
     const data = (await call(
       'GET',
-      // Ascending by creation: the default (created desc) puts new issues on
-      // page 1, so an issue filed mid-enumeration shifts every later page by one
-      // and can slip an unread issue past a page boundary — a silent duplicate.
-      // Ascending appends new items to the LAST page, leaving read pages stable.
-      `${ISSUES_BASE}?state=open&sort=created&direction=asc&per_page=${PER_PAGE}&page=${page}`,
-    )) as { number: number; title: string; body?: string; pull_request?: unknown }[];
+      // Ascending by creation appends new items to the last page. `state=all`
+      // keeps close/reopen transitions in the same ordered universe, while the
+      // local filter below preserves the existing open-only match policy.
+      `${ISSUES_BASE}?state=all&sort=created&direction=asc&per_page=${PER_PAGE}&page=${page}`,
+    )) as {
+      number: number;
+      title: string;
+      body?: string;
+      state: 'open' | 'closed';
+      pull_request?: unknown;
+    }[];
     const issues = data
       // Falsy, not `=== undefined`: this module's asymmetry is that a missed
       // match files a duplicate, so a `pull_request: null` must not drop a
       // real issue out of the dedup view.
-      .filter(issue => !issue.pull_request)
+      .filter(issue => !issue.pull_request && issue.state === 'open')
       .map(issue => ({ number: issue.number, title: issue.title, body: issue.body ?? '' }));
     return { issues, rawLength: data.length };
   }
@@ -226,7 +232,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
       // isolates this as a failed encounter and leaves the draft spooled, which is
       // recoverable. Silently returning [] would file the duplicate this replaces.
       throw latchTerminal(
-        `retro dedup: open items exceed ${MAX_DEDUP_PAGES * PER_PAGE}; enumeration truncated`,
+        `retro dedup: repository items exceed ${MAX_DEDUP_PAGES * PER_PAGE}; enumeration truncated`,
       );
     }
     return issues;
@@ -258,61 +264,6 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   }
 
   /**
-   * Page-number pagination is sound only while nothing is REMOVED mid-sweep.
-   * Ascending order stops a new issue from shifting already-read pages, but
-   * closing one shifts every later item back a position, so an item can fall
-   * across a page boundary unseen. If that item carried the marker, the sweep
-   * reports "no duplicate" and files one — the failure this module exists to stop.
-   *
-   * A MISS is therefore answered from a freshly-swept `later`, never from the
-   * cached snapshot — so an item the CACHED sweep skipped is already healed by the
-   * time the answer is given. The only completeness that matters is `later`'s.
-   *
-   * `earlier` exists solely to test that. If a close lands during `later`'s window
-   * it shifts `later`'s pages, and the item that fell through appears in `earlier`
-   * and not in `later` — so an issue going MISSING between the two is the tell. An
-   * issue merely appearing is benign: ascending order appends new issues to the
-   * last page, where they displace nothing.
-   *
-   * Both sweeps are taken here rather than reusing the cached one, so the window
-   * under test is these two calls — not every `listComments`/`createIssue` round
-   * trip since the run began, during which an unrelated close is routine.
-   *
-   * Instability is NOT latched: unlike truncation it is a one-off, so it fails
-   * this encounter (triage isolates it, the draft stays spooled) and the next
-   * encounter re-confirms. Bounded, so a genuinely churning tracker cannot spin.
-   *
-   * Paid once per run, and only on the answer that can cause a duplicate — a hit
-   * needs no confirmation, because a skipped item cannot invent one.
-   */
-  async function confirmedSnapshot(): Promise<OpenIssue[]> {
-    if (stabilityConfirmed) return await currentSnapshot();
-    if (confirmationAttempts >= MAX_CONFIRMATION_ATTEMPTS) {
-      throw latchTerminal(
-        `retro dedup: the open-issue set kept shifting across ` +
-          `${MAX_CONFIRMATION_ATTEMPTS} confirmation attempts; cannot rule out a skip`,
-      );
-    }
-    confirmationAttempts += 1;
-
-    const earlier = await listOpenIssues();
-    const later = await listOpenIssues();
-    const laterNumbers = new Set(later.map(issue => issue.number));
-    const vanished = earlier.filter(issue => !laterNumbers.has(issue.number));
-    if (vanished.length > 0) {
-      // Deliberately not latched — see the note above.
-      throw new Error(
-        `retro dedup: ${vanished.length} open issue(s) closed mid-enumeration ` +
-          `(e.g. #${vanished[0]?.number}); a page-boundary skip in this sweep ` +
-          `cannot be ruled out`,
-      );
-    }
-    stabilityConfirmed = true;
-    openIssues = Promise.resolve(later);
-    return later;
-  }
-
-  /**
    * Issues this transport filed during the current run.
    *
    * The enumeration above is a snapshot taken before the first create, and
@@ -333,12 +284,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   }
 
   async function findByExactMarker(marker: string): Promise<IssueReference[]> {
-    const matches = matchesIn(await currentSnapshot(), marker);
-    // A hit is trustworthy as-is: a page-boundary skip can hide an issue, never
-    // fabricate one. Only the MISS — the answer that authorizes a create — has to
-    // be paid for with a stability check.
-    if (matches.length > 0) return matches;
-    return matchesIn(await confirmedSnapshot(), marker);
+    return matchesIn(await currentSnapshot(), marker);
   }
 
   return {

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -28,13 +28,18 @@ const PER_PAGE = 100;
 const MAX_COMMENT_PAGES = 20;
 // Safety bound on issue-listing pagination for the reconcile sweep (→ 1000 issues).
 const MAX_ISSUE_PAGES = 10;
-// Safety bound on the dedup enumeration (→ 3000 repository *items*: the stable
+// Safety bound on the dedup enumeration (→ 20,000 repository *items*: the stable
 // all-state listing includes closed issues and PRs, which are filtered after the
 // fetch, so both consume this budget). Deliberately looser than
 // MAX_ISSUE_PAGES: hitting this bound THROWS rather than truncating (see
 // listOpenIssues), so it halts filing entirely — it needs real headroom above
 // the repo's total issue/PR count, not just enough for one sweep.
-const MAX_DEDUP_PAGES = 30;
+//
+// Measured 2026-07-27: 1,550 items (16 pages), with 1,020 created in the prior
+// 30 days and 311 in the prior 7. A 200-page guard leaves 18,450 items — about
+// 415 days even at the faster trailing-7-day rate — without adding a request to
+// the normal 16-page sweep. Revisit before the repository approaches 20,000.
+const MAX_DEDUP_PAGES = 200;
 
 /** Ask the `gh` CLI for the environment's GitHub token, or undefined if unavailable. */
 function ghAuthToken(): string | undefined {
@@ -174,7 +179,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
   /**
    * A failure the enumeration cannot recover from by trying again — the bound was
    * exceeded. Unlike a transient 5xx, this is deterministic, so re-running costs
-   * a full 31-request sweep to reach the same answer. Latched for the transport's
+   * a full 201-request sweep to reach the same answer. Latched for the transport's
    * life and rethrown to every later encounter (each still lands as its own
    * isolated `failed` in triage).
    */
@@ -225,7 +230,7 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
     // never accept the probe's contents: at exactly MAX_DEDUP_PAGES * PER_PAGE the
     // probe is empty and the enumeration is genuinely complete, while anything at
     // all on it means a real tail. Appending the probe instead would quietly raise
-    // the advertised cap to 3099 — the cap has to mean what it says.
+    // the advertised cap to 20,099 — the cap has to mean what it says.
     const probe = await fetchIssuePage(MAX_DEDUP_PAGES + 1);
     if (probe.rawLength > 0) {
       // A real unread tail, so "no match" would be a guess about it. Throw: triage


### PR DESCRIPTION
## Summary

- enumerate the all-state GitHub issue universe in creation order so close/reopen transitions cannot shift page membership
- filter closed issues and pull requests locally, preserving the existing eligible-match policy
- remove the repeated-sweep confirmation state machine and cover the page-boundary regression through the real REST transport
- raise the fail-closed dedup guard to 20,000 repository items, providing about 415 days of measured headroom at the trailing-seven-day growth rate
- make issue state explicit in every REST fixture

Fixes #1481

Follow-up: #1552 tracks Link-header traversal, safe cross-run caching, mutation lifecycle, equal-timestamp ordering, and guard observability.

## Verification

- 5,549/5,549 Vitest tests passed (5 skipped)
- 505/508 acceptance scenarios passed (3 skipped); 15,645/15,645 executed steps passed
- build, ESLint, Prettier, TypeScript, and diff hygiene passed
- focused REST transport suite: 41/41 passed
- audit: 0 change-scoped errors; dependency boundaries, dead code, architecture, docs, learning/domain docs, and changed-test quality clean

## Quality and engineering review

The review feedback and its corrections, evidence, measured cap decision, and post-fix **APPROVE** verdict are recorded in the durable [quality review artifact](https://github.com/ArcadeAI/safeword/blob/codex/1481-stable-retro-pagination/.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure/quality-review.md). The post-fix review found no critical issues.

The API contract was checked against GitHub primary documentation for [listing repository issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues), [REST pagination](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api), and [REST API versions](https://docs.github.com/en/rest/about-the-rest-api/api-versions).