### PR TITLE
chore(release): v0.72.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.72.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.72.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.72.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.72.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.71.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.72.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.71.0",
+  "plugin_version": "0.72.0",
   "hook_manifest_sha256": "79728d2f2251659a458208ac8d5ea45fe7aebe54e9204e4aaa108de491e39503",
-  "inventory_sha256": "4691ad76d03f877c95c97f303e91faaefd46e345283b7c8572b583a0fad1aa95"
+  "inventory_sha256": "4e17b59fae0032b12410082d810d0ea9725e60b121568c1ca1a1fc06da1c3694"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -11,7 +11,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "45a45ac44b6c8047e66a19b065373448db7293e3f1084e2f206dcded4f31166c"
+      "sha256": "75baa03967c3ecc256ba31943308557d4458af4246951884036245f191daf4c4"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "type": "module"
 }


### PR DESCRIPTION
## Release

Bumps Safeword from 0.71.0 to 0.72.0.

## Highlights

- Ship native Claude Code plugin delivery with verified activation and migration safety.
- Add cross-agent adversarial reviews with bounded provenance-aware execution.
- Add safe closeout workflows across Claude, Cursor, and Codex.
- Prevent retro drafts from draining without durable destination acknowledgements.
- Harden headless Codex activation validation and closeout retro invocation.

## Verification

- Exact-head main CI passed before the bump.
- Release contract: 28 of 28 tests passed.
- Native Claude plugin package, identity, inventory, and catalogue align at 0.72.0.
- bun install completed with no dependency-resolution changes.

After merge, an annotated v0.72.0 tag will trigger the OIDC Release workflow and npm publication.