### PR TITLE
chore(release): prepare v0.71.0-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.71.0-rc.0",
+      "version": "0.71.0-rc.1",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0-rc.0",
+  "version": "0.71.0-rc.1",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0-rc.1 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0-rc.1 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0-rc.1 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0-rc.1 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0-rc.1 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0-rc.0",
+  "version": "0.71.0-rc.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump the CLI, Claude marketplace manifest, Codex plugin manifest, and all version-pinned Codex hook commands to `0.71.0-rc.1`
- preserve the tested new-task activation boundary for Codex plugin upgrades
- include current `main`, including the dependency-audit work merged after `rc.0`

## Verification

- focused Codex migration/release coverage: 106 tests passed
- full Vitest suite in three sequential shards: 404 files, 6,096 tests passed, 5 skipped
- Cucumber: 685 scenarios passed, 3 skipped; 22,432 steps passed, 4 skipped
- release suite: 27 tests passed
- ESLint and Gherkin lint
- TypeScript typecheck
- Prettier check
- Astro check: 0 errors, warnings, or hints

## Host follow-up

Current-task plugin hot reload remains a Codex Desktop host issue and is not claimed by this release. Reproduction filed upstream: https://github.com/openai/codex/issues/36605