### PR TITLE
fix: regenerate corrupted and stale ticket index

### DIFF
--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,9 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (458)
-## Tickets (457)
-## Tickets (455)
+## Tickets (461)
 
 ### 001
 
@@ -1020,6 +1018,10 @@
 - **Use generic file paths in shipped guidance examples (4YJV1N)** (in_progress, epic: —)
   Shipped guidance examples should cite generic `src/...` paths, not safeword's own `packages/cli/src/...` monorepo paths.
   → `.project/tickets/4YJV1N-generic-paths-in-shipped-guidance`
+- **Keep shipped hooks host-lintable (505)** (done, epic: —)
+  Let a Safeword upgrade complete without shipped hooks blocking the host project's lint.
+  external issue: https://github.com/ArcadeAI/safeword/issues/505
+  → `.project/tickets/505-keep-shipped-hooks-host-lintable`
 - **lint-config-unify (54XH90)** (open, epic: —)
   Eliminate the local-vs-CI eslint config drift so devs don't ship code that passes locally then fails CI (or vice versa).
   → `.project/tickets/54XH90-lint-config-unify`
@@ -1027,6 +1029,10 @@
   Stop `safeword setup` from scaffolding a second cucumber harness into repos that already have one, and let hosts point safeword's BDD readers (codify / lint-gherkin / check) and the scaffolded runner at their own feature/step directories.
   external issue: https://github.com/ArcadeAI/safeword/issues/645
   → `.project/tickets/56JCFZ-bdd-lane-collision-detection-and-paths`
+- **Protect retro filing from malformed GitHub CLI credentials (5EEKMD)** (done, epic: —)
+  Keep gh-based retro filing header-safe without prompting users for a token.
+  external issue: https://github.com/ArcadeAI/safeword/issues/1637
+  → `.project/tickets/5EEKMD-harden-gh-fallback-credentials`
 - **Re-validate a ticket's premise when it's picked up (5JN5E4)** (superseded, epic: —)
   When a ticket is picked up or resumed, re-validate its premise before doing the work — confirm the problem still reproduces, the scope is still current, dependencies still hold, and it hasn't been fixed or obsoleted by intervening changes (e.g. a merge) — and surface any drift to the user before proceeding.
   → `.project/tickets/5JN5E4-revalidate-ticket-on-pickup`


### PR DESCRIPTION
## Summary

- `.project/tickets/INDEX.md` carried three stacked `## Tickets (N)` headers (the #397 version-skew corruption) and was missing entries for tickets added since the last regen (`5EEKMD`, `505`, and others).
- Regenerated with the tree-source `sync-tickets` command (`bun packages/cli/src/cli.ts sync-tickets`) rather than an installed/global CLI, to avoid reproducing the version skew that caused the corruption.

Closes #1676

## Decision on enforcement

#1676 also raised whether a check should fail when a ticket directory has no INDEX.md entry. Discussed with the repo owner: **no new gate** — `safeword check` already best-effort-regenerates the index (swallowing errors by design), and this repo has recent scars from over-eager blocking gates (done-flip guard, LOC gate, dep-readiness). Staying warn-mode/best-effort matches that pattern; documenting the decision here rather than in code.

## Validation

- `git diff --stat`: single-file change, `.project/tickets/INDEX.md` only
- Confirmed no test hardcodes the stale `(458)/(457)/(455)` counts
- `INDEX-completed.md` untouched (no drift there)
- Pre-commit hooks (markdownlint, prettier, parity-check) passed clean