### PR TITLE
Decouple GitHub token format validation

### DIFF
--- a/.project/tickets/1520-decouple-github-token-format/ticket.md
+++ b/.project/tickets/1520-decouple-github-token-format/ticket.md
@@ -1,0 +1,42 @@
+---
+id: 1520
+type: task
+phase: done
+status: done
+created: 2026-07-28T00:00:00Z
+last_modified: 2026-07-28T06:50:00Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1520
+scope: Treat GITHUB_TOKEN as an opaque RFC 6750 Bearer credential while rejecting documented environment placeholders and unusable characters.
+out_of_scope: Changing the egress scrubber or validating whether a credential is authorized by GitHub.
+done_when: The resolver has no GitHub-format allowlist, accepts valid opaque Bearer tokens without a length floor, and preserves proxy-placeholder fallback.
+---
+
+# Task: Keep future GitHub credentials usable without format updates
+
+**Type:** Improvement
+
+**Scope:** Make the retro REST token resolver accept opaque values that satisfy RFC 6750 Bearer-token grammar, while retaining the documented `proxy-injected` fallback to `gh`.
+
+**Out of Scope:** Changing the format-coupled egress scrubber, adding authorization preflight, or interpreting GitHub token prefixes and lengths.
+
+**Done When:**
+
+- [x] Resolver accepts arbitrary valid Bearer-token syntax without a GitHub-specific prefix or minimum length.
+- [x] Empty values, documented placeholders, whitespace, and control characters fall back to `gh` before an Authorization header is built.
+- [x] A syntactically usable unauthorized value reaches the REST transport and its 401 remains terminal.
+
+**Tests:**
+
+- [x] Unit: current classic, stateless, fine-grained, and legacy hex fixtures remain accepted alongside opaque valid Bearer values.
+- [x] Unit: empty, placeholder, whitespace, and control-character values fall back to `gh`.
+- [x] Unit: an opaque valid Bearer value is sent in the Authorization header and a 401 is terminal.
+
+## Work Log
+
+- 2026-07-28T06:50:00Z Complete: `$safeword:quality-review`, `$safeword:refactor`, `$safeword:verify`, and `$safeword:audit` completed. Full Vitest suite (5,596 passing; 5 skipped), BDD lane (505 passing; 3 skipped), typecheck, lint, format, and scope checks are green; audit baseline warnings are recorded in `verify.md`.
+- 2026-07-28T06:15:00Z Corrected: Moved this record from the schema-managed `.safeword/` template directory to the project ticket namespace after full verification exposed the inventory violation.
+- 2026-07-28T06:08:00Z Improved: Renamed the token predicate to describe Bearer-credential usability and added one-character, full-grammar, and NUL-control regression cases; targeted tests passed (45 tests).
+- 2026-07-28T06:01:00Z Complete: Targeted tests, typecheck, ESLint, Prettier, and diff whitespace checks passed; no commit or tracker-state change was requested.
+- 2026-07-28T05:59:00Z Verified: `bun run test src/retro/github-rest.test.ts` passed (42 tests); `bun run typecheck` passed.
+- 2026-07-28T05:58:00Z Implemented: Replaced GitHub-specific token prefixes and length checks with RFC 6750 Bearer-token syntax plus the exact `proxy-injected` exclusion; added opaque-token, invalid-character, Authorization-header, and terminal-401 regression coverage.
+- 2026-07-28T00:00:00Z Started: Triaged GitHub issue #1520 and recorded the scoped implementation and test plan.

--- a/.project/tickets/1520-decouple-github-token-format/ticket.md
+++ b/.project/tickets/1520-decouple-github-token-format/ticket.md
@@ -4,9 +4,9 @@ type: task
 phase: done
 status: done
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-28T06:50:00Z
+last_modified: 2026-07-28T14:39:38Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1520
-scope: Treat GITHUB_TOKEN as an opaque RFC 6750 Bearer credential while rejecting documented environment placeholders and unusable characters.
+scope: Treat GITHUB_TOKEN as an opaque RFC 6750 Bearer credential while rejecting documented environment placeholders and unusable characters, including from the gh fallback child environment.
 out_of_scope: Changing the egress scrubber or validating whether a credential is authorized by GitHub.
 done_when: The resolver has no GitHub-format allowlist, accepts valid opaque Bearer tokens without a length floor, and preserves proxy-placeholder fallback.
 ---
@@ -24,15 +24,18 @@ done_when: The resolver has no GitHub-format allowlist, accepts valid opaque Bea
 - [x] Resolver accepts arbitrary valid Bearer-token syntax without a GitHub-specific prefix or minimum length.
 - [x] Empty values, documented placeholders, whitespace, and control characters fall back to `gh` before an Authorization header is built.
 - [x] A syntactically usable unauthorized value reaches the REST transport and its 401 remains terminal.
+- [x] The `gh` child cannot reintroduce a rejected `GITHUB_TOKEN` placeholder.
 
 **Tests:**
 
 - [x] Unit: current classic, stateless, fine-grained, and legacy hex fixtures remain accepted alongside opaque valid Bearer values.
 - [x] Unit: empty, placeholder, whitespace, and control-character values fall back to `gh`.
 - [x] Unit: an opaque valid Bearer value is sent in the Authorization header and a 401 is terminal.
+- [x] Unit: the default `gh` fallback omits rejected `GITHUB_TOKEN` while retaining an independent `GH_TOKEN` credential source.
 
 ## Work Log
 
+- 2026-07-28T14:39:38Z Improved: Resolved all PR #1577 review items after fresh quality-review and figure-it-out passes. The syntax and placeholder-policy checks are separate, #1465 and #1520 own distinct terminal-401 regressions, nonliteral placeholders and terminal CR/LF are pinned, and the default `gh` child no longer inherits a rejected `GITHUB_TOKEN` (#1602) while retaining `GH_TOKEN`.
 - 2026-07-28T06:50:00Z Complete: `$safeword:quality-review`, `$safeword:refactor`, `$safeword:verify`, and `$safeword:audit` completed. Full Vitest suite (5,596 passing; 5 skipped), BDD lane (505 passing; 3 skipped), typecheck, lint, format, and scope checks are green; audit baseline warnings are recorded in `verify.md`.
 - 2026-07-28T06:15:00Z Corrected: Moved this record from the schema-managed `.safeword/` template directory to the project ticket namespace after full verification exposed the inventory violation.
 - 2026-07-28T06:08:00Z Improved: Renamed the token predicate to describe Bearer-credential usability and added one-character, full-grammar, and NUL-control regression cases; targeted tests passed (45 tests).

--- a/.project/tickets/1520-decouple-github-token-format/verify.md
+++ b/.project/tickets/1520-decouple-github-token-format/verify.md
@@ -1,0 +1,15 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 5596/5596 tests pass (5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (505 scenarios passed, 3 skipped)
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** ⏭️ Skipped — task has no separate test definitions
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal plumbing
+**Evidence limits:** ✅ None
+
+Audit passed with baseline warnings: two available dev-tool patch releases, intentional template-parity duplication, and unavailable Python import/dead-code tooling in experimental code. None is introduced by this task.

--- a/.project/tickets/1520-decouple-github-token-format/verify.md
+++ b/.project/tickets/1520-decouple-github-token-format/verify.md
@@ -1,6 +1,6 @@
 ## Verify Checklist
 
-**Test Suite:** ✓ 5596/5596 tests pass (5 skipped)
+**Test Suite:** ✓ 5601/5601 tests pass (5 skipped)
 **Gherkin:** ✅ Acceptance lane passes (505 scenarios passed, 3 skipped)
 **Build:** ✅ Success
 **Lint:** ✅ Clean
@@ -12,4 +12,4 @@
 **Experience:** ⏭️ N/A — internal plumbing
 **Evidence limits:** ✅ None
 
-Audit passed with baseline warnings: two available dev-tool patch releases, intentional template-parity duplication, and unavailable Python import/dead-code tooling in experimental code. None is introduced by this task.
+Audit passed with baseline warnings: two available dev-tool patch releases, intentional template-parity duplication, and unavailable Python import/dead-code tooling in experimental code. None is introduced by this task. A fresh quality-review pass verified the comment-resolution changes against RFC 6750, GitHub's opaque-token guidance, and GitHub CLI credential precedence.

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (457)
+## Tickets (458)
 
 ### 001
 
@@ -915,6 +915,9 @@
 - **Resolve `bun audit` advisories surfaced 2026-05-18 (152)** (done, epic: —)
   Clear the 4 advisories that `bun audit` flags in safeword's tree (1 high, 3 moderate) by bumping the deps that pull in vulnerable transitives. None of these are caused by safeword's own direct deps — they're all transitives — but they show up in `bun audit` output, which customers run too.
   → `.project/tickets/152-resolve-bun-audit-advisories`
+- **Task: Keep future GitHub credentials usable without format updates (1520)** (done, epic: —)
+  external issue: https://github.com/ArcadeAI/safeword/issues/1520
+  → `.project/tickets/1520-decouple-github-token-format`
 - **Boundary Resilience: Replan-on-Resume (153)** (done, epic: —)
   Eliminate the plan-staleness failure mode when resuming a ticket after sibling work landed — a ticket written before its siblings shipped reflects assumptions the new commits have invalidated, and today nothing re-checks the plan at resume. (The companion failure — forgetting cross-ticket contracts mid-session — is deferred with the epic-anchor hook.)
   → `.project/tickets/153-boundary-resilience`

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }));
+
 import { createRestTransport, resolveGitHubToken } from './github-rest.js';
 
 interface MockResponse {
@@ -60,6 +64,8 @@ function mockFetchCapturing(responder: (url: string) => MockResponse): CapturedC
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
 });
 
 describe('createRestTransport', () => {
@@ -367,8 +373,21 @@ describe('createRestTransport', () => {
 
   // A wrong credential fails the same way every time. Retrying it once per
   // finding burns a whole sweep each and can trip rate limits (#1465 review).
-  it('#1520: sends an opaque Bearer credential to GitHub, where a terminal 401 is latched', async () => {
+  it('#1465: latches a terminal auth failure instead of re-sweeping per encounter', async () => {
     const calls = mockFetch(() => ({ ok: false, status: 401, json: () => ({}) }));
+    const transport = createRestTransport('tok');
+    if (!transport) throw new Error('expected a transport');
+
+    await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow('401');
+    expect(calls).toHaveLength(1);
+
+    // The next encounter fails from the latch — no second request.
+    await expect(transport.searchByCanonical('canonical:abc123def456')).rejects.toThrow('401');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('#1520: sends an opaque Bearer credential to GitHub, where its 401 is terminal', async () => {
+    const calls = mockFetchCapturing(() => ({ ok: false, status: 401, json: () => ({}) }));
     const token = resolveGitHubToken({ GITHUB_TOKEN: 'future-token~1' }, () => {
       throw new Error('gh fallback must not be consulted');
     });
@@ -378,6 +397,9 @@ describe('createRestTransport', () => {
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow('401');
     expect(calls).toHaveLength(1);
+    expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer future-token~1',
+    );
 
     // The next encounter fails from the latch — no second request.
     await expect(transport.searchByCanonical('canonical:abc123def456')).rejects.toThrow('401');
@@ -572,6 +594,8 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     ['single-character Bearer credential', 'a'],
     ['Bearer credential with every permitted punctuation character and padding', 'a-._~+/==='],
     ['arbitrary opaque Bearer credential', opaqueBearerToken],
+    ['RFC-valid value that is not the exact documented placeholder', 'not-set'],
+    ['case variant of the exact documented placeholder', 'PROXY-INJECTED'],
   ])('accepts a %s from GITHUB_TOKEN without consulting gh', (_label, shaped) => {
     let ghConsulted = false;
     const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
@@ -582,23 +606,23 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     expect(ghConsulted).toBe(false);
   });
 
-  it.each([
-    ['arbitrary opaque credential', opaqueBearerToken],
-    ['stateless GitHub credential', representativeStatelessToken],
-  ])('passes a selected %s GITHUB_TOKEN to the REST transport', async (_label, shaped) => {
-    const calls = mockFetchCapturing(() => ({ json: () => ({ id: 99, body: 'hi' }) }));
-    const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
-      throw new Error('gh fallback must not be consulted');
-    });
-    const transport = createRestTransport(token);
-    if (!transport) throw new Error('expected a transport');
+  it.each([['stateless GitHub credential', representativeStatelessToken]])(
+    'passes a selected %s GITHUB_TOKEN to the REST transport',
+    async (_label, shaped) => {
+      const calls = mockFetchCapturing(() => ({ json: () => ({ id: 99, body: 'hi' }) }));
+      const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
+        throw new Error('gh fallback must not be consulted');
+      });
+      const transport = createRestTransport(token);
+      if (!transport) throw new Error('expected a transport');
 
-    await transport.createComment(42, 'hi');
+      await transport.createComment(42, 'hi');
 
-    expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe(
-      `Bearer ${shaped}`,
-    );
-  });
+      expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe(
+        `Bearer ${shaped}`,
+      );
+    },
+  );
 
   it.each([
     ['a proxy placeholder', 'proxy-injected'],
@@ -606,11 +630,31 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     ['a value containing a space', 'opaque token'],
     ['a value containing a tab', 'opaque\ttoken'],
     ['a value containing a newline', 'opaque\ntoken'],
+    ['a value ending in a newline', 'opaque-token\n'],
+    ['a value ending in a carriage return', 'opaque-token\r'],
     ['a value containing a NUL control character', 'opaque\0token'],
     ['a value with equals outside the optional suffix', 'opaque=token'],
   ])('rejects %s and falls back to gh', (_label, bogus) => {
     const token = resolveGitHubToken({ GITHUB_TOKEN: bogus }, () => ghToken);
     expect(token).toBe(ghToken);
+  });
+
+  it('#1602: removes a rejected GITHUB_TOKEN before asking gh for its credential', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
+    vi.stubEnv('GH_TOKEN', 'explicit-gh-token');
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'gh-keyring-token\n' });
+
+    expect(resolveGitHubToken()).toBe('gh-keyring-token');
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'gh',
+      ['auth', 'token'],
+      expect.objectContaining({ encoding: 'utf8', timeout: 10_000 }),
+    );
+    const spawnCall = spawnSyncMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
+    if (!spawnCall) throw new Error('expected gh auth token to be called');
+    const options = spawnCall[2];
+    expect(options.env).toMatchObject({ GH_TOKEN: 'explicit-gh-token' });
+    expect(options.env).not.toHaveProperty('GITHUB_TOKEN');
   });
 
   // invisible-retro-claude.SM1.AC1 (token arm) — GITHUB_TOKEN present → the REST

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -367,9 +367,13 @@ describe('createRestTransport', () => {
 
   // A wrong credential fails the same way every time. Retrying it once per
   // finding burns a whole sweep each and can trip rate limits (#1465 review).
-  it('#1465: latches a terminal auth failure instead of re-sweeping per encounter', async () => {
+  it('#1520: sends an opaque Bearer credential to GitHub, where a terminal 401 is latched', async () => {
     const calls = mockFetch(() => ({ ok: false, status: 401, json: () => ({}) }));
-    const transport = createRestTransport('tok');
+    const token = resolveGitHubToken({ GITHUB_TOKEN: 'future-token~1' }, () => {
+      throw new Error('gh fallback must not be consulted');
+    });
+    expect(token).toBe('future-token~1');
+    const transport = createRestTransport(token);
     if (!transport) throw new Error('expected a transport');
 
     await expect(transport.searchBySignature('retro:abc123def456')).rejects.toThrow('401');
@@ -550,10 +554,13 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
   // `ghs_APPID_JWT` rollout shape.
   const minimumStatelessToken = `ghs_${'a'.repeat(10)}_${'b'.repeat(10)}.${'c'.repeat(6)}.${'d'.repeat(7)}`;
   const representativeStatelessToken = `ghs_1234567_${'a'.repeat(160)}.${'b'.repeat(160)}.${'c'.repeat(186)}`;
+  // RFC 6750 Bearer credentials are opaque to this resolver. This deliberately
+  // has no GitHub prefix or minimum length, so a future token format does not
+  // require a resolver release before it can reach GitHub for validation.
+  const opaqueBearerToken = 'future-token~1';
 
-  // #634 — every accepted GitHub token shape must survive resolution, or a
-  // regex that quietly stopped matching one form (e.g. fine-grained PATs) would
-  // break a working auth path with no test to catch it.
+  // Existing GitHub token fixtures remain regression controls; the resolver
+  // must also accept an arbitrary value that satisfies the Bearer grammar.
   it.each([
     ['classic PAT (ghp_)', `ghp_${'a'.repeat(32)}`],
     ['OAuth (gho_)', `gho_${'b'.repeat(32)}`],
@@ -562,6 +569,9 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     ['representative stateless app server-to-server (ghs_APPID_JWT)', representativeStatelessToken],
     ['fine-grained PAT (github_pat_)', `github_pat_${'d'.repeat(40)}`],
     ['legacy 40-char hex', '0123456789'.repeat(4)],
+    ['single-character Bearer credential', 'a'],
+    ['Bearer credential with every permitted punctuation character and padding', 'a-._~+/==='],
+    ['arbitrary opaque Bearer credential', opaqueBearerToken],
   ])('accepts a %s from GITHUB_TOKEN without consulting gh', (_label, shaped) => {
     let ghConsulted = false;
     const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
@@ -573,8 +583,8 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
   });
 
   it.each([
-    ['classic opaque', `ghs_${'a'.repeat(40)}`],
-    ['stateless', representativeStatelessToken],
+    ['arbitrary opaque credential', opaqueBearerToken],
+    ['stateless GitHub credential', representativeStatelessToken],
   ])('passes a selected %s GITHUB_TOKEN to the REST transport', async (_label, shaped) => {
     const calls = mockFetchCapturing(() => ({ json: () => ({ id: 99, body: 'hi' }) }));
     const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
@@ -592,14 +602,12 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
 
   it.each([
     ['a proxy placeholder', 'proxy-injected'],
-    ['an unknown prefix', `gha_${'a'.repeat(32)}`],
-    ['a 35-character stateless token', minimumStatelessToken.slice(0, -1)],
-    ['a stateless token embedded in prose', `prefix-ghs_${'a'.repeat(40)}.${'b'.repeat(40)}`],
-    [
-      'a stateless token followed by trailing prose',
-      `ghs_${'a'.repeat(40)}.${'b'.repeat(40)} extra`,
-    ],
     ['an empty string', ''],
+    ['a value containing a space', 'opaque token'],
+    ['a value containing a tab', 'opaque\ttoken'],
+    ['a value containing a newline', 'opaque\ntoken'],
+    ['a value containing a NUL control character', 'opaque\0token'],
+    ['a value with equals outside the optional suffix', 'opaque=token'],
   ])('rejects %s and falls back to gh', (_label, bogus) => {
     const token = resolveGitHubToken({ GITHUB_TOKEN: bogus }, () => ghToken);
     expect(token).toBe(ghToken);

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -43,10 +43,23 @@ const MAX_ISSUE_PAGES = 10;
 // observable revisit threshold its first independent deliverable.
 const MAX_DEDUP_PAGES = 200;
 
-/** Ask the `gh` CLI for the environment's GitHub token, or undefined if unavailable. */
-function ghAuthToken(): string | undefined {
+/**
+ * Ask `gh` for the environment's GitHub token, or undefined if unavailable.
+ * `GITHUB_TOKEN` is stripped because the resolver only calls this fallback
+ * after rejecting that value; preserve `GH_TOKEN`, which is an independent
+ * documented gh credential source with higher precedence.
+ */
+function ghAuthToken(
+  environment: Record<string, string | undefined> = process.env,
+): string | undefined {
   try {
-    const result = spawnSync('gh', ['auth', 'token'], { encoding: 'utf8', timeout: 10_000 });
+    const childEnvironment = { ...environment };
+    delete childEnvironment.GITHUB_TOKEN;
+    const result = spawnSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: childEnvironment,
+    });
     const token = (result.stdout ?? '').trim();
     return result.status === 0 && token.length > 0 ? token : undefined;
   } catch {
@@ -55,13 +68,12 @@ function ghAuthToken(): string | undefined {
 }
 
 /**
- * Whether a value is syntactically usable as an RFC 6750 Bearer credential.
- * GitHub tokens are opaque: their API, not this resolver, decides whether the
- * credential is valid or authorized. Keep the documented cloud placeholder
- * out of the API so `gh` can supply a usable credential instead (#634).
+ * Whether a value has RFC 6750 Bearer credential syntax. GitHub tokens are
+ * opaque: their API, not this resolver, decides whether the credential is
+ * valid or authorized.
  */
-function isUsableBearerCredential(value: string): boolean {
-  return value !== 'proxy-injected' && /^[\w.~+/-]+=*$/.test(value);
+function isBearerCredentialSyntax(value: string): boolean {
+  return /^[\w.~+/-]+=*$/.test(value);
 }
 
 /**
@@ -70,20 +82,25 @@ function isUsableBearerCredential(value: string): boolean {
  * environment's existing GitHub access via `gh auth token`. Returns undefined when
  * neither is available, so the caller can no-op gracefully instead of failing.
  *
- * The env var is honored when it is syntactically usable as a Bearer credential.
- * Some environments (e.g. Claude cloud containers) populate `GITHUB_TOKEN` with
- * the non-credential `proxy-injected` placeholder, which would 401 and muddy
- * diagnosis; treat it as absent and fall through to `gh`. Other opaque values
- * reach GitHub, where an invalid or unauthorized credential gets its terminal
- * 401 response instead of being guessed at locally.
+ * The env var is honored when it has Bearer syntax, except for the exact
+ * documented `proxy-injected` cloud placeholder. Treat that value as absent and
+ * fall through to `gh`; every other opaque syntax-valid value reaches GitHub,
+ * where an invalid or unauthorized credential gets its terminal 401 response
+ * instead of being guessed at locally.
  */
 export function resolveGitHubToken(
   env: Record<string, string | undefined> = process.env,
-  getGhToken: () => string | undefined = ghAuthToken,
+  getGhToken: (environment: Record<string, string | undefined>) => string | undefined = ghAuthToken,
 ): string | undefined {
   const fromEnvironment = env.GITHUB_TOKEN;
-  if (fromEnvironment && isUsableBearerCredential(fromEnvironment)) return fromEnvironment;
-  return getGhToken();
+  if (
+    fromEnvironment &&
+    fromEnvironment !== 'proxy-injected' &&
+    isBearerCredentialSyntax(fromEnvironment)
+  ) {
+    return fromEnvironment;
+  }
+  return getGhToken(env);
 }
 
 /** The one place auth + API headers are wired to fetch; both transports compose this. */

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -55,20 +55,13 @@ function ghAuthToken(): string | undefined {
 }
 
 /**
- * A value shaped like a real GitHub token: a modern prefixed token
- * (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, or fine-grained `github_pat_`) or a
- * legacy 40-char hex PAT. Deliberately narrow so proxy-injected placeholders
- * such as `proxy-injected` are rejected before they reach the API (#634).
- * Stateless `ghs_` tokens use GitHub's published `{36,}` matcher:
- * https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/
+ * Whether a value is syntactically usable as an RFC 6750 Bearer credential.
+ * GitHub tokens are opaque: their API, not this resolver, decides whether the
+ * credential is valid or authorized. Keep the documented cloud placeholder
+ * out of the API so `gh` can supply a usable credential instead (#634).
  */
-function looksLikeGitHubToken(value: string): boolean {
-  return (
-    /^ghs_[\w.-]{36,}$/.test(value) ||
-    /^gh[opusr]_[A-Za-z0-9]{20,}$/.test(value) ||
-    /^github_pat_\w{20,}$/.test(value) ||
-    /^[0-9a-f]{40}$/.test(value)
-  );
+function isUsableBearerCredential(value: string): boolean {
+  return value !== 'proxy-injected' && /^[\w.~+/-]+=*$/.test(value);
 }
 
 /**
@@ -77,17 +70,19 @@ function looksLikeGitHubToken(value: string): boolean {
  * environment's existing GitHub access via `gh auth token`. Returns undefined when
  * neither is available, so the caller can no-op gracefully instead of failing.
  *
- * The env var is only honored when it is *shaped* like a GitHub token (#634):
- * some environments (e.g. Claude cloud containers) populate `GITHUB_TOKEN` with
- * a non-credential placeholder that would 401, muddying diagnosis — treat that
- * as absent and fall through to `gh` instead of passing it to the API.
+ * The env var is honored when it is syntactically usable as a Bearer credential.
+ * Some environments (e.g. Claude cloud containers) populate `GITHUB_TOKEN` with
+ * the non-credential `proxy-injected` placeholder, which would 401 and muddy
+ * diagnosis; treat it as absent and fall through to `gh`. Other opaque values
+ * reach GitHub, where an invalid or unauthorized credential gets its terminal
+ * 401 response instead of being guessed at locally.
  */
 export function resolveGitHubToken(
   env: Record<string, string | undefined> = process.env,
   getGhToken: () => string | undefined = ghAuthToken,
 ): string | undefined {
   const fromEnvironment = env.GITHUB_TOKEN;
-  if (fromEnvironment && looksLikeGitHubToken(fromEnvironment)) return fromEnvironment;
+  if (fromEnvironment && isUsableBearerCredential(fromEnvironment)) return fromEnvironment;
   return getGhToken();
 }
 


### PR DESCRIPTION
## Summary

- Treat `GITHUB_TOKEN` as an opaque RFC 6750 Bearer credential instead of recognizing GitHub-specific prefixes or lengths.
- Preserve the exact `proxy-injected` fallback and prevent `gh auth token` from reintroducing that rejected value from its child environment.
- Add regression coverage for opaque credentials, RFC-valid nonliteral placeholders, terminal CR/LF rejection, Authorization-header propagation, terminal 401 behavior, and the default `gh` fallback boundary.

## Why

GitHub token formats can change independently of this CLI. The resolver leaves credential validity and authorization to GitHub rather than rejecting future valid token formats locally, while retaining the documented cloud-placeholder escape hatch.

Fixes #1520.

## Validation

- `bun run test` — 5,601 passed, 5 skipped
- `bun run test:bdd` — 505 scenarios passed, 3 skipped
- Build, typecheck, ESLint, Prettier, and `git diff --check`
- Fresh independent quality review against RFC 6750, GitHub token guidance, and GitHub CLI credential precedence
- Verification and audit workflows