### PR TITLE
Reuse monorepo discovery during architecture healing

### DIFF
--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
@@ -9,15 +9,15 @@ spy only on Node's filesystem process boundary.
 
 ### Scenario: A readable workspace manifest is read once
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ### Scenario: An unreadable workspace manager is read once
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: One leaf skeleton extraction per architecture operation
 

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
@@ -19,6 +19,12 @@ spy only on Node's filesystem process boundary.
 - [x] GREEN
 - [x] REFACTOR
 
+### Scenario: A readable zero-leaf workspace manager is probed once
+
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
+
 ## Rule: One leaf skeleton extraction per architecture operation
 
 ### Scenario: A source header used for purpose seeding is read once

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
@@ -23,17 +23,17 @@ spy only on Node's filesystem process boundary.
 
 ### Scenario: A source header used for purpose seeding is read once
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Rule: Generated architecture behavior is unchanged
 
 ### Scenario: Existing architecture regression suites remain green
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED
+- [x] GREEN
+- [x] REFACTOR
 
 ## Task-level cross-scenario refactor
 

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
@@ -1,0 +1,40 @@
+# Test Definitions: Reuse monorepo architecture discovery
+
+This task uses integration-level filesystem-boundary evidence because the
+observable contract spans workspace discovery, model construction, target
+enumeration, fingerprinting, and rendering. Tests use real collaborators and
+spy only on Node's filesystem process boundary.
+
+## Rule: One topology discovery per architecture operation
+
+### Scenario: A readable workspace manifest is read once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An unreadable workspace manager is read once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: One leaf skeleton extraction per architecture operation
+
+### Scenario: A source header used for purpose seeding is read once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: Generated architecture behavior is unchanged
+
+### Scenario: Existing architecture regression suites remain green
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Task-level cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/test-definitions.md
@@ -43,4 +43,4 @@ spy only on Node's filesystem process boundary.
 
 ## Task-level cross-scenario refactor
 
-- [ ] cross-scenario
+- [x] cross-scenario 358566921

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -1,0 +1,49 @@
+---
+id: N3JTV5
+slug: avoid-repeated-monorepo-architecture-discovery
+type: task
+phase: plan-implementation
+status: in_progress
+created: 2026-07-30T00:00:10.960Z
+last_modified: 2026-07-30T00:00:10.960Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1667
+---
+
+# Reuse monorepo topology during architecture healing
+
+**Goal:** Build one monorepo model per architecture operation and reuse it for root and leaf work without changing output.
+
+**Why:** Repeated discovery adds filesystem work and can observe inconsistent snapshots during one heal.
+
+**Type:** Refactor
+
+**Scope:** Reuse one operation-scoped monorepo architecture snapshot for root-index
+rendering, leaf-target enumeration, and leaf skeleton rendering/fingerprinting.
+
+**Out of Scope:** Redesigning workspace discovery, supporting new workspace layouts,
+changing generated architecture bytes, or changing released fingerprint recipes.
+
+**Done When:**
+
+- [ ] Root and leaf architecture output remains byte-identical for unchanged projects.
+- [ ] Readable workspace packages and unreadable workspace managers are discovered once per operation.
+- [ ] Each leaf skeleton is extracted once and reused for its target fingerprint and rendering.
+- [ ] Polyglot, nested, zero-leaf, and unreadable-workspace behavior remains covered.
+- [ ] Package ordering, dependency edges, fingerprints, and coverage-gap reporting remain unchanged.
+
+**Tests:**
+
+- [ ] Integration: a readable workspace manifest is read once by one project heal.
+- [ ] Integration: an unreadable workspace manager is read once by one project heal.
+- [ ] Integration: a source header used for a leaf purpose is read once by one project heal.
+- [ ] Regression: architecture project, monorepo, fingerprint, skeleton, and document suites remain green.
+
+## Work Log
+
+- 2026-07-30T00:00:10.960Z Started: Created ticket N3JTV5
+- 2026-07-30T00:12:00.000Z Found: `projectTargets` discovers leaves, `rootIndexTarget`
+  independently extracts the model, and `skeletonTarget` independently extracts
+  nodes after `shapeFingerprint` already extracted them.
+- 2026-07-30T00:15:00.000Z Decided: use an operation-scoped wrapper containing the
+  unchanged `MonorepoModel` plus precomputed leaf skeletons; reject path-keyed
+  memoization because it adds invalidation state.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: verify
 status: in_progress
 created: 2026-07-30T00:00:10.960Z
-last_modified: 2026-07-30T00:56:55.000Z
+last_modified: 2026-07-30T16:32:18.000Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1667
 ---
 
@@ -63,3 +63,8 @@ changing generated architecture bytes, or changing released fingerprint recipes.
 - 2026-07-30T00:56:55.000Z Verified: 5,631 tests and 499 executable acceptance
   scenarios pass; build, lint, typecheck, dependency, and audit gates are green.
   Ticket remains in progress pending user confirmation.
+- 2026-07-30T16:32:18.000Z Resolved: latest PR review comments now enforce
+  precomputed skeletons at the type boundary and remove the complete test-only
+  monorepo compatibility chain from production. A fresh independent review
+  approved both fixes; 191 focused architecture tests and the full verification
+  and audit gates remain green.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -50,3 +50,7 @@ changing generated architecture bytes, or changing released fingerprint recipes.
 - 2026-07-30T00:28:00.000Z Complete: project target construction now extracts one
   model and reuses it for the root target and directory-sorted leaf enumeration;
   112 focused architecture tests pass.
+- 2026-07-30T00:42:00.000Z Complete: the operation snapshot now carries each
+  precomputed leaf skeleton through introspection, fingerprinting, matching, and
+  rendering; the seeded-source boundary read dropped from three to one and 190
+  focused tests plus TypeScript pass.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -54,3 +54,7 @@ changing generated architecture bytes, or changing released fingerprint recipes.
   precomputed leaf skeleton through introspection, fingerprinting, matching, and
   rendering; the seeded-source boundary read dropped from three to one and 190
   focused tests plus TypeScript pass.
+- 2026-07-30T00:50:00.000Z Fixed: independent review found readable zero-leaf
+  workspaces re-probed their manager during the single-repo fallback; the known
+  workspace-root fact now flows into skeleton extraction and the noop behavior
+  remains pinned.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -2,10 +2,10 @@
 id: N3JTV5
 slug: avoid-repeated-monorepo-architecture-discovery
 type: task
-phase: implement
+phase: verify
 status: in_progress
 created: 2026-07-30T00:00:10.960Z
-last_modified: 2026-07-30T00:00:10.960Z
+last_modified: 2026-07-30T00:56:55.000Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1667
 ---
 
@@ -25,18 +25,18 @@ changing generated architecture bytes, or changing released fingerprint recipes.
 
 **Done When:**
 
-- [ ] Root and leaf architecture output remains byte-identical for unchanged projects.
-- [ ] Readable workspace packages and unreadable workspace managers are discovered once per operation.
-- [ ] Each leaf skeleton is extracted once and reused for its target fingerprint and rendering.
-- [ ] Polyglot, nested, zero-leaf, and unreadable-workspace behavior remains covered.
-- [ ] Package ordering, dependency edges, fingerprints, and coverage-gap reporting remain unchanged.
+- [x] Root and leaf architecture output remains byte-identical for unchanged projects.
+- [x] Readable workspace packages and unreadable workspace managers are discovered once per operation.
+- [x] Each leaf skeleton is extracted once and reused for its target fingerprint and rendering.
+- [x] Polyglot, nested, zero-leaf, and unreadable-workspace behavior remains covered.
+- [x] Package ordering, dependency edges, fingerprints, and coverage-gap reporting remain unchanged.
 
 **Tests:**
 
-- [ ] Integration: a readable workspace manifest is read once by one project heal.
-- [ ] Integration: an unreadable workspace manager is read once by one project heal.
-- [ ] Integration: a source header used for a leaf purpose is read once by one project heal.
-- [ ] Regression: architecture project, monorepo, fingerprint, skeleton, and document suites remain green.
+- [x] Integration: a readable workspace manifest is read once by one project heal.
+- [x] Integration: an unreadable workspace manager is read once by one project heal.
+- [x] Integration: a source header used for a leaf purpose is read once by one project heal.
+- [x] Regression: architecture project, monorepo, fingerprint, skeleton, and document suites remain green.
 
 ## Work Log
 
@@ -58,3 +58,8 @@ changing generated architecture bytes, or changing released fingerprint recipes.
   workspaces re-probed their manager during the single-repo fallback; the known
   workspace-root fact now flows into skeleton extraction and the noop behavior
   remains pinned.
+- 2026-07-30T00:54:00.000Z Reviewed: fresh second-pass quality review approved
+  the complete diff with no critical issues or suggested improvements.
+- 2026-07-30T00:56:55.000Z Verified: 5,631 tests and 499 executable acceptance
+  scenarios pass; build, lint, typecheck, dependency, and audit gates are green.
+  Ticket remains in progress pending user confirmation.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md
@@ -2,7 +2,7 @@
 id: N3JTV5
 slug: avoid-repeated-monorepo-architecture-discovery
 type: task
-phase: plan-implementation
+phase: implement
 status: in_progress
 created: 2026-07-30T00:00:10.960Z
 last_modified: 2026-07-30T00:00:10.960Z
@@ -47,3 +47,6 @@ changing generated architecture bytes, or changing released fingerprint recipes.
 - 2026-07-30T00:15:00.000Z Decided: use an operation-scoped wrapper containing the
   unchanged `MonorepoModel` plus precomputed leaf skeletons; reject path-keyed
   memoization because it adds invalidation state.
+- 2026-07-30T00:28:00.000Z Complete: project target construction now extracts one
+  model and reuses it for the root target and directory-sorted leaf enumeration;
+  112 focused architecture tests pass.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/user-stories.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/user-stories.md
@@ -1,0 +1,35 @@
+# User Stories: Reuse monorepo architecture discovery
+
+## US1 — Heal from one coherent project snapshot
+
+As a Safeword user healing a monorepo architecture document, I want one
+operation to discover the project once so the root index and leaf documents
+describe the same filesystem snapshot.
+
+Given a monorepo with readable workspace packages, when a project architecture
+heal runs, then package discovery supplies both the root index and leaf target
+enumeration without a second workspace-manager pass.
+
+Given a monorepo whose only workspace signal is unreadable, when a project
+architecture heal runs, then that unreadable manager is observed once and its
+coverage gap still appears in the root index.
+
+## US2 — Preserve generated architecture contracts
+
+As a Safeword user with generated architecture documents under version control,
+I want the refactor to preserve existing bytes and fingerprints so an upgrade
+does not create false architectural drift.
+
+Given an unchanged monorepo, when architecture healing runs before and after
+the refactor, then root and leaf output, target order, package order, dependency
+edges, fingerprints, and coverage-gap reporting are identical.
+
+## US3 — Avoid repeated purpose extraction
+
+As a Safeword user with a large monorepo, I want each leaf skeleton extracted
+once per operation so source-header purpose seeding does not repeat filesystem
+reads.
+
+Given a package whose module purpose is seeded from a source header, when a
+project architecture heal runs, then the same precomputed skeleton supplies
+introspection, fingerprint module names, matching, and rendering.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/verify.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/verify.md
@@ -1,6 +1,6 @@
 # Verify: Reuse monorepo topology during architecture healing (N3JTV5)
 
-Evidence captured 2026-07-29 after the final audit cleanup.
+Evidence captured 2026-07-30 after resolving the latest PR review comments.
 
 ## Verify Checklist
 
@@ -21,8 +21,8 @@ dependency-cruiser (669 modules, 2,185 dependencies, 0 violations), Knip,
 learning/domain docs, the 20-file test-quality sample, architecture narrative
 reconciliation, configured documentation sources (`README.md` and website
 docs), and `bun audit` were clean. The audit's one change-scoped finding—an
-unnecessarily exported leaf-snapshot type—was fixed and rechecked. Clones: 509
-(8.85%) [repo minus `.safeword`, `.project`, `.safeword-project`], down 5 from
+unnecessarily exported leaf-snapshot type—was fixed and rechecked. Clones: 506
+(8.80%) [repo minus `.safeword`, `.project`, `.safeword-project`], down 8 from
 the latest same-scope 514-clone record; none were introduced by this diff.
 
 Repository-wide advisories remain outside this ticket: the Python experiment
@@ -39,6 +39,15 @@ initial read-count evidence missed. The fix propagated the already-observed
 workspace-root fact into skeleton extraction and added a regression test that
 also pins the prior noop result. A fresh second-pass review then returned
 **APPROVE** with no critical issues or suggested improvements.
+
+The latest PR review added two optional cleanup comments. Skeleton target
+construction now requires its precomputed skeleton so future callers cannot
+silently reintroduce extraction. The complete test-only compatibility chain
+(`discoverLeafDirectories`, `extractMonorepoModel`, and `monorepoFingerprint`)
+was removed from production code, with transparent snapshot projections kept
+inside the tests. A fresh independent review approved both resolutions with no
+critical issues or suggested improvements. Focused architecture coverage
+remained green at 191/191 before the full verification run above.
 
 **Next:** Ask the user to confirm completion; only then transition the ticket
 from `in_progress` to `done`.

--- a/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/verify.md
+++ b/.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/verify.md
@@ -1,0 +1,44 @@
+# Verify: Reuse monorepo topology during architecture healing (N3JTV5)
+
+Evidence captured 2026-07-29 after the final audit cleanup.
+
+## Verify Checklist
+
+**Test Suite:** ✓ 5631/5631 tests pass (5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (499/502 scenarios; 3 skipped; 15444/15444 executed steps)
+**Build:** ✅ Success (tsup + DTS)
+**Lint:** ✅ Clean (ESLint, Prettier, TypeScript, and diff hygiene)
+**Scenarios:** All 16 scenario checks marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal architecture-heal orchestration refactor
+**Evidence limits:** ✅ None
+
+Audit passed with warnings — 0 change-scoped errors. Config synchronization,
+dependency-cruiser (669 modules, 2,185 dependencies, 0 violations), Knip,
+learning/domain docs, the 20-file test-quality sample, architecture narrative
+reconciliation, configured documentation sources (`README.md` and website
+docs), and `bun audit` were clean. The audit's one change-scoped finding—an
+unnecessarily exported leaf-snapshot type—was fixed and rechecked. Clones: 509
+(8.85%) [repo minus `.safeword`, `.project`, `.safeword-project`], down 5 from
+the latest same-scope 514-clone record; none were introduced by this diff.
+
+Repository-wide advisories remain outside this ticket: the Python experiment
+lacks import-linter/dead-code executables; project Safeword config is v0.58.0
+against CLI v0.69.0; and three dev dependencies have newer releases.
+`@types/node` 26.1.1→26.1.2 and `markdownlint-cli2` 0.23.1→0.23.2 are low-risk
+patches. `@openai/codex` 0.145.0→0.146.0 is a medium-risk 0.x minor and should
+be reviewed in a dedicated dependency update.
+
+## Independent review
+
+The first fresh-context review found a zero-leaf workspace re-probe that the
+initial read-count evidence missed. The fix propagated the already-observed
+workspace-root fact into skeleton extraction and added a regression test that
+also pins the prior noop result. A fresh second-pass review then returned
+**APPROVE** with no critical issues or suggested improvements.
+
+**Next:** Ask the user to confirm completion; only then transition the ticket
+from `in_progress` to `done`.

--- a/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
+++ b/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
@@ -1,0 +1,22 @@
+# Work Log: Reuse monorepo topology during architecture healing
+
+**Anchored to:** `.project/tickets/N3JTV5-avoid-repeated-monorepo-architecture-discovery/ticket.md`
+
+## Session: 2026-07-29
+
+- [17:00] Started from GitHub issue 1667; created task ticket N3JTV5.
+- [17:05] Current call graph: `projectTargets` discovers leaves,
+  `rootIndexTarget` rebuilds the model, and each `skeletonTarget` extracts nodes
+  once for `shapeFingerprint` and again for rendering.
+- [17:10] Figure-it-out options: pass only `MonorepoModel`; create an
+  operation-scoped model + leaf-skeleton snapshot; or memoize existing helpers.
+- [17:15] Research: Node documents filesystem race windows between separate
+  calls; Bazel Skyframe models one evaluation as immutable input-derived values;
+  Vitest supports spying on real module exports so filesystem-boundary counts
+  can stay real-collaborator integration tests.
+- [17:20] Decision: operation-scoped wrapper around the unchanged public model,
+  with leaf skeletons precomputed once. Preserve target ordering by keeping the
+  directory-sorted leaf list separate from the name-sorted package model.
+- [17:25] Mikado ledger: (1) reuse one model for root rendering and leaf
+  enumeration; (2) reuse each precomputed leaf skeleton for introspection,
+  fingerprinting, matching, and rendering.

--- a/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
+++ b/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
@@ -50,3 +50,12 @@
   accepts that observed fact and skips its defensive re-probe. The test also
   pins the prior `noop` result and absence of a generated document.
 - [17:54] Regression check: 191 architecture tests and `tsc --noEmit` pass.
+- [17:54] Fresh second-pass quality review: APPROVE. No critical issues or
+  suggested improvements; reviewer independently confirmed full tests, lint,
+  typecheck, and dependency audit.
+- [17:55] Audit found one change-scoped dead-code issue: the leaf snapshot
+  interface was exported despite being orchestration-internal. Removed the
+  export in `769b9a6aa`; Knip and TypeScript then passed cleanly.
+- [17:56] Full verification passed: 5,631 Vitest tests (5 skipped), 499/502
+  Cucumber scenarios (3 skipped), 15,444 executed steps (4 skipped), build,
+  lint, typecheck, and `bun audit` with no vulnerabilities.

--- a/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
+++ b/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
@@ -20,3 +20,13 @@
 - [17:25] Mikado ledger: (1) reuse one model for root rendering and leaf
   enumeration; (2) reuse each precomputed leaf skeleton for introspection,
   fingerprinting, matching, and rendering.
+- [17:28] RED confirmed: one project heal read the root `package.json` twice.
+- [17:30] GREEN: `projectTargets` now extracts one `MonorepoModel`, passes it to
+  the root target, and derives a directory-sorted leaf list from the same model.
+- [17:32] Regression check: 112 architecture project/model/document tests pass;
+  target ordering remains directory-sorted and the unreadable-manager guard now
+  reads the model's existing status.
+- [17:35] Added focused unreadable-manager evidence: a malformed `go.work` is
+  read once and still renders `## Coverage gaps`. The pre-refactor call graph
+  read this path three times (leaf discovery, unreadable fallback, root model);
+  the boundary test passes with one read after topology reuse.

--- a/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
+++ b/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
@@ -30,3 +30,12 @@
   read once and still renders `## Coverage gaps`. The pre-refactor call graph
   read this path three times (leaf discovery, unreadable fallback, root model);
   the boundary test passes with one read after topology reuse.
+- [17:40] RED confirmed: a leaf source header used for generated purpose prose
+  was read three times during one project heal.
+- [17:42] GREEN: `MonorepoArchitectureSnapshot` now carries directory-sorted
+  leaves and their skeletons alongside the unchanged name-sorted root model;
+  `shapeFingerprintOf` accepts the observed skeleton just as
+  `monorepoFingerprintOf` accepts the observed model.
+- [17:44] Regression check: 190 architecture tests and `tsc --noEmit` pass.
+  Existing tests pin the released fingerprint digest, root/leaf bytes, polyglot
+  discovery, nested workspaces, zero-leaf behavior, and unreadable managers.

--- a/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
+++ b/.safeword/logs/ticket-N3JTV5-avoid-repeated-monorepo-architecture-discovery.md
@@ -39,3 +39,14 @@
 - [17:44] Regression check: 190 architecture tests and `tsc --noEmit` pass.
   Existing tests pin the released fingerprint digest, root/leaf bytes, polyglot
   discovery, nested workspaces, zero-leaf behavior, and unreadable managers.
+- [17:46] Cross-scenario refactor recorded at `ed9aa3dc3`; the shared operation
+  snapshot and `shapeFingerprintOf` seam replace repeated per-scenario helpers.
+- [17:47] Invoked the required fresh-context quality review for this two-loop task.
+- [17:49] Quality review requested changes: readable zero-leaf workspaces fell
+  back to single-repo extraction, whose workspace-root guard probed the manager
+  a second time. Existing read-count tests missed the `existsSync` boundary.
+- [17:50] RED confirmed: a readable zero-leaf `go.work` was probed twice.
+- [17:52] GREEN: the snapshot now carries `workspaceRoot`; skeleton extraction
+  accepts that observed fact and skips its defensive re-probe. The test also
+  pins the prior `noop` result and absence of a generated document.
+- [17:54] Regression check: 191 architecture tests and `tsc --noEmit` pass.

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -141,11 +141,7 @@ function planTarget(target: HealTarget): SelfHealAction {
 }
 
 /** A `src/`-skeleton doc: the skeleton of `directory`, rendered to `path`. */
-function skeletonTarget(
-  directory: string,
-  path: string,
-  skeleton = extractSkeleton(directory),
-): HealTarget {
+function skeletonTarget(directory: string, path: string, skeleton: Skeleton): HealTarget {
   const fingerprint = shapeFingerprintOf(directory, skeleton);
   const nodes = skeleton.nodes;
   return {

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -159,8 +159,12 @@ function skeletonTarget(
 }
 
 /** The single-repo doc: the project's `src/` skeleton at the namespace-root path. */
-function singleRepoTarget(projectDirectory: string): HealTarget {
-  return skeletonTarget(projectDirectory, resolveGeneratedArchitecturePath(projectDirectory));
+function singleRepoTarget(projectDirectory: string, workspaceRoot = false): HealTarget {
+  return skeletonTarget(
+    projectDirectory,
+    resolveGeneratedArchitecturePath(projectDirectory),
+    extractSkeleton(projectDirectory, { workspaceRoot }),
+  );
 }
 
 /** A colocated leaf: the package's own skeleton at `packages/<pkg>/architecture.generated.md`. */
@@ -190,13 +194,13 @@ function rootIndexTarget(projectDirectory: string, model: MonorepoModel): HealTa
 
 /** The targets a project heals: single-repo → one; monorepo → root index + per-leaf. */
 function projectTargets(projectDirectory: string): HealTarget[] {
-  const { model, leaves } = extractMonorepoArchitectureSnapshot(projectDirectory);
+  const { model, leaves, workspaceRoot } = extractMonorepoArchitectureSnapshot(projectDirectory);
   // A repo whose ONLY workspace signal is an unparseable manager (zero discovered leaves)
   // is still a monorepo we must not mistake for a single-repo: render the root index so the
   // "config unreadable" advisory has a home, rather than silently emitting a single-repo doc
   // that omits the whole declared-but-unreadable workspace (UWP4XK).
   if (model.packages.length === 0 && model.unreadableWorkspaces.length === 0) {
-    return [singleRepoTarget(projectDirectory)];
+    return [singleRepoTarget(projectDirectory, workspaceRoot)];
   }
   return [
     rootIndexTarget(projectDirectory, model),

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -16,8 +16,6 @@ import nodePath from 'node:path';
 
 import { shapeFingerprint } from './architecture-fingerprint.js';
 import {
-  discoverLeafDirectories,
-  discoverUnreadableWorkspaces,
   extractMonorepoModel,
   monorepoFingerprintOf,
   type MonorepoModel,
@@ -169,8 +167,7 @@ function leafTarget(packageDirectory: string): HealTarget {
 }
 
 /** The derived root index: the package graph at the namespace-root path. */
-function rootIndexTarget(projectDirectory: string): HealTarget {
-  const model = extractMonorepoModel(projectDirectory);
+function rootIndexTarget(projectDirectory: string, model: MonorepoModel): HealTarget {
   const fingerprint = monorepoFingerprintOf(projectDirectory, model);
   return {
     path: resolveGeneratedArchitecturePath(projectDirectory),
@@ -187,15 +184,16 @@ function rootIndexTarget(projectDirectory: string): HealTarget {
 
 /** The targets a project heals: single-repo → one; monorepo → root index + per-leaf. */
 function projectTargets(projectDirectory: string): HealTarget[] {
-  const leaves = discoverLeafDirectories(projectDirectory);
+  const model = extractMonorepoModel(projectDirectory);
   // A repo whose ONLY workspace signal is an unparseable manager (zero discovered leaves)
   // is still a monorepo we must not mistake for a single-repo: render the root index so the
   // "config unreadable" advisory has a home, rather than silently emitting a single-repo doc
   // that omits the whole declared-but-unreadable workspace (UWP4XK).
-  if (leaves.length === 0 && discoverUnreadableWorkspaces(projectDirectory).length === 0) {
+  if (model.packages.length === 0 && model.unreadableWorkspaces.length === 0) {
     return [singleRepoTarget(projectDirectory)];
   }
-  return [rootIndexTarget(projectDirectory), ...leaves.map(leaf => leafTarget(leaf))];
+  const leaves = model.packages.map(node => node.dir).toSorted((a, b) => a.localeCompare(b));
+  return [rootIndexTarget(projectDirectory, model), ...leaves.map(leaf => leafTarget(leaf))];
 }
 
 export function selfHeal(projectDirectory: string): SelfHealResult {

--- a/packages/cli/src/utils/architecture-document.ts
+++ b/packages/cli/src/utils/architecture-document.ts
@@ -14,9 +14,9 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { shapeFingerprint } from './architecture-fingerprint.js';
+import { shapeFingerprintOf } from './architecture-fingerprint.js';
 import {
-  extractMonorepoModel,
+  extractMonorepoArchitectureSnapshot,
   monorepoFingerprintOf,
   type MonorepoModel,
   type PackageNode,
@@ -26,6 +26,7 @@ import { reconcileSections, type SectionStatus } from './architecture-reconcile.
 import {
   extractSkeleton,
   PURPOSE_PLACEHOLDER,
+  type Skeleton,
   type SkeletonNode,
 } from './architecture-skeleton.js';
 import {
@@ -140,9 +141,13 @@ function planTarget(target: HealTarget): SelfHealAction {
 }
 
 /** A `src/`-skeleton doc: the skeleton of `directory`, rendered to `path`. */
-function skeletonTarget(directory: string, path: string): HealTarget {
-  const fingerprint = shapeFingerprint(directory);
-  const nodes = extractSkeleton(directory).nodes;
+function skeletonTarget(
+  directory: string,
+  path: string,
+  skeleton = extractSkeleton(directory),
+): HealTarget {
+  const fingerprint = shapeFingerprintOf(directory, skeleton);
+  const nodes = skeleton.nodes;
   return {
     path,
     fingerprint,
@@ -159,10 +164,11 @@ function singleRepoTarget(projectDirectory: string): HealTarget {
 }
 
 /** A colocated leaf: the package's own skeleton at `packages/<pkg>/architecture.generated.md`. */
-function leafTarget(packageDirectory: string): HealTarget {
+function leafTarget(packageDirectory: string, skeleton: Skeleton): HealTarget {
   return skeletonTarget(
     packageDirectory,
     nodePath.join(packageDirectory, GENERATED_ARCHITECTURE_FILENAME),
+    skeleton,
   );
 }
 
@@ -184,7 +190,7 @@ function rootIndexTarget(projectDirectory: string, model: MonorepoModel): HealTa
 
 /** The targets a project heals: single-repo → one; monorepo → root index + per-leaf. */
 function projectTargets(projectDirectory: string): HealTarget[] {
-  const model = extractMonorepoModel(projectDirectory);
+  const { model, leaves } = extractMonorepoArchitectureSnapshot(projectDirectory);
   // A repo whose ONLY workspace signal is an unparseable manager (zero discovered leaves)
   // is still a monorepo we must not mistake for a single-repo: render the root index so the
   // "config unreadable" advisory has a home, rather than silently emitting a single-repo doc
@@ -192,8 +198,10 @@ function projectTargets(projectDirectory: string): HealTarget[] {
   if (model.packages.length === 0 && model.unreadableWorkspaces.length === 0) {
     return [singleRepoTarget(projectDirectory)];
   }
-  const leaves = model.packages.map(node => node.dir).toSorted((a, b) => a.localeCompare(b));
-  return [rootIndexTarget(projectDirectory, model), ...leaves.map(leaf => leafTarget(leaf))];
+  return [
+    rootIndexTarget(projectDirectory, model),
+    ...leaves.map(leaf => leafTarget(leaf.dir, leaf.skeleton)),
+  ];
 }
 
 export function selfHeal(projectDirectory: string): SelfHealResult {

--- a/packages/cli/src/utils/architecture-fingerprint.ts
+++ b/packages/cli/src/utils/architecture-fingerprint.ts
@@ -13,7 +13,7 @@ import { createHash } from 'node:crypto';
 import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { extractSkeleton } from './architecture-skeleton.js';
+import { extractSkeleton, type Skeleton } from './architecture-skeleton.js';
 import { readBoundaryConfig } from './boundary-config.js';
 import { readCargoDependencyNames } from './cargo-manifest.js';
 import { readJson } from './fs.js';
@@ -47,13 +47,9 @@ interface ShapeInputs {
   schemaFiles: string[];
 }
 
-function collectShapeInputs(projectDirectory: string): ShapeInputs {
-  const moduleNames = extractSkeleton(projectDirectory)
-    .nodes.map(node => node.name)
-    .toSorted(byString);
-
+function collectShapeInputs(projectDirectory: string, skeleton: Skeleton): ShapeInputs {
   return {
-    moduleNames,
+    moduleNames: skeleton.nodes.map(node => node.name).toSorted(byString),
     dependencyNames: readDependencyNames(projectDirectory),
     boundaryConfig: readBoundaryConfig(projectDirectory),
     schemaFiles: collectSchemaFiles(projectDirectory),
@@ -61,7 +57,15 @@ function collectShapeInputs(projectDirectory: string): ShapeInputs {
 }
 
 export function shapeFingerprint(projectDirectory: string): string {
-  const inputs = collectShapeInputs(projectDirectory);
+  return shapeFingerprintOf(projectDirectory, extractSkeleton(projectDirectory));
+}
+
+/**
+ * {@link shapeFingerprint} over an already-extracted skeleton, so an architecture
+ * operation can use one coherent leaf snapshot for fingerprinting and rendering.
+ */
+export function shapeFingerprintOf(projectDirectory: string, skeleton: Skeleton): string {
+  const inputs = collectShapeInputs(projectDirectory, skeleton);
   return createHash('sha256').update(JSON.stringify(inputs)).digest('hex');
 }
 

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -113,6 +113,8 @@ export interface MonorepoLeafSnapshot {
 export interface MonorepoArchitectureSnapshot {
   model: MonorepoModel;
   leaves: MonorepoLeafSnapshot[];
+  /** Discovery observed workspace member patterns, even if they resolve to zero leaves. */
+  workspaceRoot: boolean;
 }
 
 /**
@@ -368,6 +370,7 @@ export function extractMonorepoArchitectureSnapshot(
   return {
     model: { packages, edges, unreadableWorkspaces },
     leaves,
+    workspaceRoot: patterns.length > 0 || unreadableWorkspaces.length > 0,
   };
 }
 

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -149,20 +149,8 @@ export function discoverWorkspaces(projectDirectory: string): WorkspaceDiscovery
 }
 
 /**
- * Absolute directories of the leaf packages, sorted. The union of two sources:
- * the DECLARED workspace members (workspace globs expanded, recognized-manifest
- * dirs kept) and the ORPHAN non-JS packages a bounded tree walk finds outside any
- * declared workspace (issue #844). A dir claimed by both is listed once. Returns
- * `[]` for a non-workspace project with no orphan packages.
- */
-export function discoverLeafDirectories(projectDirectory: string): string[] {
-  return leafDirectoriesFrom(projectDirectory, discoverWorkspaces(projectDirectory).patterns);
-}
-
-/**
- * The declared-workspace ∪ orphan leaf union behind {@link discoverLeafDirectories},
- * taking already-read workspace patterns so a caller that has run discovery (the
- * model extractor) doesn't probe every manager a second time.
+ * The declared-workspace ∪ orphan leaf union, taking already-read workspace
+ * patterns so snapshot extraction doesn't probe every manager a second time.
  */
 function leafDirectoriesFrom(projectDirectory: string, patterns: string[]): string[] {
   const workspaceLeaves = resolveLeafDirectories(projectDirectory, patterns);
@@ -323,11 +311,6 @@ function hasRecognizedManifest(directory: string): boolean {
   );
 }
 
-/** The package/edge model the root index renders over. */
-export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
-  return extractMonorepoArchitectureSnapshot(projectDirectory).model;
-}
-
 /**
  * Build the root model and leaf inputs from one workspace discovery pass.
  *
@@ -375,17 +358,8 @@ export function extractMonorepoArchitectureSnapshot(
 }
 
 /**
- * Root-index fingerprint: a hash over the package set, the inter-package edges,
- * and the shared boundary config. Distinct from per-leaf `shapeFingerprint`.
- */
-export function monorepoFingerprint(projectDirectory: string): string {
-  return monorepoFingerprintOf(projectDirectory, extractMonorepoModel(projectDirectory));
-}
-
-/**
- * {@link monorepoFingerprint} over an already-extracted model, so a caller that
- * needs both (the root-index heal renders the model AND stamps its fingerprint)
- * extracts once instead of re-running discovery and the orphan tree walk.
+ * Root-index fingerprint over an already-extracted model, so a caller that
+ * renders the model and stamps its fingerprint does not re-run discovery.
  */
 export function monorepoFingerprintOf(projectDirectory: string, model: MonorepoModel): string {
   const inputs = {

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -14,7 +14,7 @@ import { createHash } from 'node:crypto';
 import { globSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { extractSkeleton, PURPOSE_PLACEHOLDER } from './architecture-skeleton.js';
+import { extractSkeleton, PURPOSE_PLACEHOLDER, type Skeleton } from './architecture-skeleton.js';
 import { readBoundaryConfig } from './boundary-config.js';
 import { readCargoPackageName, readCargoWorkspaceMembers } from './cargo-manifest.js';
 import { findAllInTree, isDirectory, readFileSafe, readJson } from './fs.js';
@@ -98,6 +98,21 @@ export interface MonorepoModel {
   edges: PackageEdge[];
   /** Managers present at the root but unparseable; surfaced in the root index + `--check`. */
   unreadableWorkspaces: UnreadableWorkspace[];
+}
+
+/** One discovered package and the leaf structure observed during the same operation. */
+export interface MonorepoLeafSnapshot {
+  dir: string;
+  skeleton: Skeleton;
+}
+
+/**
+ * Operation-scoped monorepo facts. The released model shape stays unchanged while
+ * orchestration can reuse the same directory-sorted leaves and extracted skeletons.
+ */
+export interface MonorepoArchitectureSnapshot {
+  model: MonorepoModel;
+  leaves: MonorepoLeafSnapshot[];
 }
 
 /**
@@ -308,17 +323,33 @@ function hasRecognizedManifest(directory: string): boolean {
 
 /** The package/edge model the root index renders over. */
 export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
+  return extractMonorepoArchitectureSnapshot(projectDirectory).model;
+}
+
+/**
+ * Build the root model and leaf inputs from one workspace discovery pass.
+ *
+ * `leaves` preserves directory ordering for target enumeration; `model.packages`
+ * preserves its released name ordering for root rendering and fingerprints.
+ */
+export function extractMonorepoArchitectureSnapshot(
+  projectDirectory: string,
+): MonorepoArchitectureSnapshot {
   const { patterns, unreadable: unreadableWorkspaces } = discoverWorkspaces(projectDirectory);
   // Includes both declared workspace members and orphan non-JS packages (issue #844).
-  const packages: PackageNode[] = leafDirectoriesFrom(projectDirectory, patterns)
-    .map(dir => {
+  const leaves = leafDirectoriesFrom(projectDirectory, patterns).map(dir => ({
+    dir,
+    skeleton: extractSkeleton(dir),
+  }));
+  const packages: PackageNode[] = leaves
+    .map(({ dir, skeleton }) => {
       const description = packageJsonDescription(dir);
       return {
         name: packageName(dir),
         dir,
         purpose: description ?? PURPOSE_PLACEHOLDER,
         ...(description !== undefined && { seededPurpose: true }),
-        introspected: extractSkeleton(dir).nodes.length > 0,
+        introspected: skeleton.nodes.length > 0,
       };
     })
     .toSorted((a, b) => byString(a.name, b.name));
@@ -334,7 +365,10 @@ export function extractMonorepoModel(projectDirectory: string): MonorepoModel {
   }
   edges.sort((a, b) => byString(a.from, b.from) || byString(a.to, b.to));
 
-  return { packages, edges, unreadableWorkspaces };
+  return {
+    model: { packages, edges, unreadableWorkspaces },
+    leaves,
+  };
 }
 
 /**

--- a/packages/cli/src/utils/architecture-monorepo.ts
+++ b/packages/cli/src/utils/architecture-monorepo.ts
@@ -101,7 +101,7 @@ export interface MonorepoModel {
 }
 
 /** One discovered package and the leaf structure observed during the same operation. */
-export interface MonorepoLeafSnapshot {
+interface MonorepoLeafSnapshot {
   dir: string;
   skeleton: Skeleton;
 }

--- a/packages/cli/src/utils/architecture-skeleton.ts
+++ b/packages/cli/src/utils/architecture-skeleton.ts
@@ -69,6 +69,11 @@ export interface Skeleton {
   nodes: SkeletonNode[];
 }
 
+export interface ExtractSkeletonOptions {
+  /** The caller already observed a workspace declaration during this operation. */
+  workspaceRoot?: boolean;
+}
+
 /**
  * Stable node ordering: every skeleton is sorted by name so the rendered doc and the
  * fingerprint are deterministic (readdirSync order is not guaranteed). Mirrors the
@@ -76,7 +81,10 @@ export interface Skeleton {
  */
 const byNodeName = (a: SkeletonNode, b: SkeletonNode): number => a.name.localeCompare(b.name);
 
-export function extractSkeleton(projectDirectory: string): Skeleton {
+export function extractSkeleton(
+  projectDirectory: string,
+  options: ExtractSkeletonOptions = {},
+): Skeleton {
   // A Python project (a `pyproject.toml` is present) is described by its top-level
   // modules — src-layout uses `src/` packages + `src/*.py`, flat-layout uses root
   // `__init__.py` dirs + root `*.py` (ticket HWSEPV). Checked BEFORE Cargo because a
@@ -138,7 +146,7 @@ export function extractSkeleton(projectDirectory: string): Skeleton {
   // relies on that emptiness to noop rather than birth a single-repo doc; a stray
   // root script (`jest.setup.js`, `gulpfile.js`) must not become "the architecture"
   // of a repo that declares itself a monorepo (quality-review of #843).
-  if (declaresWorkspaces(projectDirectory)) return { nodes: [] };
+  if (options.workspaceRoot === true || declaresWorkspaces(projectDirectory)) return { nodes: [] };
   return { nodes: topLevelJsModuleNodes(projectDirectory) };
 }
 

--- a/packages/cli/tests/utils/architecture-monorepo.test.ts
+++ b/packages/cli/tests/utils/architecture-monorepo.test.ts
@@ -11,15 +11,28 @@ import nodePath from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  discoverLeafDirectories,
   discoverUnreadableWorkspaces,
   discoverWorkspaces,
-  extractMonorepoModel,
-  monorepoFingerprint,
+  extractMonorepoArchitectureSnapshot,
+  monorepoFingerprintOf,
+  type MonorepoModel,
 } from '../../src/utils/architecture-monorepo.js';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
 
 const context: { directory: string } = { directory: '' };
+
+function discoverLeafDirectories(projectDirectory: string): string[] {
+  return extractMonorepoArchitectureSnapshot(projectDirectory).leaves.map(leaf => leaf.dir);
+}
+
+function extractMonorepoModel(projectDirectory: string): MonorepoModel {
+  return extractMonorepoArchitectureSnapshot(projectDirectory).model;
+}
+
+function monorepoFingerprint(projectDirectory: string): string {
+  const { model } = extractMonorepoArchitectureSnapshot(projectDirectory);
+  return monorepoFingerprintOf(projectDirectory, model);
+}
 
 function writeManifest(dir: string, manifest: Record<string, unknown>): void {
   mkdirSync(dir, { recursive: true });

--- a/packages/cli/tests/utils/architecture-project.test.ts
+++ b/packages/cli/tests/utils/architecture-project.test.ts
@@ -8,7 +8,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   planSelfHealProject,
@@ -19,6 +19,8 @@ import {
 import { shapeFingerprint } from '../../src/utils/architecture-fingerprint.js';
 import { resolveGeneratedArchitecturePath } from '../../src/utils/configured-paths.js';
 import { createTemporaryDirectory, removeTemporaryDirectory } from '../helpers.js';
+
+vi.mock('node:fs', { spy: true });
 
 const context: { directory: string } = { directory: '' };
 
@@ -45,7 +47,12 @@ function leafDocumentPath(root: string, name: string): string {
   return nodePath.join(root, 'packages', name, 'architecture.generated.md');
 }
 
+function readCount(path: string): number {
+  return vi.mocked(readFileSync).mock.calls.filter(([candidate]) => candidate === path).length;
+}
+
 beforeEach(() => {
+  vi.mocked(readFileSync).mockClear();
   context.directory = createTemporaryDirectory();
 });
 
@@ -104,6 +111,14 @@ describe('selfHealProject — monorepo root index + colocated leaves', () => {
     expect(root).toContain('### core');
     expect(root).toContain('### web');
     expect(root).toContain('`web` → `core`');
+  });
+
+  it('reads the workspace manifest once while building every project target', () => {
+    makePackage(context.directory, 'core', { modules: ['auth'] });
+
+    selfHealProject(context.directory);
+
+    expect(readCount(nodePath.join(context.directory, 'package.json'))).toBe(1);
   });
 
   it('writes a colocated leaf doc fingerprinted over each package with a src tree', () => {
@@ -176,5 +191,19 @@ describe('selfHealProject — monorepo root index + colocated leaves', () => {
     const actions = planSelfHealProject(context.directory);
 
     expect(actions).toContain('healed');
+  });
+});
+
+describe('selfHealProject — unreadable workspace discovery', () => {
+  it('reads an unreadable workspace manager once while building every project target', () => {
+    const goWorkPath = nodePath.join(context.directory, 'go.work');
+    writeFileSync(goWorkPath, 'go 1.22\n\nuse (\n\t@@@ not a path @@@\n)\n');
+
+    selfHealProject(context.directory);
+
+    expect(readCount(goWorkPath)).toBe(1);
+    expect(readFileSync(resolveGeneratedArchitecturePath(context.directory), 'utf8')).toContain(
+      '## Coverage gaps',
+    );
   });
 });

--- a/packages/cli/tests/utils/architecture-project.test.ts
+++ b/packages/cli/tests/utils/architecture-project.test.ts
@@ -51,7 +51,12 @@ function readCount(path: string): number {
   return vi.mocked(readFileSync).mock.calls.filter(([candidate]) => candidate === path).length;
 }
 
+function existsCount(path: string): number {
+  return vi.mocked(existsSync).mock.calls.filter(([candidate]) => candidate === path).length;
+}
+
 beforeEach(() => {
+  vi.mocked(existsSync).mockClear();
   vi.mocked(readFileSync).mockClear();
   context.directory = createTemporaryDirectory();
 });
@@ -218,5 +223,20 @@ describe('selfHealProject — unreadable workspace discovery', () => {
     expect(readFileSync(resolveGeneratedArchitecturePath(context.directory), 'utf8')).toContain(
       '## Coverage gaps',
     );
+  });
+});
+
+describe('selfHealProject — readable zero-leaf workspace discovery', () => {
+  it('probes a readable zero-leaf workspace manager once and preserves the noop target', () => {
+    const goWorkPath = nodePath.join(context.directory, 'go.work');
+    writeFileSync(goWorkPath, 'go 1.22\n\nuse ./missing\n');
+
+    const results = selfHealProject(context.directory);
+
+    expect(existsCount(goWorkPath)).toBe(1);
+    expect(results).toEqual([
+      { action: 'noop', path: resolveGeneratedArchitecturePath(context.directory) },
+    ]);
+    expect(existsSync(resolveGeneratedArchitecturePath(context.directory))).toBe(false);
   });
 });

--- a/packages/cli/tests/utils/architecture-project.test.ts
+++ b/packages/cli/tests/utils/architecture-project.test.ts
@@ -121,6 +121,19 @@ describe('selfHealProject — monorepo root index + colocated leaves', () => {
     expect(readCount(nodePath.join(context.directory, 'package.json'))).toBe(1);
   });
 
+  it('reads a purpose-seeding source header once while building its leaf target', () => {
+    const coreDirectory = makePackage(context.directory, 'core', { modules: ['auth'] });
+    const sourcePath = nodePath.join(coreDirectory, 'src', 'auth', 'index.ts');
+    writeFileSync(sourcePath, '/** Authenticates users. */\nexport {};\n');
+
+    selfHealProject(context.directory);
+
+    expect(readCount(sourcePath)).toBe(1);
+    expect(readFileSync(leafDocumentPath(context.directory, 'core'), 'utf8')).toContain(
+      'Authenticates users.',
+    );
+  });
+
   it('writes a colocated leaf doc fingerprinted over each package with a src tree', () => {
     const coreDirectory = makePackage(context.directory, 'core', { modules: ['auth'] });
 


### PR DESCRIPTION
Closes #1667

## What changed

- Build one operation-scoped monorepo architecture snapshot and reuse its model for root rendering and leaf enumeration.
- Extract each leaf skeleton once, then reuse it for fingerprinting, matching, and rendering.
- Carry the already-observed workspace-root state through the zero-leaf fallback so workspace managers are not probed again.
- Add filesystem-boundary regression tests for readable, unreadable, zero-leaf, and source-purpose discovery.

## Why

Architecture healing independently rediscovered workspace topology and leaf structure at several stages. Besides redundant filesystem work, those reads could observe different filesystem states during one operation.

## Impact

Architecture output remains byte-identical: package ordering, dependency edges, fingerprints, coverage gaps, nested/polyglot behavior, and zero-leaf behavior are preserved. The heal path now observes each relevant manager or source boundary once.

## Validation

- 5,631 Vitest tests passed; 5 skipped
- 499/502 Cucumber scenarios passed; 3 skipped
- 15,444 executed Cucumber steps passed; 4 skipped
- Focused architecture suite: 191 tests passed
- ESLint, Prettier, TypeScript, build, dependency-cruiser, Knip, and Safeword audit passed
- `bun audit`: no vulnerabilities
- Fresh independent quality review: approved after resolving its zero-leaf re-probe finding