### PR TITLE
Add dependency audits for all supported languages

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -172,9 +172,9 @@ run_plan
 plan_kind=typecheck
 run_plan
 
-# --- Supply-chain: `cargo deny check advisories` (RustSec DB) for Rust —
-#     the zero-false-positive security signal. Empty for non-Rust or when
-#     cargo-deny is absent (a visible skip, never a false green). ---
+# --- Supply-chain: JavaScript's package-manager audit, Python's `uv audit` or
+#     `pip-audit`, Go's pinned `govulncheck`, and Rust's cargo-deny advisories.
+#     A missing scanner prints a visible skip, never a false green. ---
 plan_kind=deps
 run_plan
 ```

--- a/packages/cli/codex-plugin/skills/verify/SKILL.md
+++ b/packages/cli/codex-plugin/skills/verify/SKILL.md
@@ -171,9 +171,9 @@ run_plan
 plan_kind=typecheck
 run_plan
 
-# --- Supply-chain: `cargo deny check advisories` (RustSec DB) for Rust —
-#     the zero-false-positive security signal. Empty for non-Rust or when
-#     cargo-deny is absent (a visible skip, never a false green). ---
+# --- Supply-chain: JavaScript's package-manager audit, Python's `uv audit` or
+#     `pip-audit`, Go's pinned `govulncheck`, and Rust's cargo-deny advisories.
+#     A missing scanner prints a visible skip, never a false green. ---
 plan_kind=deps
 run_plan
 ```

--- a/packages/cli/src/test-plan/resolve.ts
+++ b/packages/cli/src/test-plan/resolve.ts
@@ -72,16 +72,16 @@ const TREE_MANIFESTS = new Set<string>([
 /**
  * Kinds each non-Rust resolver opts out of, so a new PlanKind fails safe (the
  * language emits nothing) instead of falling through to a wrong command. `deps`
- * (supply-chain) is Rust-only for now. `typecheck` emits for JS/TS (`typecheck`
+ * emits an ecosystem-native vulnerability scan for every supported language.
+ * `typecheck` emits for JS/TS (`typecheck`
  * script), Python (mypy/pyright when configured), and Rust (clippy, in
  * resolveRust); Go's compiler covers it. `bdd` (Gherkin acceptance) emits for JS
  * (cucumber-js) and Python (behave); Go's godog and Rust's cucumber-rs fold into
  * the native test lane, so those skip it. Frozen sets mirror the manifest-set
  * idiom above and keep the guards uniform.
  */
-const JS_SKIP_KINDS: ReadonlySet<PlanKind> = new Set<PlanKind>(['deps']);
-const PYTHON_SKIP_KINDS: ReadonlySet<PlanKind> = new Set<PlanKind>(['build', 'deps']);
-const GO_SKIP_KINDS: ReadonlySet<PlanKind> = new Set<PlanKind>(['typecheck', 'deps', 'bdd']);
+const PYTHON_SKIP_KINDS: ReadonlySet<PlanKind> = new Set<PlanKind>(['build']);
+const GO_SKIP_KINDS: ReadonlySet<PlanKind> = new Set<PlanKind>(['typecheck', 'bdd']);
 
 /**
  * Parse the `SAFEWORD_FAKE_TOOLS` test seam (same spirit as `SAFEWORD_SKIP_INSTALL`):
@@ -192,11 +192,14 @@ function resolveJs(
   kind: PlanKind,
   isAvailable: ToolProbe,
 ): PlanEntry | undefined {
-  if (JS_SKIP_KINDS.has(kind)) return undefined;
   // JS is detected root-only: subdirectory package.json is too common to treat as a project root.
   const scripts = readRootScripts(root);
   if (!scripts) return undefined;
   const pm = detectPackageManager(root);
+  if (kind === 'deps') {
+    const command = pm === 'yarn' ? 'yarn npm audit' : `${pm} audit`;
+    return entry('javascript', root, command, pm, isAvailable(pm));
+  }
   const directScript = JS_DIRECT_SCRIPT[kind];
   if (directScript !== undefined) {
     const command = scripts[directScript];
@@ -363,7 +366,7 @@ function resolvePython(
   kind: PlanKind,
   isAvailable: ToolProbe,
 ): PlanEntry | undefined {
-  if (PYTHON_SKIP_KINDS.has(kind)) return undefined; // build/deps: no standard Python lane
+  if (PYTHON_SKIP_KINDS.has(kind)) return undefined; // build: no standard Python lane
   // typecheck/bdd detect Python via their OWN config markers (mypy/pyright/behave
   // configs are Python-only), so they don't require a packaging manifest — a repo
   // carrying just `mypy.ini` or `behave.ini` still gets its lane, run in the dir the
@@ -387,6 +390,28 @@ function resolvePython(
     return resolvePythonBdd(index, cwd, isAvailable);
   }
   if (PYTHON_MANIFESTS.every(manifest => !index.has(manifest))) return undefined;
+  if (kind === 'deps') {
+    const cwd = firstDirectory(root, index, PYTHON_MANIFESTS);
+    // `uv audit` is uv's native dependency audit. Other Python packaging
+    // layouts use pip-audit, which is maintained by PyPA. Select from project
+    // evidence rather than tool availability so a missing scanner stays a
+    // visible skip in the rendered plan instead of a false-green no-op.
+    if (index.has('uv.lock')) return entry('python', cwd, 'uv audit', 'uv', isAvailable('uv'));
+    if (index.has('requirements.txt'))
+      return entry(
+        'python',
+        cwd,
+        'pip-audit -r requirements.txt',
+        'pip-audit',
+        isAvailable('pip-audit'),
+      );
+    if (index.has('pyproject.toml'))
+      return entry('python', cwd, 'pip-audit .', 'pip-audit', isAvailable('pip-audit'));
+    // Legacy setup.py/setup.cfg/tox projects have no project-file input that
+    // pip-audit understands. Auditing the active environment is the supported
+    // fallback and remains visible if the scanner is unavailable.
+    return entry('python', cwd, 'pip-audit', 'pip-audit', isAvailable('pip-audit'));
+  }
   return resolvePythonTest(index, firstDirectory(root, index, PYTHON_MANIFESTS), isAvailable);
 }
 
@@ -396,10 +421,22 @@ function resolveGo(
   kind: PlanKind,
   isAvailable: ToolProbe,
 ): PlanEntry | undefined {
-  // Go skips typecheck/deps/bdd (GO_SKIP_KINDS): the compiler is the type checker,
-  // godog runs as `go test` subtests, and supply-chain is Rust-only for now.
+  // Go skips typecheck/bdd (GO_SKIP_KINDS): the compiler is the type checker and
+  // godog runs as `go test` subtests.
   if (GO_SKIP_KINDS.has(kind)) return undefined;
   if (!index.has('go.mod')) return undefined;
+  if (kind === 'deps') {
+    const cwd = existsSync(nodePath.join(root, 'go.work')) ? root : (index.get('go.mod') ?? root);
+    // Pin the scanner so this gate is reproducible and does not unexpectedly
+    // inherit a new govulncheck release through `@latest`.
+    return entry(
+      'go',
+      cwd,
+      'go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...',
+      'govulncheck',
+      isAvailable('go'),
+    );
+  }
   const verb = kind === 'build' ? 'build' : 'test';
   // A root go.work tests every workspace module — run the expansion from root.
   // Otherwise run `./...` in the module's own directory (supports nested modules).

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -172,9 +172,9 @@ run_plan
 plan_kind=typecheck
 run_plan
 
-# --- Supply-chain: `cargo deny check advisories` (RustSec DB) for Rust —
-#     the zero-false-positive security signal. Empty for non-Rust or when
-#     cargo-deny is absent (a visible skip, never a false green). ---
+# --- Supply-chain: JavaScript's package-manager audit, Python's `uv audit` or
+#     `pip-audit`, Go's pinned `govulncheck`, and Rust's cargo-deny advisories.
+#     A missing scanner prints a visible skip, never a false green. ---
 plan_kind=deps
 run_plan
 ```

--- a/packages/cli/tests/test-plan/cli-sh.test.ts
+++ b/packages/cli/tests/test-plan/cli-sh.test.ts
@@ -79,6 +79,19 @@ describe('safeword test-plan --format sh', () => {
     expect(sh).toContain('cargo deny check advisories');
   });
 
+  it('renders --kind deps for Go as a pinned govulncheck scan', async () => {
+    const sh = await renderSh(makeRepo({ 'go.mod': 'module x\n' }), 'deps');
+    expect(sh).toContain('go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...');
+  });
+
+  it('renders --kind deps for uv projects as uv audit', async () => {
+    const sh = await renderSh(
+      makeRepo({ 'pyproject.toml': '[project]\nname="x"\n', 'uv.lock': 'version = 1\n' }),
+      'deps',
+    );
+    expect(sh).toContain('uv audit');
+  });
+
   it('eval runs the resolved suite and exits zero on success', async () => {
     const root = makeRepo({
       'package.json': JSON.stringify({ scripts: { test: 'echo RAN_SUITE' } }),

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -373,15 +373,60 @@ describe('resolveTestPlan — deps plan (kind: deps, supply-chain gate)', () => 
     expect(entryFor(plan, 'rust')?.runner).toBe('cargo-deny');
   });
 
-  it('is Rust-only — never emits JS/Python/Go entries', () => {
+  it('emits ecosystem-native supply-chain checks for every detected language', () => {
     const root = makeRepo({
       'pyproject.toml': '[project]\nname="x"\n',
       'go.mod': 'module x\n',
       'Cargo.toml': '[package]\nname="x"\n',
       'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+      'bun.lock': '',
     });
     const plan = resolveTestPlan(root, { kind: 'deps', isToolAvailable: allTools });
-    expect(languages(plan)).toEqual(['rust']);
+    expect(languages(plan)).toEqual(['javascript', 'python', 'go', 'rust']);
+    expect(entryFor(plan, 'javascript')?.command).toBe('bun audit');
+    expect(entryFor(plan, 'python')?.command).toBe('pip-audit .');
+    expect(entryFor(plan, 'go')?.command).toBe(
+      'go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...',
+    );
+  });
+
+  it('uses uv audit for uv-locked Python projects', () => {
+    const root = makeRepo({
+      'pyproject.toml': '[project]\nname="x"\n',
+      'uv.lock': 'version = 1\n',
+    });
+    const plan = resolveTestPlan(root, { kind: 'deps', isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')?.command).toBe('uv audit');
+    expect(entryFor(plan, 'python')?.runner).toBe('uv');
+  });
+
+  it('audits requirements files directly instead of the active environment', () => {
+    const root = makeRepo({ 'requirements.txt': 'requests==2.32.0\n' });
+    const plan = resolveTestPlan(root, { kind: 'deps', isToolAvailable: allTools });
+    expect(entryFor(plan, 'python')?.command).toBe('pip-audit -r requirements.txt');
+  });
+
+  it('routes JavaScript audits through the detected package manager', () => {
+    const root = makeRepo({
+      'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+      'yarn.lock': '',
+    });
+    const plan = resolveTestPlan(root, { kind: 'deps', isToolAvailable: allTools });
+    expect(entryFor(plan, 'javascript')?.command).toBe('yarn npm audit');
+  });
+
+  it('keeps each missing supply-chain scanner visible', () => {
+    const root = makeRepo({
+      'package.json': JSON.stringify({ scripts: {} }),
+      'pyproject.toml': '[project]\nname="x"\n',
+      'go.mod': 'module x\n',
+    });
+    const plan = resolveTestPlan(root, { kind: 'deps', isToolAvailable: () => false });
+    expect(plan.map(({ language, available }) => [language, available])).toEqual([
+      ['javascript', false],
+      ['python', false],
+      ['go', false],
+    ]);
   });
 
   it('keeps the Rust entry visible but unavailable when cargo-deny is missing', () => {


### PR DESCRIPTION
## Summary

Adds non-Rust supply-chain checks to `safeword project test-plan --kind deps`.

- Routes JavaScript audits through the detected package manager.
- Uses `uv audit` for uv projects and project-aware `pip-audit` commands elsewhere.
- Adds a pinned Go `govulncheck` scan.
- Keeps missing scanners visible as skips and updates the verify skill guidance.

## Why

Previously, Go, Python, and JavaScript/TypeScript projects produced an empty dependency plan, creating a silent false-green in verify and audit workflows. Fixes #1776.

## Validation

- `bun run test tests/test-plan/resolve.test.ts tests/test-plan/cli-sh.test.ts tests/verify-skill.test.ts`
- `bun run lint`
- `git diff --check`