### PR TITLE
Show Linear users how to sync through portable transport

### DIFF
--- a/packages/cli/src/commands/sync-tracker.ts
+++ b/packages/cli/src/commands/sync-tracker.ts
@@ -116,7 +116,8 @@ function runApply(cwd: string, config: TicketBridgeConfig, filePath: string): vo
 
 /** An advisory on stderr — never stdout, which must stay a pure SyncPlan document. */
 function note(message: string): void {
-  process.stderr.write(`sync-tracker: ${message}.\n`);
+  const suffix = /[.!?]$/.test(message) ? '' : '.';
+  process.stderr.write(`sync-tracker: ${message}${suffix}\n`);
 }
 
 /**
@@ -171,7 +172,7 @@ async function runLiveSync(
   // Linear has no live adapter yet, so asking for a credential or sidecar first
   // is a dead end. Point directly to the two supported transport paths.
   if (provider === 'linear') {
-    console.log(LINEAR_LIVE_PROJECTION_GUIDANCE);
+    note(LINEAR_LIVE_PROJECTION_GUIDANCE);
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/commands/sync-tracker.ts
+++ b/packages/cli/src/commands/sync-tracker.ts
@@ -9,7 +9,11 @@ import { readFileSync } from 'node:fs';
 import process from 'node:process';
 
 import { applyResults } from '../tracker-sync/apply-results.js';
-import { buildWriterRegistry, resolveRepoVisibility } from '../tracker-sync/clients.js';
+import {
+  buildWriterRegistry,
+  LINEAR_LIVE_PROJECTION_GUIDANCE,
+  resolveRepoVisibility,
+} from '../tracker-sync/clients.js';
 import { readTicketBridgeConfig } from '../tracker-sync/config.js';
 import { emptyPlan, parseResults } from '../tracker-sync/contract.js';
 import { readCorpus } from '../tracker-sync/corpus.js';
@@ -153,7 +157,8 @@ export async function syncTrackerCommand(options: SyncTrackerCommandOptions = {}
     return;
   }
 
-  // No flag → the live one-way projection (unchanged gh/Linear path).
+  // No flag → the live one-way projection. GitHub uses its live writer; Linear
+  // reports the portable path until its live adapter is wired.
   await runLiveSync(cwd, config, options);
 }
 
@@ -163,6 +168,13 @@ async function runLiveSync(
   options: SyncTrackerCommandOptions,
 ): Promise<void> {
   const provider = supportedProvider(config.provider);
+  // Linear has no live adapter yet, so asking for a credential or sidecar first
+  // is a dead end. Point directly to the two supported transport paths.
+  if (provider === 'linear') {
+    console.log(LINEAR_LIVE_PROJECTION_GUIDANCE);
+    process.exitCode = 1;
+    return;
+  }
   const dependencies: SyncTrackerDependencies = {
     config,
     tickets: provider === undefined ? [] : readCorpus(cwd, config.target?.repo),

--- a/packages/cli/src/tracker-connect/verify.ts
+++ b/packages/cli/src/tracker-connect/verify.ts
@@ -27,7 +27,7 @@ export function createVerifyClient(): VerifyClient {
       if (provider === 'linear') {
         return Promise.resolve({
           ok: false,
-          missing: 'Linear verification needs the Arcade integration — not wired in v1',
+          missing: 'Linear verification needs the Arcade integration — not wired yet',
         });
       }
       try {

--- a/packages/cli/src/tracker-sync/clients.ts
+++ b/packages/cli/src/tracker-sync/clients.ts
@@ -167,11 +167,12 @@ function throwingClient(message: string): TrackerClient {
   return { createIssue: fail, updateIssue: fail, projectGraph: fail };
 }
 
+export const LINEAR_LIVE_PROJECTION_GUIDANCE =
+  'Linear live projection is not wired. Adopt an existing Linear issue with `safeword ticket new <slug> --issue <key>`, or sync existing local tickets through `safeword sync-tracker --plan` and `--apply-results`.';
+
 /** The Linear live client is pending the Arcade integration. */
 function linearNotWired(): TrackerClient {
-  return throwingClient(
-    'Linear live projection is not wired. Adopt an existing Linear issue with `safeword ticket new <slug> --issue <key>`, or sync existing local tickets through `safeword sync-tracker --plan` and `--apply-results`.',
-  );
+  return throwingClient(LINEAR_LIVE_PROJECTION_GUIDANCE);
 }
 
 /** A placeholder client for the non-selected provider — never invoked. */

--- a/packages/cli/src/tracker-sync/clients.ts
+++ b/packages/cli/src/tracker-sync/clients.ts
@@ -1,9 +1,9 @@
 /**
  * Live TrackerClient adapters — the I/O boundary (JS5K5G). The GitHub adapter
  * shells out to `gh` (no new dependency; the ticket sanctions `gh` for stable
- * create/update). The Linear live client needs the Arcade integration, whose
- * auth/setup is owned by the connect-flow ticket (2TK5AD); until that lands it
- * surfaces an actionable error rather than failing obscurely. Both providers'
+ * create/update). The Linear live client still needs the Arcade integration;
+ * until that lands it points users to the supported adoption and portable-sync
+ * paths rather than a setup flow that cannot wire the client. Both providers'
  * *writer logic* ships and is unit-tested (writers.test.ts) over this port — only
  * the live adapter is the untested-by-unit shim, by design ("no live tracker in
  * tests").
@@ -167,10 +167,10 @@ function throwingClient(message: string): TrackerClient {
   return { createIssue: fail, updateIssue: fail, projectGraph: fail };
 }
 
-/** The Linear live client is pending the Arcade integration (2TK5AD). */
+/** The Linear live client is pending the Arcade integration. */
 function linearNotWired(): TrackerClient {
   return throwingClient(
-    'Linear projection needs the Arcade integration — run `safeword setup` to wire it (tracked by 2TK5AD).',
+    'Linear live projection is not wired. Adopt an existing Linear issue with `safeword ticket new <slug> --issue <key>`, or sync existing local tickets through `safeword sync-tracker --plan` and `--apply-results`.',
   );
 }
 

--- a/packages/cli/tests/tracker-connect/verify.test.ts
+++ b/packages/cli/tests/tracker-connect/verify.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { createVerifyClient } from '../../src/tracker-connect/verify.js';
+
+describe('tracker-connect live verification', () => {
+  it('explains that Linear verification is not wired yet', async () => {
+    const result = await createVerifyClient().whoami('linear');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected Linear verification to be unavailable');
+    expect(result.missing).toMatch(/Arcade integration.*not wired yet/i);
+  });
+});

--- a/packages/cli/tests/tracker-sync/clients-visibility.test.ts
+++ b/packages/cli/tests/tracker-sync/clients-visibility.test.ts
@@ -104,3 +104,21 @@ describe('GitHub graph projection client', () => {
     );
   });
 });
+
+describe('Linear live projection client', () => {
+  it('points users to the supported adoption and portable-sync paths', async () => {
+    const writer = buildWriterRegistry('linear', undefined).linear;
+
+    await expect(
+      writer.create({
+        title: 'Wire it up',
+        body: 'banner',
+        issueType: 'task',
+        labels: ['type:task'],
+        state: 'open',
+      }),
+    ).rejects.toThrow(
+      'Adopt an existing Linear issue with `safeword ticket new <slug> --issue <key>`, or sync existing local tickets through `safeword sync-tracker --plan` and `--apply-results`.',
+    );
+  });
+});

--- a/packages/cli/tests/tracker-sync/clients.test.ts
+++ b/packages/cli/tests/tracker-sync/clients.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from 'node:child_process';
 import { buildWriterRegistry, resolveRepoVisibility } from '../../src/tracker-sync/clients.js';
 
 /**
- * resolveRepoVisibility (JS5K5G AC10) — locks the public/private collapse and the
+ * Client adapter coverage (JS5K5G) — locks the public/private collapse and the
  * catch→undefined fail-safe the egress warning depends on. child_process is
  * mocked so no real `gh` is invoked.
  */
@@ -106,18 +106,27 @@ describe('GitHub graph projection client', () => {
 });
 
 describe('Linear live projection client', () => {
-  it('points users to the supported adoption and portable-sync paths', async () => {
-    const writer = buildWriterRegistry('linear', undefined).linear;
+  const payload = {
+    title: 'Wire it up',
+    body: 'banner',
+    issueType: 'task',
+    labels: ['type:task'],
+    state: 'open' as const,
+  };
+  const ref = { provider: 'linear' as const, id: 'ENG-45' };
 
-    await expect(
-      writer.create({
-        title: 'Wire it up',
-        body: 'banner',
-        issueType: 'task',
-        labels: ['type:task'],
-        state: 'open',
-      }),
-    ).rejects.toThrow(
+  it.each([
+    ['create', () => buildWriterRegistry('linear', undefined).linear.create(payload)],
+    ['update', () => buildWriterRegistry('linear', undefined).linear.update(ref, payload)],
+    [
+      'projectGraph',
+      () =>
+        buildWriterRegistry('linear', undefined).linear.projectGraph(ref, payload, {
+          blockedBy: [],
+        }),
+    ],
+  ])('points %s callers to the supported adoption and portable-sync paths', async (_name, call) => {
+    await expect(call()).rejects.toThrow(
       'Adopt an existing Linear issue with `safeword ticket new <slug> --issue <key>`, or sync existing local tickets through `safeword sync-tracker --plan` and `--apply-results`.',
     );
   });

--- a/packages/cli/tests/tracker-sync/command-linear.test.ts
+++ b/packages/cli/tests/tracker-sync/command-linear.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { syncTrackerCommand } from '../../src/commands/sync-tracker.js';
+
+describe('sync-tracker Linear live-sync guidance', () => {
+  let cwd: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    cwd = mkdtempSync(nodePath.join(tmpdir(), 'sync-linear-'));
+    mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });
+    writeFileSync(
+      nodePath.join(cwd, '.safeword', 'config.json'),
+      JSON.stringify({ ticketBridge: { provider: 'linear', target: { team: 'ENG' } } }),
+    );
+    logs = [];
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    vi.spyOn(console, 'log').mockImplementation(message => {
+      logs.push(String(message));
+    });
+    delete process.env.LINEAR_API_KEY;
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.LINEAR_API_KEY;
+    process.exitCode = 0;
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['without a credential', undefined],
+    ['with a credential', 'dummy-linear-token'],
+  ])('points directly to portable sync %s', async (_condition, credential) => {
+    if (credential !== undefined) process.env.LINEAR_API_KEY = credential;
+
+    await syncTrackerCommand();
+
+    const output = logs.join('\n');
+    expect(process.exitCode).toBe(1);
+    expect(output).toContain('safeword sync-tracker --plan');
+    expect(output).toContain('--apply-results');
+    expect(output).not.toMatch(/credential|token/i);
+  });
+});

--- a/packages/cli/tests/tracker-sync/command-linear.test.ts
+++ b/packages/cli/tests/tracker-sync/command-linear.test.ts
@@ -9,7 +9,7 @@ import { syncTrackerCommand } from '../../src/commands/sync-tracker.js';
 
 describe('sync-tracker Linear live-sync guidance', () => {
   let cwd: string;
-  let logs: string[];
+  let stderr: string[];
 
   beforeEach(() => {
     cwd = mkdtempSync(nodePath.join(tmpdir(), 'sync-linear-'));
@@ -18,18 +18,19 @@ describe('sync-tracker Linear live-sync guidance', () => {
       nodePath.join(cwd, '.safeword', 'config.json'),
       JSON.stringify({ ticketBridge: { provider: 'linear', target: { team: 'ENG' } } }),
     );
-    logs = [];
+    stderr = [];
     vi.spyOn(process, 'cwd').mockReturnValue(cwd);
-    vi.spyOn(console, 'log').mockImplementation(message => {
-      logs.push(String(message));
+    vi.spyOn(process.stderr, 'write').mockImplementation(chunk => {
+      stderr.push(String(chunk));
+      return true;
     });
-    delete process.env.LINEAR_API_KEY;
+    vi.stubEnv('LINEAR_API_KEY', '');
     process.exitCode = 0;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete process.env.LINEAR_API_KEY;
+    vi.unstubAllEnvs();
     process.exitCode = 0;
     rmSync(cwd, { recursive: true, force: true });
   });
@@ -38,11 +39,11 @@ describe('sync-tracker Linear live-sync guidance', () => {
     ['without a credential', undefined],
     ['with a credential', 'dummy-linear-token'],
   ])('points directly to portable sync %s', async (_condition, credential) => {
-    if (credential !== undefined) process.env.LINEAR_API_KEY = credential;
+    if (credential !== undefined) vi.stubEnv('LINEAR_API_KEY', credential);
 
     await syncTrackerCommand();
 
-    const output = logs.join('\n');
+    const output = stderr.join('');
     expect(process.exitCode).toBe(1);
     expect(output).toContain('safeword sync-tracker --plan');
     expect(output).toContain('--apply-results');

--- a/packages/website/src/content/docs/reference/tracker-integration.mdx
+++ b/packages/website/src/content/docs/reference/tracker-integration.mdx
@@ -31,9 +31,11 @@ safeword connect linear --team ENG
 ```
 
 `connect` writes the `ticketBridge` block to `.safeword/config.json`. GitHub's live connection also
-verifies auth and seeds an empty sidecar. For Linear, the command records the provider/team identity;
-the portable executor owns the network call, and `--plan` can start without a sidecar. Credentials
-stay outside config and are never written to logs.
+verifies auth and seeds an empty sidecar. For Linear, the command records the provider/team identity
+before attempting live verification. Because live Linear verification is not wired yet, it then
+reports `Not connected` and exits 1; the printed Arcade OAuth handoff does not enable live sync in
+this release. The saved config is sufficient for the portable path, and `--plan` can start without a
+sidecar. Credentials stay outside config and are never written to logs.
 
 :::note[GitHub live sync; Linear portable sync]
 **GitHub** supports both the one-command live sync and the portable transport. **Linear** supports
@@ -44,7 +46,9 @@ GitHub-only; use the portable transport with a Linear-capable executor.
 
 With GitHub's live transport, `safeword ticket new <slug>` mints the tracker issue first and keys
 the local ticket to it. For either provider, `--issue <key>` adopts an existing issue instead of
-creating one. New Linear tickets become `create` intents when you generate a portable sync plan.
+creating one. For non-epic Linear tickets, live minting is not wired: `ticket new` without `--issue`
+fails, while `--issue ENG-45` adopts that existing issue and later plans an `update`. A local ticket
+with no recorded tracker ref — for example, one that predates the connect — plans a `create`.
 
 ## Sync status to the tracker
 
@@ -58,7 +62,7 @@ This GitHub path walks your active tickets and creates/updates their issues (and
 when a ticket is terminal). It is safe to run repeatedly. Run it whenever you want the tracker
 refreshed — or automate it in CI so nobody has to remember.
 
-### Automate in CI (GitHub Actions)
+#### Automate in CI (GitHub Actions)
 
 Safeword does not install a workflow for you — copy this into
 `.github/workflows/sync-tracker.yml`:
@@ -113,11 +117,27 @@ Running `sync-tracker` with neither flag is the usual `gh` path, unchanged.
 
 #### Linear example
 
-First record the Linear team identity and generate the provider-neutral plan. These steps do not
-need Safeword to construct a Linear client:
+First record the Linear team identity:
 
 ```bash
 safeword connect linear --team ENG
+```
+
+The command writes the Linear provider and team to `.safeword/config.json`, then reports the
+following result and exits 1 because live verification is not wired:
+
+```text
+Not connected — Linear verification needs the Arcade integration — not wired in v1.
+```
+
+That exit is expected for the portable path; the required config has already landed. The printed
+Arcade OAuth step does not enable live Linear sync in this release. Run `connect linear` once
+outside `set -e` automation, confirm the saved provider and team, then run only the planning step in
+automation.
+
+Now generate the provider-neutral plan; this does not construct a Linear client:
+
+```bash
 safeword sync-tracker --plan > linear-plan.json
 ```
 
@@ -152,9 +172,10 @@ invalid result leaves the map untouched.
 
 ## Egress
 
-The projected issue body defaults to **minimal** (title, status, labels, back-link to the
-canonical ticket) — never your spec or work-log. `body: full` is opt-in per project, and projecting
-`full` to a **public** GitHub repo emits a loud egress warning.
+The projected issue body defaults to **minimal** (title, status, labels, and a pointer to the
+canonical ticket) — never your spec or work-log. For GitHub, that pointer is a clickable repository
+URL; in a Linear plan it is the ticket's relative path inside the repository. `body: full` is opt-in
+per project, and projecting `full` to a **public** GitHub repo emits a loud egress warning.
 
 That automatic public-target warning is GitHub-only. Linear has
 [private teams](https://linear.app/docs/private-teams), but its access boundary is workspace/team

--- a/packages/website/src/content/docs/reference/tracker-integration.mdx
+++ b/packages/website/src/content/docs/reference/tracker-integration.mdx
@@ -87,10 +87,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-`sync-tracker` **fails loudly (non-zero exit)** when a provider is configured but no credential
-resolves — it never silently exits 0 and does nothing, so a misconfigured CI job turns red instead
-of quietly drifting. In a non-interactive run authenticated by an `ARCADE_USER_ID` (a user
-identity, not a service account), it also warns that a lapsed grant would otherwise fail silently.
+GitHub live sync **fails loudly (non-zero exit)** when no credential resolves — it never silently
+exits 0 and does nothing, so a misconfigured CI job turns red instead of quietly drifting. Plain
+Linear live sync also exits non-zero, but points directly to the supported portable path instead of
+asking for a credential that the unwired live adapter cannot use. In a non-interactive run
+authenticated by an `ARCADE_USER_ID` (a user identity, not a service account), Safeword also warns
+that a lapsed grant would otherwise fail silently.
 
 ### Portable transport (`--plan` / `--apply-results`)
 
@@ -123,12 +125,8 @@ First record the Linear team identity:
 safeword connect linear --team ENG
 ```
 
-The command writes the Linear provider and team to `.safeword/config.json`, then reports the
-following result and exits 1 because live verification is not wired:
-
-```text
-Not connected — Linear verification needs the Arcade integration — not wired in v1.
-```
+The command writes the Linear provider and team to `.safeword/config.json`, then reports
+`Not connected` and exits 1 because live Linear verification still needs the Arcade integration.
 
 That exit is expected for the portable path; the required config has already landed. The printed
 Arcade OAuth step does not enable live Linear sync in this release. Run `connect linear` once

--- a/packages/website/src/content/docs/reference/tracker-integration.mdx
+++ b/packages/website/src/content/docs/reference/tracker-integration.mdx
@@ -52,6 +52,13 @@ with no recorded tracker ref — for example, one that predates the connect — 
 
 ## Sync status to the tracker
 
+Plain live sync fails loudly (with a non-zero exit) when it cannot proceed. For GitHub, that means
+a missing credential turns CI red instead of silently allowing tracker state to drift. For Linear,
+plain live sync points directly to the supported portable path instead of asking for a credential
+that the unwired live adapter cannot use. In a non-interactive GitHub run authenticated by an
+`ARCADE_USER_ID` (a user identity, not a service account), Safeword also warns that a lapsed grant
+would otherwise fail silently.
+
 ### Live transport (GitHub)
 
 ```bash
@@ -86,13 +93,6 @@ jobs:
           # safeword reads the credential from GITHUB_TOKEN (not GH_TOKEN).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-GitHub live sync **fails loudly (non-zero exit)** when no credential resolves — it never silently
-exits 0 and does nothing, so a misconfigured CI job turns red instead of quietly drifting. Plain
-Linear live sync also exits non-zero, but points directly to the supported portable path instead of
-asking for a credential that the unwired live adapter cannot use. In a non-interactive run
-authenticated by an `ARCADE_USER_ID` (a user identity, not a service account), Safeword also warns
-that a lapsed grant would otherwise fail silently.
 
 ### Portable transport (`--plan` / `--apply-results`)
 

--- a/packages/website/src/content/docs/reference/tracker-integration.mdx
+++ b/packages/website/src/content/docs/reference/tracker-integration.mdx
@@ -30,29 +30,33 @@ safeword connect github --repo owner/name
 safeword connect linear --team ENG
 ```
 
-`connect` writes the `ticketBridge` block to `.safeword/config.json`, verifies auth, and seeds an
-empty sidecar. Credentials are read from your OS keychain or an environment variable — **never**
-from config and never written to logs.
+`connect` writes the `ticketBridge` block to `.safeword/config.json`. GitHub's live connection also
+verifies auth and seeds an empty sidecar. For Linear, the command records the provider/team identity;
+the portable executor owns the network call, and `--plan` can start without a sidecar. Credentials
+stay outside config and are never written to logs.
 
-:::note[GitHub today; Linear projection is pending]
-**GitHub** is fully wired end-to-end. **Linear** identity works — `connect linear` and adopting an
-existing issue with `--issue` need no network — but `sync-tracker` to Linear is **not yet wired**
-(it errors with an actionable message, tracked by ticket 2TK5AD). Use GitHub for the live
-status mirror today.
+:::note[GitHub live sync; Linear portable sync]
+**GitHub** supports both the one-command live sync and the portable transport. **Linear** supports
+tracker identity (`connect linear` and adopting an existing issue with `--issue`) plus sync through
+`--plan` / `--apply-results`. Only the built-in live transport behind plain `sync-tracker` is
+GitHub-only; use the portable transport with a Linear-capable executor.
 :::
 
-Once connected, `safeword ticket new <slug>` mints the tracker issue first and keys the local
-ticket to it; `--issue <key>` adopts an existing issue instead of creating one.
+With GitHub's live transport, `safeword ticket new <slug>` mints the tracker issue first and keys
+the local ticket to it. For either provider, `--issue <key>` adopts an existing issue instead of
+creating one. New Linear tickets become `create` intents when you generate a portable sync plan.
 
 ## Sync status to the tracker
+
+### Live transport (GitHub)
 
 ```bash
 safeword sync-tracker
 ```
 
-This walks your active tickets and creates/updates their issues (and closes the issue when a
-ticket is terminal). It is safe to run repeatedly. Run it whenever you want the tracker refreshed —
-or automate it in CI so nobody has to remember.
+This GitHub path walks your active tickets and creates/updates their issues (and closes the issue
+when a ticket is terminal). It is safe to run repeatedly. Run it whenever you want the tracker
+refreshed — or automate it in CI so nobody has to remember.
 
 ### Automate in CI (GitHub Actions)
 
@@ -86,15 +90,15 @@ identity, not a service account), it also warns that a lapsed grant would otherw
 
 ### Portable transport (`--plan` / `--apply-results`)
 
-Plain `sync-tracker` reaches GitHub through the `gh` CLI. Where `gh` isn't installed — an agent
-session, a token-only runner — you can drive the sync in two offline steps and let **whatever has
-GitHub access** do the actual calls:
+The portable transport works with both GitHub and Linear. It is the current sync path for Linear,
+and it also lets GitHub users sync where the `gh` CLI is unavailable. Safeword computes and records
+the sync offline; an executor with access to the configured tracker performs the network calls:
 
 ```bash
 # 1. Compute the plan (no network, no credential) — JSON on stdout.
 safeword sync-tracker --plan > plan.json
 
-# 2. Your executor (an agent via its GitHub tools, a token+API script, …) reads plan.json,
+# 2. Your executor (an agent via tracker tools, a token+API script, …) reads plan.json,
 #    creates/updates/closes the issues, and writes back a results file:
 #    { "version": 1, "results": [{ "ticketId": "…", "number": "549", "url": "…/549" }] }
 
@@ -107,11 +111,57 @@ issue's number and back-link, and is idempotent — re-applying the same file ch
 flags are mutually exclusive, and a malformed results file is rejected without touching the map.
 Running `sync-tracker` with neither flag is the usual `gh` path, unchanged.
 
+#### Linear example
+
+First record the Linear team identity and generate the provider-neutral plan. These steps do not
+need Safeword to construct a Linear client:
+
+```bash
+safeword connect linear --team ENG
+safeword sync-tracker --plan > linear-plan.json
+```
+
+Have an executor with Linear access apply each `create`, `update`, or `close` intent in
+`linear-plan.json`. It then writes a result for each intent, preserving the plan's `ticketId`. For
+example, if local ticket `AB12CD` became Linear issue `ENG-45`:
+
+```json
+{
+  "version": 1,
+  "results": [
+    {
+      "ticketId": "AB12CD",
+      "number": "ENG-45",
+      "url": "https://linear.app/acme/issue/ENG-45/login-bug"
+    }
+  ]
+}
+```
+
+Save that document as `linear-results.json`, then record the Linear reference in the local map:
+
+```bash
+safeword sync-tracker --apply-results linear-results.json
+```
+
+Despite the field name `number`, Linear issue keys such as `ENG-45` are valid strings.
+`--apply-results` rejects a blank issue key or a URL that is not HTTP(S) for every provider; it
+also rejects results for tickets outside the local corpus. GitHub results receive additional
+numeric issue-number and URL-tail checks. Validation finishes before the map is changed, so one
+invalid result leaves the map untouched.
+
 ## Egress
 
 The projected issue body defaults to **minimal** (title, status, labels, back-link to the
 canonical ticket) — never your spec or work-log. `body: full` is opt-in per project, and projecting
 `full` to a **public** GitHub repo emits a loud egress warning.
+
+That automatic public-target warning is GitHub-only. Linear has
+[private teams](https://linear.app/docs/private-teams), but its access boundary is workspace/team
+membership rather than GitHub's internet-public repository visibility, and Safeword does not
+inspect a Linear team's access settings. Before projecting `body: full` to Linear, verify that the
+configured team has the intended membership. Also protect the generated plan: under `body: full`,
+the plan file itself contains the full local ticket bodies.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- replace stale Linear projection guidance with the supported `--plan` / `--apply-results` workflow
- add an end-to-end Linear example with precise connect, adoption, create, and update behavior
- make plain Linear live sync point directly to the supported portable path before credential or sidecar checks
- replace stale setup/2TK5AD and version-bound runtime guidance, with command and client regression coverage
- document the validation floor, relative Linear body pointer, and GitHub-only egress warning

## Why

The docs and runtime errors made the working portable Linear path look blocked. This update documents the actual workflow and ensures unsupported live-sync journeys lead directly to supported next steps.

## Impact

Users can configure Linear, adopt an existing issue, export plans for a trusted executor, and apply result artifacts without relying on live Linear projection. Plain Linear `sync-tracker` now exits non-zero with portable-path guidance instead of first asking for a credential the unwired adapter cannot use.

## Validation

- final independent quality review: **APPROVE**, no critical issues
- full Safeword verification: **5,640 Vitest tests passed, 5 skipped**
- Cucumber: **499 scenarios passed, 3 skipped; 15,444 steps passed, 4 skipped**
- focused post-review regression suite, lint, typecheck, CLI build, website build, Prettier, diff checks, and diff audit passed

Closes #1679