### PR TITLE
Keep optional lint sections from failing nonmatching projects

### DIFF
--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -41,12 +41,12 @@ Run these commands based on project type. All detected languages run for polyglo
 }
 
 # Go linting (if go.mod exists)
-[ -f go.mod ] && {
+if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
   golangci-lint run --fix ./... 2>&1 || true
   # golangci-lint - format
   golangci-lint fmt ./... 2>&1 || true
-}
+fi
 ```
 
 ## Summary

--- a/.cursor/commands/lint.md
+++ b/.cursor/commands/lint.md
@@ -36,12 +36,12 @@ Run these commands based on project type. All detected languages run for polyglo
 }
 
 # Go linting (if go.mod exists)
-[ -f go.mod ] && {
+if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
   golangci-lint run --fix ./... 2>&1 || true
   # golangci-lint - format
   golangci-lint fmt ./... 2>&1 || true
-}
+fi
 ```
 
 ## Summary

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/quality-review.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/quality-review.md
@@ -1,0 +1,33 @@
+# Quality Review: Keep optional lint sections from failing nonmatching projects
+
+Review completed 2026-07-31 against the #1701 report, the current template
+distribution, and the focused real-process contract.
+
+**Currency:** ✓ Shell behavior verified against current GNU Bash documentation  
+**Sources:** ✓ Primary Bash documentation; current repository files  
+**Correct:** ✓ An absent `go.mod` now skips successfully; a present one still
+runs the established Go commands  
+**Elegant:** ✓ `if` expresses optional control flow directly  
+**No-bloat:** ✓ One control-flow substitution plus the required generated copies  
+**Wiring:** ✓ The test extracts and executes every shipped shell block, stubbing
+only external process commands
+
+**Verdict:** APPROVE
+
+**Critical issues:** None.  
+**Suggested improvements:** None.
+
+The old AND list returned the failed manifest check when Go was absent. The
+explicit `if` returns success when its condition is false while preserving the
+existing best-effort command behavior in the true branch. The contract covers
+the two canonical templates, both dogfood installs, and the generated Codex
+plugin surface, so a stale distribution copy is detectable.
+
+## Provenance
+
+- [GNU Bash lists](https://www.gnu.org/software/bash/manual/html_node/Lists.html)
+- [GNU Bash conditional constructs](https://www.gnu.org/software/bash/manual/bash.html)
+- Issue [#1701](https://github.com/ArcadeAI/safeword/issues/1701)
+
+**Next:** Run full Safeword verification; retain the ticket and issue as
+in-progress until delivery receives user confirmation.

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/quality-review.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/quality-review.md
@@ -3,18 +3,18 @@
 Review completed 2026-07-31 against the #1701 report, the current template
 distribution, and the focused real-process contract.
 
-**Currency:** ✓ Shell behavior verified against current GNU Bash documentation  
-**Sources:** ✓ Primary Bash documentation; current repository files  
-**Correct:** ✓ An absent `go.mod` now skips successfully; a present one still
-runs the established Go commands  
-**Elegant:** ✓ `if` expresses optional control flow directly  
-**No-bloat:** ✓ One control-flow substitution plus the required generated copies  
-**Wiring:** ✓ The test extracts and executes every shipped shell block, stubbing
+- **Currency:** ✓ Shell behavior verified against current GNU Bash documentation
+- **Sources:** ✓ Primary Bash documentation; current repository files
+- **Correct:** ✓ An absent `go.mod` now skips successfully; a present one still
+runs the established Go commands
+- **Elegant:** ✓ `if` expresses optional control flow directly
+- **No-bloat:** ✓ One control-flow substitution plus the required generated copies
+- **Wiring:** ✓ The test extracts and executes every shipped shell block, stubbing
 only external process commands
 
 **Verdict:** APPROVE
 
-**Critical issues:** None.  
+- **Critical issues:** None.
 **Suggested improvements:** None.
 
 The old AND list returned the failed manifest check when Go was absent. The

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/refactor-ledger.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/refactor-ledger.md
@@ -1,0 +1,15 @@
+# Refactor Ledger
+
+Scope: #1701 optional Go lint sections across the canonical templates and their
+shipped copies.
+
+- [x] Scout completed: no source abstraction is appropriate because the
+  commands and skill are separate canonical templates, while dogfood and Codex
+  plugin copies are generated distribution artifacts.
+- [x] Keep the five-surface process contract explicit: it proves consumers
+  receive the same executable behavior and fails if any copy drifts.
+- [x] Keep the two fixture cases separate: a JavaScript-only project proves the
+  absent-manifest success path, while a Go project proves the existing commands
+  still run.
+
+No findings were deferred.

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
@@ -6,16 +6,16 @@ This task's behavioral scenarios and RED/GREEN/REFACTOR evidence are defined in 
 
 ### Scenario: JavaScript-only lint instructions complete successfully
 
-- [x] RED: focused contract failed five JavaScript-only surfaces with status 1
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: focused contract failed five JavaScript-only surfaces with status 1
+- [x] GREEN d07030c36
+- [x] REFACTOR skip: each shipped surface stays explicit so distribution drift is observable in the process-level contract
 
 ### Scenario: Go lint instructions remain conditional on a Go manifest
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: this control behavior already passed before the fix; the JavaScript-only scenario supplied the regression failure
+- [x] GREEN d07030c36
+- [x] REFACTOR skip: the shared fixture is the only common structure; the control asserts distinct Go-manifest behavior
 
 ## Cross-scenario refactor
 
-- [ ] cross-scenario
+- [x] cross-scenario skip: the two cases share only the process fixture, and extracting more would obscure their distinct language-manifest assertions

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
@@ -1,0 +1,21 @@
+# Test Definitions: Keep optional lint sections from failing nonmatching projects
+
+This task's behavioral scenarios and RED/GREEN/REFACTOR evidence are defined in `ticket.md` under **Test Definitions**. This ledger mirrors their completion state for Safeword phase and done-gate checks.
+
+## Rule: Optional language sections do not determine an otherwise-successful lint run
+
+### Scenario: JavaScript-only lint instructions complete successfully
+
+- [x] RED: focused contract failed five JavaScript-only surfaces with status 1
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Go lint instructions remain conditional on a Go manifest
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/test-definitions.md
@@ -7,13 +7,13 @@ This task's behavioral scenarios and RED/GREEN/REFACTOR evidence are defined in 
 ### Scenario: JavaScript-only lint instructions complete successfully
 
 - [x] RED skip: focused contract failed five JavaScript-only surfaces with status 1
-- [x] GREEN d07030c36
+- [x] GREEN 740d137d9
 - [x] REFACTOR skip: each shipped surface stays explicit so distribution drift is observable in the process-level contract
 
 ### Scenario: Go lint instructions remain conditional on a Go manifest
 
 - [x] RED skip: this control behavior already passed before the fix; the JavaScript-only scenario supplied the regression failure
-- [x] GREEN d07030c36
+- [x] GREEN 740d137d9
 - [x] REFACTOR skip: the shared fixture is the only common structure; the control asserts distinct Go-manifest behavior
 
 ## Cross-scenario refactor

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
@@ -5,7 +5,7 @@ type: task
 phase: verify
 status: in_progress
 created: 2026-07-31T16:12:59.734Z
-last_modified: 2026-07-31T16:32:31Z
+last_modified: 2026-07-31T23:38:15Z
 scope: "Correct the optional Go lint section's shell control flow across the shipped lint guidance surfaces."
 out_of_scope: "Changing the lint commands, their best-effort error-reporting policy, or other language sections."
 done_when: "A JavaScript-only project runs the shipped lint instructions to completion without an absent go.mod determining the exit status."
@@ -59,7 +59,7 @@ When the shipped lint instructions run with successful JavaScript command stubs
 Then every shipped surface exits with status zero
 
 - [x] RED skip: `bun run test tests/skills/lint-skill-exit-status.test.ts` failed the five JavaScript-only surfaces with exit status 1 while the five Go-manifest controls passed.
-- [x] GREEN d07030c36
+- [x] GREEN 740d137d9
 - [x] REFACTOR skip: each shipped surface is intentionally covered by one process-level contract; extracting source-specific assertions would hide distribution drift.
 
 ### Scenario: Go lint instructions remain conditional on a Go manifest
@@ -69,7 +69,7 @@ When the shipped lint instructions run with a Go lint command stub
 Then the existing Go lint commands execute
 
 - [x] RED skip: this control behavior already passed before the fix; the JavaScript-only scenario supplied the regression failure.
-- [x] GREEN d07030c36
+- [x] GREEN 740d137d9
 - [x] REFACTOR skip: the Go-manifest control shares only the fixture and remains a distinct observable behavior.
 
 ## Work Log
@@ -77,9 +77,10 @@ Then the existing Go lint commands execute
 - 2026-07-31T16:13:28Z Revalidated: Selected #1661 after duplicate aggregation, but closed it as completed because current main contains the fingerprint-marker fix and its no-op install regression; selected #1701 on the next low-risk/high-impact/frequency tie and reproduced its JavaScript-only exit status of 1.
 - 2026-07-31T16:13:28Z Figure-it-out: Chose explicit `if [ -f go.mod ]; then ... fi` over `|| true` or a trailing success command after verifying current Bash list and conditional semantics; source distribution requires template parity plus Codex-plugin generation.
 - 2026-07-31T16:15:32Z RED: Added the real-process lint-instruction contract; the JavaScript-only case fails on all five shipped surfaces with status 1, while the `go.mod` control cases pass.
-- 2026-07-31T16:18:06Z GREEN: Replaced the optional Go `&&` list with an explicit `if` block, regenerated dogfood and Codex plugin copies, and passed the focused 10-case contract, parity, and repository lint/typecheck. (refs: d07030c36)
+- 2026-07-31T16:18:06Z GREEN: Replaced the optional Go `&&` list with an explicit `if` block, regenerated dogfood and Codex plugin copies, and passed the focused 10-case contract, parity, and repository lint/typecheck. (refs: 740d137d9; remapped after the 2026-07-31 rebase)
 - 2026-07-31T16:22:02Z REFACTOR: No structural extraction was warranted; the test intentionally executes each shipped surface so template, dogfood, and plugin drift remains observable.
 - 2026-07-31T16:22:02Z Audit: Passed the Safeword diff-scope audit against `origin/main`, including sync and dependency checks; no domain-document or code-quality findings.
 - 2026-07-31T16:22:02Z Quality review: Approved the explicit optional-section control flow, five-surface distribution contract, and real-process test boundary; no critical or suggested changes.
 - 2026-07-31T16:32:31Z Verify: Full Safeword verify gate passed: 377 test files / 5,649 tests passed with 5 expected skips; 499 Gherkin scenarios passed with 3 expected skips; build, typecheck, and dependency-plan stages exited successfully.
+- 2026-07-31T23:38:15Z Revalidated after a clean rebase onto `origin/main` at `4925d2312`: remapped the GREEN evidence to reachable commit `740d137d9`; focused real-process contract passes 10/10; repository lint/typecheck and parity (200 pairs / 8 contracts) pass. Keep the ticket in `verify` pending delivery authority.
 - 2026-07-31T16:12:59.734Z Started: Created ticket WB3Y9Q

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
@@ -2,10 +2,10 @@
 id: WB3Y9Q
 slug: lint-skill-exit-status
 type: task
-phase: implement
+phase: verify
 status: in_progress
 created: 2026-07-31T16:12:59.734Z
-last_modified: 2026-07-31T16:15:32Z
+last_modified: 2026-07-31T16:32:31Z
 scope: "Correct the optional Go lint section's shell control flow across the shipped lint guidance surfaces."
 out_of_scope: "Changing the lint commands, their best-effort error-reporting policy, or other language sections."
 done_when: "A JavaScript-only project runs the shipped lint instructions to completion without an absent go.mod determining the exit status."
@@ -58,9 +58,9 @@ Given a project with `package.json` and no `go.mod`
 When the shipped lint instructions run with successful JavaScript command stubs
 Then every shipped surface exits with status zero
 
-- [x] RED: `bun run test tests/skills/lint-skill-exit-status.test.ts` failed the five JavaScript-only surfaces with exit status 1 while the five Go-manifest controls passed.
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: `bun run test tests/skills/lint-skill-exit-status.test.ts` failed the five JavaScript-only surfaces with exit status 1 while the five Go-manifest controls passed.
+- [x] GREEN d07030c36
+- [x] REFACTOR skip: each shipped surface is intentionally covered by one process-level contract; extracting source-specific assertions would hide distribution drift.
 
 ### Scenario: Go lint instructions remain conditional on a Go manifest
 
@@ -68,13 +68,18 @@ Given a project containing `go.mod`
 When the shipped lint instructions run with a Go lint command stub
 Then the existing Go lint commands execute
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: this control behavior already passed before the fix; the JavaScript-only scenario supplied the regression failure.
+- [x] GREEN d07030c36
+- [x] REFACTOR skip: the Go-manifest control shares only the fixture and remains a distinct observable behavior.
 
 ## Work Log
 
 - 2026-07-31T16:13:28Z Revalidated: Selected #1661 after duplicate aggregation, but closed it as completed because current main contains the fingerprint-marker fix and its no-op install regression; selected #1701 on the next low-risk/high-impact/frequency tie and reproduced its JavaScript-only exit status of 1.
 - 2026-07-31T16:13:28Z Figure-it-out: Chose explicit `if [ -f go.mod ]; then ... fi` over `|| true` or a trailing success command after verifying current Bash list and conditional semantics; source distribution requires template parity plus Codex-plugin generation.
 - 2026-07-31T16:15:32Z RED: Added the real-process lint-instruction contract; the JavaScript-only case fails on all five shipped surfaces with status 1, while the `go.mod` control cases pass.
+- 2026-07-31T16:18:06Z GREEN: Replaced the optional Go `&&` list with an explicit `if` block, regenerated dogfood and Codex plugin copies, and passed the focused 10-case contract, parity, and repository lint/typecheck. (refs: d07030c36)
+- 2026-07-31T16:22:02Z REFACTOR: No structural extraction was warranted; the test intentionally executes each shipped surface so template, dogfood, and plugin drift remains observable.
+- 2026-07-31T16:22:02Z Audit: Passed the Safeword diff-scope audit against `origin/main`, including sync and dependency checks; no domain-document or code-quality findings.
+- 2026-07-31T16:22:02Z Quality review: Approved the explicit optional-section control flow, five-surface distribution contract, and real-process test boundary; no critical or suggested changes.
+- 2026-07-31T16:32:31Z Verify: Full Safeword verify gate passed: 377 test files / 5,649 tests passed with 5 expected skips; 499 Gherkin scenarios passed with 3 expected skips; build, typecheck, and dependency-plan stages exited successfully.
 - 2026-07-31T16:12:59.734Z Started: Created ticket WB3Y9Q

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/ticket.md
@@ -1,0 +1,80 @@
+---
+id: WB3Y9Q
+slug: lint-skill-exit-status
+type: task
+phase: implement
+status: in_progress
+created: 2026-07-31T16:12:59.734Z
+last_modified: 2026-07-31T16:15:32Z
+scope: "Correct the optional Go lint section's shell control flow across the shipped lint guidance surfaces."
+out_of_scope: "Changing the lint commands, their best-effort error-reporting policy, or other language sections."
+done_when: "A JavaScript-only project runs the shipped lint instructions to completion without an absent go.mod determining the exit status."
+external_issue: "https://github.com/ArcadeAI/safeword/issues/1701"
+---
+
+# Keep optional lint sections from failing nonmatching projects
+
+**Goal:** Make the lint workflow complete successfully after all applicable language sections run.
+
+**Why:** JavaScript-only projects currently receive a false failure because an absent optional Go manifest becomes the script exit status.
+
+## User Story
+
+As a JavaScript-only project maintainer, I want the lint instructions to skip the optional Go section successfully so that a completed applicable lint run is not reported as failed.
+
+### Acceptance Criteria
+
+- A project with `package.json` and no `go.mod` receives a zero exit status after the documented lint block runs.
+- A project with `go.mod` still executes the existing Go lint commands.
+- The canonical templates, dogfood files, and packaged Codex plugin keep the same behavior.
+
+## Figure-it-out Decision
+
+**Decision:** How should an optional language section skip cleanly without masking the behavior of a present section?
+
+**Investigation plan:** confirm shell exit semantics, compare a conditional block with catch-all alternatives, and verify every shipped lint surface derives from the canonical template.
+
+**Domains researched:** shell control-flow semantics; error-reporting behavior of the existing lint instructions; template, dogfood, and Codex-plugin distribution.
+
+**Options considered:**
+
+1. Keep `[ -f go.mod ] && { ...; }` and append `|| true`. Small, but a catch-all makes the optionality and any future command failure harder to reason about.
+2. End the document with an unconditional `true`. Fixes this report but couples the whole document's status to a trailing workaround.
+3. Use `if [ -f go.mod ]; then ... fi`. The skipped branch returns success while the existing inner reporting behavior is unchanged.
+
+**Decision:** Choose option 3. Bash documents that an AND list returns the status of its last executed command, which makes a false manifest check return non-zero; it also documents that an `if` with no true condition returns zero. The explicit conditional is the smallest portable expression of an optional language section. (verified: [GNU Bash lists](https://www.gnu.org/software/bash/manual/html_node/Lists.html), [GNU Bash conditional constructs](https://www.gnu.org/software/bash/manual/bash.html))
+
+**Premortem:** A future copy of the lint instructions could retain the old guard; the regression test will execute every shipped surface in a JavaScript-only fixture.
+
+**Next:** Add the failing multi-surface lint-instruction contract test before changing the templates.
+
+## Test Definitions
+
+**Test scope:** A focused integration-style documentation contract test runs each shipped lint block in a temporary JavaScript-only project, stubbing only the process commands at the boundary.
+
+### Scenario: JavaScript-only lint instructions complete successfully
+
+Given a project with `package.json` and no `go.mod`
+When the shipped lint instructions run with successful JavaScript command stubs
+Then every shipped surface exits with status zero
+
+- [x] RED: `bun run test tests/skills/lint-skill-exit-status.test.ts` failed the five JavaScript-only surfaces with exit status 1 while the five Go-manifest controls passed.
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Go lint instructions remain conditional on a Go manifest
+
+Given a project containing `go.mod`
+When the shipped lint instructions run with a Go lint command stub
+Then the existing Go lint commands execute
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Work Log
+
+- 2026-07-31T16:13:28Z Revalidated: Selected #1661 after duplicate aggregation, but closed it as completed because current main contains the fingerprint-marker fix and its no-op install regression; selected #1701 on the next low-risk/high-impact/frequency tie and reproduced its JavaScript-only exit status of 1.
+- 2026-07-31T16:13:28Z Figure-it-out: Chose explicit `if [ -f go.mod ]; then ... fi` over `|| true` or a trailing success command after verifying current Bash list and conditional semantics; source distribution requires template parity plus Codex-plugin generation.
+- 2026-07-31T16:15:32Z RED: Added the real-process lint-instruction contract; the JavaScript-only case fails on all five shipped surfaces with status 1, while the `go.mod` control cases pass.
+- 2026-07-31T16:12:59.734Z Started: Created ticket WB3Y9Q

--- a/.project/tickets/WB3Y9Q-lint-skill-exit-status/verify.md
+++ b/.project/tickets/WB3Y9Q-lint-skill-exit-status/verify.md
@@ -1,0 +1,37 @@
+## Verify Checklist
+
+**Test Suite:** ✓ The focused real-process contract passes all 10 checks; the
+full suite passes 377 files and 5,649 tests (5 expected skips).
+
+**Gherkin:** ✓ 499 scenarios and 15,444 steps passed (3 scenarios and 4 steps
+skipped by suite tags).
+
+**Build:** ✓ The verify gate rebuilt the CLI successfully before its test suite.
+
+**Lint:** ✓ Repository lint/typecheck, Prettier, and Markdown lint passed.
+
+**Scenarios:** ✓ Both ticket test-definition scenarios have RED, GREEN, and
+REFACTOR evidence.
+
+**PR Scope:** ✓ The diff is limited to the optional-Go condition, synchronized
+installed surfaces, its contract test, and ticket evidence.
+
+**Dep Drift:** ✓ No dependency changes.
+
+**Parent Epic:** N/A.
+
+**Reconcile:** ✓ `bun scripts/parity-check.ts` reports all 200 pairs and 8
+contracts in sync.
+
+**Experience:** ⏭️ N/A — this is internal lint-workflow guidance.
+
+**Evidence limits:** None. Temporary git-repository preflight succeeded, so the
+full git-backed integration suite is valid local evidence.
+
+Audit passed — diff-scoped audit found no architecture, configuration,
+dependency, domain-document, or code-quality findings. Quality review approved
+the completed change with no critical or suggested improvements.
+
+**Next:** Commit the verification artifacts and offer the branch for delivery;
+keep #1701 open and the ticket in `verify` / `in_progress` until the user
+confirms delivery.

--- a/packages/cli/codex-plugin/skills/lint/SKILL.md
+++ b/packages/cli/codex-plugin/skills/lint/SKILL.md
@@ -39,12 +39,12 @@ Run these commands based on project type. All detected languages run for polyglo
 }
 
 # Go linting (if go.mod exists)
-[ -f go.mod ] && {
+if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
   golangci-lint run --fix ./... 2>&1 || true
   # golangci-lint - format
   golangci-lint fmt ./... 2>&1 || true
-}
+fi
 ```
 
 ## Summary

--- a/packages/cli/templates/commands/lint.md
+++ b/packages/cli/templates/commands/lint.md
@@ -36,12 +36,12 @@ Run these commands based on project type. All detected languages run for polyglo
 }
 
 # Go linting (if go.mod exists)
-[ -f go.mod ] && {
+if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
   golangci-lint run --fix ./... 2>&1 || true
   # golangci-lint - format
   golangci-lint fmt ./... 2>&1 || true
-}
+fi
 ```
 
 ## Summary

--- a/packages/cli/templates/skills/lint/SKILL.md
+++ b/packages/cli/templates/skills/lint/SKILL.md
@@ -41,12 +41,12 @@ Run these commands based on project type. All detected languages run for polyglo
 }
 
 # Go linting (if go.mod exists)
-[ -f go.mod ] && {
+if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
   golangci-lint run --fix ./... 2>&1 || true
   # golangci-lint - format
   golangci-lint fmt ./... 2>&1 || true
-}
+fi
 ```
 
 ## Summary

--- a/packages/cli/tests/skills/lint-skill-exit-status.test.ts
+++ b/packages/cli/tests/skills/lint-skill-exit-status.test.ts
@@ -1,0 +1,95 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPOSITORY_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+
+const LINT_SURFACES = [
+  'packages/cli/templates/skills/lint/SKILL.md',
+  'packages/cli/templates/commands/lint.md',
+  '.claude/skills/lint/SKILL.md',
+  '.cursor/commands/lint.md',
+  'packages/cli/codex-plugin/skills/lint/SKILL.md',
+] as const;
+
+function extractLintBlock(relativePath: string): string {
+  const content = readFileSync(nodePath.join(REPOSITORY_ROOT, relativePath), 'utf8');
+  const block = /```bash\n([\s\S]*?)\n```/.exec(content)?.[1];
+  if (block === undefined) throw new Error(`Missing lint bash block in ${relativePath}`);
+  return block;
+}
+
+function writeExecutable(directory: string, name: string, body: string): void {
+  const executablePath = nodePath.join(directory, name);
+  writeFileSync(executablePath, `#!/usr/bin/env bash\n${body}\n`);
+  chmodSync(executablePath, 0o755);
+}
+
+function runLintInstructions(
+  relativePath: string,
+  options: { hasGoManifest?: boolean } = {},
+): { status: number | null; goCommands: string[] } {
+  const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-lint-skill-'));
+  const binDirectory = nodePath.join(projectDirectory, 'fake-bin');
+  const goCommandsPath = nodePath.join(projectDirectory, 'go-commands.log');
+
+  try {
+    mkdirSync(binDirectory);
+    writeFileSync(nodePath.join(projectDirectory, 'package.json'), '{"scripts":{}}\n');
+    if (options.hasGoManifest)
+      writeFileSync(nodePath.join(projectDirectory, 'go.mod'), 'module example\n');
+
+    writeExecutable(binDirectory, 'bun', 'exit 0');
+    writeExecutable(binDirectory, 'bunx', 'exit 0');
+    writeExecutable(
+      binDirectory,
+      'golangci-lint',
+      String.raw`printf '%s\n' "$*" >> "${goCommandsPath}"`,
+    );
+
+    const result = spawnSync('bash', ['-c', extractLintBlock(relativePath)], {
+      cwd: projectDirectory,
+      env: { ...process.env, PATH: `${binDirectory}:/usr/bin:/bin` },
+      encoding: 'utf8',
+    });
+
+    return {
+      status: result.status,
+      goCommands: existsSync(goCommandsPath)
+        ? readFileSync(goCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
+        : [],
+    };
+  } finally {
+    rmSync(projectDirectory, { recursive: true, force: true });
+  }
+}
+
+describe('lint instructions exit status (#1701)', () => {
+  it.each(LINT_SURFACES)('%s succeeds for a JavaScript-only project', relativePath => {
+    const result = runLintInstructions(relativePath);
+
+    expect(result.status).toBe(0);
+    expect(result.goCommands).toEqual([]);
+  });
+
+  it.each(LINT_SURFACES)(
+    '%s runs the existing Go commands when go.mod is present',
+    relativePath => {
+      const result = runLintInstructions(relativePath, { hasGoManifest: true });
+
+      expect(result.status).toBe(0);
+      expect(result.goCommands).toEqual(['run --fix ./...', 'fmt ./...']);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #1701: a JavaScript-only project could finish all applicable lint checks yet receive exit status 1 because the optional Go manifest guard was the final shell command.

The shipped lint instructions now use an explicit `if [ -f go.mod ]; then … fi` block. That makes the absent-Go path succeed while preserving the existing Go commands when `go.mod` exists.

A real-process contract executes all five shipped lint surfaces in JavaScript-only and Go fixtures, so future template or generated-copy drift is detected.

## Validation

- `bun run test tests/skills/lint-skill-exit-status.test.ts tests/parity.test.ts`
- `bun run lint`
- `bun run typecheck`
- `git diff --check origin/main...HEAD`