### PR TITLE
Protect retro filing from malformed GitHub CLI credentials

### DIFF
--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
@@ -8,6 +8,8 @@
 | TD-2 | Preserve real child environment | Supply a lookup-only environment; set a process-only marker; mocked `gh` returns a valid credential | Resolution succeeds and `gh` receives the process marker but no `GITHUB_TOKEN` |
 | TD-3 | Preserve explicit `GH_TOKEN` | Rejected `GITHUB_TOKEN`; set `GH_TOKEN`; mocked `gh` returns a valid credential | `gh` child environment includes `GH_TOKEN` and excludes `GITHUB_TOKEN` |
 | TD-4 | Isolate mocks between tests | Reset mocks in `afterEach` | Every subprocess-dependent test explicitly sets its own response |
+| TD-5 | Accept one terminal line ending only | Mocked `gh` returns a valid credential followed by one LF or CRLF | Resolution succeeds; leading/trailing whitespace and repeated line endings remain rejected |
+| TD-6 | Remove token keys case-insensitively | Lookup-only rejected token; process context has a differently cased `github_token` | The `gh` child environment excludes differently cased `GITHUB_TOKEN` keys |
 
 ## Completion
 
@@ -15,5 +17,7 @@
 - [x] TD-2 — added RED→GREEN process-boundary coverage with a process-only marker.
 - [x] TD-3 — retained and passed the #1602 child-environment regression.
 - [x] TD-4 — added a regression proving no earlier mock response can leak.
+- [x] TD-5 — added terminal LF/CRLF acceptance and malformed-whitespace rejection coverage.
+- [x] TD-6 — added a case-insensitive Windows child-environment regression.
 
-Each new behavior test is added and run red before its implementation changes. The test scope is integration because it validates the real resolver-to-transport behavior and mocks only the external subprocess boundary.
+The test scope is integration because it validates the real resolver-to-transport behavior and mocks only the external subprocess boundary.

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
@@ -7,7 +7,7 @@
 | TD-1 | Reject unsafe `gh` output | Rejected `GITHUB_TOKEN`; mocked `gh` returns a value with a space | `resolveGitHubToken()` is undefined and `createRestTransport()` is undefined |
 | TD-2 | Preserve real child environment | Supply a lookup-only environment; set a process-only marker; mocked `gh` returns a valid credential | Resolution succeeds and `gh` receives the process marker but no `GITHUB_TOKEN` |
 | TD-3 | Preserve explicit `GH_TOKEN` | Rejected `GITHUB_TOKEN`; set `GH_TOKEN`; mocked `gh` returns a valid credential | `gh` child environment includes `GH_TOKEN` and excludes `GITHUB_TOKEN` |
-| TD-4 | Isolate mocks between tests | Reset mocks in `afterEach` | Every subprocess-dependent test explicitly sets its own response |
+| TD-4 | Reset mock implementations during test cleanup | Configure a `gh` response, then run the shared cleanup | The next fallback call receives no retained subprocess response |
 | TD-5 | Accept one terminal line ending only | Mocked `gh` returns a valid credential followed by one LF or CRLF | Resolution succeeds; leading/trailing whitespace and repeated line endings remain rejected |
 | TD-6 | Remove token keys case-insensitively | Lookup-only rejected token; process context has a differently cased `github_token` | The `gh` child environment excludes differently cased `GITHUB_TOKEN` keys |
 

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/test-definitions.md
@@ -1,0 +1,19 @@
+# Test Definitions: Protect retro filing from malformed GitHub CLI credentials
+
+**Scope:** Integration tests in `packages/cli/src/retro/github-rest.test.ts`, using the real resolver and REST transport while mocking only the `gh` subprocess boundary.
+
+| ID | Behavior | Setup | Assertion |
+| --- | --- | --- | --- |
+| TD-1 | Reject unsafe `gh` output | Rejected `GITHUB_TOKEN`; mocked `gh` returns a value with a space | `resolveGitHubToken()` is undefined and `createRestTransport()` is undefined |
+| TD-2 | Preserve real child environment | Supply a lookup-only environment; set a process-only marker; mocked `gh` returns a valid credential | Resolution succeeds and `gh` receives the process marker but no `GITHUB_TOKEN` |
+| TD-3 | Preserve explicit `GH_TOKEN` | Rejected `GITHUB_TOKEN`; set `GH_TOKEN`; mocked `gh` returns a valid credential | `gh` child environment includes `GH_TOKEN` and excludes `GITHUB_TOKEN` |
+| TD-4 | Isolate mocks between tests | Reset mocks in `afterEach` | Every subprocess-dependent test explicitly sets its own response |
+
+## Completion
+
+- [x] TD-1 — added RED→GREEN integration coverage at the resolver-to-transport boundary.
+- [x] TD-2 — added RED→GREEN process-boundary coverage with a process-only marker.
+- [x] TD-3 — retained and passed the #1602 child-environment regression.
+- [x] TD-4 — added a regression proving no earlier mock response can leak.
+
+Each new behavior test is added and run red before its implementation changes. The test scope is integration because it validates the real resolver-to-transport behavior and mocks only the external subprocess boundary.

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/ticket.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/ticket.md
@@ -1,0 +1,43 @@
+---
+id: 5EEKMD
+slug: harden-gh-fallback-credentials
+type: task
+phase: implement
+status: in_progress
+created: 2026-07-29T17:33:42.554Z
+last_modified: 2026-07-29T17:39:00.000Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1637
+external_prs:
+  - https://github.com/ArcadeAI/safeword/pull/1577
+---
+
+# Protect retro filing from malformed GitHub CLI credentials
+
+**Goal:** Keep gh-based retro filing header-safe without prompting users for a token.
+
+**Why:** Malformed gh output and environment coupling can make automatic filing fail or send unusable credentials.
+
+## Scope
+
+- Accept only RFC 6750 Bearer-syntax output from `gh auth token`.
+- Run `gh auth token` with the real process environment, excluding only the rejected `GITHUB_TOKEN`.
+- Reset subprocess mocks after each test and simplify the one-row parameterized test.
+
+## Out of Scope
+
+- Prompting for, storing, or creating GitHub credentials.
+- Guessing whether opaque `GH_TOKEN` values are valid; GitHub remains the authority.
+
+## Done When
+
+- A malformed `gh` result cannot create a REST transport or Authorization header.
+- An injected lookup environment cannot remove process context needed to invoke `gh`.
+- The focused and repository verification lanes pass with isolated mocks.
+
+## Work Log
+
+- 2026-07-29T17:33:42.554Z Started: Created ticket 5EEKMD
+- 2026-07-29T17:39:00.000Z Defined: Captured the late #1577 review findings as #1637 scope and acceptance criteria.
+- 2026-07-29T17:42:14.000Z Implemented: Added RED→GREEN coverage for unsafe gh output, lookup-environment isolation, and mock reset; simplified the single-case test table.
+- 2026-07-29T17:48:00.000Z Reviewed: Fresh independent quality review approved the implementation with no blocking findings.
+- 2026-07-29T18:15:00.000Z Verified: Focused tests, canonical test plan, BDD acceptance lane, lint, formatting, and audit completed; recorded evidence in verify.md.

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/ticket.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/ticket.md
@@ -2,10 +2,10 @@
 id: 5EEKMD
 slug: harden-gh-fallback-credentials
 type: task
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-07-29T17:33:42.554Z
-last_modified: 2026-07-29T17:39:00.000Z
+last_modified: 2026-07-30T00:46:48Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1637
 external_prs:
   - https://github.com/ArcadeAI/safeword/pull/1577
@@ -41,3 +41,4 @@ external_prs:
 - 2026-07-29T17:42:14.000Z Implemented: Added RED→GREEN coverage for unsafe gh output, lookup-environment isolation, and mock reset; simplified the single-case test table.
 - 2026-07-29T17:48:00.000Z Reviewed: Fresh independent quality review approved the implementation with no blocking findings.
 - 2026-07-29T18:15:00.000Z Verified: Focused tests, canonical test plan, BDD acceptance lane, lint, formatting, and audit completed; recorded evidence in verify.md.
+- 2026-07-30T00:46:48Z Completed: User authorized the done transition after the ready-PR closure gate confirmed the recorded verification evidence.

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/user-stories.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/user-stories.md
@@ -1,0 +1,17 @@
+# User Story: Protect retro filing from malformed GitHub CLI credentials
+
+As a developer with an existing GitHub CLI login,
+I want retro filing to use that login safely when `GITHUB_TOKEN` is unavailable or rejected,
+so that filing works without asking me to create or provide another token.
+
+## Acceptance Criteria
+
+1. Given `gh auth token` returns text outside RFC 6750 Bearer syntax, when retro resolves credentials, then it resolves no token and creates no REST transport.
+2. Given a caller supplies an environment only to look up `GITHUB_TOKEN`, when fallback invokes `gh`, then the child receives the real process environment except for `GITHUB_TOKEN`.
+3. Given `GH_TOKEN` is configured explicitly, when fallback invokes `gh`, then it remains available to `gh` as an opaque operator-controlled credential.
+4. Given one test configures a subprocess response, when the next test runs, then it starts with a reset mock implementation.
+
+## Non-goals
+
+- Prompting users for a token.
+- Interpreting token ownership, authorization, or GitHub-specific token formats locally.

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
@@ -1,18 +1,18 @@
 ## Verify Checklist
 
-**Test Suite:** ✓ 53/53 focused resolver/transport tests pass; canonical `bun run test` completed
-**Gherkin:** ✅ Acceptance lane passes (`bun run test:bdd`)
+**Test Suite:** ⚠️ Local environment limitation: 58/58 focused resolver/transport tests pass; the canonical suite under shared load timed out in two unrelated integration tests, both of which pass in isolation
+**Gherkin:** ✅ Acceptance lane passes (`bun run test:bdd`: 93 scenarios, 1,109 steps)
 **Build:** ✅ Success (`tsup`)
-**Lint:** ✅ Clean (`bun run lint`; Prettier applied only to the edited test file)
-**Scenarios:** All 4 scenarios marked complete
+**Lint:** ✅ Clean (`bun run lint`; TypeScript typecheck and Prettier check pass)
+**Scenarios:** All 6 scenarios marked complete
 **PR Scope:** ✅ Diff matches ticket scope
 **Dep Drift:** ✅ Clean — no dependency or architecture change in this ticket
 **Parent Epic:** N/A
 **Reconcile:** ✅ No pattern deviation
 **Experience:** ⏭️ N/A — internal credential-resolution plumbing
-**Evidence limits:** ⚠️ Audit cannot statically inspect Python imports in the unrelated `experiments/gepa-review-spec/gepa` area because it has no import-linter contracts
+**Evidence limits:** ⚠️ The full suite ran under shared-load pressure and hit two unrelated 30-second integration-test timeouts; both passed on isolated rerun. Audit also cannot statically inspect Python imports in the unrelated `experiments/gepa-review-spec/gepa` area because it has no import-linter contracts.
 
-Audit passed with warnings: dependency-cruiser found no violations across 670 modules and 2,188 dependencies; Knip is clean; jscpd reported the existing repository baseline of 509 clones (mostly generated/template mirrors); `bun outdated` reported three unrelated dev-only patch updates.
+Audit passed with warnings: dependency-cruiser found no violations across 667 modules and 2,178 dependencies; Knip is clean; jscpd reported 514 repository-wide clones (8.92%, primarily template/IDE mirrors and none in the changed files); `bun outdated` reported three unrelated dev-only patch updates.
 
 ## Scope Walk
 

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
@@ -4,7 +4,7 @@
 **Gherkin:** ✅ Acceptance lane passes (`bun run test:bdd`: 93 scenarios, 1,109 steps)
 **Build:** ✅ Success (`tsup`)
 **Lint:** ✅ Clean (`bun run lint`; TypeScript typecheck and Prettier check pass)
-**Scenarios:** All 6 scenarios marked complete
+**Test Definitions:** All 6 test definitions complete
 **PR Scope:** ✅ Diff matches ticket scope
 **Dep Drift:** ✅ Clean — no dependency or architecture change in this ticket
 **Parent Epic:** N/A

--- a/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
+++ b/.project/tickets/5EEKMD-harden-gh-fallback-credentials/verify.md
@@ -1,0 +1,19 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 53/53 focused resolver/transport tests pass; canonical `bun run test` completed
+**Gherkin:** ✅ Acceptance lane passes (`bun run test:bdd`)
+**Build:** ✅ Success (`tsup`)
+**Lint:** ✅ Clean (`bun run lint`; Prettier applied only to the edited test file)
+**Scenarios:** All 4 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean — no dependency or architecture change in this ticket
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal credential-resolution plumbing
+**Evidence limits:** ⚠️ Audit cannot statically inspect Python imports in the unrelated `experiments/gepa-review-spec/gepa` area because it has no import-linter contracts
+
+Audit passed with warnings: dependency-cruiser found no violations across 670 modules and 2,188 dependencies; Knip is clean; jscpd reported the existing repository baseline of 509 clones (mostly generated/template mirrors); `bun outdated` reported three unrelated dev-only patch updates.
+
+## Scope Walk
+
+Walked a developer with an existing GitHub CLI login through retro filing fallback; worst step = an invalid credential reaches GitHub and receives its terminal 401; new steps vs before = 0. The changed resolver now rejects malformed subprocess output locally, preserves normal CLI process context, and does not prompt for credentials.

--- a/.safeword/logs/ticket-5EEKMD-harden-gh-fallback-credentials.md
+++ b/.safeword/logs/ticket-5EEKMD-harden-gh-fallback-credentials.md
@@ -1,0 +1,5 @@
+# Ticket 5EEKMD Work Log
+
+- 2026-07-29: Created from late review feedback on merged PR #1577 and linked to GitHub issue #1637.
+- 2026-07-29: Defined direct-TDD coverage for credential syntax, process environment isolation, explicit `GH_TOKEN`, and mock isolation.
+- 2026-07-29: Fresh independent quality review approved the patch; focused tests, canonical verification, BDD, lint, formatting, and audit completed.

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -65,7 +65,7 @@ function mockFetchCapturing(responder: (url: string) => MockResponse): CapturedC
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
-  vi.clearAllMocks();
+  vi.resetAllMocks();
 });
 
 describe('createRestTransport', () => {
@@ -606,23 +606,20 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     expect(ghConsulted).toBe(false);
   });
 
-  it.each([['stateless GitHub credential', representativeStatelessToken]])(
-    'passes a selected %s GITHUB_TOKEN to the REST transport',
-    async (_label, shaped) => {
-      const calls = mockFetchCapturing(() => ({ json: () => ({ id: 99, body: 'hi' }) }));
-      const token = resolveGitHubToken({ GITHUB_TOKEN: shaped }, () => {
-        throw new Error('gh fallback must not be consulted');
-      });
-      const transport = createRestTransport(token);
-      if (!transport) throw new Error('expected a transport');
+  it('passes a selected stateless GITHUB_TOKEN to the REST transport', async () => {
+    const calls = mockFetchCapturing(() => ({ json: () => ({ id: 99, body: 'hi' }) }));
+    const token = resolveGitHubToken({ GITHUB_TOKEN: representativeStatelessToken }, () => {
+      throw new Error('gh fallback must not be consulted');
+    });
+    const transport = createRestTransport(token);
+    if (!transport) throw new Error('expected a transport');
 
-      await transport.createComment(42, 'hi');
+    await transport.createComment(42, 'hi');
 
-      expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe(
-        `Bearer ${shaped}`,
-      );
-    },
-  );
+    expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${representativeStatelessToken}`,
+    );
+  });
 
   it.each([
     ['a proxy placeholder', 'proxy-injected'],
@@ -655,6 +652,34 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     const options = spawnCall[2];
     expect(options.env).toMatchObject({ GH_TOKEN: 'explicit-gh-token' });
     expect(options.env).not.toHaveProperty('GITHUB_TOKEN');
+  });
+
+  it('starts without a gh response configured by an earlier test', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
+
+    expect(resolveGitHubToken()).toBeUndefined();
+  });
+
+  it('does not build a REST transport from malformed gh output', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'unsafe token\n' });
+
+    const token = resolveGitHubToken();
+
+    expect(token).toBeUndefined();
+    expect(createRestTransport(token)).toBeUndefined();
+  });
+
+  it('uses process context when a lookup-only environment falls back to gh', () => {
+    vi.stubEnv('SW_TEST_GH_CONTEXT', 'available');
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'gh-keyring-token\n' });
+
+    expect(resolveGitHubToken({ GITHUB_TOKEN: 'proxy-injected' })).toBe('gh-keyring-token');
+
+    const spawnCall = spawnSyncMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
+    if (!spawnCall) throw new Error('expected gh auth token to be called');
+    expect(spawnCall[2].env).toMatchObject({ SW_TEST_GH_CONTEXT: 'available' });
+    expect(spawnCall[2].env).not.toHaveProperty('GITHUB_TOKEN');
   });
 
   // invisible-retro-claude.SM1.AC1 (token arm) — GITHUB_TOKEN present → the REST

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -62,6 +62,12 @@ function mockFetchCapturing(responder: (url: string) => MockResponse): CapturedC
   return calls;
 }
 
+function getGhChildEnvironment(): NodeJS.ProcessEnv {
+  const spawnCall = spawnSyncMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
+  if (!spawnCall) throw new Error('expected gh auth token to be called');
+  return spawnCall[2].env;
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
@@ -647,11 +653,24 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
       ['auth', 'token'],
       expect.objectContaining({ encoding: 'utf8', timeout: 10_000 }),
     );
-    const spawnCall = spawnSyncMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
-    if (!spawnCall) throw new Error('expected gh auth token to be called');
-    const options = spawnCall[2];
-    expect(options.env).toMatchObject({ GH_TOKEN: 'explicit-gh-token' });
-    expect(options.env).not.toHaveProperty('GITHUB_TOKEN');
+    const childEnvironment = getGhChildEnvironment();
+    expect(childEnvironment).toMatchObject({ GH_TOKEN: 'explicit-gh-token' });
+    expect(childEnvironment).not.toHaveProperty('GITHUB_TOKEN');
+  });
+
+  it('accepts a single optional CRLF terminator', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'gh-keyring-token\r\n' });
+
+    expect(resolveGitHubToken()).toBe('gh-keyring-token');
+  });
+
+  it('removes differently cased rejected token keys before asking gh', () => {
+    vi.stubEnv('github_token', 'proxy-injected');
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'gh-keyring-token\n' });
+
+    expect(resolveGitHubToken({ GITHUB_TOKEN: 'proxy-injected' })).toBe('gh-keyring-token');
+    expect(getGhChildEnvironment()).not.toHaveProperty('github_token');
   });
 
   it('starts without a gh response configured by an earlier test', () => {
@@ -660,9 +679,14 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     expect(resolveGitHubToken()).toBeUndefined();
   });
 
-  it('does not build a REST transport from malformed gh output', () => {
+  it.each([
+    ['an embedded space', 'unsafe token\n'],
+    ['leading whitespace', ' gh-keyring-token\n'],
+    ['a trailing tab before the line ending', 'gh-keyring-token\t\n'],
+    ['two line endings', 'gh-keyring-token\n\n'],
+  ])('does not build a REST transport from gh output with %s', (_label, output) => {
     vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'unsafe token\n' });
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: output });
 
     const token = resolveGitHubToken();
 
@@ -676,10 +700,9 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
 
     expect(resolveGitHubToken({ GITHUB_TOKEN: 'proxy-injected' })).toBe('gh-keyring-token');
 
-    const spawnCall = spawnSyncMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
-    if (!spawnCall) throw new Error('expected gh auth token to be called');
-    expect(spawnCall[2].env).toMatchObject({ SW_TEST_GH_CONTEXT: 'available' });
-    expect(spawnCall[2].env).not.toHaveProperty('GITHUB_TOKEN');
+    const childEnvironment = getGhChildEnvironment();
+    expect(childEnvironment).toMatchObject({ SW_TEST_GH_CONTEXT: 'available' });
+    expect(childEnvironment).not.toHaveProperty('GITHUB_TOKEN');
   });
 
   // invisible-retro-claude.SM1.AC1 (token arm) — GITHUB_TOKEN present → the REST

--- a/packages/cli/src/retro/github-rest.test.ts
+++ b/packages/cli/src/retro/github-rest.test.ts
@@ -68,11 +68,13 @@ function getGhChildEnvironment(): NodeJS.ProcessEnv {
   return spawnCall[2].env;
 }
 
-afterEach(() => {
+function resetTestState(): void {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   vi.resetAllMocks();
-});
+}
+
+afterEach(resetTestState);
 
 describe('createRestTransport', () => {
   it('returns undefined without a token', () => {
@@ -673,10 +675,13 @@ describe('resolveGitHubToken (7D8PJP — no hard GITHUB_TOKEN requirement)', () 
     expect(getGhChildEnvironment()).not.toHaveProperty('github_token');
   });
 
-  it('starts without a gh response configured by an earlier test', () => {
-    vi.stubEnv('GITHUB_TOKEN', 'proxy-injected');
+  it('clears a configured gh response during test cleanup', () => {
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'gh-keyring-token\n' });
 
-    expect(resolveGitHubToken()).toBeUndefined();
+    resetTestState();
+
+    expect(resolveGitHubToken({ GITHUB_TOKEN: 'proxy-injected' })).toBeUndefined();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -49,11 +49,9 @@ const MAX_DEDUP_PAGES = 200;
  * after rejecting that value; preserve `GH_TOKEN`, which is an independent
  * documented gh credential source with higher precedence.
  */
-function ghAuthToken(
-  environment: Record<string, string | undefined> = process.env,
-): string | undefined {
+function ghAuthToken(): string | undefined {
   try {
-    const childEnvironment = { ...environment };
+    const childEnvironment = { ...process.env };
     delete childEnvironment.GITHUB_TOKEN;
     const result = spawnSync('gh', ['auth', 'token'], {
       encoding: 'utf8',
@@ -61,7 +59,7 @@ function ghAuthToken(
       env: childEnvironment,
     });
     const token = (result.stdout ?? '').trim();
-    return result.status === 0 && token.length > 0 ? token : undefined;
+    return result.status === 0 && isBearerCredentialSyntax(token) ? token : undefined;
   } catch {
     return undefined;
   }
@@ -90,7 +88,7 @@ function isBearerCredentialSyntax(value: string): boolean {
  */
 export function resolveGitHubToken(
   env: Record<string, string | undefined> = process.env,
-  getGhToken: (environment: Record<string, string | undefined>) => string | undefined = ghAuthToken,
+  getGhToken: () => string | undefined = ghAuthToken,
 ): string | undefined {
   const fromEnvironment = env.GITHUB_TOKEN;
   if (
@@ -100,7 +98,7 @@ export function resolveGitHubToken(
   ) {
     return fromEnvironment;
   }
-  return getGhToken(env);
+  return getGhToken();
 }
 
 /** The one place auth + API headers are wired to fetch; both transports compose this. */

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -20,6 +20,7 @@ interface OpenIssue {
 const UPSTREAM_REPO = 'ArcadeAI/safeword';
 const ISSUES_BASE = `/repos/${UPSTREAM_REPO}/issues`;
 const API = 'https://api.github.com';
+const GITHUB_TOKEN_ENV_KEY = 'GITHUB_TOKEN';
 // GitHub's max page size. The paginated loops interpolate this into the URL
 // AND compare against it to detect the last (short) page — one constant keeps
 // the two from drifting (a mismatch silently truncates or over-fetches).
@@ -51,14 +52,21 @@ const MAX_DEDUP_PAGES = 200;
  */
 function ghAuthToken(): string | undefined {
   try {
-    const childEnvironment = { ...process.env };
-    delete childEnvironment.GITHUB_TOKEN;
+    // Node's Windows environment keys are case-insensitive, while this copied
+    // JavaScript object has case-sensitive keys. Exclude every casing so a
+    // rejected token cannot re-enter `gh` under a different key spelling.
+    const childEnvironment = Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => key.toUpperCase() !== GITHUB_TOKEN_ENV_KEY),
+    );
     const result = spawnSync('gh', ['auth', 'token'], {
       encoding: 'utf8',
       timeout: 10_000,
       env: childEnvironment,
     });
-    const token = (result.stdout ?? '').trim();
+    // Accept at most one terminal LF or CRLF. Broad trimming could turn malformed
+    // credential output into a token-shaped value by silently discarding
+    // whitespace or control characters.
+    const token = (result.stdout ?? '').replace(/\r?\n$/, '');
     return result.status === 0 && isBearerCredentialSyntax(token) ? token : undefined;
   } catch {
     return undefined;
@@ -90,7 +98,7 @@ export function resolveGitHubToken(
   env: Record<string, string | undefined> = process.env,
   getGhToken: () => string | undefined = ghAuthToken,
 ): string | undefined {
-  const fromEnvironment = env.GITHUB_TOKEN;
+  const fromEnvironment = env[GITHUB_TOKEN_ENV_KEY];
   if (
     fromEnvironment &&
     fromEnvironment !== 'proxy-injected' &&
@@ -298,16 +306,16 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
    * path had the same hole for a different reason: the index cannot return an
    * issue created seconds earlier.)
    */
-  const createdThisRun: { number: number; title: string; body: string }[] = [];
+  const createdThisRun: OpenIssue[] = [];
 
-  function matchesIn(issues: readonly OpenIssue[], marker: string): IssueReference[] {
+  function findMarkerMatches(issues: readonly OpenIssue[], marker: string): IssueReference[] {
     return [...issues, ...createdThisRun]
       .filter(issue => issue.body.includes(marker))
       .map(issue => ({ number: issue.number, title: issue.title }));
   }
 
   async function findByExactMarker(marker: string): Promise<IssueReference[]> {
-    return matchesIn(await currentSnapshot(), marker);
+    return findMarkerMatches(await currentSnapshot(), marker);
   }
 
   return {

--- a/packages/cli/src/retro/github-rest.ts
+++ b/packages/cli/src/retro/github-rest.ts
@@ -48,7 +48,9 @@ const MAX_DEDUP_PAGES = 200;
  * Ask `gh` for the environment's GitHub token, or undefined if unavailable.
  * `GITHUB_TOKEN` is stripped because the resolver only calls this fallback
  * after rejecting that value; preserve `GH_TOKEN`, which is an independent
- * documented gh credential source with higher precedence.
+ * documented gh credential source with higher precedence. The exact
+ * `proxy-injected` sentinel is rejected only from `GITHUB_TOKEN`: #1637 keeps
+ * syntax-valid explicit `GH_TOKEN` values opaque and lets GitHub authorize them.
  */
 function ghAuthToken(): string | undefined {
   try {
@@ -56,7 +58,9 @@ function ghAuthToken(): string | undefined {
     // JavaScript object has case-sensitive keys. Exclude every casing so a
     // rejected token cannot re-enter `gh` under a different key spelling.
     const childEnvironment = Object.fromEntries(
-      Object.entries(process.env).filter(([key]) => key.toUpperCase() !== GITHUB_TOKEN_ENV_KEY),
+      Object.entries(process.env).filter(
+        ([key]) => key.toUpperCase() !== GITHUB_TOKEN_ENV_KEY.toUpperCase(),
+      ),
     );
     const result = spawnSync('gh', ['auth', 'token'], {
       encoding: 'utf8',
@@ -306,16 +310,16 @@ export function createRestTransport(token: string | undefined): IssueTracker | u
    * path had the same hole for a different reason: the index cannot return an
    * issue created seconds earlier.)
    */
-  const createdThisRun: OpenIssue[] = [];
+  const createdThisRun: { number: number; title: string; body: string }[] = [];
 
-  function findMarkerMatches(issues: readonly OpenIssue[], marker: string): IssueReference[] {
+  function matchesIn(issues: readonly OpenIssue[], marker: string): IssueReference[] {
     return [...issues, ...createdThisRun]
       .filter(issue => issue.body.includes(marker))
       .map(issue => ({ number: issue.number, title: issue.title }));
   }
 
   async function findByExactMarker(marker: string): Promise<IssueReference[]> {
-    return findMarkerMatches(await currentSnapshot(), marker);
+    return matchesIn(await currentSnapshot(), marker);
   }
 
   return {


### PR DESCRIPTION
## Summary

- reject gh auth token output that is unsafe for a Bearer header
- keep fallback child-process context independent from injected token lookup input
- reset subprocess mocks between tests and simplify the single-case test table

This follows up the four late review threads on merged PR #1577 without prompting users for credentials. GH_TOKEN remains an opaque, explicit GitHub CLI credential; only RFC-invalid output is rejected locally.

Closes #1637

## Validation

- focused resolver/transport suite: 58/58
- bun run test exercised; two unrelated integration tests timed out under shared load, and both passed in isolation
- bun run test:bdd: 93 scenarios and 1,109 steps passed
- bun run lint, TypeScript typecheck, Prettier, dependency-cruiser, Knip, and audit
- fresh independent quality reviews: approved