### PR TITLE
Close the completed reply reminder ticket

### DIFF
--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (454)
+## Tickets (457)
 
 ### 001
 
@@ -665,7 +665,7 @@
 - **Keep Cursor wrappers aligned from shared metadata (F1HTQ4)** (in_progress, epic: agent-surface-refactor)
   Prevent Cursor command and rule wrappers from drifting away from the skills they point to.
   → `.project/tickets/F1HTQ4-cursor-wrapper-generation`
-- **Keep default tests responsive for maintainers (SFQ1EQ)** (in_progress, epic: agent-surface-refactor)
+- **Keep default tests responsive for maintainers (SFQ1EQ)** (done, epic: agent-surface-refactor)
   Keep the default Vitest suite fast and observable while retaining explicit coverage for real setup installs.
   → `.project/tickets/SFQ1EQ-keep-default-tests-responsive`
 - **Make Codex hook adapter behavior easier to test (W0E292)** (done, epic: agent-surface-refactor)
@@ -897,6 +897,9 @@
 - **Enable MD040 + MD036 in markdownlint-cli2 config (145)** (open, epic: —)
   Catch two LLM-specific markdown antipatterns at pre-commit time before they degrade the repo's LLM comprehension surface.
   → `.project/tickets/145-markdown-llm-rules`
+- **Task: Keep zombie cleanup inside the current project (1451)** (done, epic: —)
+  external issue: https://github.com/ArcadeAI/safeword/issues/1451
+  → `.project/tickets/1451-cleanup-zombies-project-safety`
 - **Auto-upgrade commit refinements: attribution + pre-commit bypass + change-list source (146)** (open, epic: —)
   Three small refinements to `session-auto-upgrade.ts`'s auto-commit step, surfaced during PR #81's quality review.
   → `.project/tickets/146-auto-commit-refinements`
@@ -1273,6 +1276,10 @@
 - **Quiet expected negative-path test output (GJGSS3)** (in_progress, epic: —)
   Keep passing full test runs quiet when negative-path fixtures intentionally print errors.
   → `.project/tickets/GJGSS3-quiet-expected-negative-path-test-output`
+- **Keep retro dedup stable during issue closure (GS2FGC)** (done, epic: —)
+  Prevent issue state changes during pagination from authorizing a duplicate retro issue.
+  external issue: https://github.com/ArcadeAI/safeword/issues/1481
+  → `.project/tickets/GS2FGC-keep-retro-dedup-stable-during-issue-closure`
 - **Lazy-load stack-specific ESLint plugins via createRequire (H150ZW)** (done, epic: —)
   Stop loading 7 stack-specific ESLint plugins (~7 × ~20ms each = ~140ms saved) into Node memory on every ESLint invocation for customers whose stack doesn't include them. The customer's generated `eslint.config.mjs` already gates plugin _usage_ with `detect.hasStorybook(deps)` etc.; this ticket gates plugin _loading_ to match.
   → `.project/tickets/H150ZW`
@@ -1349,6 +1356,10 @@
 - **Epic: Make safeword legible to the Non-Technical Builder (K6CAJN)** (done, epic: —)
   Close the gaps where safeword speaks to the Non-Technical Builder (NTB) in raw jargon — across the CLI terminal, first-run runtime checks, gate blocks, and the framing rules that govern translation — so a user who can't read the diff always gets a plain-language explanation and a concrete next action.
   → `.project/tickets/K6CAJN-ntb-experience-epic`
+- **Surface reply format before Claude responds (K8D3M4)** (done, epic: —)
+  Keep substantive Claude work updates in Safeword’s concise decision-brief shape before they reach the user.
+  external issue: https://github.com/ArcadeAI/safeword/issues/1524
+  → `.project/tickets/K8D3M4-reply-format-proactive-reminder`
 - **Keep verification preflight runnable in restricted agent shells (KCFH00)** (done, epic: —)
   Let the verification skill classify temporary Git-repository limits without being rejected by safe command policies.
   external issue: https://github.com/ArcadeAI/safeword/issues/469

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/ticket.md
@@ -2,11 +2,13 @@
 id: K8D3M4
 slug: reply-format-proactive-reminder
 type: task
-phase: verify
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/1524
+external_prs:
+  - https://github.com/ArcadeAI/safeword/pull/1540
 created: 2026-07-27T16:11:23.968Z
-last_modified: 2026-07-28T00:33:10Z
+last_modified: 2026-07-28T01:02:07Z
 ---
 
 # Surface reply format before Claude responds
@@ -172,3 +174,7 @@ open.
   transient connection refusal while installing React fixture dependencies;
   its isolated 11-test suite passed on retry, then a clean full rerun passed
   5,553 tests across all 373 files with 5 skipped.
+- 2026-07-28T01:02:07Z Done: user accepted the merged result. PR #1540 was
+  green on lint, Node 22, Node 24, and dogfood parity and squash-merged to
+  `main` as `2168ed054f`; GitHub issue #1524 closed automatically. Status and
+  phase moved to `done`.

--- a/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
+++ b/.project/tickets/K8D3M4-reply-format-proactive-reminder/verify.md
@@ -56,5 +56,8 @@ new clone pattern. `bun outdated` found one low-risk dev-only patch update
 dead-code/import checks remain unavailable in an unrelated experiment because
 their tools are not installed.
 
-**Evidence limits:** ✅ None for this task. The ticket intentionally remains
-`in_progress` pending user confirmation before it is marked done.
+**User acceptance:** ✅ Accepted after PR #1540 passed all required CI checks
+and squash-merged to `main` as `2168ed054f`. GitHub issue #1524 closed
+automatically.
+
+**Evidence limits:** ✅ None for this task.


### PR DESCRIPTION
## Summary

- Mark K8D3M4 done after explicit user acceptance of the merged result.
- Record merged PR #1540 and squash commit `2168ed054f` as durable completion evidence.
- Regenerate the ticket index from the current corpus, including three previously stale entries already present on `main`.

## Why

PR #1540 passed all required checks, merged, and closed issue #1524, but its internal Safeword ticket intentionally remained in verify until the user explicitly accepted it. That acceptance has now been given.

## Validation

- `bun run lint`
- Gherkin lint and TypeScript typecheck
- Template parity: 195 pairs and 8 contracts
- markdownlint on all changed Markdown
- `safeword boundary --at commit`
- `git diff --check`