### PR TITLE
Validate shipped TypeScript hook templates

### DIFF
--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -1,0 +1,78 @@
+---
+id: 505
+slug: keep-shipped-hooks-host-lintable
+type: task
+phase: done
+status: done
+external_issue: https://github.com/ArcadeAI/safeword/issues/505
+created: 2026-07-28T00:00:00Z
+last_modified: 2026-07-28T14:59:03Z
+scope:
+  - Keep every shipped TypeScript hook compatible with the supported ESLint baseline used by host projects.
+  - Add release validation for the physical distributed hook surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
+out_of_scope:
+  - Adding a host-project lint ignore for .safeword/hooks.
+  - Normalizing the existing hook corpus to every stylistic and security rule in the full typed host preset.
+done_when:
+  - Shipped TypeScript hooks have no errors from the supported ESLint baseline.
+  - Every physical shipped hook loads without a fatal parser/config diagnostic under the actual typed host preset.
+  - Every physical shipped hook typechecks in a generated installed-shape fixture without customer dependencies.
+---
+
+# Keep shipped hooks host-lintable
+
+**Goal:** Let a Safeword upgrade complete without shipped hooks blocking the host project's lint.
+
+**Why:** Installed hooks are part of the host repository's lint surface and can otherwise break a customer commit after an upgrade.
+
+**Type:** Bug
+
+**Scope:** Remove the reported lint violations from the shipped TypeScript hook
+templates and add release-lane validation for every shipped TypeScript hook:
+the supported host baseline, fatal parser/config loading under Safeword's typed
+preset, and strict typechecking in its installed shape.
+
+**Out of Scope:** Ignoring `.safeword/hooks/**` in generated host configs,
+changing unrelated ESLint policies, or expanding validation to non-hook templates.
+
+## Decision
+
+Use the preferred upstream contract: shipped hooks stay in host lint scope and
+must pass the supported ESLint baseline. The release test validates the exact
+`packages/cli/templates/hooks/**` TypeScript surface that the package publishes,
+including parser/config integration and strict typechecking in a temporary
+installed fixture. Full-preset policy cleanup is separately scoped because the
+pre-existing corpus has a broad backlog unrelated to issue #505.
+
+**Figure-it-out:**
+
+- [x] Phase 1: Frame the choice as lint-clean templates versus a generated host ignore.
+- [x] Phase 2: Compare upstream validation, a host ignore, and both together.
+- [x] Phase 3a: Examine ESLint rule semantics, package distribution, and template/reconciliation ownership.
+- [x] Phase 3b: Validate the two rules with current ESLint documentation and inspect Safeword's published `templates` contract.
+- [x] Phase 4: Commit to upstream lint validation and minimal source fixes.
+
+## Done When:
+
+- [x] The literal BOM and dead-store initializations no longer create host-lint failures.
+- [x] A release test checks every shipped TypeScript hook with the supported baseline.
+- [x] A release test loads every shipped hook through the typed host preset and fails on fatal parser/config diagnostics.
+- [x] A release test strictly typechecks the installed-shape hook tree with package-owned `@types/bun` support.
+
+## Test Definitions:
+
+- [x] RED — The baseline reported five current violations across the shipped hook tree.
+- [x] GREEN — The release test reports no errors after the minimal template fixes.
+- [x] RED — The installed-shape strict typecheck exposed 22 real template diagnostics; the minimal fixes preserve each hook's fail-open behavior.
+- [x] GREEN — The installed fixture typechecks all physical hook templates without customer dependencies.
+- [x] REFACTOR — The test has one owner, discovers the shipped hook tree instead of maintaining a file list, and centralizes Claude session resolution for the two retro filing hooks.
+
+## Work Log
+
+- 2026-07-28T00:00:00Z Started: Triaged GitHub issue #505 and created this scoped task record.
+- 2026-07-28T00:00:00Z Figure-it-out: chose host-lint-clean templates plus upstream release validation; a host ignore would conceal defects in shipped code and leave customers without lint coverage.
+- 2026-07-28T07:22:02Z RED/GREEN: added a release-lane ESLint gate for the shipped hook tree; it found five current errors. Replaced the literal BOM and removed four dead-store initializations without changing fallback behavior.
+- 2026-07-28T07:22:02Z Verified: focused gate, package typecheck, root lint, formatting, and the release suite passed (23 tests). The first full release attempt had one unrelated five-second timing timeout in `pre-tool-git-bare-fix`; its isolated rerun and the clean full rerun passed.
+- 2026-07-28T14:38:21Z Quality review closed a coverage gap: added a package-owned `@types/bun` installed-fixture typecheck and fixed 22 strict diagnostics across the physical hook tree. The typed host preset now also loads that fixture and fails on fatal parser/config errors; full-preset policy diagnostics remain explicitly out of scope because the existing corpus has a separate broad backlog.
+- 2026-07-28T14:38:21Z Refactor/audit: centralized Claude session environment resolution for the two retro filing hooks and synchronized all changed hook templates to dogfood copies.
+- 2026-07-28T14:59:03Z Final verification: release validation (25 tests), direct release-test lint, root lint, build, Gherkin acceptance, parity (195 pairs / 8 contracts), `bun audit`, and two independent quality reviews passed. Reverted the unrelated root patch upgrades found during audit; the required CLI-local Bun types remain. The complete Vitest suite runner hung after workers exited under isolated locks, recorded as a local evidence limitation in `verify.md`.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -2,17 +2,18 @@
 id: 505
 slug: keep-shipped-hooks-host-lintable
 type: task
-phase: done
-status: done
+phase: verify
+status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-28T14:59:03Z
+last_modified: 2026-07-29T01:00:00Z
 scope:
-  - Keep every shipped TypeScript hook compatible with the supported ESLint baseline used by host projects.
-  - Add release validation for the physical distributed hook surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
+  - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
+  - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
+  - Keep package-owned Codex runtime template mirrors under parity validation.
 out_of_scope:
   - Adding a host-project lint ignore for .safeword/hooks.
-  - Normalizing the existing hook corpus to every stylistic and security rule in the full typed host preset.
+  - Normalizing the existing template corpus to every stylistic and security rule in the full typed host preset.
 done_when:
   - Shipped TypeScript hooks have no errors from the supported ESLint baseline.
   - Every physical shipped hook loads without a fatal parser/config diagnostic under the actual typed host preset.
@@ -28,21 +29,23 @@ done_when:
 **Type:** Bug
 
 **Scope:** Remove the reported lint violations from the shipped TypeScript hook
-templates and add release-lane validation for every shipped TypeScript hook:
+templates and add release-lane validation for every schema-declared shipped TypeScript template:
 the supported host baseline, fatal parser/config loading under Safeword's typed
 preset, and strict typechecking in its installed shape.
 
 **Out of Scope:** Ignoring `.safeword/hooks/**` in generated host configs,
-changing unrelated ESLint policies, or expanding validation to non-hook templates.
+changing unrelated ESLint policies, or validating arbitrary customer dependency versions.
 
 ## Decision
 
-Use the preferred upstream contract: shipped hooks stay in host lint scope and
-must pass the supported ESLint baseline. The release test validates the exact
-`packages/cli/templates/hooks/**` TypeScript surface that the package publishes,
-including parser/config integration and strict typechecking in a temporary
-installed fixture. Full-preset policy cleanup is separately scoped because the
-pre-existing corpus has a broad backlog unrelated to issue #505.
+Use the preferred upstream contract: shipped templates stay in host lint scope
+and must pass the supported ESLint baseline. The release test derives the exact
+TypeScript install surface from `SAFEWORD_SCHEMA`, including parser/config
+integration and strict typechecking in a temporary installed fixture using
+Safeword's package-pinned development types. Full-preset policy cleanup is
+separately scoped because the pre-existing corpus has a broad backlog unrelated
+to issue #505. Codex runtime assets remain managed (they must not be installed
+in customer repositories) but opt into dogfood parity so template edits cannot drift.
 
 **Figure-it-out:**
 
@@ -51,6 +54,14 @@ pre-existing corpus has a broad backlog unrelated to issue #505.
 - [x] Phase 3a: Examine ESLint rule semantics, package distribution, and template/reconciliation ownership.
 - [x] Phase 3b: Validate the two rules with current ESLint documentation and inspect Safeword's published `templates` contract.
 - [x] Phase 4: Commit to upstream lint validation and minimal source fixes.
+- [x] PR-review follow-up: expand the fixture to all schema-declared distributed
+  TypeScript templates, because statusline and BDD files are customer-facing and
+  the former already exposed the same unchecked-index defect.
+- [x] PR-review follow-up: preserve Codex runtime adapters as managed files while
+  opting them into parity; moving them to owned files would change installation semantics.
+- [x] PR-review follow-up: remove the narrow exported Claude-session convenience
+  helper; the existing pure resolver already owns precedence and two explicit
+  environment projections keep the shipped public surface smaller.
 
 ## Done When:
 
@@ -66,6 +77,8 @@ pre-existing corpus has a broad backlog unrelated to issue #505.
 - [x] RED — The installed-shape strict typecheck exposed 22 real template diagnostics; the minimal fixes preserve each hook's fail-open behavior.
 - [x] GREEN — The installed fixture typechecks all physical hook templates without customer dependencies.
 - [x] REFACTOR — The test has one owner, discovers the shipped hook tree instead of maintaining a file list, and centralizes Claude session resolution for the two retro filing hooks.
+  - [x] RED — The schema-driven fixture caught the statusline unchecked-index error and includes the BDD step templates.
+  - [x] GREEN — The fixture typechecks every schema-declared TypeScript template in its real destination path and the Codex runtime mirrors have parity coverage.
 
 ## Work Log
 
@@ -76,3 +89,5 @@ pre-existing corpus has a broad backlog unrelated to issue #505.
 - 2026-07-28T14:38:21Z Quality review closed a coverage gap: added a package-owned `@types/bun` installed-fixture typecheck and fixed 22 strict diagnostics across the physical hook tree. The typed host preset now also loads that fixture and fails on fatal parser/config errors; full-preset policy diagnostics remain explicitly out of scope because the existing corpus has a separate broad backlog.
 - 2026-07-28T14:38:21Z Refactor/audit: centralized Claude session environment resolution for the two retro filing hooks and synchronized all changed hook templates to dogfood copies.
 - 2026-07-28T14:59:03Z Final verification: release validation (25 tests), direct release-test lint, root lint, build, Gherkin acceptance, parity (195 pairs / 8 contracts), `bun audit`, and two independent quality reviews passed. Reverted the unrelated root patch upgrades found during audit; the required CLI-local Bun types remain. The complete Vitest suite runner hung after workers exited under isolated locks, recorded as a local evidence limitation in `verify.md`.
+- 2026-07-29T00:50:00Z Reopened for PR review: nine actionable findings identified. The release fixture omitted schema-declared statusline and BDD TypeScript templates, and Codex runtime assets were managed-but-not-paired. The follow-up keeps each ownership contract intact while extending validation and parity.
+- 2026-07-29T01:00:00Z Review follow-up GREEN: strict typechecking now covers 106 schema-declared TypeScript templates in real destination paths, including statusline and BDD steps. The new Codex parity opt-in surfaced and healed one additional stale runtime mirror. Focused release tests, parity tests, direct lint, formatting, parity (200 pairs / 8 contracts), and an independent fresh review passed.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -6,7 +6,7 @@ phase: implement
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T02:00:00Z
+last_modified: 2026-07-29T02:20:00Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -79,6 +79,10 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - [x] REFACTOR — The test has one owner, discovers the shipped hook tree instead of maintaining a file list, and centralizes Claude session resolution for the two retro filing hooks.
   - [x] RED — The schema-driven fixture caught the statusline unchecked-index error and includes the BDD step templates.
   - [x] GREEN — The fixture typechecks every schema-declared TypeScript template in its real destination path and the Codex runtime mirrors have parity coverage.
+  - [x] RED — The generated `owned-paths.ts` module was absent from both ESLint
+    passes despite being part of the installed hook tree.
+  - [x] GREEN — Every lint/typecheck pass receives the generated module as part
+    of the same installed fixture file list.
 
 ## Work Log
 
@@ -91,13 +95,14 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-28T14:59:03Z Final verification: release validation (25 tests), direct release-test lint, root lint, build, Gherkin acceptance, parity (195 pairs / 8 contracts), `bun audit`, and two independent quality reviews passed. Reverted the unrelated root patch upgrades found during audit; the required CLI-local Bun types remain. The complete Vitest suite runner hung after workers exited under isolated locks, recorded as a local evidence limitation in `verify.md`.
 - 2026-07-29T00:50:00Z Reopened for PR review: nine actionable findings identified. The release fixture omitted schema-declared statusline and BDD TypeScript templates, and Codex runtime assets were managed-but-not-paired. The follow-up keeps each ownership contract intact while extending validation and parity.
 - 2026-07-29T01:00:00Z Review follow-up GREEN: strict typechecking now covers 106 schema-declared TypeScript templates in real destination paths, including statusline and BDD steps. The new Codex parity opt-in surfaced and healed one additional stale runtime mirror. Focused release tests, parity tests, direct lint, formatting, parity (200 pairs / 8 contracts), and an independent fresh review passed.
+- 2026-07-29T02:20:00Z Regression follow-up: the generated owned-paths module was typechecked but omitted from both fixture lint passes. Added it to the common fixture file list; the focused release gate and direct lint pass now cover the same installed tree.
 
 ## Refactor Ledger
 
 Scout findings, ordered leaf-first. Each entry is one behavior-preserving change
 with its own test and commit.
 
-- [ ] P1 — Eliminate the duplicate parity-pair membership traversal in
+- [x] P1 — Eliminate the duplicate parity-pair membership traversal in
   `scripts/parity-check.ts`; the CLI count must derive from `runParity` so it
   cannot drift from check/sync coverage.
 - [x] P2 — Rename the broadened release test and its temporary-fixture prefix
@@ -109,5 +114,5 @@ with its own test and commit.
   abstraction would recreate a rejected shipped API.
 - [ ] Struck — Do not merge baseline and fatal-diagnostic formatting: their
   distinct predicates make the test policy legible.
-- [ ] Struck — Keep `as unknown as` for the regex tuple: direct conversion is
+- [x] Struck — Keep `as unknown as` for the regex tuple: direct conversion is
   rejected by the strict fixture compiler.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -6,7 +6,7 @@ phase: implement
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T02:20:00Z
+last_modified: 2026-07-29T02:30:00Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -96,6 +96,7 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-29T00:50:00Z Reopened for PR review: nine actionable findings identified. The release fixture omitted schema-declared statusline and BDD TypeScript templates, and Codex runtime assets were managed-but-not-paired. The follow-up keeps each ownership contract intact while extending validation and parity.
 - 2026-07-29T01:00:00Z Review follow-up GREEN: strict typechecking now covers 106 schema-declared TypeScript templates in real destination paths, including statusline and BDD steps. The new Codex parity opt-in surfaced and healed one additional stale runtime mirror. Focused release tests, parity tests, direct lint, formatting, parity (200 pairs / 8 contracts), and an independent fresh review passed.
 - 2026-07-29T02:20:00Z Regression follow-up: the generated owned-paths module was typechecked but omitted from both fixture lint passes. Added it to the common fixture file list; the focused release gate and direct lint pass now cover the same installed tree.
+- 2026-07-29T02:30:00Z Refactor: split release-fixture materialization from tsconfig generation without changing the installed file set, fixture lifetime, or compiler options. Focused release checks and direct lint passed.
 
 ## Refactor Ledger
 
@@ -107,12 +108,12 @@ with its own test and commit.
   cannot drift from check/sync coverage.
 - [x] P2 — Rename the broadened release test and its temporary-fixture prefix
   from “hooks” to “templates”.
-- [ ] P3 — Split the release fixture builder into named materialization and
+- [x] P3 — Split the release fixture builder into named materialization and
   tsconfig-writing helpers without changing fixture lifetime or contents.
-- [ ] Struck — Do not extract the two Claude environment projections: the
+- [x] Struck — Do not extract the two Claude environment projections: the
   exported helper was deliberately removed during review, so reintroducing an
   abstraction would recreate a rejected shipped API.
-- [ ] Struck — Do not merge baseline and fatal-diagnostic formatting: their
+- [x] Struck — Do not merge baseline and fatal-diagnostic formatting: their
   distinct predicates make the test policy legible.
 - [x] Struck — Keep `as unknown as` for the regex tuple: direct conversion is
   rejected by the strict fixture compiler.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -2,11 +2,11 @@
 id: 505
 slug: keep-shipped-hooks-host-lintable
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T02:30:00Z
+last_modified: 2026-07-29T02:40:00Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -97,6 +97,7 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-29T01:00:00Z Review follow-up GREEN: strict typechecking now covers 106 schema-declared TypeScript templates in real destination paths, including statusline and BDD steps. The new Codex parity opt-in surfaced and healed one additional stale runtime mirror. Focused release tests, parity tests, direct lint, formatting, parity (200 pairs / 8 contracts), and an independent fresh review passed.
 - 2026-07-29T02:20:00Z Regression follow-up: the generated owned-paths module was typechecked but omitted from both fixture lint passes. Added it to the common fixture file list; the focused release gate and direct lint pass now cover the same installed tree.
 - 2026-07-29T02:30:00Z Refactor: split release-fixture materialization from tsconfig generation without changing the installed file set, fixture lifetime, or compiler options. Focused release checks and direct lint passed.
+- 2026-07-29T02:40:00Z Final refactor verification: release validation (3 tests), parity tests (27 tests), parity (200 pairs / 8 contracts), direct lint, diff check, and audit passed. Audit found no new architecture or dead-code issue; its repository-wide clone and dependency-freshness findings are pre-existing follow-up inventory, not part of this scoped change.
 
 ## Refactor Ledger
 

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -6,7 +6,7 @@ phase: done
 status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T02:40:00Z
+last_modified: 2026-07-29T17:32:25Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -15,9 +15,9 @@ out_of_scope:
   - Adding a host-project lint ignore for .safeword/hooks.
   - Normalizing the existing template corpus to every stylistic and security rule in the full typed host preset.
 done_when:
-  - Shipped TypeScript hooks have no errors from the supported ESLint baseline.
-  - Every physical shipped hook loads without a fatal parser/config diagnostic under the actual typed host preset.
-  - Every physical shipped hook typechecks in a generated installed-shape fixture without customer dependencies.
+  - Schema-declared shipped TypeScript templates have no errors from the supported ESLint baseline.
+  - Every schema-declared shipped TypeScript template loads without a fatal parser/config diagnostic under the actual typed host preset.
+  - Every schema-declared shipped TypeScript template typechecks in a generated installed-shape fixture against Safeword's package-pinned type dependencies.
 ---
 
 # Keep shipped hooks host-lintable
@@ -66,9 +66,9 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 ## Done When:
 
 - [x] The literal BOM and dead-store initializations no longer create host-lint failures.
-- [x] A release test checks every shipped TypeScript hook with the supported baseline.
-- [x] A release test loads every shipped hook through the typed host preset and fails on fatal parser/config diagnostics.
-- [x] A release test strictly typechecks the installed-shape hook tree with package-owned `@types/bun` support.
+- [x] A release test checks every schema-declared TypeScript template with the supported baseline.
+- [x] A release test loads every schema-declared TypeScript template through the typed host preset and fails on fatal parser/config diagnostics.
+- [x] A release test strictly typechecks the installed-shape TypeScript template tree with package-owned `@types/bun` support.
 
 ## Test Definitions:
 
@@ -98,6 +98,7 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-29T02:20:00Z Regression follow-up: the generated owned-paths module was typechecked but omitted from both fixture lint passes. Added it to the common fixture file list; the focused release gate and direct lint pass now cover the same installed tree.
 - 2026-07-29T02:30:00Z Refactor: split release-fixture materialization from tsconfig generation without changing the installed file set, fixture lifetime, or compiler options. Focused release checks and direct lint passed.
 - 2026-07-29T02:40:00Z Final refactor verification: release validation (3 tests), parity tests (27 tests), parity (200 pairs / 8 contracts), direct lint, diff check, and audit passed. Audit found no new architecture or dead-code issue; its repository-wide clone and dependency-freshness findings are pre-existing follow-up inventory, not part of this scoped change.
+- 2026-07-29T17:30:00Z PR review follow-up: made `parseLogLine` fail closed for missing captures, added its regression coverage, made the release surface non-vacuous (minimum 106 templates), let Cucumber resolve its package-declared types, simplified the equivalent statusline guard, and corrected the acceptance criteria.
 
 ## Refactor Ledger
 
@@ -116,5 +117,12 @@ with its own test and commit.
   abstraction would recreate a rejected shipped API.
 - [x] Struck — Do not merge baseline and fatal-diagnostic formatting: their
   distinct predicates make the test policy legible.
-- [x] Struck — Keep `as unknown as` for the regex tuple: direct conversion is
-  rejected by the strict fixture compiler.
+- [x] PR-review follow-up: replace the regex tuple assertion with a fail-closed
+  runtime guard, so an optional future capture cannot escape as `undefined`.
+- [x] PR-review follow-up: require at least 106 schema-declared TypeScript
+  templates, preventing a vacuous ESLint run if discovery regresses while
+  allowing deliberate release-surface additions.
+- [x] PR-review follow-up: map Cucumber at its package root so TypeScript uses
+  the package's declared types instead of this test pinning its internal layout.
+- [x] PR-review follow-up: use the same final-element guard in the statusline
+  and correct the ticket acceptance criteria to cover all distributed templates.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -100,7 +100,7 @@ with its own test and commit.
 - [ ] P1 — Eliminate the duplicate parity-pair membership traversal in
   `scripts/parity-check.ts`; the CLI count must derive from `runParity` so it
   cannot drift from check/sync coverage.
-- [ ] P2 — Rename the broadened release test and its temporary-fixture prefix
+- [x] P2 — Rename the broadened release test and its temporary-fixture prefix
   from “hooks” to “templates”.
 - [ ] P3 — Split the release fixture builder into named materialization and
   tsconfig-writing helpers without changing fixture lifetime or contents.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -6,7 +6,7 @@ phase: done
 status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T17:32:25Z
+last_modified: 2026-07-29T19:36:21Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -62,6 +62,20 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - [x] PR-review follow-up: remove the narrow exported Claude-session convenience
   helper; the existing pure resolver already owns precedence and two explicit
   environment projections keep the shipped public surface smaller.
+- [x] Round-3 Phase 1: decide whether three advisory review notes merit code
+  changes, while repairing the CI-blocking generated architecture state.
+- [x] Round-3 Phase 2: compare clarifying the test/comment, exposing structured
+  parity counts, or retaining the proven aggregate with an invariant comment.
+- [x] Round-3 Phase 3a: inspect test-contract accuracy, TypeScript indexed
+  access safety, parity-result coupling, release-surface coverage, and CI's
+  generated-document contract.
+- [x] Round-3 Phase 3b: verify current TypeScript and Vitest documentation,
+  trace every `passedCount` increment/call site, inspect the live CI failure,
+  and regenerate the authoritative architecture document.
+- [x] Round-3 Phase 4: keep the fail-closed guard, clarify what its unit test
+  does cover, document the release count as a floor, and retain the aggregate
+  parity result with an explicit two-category invariant; a structured result
+  would add surface for a display-only concern without a present third category.
 
 ## Done When:
 
@@ -99,6 +113,14 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-29T02:30:00Z Refactor: split release-fixture materialization from tsconfig generation without changing the installed file set, fixture lifetime, or compiler options. Focused release checks and direct lint passed.
 - 2026-07-29T02:40:00Z Final refactor verification: release validation (3 tests), parity tests (27 tests), parity (200 pairs / 8 contracts), direct lint, diff check, and audit passed. Audit found no new architecture or dead-code issue; its repository-wide clone and dependency-freshness findings are pre-existing follow-up inventory, not part of this scoped change.
 - 2026-07-29T17:30:00Z PR review follow-up: made `parseLogLine` fail closed for missing captures, added its regression coverage, made the release surface non-vacuous (minimum 106 templates), let Cucumber resolve its package-declared types, simplified the equivalent statusline guard, and corrected the acceptance criteria.
+- 2026-07-29T19:15:00Z Round-3 review follow-up: clarified the parser test's
+  real boundary, documented both the parity-count invariant and the release
+  count's floor-not-census role, and regenerated the CI-required package
+  architecture state. An independent fresh review found no further blocker.
+- 2026-07-29T19:20:00Z Verification follow-up: gave the two real installed-tree
+  ESLint passes explicit 15s/60s budgets after concurrent workspace load pushed
+  them beyond Vitest's default 5s/previous 30s thresholds; the release gate's
+  scope and assertions are unchanged.
 
 ## Refactor Ledger
 

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/ticket.md
@@ -2,11 +2,11 @@
 id: 505
 slug: keep-shipped-hooks-host-lintable
 type: task
-phase: verify
+phase: implement
 status: in_progress
 external_issue: https://github.com/ArcadeAI/safeword/issues/505
 created: 2026-07-28T00:00:00Z
-last_modified: 2026-07-29T01:00:00Z
+last_modified: 2026-07-29T02:00:00Z
 scope:
   - Keep every shipped TypeScript template compatible with the supported ESLint baseline used by host projects.
   - Add release validation for the schema-declared distributed TypeScript surface: baseline lint, typed-preset parse/config loading, and strict installed-shape TypeScript checking.
@@ -91,3 +91,23 @@ in customer repositories) but opt into dogfood parity so template edits cannot d
 - 2026-07-28T14:59:03Z Final verification: release validation (25 tests), direct release-test lint, root lint, build, Gherkin acceptance, parity (195 pairs / 8 contracts), `bun audit`, and two independent quality reviews passed. Reverted the unrelated root patch upgrades found during audit; the required CLI-local Bun types remain. The complete Vitest suite runner hung after workers exited under isolated locks, recorded as a local evidence limitation in `verify.md`.
 - 2026-07-29T00:50:00Z Reopened for PR review: nine actionable findings identified. The release fixture omitted schema-declared statusline and BDD TypeScript templates, and Codex runtime assets were managed-but-not-paired. The follow-up keeps each ownership contract intact while extending validation and parity.
 - 2026-07-29T01:00:00Z Review follow-up GREEN: strict typechecking now covers 106 schema-declared TypeScript templates in real destination paths, including statusline and BDD steps. The new Codex parity opt-in surfaced and healed one additional stale runtime mirror. Focused release tests, parity tests, direct lint, formatting, parity (200 pairs / 8 contracts), and an independent fresh review passed.
+
+## Refactor Ledger
+
+Scout findings, ordered leaf-first. Each entry is one behavior-preserving change
+with its own test and commit.
+
+- [ ] P1 — Eliminate the duplicate parity-pair membership traversal in
+  `scripts/parity-check.ts`; the CLI count must derive from `runParity` so it
+  cannot drift from check/sync coverage.
+- [ ] P2 — Rename the broadened release test and its temporary-fixture prefix
+  from “hooks” to “templates”.
+- [ ] P3 — Split the release fixture builder into named materialization and
+  tsconfig-writing helpers without changing fixture lifetime or contents.
+- [ ] Struck — Do not extract the two Claude environment projections: the
+  exported helper was deliberately removed during review, so reintroducing an
+  abstraction would recreate a rejected shipped API.
+- [ ] Struck — Do not merge baseline and fatal-diagnostic formatting: their
+  distinct predicates make the test policy legible.
+- [ ] Struck — Keep `as unknown as` for the regex tuple: direct conversion is
+  rejected by the strict fixture compiler.

--- a/.project/tickets/505-keep-shipped-hooks-host-lintable/verify.md
+++ b/.project/tickets/505-keep-shipped-hooks-host-lintable/verify.md
@@ -1,0 +1,19 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 25/25 tests pass in the release gate; ⚠️ Local environment limitation: the complete Vitest suite stayed idle after all workers exited under both the shared and an isolated lock, so it was terminated after seven minutes without a test failure.
+**Gherkin:** ✅ Acceptance lane passes
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 14 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal release validation plumbing
+**Evidence limits:** ⚠️ Complete-suite runner lifecycle hang; focused release, direct lint, typecheck, and acceptance evidence completed successfully.
+
+Audit passed with warnings — JavaScript architecture/dead-code checks, configuration sync, domain docs, and dependency audit are clean; unrelated experimental Python tooling lacks import-linter contracts and `deadcode`.
+
+**Verification detail:** The release gate directly linted all 103 physical hook templates against the supported baseline, loaded the copied installed shape through the actual typed preset with no fatal parser/config diagnostics, and strictly typechecked it with package-owned Bun types. `bun scripts/parity-check.ts` reported 195 pairs and 8 contracts in sync; `bun audit` found no vulnerabilities; final independent quality review approved.
+
+**Next:** Commit the scoped #505 fix and investigate the full-suite runner lifecycle hang separately if it reproduces in CI.

--- a/.safeword/hooks/codex/post-tool-skill-nudge.ts
+++ b/.safeword/hooks/codex/post-tool-skill-nudge.ts
@@ -5,8 +5,8 @@
 // SAME output shape the standalone post-tool-skill-nudge.ts hook already emits.
 // So this adapter only translates Codex INPUT (notably apply_patch, whose target
 // path is embedded in the patch text) into the Claude-shaped input the hook
-// understands, runs it per target, and forwards the first non-empty nudge
-// verbatim. Fail-open: no target / no nudge → exit 0 with no output.
+// understands, runs it per target, and aggregates every valid nudge. Fail-open:
+// no target / no nudge → exit 0 with no output.
 
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,6 +25,20 @@ async function readInput(): Promise<CodexHookInput | undefined> {
   }
 }
 
+function postToolAdditionalContext(stdout: string | undefined): string | undefined {
+  try {
+    const output = JSON.parse(stdout ?? '') as {
+      hookSpecificOutput?: { hookEventName?: string; additionalContext?: unknown };
+    };
+    const context = output.hookSpecificOutput?.additionalContext;
+    return output.hookSpecificOutput?.hookEventName === 'PostToolUse' && typeof context === 'string'
+      ? context
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const input = await readInput();
 if (!input) process.exit(0);
 
@@ -34,14 +48,20 @@ if (translatedInputs.length === 0) process.exit(0);
 const hookDirectory = nodePath.dirname(fileURLToPath(import.meta.url));
 const claudeHookPath = nodePath.join(hookDirectory, '..', 'post-tool-skill-nudge.ts');
 
-// Run per target; the hook dedups per scenario, so at most one fires. Forward the
-// first non-empty additionalContext payload (Codex shares Claude's output shape).
+const contexts: string[] = [];
 for (const translated of translatedInputs) {
   const result = runClaudeHookAsCodex(claudeHookPath, translated);
-  if ((result.stdout ?? '').trim() !== '') {
-    process.stdout.write(result.stdout ?? '');
-    process.exit(0);
-  }
+  const context = postToolAdditionalContext(result.stdout);
+  if (context !== undefined) contexts.push(context);
 }
 
-process.exit(0);
+if (contexts.length > 0) {
+  process.stdout.write(
+    `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: contexts.join('\n\n'),
+      },
+    })}\n`,
+  );
+}

--- a/.safeword/hooks/codex/stop.ts
+++ b/.safeword/hooks/codex/stop.ts
@@ -181,7 +181,8 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     timeout: 600_000,
   });
   const error = result.error as (Error & { code?: string }) | undefined;
-  const ok = result.status === 0 && !result.error && pendingOffsetState !== undefined;
+  const offsetState = pendingOffsetState;
+  const ok = result.status === 0 && !result.error && offsetState !== undefined;
   recordRetroDebugEvent({
     event: 'codex_stop_child_exit',
     command: nodePath.basename(command),
@@ -195,23 +196,19 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     pendingOffsetState: pendingOffsetState !== undefined,
     ok,
   });
-  if (!ok) return;
+  if (!ok || !offsetState) return;
 
   try {
-    writeOffsetState(
-      pendingOffsetState.sessionId,
-      pendingOffsetState.state,
-      pendingOffsetState.baseDirectory,
-    );
+    writeOffsetState(offsetState.sessionId, offsetState.state, offsetState.baseDirectory);
     recordRetroDebugEvent({
       event: 'codex_stop_offset_write',
-      sessionId: pendingOffsetState.sessionId,
+      sessionId: offsetState.sessionId,
       ok: true,
     });
   } catch {
     recordRetroDebugEvent({
       event: 'codex_stop_offset_write',
-      sessionId: pendingOffsetState.sessionId,
+      sessionId: offsetState.sessionId,
       ok: false,
     });
     // A state-write failure must not make Stop visible or blocking.
@@ -267,7 +264,7 @@ async function main(): Promise<string> {
   return SILENT;
 }
 
-let output = SILENT;
+let output: string;
 try {
   output = await main();
 } catch {

--- a/.safeword/hooks/lib/re-entry.ts
+++ b/.safeword/hooks/lib/re-entry.ts
@@ -38,15 +38,9 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
-  // LINE_REGEX has four required, non-empty capture groups. The tuple records
-  // that contract for noUncheckedIndexedAccess without a dead runtime branch.
-  const [, timestamp, sessionId, ticket, nextImperative] = match as unknown as [
-    string,
-    string,
-    string,
-    string,
-    string,
-  ];
+  const [, timestamp, sessionId, ticket, nextImperative] = match;
+  // Keep this fail-closed even if a later regex edit makes a capture optional.
+  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
   return {
     timestamp,
     sessionId,

--- a/.safeword/hooks/lib/re-entry.ts
+++ b/.safeword/hooks/lib/re-entry.ts
@@ -38,11 +38,13 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
+  const [timestamp, sessionId, ticket, nextImperative] = match.slice(1);
+  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
   return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
+    timestamp,
+    sessionId,
+    ticket,
+    nextImperative,
   };
 }
 

--- a/.safeword/hooks/lib/re-entry.ts
+++ b/.safeword/hooks/lib/re-entry.ts
@@ -38,8 +38,15 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
-  const [timestamp, sessionId, ticket, nextImperative] = match.slice(1);
-  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
+  // LINE_REGEX has four required, non-empty capture groups. The tuple records
+  // that contract for noUncheckedIndexedAccess without a dead runtime branch.
+  const [, timestamp, sessionId, ticket, nextImperative] = match as unknown as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
   return {
     timestamp,
     sessionId,

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -243,21 +243,6 @@ export function resolveSessionId(
   return firstNonEmpty(input.session_id, env.CLAUDE_CODE_REMOTE_SESSION_ID, env.CLAUDE_SESSION_ID);
 }
 
-/**
- * Resolve a Claude hook's session id using the process environment. Keeping
- * this boundary here prevents each Claude-facing hook from rebuilding the same
- * narrow environment object (and keeps cloud/local precedence in one place).
- */
-export function resolveClaudeSessionId(
-  input: { session_id?: string },
-  env: Record<string, string | undefined> = process.env,
-): string | undefined {
-  return resolveSessionId(input, {
-    CLAUDE_CODE_REMOTE_SESSION_ID: env.CLAUDE_CODE_REMOTE_SESSION_ID,
-    CLAUDE_SESSION_ID: env.CLAUDE_SESSION_ID,
-  });
-}
-
 /** The first argument that is a non-empty string, else undefined. */
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
   for (const value of values) {

--- a/.safeword/hooks/lib/retro-trigger.ts
+++ b/.safeword/hooks/lib/retro-trigger.ts
@@ -243,6 +243,21 @@ export function resolveSessionId(
   return firstNonEmpty(input.session_id, env.CLAUDE_CODE_REMOTE_SESSION_ID, env.CLAUDE_SESSION_ID);
 }
 
+/**
+ * Resolve a Claude hook's session id using the process environment. Keeping
+ * this boundary here prevents each Claude-facing hook from rebuilding the same
+ * narrow environment object (and keeps cloud/local precedence in one place).
+ */
+export function resolveClaudeSessionId(
+  input: { session_id?: string },
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  return resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: env.CLAUDE_SESSION_ID,
+  });
+}
+
 /** The first argument that is a non-empty string, else undefined. */
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
   for (const value of values) {

--- a/.safeword/hooks/lib/skill-nudge.ts
+++ b/.safeword/hooks/lib/skill-nudge.ts
@@ -125,7 +125,7 @@ export function entrySkillFor(
  * description (the caller then uses the fallback nudge line).
  */
 export function parseSkillDescription(skillMd: string): string | null {
-  const frontmatter = skillMd.match(/^﻿?---\r?\n([\s\S]*?)\r?\n---/);
+  const frontmatter = skillMd.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---/);
   if (!frontmatter) return null;
   const lines = (frontmatter[1] ?? '').split(/\r?\n/);
 

--- a/.safeword/hooks/post-tool-quality.ts
+++ b/.safeword/hooks/post-tool-quality.ts
@@ -113,7 +113,7 @@ function countLoc(): number {
     });
     const insMatch = diffStat.match(/(\d+) insertions?\(\+\)/);
     const delMatch = diffStat.match(/(\d+) deletions?\(-\)/);
-    return (insMatch ? parseInt(insMatch[1]) : 0) + (delMatch ? parseInt(delMatch[1]) : 0);
+    return parseInt(insMatch?.[1] ?? '0') + parseInt(delMatch?.[1] ?? '0');
   } catch {
     return 0;
   }

--- a/.safeword/hooks/post-tool-skill-nudge.ts
+++ b/.safeword/hooks/post-tool-skill-nudge.ts
@@ -49,7 +49,12 @@ const language = languageForFile(filePath);
 if (!language) process.exit(0);
 
 const skillDirs = installedSkillDirs(projectDirectory);
-const installed = new Set(skillDirs.map(dir => dir.name.split('-')[0]));
+const installed = new Set(
+  skillDirs.flatMap(dir => {
+    const prefix = dir.name.split('-')[0];
+    return prefix ? [prefix] : [];
+  }),
+);
 if (!installed.has(language.prefix)) process.exit(0);
 
 // Resolve the single entry skill (the sole installed skill for a single-skill

--- a/.safeword/hooks/pre-tool-quality.ts
+++ b/.safeword/hooks/pre-tool-quality.ts
@@ -357,7 +357,7 @@ if (
     // Multi-line content-bearing files don't match this regex and pass through.
     const dimensionsContent = readFileSync(dimensionsFile, 'utf8').trim();
     const skipMatch = /^skip:(.*)$/i.exec(dimensionsContent);
-    if (skipMatch && !isValidSkipReason(skipMatch[1])) {
+    if (skipMatch && !isValidSkipReason(skipMatch[1] ?? '')) {
       deny(
         'dimensions.md `skip:` declaration requires a non-empty reason after the colon.',
         'Either write a real dimension table, or use `skip: <reason>` where the reason explains why no dimensions need enumerating (e.g., `skip: single behavioral dimension, no partitioning to enumerate`).',

--- a/.safeword/hooks/prompt-questions.ts
+++ b/.safeword/hooks/prompt-questions.ts
@@ -159,7 +159,10 @@ if (existsSync(stateFile)) {
     // One-shot reminder: verify novel research claims before building on them.
     // Atomic move pending → acknowledged so the setter's dedup still works
     // after the nudge has been shown (ticket 4N5Y28).
-    const pending = state.learningsNudgesPending ?? [];
+    const rawPending: unknown[] = Array.isArray(state.learningsNudgesPending)
+      ? state.learningsNudgesPending
+      : [];
+    const pending = rawPending.filter((value): value is string => typeof value === 'string');
     if (pending.length > 0) {
       const files = pending.map(f => f.split('/').pop() ?? f).join(', ');
       lines.push(

--- a/.safeword/hooks/prompt-retro-nudge.ts
+++ b/.safeword/hooks/prompt-retro-nudge.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingNudge } from './lib/retro-nudge.ts';
-import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
+import { resolveSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -31,7 +31,10 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   }
 
   // Resolver parity with the spool writer — see stop-retro-filing.ts.
-  const sessionId = resolveClaudeSessionId(input);
+  const sessionId = resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: process.env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+  });
   if (sessionId) {
     try {
       const additionalContext = decideRetroFilingNudge(projectDirectory, sessionId);

--- a/.safeword/hooks/prompt-retro-nudge.ts
+++ b/.safeword/hooks/prompt-retro-nudge.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingNudge } from './lib/retro-nudge.ts';
-import { resolveSessionId } from './lib/retro-trigger.ts';
+import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -23,7 +23,7 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
 // Not a safeword project — nothing to do.
 if (existsSync(`${projectDirectory}/.safeword`)) {
-  let input: HookInput = {};
+  let input: HookInput;
   try {
     input = await Bun.stdin.json();
   } catch {
@@ -31,7 +31,7 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   }
 
   // Resolver parity with the spool writer — see stop-retro-filing.ts.
-  const sessionId = resolveSessionId(input, process.env);
+  const sessionId = resolveClaudeSessionId(input);
   if (sessionId) {
     try {
       const additionalContext = decideRetroFilingNudge(projectDirectory, sessionId);

--- a/.safeword/hooks/session-codex-start.ts
+++ b/.safeword/hooks/session-codex-start.ts
@@ -16,7 +16,7 @@ import {
 
 const hookInput = await readHookInput();
 const projectDir = resolveProjectDir(hookInput);
-let outcome: AutoUpgradeOutcome = { kind: 'skipped', reason: 'not checked' };
+let outcome: AutoUpgradeOutcome;
 
 try {
   outcome = await runAutoUpgrade({ projectDir, filterSafewordFiles });

--- a/.safeword/hooks/session-start-reentry.ts
+++ b/.safeword/hooks/session-start-reentry.ts
@@ -73,8 +73,11 @@ async function main(): Promise<void> {
   let briefBody = '';
   if (currentEntries.length > 0) {
     briefBody = renderBrief(currentEntries.slice(-3));
-  } else if (source === 'startup' && allEntries.length > 0) {
-    briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
+  } else if (source === 'startup') {
+    const lastEntry = allEntries.at(-1);
+    if (lastEntry) {
+      briefBody = renderBrief([lastEntry], { fromAnotherSession: true });
+    }
   }
 
   const conflictFiles = detectConflictFiles(projectRoot, transcript_path);

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -411,8 +411,10 @@ function checkUsageLimit(transcriptLines: string[]): void {
 function detectEditToolsUsed(transcriptLines: string[]): boolean {
   let checked = 0;
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    const transcriptLine = transcriptLines[i];
+    if (transcriptLine === undefined) continue;
     try {
-      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const message: TranscriptMessage = JSON.parse(transcriptLine);
       if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
         if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
@@ -433,8 +435,10 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
 function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolean | undefined {
   let checked = 0;
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    const transcriptLine = transcriptLines[i];
+    if (transcriptLine === undefined) continue;
     try {
-      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const message: TranscriptMessage = JSON.parse(transcriptLine);
       if (isGenuineUserPrompt(message)) {
         return false;
       }
@@ -765,7 +769,7 @@ const phaseFailurePatterns: Record<string, string> = {
   implement: 'loc-exceeded',
   done: 'done-gate-tests-failed',
 };
-const relevantPattern = phaseFailurePatterns[currentPhase];
+const relevantPattern = currentPhase ? (phaseFailurePatterns[currentPhase] ?? null) : null;
 const recentRelevant = relevantPattern
   ? (sessionState?.recentFailures ?? []).find((f: FailureEntry) => f.pattern === relevantPattern)
       ?.pattern

--- a/.safeword/hooks/stop-reentry.ts
+++ b/.safeword/hooks/stop-reentry.ts
@@ -37,9 +37,11 @@ interface TranscriptEntry {
 function extractLastNextImperative(text: string): string | null {
   const lines = text.split('\n');
   for (let index = lines.length - 1; index >= 0; index--) {
-    const match = /^\*\*Next:\*\*\s+(.+)$/.exec(lines[index].trim());
+    const line = lines[index];
+    if (!line) continue;
+    const match = /^\*\*Next:\*\*\s+(.+)$/.exec(line.trim());
     if (match) {
-      const imperative = match[1].trim();
+      const imperative = match[1]?.trim() ?? '';
       return imperative.length > 0 ? imperative : null;
     }
   }
@@ -76,8 +78,10 @@ function readLastAssistantText(transcriptPath: string): string {
   if (raw.length === 0) return '';
   const lines = raw.split('\n');
   for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    if (!line) continue;
     try {
-      const entry = JSON.parse(lines[index]) as TranscriptEntry;
+      const entry = JSON.parse(line) as TranscriptEntry;
       if (entry.type === 'assistant' && entry.message?.content) {
         return entry.message.content
           .filter(c => c.type === 'text' && typeof c.text === 'string')

--- a/.safeword/hooks/stop-retro-filing.ts
+++ b/.safeword/hooks/stop-retro-filing.ts
@@ -22,7 +22,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingGate } from './lib/retro-filing-gate.ts';
-import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
+import { resolveSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -43,7 +43,10 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   // payload without session_id must still key the SAME spool the extraction
   // wrote (cloud/local env fallbacks), else drafts spool under the env id and
   // this gate silently never fires.
-  const sessionId = resolveClaudeSessionId(input);
+  const sessionId = resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: process.env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+  });
   // The gate reads selfReport config itself (GH644A): capture gates the
   // tripwire evaluation, file gates only the dispatch emission — so watch-only
   // installs still police bare drains.

--- a/.safeword/hooks/stop-retro-filing.ts
+++ b/.safeword/hooks/stop-retro-filing.ts
@@ -22,7 +22,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingGate } from './lib/retro-filing-gate.ts';
-import { resolveSessionId } from './lib/retro-trigger.ts';
+import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -32,7 +32,7 @@ interface HookInput {
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
 if (existsSync(`${projectDirectory}/.safeword`)) {
-  let input: HookInput = {};
+  let input: HookInput;
   try {
     input = await Bun.stdin.json();
   } catch {
@@ -43,7 +43,7 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   // payload without session_id must still key the SAME spool the extraction
   // wrote (cloud/local env fallbacks), else drafts spool under the env id and
   // this gate silently never fires.
-  const sessionId = resolveSessionId(input, process.env);
+  const sessionId = resolveClaudeSessionId(input);
   // The gate reads selfReport config itself (GH644A): capture gates the
   // tripwire evaluation, file gates only the dispatch emission — so watch-only
   // installs still police bare drains.

--- a/.safeword/statusline/reentry.ts
+++ b/.safeword/statusline/reentry.ts
@@ -54,8 +54,6 @@ async function main(): Promise<void> {
     .filter((e): e is Entry => e !== null)
     .filter(e => e.sessionId === session_id);
 
-  if (entries.length === 0) return;
-
   const latest = entries.at(-1);
   if (!latest) return;
 

--- a/.safeword/statusline/reentry.ts
+++ b/.safeword/statusline/reentry.ts
@@ -56,7 +56,8 @@ async function main(): Promise<void> {
 
   if (entries.length === 0) return;
 
-  const latest = entries[entries.length - 1];
+  const latest = entries.at(-1);
+  if (!latest) return;
 
   const conflictFiles = detectConflictFiles(cwd, transcript_path);
   const prefix = conflictFiles.length > 0 ? `⚠️ conflict: ${conflictFiles.join(', ')} — ` : '';

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
       },
       "devDependencies": {
         "@cucumber/cucumber": "^13.1.1",
+        "@types/bun": "^1.3.14",
         "@types/estree": "^1.0.9",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.9",
@@ -735,6 +736,8 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
@@ -1042,6 +1045,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2734,6 +2739,8 @@
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "safeword/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "safeword/knip": ["knip@6.27.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.137.0", "oxc-resolver": "11.21.3", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.1", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-CngYEYrD0n20N06FXA8n3u/0Wnnugoa+B9k14OP+iKIgkCHuzvIdsP3nfwjhByoc1WfogpxfiriMboAXFETDUw=="],
 

--- a/packages/cli/architecture.generated.md
+++ b/packages/cli/architecture.generated.md
@@ -1,6 +1,6 @@
 ---
 generator: safeword-architecture
-fingerprint: b5e10ab759c1bd1b8ecbc876dbbc0b76784831cacf5438183665db386a5ed922
+fingerprint: aafc114899d86f51f3991fe5ed83890959874c8fcc2bea3f0a19085371d21c90
 ---
 
 # Architecture
@@ -24,6 +24,8 @@ No description yet — awaiting prose.
 `src/cli.ts`
 
 No description yet — awaiting prose.
+
+> ⚠ stale: structure changed since this section was reconciled.
 
 ### codex-plugin
 
@@ -53,6 +55,8 @@ No description yet — awaiting prose.
 
 No description yet — awaiting prose.
 
+> ⚠ stale: structure changed since this section was reconciled.
+
 ### health
 
 <!-- reconciled: b5e10ab759c1bd1b8ecbc876dbbc0b76784831cacf5438183665db386a5ed922 -->
@@ -61,6 +65,8 @@ No description yet — awaiting prose.
 
 No description yet — awaiting prose.
 
+> ⚠ stale: structure changed since this section was reconciled.
+
 ### index
 
 <!-- reconciled: b5e10ab759c1bd1b8ecbc876dbbc0b76784831cacf5438183665db386a5ed922 -->
@@ -68,6 +74,8 @@ No description yet — awaiting prose.
 `src/index.ts`
 
 No description yet — awaiting prose.
+
+> ⚠ stale: structure changed since this section was reconciled.
 
 ### learning-sync
 
@@ -87,6 +95,8 @@ No description yet — awaiting prose.
 
 No description yet — awaiting prose.
 
+> ⚠ stale: structure changed since this section was reconciled.
+
 ### packs
 
 <!-- reconciled: baf84fad13ff152cf8bceed63ef6a6e65c6edbb3dcf8ac0cbf76fc4caa39fe38 -->
@@ -104,6 +114,8 @@ No description yet — awaiting prose.
 `src/parity.ts`
 
 No description yet — awaiting prose.
+
+> ⚠ stale: structure changed since this section was reconciled.
 
 ### presets
 
@@ -123,6 +135,8 @@ No description yet — awaiting prose.
 
 No description yet — awaiting prose.
 
+> ⚠ stale: structure changed since this section was reconciled.
+
 ### retro
 
 <!-- reconciled: 3dd53c1fa45850e6d2d4894c1c7556870663b58d05710e8dc248b4424eaf8b62 -->
@@ -141,6 +155,8 @@ No description yet — awaiting prose.
 
 No description yet — awaiting prose.
 
+> ⚠ stale: structure changed since this section was reconciled.
+
 ### self-report-capture
 
 <!-- reconciled: b5e10ab759c1bd1b8ecbc876dbbc0b76784831cacf5438183665db386a5ed922 -->
@@ -148,6 +164,8 @@ No description yet — awaiting prose.
 `src/self-report-capture.ts`
 
 No description yet — awaiting prose.
+
+> ⚠ stale: structure changed since this section was reconciled.
 
 ### skills
 
@@ -246,3 +264,5 @@ No description yet — awaiting prose.
 `src/version.ts`
 
 No description yet — awaiting prose.
+
+> ⚠ stale: structure changed since this section was reconciled.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,6 +97,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^13.1.1",
+    "@types/bun": "^1.3.14",
     "@types/estree": "^1.0.9",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.9",

--- a/packages/cli/src/packs/types.ts
+++ b/packages/cli/src/packs/types.ts
@@ -150,6 +150,13 @@ export interface FileDefinition {
 // managedFiles: created if missing, updated only if content === current template output
 export interface ManagedFileDefinition extends FileDefinition {
   /**
+   * Keep a package-owned runtime template byte-identical to its dogfood mirror.
+   * Managed files normally have no mirror because customers may own their
+   * content; this opt-in is for runtime assets the package executes directly.
+   */
+  dogfoodParity?: boolean;
+
+  /**
    * Optional logical key linking this entry to a user-configurable path
    * override in `.safeword/config.json` (`paths.<configKey>`). When the
    * override is set, reconcile suppresses this entry uniformly — install

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -1,13 +1,13 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import type { ContractDefinition, FileDefinition } from './schema.js';
+import type { ContractDefinition, FileDefinition, ManagedFileDefinition } from './schema.js';
 
 interface ParitySchema {
   ownedFiles: Record<string, FileDefinition>;
   // Optional: personas/glossary/surfaces templates are referenced here, not in ownedFiles.
   // Included so the orphan-template scan doesn't false-flag them.
-  managedFiles?: Record<string, FileDefinition>;
+  managedFiles?: Record<string, ManagedFileDefinition>;
   contracts: Record<string, ContractDefinition>;
 }
 
@@ -26,6 +26,16 @@ export interface ParityInput {
   mode: 'all' | 'contracts-only';
   rootDirectory: string;
   templatesDirectory: string;
+}
+
+/** Files that must stay byte-identical between templates and dogfood. */
+function parityPairs(schema: ParitySchema): [string, FileDefinition][] {
+  return [
+    ...Object.entries(schema.ownedFiles),
+    ...Object.entries(schema.managedFiles ?? {}).filter(
+      ([, definition]) => definition.dogfoodParity,
+    ),
+  ];
 }
 
 function checkPair(
@@ -141,7 +151,7 @@ export function runParity(input: ParityInput): ParityResult {
   let passedCount = 0;
 
   if (input.mode === 'all') {
-    for (const [destinationPath, definition] of Object.entries(input.schema.ownedFiles)) {
+    for (const [destinationPath, definition] of parityPairs(input.schema)) {
       if (!definition.template) continue;
       const failure = checkPair(
         destinationPath,
@@ -192,7 +202,7 @@ export function syncParityPairs(input: ParityInput): ParitySyncResult {
   const synced: string[] = [];
   const unfixable: ParityFailure[] = [];
 
-  for (const [destinationPath, definition] of Object.entries(input.schema.ownedFiles)) {
+  for (const [destinationPath, definition] of parityPairs(input.schema)) {
     if (!definition.template) continue;
     const templateFile = nodePath.join(input.templatesDirectory, definition.template);
 

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -238,7 +238,11 @@ const CODEX_RUNTIME_ASSET_FILENAMES = [
 const CODEX_RUNTIME_ASSETS: Record<string, ManagedFileDefinition> = Object.fromEntries(
   CODEX_RUNTIME_ASSET_FILENAMES.map(file => [
     `.safeword/hooks/codex/${file}`,
-    { template: `hooks/codex/${file}`, generator: skipCodexRuntimeAssetInstall },
+    {
+      dogfoodParity: true,
+      template: `hooks/codex/${file}`,
+      generator: skipCodexRuntimeAssetInstall,
+    },
   ]),
 );
 

--- a/packages/cli/templates/hooks/codex/stop.ts
+++ b/packages/cli/templates/hooks/codex/stop.ts
@@ -181,7 +181,8 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     timeout: 600_000,
   });
   const error = result.error as (Error & { code?: string }) | undefined;
-  const ok = result.status === 0 && !result.error && pendingOffsetState !== undefined;
+  const offsetState = pendingOffsetState;
+  const ok = result.status === 0 && !result.error && offsetState !== undefined;
   recordRetroDebugEvent({
     event: 'codex_stop_child_exit',
     command: nodePath.basename(command),
@@ -195,23 +196,19 @@ function runRetroExtraction(projectDirectory: string, input: CodexStopInput): vo
     pendingOffsetState: pendingOffsetState !== undefined,
     ok,
   });
-  if (!ok) return;
+  if (!ok || !offsetState) return;
 
   try {
-    writeOffsetState(
-      pendingOffsetState.sessionId,
-      pendingOffsetState.state,
-      pendingOffsetState.baseDirectory,
-    );
+    writeOffsetState(offsetState.sessionId, offsetState.state, offsetState.baseDirectory);
     recordRetroDebugEvent({
       event: 'codex_stop_offset_write',
-      sessionId: pendingOffsetState.sessionId,
+      sessionId: offsetState.sessionId,
       ok: true,
     });
   } catch {
     recordRetroDebugEvent({
       event: 'codex_stop_offset_write',
-      sessionId: pendingOffsetState.sessionId,
+      sessionId: offsetState.sessionId,
       ok: false,
     });
     // A state-write failure must not make Stop visible or blocking.
@@ -267,7 +264,7 @@ async function main(): Promise<string> {
   return SILENT;
 }
 
-let output = SILENT;
+let output: string;
 try {
   output = await main();
 } catch {

--- a/packages/cli/templates/hooks/lib/re-entry.ts
+++ b/packages/cli/templates/hooks/lib/re-entry.ts
@@ -38,15 +38,9 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
-  // LINE_REGEX has four required, non-empty capture groups. The tuple records
-  // that contract for noUncheckedIndexedAccess without a dead runtime branch.
-  const [, timestamp, sessionId, ticket, nextImperative] = match as unknown as [
-    string,
-    string,
-    string,
-    string,
-    string,
-  ];
+  const [, timestamp, sessionId, ticket, nextImperative] = match;
+  // Keep this fail-closed even if a later regex edit makes a capture optional.
+  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
   return {
     timestamp,
     sessionId,

--- a/packages/cli/templates/hooks/lib/re-entry.ts
+++ b/packages/cli/templates/hooks/lib/re-entry.ts
@@ -38,11 +38,13 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
+  const [timestamp, sessionId, ticket, nextImperative] = match.slice(1);
+  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
   return {
-    timestamp: match[1],
-    sessionId: match[2],
-    ticket: match[3],
-    nextImperative: match[4],
+    timestamp,
+    sessionId,
+    ticket,
+    nextImperative,
   };
 }
 

--- a/packages/cli/templates/hooks/lib/re-entry.ts
+++ b/packages/cli/templates/hooks/lib/re-entry.ts
@@ -38,8 +38,15 @@ const RECENT_TURNS = 10;
 export function parseLogLine(line: string): Entry | null {
   const match = LINE_REGEX.exec(line.trim());
   if (!match) return null;
-  const [timestamp, sessionId, ticket, nextImperative] = match.slice(1);
-  if (!timestamp || !sessionId || !ticket || !nextImperative) return null;
+  // LINE_REGEX has four required, non-empty capture groups. The tuple records
+  // that contract for noUncheckedIndexedAccess without a dead runtime branch.
+  const [, timestamp, sessionId, ticket, nextImperative] = match as unknown as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
   return {
     timestamp,
     sessionId,

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -243,21 +243,6 @@ export function resolveSessionId(
   return firstNonEmpty(input.session_id, env.CLAUDE_CODE_REMOTE_SESSION_ID, env.CLAUDE_SESSION_ID);
 }
 
-/**
- * Resolve a Claude hook's session id using the process environment. Keeping
- * this boundary here prevents each Claude-facing hook from rebuilding the same
- * narrow environment object (and keeps cloud/local precedence in one place).
- */
-export function resolveClaudeSessionId(
-  input: { session_id?: string },
-  env: Record<string, string | undefined> = process.env,
-): string | undefined {
-  return resolveSessionId(input, {
-    CLAUDE_CODE_REMOTE_SESSION_ID: env.CLAUDE_CODE_REMOTE_SESSION_ID,
-    CLAUDE_SESSION_ID: env.CLAUDE_SESSION_ID,
-  });
-}
-
 /** The first argument that is a non-empty string, else undefined. */
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
   for (const value of values) {

--- a/packages/cli/templates/hooks/lib/retro-trigger.ts
+++ b/packages/cli/templates/hooks/lib/retro-trigger.ts
@@ -243,6 +243,21 @@ export function resolveSessionId(
   return firstNonEmpty(input.session_id, env.CLAUDE_CODE_REMOTE_SESSION_ID, env.CLAUDE_SESSION_ID);
 }
 
+/**
+ * Resolve a Claude hook's session id using the process environment. Keeping
+ * this boundary here prevents each Claude-facing hook from rebuilding the same
+ * narrow environment object (and keeps cloud/local precedence in one place).
+ */
+export function resolveClaudeSessionId(
+  input: { session_id?: string },
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  return resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: env.CLAUDE_SESSION_ID,
+  });
+}
+
 /** The first argument that is a non-empty string, else undefined. */
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
   for (const value of values) {

--- a/packages/cli/templates/hooks/lib/skill-nudge.ts
+++ b/packages/cli/templates/hooks/lib/skill-nudge.ts
@@ -125,7 +125,7 @@ export function entrySkillFor(
  * description (the caller then uses the fallback nudge line).
  */
 export function parseSkillDescription(skillMd: string): string | null {
-  const frontmatter = skillMd.match(/^﻿?---\r?\n([\s\S]*?)\r?\n---/);
+  const frontmatter = skillMd.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---/);
   if (!frontmatter) return null;
   const lines = (frontmatter[1] ?? '').split(/\r?\n/);
 

--- a/packages/cli/templates/hooks/post-tool-quality.ts
+++ b/packages/cli/templates/hooks/post-tool-quality.ts
@@ -113,7 +113,7 @@ function countLoc(): number {
     });
     const insMatch = diffStat.match(/(\d+) insertions?\(\+\)/);
     const delMatch = diffStat.match(/(\d+) deletions?\(-\)/);
-    return (insMatch ? parseInt(insMatch[1]) : 0) + (delMatch ? parseInt(delMatch[1]) : 0);
+    return parseInt(insMatch?.[1] ?? '0') + parseInt(delMatch?.[1] ?? '0');
   } catch {
     return 0;
   }

--- a/packages/cli/templates/hooks/post-tool-skill-nudge.ts
+++ b/packages/cli/templates/hooks/post-tool-skill-nudge.ts
@@ -49,7 +49,12 @@ const language = languageForFile(filePath);
 if (!language) process.exit(0);
 
 const skillDirs = installedSkillDirs(projectDirectory);
-const installed = new Set(skillDirs.map(dir => dir.name.split('-')[0]));
+const installed = new Set(
+  skillDirs.flatMap(dir => {
+    const prefix = dir.name.split('-')[0];
+    return prefix ? [prefix] : [];
+  }),
+);
 if (!installed.has(language.prefix)) process.exit(0);
 
 // Resolve the single entry skill (the sole installed skill for a single-skill

--- a/packages/cli/templates/hooks/pre-tool-quality.ts
+++ b/packages/cli/templates/hooks/pre-tool-quality.ts
@@ -357,7 +357,7 @@ if (
     // Multi-line content-bearing files don't match this regex and pass through.
     const dimensionsContent = readFileSync(dimensionsFile, 'utf8').trim();
     const skipMatch = /^skip:(.*)$/i.exec(dimensionsContent);
-    if (skipMatch && !isValidSkipReason(skipMatch[1])) {
+    if (skipMatch && !isValidSkipReason(skipMatch[1] ?? '')) {
       deny(
         'dimensions.md `skip:` declaration requires a non-empty reason after the colon.',
         'Either write a real dimension table, or use `skip: <reason>` where the reason explains why no dimensions need enumerating (e.g., `skip: single behavioral dimension, no partitioning to enumerate`).',

--- a/packages/cli/templates/hooks/prompt-questions.ts
+++ b/packages/cli/templates/hooks/prompt-questions.ts
@@ -159,7 +159,10 @@ if (existsSync(stateFile)) {
     // One-shot reminder: verify novel research claims before building on them.
     // Atomic move pending → acknowledged so the setter's dedup still works
     // after the nudge has been shown (ticket 4N5Y28).
-    const pending = state.learningsNudgesPending ?? [];
+    const rawPending: unknown[] = Array.isArray(state.learningsNudgesPending)
+      ? state.learningsNudgesPending
+      : [];
+    const pending = rawPending.filter((value): value is string => typeof value === 'string');
     if (pending.length > 0) {
       const files = pending.map(f => f.split('/').pop() ?? f).join(', ');
       lines.push(

--- a/packages/cli/templates/hooks/prompt-retro-nudge.ts
+++ b/packages/cli/templates/hooks/prompt-retro-nudge.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingNudge } from './lib/retro-nudge.ts';
-import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
+import { resolveSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -31,7 +31,10 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   }
 
   // Resolver parity with the spool writer — see stop-retro-filing.ts.
-  const sessionId = resolveClaudeSessionId(input);
+  const sessionId = resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: process.env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+  });
   if (sessionId) {
     try {
       const additionalContext = decideRetroFilingNudge(projectDirectory, sessionId);

--- a/packages/cli/templates/hooks/prompt-retro-nudge.ts
+++ b/packages/cli/templates/hooks/prompt-retro-nudge.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingNudge } from './lib/retro-nudge.ts';
-import { resolveSessionId } from './lib/retro-trigger.ts';
+import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -23,7 +23,7 @@ const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
 // Not a safeword project — nothing to do.
 if (existsSync(`${projectDirectory}/.safeword`)) {
-  let input: HookInput = {};
+  let input: HookInput;
   try {
     input = await Bun.stdin.json();
   } catch {
@@ -31,7 +31,7 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   }
 
   // Resolver parity with the spool writer — see stop-retro-filing.ts.
-  const sessionId = resolveSessionId(input, process.env);
+  const sessionId = resolveClaudeSessionId(input);
   if (sessionId) {
     try {
       const additionalContext = decideRetroFilingNudge(projectDirectory, sessionId);

--- a/packages/cli/templates/hooks/session-codex-start.ts
+++ b/packages/cli/templates/hooks/session-codex-start.ts
@@ -16,7 +16,7 @@ import {
 
 const hookInput = await readHookInput();
 const projectDir = resolveProjectDir(hookInput);
-let outcome: AutoUpgradeOutcome = { kind: 'skipped', reason: 'not checked' };
+let outcome: AutoUpgradeOutcome;
 
 try {
   outcome = await runAutoUpgrade({ projectDir, filterSafewordFiles });

--- a/packages/cli/templates/hooks/session-start-reentry.ts
+++ b/packages/cli/templates/hooks/session-start-reentry.ts
@@ -73,8 +73,11 @@ async function main(): Promise<void> {
   let briefBody = '';
   if (currentEntries.length > 0) {
     briefBody = renderBrief(currentEntries.slice(-3));
-  } else if (source === 'startup' && allEntries.length > 0) {
-    briefBody = renderBrief([allEntries[allEntries.length - 1]], { fromAnotherSession: true });
+  } else if (source === 'startup') {
+    const lastEntry = allEntries.at(-1);
+    if (lastEntry) {
+      briefBody = renderBrief([lastEntry], { fromAnotherSession: true });
+    }
   }
 
   const conflictFiles = detectConflictFiles(projectRoot, transcript_path);

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -411,8 +411,10 @@ function checkUsageLimit(transcriptLines: string[]): void {
 function detectEditToolsUsed(transcriptLines: string[]): boolean {
   let checked = 0;
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    const transcriptLine = transcriptLines[i];
+    if (transcriptLine === undefined) continue;
     try {
-      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const message: TranscriptMessage = JSON.parse(transcriptLine);
       if (message.type === 'assistant' && message.message?.content !== undefined) {
         checked++;
         if (containsEditToolUse(normalizeContentItems(message.message.content))) return true;
@@ -433,8 +435,10 @@ function detectEditToolsUsed(transcriptLines: string[]): boolean {
 function detectEditToolsUsedInCurrentUserTurn(transcriptLines: string[]): boolean | undefined {
   let checked = 0;
   for (let i = transcriptLines.length - 1; i >= 0 && checked < MAX_MESSAGES_FOR_TOOLS; i--) {
+    const transcriptLine = transcriptLines[i];
+    if (transcriptLine === undefined) continue;
     try {
-      const message: TranscriptMessage = JSON.parse(transcriptLines[i]);
+      const message: TranscriptMessage = JSON.parse(transcriptLine);
       if (isGenuineUserPrompt(message)) {
         return false;
       }
@@ -765,7 +769,7 @@ const phaseFailurePatterns: Record<string, string> = {
   implement: 'loc-exceeded',
   done: 'done-gate-tests-failed',
 };
-const relevantPattern = phaseFailurePatterns[currentPhase];
+const relevantPattern = currentPhase ? (phaseFailurePatterns[currentPhase] ?? null) : null;
 const recentRelevant = relevantPattern
   ? (sessionState?.recentFailures ?? []).find((f: FailureEntry) => f.pattern === relevantPattern)
       ?.pattern

--- a/packages/cli/templates/hooks/stop-reentry.ts
+++ b/packages/cli/templates/hooks/stop-reentry.ts
@@ -37,9 +37,11 @@ interface TranscriptEntry {
 function extractLastNextImperative(text: string): string | null {
   const lines = text.split('\n');
   for (let index = lines.length - 1; index >= 0; index--) {
-    const match = /^\*\*Next:\*\*\s+(.+)$/.exec(lines[index].trim());
+    const line = lines[index];
+    if (!line) continue;
+    const match = /^\*\*Next:\*\*\s+(.+)$/.exec(line.trim());
     if (match) {
-      const imperative = match[1].trim();
+      const imperative = match[1]?.trim() ?? '';
       return imperative.length > 0 ? imperative : null;
     }
   }
@@ -76,8 +78,10 @@ function readLastAssistantText(transcriptPath: string): string {
   if (raw.length === 0) return '';
   const lines = raw.split('\n');
   for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    if (!line) continue;
     try {
-      const entry = JSON.parse(lines[index]) as TranscriptEntry;
+      const entry = JSON.parse(line) as TranscriptEntry;
       if (entry.type === 'assistant' && entry.message?.content) {
         return entry.message.content
           .filter(c => c.type === 'text' && typeof c.text === 'string')

--- a/packages/cli/templates/hooks/stop-retro-filing.ts
+++ b/packages/cli/templates/hooks/stop-retro-filing.ts
@@ -22,7 +22,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingGate } from './lib/retro-filing-gate.ts';
-import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
+import { resolveSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -43,7 +43,10 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   // payload without session_id must still key the SAME spool the extraction
   // wrote (cloud/local env fallbacks), else drafts spool under the env id and
   // this gate silently never fires.
-  const sessionId = resolveClaudeSessionId(input);
+  const sessionId = resolveSessionId(input, {
+    CLAUDE_CODE_REMOTE_SESSION_ID: process.env.CLAUDE_CODE_REMOTE_SESSION_ID,
+    CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+  });
   // The gate reads selfReport config itself (GH644A): capture gates the
   // tripwire evaluation, file gates only the dispatch emission — so watch-only
   // installs still police bare drains.

--- a/packages/cli/templates/hooks/stop-retro-filing.ts
+++ b/packages/cli/templates/hooks/stop-retro-filing.ts
@@ -22,7 +22,7 @@
 import { existsSync } from 'node:fs';
 
 import { decideRetroFilingGate } from './lib/retro-filing-gate.ts';
-import { resolveSessionId } from './lib/retro-trigger.ts';
+import { resolveClaudeSessionId } from './lib/retro-trigger.ts';
 
 interface HookInput {
   session_id?: string;
@@ -32,7 +32,7 @@ interface HookInput {
 const projectDirectory = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 
 if (existsSync(`${projectDirectory}/.safeword`)) {
-  let input: HookInput = {};
+  let input: HookInput;
   try {
     input = await Bun.stdin.json();
   } catch {
@@ -43,7 +43,7 @@ if (existsSync(`${projectDirectory}/.safeword`)) {
   // payload without session_id must still key the SAME spool the extraction
   // wrote (cloud/local env fallbacks), else drafts spool under the env id and
   // this gate silently never fires.
-  const sessionId = resolveSessionId(input, process.env);
+  const sessionId = resolveClaudeSessionId(input);
   // The gate reads selfReport config itself (GH644A): capture gates the
   // tripwire evaluation, file gates only the dispatch emission — so watch-only
   // installs still police bare drains.

--- a/packages/cli/templates/statusline/reentry.ts
+++ b/packages/cli/templates/statusline/reentry.ts
@@ -54,8 +54,6 @@ async function main(): Promise<void> {
     .filter((e): e is Entry => e !== null)
     .filter(e => e.sessionId === session_id);
 
-  if (entries.length === 0) return;
-
   const latest = entries.at(-1);
   if (!latest) return;
 

--- a/packages/cli/templates/statusline/reentry.ts
+++ b/packages/cli/templates/statusline/reentry.ts
@@ -56,7 +56,8 @@ async function main(): Promise<void> {
 
   if (entries.length === 0) return;
 
-  const latest = entries[entries.length - 1];
+  const latest = entries.at(-1);
+  if (!latest) return;
 
   const conflictFiles = detectConflictFiles(cwd, transcript_path);
   const prefix = conflictFiles.length > 0 ? `⚠️ conflict: ${conflictFiles.join(', ')} — ` : '';

--- a/packages/cli/tests/hooks/re-entry.test.ts
+++ b/packages/cli/tests/hooks/re-entry.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseLogLine } from '../../templates/hooks/lib/re-entry.js';
+
+describe('parseLogLine', () => {
+  it('parses every required field from a canonical re-entry line', () => {
+    expect(
+      parseLogLine('2026-07-29T12:34:56Z sess_123 ticket=505/implement Next: run verification'),
+    ).toEqual({
+      timestamp: '2026-07-29T12:34:56Z',
+      sessionId: 'sess_123',
+      ticket: 'ticket=505/implement',
+      nextImperative: 'run verification',
+    });
+  });
+
+  it('rejects a line with a missing imperative', () => {
+    expect(parseLogLine('2026-07-29T12:34:56Z sess_123 ticket=505/implement Next:')).toBeNull();
+  });
+});

--- a/packages/cli/tests/hooks/re-entry.test.ts
+++ b/packages/cli/tests/hooks/re-entry.test.ts
@@ -14,7 +14,9 @@ describe('parseLogLine', () => {
     });
   });
 
-  it('rejects a line with a missing imperative', () => {
+  it('rejects a line outside the canonical log format', () => {
+    // The current regex rejects this before capture validation. The guard in
+    // parseLogLine deliberately protects a future regex that weakens a capture.
     expect(parseLogLine('2026-07-29T12:34:56Z sess_123 ticket=505/implement Next:')).toBeNull();
   });
 });

--- a/packages/cli/tests/hooks/retro-trigger.test.ts
+++ b/packages/cli/tests/hooks/retro-trigger.test.ts
@@ -19,6 +19,7 @@ import {
   hasNudged,
   isSubstantial,
   markNudged,
+  resolveClaudeSessionId,
   resolveSessionId,
   SUBSTANCE_THRESHOLD,
 } from '../../templates/hooks/lib/retro-trigger.js';
@@ -115,6 +116,17 @@ describe('resolveSessionId (precedence: input > cloud > local)', () => {
 
   it('returns undefined when no session id can be resolved', () => {
     expect(resolveSessionId({}, {})).toBeUndefined();
+  });
+});
+
+describe('resolveClaudeSessionId', () => {
+  it('uses the same input, cloud, then local precedence with a narrow environment', () => {
+    expect(
+      resolveClaudeSessionId(
+        {},
+        { CLAUDE_CODE_REMOTE_SESSION_ID: 'sess-cloud', CLAUDE_SESSION_ID: 'sess-local' },
+      ),
+    ).toBe('sess-cloud');
   });
 });
 

--- a/packages/cli/tests/hooks/retro-trigger.test.ts
+++ b/packages/cli/tests/hooks/retro-trigger.test.ts
@@ -19,7 +19,6 @@ import {
   hasNudged,
   isSubstantial,
   markNudged,
-  resolveClaudeSessionId,
   resolveSessionId,
   SUBSTANCE_THRESHOLD,
 } from '../../templates/hooks/lib/retro-trigger.js';
@@ -116,17 +115,6 @@ describe('resolveSessionId (precedence: input > cloud > local)', () => {
 
   it('returns undefined when no session id can be resolved', () => {
     expect(resolveSessionId({}, {})).toBeUndefined();
-  });
-});
-
-describe('resolveClaudeSessionId', () => {
-  it('uses the same input, cloud, then local precedence with a narrow environment', () => {
-    expect(
-      resolveClaudeSessionId(
-        {},
-        { CLAUDE_CODE_REMOTE_SESSION_ID: 'sess-cloud', CLAUDE_SESSION_ID: 'sess-local' },
-      ),
-    ).toBe('sess-cloud');
   });
 });
 

--- a/packages/cli/tests/parity.test.ts
+++ b/packages/cli/tests/parity.test.ts
@@ -156,6 +156,29 @@ describe('runParity', () => {
       expect(result.failures[0]?.message).toContain('sample.ts');
     });
 
+    it('includes managed runtime files that opt into dogfood parity', () => {
+      const { rootDirectory, templatesDirectory } = makeFixture();
+      mkdirSync(nodePath.join(rootDirectory, '.safeword'), { recursive: true });
+      writeFileSync(nodePath.join(templatesDirectory, 'runtime.ts'), 'CANONICAL\n');
+      writeFileSync(nodePath.join(rootDirectory, '.safeword/runtime.ts'), 'DRIFTED\n');
+
+      const result = runParity({
+        schema: {
+          ownedFiles: {},
+          managedFiles: {
+            '.safeword/runtime.ts': { dogfoodParity: true, template: 'runtime.ts' },
+          },
+          contracts: {},
+        },
+        mode: 'all',
+        rootDirectory,
+        templatesDirectory,
+      });
+
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]?.message).toContain('.safeword/runtime.ts');
+    });
+
     it('fails identifying the missing path when one side of a pair is missing', () => {
       const { rootDirectory, templatesDirectory } = makeFixture();
       writeFileSync(nodePath.join(templatesDirectory, 'sample.ts'), 'only template\n');
@@ -396,6 +419,31 @@ describe('syncParityPairs (--fix, issue #585)', () => {
     expect(result.synced).toEqual(['.safeword/sample.ts']);
     expect(result.unfixable).toHaveLength(0);
     expect(readFileSync(nodePath.join(rootDirectory, '.safeword/sample.ts'), 'utf8')).toBe(
+      'CANONICAL\n',
+    );
+  });
+
+  it('syncs managed runtime files that opt into dogfood parity', () => {
+    const { rootDirectory, templatesDirectory } = makeFixture();
+    mkdirSync(nodePath.join(rootDirectory, '.safeword'), { recursive: true });
+    writeFileSync(nodePath.join(templatesDirectory, 'runtime.ts'), 'CANONICAL\n');
+    writeFileSync(nodePath.join(rootDirectory, '.safeword/runtime.ts'), 'DRIFTED\n');
+
+    const result = syncParityPairs({
+      schema: {
+        ownedFiles: {},
+        managedFiles: {
+          '.safeword/runtime.ts': { dogfoodParity: true, template: 'runtime.ts' },
+        },
+        contracts: {},
+      },
+      mode: 'all',
+      rootDirectory,
+      templatesDirectory,
+    });
+
+    expect(result.synced).toEqual(['.safeword/runtime.ts']);
+    expect(readFileSync(nodePath.join(rootDirectory, '.safeword/runtime.ts'), 'utf8')).toBe(
       'CANONICAL\n',
     );
   });

--- a/packages/cli/tests/shipped-hooks-validation.release.test.ts
+++ b/packages/cli/tests/shipped-hooks-validation.release.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Release gate: shipped TypeScript hooks remain valid in the installed shape.
+ *
+ * Hook templates are copied into customer repositories, where both host lint
+ * and TypeScript tooling can inspect them. Validate the entire physical hook
+ * tree here without requiring a customer project's dependencies or generated
+ * files.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { ESLint } from 'eslint';
+import tseslint from 'typescript-eslint';
+import { describe, expect, it } from 'vitest';
+
+import { generateOwnedPathsModule } from '../src/owned-paths.js';
+import { recommendedTypeScript } from '../src/presets/typescript/eslint-configs/recommended-typescript.js';
+import { SAFEWORD_SCHEMA } from '../src/schema.js';
+
+const cliRoot = nodePath.resolve(import.meta.dirname, '..');
+const hooksDirectory = nodePath.join(cliRoot, 'templates', 'hooks');
+const tscPath = nodePath.join(cliRoot, 'node_modules', '.bin', 'tsc');
+
+// The public baseline that host projects use for distributed hook files. Keep
+// this intentionally small: the full Safeword preset has policy rules that
+// predate the existing template corpus; this release gate owns distributable
+// syntax/type validity, not a repository-wide style migration.
+const supportedHostBaseline = [
+  eslintJs.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+];
+
+function createInstalledHooksFixture(): { cleanup: () => void; directory: string } {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-hooks-'));
+  const fixtureHooksDirectory = nodePath.join(directory, 'hooks');
+  cpSync(hooksDirectory, fixtureHooksDirectory, { recursive: true });
+  writeFileSync(
+    nodePath.join(fixtureHooksDirectory, 'lib', 'owned-paths.ts'),
+    generateOwnedPathsModule(SAFEWORD_SCHEMA),
+  );
+  writeFileSync(
+    nodePath.join(directory, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          allowImportingTsExtensions: true,
+          module: 'Preserve',
+          moduleDetection: 'force',
+          moduleResolution: 'bundler',
+          noEmit: true,
+          noFallthroughCasesInSwitch: true,
+          noImplicitOverride: true,
+          noUncheckedIndexedAccess: true,
+          noUnusedLocals: false,
+          noUnusedParameters: false,
+          skipLibCheck: true,
+          strict: true,
+          target: 'ESNext',
+          typeRoots: [nodePath.join(cliRoot, 'node_modules', '@types')],
+          types: ['node', 'bun'],
+        },
+        include: ['hooks/**/*.ts'],
+      },
+      undefined,
+      2,
+    )}\n`,
+  );
+  return {
+    cleanup: () => {
+      rmSync(directory, { force: true, maxRetries: 3, recursive: true });
+    },
+    directory,
+  };
+}
+
+describe('shipped TypeScript hooks', () => {
+  it('pass Safeword’s supported host ESLint baseline', async () => {
+    const eslint = new ESLint({
+      cwd: cliRoot,
+      ignore: false,
+      overrideConfig: supportedHostBaseline,
+      overrideConfigFile: true,
+    });
+
+    const results = await eslint.lintFiles([hooksDirectory]);
+    const errors = results.flatMap(result =>
+      result.messages
+        .filter(message => message.severity === 2)
+        .map(
+          message =>
+            `${nodePath.relative(cliRoot, result.filePath)}:${message.line}:${message.ruleId}`,
+        ),
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  it('loads every installed hook through Safeword’s actual typed host preset', async () => {
+    const fixture = createInstalledHooksFixture();
+    try {
+      const eslint = new ESLint({
+        cwd: fixture.directory,
+        ignore: false,
+        overrideConfig: recommendedTypeScript,
+        overrideConfigFile: true,
+      });
+
+      const results = await eslint.lintFiles(['hooks']);
+      const fatalErrors = results.flatMap(result =>
+        result.messages
+          .filter(message => message.fatal)
+          .map(
+            message =>
+              `${nodePath.relative(fixture.directory, result.filePath)}:${message.line}:${message.ruleId}`,
+          ),
+      );
+
+      expect(fatalErrors).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  }, 30_000);
+
+  it('typechecks every template in its installed shape', () => {
+    const fixture = createInstalledHooksFixture();
+    try {
+      const result = spawnSync(tscPath, ['--project', 'tsconfig.json'], {
+        cwd: fixture.directory,
+        encoding: 'utf8',
+      });
+
+      expect(
+        result.status,
+        `tsc exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      ).toBe(0);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+import eslintJs from '@eslint/js';

--- a/packages/cli/tests/shipped-hooks-validation.release.test.ts
+++ b/packages/cli/tests/shipped-hooks-validation.release.test.ts
@@ -1,17 +1,18 @@
 /**
- * Release gate: shipped TypeScript hooks remain valid in the installed shape.
+ * Release gate: shipped TypeScript templates remain valid in their installed shape.
  *
- * Hook templates are copied into customer repositories, where both host lint
- * and TypeScript tooling can inspect them. Validate the entire physical hook
- * tree here without requiring a customer project's dependencies or generated
- * files.
+ * Schema-declared templates are copied into customer repositories, where host
+ * lint and TypeScript tooling can inspect them. Validate each physical
+ * TypeScript template here with Safeword's package-pinned type dependencies;
+ * customers may use different dependency versions outside this release contract.
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
+import eslintJs from '@eslint/js';
 import { ESLint } from 'eslint';
 import tseslint from 'typescript-eslint';
 import { describe, expect, it } from 'vitest';
@@ -21,7 +22,7 @@ import { recommendedTypeScript } from '../src/presets/typescript/eslint-configs/
 import { SAFEWORD_SCHEMA } from '../src/schema.js';
 
 const cliRoot = nodePath.resolve(import.meta.dirname, '..');
-const hooksDirectory = nodePath.join(cliRoot, 'templates', 'hooks');
+const templatesDirectory = nodePath.join(cliRoot, 'templates');
 const tscPath = nodePath.join(cliRoot, 'node_modules', '.bin', 'tsc');
 
 // The public baseline that host projects use for distributed hook files. Keep
@@ -41,20 +42,41 @@ const supportedHostBaseline = [
   },
 ];
 
-function createInstalledHooksFixture(): { cleanup: () => void; directory: string } {
+interface InstalledTemplate {
+  destinationPath: string;
+  templatePath: string;
+}
+
+const shippedTypeScriptTemplates: InstalledTemplate[] = [
+  ...Object.entries(SAFEWORD_SCHEMA.ownedFiles),
+  ...Object.entries(SAFEWORD_SCHEMA.managedFiles),
+].flatMap(([destinationPath, definition]) => {
+  const templatePath = definition.template;
+  return templatePath?.endsWith('.ts') ? [{ destinationPath, templatePath }] : [];
+});
+
+function createInstalledTemplatesFixture(): {
+  cleanup: () => void;
+  directory: string;
+  templatePaths: string[];
+} {
   const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-hooks-'));
-  const fixtureHooksDirectory = nodePath.join(directory, 'hooks');
-  cpSync(hooksDirectory, fixtureHooksDirectory, { recursive: true });
-  writeFileSync(
-    nodePath.join(fixtureHooksDirectory, 'lib', 'owned-paths.ts'),
-    generateOwnedPathsModule(SAFEWORD_SCHEMA),
-  );
+  const templatePaths = shippedTypeScriptTemplates.map(({ destinationPath, templatePath }) => {
+    const target = nodePath.join(directory, destinationPath);
+    mkdirSync(nodePath.dirname(target), { recursive: true });
+    cpSync(nodePath.join(templatesDirectory, templatePath), target);
+    return target;
+  });
+  const ownedPathsTarget = nodePath.join(directory, '.safeword', 'hooks', 'lib', 'owned-paths.ts');
+  mkdirSync(nodePath.dirname(ownedPathsTarget), { recursive: true });
+  writeFileSync(ownedPathsTarget, generateOwnedPathsModule(SAFEWORD_SCHEMA));
   writeFileSync(
     nodePath.join(directory, 'tsconfig.json'),
     `${JSON.stringify(
       {
         compilerOptions: {
           allowImportingTsExtensions: true,
+          baseUrl: directory,
           module: 'Preserve',
           moduleDetection: 'force',
           moduleResolution: 'bundler',
@@ -67,10 +89,18 @@ function createInstalledHooksFixture(): { cleanup: () => void; directory: string
           skipLibCheck: true,
           strict: true,
           target: 'ESNext',
+          paths: {
+            '@cucumber/cucumber': [
+              nodePath.join(cliRoot, 'node_modules', '@cucumber', 'cucumber', 'lib', 'index.d.ts'),
+            ],
+          },
           typeRoots: [nodePath.join(cliRoot, 'node_modules', '@types')],
           types: ['node', 'bun'],
         },
-        include: ['hooks/**/*.ts'],
+        include: [
+          ...shippedTypeScriptTemplates.map(({ destinationPath }) => destinationPath),
+          ownedPathsTarget,
+        ],
       },
       undefined,
       2,
@@ -81,33 +111,39 @@ function createInstalledHooksFixture(): { cleanup: () => void; directory: string
       rmSync(directory, { force: true, maxRetries: 3, recursive: true });
     },
     directory,
+    templatePaths,
   };
 }
 
-describe('shipped TypeScript hooks', () => {
+describe('shipped TypeScript templates', () => {
   it('pass Safeword’s supported host ESLint baseline', async () => {
+    const fixture = createInstalledTemplatesFixture();
     const eslint = new ESLint({
-      cwd: cliRoot,
+      cwd: fixture.directory,
       ignore: false,
       overrideConfig: supportedHostBaseline,
       overrideConfigFile: true,
     });
 
-    const results = await eslint.lintFiles([hooksDirectory]);
-    const errors = results.flatMap(result =>
-      result.messages
-        .filter(message => message.severity === 2)
-        .map(
-          message =>
-            `${nodePath.relative(cliRoot, result.filePath)}:${message.line}:${message.ruleId}`,
-        ),
-    );
+    try {
+      const results = await eslint.lintFiles(fixture.templatePaths);
+      const errors = results.flatMap(result =>
+        result.messages
+          .filter(message => message.severity === 2)
+          .map(
+            message =>
+              `${nodePath.relative(fixture.directory, result.filePath)}:${message.line}:${message.ruleId}`,
+          ),
+      );
 
-    expect(errors).toEqual([]);
+      expect(errors).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
   });
 
-  it('loads every installed hook through Safeword’s actual typed host preset', async () => {
-    const fixture = createInstalledHooksFixture();
+  it('parses and resolves type information without fatal errors under Safeword’s typed host preset', async () => {
+    const fixture = createInstalledTemplatesFixture();
     try {
       const eslint = new ESLint({
         cwd: fixture.directory,
@@ -116,7 +152,7 @@ describe('shipped TypeScript hooks', () => {
         overrideConfigFile: true,
       });
 
-      const results = await eslint.lintFiles(['hooks']);
+      const results = await eslint.lintFiles(fixture.templatePaths);
       const fatalErrors = results.flatMap(result =>
         result.messages
           .filter(message => message.fatal)
@@ -132,14 +168,15 @@ describe('shipped TypeScript hooks', () => {
     }
   }, 30_000);
 
-  it('typechecks every template in its installed shape', () => {
-    const fixture = createInstalledHooksFixture();
+  it('typechecks every schema-declared template in its installed shape', () => {
+    const fixture = createInstalledTemplatesFixture();
     try {
       const result = spawnSync(tscPath, ['--project', 'tsconfig.json'], {
         cwd: fixture.directory,
         encoding: 'utf8',
       });
 
+      expect(result.error, `failed to spawn ${tscPath}`).toBeUndefined();
       expect(
         result.status,
         `tsc exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
@@ -149,4 +186,3 @@ describe('shipped TypeScript hooks', () => {
     }
   });
 });
-import eslintJs from '@eslint/js';

--- a/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
+++ b/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
@@ -60,6 +60,10 @@ const shippedTypeScriptTemplates: InstalledTemplate[] = [
   return templatePath?.endsWith('.ts') ? [{ destinationPath, templatePath }] : [];
 });
 
+// This minimum blocks a vacuous ESLint run if schema discovery regresses while
+// allowing deliberate additions to the distributed TypeScript surface.
+const MIN_SHIPPED_TYPESCRIPT_TEMPLATE_COUNT = 106;
+
 function materializeInstalledTemplates(directory: string): MaterializedTemplates {
   const templatePaths = shippedTypeScriptTemplates.map(({ destinationPath, templatePath }) => {
     const target = nodePath.join(directory, destinationPath);
@@ -95,9 +99,7 @@ function writeFixtureTypeScriptConfig(directory: string, ownedPathsTarget: strin
           strict: true,
           target: 'ESNext',
           paths: {
-            '@cucumber/cucumber': [
-              nodePath.join(cliRoot, 'node_modules', '@cucumber', 'cucumber', 'lib', 'index.d.ts'),
-            ],
+            '@cucumber/cucumber': [nodePath.join(cliRoot, 'node_modules', '@cucumber', 'cucumber')],
           },
           typeRoots: [nodePath.join(cliRoot, 'node_modules', '@types')],
           types: ['node', 'bun'],
@@ -131,6 +133,12 @@ function createInstalledTemplatesFixture(): {
 }
 
 describe('shipped TypeScript templates', () => {
+  it('has a non-vacuous schema-declared TypeScript release surface', () => {
+    expect(shippedTypeScriptTemplates.length).toBeGreaterThanOrEqual(
+      MIN_SHIPPED_TYPESCRIPT_TEMPLATE_COUNT,
+    );
+  });
+
   it('pass Safeword’s supported host ESLint baseline', async () => {
     const fixture = createInstalledTemplatesFixture();
     const eslint = new ESLint({

--- a/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
+++ b/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
@@ -47,6 +47,11 @@ interface InstalledTemplate {
   templatePath: string;
 }
 
+interface MaterializedTemplates {
+  ownedPathsTarget: string;
+  templatePaths: string[];
+}
+
 const shippedTypeScriptTemplates: InstalledTemplate[] = [
   ...Object.entries(SAFEWORD_SCHEMA.ownedFiles),
   ...Object.entries(SAFEWORD_SCHEMA.managedFiles),
@@ -55,12 +60,7 @@ const shippedTypeScriptTemplates: InstalledTemplate[] = [
   return templatePath?.endsWith('.ts') ? [{ destinationPath, templatePath }] : [];
 });
 
-function createInstalledTemplatesFixture(): {
-  cleanup: () => void;
-  directory: string;
-  templatePaths: string[];
-} {
-  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-templates-'));
+function materializeInstalledTemplates(directory: string): MaterializedTemplates {
   const templatePaths = shippedTypeScriptTemplates.map(({ destinationPath, templatePath }) => {
     const target = nodePath.join(directory, destinationPath);
     mkdirSync(nodePath.dirname(target), { recursive: true });
@@ -71,6 +71,10 @@ function createInstalledTemplatesFixture(): {
   mkdirSync(nodePath.dirname(ownedPathsTarget), { recursive: true });
   writeFileSync(ownedPathsTarget, generateOwnedPathsModule(SAFEWORD_SCHEMA));
   templatePaths.push(ownedPathsTarget);
+  return { ownedPathsTarget, templatePaths };
+}
+
+function writeFixtureTypeScriptConfig(directory: string, ownedPathsTarget: string): void {
   writeFileSync(
     nodePath.join(directory, 'tsconfig.json'),
     `${JSON.stringify(
@@ -107,6 +111,16 @@ function createInstalledTemplatesFixture(): {
       2,
     )}\n`,
   );
+}
+
+function createInstalledTemplatesFixture(): {
+  cleanup: () => void;
+  directory: string;
+  templatePaths: string[];
+} {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-templates-'));
+  const { ownedPathsTarget, templatePaths } = materializeInstalledTemplates(directory);
+  writeFixtureTypeScriptConfig(directory, ownedPathsTarget);
   return {
     cleanup: () => {
       rmSync(directory, { force: true, maxRetries: 3, recursive: true });

--- a/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
+++ b/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
@@ -60,7 +60,7 @@ function createInstalledTemplatesFixture(): {
   directory: string;
   templatePaths: string[];
 } {
-  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-hooks-'));
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-shipped-templates-'));
   const templatePaths = shippedTypeScriptTemplates.map(({ destinationPath, templatePath }) => {
     const target = nodePath.join(directory, destinationPath);
     mkdirSync(nodePath.dirname(target), { recursive: true });

--- a/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
+++ b/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
@@ -70,6 +70,7 @@ function createInstalledTemplatesFixture(): {
   const ownedPathsTarget = nodePath.join(directory, '.safeword', 'hooks', 'lib', 'owned-paths.ts');
   mkdirSync(nodePath.dirname(ownedPathsTarget), { recursive: true });
   writeFileSync(ownedPathsTarget, generateOwnedPathsModule(SAFEWORD_SCHEMA));
+  templatePaths.push(ownedPathsTarget);
   writeFileSync(
     nodePath.join(directory, 'tsconfig.json'),
     `${JSON.stringify(

--- a/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
+++ b/packages/cli/tests/shipped-typescript-templates-validation.release.test.ts
@@ -60,8 +60,9 @@ const shippedTypeScriptTemplates: InstalledTemplate[] = [
   return templatePath?.endsWith('.ts') ? [{ destinationPath, templatePath }] : [];
 });
 
-// This minimum blocks a vacuous ESLint run if schema discovery regresses while
-// allowing deliberate additions to the distributed TypeScript surface.
+// This floor blocks a vacuous ESLint run if schema discovery regresses while
+// allowing deliberate additions. It is not a census: schema/parity validation
+// remains responsible for catching a removal offset by a new template.
 const MIN_SHIPPED_TYPESCRIPT_TEMPLATE_COUNT = 106;
 
 function materializeInstalledTemplates(directory: string): MaterializedTemplates {
@@ -163,7 +164,7 @@ describe('shipped TypeScript templates', () => {
     } finally {
       fixture.cleanup();
     }
-  });
+  }, 15_000);
 
   it('parses and resolves type information without fatal errors under Safeword’s typed host preset', async () => {
     const fixture = createInstalledTemplatesFixture();
@@ -189,7 +190,7 @@ describe('shipped TypeScript templates', () => {
     } finally {
       fixture.cleanup();
     }
-  }, 30_000);
+  }, 60_000);
 
   it('typechecks every schema-declared template in its installed shape', () => {
     const fixture = createInstalledTemplatesFixture();

--- a/scripts/parity-check.ts
+++ b/scripts/parity-check.ts
@@ -53,10 +53,6 @@ if (arguments_.includes('--fix')) {
   process.exit(report.exitCode);
 }
 
-const pairCount = [
-  ...Object.values(SAFEWORD_SCHEMA.ownedFiles),
-  ...Object.values(SAFEWORD_SCHEMA.managedFiles).filter(definition => definition.dogfoodParity),
-].filter(definition => definition.template).length;
 const contractCount = Object.keys(SAFEWORD_SCHEMA.contracts).length;
 
 const result = runParity({
@@ -68,6 +64,7 @@ const result = runParity({
 
 if (result.failures.length === 0) {
   if (mode === 'all') {
+    const pairCount = result.passedCount - contractCount;
     console.log(
       `All ${pairCount} pairs and ${contractCount} contracts in sync; no unregistered templates; cursor rules are thin @reference pointers.`,
     );

--- a/scripts/parity-check.ts
+++ b/scripts/parity-check.ts
@@ -64,6 +64,8 @@ const result = runParity({
 
 if (result.failures.length === 0) {
   if (mode === 'all') {
+    // runParity counts only successful pairs and contracts; the other scans
+    // produce failures but never contribute successful items to this total.
     const pairCount = result.passedCount - contractCount;
     console.log(
       `All ${pairCount} pairs and ${contractCount} contracts in sync; no unregistered templates; cursor rules are thin @reference pointers.`,

--- a/scripts/parity-check.ts
+++ b/scripts/parity-check.ts
@@ -53,7 +53,10 @@ if (arguments_.includes('--fix')) {
   process.exit(report.exitCode);
 }
 
-const pairCount = Object.values(SAFEWORD_SCHEMA.ownedFiles).filter(d => d.template).length;
+const pairCount = [
+  ...Object.values(SAFEWORD_SCHEMA.ownedFiles),
+  ...Object.values(SAFEWORD_SCHEMA.managedFiles).filter(definition => definition.dogfoodParity),
+].filter(definition => definition.template).length;
 const contractCount = Object.keys(SAFEWORD_SCHEMA.contracts).length;
 
 const result = runParity({


### PR DESCRIPTION
## Summary

Validates every published TypeScript hook template in its installed shape before release.

- Adds baseline lint, typed-preset parser/config, and strict TypeScript release checks.
- Fixes shipped-template diagnostics and preserves dogfood parity.
- Adds package-local Bun types required by the fixture.

## Validation

- `bun run --cwd packages/cli test:release`
- `bun run --cwd packages/cli lint`
- `bun run --cwd packages/cli test:bdd`
- `bun scripts/parity-check.ts`
- `bun audit`

The complete Vitest suite has a runner lifecycle hang in this environment after workers exit; focused/release/BDD checks passed.