### PR TITLE
Keep BDD scenario evidence honest

### DIFF
--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -24,6 +24,32 @@ Degradation is the intended path — no gate blocks on harness absence.
 
 Start with the most constraining test — usually E2E or integration. Prefer the highest scope that covers the behavior with acceptable feedback speed.
 
+### Scenario proof fidelity
+
+The primary proof must preserve the scenario's contract boundary. Declarative
+wording does not require literal keystroke fidelity, but it does require the
+same actor-facing entry point and actor-visible result that the `When` and
+`Then` claim.
+
+- **Setup shortcuts belong in `Given`.** Fixtures, direct state setup, and
+  lower-level helpers may establish context without replaying every prior user
+  action.
+- **Exercise the `When` through the actor-facing entry point.** A direct
+  application-store call or injected lower-level browser event may prove
+  underlying logic, but it does not prove a named UI control, keyboard or
+  operating-system gesture, CLI command, or API request.
+- **Observe the `Then` as the actor-visible result.** Store, editor, or component
+  state is supporting evidence; it does not prove a visible UI result, emitted
+  CLI output, or external API response.
+- **Keep evidence limits explicit.** When the real boundary cannot be automated
+  reliably, use the existing `@manual` or `@live` path and perform and record
+  that check separately. A tag, skip reason, or narrower automated test does
+  not prove the broader scenario by itself.
+
+If a scenario accidentally names incidental UI mechanics rather than product
+behavior, loop back to define-behavior and rewrite it; do not silently reinterpret
+the scenario during implementation.
+
 ### Feature-source executable path
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:

--- a/.claude/skills/tdd-review/SKILL.md
+++ b/.claude/skills/tdd-review/SKILL.md
@@ -33,6 +33,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
+- **Scenario fidelity?** For a BDD scenario, does the primary test exercise the
+  `When` through the actor-facing entry point and observe the `Then` as the
+  actor-visible result? Setup shortcuts belong in `Given`; direct store calls,
+  injected lower-level events, and internal-state assertions are supporting
+  evidence only.
 - **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior, re-run the scenario-gate, and re-enter plan-implementation (update impl-plan.md for the new scenario) before implement. Don't silently append scenarios to a signed-off `test-definitions.md`.
@@ -57,6 +62,9 @@ If issues found: fix before refactoring. If clean: run /refactor, commit, procee
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
 - **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Scenario fidelity?** Does the completed proof still use the scenario's
+  actor-facing entry point and observe its actor-visible result, with
+  implementation-level checks kept as supporting evidence?
 - **Full suite green?** Run the full suite once here to catch cross-module regressions.
 - **New external dependency or API in this scenario?** Only then run **/quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -14,7 +14,7 @@ Then it says direct store calls, injected lower-level events, and internal-state
 assertions are supporting evidence rather than proof of those clauses
 
 - [x] RED skip: no per-step commit requested; focused test failed on the absent contract
-- [x] GREEN skip: no per-step commit requested; focused contract test passed
+- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
 - [x] REFACTOR skip: no additional cleanup after the single-behavior split during GREEN
 
 ## Rule: Setup and supporting proof remain proportionate
@@ -28,7 +28,7 @@ Then it permits setup shortcuts in `Given` and supporting tests without
 weakening the required `When` and `Then` evidence
 
 - [x] RED skip: covered by the same missing-contract RED
-- [x] GREEN skip: no per-step commit requested; setup and support contract passed
+- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
 - [x] REFACTOR skip: no further structural improvement needed
 
 ## Rule: Evidence limits remain visible
@@ -41,7 +41,7 @@ Then it uses the existing `@manual` or `@live` path and never promotes a
 narrower automated test into full scenario evidence
 
 - [x] RED skip: covered by the same missing-contract RED
-- [x] GREEN skip: no per-step commit requested; evidence-limit contract passed
+- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
 - [x] REFACTOR skip: no further structural improvement needed
 
 ## Feature-level cross-scenario refactor

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -14,7 +14,7 @@ Then it says direct store calls, injected lower-level events, and internal-state
 assertions are supporting evidence rather than proof of those clauses
 
 - [x] RED skip: no per-step commit requested; focused test failed on the absent contract
-- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
+- [x] GREEN fa16069cb
 - [x] REFACTOR skip: no additional cleanup after the single-behavior split during GREEN
 
 ## Rule: Setup and supporting proof remain proportionate
@@ -28,7 +28,7 @@ Then it permits setup shortcuts in `Given` and supporting tests without
 weakening the required `When` and `Then` evidence
 
 - [x] RED skip: covered by the same missing-contract RED
-- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
+- [x] GREEN fa16069cb
 - [x] REFACTOR skip: no further structural improvement needed
 
 ## Rule: Evidence limits remain visible
@@ -41,7 +41,7 @@ Then it uses the existing `@manual` or `@live` path and never promotes a
 narrower automated test into full scenario evidence
 
 - [x] RED skip: covered by the same missing-contract RED
-- [x] GREEN fa16069cb # scenario-proof guidance and regression coverage
+- [x] GREEN fa16069cb
 - [x] REFACTOR skip: no further structural improvement needed
 
 ## Feature-level cross-scenario refactor

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -44,6 +44,20 @@ narrower automated test into full scenario evidence
 - [x] GREEN fa16069cb
 - [x] REFACTOR skip: no further structural improvement needed
 
+## Rule: Generated agent surfaces remain in sync
+
+### Scenario: 1698.SU1.AC5.generates_the_codex_plugin_from_canonical_templates
+
+Given the BDD and TDD-review canonical templates contain the proof-fidelity
+contract
+When the Codex plugin catalogue is regenerated and release tests run
+Then its generated BDD and TDD-review skills contain the same contract
+And the release catalogue accepts every generated asset exactly
+
+- [x] RED: `bun run --cwd packages/cli test:release` rejected the stale generated assets
+- [x] GREEN: regenerate the Codex plugin and pass the release suite
+- [x] REFACTOR: generated output remains owned by its generator rather than hand-edited
+
 ## Feature-level cross-scenario refactor
 
 - [x] cross-scenario skip: one canonical rule with two local review checkpoints; no shared abstraction needed

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -54,9 +54,9 @@ When the Codex plugin catalogue is regenerated and release tests run
 Then its generated BDD and TDD-review skills contain the same contract
 And the release catalogue accepts every generated asset exactly
 
-- [x] RED: `bun run --cwd packages/cli test:release` rejected the stale generated assets
-- [x] GREEN: regenerate the Codex plugin and pass the release suite
-- [x] REFACTOR: generated output remains owned by its generator rather than hand-edited
+- [x] RED 09ac816ab
+- [x] GREEN 09ac816ab
+- [x] REFACTOR 09ac816ab
 
 ## Feature-level cross-scenario refactor
 

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -1,0 +1,49 @@
+# Test Definitions: Keep BDD evidence honest
+
+No `.feature` file: the executable proof is Vitest over the shipped BDD/TDD
+instruction surfaces. The tests fail if the scenario proof-fidelity contract disappears
+from either the canonical templates or installed dogfood copies.
+
+## Rule: Primary proof preserves the scenario's actor-facing contract
+
+### Scenario: 1698.SU1.AC1-2.rejects_internal_substitutes_for_user-visible_clauses
+
+Given a BDD scenario names an actor-facing action and actor-visible result
+When Safeword teaches the agent how to choose and review the primary proof
+Then it says direct store calls, injected lower-level events, and internal-state
+assertions are supporting evidence rather than proof of those clauses
+
+- [x] RED skip: no per-step commit requested; focused test failed on the absent contract
+- [x] GREEN skip: no per-step commit requested; focused contract test passed
+- [x] REFACTOR skip: no additional cleanup after the single-behavior split during GREEN
+
+## Rule: Setup and supporting proof remain proportionate
+
+### Scenario: 1698.SU1.AC3.allows_given_shortcuts_and_lower_level_support
+
+Given fixtures and lower-level tests make the scenario cheaper and easier to
+diagnose
+When Safeword applies the scenario proof contract
+Then it permits setup shortcuts in `Given` and supporting tests without
+weakening the required `When` and `Then` evidence
+
+- [x] RED skip: covered by the same missing-contract RED
+- [x] GREEN skip: no per-step commit requested; setup and support contract passed
+- [x] REFACTOR skip: no further structural improvement needed
+
+## Rule: Evidence limits remain visible
+
+### Scenario: 1698.SU1.AC4.routes_unavailable_automation_without_overclaiming
+
+Given the named user or operating-system boundary cannot be automated reliably
+When Safeword records the scenario's completion state
+Then it uses the existing `@manual` or `@live` path and never promotes a
+narrower automated test into full scenario evidence
+
+- [x] RED skip: covered by the same missing-contract RED
+- [x] GREEN skip: no per-step commit requested; evidence-limit contract passed
+- [x] REFACTOR skip: no further structural improvement needed
+
+## Feature-level cross-scenario refactor
+
+- [x] cross-scenario skip: one canonical rule with two local review checkpoints; no shared abstraction needed

--- a/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/test-definitions.md
@@ -54,9 +54,9 @@ When the Codex plugin catalogue is regenerated and release tests run
 Then its generated BDD and TDD-review skills contain the same contract
 And the release catalogue accepts every generated asset exactly
 
-- [x] RED 09ac816ab
+- [x] RED skip: release suite failed before regeneration
 - [x] GREEN 09ac816ab
-- [x] REFACTOR 09ac816ab
+- [x] REFACTOR skip: generated output remains exclusively generator-owned
 
 ## Feature-level cross-scenario refactor
 

--- a/.project/tickets/1698-keep-bdd-evidence-honest/ticket.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/ticket.md
@@ -5,7 +5,7 @@ subtype: bug-investigated
 phase: done
 status: done
 created: 2026-07-30T23:02:19Z
-last_modified: 2026-07-31T03:56:10Z
+last_modified: 2026-07-31T06:21:12Z
 external_issue: https://github.com/ArcadeAI/safeword/issues/1698
 ---
 
@@ -39,6 +39,9 @@ Ruled out:
 
 ## Work Log
 
+- 2026-07-31T06:21:12Z Review follow-up: Regenerated the Codex plugin from
+  canonical BDD/TDD and TDD-review templates after the release catalogue
+  detected stale derived assets. `test:release` passed 26/26 tests.
 - 2026-07-31T03:56:10Z Investigated: The apparent full-suite hang was global
   test-lock contention from another worktree. After the lock released,
   `bun run test` passed 5,645 tests with 5 skips across 377 files.

--- a/.project/tickets/1698-keep-bdd-evidence-honest/ticket.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/ticket.md
@@ -1,0 +1,59 @@
+---
+id: 1698
+type: task
+subtype: bug-investigated
+phase: done
+status: done
+created: 2026-07-30T23:02:19Z
+last_modified: 2026-07-31T03:56:10Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1698
+---
+
+# Keep BDD evidence honest for user-visible scenarios
+
+**Goal:** Prevent implementation-level tests from being reported as proof of a
+user-visible scenario they do not exercise.
+
+**Why:** A green scenario should mean the named user action and observable
+result were demonstrated, not only the underlying state transition.
+
+## Root Cause
+
+The earlier `bun run test` appeared idle because the test wrapper was waiting
+for safeword's global package-test lock, which was legitimately owned by a test
+run in another worktree. The wrapper serializes package tests across worktrees
+and permits up to 20 minutes of lock waiting.
+
+This was confirmed by reading the lock's `owner.json`, matching its live PID to
+the other worktree's `run-vitest-with-build-lock.mjs` process, and observing
+that run advance through changing Vitest worker PIDs until it released the
+lock. Our queued command then built, ran, and passed normally.
+
+Ruled out:
+
+- A stale lock: its owner PID was alive and released the lock naturally.
+- A frozen Vitest process: our command had not entered Vitest while it appeared
+  idle.
+- An open handle introduced by issue #1698: the full suite exited successfully
+  after running the new tests.
+
+## Work Log
+
+- 2026-07-31T03:56:10Z Investigated: The apparent full-suite hang was global
+  test-lock contention from another worktree. After the lock released,
+  `bun run test` passed 5,645 tests with 5 skips across 377 files.
+- 2026-07-31T01:19:43Z Refactored: Added explicit result-boundary
+  characterization coverage, clarified test helper names and terminology, and
+  reverified 1,244 done-gate tests plus 44 focused and adjacent tests.
+- 2026-07-30T23:13:55Z Complete: Added the scenario proof-fidelity contract,
+  RED/REFACTOR review checks, template parity coverage, and verification
+  evidence.
+- 2026-07-30T23:13:21Z Verified: Done-gate suite passed 1,242 tests; lint,
+  Gherkin validation, and typecheck passed. The broader full suite remained
+  idle past five minutes and was stopped without a failure result.
+- 2026-07-30T23:06:15Z GREEN: Scenario proof-fidelity contract passed 4/4
+  focused checks; refactored the checks into single-behavior cases.
+- 2026-07-30T23:03:35Z RED: Contract test failed 4/4 because the fidelity rule
+  and review checkpoints were absent.
+- 2026-07-30T23:02:19Z Started: Agreed on a contract-boundary rule after
+  comparing clause-fidelity guidance, metadata, and deterministic gates.

--- a/.project/tickets/1698-keep-bdd-evidence-honest/user-stories.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/user-stories.md
@@ -37,3 +37,10 @@ Given the actor-facing action or result cannot be automated reliably
 When the agent records scenario evidence
 Then it routes the scenario through the existing `@manual` or `@live` path and
 does not complete it from narrower implementation evidence alone.
+
+#### 1698.SU1.AC5 - Every shipped agent surface carries the contract
+
+Given Safeword generates its Codex plugin from the canonical skill templates
+When the scenario-proof contract changes
+Then the generated Codex plugin carries the same contract and passes the
+release-catalogue verification.

--- a/.project/tickets/1698-keep-bdd-evidence-honest/user-stories.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/user-stories.md
@@ -1,0 +1,39 @@
+# User Stories: Keep BDD evidence honest
+
+## Story 1: Trust scenario completion claims
+
+As a Safeword user,
+I want a user-visible BDD scenario to be completed only by evidence that
+exercises its actor-facing action and observes its actor-visible result,
+so that a green scenario means the described experience was actually
+demonstrated.
+
+### Acceptance Criteria
+
+#### 1698.SU1.AC1 - Primary proof preserves the scenario contract
+
+Given a scenario whose `When` names or implies an actor-facing entry point
+When the agent chooses the scenario's primary proof
+Then that proof exercises the same entry point instead of substituting a direct
+application-store call or lower-level injected event.
+
+#### 1698.SU1.AC2 - Assertions preserve the observable result
+
+Given a scenario whose `Then` names an actor-visible result
+When the agent completes the scenario
+Then the primary proof observes that result instead of treating internal store
+or editor state as equivalent evidence.
+
+#### 1698.SU1.AC3 - Setup and supporting tests remain proportionate
+
+Given a scenario also needs fixtures or lower-level logic coverage
+When the agent builds its proof
+Then direct setup remains allowed in `Given` and lower-level tests remain
+supporting evidence without inheriting the broader scenario claim.
+
+#### 1698.SU1.AC4 - Unavailable automation is reported honestly
+
+Given the actor-facing action or result cannot be automated reliably
+When the agent records scenario evidence
+Then it routes the scenario through the existing `@manual` or `@live` path and
+does not complete it from narrower implementation evidence alone.

--- a/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
@@ -16,8 +16,13 @@ tests passed 44/44.
 **Template Parity:** ✅ Canonical BDD/TDD and TDD-review templates exactly match
 their installed `.claude/skills/` dogfood copies.
 
+**Codex Plugin Release Gate:** ✅ `bun run --cwd packages/cli test:release`
+passed 26/26 tests across 8 files after `bun run --cwd packages/cli
+generate:codex-plugin` regenerated the BDD and TDD-review skill assets.
+
 **PR Scope:** ✅ Changes are limited to issue #1698's planning artifacts,
-scenario-proof guidance, installed dogfood copies, and the regression test.
+scenario-proof guidance, installed and generated agent-surface copies, and
+regression tests.
 
 **Lock Investigation:** ✅ The earlier apparent idle run was waiting for a
 legitimate test owner in another worktree, not hanging inside Vitest. The

--- a/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
@@ -1,0 +1,24 @@
+# Verification: Keep BDD evidence honest
+
+**Test Suite:** ✅ `bun run test:done` passed 1,244/1,244 tests across 81 files.
+
+**Full Suite:** ✅ `bun run test` passed 5,645 tests with 5 skips across 377
+files. Vitest completed in 379.17 seconds after the global package-test lock
+became available.
+
+**Focused Proof:** ✅ The scenario-fidelity and adjacent BDD documentation
+tests passed 44/44.
+
+**Lint:** ✅ ESLint and Gherkin validation passed.
+
+**Typecheck:** ✅ `tsc --noEmit` passed.
+
+**Template Parity:** ✅ Canonical BDD/TDD and TDD-review templates exactly match
+their installed `.claude/skills/` dogfood copies.
+
+**PR Scope:** ✅ Changes are limited to issue #1698's planning artifacts,
+scenario-proof guidance, installed dogfood copies, and the regression test.
+
+**Lock Investigation:** ✅ The earlier apparent idle run was waiting for a
+legitimate test owner in another worktree, not hanging inside Vitest. The
+global wrapper allows up to 20 minutes of lock waiting.

--- a/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
+++ b/.project/tickets/1698-keep-bdd-evidence-honest/verify.md
@@ -2,9 +2,10 @@
 
 **Test Suite:** ✅ `bun run test:done` passed 1,244/1,244 tests across 81 files.
 
-**Full Suite:** ✅ `bun run test` passed 5,645 tests with 5 skips across 377
-files. Vitest completed in 379.17 seconds after the global package-test lock
-became available.
+**Full Suite:** ✅ At the issue #1698 snapshot, `bun run test` passed 5,645
+tests with 5 skips across 377 files. Vitest completed in 379.17 seconds after
+the global package-test lock became available. The later CCYD5S snapshot records
+its then-current 5,647-test suite after additional lock-runner coverage.
 
 **Focused Proof:** ✅ The scenario-fidelity and adjacent BDD documentation
 tests passed 44/44.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -57,7 +57,7 @@ When lock creation is extracted from the wait loop
 Then successful acquisition, serialization, stale-lock recovery, and wait-cap
 behavior remain unchanged
 
-- [x] REFACTOR skip: focused lock-runner suite passed 9/9 after the extract
+- [x] REFACTOR f4195b63e
 
 ## Patch-level refactor
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -39,9 +39,9 @@ When the runner waits for its configured wait cap
 Then it reports status no more often than the supported minimum interval
 And malformed interval settings fall back to the default interval
 
-- [x] RED 09ac816ab
+- [x] RED skip: unsafe-interval test failed before the minimum clamp
 - [x] GREEN 09ac816ab
-- [x] REFACTOR 09ac816ab
+- [x] REFACTOR skip: shared helpers are the completed cleanup
 
 ## Patch-level refactor
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -21,10 +21,12 @@ And it emits increasing elapsed-wait status more than once
 
 ### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
 
-Given a live lock has readable but incomplete or non-object owner metadata
+Given a live lock has readable but incomplete owner metadata, or stale non-object
+owner metadata
 When another runner reports its wait
 Then it prints the fields that are available, or marks unavailable fields clearly
 And it continues waiting or reaches the configured wait cap without crashing
+And stale non-object metadata is reaped through the normal mtime fallback
 
 - [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
 - [x] GREEN fa16069cb
@@ -38,6 +40,13 @@ Given a live package-test lock and a one-millisecond status interval setting
 When the runner waits for its configured wait cap
 Then it reports status no more often than the supported minimum interval
 And malformed and zero interval settings fall back to the default interval
+
+### Scenario: CCYD5S.SM1.AC6.negative_maximum_wait_uses_the_default
+
+Given another runner owns a live package-test lock
+When a waiting runner sets its maximum wait to a negative value
+Then it waits for the owner under the default maximum wait
+And it does not proceed without the lock or overlap the owner's build and test
 
 - [x] RED skip: unsafe-interval test failed before the minimum clamp
 - [x] GREEN 09ac816ab

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -15,9 +15,9 @@ Then the queued runner reports the owner's process ID
 And it reports the owner's checkout root
 And it emits increasing elapsed-wait status more than once
 
-- [x] RED: focused runner suite failed because no periodic owner status existed
-- [x] GREEN: owner checkout and increasing elapsed statuses passed
-- [x] REFACTOR: shared status formatting and scheduling remained local to the runner
+- [x] RED skip: focused runner suite failed because no periodic owner status existed
+- [x] GREEN fa16069cb # owner checkout and increasing elapsed statuses passed
+- [x] REFACTOR skip: shared status formatting and scheduling remained local to the runner
 
 ### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
 
@@ -26,10 +26,10 @@ When another runner reports its wait
 Then it prints the fields that are available
 And it continues waiting or reaches the configured wait cap without crashing
 
-- [x] RED: focused runner suite failed because incomplete metadata emitted no details
-- [x] GREEN: available owner fields and fallback labels passed
-- [x] REFACTOR: no additional structure was needed
+- [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
+- [x] GREEN fa16069cb # available owner fields and fallback labels passed
+- [x] REFACTOR skip: no additional structure was needed
 
 ## Patch-level refactor
 
-- [x] cross-scenario: both scenarios use the same metadata reader and wait reporter
+- [x] cross-scenario skip: both scenarios use the same metadata reader and wait reporter

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -32,8 +32,14 @@ timestamp, is reaped through the normal recovery paths
 - [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
 - [x] GREEN fa16069cb
 - [x] REFACTOR skip: no additional structure was needed
-- [ ] RED: reproduce stale recovery for a syntactically valid owner object
-  with no usable process ID or timestamp, including an epoch timestamp.
+- [x] RED 8a5d2d35e
+  Reproduced stale recovery for a syntactically valid owner object with no
+  usable process ID or timestamp, including an epoch timestamp.
+- [x] GREEN 8e5ebbf9e
+  Focused runner suite passed 11/11 with mtime recovery for `{}` and age
+  recovery for the Unix epoch.
+- [x] REFACTOR skip: retained the existing recovery paths and named their
+  shared metadata validity checks.
 
 ## Rule: Wait diagnostics remain safely rate-limited
 
@@ -64,7 +70,11 @@ When a waiting runner sets its maximum wait to a negative or blank value
 Then it waits for the owner under the default maximum wait
 And it does not proceed without the lock or overlap the owner's build and test
 
-- [ ] RED: reproduce blank maximum-wait fallback while a real owner holds the lock.
+- [x] RED 8a5d2d35e
+  Reproduced blank maximum-wait fallback while a real owner holds the lock.
+- [x] GREEN 8e5ebbf9e
+  Focused runner suite passed 11/11 with blank and negative fallback.
+- [x] REFACTOR skip: reused the existing safe-integer environment resolver.
 
 ## Refactoring ledger
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -43,6 +43,22 @@ And malformed interval settings fall back to the default interval
 - [x] GREEN 09ac816ab
 - [x] REFACTOR skip: shared helpers are the completed cleanup
 
+## Refactoring ledger
+
+- [x] CCYD5S.RF1 skip: Extracted lock creation from `acquireLock()` in
+  `packages/cli/scripts/run-vitest-with-build-lock.mjs`; existing integration
+  scenarios cover successful creation, contention, stale-lock recovery, and
+  wait-cap behavior.
+
+### Scenario: CCYD5S.SM1.AC5.preserves_lock_behavior_after_extracting_creation
+
+Given the existing lock-runner integration scenarios
+When lock creation is extracted from the wait loop
+Then successful acquisition, serialization, stale-lock recovery, and wait-cap
+behavior remain unchanged
+
+- [x] REFACTOR skip: focused lock-runner suite passed 9/9 after the extract
+
 ## Patch-level refactor
 
 - [x] cross-scenario skip: both scenarios use the same metadata reader and wait reporter

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -21,16 +21,19 @@ And it emits increasing elapsed-wait status more than once
 
 ### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
 
-Given a live lock has readable but incomplete owner metadata, or stale non-object
-owner metadata
+Given a live lock has readable but incomplete owner metadata, or stale metadata
+that is non-object or lacks both a usable process ID and timestamp
 When another runner reports its wait
 Then it prints the fields that are available, or marks unavailable fields clearly
 And it continues waiting or reaches the configured wait cap without crashing
-And stale non-object metadata is reaped through the normal mtime fallback
+And stale metadata without a usable process ID or timestamp, or with an expired
+timestamp, is reaped through the normal recovery paths
 
 - [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
 - [x] GREEN fa16069cb
 - [x] REFACTOR skip: no additional structure was needed
+- [ ] RED: reproduce stale recovery for a syntactically valid owner object
+  with no usable process ID or timestamp, including an epoch timestamp.
 
 ## Rule: Wait diagnostics remain safely rate-limited
 
@@ -41,23 +44,9 @@ When the runner waits for its configured wait cap
 Then it reports status no more often than the supported minimum interval
 And malformed and zero interval settings fall back to the default interval
 
-### Scenario: CCYD5S.SM1.AC6.negative_maximum_wait_uses_the_default
-
-Given another runner owns a live package-test lock
-When a waiting runner sets its maximum wait to a negative value
-Then it waits for the owner under the default maximum wait
-And it does not proceed without the lock or overlap the owner's build and test
-
 - [x] RED skip: unsafe-interval test failed before the minimum clamp
 - [x] GREEN 09ac816ab
 - [x] REFACTOR skip: shared helpers are the completed cleanup
-
-## Refactoring ledger
-
-- [x] CCYD5S.RF1 skip: Extracted lock creation from `acquireLock()` in
-  `packages/cli/scripts/run-vitest-with-build-lock.mjs`; existing integration
-  scenarios cover successful creation, contention, stale-lock recovery, and
-  wait-cap behavior.
 
 ### Scenario: CCYD5S.SM1.AC5.preserves_lock_behavior_after_extracting_creation
 
@@ -67,6 +56,22 @@ Then successful acquisition, serialization, stale-lock recovery, and wait-cap
 behavior remain unchanged
 
 - [x] REFACTOR f4195b63e
+
+### Scenario: CCYD5S.SM1.AC6.negative_maximum_wait_uses_the_default
+
+Given another runner owns a live package-test lock
+When a waiting runner sets its maximum wait to a negative or blank value
+Then it waits for the owner under the default maximum wait
+And it does not proceed without the lock or overlap the owner's build and test
+
+- [ ] RED: reproduce blank maximum-wait fallback while a real owner holds the lock.
+
+## Refactoring ledger
+
+- [x] CCYD5S.RF1 skip: Extracted lock creation from `acquireLock()` in
+  `packages/cli/scripts/run-vitest-with-build-lock.mjs`; existing integration
+  scenarios cover successful creation, contention, stale-lock recovery, and
+  wait-cap behavior.
 
 ## Patch-level refactor
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -16,7 +16,7 @@ And it reports the owner's checkout root
 And it emits increasing elapsed-wait status more than once
 
 - [x] RED skip: focused runner suite failed because no periodic owner status existed
-- [x] GREEN fa16069cb # owner checkout and increasing elapsed statuses passed
+- [x] GREEN fa16069cb
 - [x] REFACTOR skip: shared status formatting and scheduling remained local to the runner
 
 ### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
@@ -27,7 +27,7 @@ Then it prints the fields that are available
 And it continues waiting or reaches the configured wait cap without crashing
 
 - [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
-- [x] GREEN fa16069cb # available owner fields and fallback labels passed
+- [x] GREEN fa16069cb
 - [x] REFACTOR skip: no additional structure was needed
 
 ## Patch-level refactor

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -1,0 +1,35 @@
+# Test Definitions: Explain test-lock waits
+
+The executable proof is the existing Vitest integration coverage around
+`run-vitest-with-build-lock.mjs`. Tests use isolated temporary locks and fake
+build/test binaries; they do not contend for the repository's real global lock.
+
+## Rule: A queued package-test command explains its wait
+
+### Scenario: CCYD5S.SM1.AC1-2.reports_owner_and_elapsed_wait_periodically
+
+Given one runner owns a package-test lock from a known checkout
+And a second runner is queued behind it
+When the wait lasts across multiple status intervals
+Then the queued runner reports the owner's process ID
+And it reports the owner's checkout root
+And it emits increasing elapsed-wait status more than once
+
+- [x] RED: focused runner suite failed because no periodic owner status existed
+- [x] GREEN: owner checkout and increasing elapsed statuses passed
+- [x] REFACTOR: shared status formatting and scheduling remained local to the runner
+
+### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
+
+Given a live lock has readable but incomplete owner metadata
+When another runner reports its wait
+Then it prints the fields that are available
+And it continues waiting or reaches the configured wait cap without crashing
+
+- [x] RED: focused runner suite failed because incomplete metadata emitted no details
+- [x] GREEN: available owner fields and fallback labels passed
+- [x] REFACTOR: no additional structure was needed
+
+## Patch-level refactor
+
+- [x] cross-scenario: both scenarios use the same metadata reader and wait reporter

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -30,6 +30,19 @@ And it continues waiting or reaches the configured wait cap without crashing
 - [x] GREEN fa16069cb
 - [x] REFACTOR skip: no additional structure was needed
 
+## Rule: Wait diagnostics remain safely rate-limited
+
+### Scenario: CCYD5S.SM1.AC4.clamps_an_unsafe_status_interval
+
+Given a live package-test lock and a one-millisecond status interval setting
+When the runner waits for its configured wait cap
+Then it reports status no more often than the supported minimum interval
+And malformed interval settings fall back to the default interval
+
+- [x] RED: the runner honored a one-millisecond interval and had no malformed-setting coverage
+- [x] GREEN: shared configuration parsing clamps unsafe values and tests pass
+- [x] REFACTOR: one parser owns integer environment-variable validation
+
 ## Patch-level refactor
 
 - [x] cross-scenario skip: both scenarios use the same metadata reader and wait reporter

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -39,9 +39,9 @@ When the runner waits for its configured wait cap
 Then it reports status no more often than the supported minimum interval
 And malformed interval settings fall back to the default interval
 
-- [x] RED: the runner honored a one-millisecond interval and had no malformed-setting coverage
-- [x] GREEN: shared configuration parsing clamps unsafe values and tests pass
-- [x] REFACTOR: one parser owns integer environment-variable validation
+- [x] RED 09ac816ab
+- [x] GREEN 09ac816ab
+- [x] REFACTOR 09ac816ab
 
 ## Patch-level refactor
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/test-definitions.md
@@ -21,9 +21,9 @@ And it emits increasing elapsed-wait status more than once
 
 ### Scenario: CCYD5S.SM1.AC3.tolerates_incomplete_owner_metadata
 
-Given a live lock has readable but incomplete owner metadata
+Given a live lock has readable but incomplete or non-object owner metadata
 When another runner reports its wait
-Then it prints the fields that are available
+Then it prints the fields that are available, or marks unavailable fields clearly
 And it continues waiting or reaches the configured wait cap without crashing
 
 - [x] RED skip: focused runner suite failed because incomplete metadata emitted no details
@@ -37,7 +37,7 @@ And it continues waiting or reaches the configured wait cap without crashing
 Given a live package-test lock and a one-millisecond status interval setting
 When the runner waits for its configured wait cap
 Then it reports status no more often than the supported minimum interval
-And malformed interval settings fall back to the default interval
+And malformed and zero interval settings fall back to the default interval
 
 - [x] RED skip: unsafe-interval test failed before the minimum clamp
 - [x] GREEN 09ac816ab

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -2,10 +2,10 @@
 id: CCYD5S
 slug: explain-test-lock-waits
 type: patch
-phase: done
-status: done
+phase: implement
+status: in_progress
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-07-31T11:00:00Z
+last_modified: 2026-08-01T15:29:25Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,6 +16,12 @@ last_modified: 2026-07-31T11:00:00Z
 
 ## Work Log
 
+- 2026-08-01T15:29:25Z Review follow-up: Restoring exact subprocess argument
+  assertions, repairing scenario-ledger ownership and ordering, and extending
+  safe fallback/recovery to blank maximum waits and unidentifiable owner JSON.
+- 2026-08-01T15:29:25Z RED: Focused lock-runner coverage reproduced a blank
+  maximum wait bypassing serialization and a stale `{}` owner reaching the
+  zero-wait escape instead of mtime recovery.
 - 2026-07-31T11:00:00Z Review follow-up: Restored the negative maximum-wait
   fallback, routed non-object owner metadata through mtime stale-lock recovery,
   and expanded the status proof across every emitted interval.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -5,7 +5,7 @@ type: patch
 phase: done
 status: done
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-07-31T05:14:21Z
+last_modified: 2026-07-31T06:21:12Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,6 +16,10 @@ last_modified: 2026-07-31T05:14:21Z
 
 ## Work Log
 
+- 2026-07-31T06:21:12Z Review follow-up: Consolidated owner-file and integer
+  environment parsing, rate-limited status intervals to a 50 ms minimum, and
+  updated runner tests for human-readable elapsed waits. Focused runner tests
+  passed 9/9.
 - 2026-07-31T05:14:21Z Done: Package-test lock owners now record their
   checkout root; queued commands report owner PID, checkout, and elapsed wait
   after one second and every thirty seconds. Focused tests, full Vitest, lint,

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -2,10 +2,10 @@
 id: CCYD5S
 slug: explain-test-lock-waits
 type: patch
-phase: implement
-status: in_progress
+phase: done
+status: done
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-08-01T15:29:25Z
+last_modified: 2026-08-01T15:44:20Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,9 +16,16 @@ last_modified: 2026-08-01T15:29:25Z
 
 ## Work Log
 
+- 2026-08-01T15:44:20Z Done: Quality-review recheck found no remaining
+  critical issues. Focused runner tests (11/11), lint/typecheck, and the
+  release catalogue (26/26) passed after GREEN 8e5ebbf9e.
 - 2026-08-01T15:29:25Z Review follow-up: Restoring exact subprocess argument
   assertions, repairing scenario-ledger ownership and ordering, and extending
   safe fallback/recovery to blank maximum waits and unidentifiable owner JSON.
+- 2026-08-01T15:29:25Z RED 8a5d2d35e: Captured the blank-maximum-wait and
+  unidentifiable-owner boundaries with real subprocess integration coverage.
+- 2026-08-01T15:29:25Z GREEN 8e5ebbf9e: Restored safe blank-value fallback
+  and extended stale recovery without weakening valid PID/timestamp behavior.
 - 2026-08-01T15:29:25Z RED: Focused lock-runner coverage reproduced a blank
   maximum wait bypassing serialization and a stale `{}` owner reaching the
   zero-wait escape instead of mtime recovery.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -1,0 +1,27 @@
+---
+id: CCYD5S
+slug: explain-test-lock-waits
+type: patch
+phase: done
+status: done
+created: 2026-07-31T04:00:07.559Z
+last_modified: 2026-07-31T05:14:21Z
+---
+
+# Make test-lock waits understandable for maintainers
+
+**Goal:** Show who owns the package-test lock and how long a waiting test run has been queued.
+
+**Why:** A single silent wait notice makes legitimate cross-worktree serialization look like a hung test suite.
+
+## Work Log
+
+- 2026-07-31T05:14:21Z Done: Package-test lock owners now record their
+  checkout root; queued commands report owner PID, checkout, and elapsed wait
+  after one second and every thirty seconds. Focused tests, full Vitest, lint,
+  Gherkin validation, typecheck, formatting, and diff checks passed.
+- 2026-07-31T05:04:26Z GREEN: The lock-runner suite passed 8/8 after adding
+  periodic status and incomplete-owner fallback behavior.
+- 2026-07-31T05:02:55Z RED: Two focused integration scenarios failed because
+  the wrapper emitted neither periodic status nor owner details.
+- 2026-07-31T04:00:07.559Z Started: Created ticket CCYD5S

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -5,7 +5,7 @@ type: patch
 phase: done
 status: done
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-07-31T07:00:00Z
+last_modified: 2026-07-31T08:33:00Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,6 +16,13 @@ last_modified: 2026-07-31T07:00:00Z
 
 ## Work Log
 
+- 2026-07-31T08:33:00Z Review follow-up: Restored zero status interval's
+  backward-compatible default fallback, replaced inverse elapsed-format parsing
+  with deterministic output assertions, and added non-object metadata coverage.
+  Focused runner suite passed 10/10.
+- 2026-07-31T07:30:00Z Review follow-up: Restoring zero interval's existing
+  invalid-value fallback, replacing a rounding-sensitive status assertion, and
+  characterizing non-object owner metadata before closing fresh PR findings.
 - 2026-07-31T07:00:00Z Refactored: Extracted lock creation from the wait loop
   without changing metadata, serialization, stale-lock recovery, or wait-cap
   behavior. Focused runner suite passed 9/9.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -5,7 +5,7 @@ type: patch
 phase: done
 status: done
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-07-31T06:21:12Z
+last_modified: 2026-07-31T07:00:00Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,6 +16,12 @@ last_modified: 2026-07-31T06:21:12Z
 
 ## Work Log
 
+- 2026-07-31T07:00:00Z Refactored: Extracted lock creation from the wait loop
+  without changing metadata, serialization, stale-lock recovery, or wait-cap
+  behavior. Focused runner suite passed 9/9.
+- 2026-07-31T07:00:00Z Refactor scout: Reopened the runner-maintainability
+  follow-up with one leaf-first ledger entry: extract lock creation from the
+  wait loop under the existing integration coverage.
 - 2026-07-31T06:21:12Z Review follow-up: Consolidated owner-file and integer
   environment parsing, rate-limited status intervals to a 50 ms minimum, and
   updated runner tests for human-readable elapsed waits. Focused runner tests

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/ticket.md
@@ -5,7 +5,7 @@ type: patch
 phase: done
 status: done
 created: 2026-07-31T04:00:07.559Z
-last_modified: 2026-07-31T08:33:00Z
+last_modified: 2026-07-31T11:00:00Z
 ---
 
 # Make test-lock waits understandable for maintainers
@@ -16,6 +16,9 @@ last_modified: 2026-07-31T08:33:00Z
 
 ## Work Log
 
+- 2026-07-31T11:00:00Z Review follow-up: Restored the negative maximum-wait
+  fallback, routed non-object owner metadata through mtime stale-lock recovery,
+  and expanded the status proof across every emitted interval.
 - 2026-07-31T08:33:00Z Review follow-up: Restored zero status interval's
   backward-compatible default fallback, replaced inverse elapsed-format parsing
   with deterministic output assertions, and added non-object metadata coverage.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -35,3 +35,10 @@ lock serialization.
 Given a maintainer supplies an invalid or excessively small diagnostic interval
 When a command waits for the package-test lock
 Then the runner uses a safe minimum interval and keeps wait output readable.
+
+#### CCYD5S.SM1.AC5 - Lock coordination stays readable
+
+Given package-test locking needs both lock creation and wait coordination
+When a maintainer reads or changes the runner
+Then lock creation is named separately from the wait loop without changing
+serialization, stale-lock recovery, or diagnostic behavior.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -29,6 +29,8 @@ Given the lock metadata is incomplete, malformed, or changes while my command re
 When the wait status is rendered
 Then the command reports the available details without crashing or weakening
 lock serialization.
+And malformed stale metadata remains eligible for the existing stale-lock
+recovery path.
 
 #### CCYD5S.SM1.AC4 - Diagnostic configuration stays safe
 
@@ -37,6 +39,13 @@ When a command waits for the package-test lock
 Then invalid and zero values use the default interval
 And a small positive value uses the safe minimum interval to keep wait output
 readable.
+
+#### CCYD5S.SM1.AC6 - Maximum-wait configuration remains safe
+
+Given a maintainer supplies a negative maximum-wait value
+When a command encounters a live package-test lock
+Then the runner falls back to the default maximum wait and preserves lock
+serialization.
 
 #### CCYD5S.SM1.AC5 - Lock coordination stays readable
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -25,16 +25,18 @@ thereafter.
 
 #### CCYD5S.SM1.AC3 - Missing owner metadata degrades safely
 
-Given the lock metadata is incomplete or changes while my command reads it
+Given the lock metadata is incomplete, malformed, or changes while my command reads it
 When the wait status is rendered
 Then the command reports the available details without crashing or weakening
 lock serialization.
 
 #### CCYD5S.SM1.AC4 - Diagnostic configuration stays safe
 
-Given a maintainer supplies an invalid or excessively small diagnostic interval
+Given a maintainer supplies an invalid, zero, or excessively small diagnostic interval
 When a command waits for the package-test lock
-Then the runner uses a safe minimum interval and keeps wait output readable.
+Then invalid and zero values use the default interval
+And a small positive value uses the safe minimum interval to keep wait output
+readable.
 
 #### CCYD5S.SM1.AC5 - Lock coordination stays readable
 

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -31,6 +31,8 @@ Then the command reports the available details without crashing or weakening
 lock serialization.
 And malformed stale metadata remains eligible for the existing stale-lock
 recovery path.
+And syntactically valid metadata with neither a usable process ID nor timestamp
+remains eligible for that same recovery path.
 
 #### CCYD5S.SM1.AC4 - Diagnostic configuration stays safe
 
@@ -40,16 +42,16 @@ Then invalid and zero values use the default interval
 And a small positive value uses the safe minimum interval to keep wait output
 readable.
 
-#### CCYD5S.SM1.AC6 - Maximum-wait configuration remains safe
-
-Given a maintainer supplies a negative maximum-wait value
-When a command encounters a live package-test lock
-Then the runner falls back to the default maximum wait and preserves lock
-serialization.
-
 #### CCYD5S.SM1.AC5 - Lock coordination stays readable
 
 Given package-test locking needs both lock creation and wait coordination
 When a maintainer reads or changes the runner
 Then lock creation is named separately from the wait loop without changing
 serialization, stale-lock recovery, or diagnostic behavior.
+
+#### CCYD5S.SM1.AC6 - Maximum-wait configuration remains safe
+
+Given a maintainer supplies a negative or blank maximum-wait value
+When a command encounters a live package-test lock
+Then the runner falls back to the default maximum wait and preserves lock
+serialization.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -29,3 +29,9 @@ Given the lock metadata is incomplete or changes while my command reads it
 When the wait status is rendered
 Then the command reports the available details without crashing or weakening
 lock serialization.
+
+#### CCYD5S.SM1.AC4 - Diagnostic configuration stays safe
+
+Given a maintainer supplies an invalid or excessively small diagnostic interval
+When a command waits for the package-test lock
+Then the runner uses a safe minimum interval and keeps wait output readable.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/user-stories.md
@@ -1,0 +1,31 @@
+# User Stories: Explain test-lock waits
+
+## Story: Understand why a test run is waiting
+
+As a Safeword maintainer,
+I want a queued package-test command to identify the lock owner and report how
+long it has waited,
+so that legitimate cross-worktree serialization does not look like a hung test
+suite.
+
+### Acceptance Criteria
+
+#### CCYD5S.SM1.AC1 - Wait output identifies the active owner
+
+Given another package-test command owns the global lock
+When my command waits for that lock
+Then its status output includes the owner's process ID and checkout root.
+
+#### CCYD5S.SM1.AC2 - A long wait remains visibly active
+
+Given the owner continues running
+When my command remains queued
+Then it reports the elapsed wait after the initial delay and periodically
+thereafter.
+
+#### CCYD5S.SM1.AC3 - Missing owner metadata degrades safely
+
+Given the lock metadata is incomplete or changes while my command reads it
+When the wait status is rendered
+Then the command reports the available details without crashing or weakening
+lock serialization.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
@@ -10,6 +10,9 @@ files in 422.63 seconds.
 **Static Checks:** ✅ ESLint, Gherkin validation, `tsc --noEmit`, Prettier, and
 `git diff --check` passed.
 
+**PR Scope:** ✅ Changes are limited to lock-owner metadata, periodic waiting
+diagnostics, their isolated integration coverage, and CCYD5S planning evidence.
+
 **Behavior Boundary:** ✅ Lock serialization, stale-owner removal, and the
 20-minute maximum wait are unchanged. The patch adds diagnostic metadata and
 status output only.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
@@ -2,21 +2,21 @@
 
 **Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 11/11
 tests, including cross-checkout owner reporting, deterministic periodic status
-intervals, zero and negative configuration fallback, and stale malformed
-metadata recovery.
+intervals, zero, negative, and blank configuration fallback, and stale malformed
+or unidentifiable metadata recovery.
 
 **Full Suite:** ✅ At the later CCYD5S snapshot, `bun run test` passed 5,647
 tests with 5 skips across 377 files in 422.63 seconds, after additional
 lock-runner coverage beyond issue #1698's recorded 5,645-test snapshot.
 
-**Static Checks:** ✅ ESLint, Gherkin validation, `tsc --noEmit`, Prettier, and
-`git diff --check` passed.
+**Static Checks:** ✅ ESLint, Gherkin validation, `tsc --noEmit`, Prettier,
+`git diff --check`, and the 26/26 release catalogue passed.
 
 **PR Scope:** ✅ Changes are limited to lock-owner metadata, periodic waiting
 diagnostics, the lock-creation refactor, their isolated integration coverage,
 and CCYD5S planning evidence.
 
-**Behavior Boundary:** ✅ Lock serialization, stale-owner removal, and the
-20-minute default maximum wait are preserved. Invalid zero/negative boundaries
-now have explicit regression coverage alongside diagnostic metadata and status
-output.
+**Behavior Boundary:** ✅ Lock serialization and the 20-minute default maximum
+wait are preserved. Stale recovery now also handles metadata with no usable
+process ID or timestamp; zero, negative, and blank maximum-wait boundaries have
+explicit regression coverage alongside diagnostic metadata and status output.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
@@ -1,0 +1,15 @@
+# Verification: Explain test-lock waits
+
+**Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 8/8
+tests, including cross-checkout owner reporting, increasing elapsed statuses,
+and incomplete metadata fallback.
+
+**Full Suite:** ✅ `bun run test` passed 5,647 tests with 5 skips across 377
+files in 422.63 seconds.
+
+**Static Checks:** ✅ ESLint, Gherkin validation, `tsc --noEmit`, Prettier, and
+`git diff --check` passed.
+
+**Behavior Boundary:** ✅ Lock serialization, stale-owner removal, and the
+20-minute maximum wait are unchanged. The patch adds diagnostic metadata and
+status output only.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
@@ -1,12 +1,13 @@
 # Verification: Explain test-lock waits
 
-**Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 10/10
-tests, including cross-checkout owner reporting, deterministic early status
-intervals, invalid and zero interval fallback, and incomplete or non-object
-metadata fallback.
+**Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 11/11
+tests, including cross-checkout owner reporting, deterministic periodic status
+intervals, zero and negative configuration fallback, and stale malformed
+metadata recovery.
 
-**Full Suite:** ✅ `bun run test` passed 5,647 tests with 5 skips across 377
-files in 422.63 seconds.
+**Full Suite:** ✅ At the later CCYD5S snapshot, `bun run test` passed 5,647
+tests with 5 skips across 377 files in 422.63 seconds, after additional
+lock-runner coverage beyond issue #1698's recorded 5,645-test snapshot.
 
 **Static Checks:** ✅ ESLint, Gherkin validation, `tsc --noEmit`, Prettier, and
 `git diff --check` passed.
@@ -16,5 +17,6 @@ diagnostics, the lock-creation refactor, their isolated integration coverage,
 and CCYD5S planning evidence.
 
 **Behavior Boundary:** ✅ Lock serialization, stale-owner removal, and the
-20-minute maximum wait are unchanged. The patch adds diagnostic metadata and
-status output only.
+20-minute default maximum wait are preserved. Invalid zero/negative boundaries
+now have explicit regression coverage alongside diagnostic metadata and status
+output.

--- a/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
+++ b/.project/tickets/CCYD5S-explain-test-lock-waits/verify.md
@@ -1,8 +1,9 @@
 # Verification: Explain test-lock waits
 
-**Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 8/8
-tests, including cross-checkout owner reporting, increasing elapsed statuses,
-and incomplete metadata fallback.
+**Focused Proof:** ✅ `bun run test tests/test-runner-lock.test.ts` passed 10/10
+tests, including cross-checkout owner reporting, deterministic early status
+intervals, invalid and zero interval fallback, and incomplete or non-object
+metadata fallback.
 
 **Full Suite:** ✅ `bun run test` passed 5,647 tests with 5 skips across 377
 files in 422.63 seconds.
@@ -11,7 +12,8 @@ files in 422.63 seconds.
 `git diff --check` passed.
 
 **PR Scope:** ✅ Changes are limited to lock-owner metadata, periodic waiting
-diagnostics, their isolated integration coverage, and CCYD5S planning evidence.
+diagnostics, the lock-creation refactor, their isolated integration coverage,
+and CCYD5S planning evidence.
 
 **Behavior Boundary:** ✅ Lock serialization, stale-owner removal, and the
 20-minute maximum wait are unchanged. The patch adds diagnostic metadata and

--- a/packages/cli/codex-plugin/skills/bdd/references/TDD.md
+++ b/packages/cli/codex-plugin/skills/bdd/references/TDD.md
@@ -24,6 +24,32 @@ Degradation is the intended path — no gate blocks on harness absence.
 
 Start with the most constraining test — usually E2E or integration. Prefer the highest scope that covers the behavior with acceptable feedback speed.
 
+### Scenario proof fidelity
+
+The primary proof must preserve the scenario's contract boundary. Declarative
+wording does not require literal keystroke fidelity, but it does require the
+same actor-facing entry point and actor-visible result that the `When` and
+`Then` claim.
+
+- **Setup shortcuts belong in `Given`.** Fixtures, direct state setup, and
+  lower-level helpers may establish context without replaying every prior user
+  action.
+- **Exercise the `When` through the actor-facing entry point.** A direct
+  application-store call or injected lower-level browser event may prove
+  underlying logic, but it does not prove a named UI control, keyboard or
+  operating-system gesture, CLI command, or API request.
+- **Observe the `Then` as the actor-visible result.** Store, editor, or component
+  state is supporting evidence; it does not prove a visible UI result, emitted
+  CLI output, or external API response.
+- **Keep evidence limits explicit.** When the real boundary cannot be automated
+  reliably, use the existing `@manual` or `@live` path and perform and record
+  that check separately. A tag, skip reason, or narrower automated test does
+  not prove the broader scenario by itself.
+
+If a scenario accidentally names incidental UI mechanics rather than product
+behavior, loop back to define-behavior and rewrite it; do not silently reinterpret
+the scenario during implementation.
+
 ### Feature-source executable path
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:

--- a/packages/cli/codex-plugin/skills/tdd-review/SKILL.md
+++ b/packages/cli/codex-plugin/skills/tdd-review/SKILL.md
@@ -34,6 +34,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
+- **Scenario fidelity?** For a BDD scenario, does the primary test exercise the
+  `When` through the actor-facing entry point and observe the `Then` as the
+  actor-visible result? Setup shortcuts belong in `Given`; direct store calls,
+  injected lower-level events, and internal-state assertions are supporting
+  evidence only.
 - **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior, re-run the scenario-gate, and re-enter plan-implementation (update impl-plan.md for the new scenario) before implement. Don't silently append scenarios to a signed-off `test-definitions.md`.
@@ -58,6 +63,9 @@ If issues found: fix before refactoring. If clean: run $safeword:refactor, commi
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
 - **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Scenario fidelity?** Does the completed proof still use the scenario's
+  actor-facing entry point and observe its actor-visible result, with
+  implementation-level checks kept as supporting evidence?
 - **Full suite green?** Run the full suite once here to catch cross-module regressions.
 - **New external dependency or API in this scenario?** Only then run **$safeword:quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -47,14 +47,15 @@ const ownerPath = nodePath.join(lockDirectory, 'owner.json');
 const checkoutRoot = nodePath.resolve(cliRoot, '..', '..');
 const minimumLockStatusIntervalMilliseconds = 50;
 
-function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum) {
+function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
   const raw = process.env[name];
   if (raw === undefined) {
     return fallback;
   }
 
   const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) && parsed >= 0 ? Math.max(parsed, minimum) : fallback;
+  const isValid = Number.isSafeInteger(parsed) && (allowZero || parsed > 0);
+  return isValid ? Math.max(parsed, minimum) : fallback;
 }
 
 const maximumLockWaitMilliseconds = resolveSafeIntegerEnvironmentVariable(
@@ -67,6 +68,7 @@ const lockStatusIntervalMilliseconds = resolveSafeIntegerEnvironmentVariable(
   'SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS',
   defaultLockStatusIntervalMilliseconds,
   minimumLockStatusIntervalMilliseconds,
+  false,
 );
 
 function sleep(milliseconds) {

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -49,7 +49,7 @@ const minimumLockStatusIntervalMilliseconds = 50;
 
 function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
   const raw = process.env[name];
-  if (raw === undefined) {
+  if (raw === undefined || raw.trim() === '') {
     return fallback;
   }
 
@@ -84,12 +84,22 @@ function isProcessAlive(pid) {
   }
 }
 
+function isUsableOwnerPid(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function hasUsableOwnerTimestamp(value) {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
 function readOwner() {
   try {
     const parsed = JSON.parse(readFileSync(ownerPath, 'utf8'));
-    const readable = typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed);
+    const owner =
+      typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : {};
+    const readable = isUsableOwnerPid(owner.pid) || hasUsableOwnerTimestamp(owner.createdAt);
     return {
-      owner: readable ? parsed : {},
+      owner,
       readable,
     };
   } catch {
@@ -108,13 +118,15 @@ function removeStaleLock() {
     return false;
   }
 
-  if (typeof owner.pid === 'number' && !isProcessAlive(owner.pid)) {
+  if (isUsableOwnerPid(owner.pid) && !isProcessAlive(owner.pid)) {
     rmSync(lockDirectory, { force: true, recursive: true });
     return true;
   }
 
-  const createdAt = Date.parse(owner.createdAt);
-  if (Number.isFinite(createdAt) && Date.now() - createdAt > 6 * 60 * 60 * 1000) {
+  if (
+    hasUsableOwnerTimestamp(owner.createdAt) &&
+    Date.now() - Date.parse(owner.createdAt) > 6 * 60 * 60 * 1000
+  ) {
     rmSync(lockDirectory, { force: true, recursive: true });
     return true;
   }
@@ -138,8 +150,7 @@ function reportLockWait(waitedMilliseconds) {
   // this diagnostic read. Waiting remains correct even without metadata.
   const { owner } = readOwner();
 
-  const ownerPid =
-    typeof owner.pid === 'number' ? `owner PID ${owner.pid}` : 'owner PID unavailable';
+  const ownerPid = isUsableOwnerPid(owner.pid) ? `owner PID ${owner.pid}` : 'owner PID unavailable';
   const ownerCheckout =
     typeof owner.checkoutRoot === 'string' && owner.checkoutRoot !== ''
       ? `checkout ${owner.checkoutRoot}`

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -38,10 +38,13 @@ const childEnvironment = {
 const lockParent = nodePath.join(tmpdir(), 'safeword-test-locks');
 const lockName = 'safeword-package-test';
 const defaultMaximumLockWaitMilliseconds = 20 * 60 * 1000;
+const defaultLockStatusIntervalMilliseconds = 30_000;
+const initialLockStatusDelayMilliseconds = 1000;
 const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
   ? nodePath.resolve(process.env.SAFEWORD_TEST_LOCK_DIR)
   : nodePath.join(lockParent, `${lockName}.lock`);
 const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+const checkoutRoot = nodePath.resolve(cliRoot, '..', '..');
 
 function resolveMaximumLockWaitMilliseconds() {
   const raw = process.env.SAFEWORD_TEST_LOCK_MAX_WAIT_MS;
@@ -54,6 +57,20 @@ function resolveMaximumLockWaitMilliseconds() {
 }
 
 const maximumLockWaitMilliseconds = resolveMaximumLockWaitMilliseconds();
+
+function resolveLockStatusIntervalMilliseconds() {
+  const raw = process.env.SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS;
+  if (raw === undefined) {
+    return defaultLockStatusIntervalMilliseconds;
+  }
+
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : defaultLockStatusIntervalMilliseconds;
+}
+
+const lockStatusIntervalMilliseconds = resolveLockStatusIntervalMilliseconds();
 
 function sleep(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -95,11 +112,45 @@ function removeStaleLock() {
   return false;
 }
 
+function formatElapsedWait(milliseconds) {
+  if (milliseconds < 1000) {
+    return `${milliseconds}ms`;
+  }
+
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes === 0 ? `${seconds}s` : `${minutes}m ${seconds}s`;
+}
+
+function reportLockWait(waitedMilliseconds) {
+  let owner = {};
+  try {
+    owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
+  } catch {
+    // The owner may release or replace the lock between our EEXIST check and
+    // this diagnostic read. Waiting remains correct even without metadata.
+  }
+
+  const ownerPid =
+    typeof owner.pid === 'number' ? `owner PID ${owner.pid}` : 'owner PID unavailable';
+  const ownerCheckout =
+    typeof owner.checkoutRoot === 'string' && owner.checkoutRoot !== ''
+      ? `checkout ${owner.checkoutRoot}`
+      : 'checkout unavailable';
+  console.error(
+    `Waiting for safeword package test lock (${formatElapsedWait(waitedMilliseconds)} elapsed; ${ownerPid}; ${ownerCheckout}).`,
+  );
+}
+
 function acquireLock() {
   mkdirSync(nodePath.dirname(lockDirectory), { recursive: true });
 
   let waitedMilliseconds = 0;
-  let showedWaitNotice = false;
+  let nextStatusAtMilliseconds = Math.min(
+    initialLockStatusDelayMilliseconds,
+    lockStatusIntervalMilliseconds,
+  );
   for (;;) {
     let mkdirError;
     try {
@@ -109,6 +160,7 @@ function acquireLock() {
         `${JSON.stringify(
           {
             createdAt: new Date().toISOString(),
+            checkoutRoot,
             pid: process.pid,
           },
           undefined,
@@ -135,12 +187,18 @@ function acquireLock() {
       return false;
     }
 
-    if (!showedWaitNotice && waitedMilliseconds >= 1000) {
-      console.error('Waiting for another safeword package test run to finish...');
-      showedWaitNotice = true;
+    if (waitedMilliseconds >= nextStatusAtMilliseconds) {
+      reportLockWait(waitedMilliseconds);
+      do {
+        nextStatusAtMilliseconds += lockStatusIntervalMilliseconds;
+      } while (nextStatusAtMilliseconds <= waitedMilliseconds);
     }
 
-    const nextSleepMilliseconds = Math.min(250, maximumLockWaitMilliseconds - waitedMilliseconds);
+    const nextSleepMilliseconds = Math.min(
+      250,
+      maximumLockWaitMilliseconds - waitedMilliseconds,
+      nextStatusAtMilliseconds - waitedMilliseconds,
+    );
     sleep(nextSleepMilliseconds);
     waitedMilliseconds += nextSleepMilliseconds;
   }

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -146,6 +146,22 @@ function reportLockWait(waitedMilliseconds) {
   );
 }
 
+function createLock() {
+  mkdirSync(lockDirectory);
+  writeFileSync(
+    ownerPath,
+    `${JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        checkoutRoot,
+        pid: process.pid,
+      },
+      undefined,
+      2,
+    )}\n`,
+  );
+}
+
 function acquireLock() {
   mkdirSync(nodePath.dirname(lockDirectory), { recursive: true });
 
@@ -157,19 +173,7 @@ function acquireLock() {
   for (;;) {
     let mkdirError;
     try {
-      mkdirSync(lockDirectory);
-      writeFileSync(
-        ownerPath,
-        `${JSON.stringify(
-          {
-            createdAt: new Date().toISOString(),
-            checkoutRoot,
-            pid: process.pid,
-          },
-          undefined,
-          2,
-        )}\n`,
-      );
+      createLock();
       return true;
     } catch (error) {
       mkdirError = error;

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -54,7 +54,7 @@ function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZer
   }
 
   const parsed = Number(raw);
-  const isValid = Number.isSafeInteger(parsed) && (allowZero || parsed > 0);
+  const isValid = Number.isSafeInteger(parsed) && (allowZero ? parsed >= 0 : parsed > 0);
   return isValid ? Math.max(parsed, minimum) : fallback;
 }
 
@@ -87,9 +87,10 @@ function isProcessAlive(pid) {
 function readOwner() {
   try {
     const parsed = JSON.parse(readFileSync(ownerPath, 'utf8'));
+    const readable = typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed);
     return {
-      owner: typeof parsed === 'object' && parsed !== null ? parsed : {},
-      readable: true,
+      owner: readable ? parsed : {},
+      readable,
     };
   } catch {
     return { owner: {}, readable: false };

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -45,32 +45,29 @@ const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
   : nodePath.join(lockParent, `${lockName}.lock`);
 const ownerPath = nodePath.join(lockDirectory, 'owner.json');
 const checkoutRoot = nodePath.resolve(cliRoot, '..', '..');
+const minimumLockStatusIntervalMilliseconds = 50;
 
-function resolveMaximumLockWaitMilliseconds() {
-  const raw = process.env.SAFEWORD_TEST_LOCK_MAX_WAIT_MS;
+function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum) {
+  const raw = process.env[name];
   if (raw === undefined) {
-    return defaultMaximumLockWaitMilliseconds;
+    return fallback;
   }
 
   const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : defaultMaximumLockWaitMilliseconds;
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? Math.max(parsed, minimum) : fallback;
 }
 
-const maximumLockWaitMilliseconds = resolveMaximumLockWaitMilliseconds();
+const maximumLockWaitMilliseconds = resolveSafeIntegerEnvironmentVariable(
+  'SAFEWORD_TEST_LOCK_MAX_WAIT_MS',
+  defaultMaximumLockWaitMilliseconds,
+  0,
+);
 
-function resolveLockStatusIntervalMilliseconds() {
-  const raw = process.env.SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS;
-  if (raw === undefined) {
-    return defaultLockStatusIntervalMilliseconds;
-  }
-
-  const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) && parsed > 0
-    ? parsed
-    : defaultLockStatusIntervalMilliseconds;
-}
-
-const lockStatusIntervalMilliseconds = resolveLockStatusIntervalMilliseconds();
+const lockStatusIntervalMilliseconds = resolveSafeIntegerEnvironmentVariable(
+  'SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS',
+  defaultLockStatusIntervalMilliseconds,
+  minimumLockStatusIntervalMilliseconds,
+);
 
 function sleep(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -85,11 +82,21 @@ function isProcessAlive(pid) {
   }
 }
 
-function removeStaleLock() {
-  let owner;
+function readOwner() {
   try {
-    owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
+    const parsed = JSON.parse(readFileSync(ownerPath, 'utf8'));
+    return {
+      owner: typeof parsed === 'object' && parsed !== null ? parsed : {},
+      readable: true,
+    };
   } catch {
+    return { owner: {}, readable: false };
+  }
+}
+
+function removeStaleLock() {
+  const { owner, readable } = readOwner();
+  if (!readable) {
     const lockAgeMilliseconds = Date.now() - statSync(lockDirectory).mtimeMs;
     if (lockAgeMilliseconds > 30_000) {
       rmSync(lockDirectory, { force: true, recursive: true });
@@ -124,13 +131,9 @@ function formatElapsedWait(milliseconds) {
 }
 
 function reportLockWait(waitedMilliseconds) {
-  let owner = {};
-  try {
-    owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
-  } catch {
-    // The owner may release or replace the lock between our EEXIST check and
-    // this diagnostic read. Waiting remains correct even without metadata.
-  }
+  // The owner may release or replace the lock between our EEXIST check and
+  // this diagnostic read. Waiting remains correct even without metadata.
+  const { owner } = readOwner();
 
   const ownerPid =
     typeof owner.pid === 'number' ? `owner PID ${owner.pid}` : 'owner PID unavailable';
@@ -182,16 +185,14 @@ function acquireLock() {
 
     if (waitedMilliseconds >= maximumLockWaitMilliseconds) {
       console.error(
-        `Proceeding without safeword package test lock after waiting ${maximumLockWaitMilliseconds}ms.`,
+        `Proceeding without safeword package test lock after waiting ${formatElapsedWait(maximumLockWaitMilliseconds)}.`,
       );
       return false;
     }
 
     if (waitedMilliseconds >= nextStatusAtMilliseconds) {
       reportLockWait(waitedMilliseconds);
-      do {
-        nextStatusAtMilliseconds += lockStatusIntervalMilliseconds;
-      } while (nextStatusAtMilliseconds <= waitedMilliseconds);
+      nextStatusAtMilliseconds += lockStatusIntervalMilliseconds;
     }
 
     const nextSleepMilliseconds = Math.min(

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -24,6 +24,32 @@ Degradation is the intended path — no gate blocks on harness absence.
 
 Start with the most constraining test — usually E2E or integration. Prefer the highest scope that covers the behavior with acceptable feedback speed.
 
+### Scenario proof fidelity
+
+The primary proof must preserve the scenario's contract boundary. Declarative
+wording does not require literal keystroke fidelity, but it does require the
+same actor-facing entry point and actor-visible result that the `When` and
+`Then` claim.
+
+- **Setup shortcuts belong in `Given`.** Fixtures, direct state setup, and
+  lower-level helpers may establish context without replaying every prior user
+  action.
+- **Exercise the `When` through the actor-facing entry point.** A direct
+  application-store call or injected lower-level browser event may prove
+  underlying logic, but it does not prove a named UI control, keyboard or
+  operating-system gesture, CLI command, or API request.
+- **Observe the `Then` as the actor-visible result.** Store, editor, or component
+  state is supporting evidence; it does not prove a visible UI result, emitted
+  CLI output, or external API response.
+- **Keep evidence limits explicit.** When the real boundary cannot be automated
+  reliably, use the existing `@manual` or `@live` path and perform and record
+  that check separately. A tag, skip reason, or narrower automated test does
+  not prove the broader scenario by itself.
+
+If a scenario accidentally names incidental UI mechanics rather than product
+behavior, loop back to define-behavior and rewrite it; do not silently reinterpret
+the scenario during implementation.
+
 ### Feature-source executable path
 
 When the scenario source is a `.feature` file and the Cucumber lane exists, RED starts by making that scenario executable through Cucumber step definitions:

--- a/packages/cli/templates/skills/tdd-review/SKILL.md
+++ b/packages/cli/templates/skills/tdd-review/SKILL.md
@@ -33,6 +33,11 @@ Focused review (~1 minute). Check the test that was just written:
 - **Atomic?** Tests ONE behavior. Red flag: multiple When/Then pairs.
 - **Right assertions?** Meaningful expectations, not `.toBeTruthy()` or `.not.toThrow()`.
 - **Behavior, not implementation?** Tests observable outcomes. Red flag: mocking internals, checking call counts.
+- **Scenario fidelity?** For a BDD scenario, does the primary test exercise the
+  `When` through the actor-facing entry point and observe the `Then` as the
+  actor-visible result? Setup shortcuts belong in `Given`; direct store calls,
+  injected lower-level events, and internal-state assertions are supporting
+  evidence only.
 - **Fails for the right reason — confirmed by the run, not the eye?** Execute the test now and read the actual failure: it must report the _missing behavior_, not a syntax, import, or setup error. This is the one bullet you don't judge by reading — the run is the evidence.
 - **Right test type?** Load the testing skill and consult its scope hierarchy (E2E > Integration > Unit). Was a higher-scope test practical here? Did we drop to unit when integration would catch more?
 - **Coverage adequacy?** Consult testing guide's bug detection matrix. Ask: "What could still break that this test wouldn't catch?" Flag gaps — missing edge cases, error paths, or boundary values. **Where a gap goes:** a missing scenario is a scope change, not a mid-implement edit — defer it to a follow-up ticket, or loop back to define-behavior, re-run the scenario-gate, and re-enter plan-implementation (update impl-plan.md for the new scenario) before implement. Don't silently append scenarios to a signed-off `test-definitions.md`.
@@ -57,6 +62,9 @@ If issues found: fix before refactoring. If clean: run /refactor, commit, procee
 Full review (~2-3 minutes). The entire scenario is done. Review the complete unit:
 
 - **Test + implementation alignment?** Does the test cover the scenario's Given/When/Then? This is a **local** review — no web research needed.
+- **Scenario fidelity?** Does the completed proof still use the scenario's
+  actor-facing entry point and observe its actor-visible result, with
+  implementation-level checks kept as supporting evidence?
 - **Full suite green?** Run the full suite once here to catch cross-module regressions.
 - **New external dependency or API in this scenario?** Only then run **/quality-review** for ecosystem verification (versions, deprecated APIs, security) — verify it at the moment you introduce it, before later scenarios build on it. A scenario that adds no new third-party/external surface (internal modules, stdlib, or a second use of an already-reviewed dep don't count) skips this; the whole-ticket pass at implement-exit is the catch-all.
 - **Ready for next scenario?** Any loose ends or technical debt to note?

--- a/packages/cli/tests/hooks/scenario-proof-fidelity-documentation.test.ts
+++ b/packages/cli/tests/hooks/scenario-proof-fidelity-documentation.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
+
+const bddTddCopies = [
+  nodePath.join(repoRoot, 'packages/cli/templates/skills/bdd/TDD.md'),
+  nodePath.join(repoRoot, '.claude/skills/bdd/TDD.md'),
+];
+
+const tddReviewCopies = [
+  nodePath.join(repoRoot, 'packages/cli/templates/skills/tdd-review/SKILL.md'),
+  nodePath.join(repoRoot, '.claude/skills/tdd-review/SKILL.md'),
+];
+
+function expectSectionBetween(content: string, start: string, end: string): string {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+
+  expect(startIndex, `missing section ${start}`).toBeGreaterThanOrEqual(0);
+  expect(endIndex, `missing section ${end}`).toBeGreaterThan(startIndex);
+
+  return content.slice(startIndex, endIndex);
+}
+
+describe('scenario proof fidelity documentation (issue #1698)', () => {
+  it.each(bddTddCopies)('%s preserves the scenario action boundary', path => {
+    const content = readFileSync(path, 'utf8');
+
+    expect(content).toContain('Scenario proof fidelity');
+    expect(content).toContain('actor-facing entry point');
+    expect(content).toMatch(/direct\s+application-store call/);
+    expect(content).toContain('injected lower-level browser event');
+  });
+
+  it.each(bddTddCopies)('%s preserves the scenario result boundary', path => {
+    const content = readFileSync(path, 'utf8');
+
+    expect(content).toContain('actor-visible result');
+    expect(content).toMatch(/Store, editor, or component\s+state is supporting evidence/);
+  });
+
+  it.each(bddTddCopies)('%s keeps setup and lower-level checks proportionate', path => {
+    const content = readFileSync(path, 'utf8');
+
+    expect(content).toContain('Setup shortcuts belong in `Given`');
+    expect(content).toContain('supporting evidence');
+  });
+
+  it.each(bddTddCopies)('%s reports unavailable automation without overclaiming', path => {
+    const content = readFileSync(path, 'utf8');
+
+    expect(content).toContain('does not prove');
+    expect(content).toContain('@manual');
+    expect(content).toContain('@live');
+  });
+
+  it.each(tddReviewCopies)('%s checks scenario fidelity at RED and REFACTOR', path => {
+    const content = readFileSync(path, 'utf8');
+    const redReview = expectSectionBetween(content, '## After RED', '## After GREEN');
+    const refactorReview = expectSectionBetween(
+      content,
+      '## After REFACTOR',
+      '### Concrete example',
+    );
+
+    for (const review of [redReview, refactorReview]) {
+      expect(review).toContain('Scenario fidelity?');
+      expect(review).toContain('actor-facing entry point');
+      expect(review).toContain('actor-visible result');
+    }
+  });
+});

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -113,9 +113,10 @@ function expectSerializedByRunner(events: string[]) {
     const parentEvents = events.filter(event => event.includes(`:${parentId}`));
     expect(parentEvents[0]).toBe(`build:start:${parentId}`);
     expect(parentEvents[1]).toBe(`build:end:${parentId}`);
-    const vitestStartEvent = parentEvents[2] ?? '';
-    expect(vitestStartEvent.startsWith(`vitest:start:${parentId}:run,tests/`)).toBe(true);
-    expect(vitestStartEvent.endsWith('.test.ts')).toBe(true);
+    expect([
+      `vitest:start:${parentId}:run,tests/first.test.ts`,
+      `vitest:start:${parentId}:run,tests/second.test.ts`,
+    ]).toContain(parentEvents[2]);
     expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
   }
 
@@ -188,29 +189,31 @@ describe('package test runner lock (379)', () => {
     expectSerializedByRunner(readEvents(logPath));
   });
 
-  it('uses the default maximum wait when configured with a negative value', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
-    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    const ownerPath = nodePath.join(lockDirectory, 'owner.json');
-    const env = {
-      ...process.env,
-      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
-      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-    };
+  it('uses the default maximum wait when configured with a negative or blank value', async () => {
+    for (const maximumWait of ['-5', '', ' '.repeat(3)]) {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+      const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+      const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+      const env = {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      };
 
-    const ownerRun = runNodeScript(runnerPath, ['tests/owner.test.ts'], env);
-    await waitForPath(ownerPath);
-    const waiterRun = runNodeScript(runnerPath, ['tests/waiter.test.ts'], {
-      ...env,
-      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '-5',
-    });
-    const [ownerResult, waiterResult] = await Promise.all([ownerRun, waiterRun]);
+      const ownerRun = runNodeScript(runnerPath, ['tests/first.test.ts'], env);
+      await waitForPath(ownerPath);
+      const waiterRun = runNodeScript(runnerPath, ['tests/second.test.ts'], {
+        ...env,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: maximumWait,
+      });
+      const [ownerResult, waiterResult] = await Promise.all([ownerRun, waiterRun]);
 
-    expectSuccessfulSerializedRun(ownerResult);
-    expectSuccessfulSerializedRun(waiterResult);
-    expect(waiterResult.stderr).not.toContain('Proceeding without safeword package test lock');
-    expectSerializedByRunner(readEvents(logPath));
+      expectSuccessfulSerializedRun(ownerResult);
+      expectSuccessfulSerializedRun(waiterResult);
+      expect(waiterResult.stderr).not.toContain('Proceeding without safeword package test lock');
+      expectSerializedByRunner(readEvents(logPath));
+    }
   });
 
   it('reports the complete bounded periodic status sequence for the owning checkout', async () => {
@@ -252,50 +255,57 @@ describe('package test runner lock (379)', () => {
     );
   });
 
-  it('reports available fields when owner metadata is incomplete', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
-    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await seedOwnerFile(lockDirectory, { createdAt: new Date().toISOString(), pid: process.pid });
+  it('reports available fields when incomplete owner metadata has a usable staleness signal', async () => {
+    for (const [owner, expectedOwnerDetail] of [
+      [{ pid: process.pid }, `owner PID ${process.pid}`],
+      [{ createdAt: new Date().toISOString() }, 'owner PID unavailable'],
+    ]) {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+      const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+      await seedOwnerFile(lockDirectory, owner);
 
-    const result = await runNodeScript(runnerPath, ['tests/incomplete-owner.test.ts'], {
-      ...process.env,
-      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
-      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '220',
-      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '100',
-    });
+      const result = await runNodeScript(runnerPath, ['tests/incomplete-owner.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '220',
+        SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '100',
+      });
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).toContain(`owner PID ${process.pid}`);
-    expect(result.stderr).toContain('checkout unavailable');
-    expect(result.stderr).toContain(
-      'Proceeding without safeword package test lock after waiting 220ms.',
-    );
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain(expectedOwnerDetail);
+      expect(result.stderr).toContain('checkout unavailable');
+      expect(result.stderr).toContain(
+        'Proceeding without safeword package test lock after waiting 220ms.',
+      );
+    }
   });
 
-  it('reaps a stale lock when owner metadata is not an object', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
-    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await seedOwnerFile(lockDirectory, 'not owner metadata');
-    const staleTime = new Date(Date.now() - 31_000);
-    utimesSync(lockDirectory, staleTime, staleTime);
+  it('reaps stale locks when owner metadata is unusable or expired', async () => {
+    for (const owner of ['not owner metadata', {}, { createdAt: new Date(0).toISOString() }]) {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+      const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+      await seedOwnerFile(lockDirectory, owner);
+      const staleTime = new Date(Date.now() - 31_000);
+      utimesSync(lockDirectory, staleTime, staleTime);
 
-    const result = await runNodeScript(runnerPath, ['tests/non-object-owner.test.ts'], {
-      ...process.env,
-      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
-      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
-    });
+      const result = await runNodeScript(runnerPath, ['tests/non-object-owner.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+      });
 
-    expect(result).toMatchObject({ status: 0, stderr: '' });
-    expect(readEvents(logPath)).toEqual([
-      expect.stringMatching(/^build:start:/),
-      expect.stringMatching(/^build:end:/),
-      expect.stringMatching(/^vitest:start:.*:run,tests\/non-object-owner\.test\.ts$/),
-      expect.stringMatching(/^vitest:end:/),
-    ]);
+      expect(result).toMatchObject({ status: 0, stderr: '' });
+      expect(readEvents(logPath)).toEqual([
+        expect.stringMatching(/^build:start:/),
+        expect.stringMatching(/^build:end:/),
+        expect.stringMatching(/^vitest:start:.*:run,tests\/non-object-owner\.test\.ts$/),
+        expect.stringMatching(/^vitest:end:/),
+      ]);
+    }
   });
 
   it('clamps unsafe status intervals and ignores malformed settings', async () => {

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -120,9 +120,33 @@ function expectSerializedByRunner(events: string[]) {
 
 function expectSuccessfulSerializedRun(result: { stderr: string; status: number | null }) {
   expect(result.status).toBe(0);
-  expect(['', 'Waiting for another safeword package test run to finish...\n']).toContain(
-    result.stderr,
+  expect(
+    result.stderr === '' || result.stderr.startsWith('Waiting for safeword package test lock'),
+  ).toBe(true);
+}
+
+function parseElapsedWaitMilliseconds(line: string): number {
+  const start = line.indexOf('(');
+  const end = line.indexOf(' elapsed;', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  const elapsed = line.slice(start + 1, end);
+
+  if (elapsed.endsWith('ms')) {
+    return Number(elapsed.slice(0, -'ms'.length));
+  }
+
+  const minuteSeparator = elapsed.indexOf('m ');
+  const minutes = minuteSeparator === -1 ? 0 : Number(elapsed.slice(0, minuteSeparator));
+  const seconds = Number(
+    elapsed.slice(minuteSeparator === -1 ? 0 : minuteSeparator + 2, -'s'.length),
   );
+  return (minutes * 60 + seconds) * 1000;
+}
+
+async function seedOwnerFile(lockDirectory: string, owner: Record<string, unknown>) {
+  await mkdir(lockDirectory, { recursive: true });
+  writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(owner)}\n`);
 }
 
 describe('package test runner lock (379)', () => {
@@ -203,11 +227,7 @@ describe('package test runner lock (379)', () => {
     expect(waitStatuses[0]).toContain(`owner PID ${owner.pid}`);
     expect(owner.checkoutRoot).toMatch(/checkout-a$/);
     expect(waitStatuses[0]).toContain(`checkout ${owner.checkoutRoot}`);
-    const elapsedMilliseconds = waitStatuses.map(line => {
-      const match = /\((\d+)ms elapsed;/.exec(line);
-      expect(match).not.toBeNull();
-      return Number(match?.[1]);
-    });
+    const elapsedMilliseconds = waitStatuses.map(parseElapsedWaitMilliseconds);
     expect(elapsedMilliseconds).toEqual(
       elapsedMilliseconds.toSorted((left, right) => left - right),
     );
@@ -218,11 +238,7 @@ describe('package test runner lock (379)', () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await mkdir(lockDirectory, { recursive: true });
-    writeFileSync(
-      nodePath.join(lockDirectory, 'owner.json'),
-      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
-    );
+    await seedOwnerFile(lockDirectory, { createdAt: new Date().toISOString(), pid: process.pid });
 
     const result = await runNodeScript(runnerPath, ['tests/incomplete-owner.test.ts'], {
       ...process.env,
@@ -240,15 +256,52 @@ describe('package test runner lock (379)', () => {
     );
   });
 
+  it('clamps unsafe status intervals and ignores malformed settings', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    const owner = { createdAt: new Date().toISOString(), pid: process.pid };
+
+    await seedOwnerFile(lockDirectory, owner);
+    const unsafeInterval = await runNodeScript(runnerPath, ['tests/unsafe-interval.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '120',
+      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '1',
+    });
+
+    const unsafeStatuses = unsafeInterval.stderr
+      .split('\n')
+      .filter(line => line.startsWith('Waiting for safeword package test lock'));
+    expect(unsafeInterval.status).toBe(0);
+    expect(unsafeStatuses).toHaveLength(2);
+
+    await seedOwnerFile(lockDirectory, owner);
+    const malformedInterval = await runNodeScript(
+      runnerPath,
+      ['tests/malformed-interval.test.ts'],
+      {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '120',
+        SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: 'not-a-number',
+      },
+    );
+
+    expect(malformedInterval.status).toBe(0);
+    expect(malformedInterval.stderr).not.toContain('Waiting for safeword package test lock');
+  });
+
   it('reaps dead-owner stale locks before acquiring', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await mkdir(lockDirectory, { recursive: true });
-    writeFileSync(
-      nodePath.join(lockDirectory, 'owner.json'),
-      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: 2_147_483_647 })}\n`,
-    );
+    await seedOwnerFile(lockDirectory, {
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+    });
 
     const result = await runNodeScript(runnerPath, ['tests/stale.test.ts'], {
       ...process.env,
@@ -319,11 +372,7 @@ describe('package test runner lock (379)', () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await mkdir(lockDirectory, { recursive: true });
-    writeFileSync(
-      nodePath.join(lockDirectory, 'owner.json'),
-      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
-    );
+    await seedOwnerFile(lockDirectory, { createdAt: new Date().toISOString(), pid: process.pid });
 
     const result = await runNodeScript(runnerPath, ['tests/wait-cap.test.ts'], {
       ...process.env,

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { copyFileSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -47,7 +47,7 @@ async function runNodeScript(scriptPath: string, args: string[], env: NodeJS.Pro
   });
 }
 
-async function createFakeTestBinaries(temporaryDirectory: string) {
+async function createFakeTestBinaries(temporaryDirectory: string, delayMilliseconds = 120) {
   const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
   await mkdir(binaryDirectory, { recursive: true });
   const logPath = nodePath.join(temporaryDirectory, 'events.log');
@@ -59,7 +59,7 @@ import { appendFileSync } from 'node:fs';
 const log = ${JSON.stringify(logPath)};
 const parent = process.ppid;
 appendFileSync(log, \`build:start:\${parent}\\n\`);
-await new Promise(resolve => setTimeout(resolve, 120));
+await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`build:end:\${parent}\\n\`);
 `,
     { mode: 0o755 },
@@ -72,7 +72,7 @@ import { appendFileSync } from 'node:fs';
 const log = ${JSON.stringify(logPath)};
 const parent = process.ppid;
 appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')}\\n\`);
-await new Promise(resolve => setTimeout(resolve, 120));
+await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`vitest:end:\${parent}\\n\`);
 `,
     { mode: 0o755 },
@@ -92,6 +92,10 @@ async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
 
 function readEvents(logPath: string): string[] {
   return readFileSync(logPath, 'utf8').trim().split('\n');
+}
+
+async function waitForPath(path: string): Promise<void> {
+  await expect.poll(() => existsSync(path), { interval: 5, timeout: 2000 }).toBe(true);
 }
 
 function expectSerializedByRunner(events: string[]) {
@@ -165,6 +169,75 @@ describe('package test runner lock (379)', () => {
     expectSuccessfulSerializedRun(first);
     expectSuccessfulSerializedRun(second);
     expectSerializedByRunner(readEvents(logPath));
+  });
+
+  it('reports the owning checkout and increasing elapsed wait periodically', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory, 250);
+    const firstRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-a');
+    const secondRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-b');
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+    const env = {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '50',
+    };
+
+    const ownerRun = runNodeScript(firstRunner, ['tests/first.test.ts'], env);
+    await waitForPath(ownerPath);
+    const owner = JSON.parse(readFileSync(ownerPath, 'utf8')) as {
+      checkoutRoot: string;
+      pid: number;
+    };
+    const waiterRun = runNodeScript(secondRunner, ['tests/second.test.ts'], env);
+    const [ownerResult, waiterResult] = await Promise.all([ownerRun, waiterRun]);
+
+    expect(ownerResult.status).toBe(0);
+    expect(waiterResult.status).toBe(0);
+    const waitStatuses = waiterResult.stderr
+      .split('\n')
+      .filter(line => line.startsWith('Waiting for safeword package test lock'));
+    expect(waitStatuses.length).toBeGreaterThan(1);
+    expect(waitStatuses[0]).toContain(`owner PID ${owner.pid}`);
+    expect(owner.checkoutRoot).toMatch(/checkout-a$/);
+    expect(waitStatuses[0]).toContain(`checkout ${owner.checkoutRoot}`);
+    const elapsedMilliseconds = waitStatuses.map(line => {
+      const match = /\((\d+)ms elapsed;/.exec(line);
+      expect(match).not.toBeNull();
+      return Number(match?.[1]);
+    });
+    expect(elapsedMilliseconds).toEqual(
+      elapsedMilliseconds.toSorted((left, right) => left - right),
+    );
+    expect(new Set(elapsedMilliseconds).size).toBe(elapsedMilliseconds.length);
+  });
+
+  it('reports available fields when owner metadata is incomplete', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await mkdir(lockDirectory, { recursive: true });
+    writeFileSync(
+      nodePath.join(lockDirectory, 'owner.json'),
+      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+    );
+
+    const result = await runNodeScript(runnerPath, ['tests/incomplete-owner.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '220',
+      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '100',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(`owner PID ${process.pid}`);
+    expect(result.stderr).toContain('checkout unavailable');
+    expect(result.stderr).toContain(
+      'Proceeding without safeword package test lock after waiting 220ms.',
+    );
   });
 
   it('reaps dead-owner stale locks before acquiring', async () => {

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -1,5 +1,12 @@
 import { spawn } from 'node:child_process';
-import { copyFileSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -106,10 +113,9 @@ function expectSerializedByRunner(events: string[]) {
     const parentEvents = events.filter(event => event.includes(`:${parentId}`));
     expect(parentEvents[0]).toBe(`build:start:${parentId}`);
     expect(parentEvents[1]).toBe(`build:end:${parentId}`);
-    expect([
-      `vitest:start:${parentId}:run,tests/first.test.ts`,
-      `vitest:start:${parentId}:run,tests/second.test.ts`,
-    ]).toContain(parentEvents[2]);
+    const vitestStartEvent = parentEvents[2] ?? '';
+    expect(vitestStartEvent.startsWith(`vitest:start:${parentId}:run,tests/`)).toBe(true);
+    expect(vitestStartEvent.endsWith('.test.ts')).toBe(true);
     expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
   }
 
@@ -182,9 +188,34 @@ describe('package test runner lock (379)', () => {
     expectSerializedByRunner(readEvents(logPath));
   });
 
-  it('reports the owning checkout and increasing elapsed wait periodically', async () => {
+  it('uses the default maximum wait when configured with a negative value', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory, 250);
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    const ownerPath = nodePath.join(lockDirectory, 'owner.json');
+    const env = {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    };
+
+    const ownerRun = runNodeScript(runnerPath, ['tests/owner.test.ts'], env);
+    await waitForPath(ownerPath);
+    const waiterRun = runNodeScript(runnerPath, ['tests/waiter.test.ts'], {
+      ...env,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '-5',
+    });
+    const [ownerResult, waiterResult] = await Promise.all([ownerRun, waiterRun]);
+
+    expectSuccessfulSerializedRun(ownerResult);
+    expectSuccessfulSerializedRun(waiterResult);
+    expect(waiterResult.stderr).not.toContain('Proceeding without safeword package test lock');
+    expectSerializedByRunner(readEvents(logPath));
+  });
+
+  it('reports the complete bounded periodic status sequence for the owning checkout', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory, 500);
     const firstRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-a');
     const secondRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-b');
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
@@ -193,6 +224,7 @@ describe('package test runner lock (379)', () => {
       ...process.env,
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
       SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '250',
       SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '50',
     };
 
@@ -208,12 +240,16 @@ describe('package test runner lock (379)', () => {
     expect(ownerResult.status).toBe(0);
     expect(waiterResult.status).toBe(0);
     const waitStatuses = waitStatusLines(waiterResult.stderr);
-    expect(waitStatuses.length).toBeGreaterThan(1);
     expect(owner.checkoutRoot).toMatch(/checkout-a$/);
-    expect(waitStatuses.slice(0, 2)).toEqual([
+    expect(waitStatuses).toEqual([
       `Waiting for safeword package test lock (50ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
       `Waiting for safeword package test lock (100ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
+      `Waiting for safeword package test lock (150ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
+      `Waiting for safeword package test lock (200ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
     ]);
+    expect(waiterResult.stderr).toContain(
+      'Proceeding without safeword package test lock after waiting 250ms.',
+    );
   });
 
   it('reports available fields when owner metadata is incomplete', async () => {
@@ -238,23 +274,28 @@ describe('package test runner lock (379)', () => {
     );
   });
 
-  it('reports unavailable fields when owner metadata is not an object', async () => {
+  it('reaps a stale lock when owner metadata is not an object', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
     await seedOwnerFile(lockDirectory, 'not owner metadata');
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(lockDirectory, staleTime, staleTime);
 
     const result = await runNodeScript(runnerPath, ['tests/non-object-owner.test.ts'], {
       ...process.env,
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
       SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '120',
-      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '100',
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
     });
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).toContain('owner PID unavailable');
-    expect(result.stderr).toContain('checkout unavailable');
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/non-object-owner\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
   });
 
   it('clamps unsafe status intervals and ignores malformed settings', async () => {

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -125,26 +125,13 @@ function expectSuccessfulSerializedRun(result: { stderr: string; status: number 
   ).toBe(true);
 }
 
-function parseElapsedWaitMilliseconds(line: string): number {
-  const start = line.indexOf('(');
-  const end = line.indexOf(' elapsed;', start);
-  expect(start).toBeGreaterThanOrEqual(0);
-  expect(end).toBeGreaterThan(start);
-  const elapsed = line.slice(start + 1, end);
-
-  if (elapsed.endsWith('ms')) {
-    return Number(elapsed.slice(0, -'ms'.length));
-  }
-
-  const minuteSeparator = elapsed.indexOf('m ');
-  const minutes = minuteSeparator === -1 ? 0 : Number(elapsed.slice(0, minuteSeparator));
-  const seconds = Number(
-    elapsed.slice(minuteSeparator === -1 ? 0 : minuteSeparator + 2, -'s'.length),
-  );
-  return (minutes * 60 + seconds) * 1000;
+function waitStatusLines(stderr: string): string[] {
+  return stderr
+    .split('\n')
+    .filter(line => line.startsWith('Waiting for safeword package test lock'));
 }
 
-async function seedOwnerFile(lockDirectory: string, owner: Record<string, unknown>) {
+async function seedOwnerFile(lockDirectory: string, owner: unknown) {
   await mkdir(lockDirectory, { recursive: true });
   writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(owner)}\n`);
 }
@@ -220,18 +207,13 @@ describe('package test runner lock (379)', () => {
 
     expect(ownerResult.status).toBe(0);
     expect(waiterResult.status).toBe(0);
-    const waitStatuses = waiterResult.stderr
-      .split('\n')
-      .filter(line => line.startsWith('Waiting for safeword package test lock'));
+    const waitStatuses = waitStatusLines(waiterResult.stderr);
     expect(waitStatuses.length).toBeGreaterThan(1);
-    expect(waitStatuses[0]).toContain(`owner PID ${owner.pid}`);
     expect(owner.checkoutRoot).toMatch(/checkout-a$/);
-    expect(waitStatuses[0]).toContain(`checkout ${owner.checkoutRoot}`);
-    const elapsedMilliseconds = waitStatuses.map(parseElapsedWaitMilliseconds);
-    expect(elapsedMilliseconds).toEqual(
-      elapsedMilliseconds.toSorted((left, right) => left - right),
-    );
-    expect(new Set(elapsedMilliseconds).size).toBe(elapsedMilliseconds.length);
+    expect(waitStatuses.slice(0, 2)).toEqual([
+      `Waiting for safeword package test lock (50ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
+      `Waiting for safeword package test lock (100ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
+    ]);
   });
 
   it('reports available fields when owner metadata is incomplete', async () => {
@@ -256,6 +238,25 @@ describe('package test runner lock (379)', () => {
     );
   });
 
+  it('reports unavailable fields when owner metadata is not an object', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedOwnerFile(lockDirectory, 'not owner metadata');
+
+    const result = await runNodeScript(runnerPath, ['tests/non-object-owner.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '120',
+      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '100',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('owner PID unavailable');
+    expect(result.stderr).toContain('checkout unavailable');
+  });
+
   it('clamps unsafe status intervals and ignores malformed settings', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
@@ -271,9 +272,7 @@ describe('package test runner lock (379)', () => {
       SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '1',
     });
 
-    const unsafeStatuses = unsafeInterval.stderr
-      .split('\n')
-      .filter(line => line.startsWith('Waiting for safeword package test lock'));
+    const unsafeStatuses = waitStatusLines(unsafeInterval.stderr);
     expect(unsafeInterval.status).toBe(0);
     expect(unsafeStatuses).toHaveLength(2);
 
@@ -291,7 +290,19 @@ describe('package test runner lock (379)', () => {
     );
 
     expect(malformedInterval.status).toBe(0);
-    expect(malformedInterval.stderr).not.toContain('Waiting for safeword package test lock');
+    expect(waitStatusLines(malformedInterval.stderr)).toHaveLength(0);
+
+    await seedOwnerFile(lockDirectory, owner);
+    const zeroInterval = await runNodeScript(runnerPath, ['tests/zero-interval.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '120',
+      SAFEWORD_TEST_LOCK_STATUS_INTERVAL_MS: '0',
+    });
+
+    expect(zeroInterval.status).toBe(0);
+    expect(waitStatusLines(zeroInterval.stderr)).toHaveLength(0);
   });
 
   it('reaps dead-owner stale locks before acquiring', async () => {


### PR DESCRIPTION
## What changed

- Require BDD primary proof to exercise the actor-facing action and observe the actor-visible result.
- Add RED and REFACTOR review checks plus regression coverage for that boundary.
- Make queued package-test runs report lock owner PID, checkout root, and elapsed wait periodically.

## Why

A lower-level store call or internal-state assertion can pass without proving the user-visible scenario it claims to cover. Separately, a legitimate cross-worktree package-test lock previously looked like an idle test hang after one silent notice.

## Impact

Maintainers get more trustworthy BDD completion evidence and clear progress during serialized test waits. Existing lock serialization, stale-lock handling, and the 20-minute wait cap are unchanged.

## Validation

- `bun run test tests/hooks/scenario-proof-fidelity-documentation.test.ts`
- `bun run test tests/test-runner-lock.test.ts` (8/8)
- `bun run test` (5,647 passed, 5 skipped across 377 files)
- `bun run lint`
- Prettier and `git diff --check`