### PR TITLE
chore(release): v0.71.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.71.0-rc.3",
+      "version": "0.71.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/.project/tickets/J761ZG-headless-codex-activation-checks/ticket.md
+++ b/.project/tickets/J761ZG-headless-codex-activation-checks/ticket.md
@@ -1,0 +1,21 @@
+---
+id: J761ZG
+slug: headless-codex-activation-checks
+type: task
+phase: intake
+status: in_progress
+created: 2026-08-02T20:01:29.002Z
+last_modified: 2026-08-02T20:01:29.002Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1798
+---
+
+# Make headless Codex activation checks reliable for release validation
+
+**Goal:** Provide deterministic headless coverage for Codex plugin hook and activation behavior.
+
+**Why:** Manual rc.3 validation worked, but model compatibility and Desktop-versus-headless host identity require a supported, structured release check.
+
+## Work Log
+
+- 2026-08-02T20:01:29.002Z Started: Created ticket J761ZG
+- 2026-08-02T20:01:29.002Z Found: Linked GitHub issue #1798 with the rc.3 headless E2E evidence and acceptance criteria.

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0-rc.3",
+  "version": "0.71.0",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.3 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.3 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.3 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.3 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0-rc.3 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.71.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0-rc.3",
+  "version": "0.71.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- promote the validated `0.71.0-rc.3` artifact to stable `0.71.0`
- keep all four release-tracked version surfaces and five pinned Codex hook commands in lockstep
- record follow-up issue #1798 and local ticket J761ZG for deterministic headless Codex activation checks

There is no runtime-code delta from rc.3.

## Validation

- `bun run lint`
- `bun run test:release` — 27 passed
- `bun run test` — 6,156 passed, 5 skipped
- manual headless `codex exec` E2E — all five rc.3 hook proofs recorded with matching version, manifest hash, and activation ID
- stale Desktop safety behavior — activation remained pending while the install-time Desktop app-server was still alive

## Follow-up disposition

#1798 tracks a supported headless harness, model/CLI compatibility handling, and isolated positive-activation coverage. It is intentionally non-blocking for this stable promotion; the rc.3 fail-closed behavior was observed directly.

## Release procedure

After protected-branch CI is green: admin squash-merge, create annotated `v0.71.0` on the merge commit, push the tag, verify the Release workflow and npm `latest`.