### PR TITLE
Fix closeout across real worktree layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Historical manual-review seals hash the reviewed ancestor blobs.
+          # A depth-1 PR checkout contains only the synthetic merge commit and
+          # cannot prove that immutable snapshot.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.project/tickets/8JN4P3-closeout-survives-real-worktree-layouts/ticket.md
+++ b/.project/tickets/8JN4P3-closeout-survives-real-worktree-layouts/ticket.md
@@ -1,0 +1,30 @@
+---
+id: 8JN4P3
+slug: closeout-survives-real-worktree-layouts
+type: patch
+phase: done
+status: done
+created: 2026-08-03T21:25:54.248Z
+last_modified: 2026-08-03T22:40:50.000Z
+---
+
+# Keep safe closeout working across real worktree layouts
+
+**Goal:** Let authenticated closeout finish after a session moves worktrees and when the primary worktree is detached.
+
+**Why:** Dogfooding merged closeout exposed issues #1849 and #1850, leaving clean merged branches impossible to remove through the safety guard.
+
+**Scope:** Resolve upstream issues #1849 and #1850 without weakening exact session, project, pull-request, branch, or worktree identity checks.
+
+**Done when:** A bound session may start in another or subsequently removed linked worktree; cleanup uses exactly one checkout of the observed default branch even when Git's primary worktree is detached; adversarial identity tests and the complete verification suite pass.
+
+## Work Log
+
+- 2026-08-03T21:25:54.248Z Started: Created ticket 8JN4P3
+- 2026-08-03T21:34:00.000Z Decided: Keep the authenticated hook project binding and exact transcript session ID as the identity boundary; treat transcript cwd as non-authoritative start metadata. Select the unique observed default-branch checkout as the surviving cleanup worktree while preserving the primary-worktree deletion guard.
+- 2026-08-03T21:44:00.000Z Reviewed: Cross-agent quality review requested explicit observation-boundary and three-surface parity proof. Added PR identity, protection resolution, canonical script parity, real detached-primary Git, and primary-target preservation tests; included the existing host-adapter orchestration suite in re-review evidence.
+- 2026-08-03T21:48:00.000Z Preserved evidence: The original 58-row manual review remains bound to the commit that introduced its manifest; before first commit the gate still hashes the working tree, and afterward it verifies the sealed commit is an ancestor and hashes reviewed blobs there. Follow-up patches no longer rewrite historical reviewer verdicts.
+- 2026-08-03T22:03:00.000Z Reviewed: Final cross-agent quality review approved the complete delta with no correctness or security defects.
+- 2026-08-03T22:12:00.000Z Corrected generated evidence: Full verification exposed the stale Claude plugin inventory digest for the changed closeout script. Regenerated `plugin/inventory.json` and `plugin/identity.json`; the focused dispatcher and 278-scenario Gherkin regression lanes then passed.
+- 2026-08-03T22:40:50.000Z Verified: Full verification passed 6,473 tests with 5 skips, 826 Gherkin scenarios with 3 skips, build, lint, typecheck, and dependency audit. Diff-scoped audit found no errors or warnings.
+- 2026-08-03T22:53:00.000Z Corrected CI evidence: Node 24 proved the default depth-1 PR checkout could not read the historical review snapshot. Kept the seal strict and configured test jobs to fetch Git history so they hash the actual reviewed ancestor blobs.

--- a/.project/tickets/8JN4P3-closeout-survives-real-worktree-layouts/verify.md
+++ b/.project/tickets/8JN4P3-closeout-survives-real-worktree-layouts/verify.md
@@ -1,0 +1,32 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 6473/6473 tests pass (5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (826 scenarios: 823 passed, 3 skipped; 29496 steps: 29492 passed, 4 skipped)
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 0 scenarios marked complete (patch ticket has no test-definitions.md)
+**PR Scope:** ✅ Diff matches ticket scope; full-history CI checkout is required to validate the preserved historical review seal
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal safety and repository-layout plumbing
+**Surface Evidence:** ✅ 3/3 affected surfaces have recorded proof
+**Evidence limits:** ✅ None
+
+Audit passed — diff-scoped audit found 0 errors and 0 warnings; dependency boundaries, generated config, principle trace, domain references, learning metadata, changed tests, and impacted documentation are clean.
+
+## Surface evidence
+
+| Affected surface | Proof | Result |
+| --- | --- | --- |
+| Claude Code closeout | `bun run test tests/integration/closeout-host-adapters.test.ts tests/closeout-skill.test.ts tests/hooks/closeout-session-binding.test.ts` plus full verification | Pass |
+| Codex closeout | Same cross-host adapter/binding suite plus full verification | Pass |
+| Cursor/shared cleanup planner | Cleanup guard unit suite, canonical three-surface parity assertion, and full verification | Pass |
+
+## Audit summary
+
+- Architecture: no dependency violations; generated dependency-cruiser config is current.
+- Dead code, duplication, and dependency freshness: intentionally skipped in diff scope per audit policy; no repository-wide baseline was requested.
+- Test quality: 2 changed test files reviewed; assertions are behavioral and cover happy, boundary, failure, adversarial identity, and real Git worktree cases.
+- Documentation: configured README and website docs inspected; their closeout claims remain accurate and no behavior-level documentation update is required.
+- Agent configs, learnings, principle traces, and domain docs: no changed-config findings or broken references.

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -147,10 +147,12 @@ function collectWorktreeBlockers(
   plan: CleanupPlan,
   pullRequest: PullRequestIdentity,
   topicWorktrees: WorktreeIdentity[],
-  mainWorktrees: WorktreeIdentity[],
+  defaultBranchWorktrees: WorktreeIdentity[],
   deliveryWorktreePath: string,
 ): void {
-  if (mainWorktrees.length !== 1) block(plan, 'exactly one surviving main worktree is required');
+  if (defaultBranchWorktrees.length !== 1) {
+    block(plan, 'exactly one surviving default-branch worktree is required');
+  }
   if (topicWorktrees.length > 1) block(plan, 'the linked topic worktree is ambiguous');
   const worktree = topicWorktrees[0];
   if (worktree && nodePath.resolve(worktree.path) !== nodePath.resolve(deliveryWorktreePath)) {
@@ -170,12 +172,12 @@ function assembleOperations(
   observation: CloseoutObservation,
   pullRequest: PullRequestIdentity,
   worktree: WorktreeIdentity | undefined,
-  mainWorktree: WorktreeIdentity,
+  survivingWorktree: WorktreeIdentity,
 ): void {
   if (worktree) {
     plan.operations.push({
       kind: 'remove-worktree',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       path: worktree.path,
       oid: pullRequest.headRefOid,
     });
@@ -185,7 +187,7 @@ function assembleOperations(
   if (observation.remote) {
     plan.operations.push({
       kind: 'delete-remote-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       remote: observation.remote.name,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
@@ -196,7 +198,7 @@ function assembleOperations(
   if (observation.localRefOid) {
     plan.operations.push({
       kind: 'delete-local-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
     });
@@ -227,17 +229,19 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
   const topicWorktrees = observation.worktrees.filter(
     worktree => worktree.branch === pullRequest.headRefName,
   );
-  const mainWorktrees = observation.worktrees.filter(worktree => worktree.main);
+  const defaultBranchWorktrees = observation.worktrees.filter(
+    worktree => worktree.branch === observation.defaultBranch,
+  );
   collectWorktreeBlockers(
     plan,
     pullRequest,
     topicWorktrees,
-    mainWorktrees,
+    defaultBranchWorktrees,
     observation.deliveryWorktreePath,
   );
-  const mainWorktree = mainWorktrees[0];
-  if (plan.blockers.length === 0 && mainWorktree) {
-    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], mainWorktree);
+  const survivingWorktree = defaultBranchWorktrees[0];
+  if (plan.blockers.length === 0 && survivingWorktree) {
+    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], survivingWorktree);
   }
 
   return plan;
@@ -486,9 +490,8 @@ interface TranscriptMetadata {
   sessionId?: unknown;
   session_id?: unknown;
   conversation_id?: unknown;
-  cwd?: unknown;
   type?: unknown;
-  payload?: { id?: unknown; cwd?: unknown };
+  payload?: { id?: unknown };
 }
 
 function exactString(value: unknown): string | undefined {
@@ -529,12 +532,7 @@ export function transcriptMatchesBinding(
           exactString(record.session_id) ??
           exactString(record.conversation_id) ??
           exactString(codexMetadata?.id);
-        const cwd = exactString(record.cwd) ?? exactString(codexMetadata?.cwd);
-        if (sessionId !== binding.id || cwd === undefined) return false;
-        const resolvedCwd = realpathSync(cwd);
-        if (resolvedCwd === expectedRoot) return true;
-        const root = git(resolvedCwd, 'rev-parse', '--show-toplevel');
-        return root.status === 0 && nodePath.resolve(root.stdout.trim()) === expectedRoot;
+        return sessionId === binding.id;
       });
   } catch {
     return false;
@@ -766,7 +764,7 @@ interface GhPullRequest {
   headRepository?: { name?: string; nameWithOwner?: string };
 }
 
-function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
+export function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
   const owner =
     value.headRepositoryOwner?.login ?? value.headRepository?.nameWithOwner?.split('/')[0];
   const repository =
@@ -878,11 +876,15 @@ function observeProtection(
     root,
   );
   const parsed = json<{ protected?: boolean }>(result);
-  return parsed?.protected === true
-    ? 'protected'
-    : parsed?.protected === false
-      ? 'unprotected'
-      : 'unknown';
+  return resolveProtection('matched', parsed?.protected);
+}
+
+export function resolveProtection(
+  remoteResolution: CloseoutObservation['remoteResolution'],
+  observed?: boolean,
+): CloseoutObservation['protection'] {
+  if (remoteResolution === 'absent') return 'unprotected';
+  return observed === true ? 'protected' : observed === false ? 'unprotected' : 'unknown';
 }
 
 export function defaultBranchArguments(identity: PullRequestIdentity): string[] {
@@ -932,7 +934,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection:
       identity && mutableTargets.remoteResolution === 'absent'
-        ? 'unprotected'
+        ? resolveProtection(mutableTargets.remoteResolution)
         : identity
           ? observeProtection(root, identity)
           : 'unknown',

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -147,10 +147,12 @@ function collectWorktreeBlockers(
   plan: CleanupPlan,
   pullRequest: PullRequestIdentity,
   topicWorktrees: WorktreeIdentity[],
-  mainWorktrees: WorktreeIdentity[],
+  defaultBranchWorktrees: WorktreeIdentity[],
   deliveryWorktreePath: string,
 ): void {
-  if (mainWorktrees.length !== 1) block(plan, 'exactly one surviving main worktree is required');
+  if (defaultBranchWorktrees.length !== 1) {
+    block(plan, 'exactly one surviving default-branch worktree is required');
+  }
   if (topicWorktrees.length > 1) block(plan, 'the linked topic worktree is ambiguous');
   const worktree = topicWorktrees[0];
   if (worktree && nodePath.resolve(worktree.path) !== nodePath.resolve(deliveryWorktreePath)) {
@@ -170,12 +172,12 @@ function assembleOperations(
   observation: CloseoutObservation,
   pullRequest: PullRequestIdentity,
   worktree: WorktreeIdentity | undefined,
-  mainWorktree: WorktreeIdentity,
+  survivingWorktree: WorktreeIdentity,
 ): void {
   if (worktree) {
     plan.operations.push({
       kind: 'remove-worktree',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       path: worktree.path,
       oid: pullRequest.headRefOid,
     });
@@ -185,7 +187,7 @@ function assembleOperations(
   if (observation.remote) {
     plan.operations.push({
       kind: 'delete-remote-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       remote: observation.remote.name,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
@@ -196,7 +198,7 @@ function assembleOperations(
   if (observation.localRefOid) {
     plan.operations.push({
       kind: 'delete-local-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
     });
@@ -227,17 +229,19 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
   const topicWorktrees = observation.worktrees.filter(
     worktree => worktree.branch === pullRequest.headRefName,
   );
-  const mainWorktrees = observation.worktrees.filter(worktree => worktree.main);
+  const defaultBranchWorktrees = observation.worktrees.filter(
+    worktree => worktree.branch === observation.defaultBranch,
+  );
   collectWorktreeBlockers(
     plan,
     pullRequest,
     topicWorktrees,
-    mainWorktrees,
+    defaultBranchWorktrees,
     observation.deliveryWorktreePath,
   );
-  const mainWorktree = mainWorktrees[0];
-  if (plan.blockers.length === 0 && mainWorktree) {
-    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], mainWorktree);
+  const survivingWorktree = defaultBranchWorktrees[0];
+  if (plan.blockers.length === 0 && survivingWorktree) {
+    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], survivingWorktree);
   }
 
   return plan;
@@ -486,9 +490,8 @@ interface TranscriptMetadata {
   sessionId?: unknown;
   session_id?: unknown;
   conversation_id?: unknown;
-  cwd?: unknown;
   type?: unknown;
-  payload?: { id?: unknown; cwd?: unknown };
+  payload?: { id?: unknown };
 }
 
 function exactString(value: unknown): string | undefined {
@@ -529,12 +532,7 @@ export function transcriptMatchesBinding(
           exactString(record.session_id) ??
           exactString(record.conversation_id) ??
           exactString(codexMetadata?.id);
-        const cwd = exactString(record.cwd) ?? exactString(codexMetadata?.cwd);
-        if (sessionId !== binding.id || cwd === undefined) return false;
-        const resolvedCwd = realpathSync(cwd);
-        if (resolvedCwd === expectedRoot) return true;
-        const root = git(resolvedCwd, 'rev-parse', '--show-toplevel');
-        return root.status === 0 && nodePath.resolve(root.stdout.trim()) === expectedRoot;
+        return sessionId === binding.id;
       });
   } catch {
     return false;
@@ -766,7 +764,7 @@ interface GhPullRequest {
   headRepository?: { name?: string; nameWithOwner?: string };
 }
 
-function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
+export function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
   const owner =
     value.headRepositoryOwner?.login ?? value.headRepository?.nameWithOwner?.split('/')[0];
   const repository =
@@ -878,11 +876,15 @@ function observeProtection(
     root,
   );
   const parsed = json<{ protected?: boolean }>(result);
-  return parsed?.protected === true
-    ? 'protected'
-    : parsed?.protected === false
-      ? 'unprotected'
-      : 'unknown';
+  return resolveProtection('matched', parsed?.protected);
+}
+
+export function resolveProtection(
+  remoteResolution: CloseoutObservation['remoteResolution'],
+  observed?: boolean,
+): CloseoutObservation['protection'] {
+  if (remoteResolution === 'absent') return 'unprotected';
+  return observed === true ? 'protected' : observed === false ? 'unprotected' : 'unknown';
 }
 
 export function defaultBranchArguments(identity: PullRequestIdentity): string[] {
@@ -932,7 +934,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection:
       identity && mutableTargets.remoteResolution === 'absent'
-        ? 'unprotected'
+        ? resolveProtection(mutableTargets.remoteResolution)
         : identity
           ? observeProtection(root, identity)
           : 'unknown',

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -15,12 +23,25 @@ import {
   executeCleanupOperation,
   operationCommand,
   parseWorktrees,
+  pullRequestIdentity,
+  resolveProtection,
   resolveRemoteRef as resolveRemoteReference,
   retroAgentForRuntime,
   runBoundRetro,
   safewordCliCommand,
   transcriptMatchesBinding,
 } from '../templates/scripts/closeout-cleanup.ts';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../..');
+
+function normalizedCloseoutScript(path: string): string {
+  return readFileSync(path, 'utf8')
+    .replace(
+      /import \{\s*type CloseoutBinding,\s*readFreshCloseoutBinding,\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/closeout-binding\.ts';/u,
+      "import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';",
+    )
+    .replace('../../runtime/hooks/lib/retro-draft-spool.ts', '../hooks/lib/retro-draft-spool.ts');
+}
 
 function safeObservation(overrides: Partial<CloseoutObservation> = {}): CloseoutObservation {
   return {
@@ -165,6 +186,59 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     ]);
   });
 
+  it('maps current GitHub pull request shapes without trusting incomplete identities', () => {
+    const expected = pullRequest();
+    expect(
+      pullRequestIdentity({
+        url: expected.url,
+        state: expected.state,
+        headRefName: expected.headRefName,
+        headRefOid: expected.headRefOid,
+        headRepositoryOwner: { login: expected.headOwner },
+        headRepository: { name: expected.headRepository },
+      }),
+    ).toEqual(expected);
+    expect(
+      pullRequestIdentity({
+        url: expected.url,
+        state: expected.state,
+        headRefName: expected.headRefName,
+        headRefOid: expected.headRefOid,
+        headRepository: { nameWithOwner: `${expected.headOwner}/${expected.headRepository}` },
+      }),
+    ).toEqual(expected);
+    expect(
+      pullRequestIdentity({
+        url: expected.url,
+        state: expected.state,
+        headRefName: expected.headRefName,
+        headRefOid: expected.headRefOid,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('derives branch protection conservatively while allowing a proven-absent remote ref', () => {
+    expect(resolveProtection('absent')).toBe('unprotected');
+    expect(resolveProtection('matched', true)).toBe('protected');
+    expect(resolveProtection('matched', false)).toBe('unprotected');
+    expect(resolveProtection('matched')).toBe('unknown');
+    expect(resolveProtection('unknown', false)).toBe('unprotected');
+  });
+
+  it('keeps installed and native-plugin closeout guards in canonical parity', () => {
+    const template = normalizedCloseoutScript(
+      nodePath.join(repoRoot, 'packages/cli/templates/scripts/closeout-cleanup.ts'),
+    );
+    expect(
+      normalizedCloseoutScript(nodePath.join(repoRoot, '.safeword/scripts/closeout-cleanup.ts')),
+    ).toBe(template);
+    expect(
+      normalizedCloseoutScript(
+        nodePath.join(repoRoot, 'plugin/resources/scripts/closeout-cleanup.ts'),
+      ),
+    ).toBe(template);
+  });
+
   it('previews exact cleanup in worktree, remote, local order with a stable digest', () => {
     const observation = safeObservation();
     const plan = buildCleanupPlan(observation);
@@ -180,6 +254,35 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     expect(plan.operations[2]).toMatchObject({ ref: 'refs/heads/feature/closeout' });
     expect(cleanupPlanDigest(plan)).toMatch(/^[a-f0-9]{64}$/);
     expect(cleanupPlanDigest(plan)).toBe(cleanupPlanDigest(buildCleanupPlan(observation)));
+  });
+
+  it('uses the unique default-branch worktree when the primary worktree is detached', () => {
+    const observation = safeObservation({
+      worktrees: [
+        { path: '/repo-main', branch: 'main', oid: 'b'.repeat(40), main: false },
+        worktree(1),
+      ],
+    });
+
+    const plan = buildCleanupPlan(observation);
+
+    expect(plan.blockers).toEqual([]);
+    expect(plan.operations).toHaveLength(3);
+    expect(plan.operations.every(operation => operation.cwd === '/repo-main')).toBe(true);
+  });
+
+  it('never removes the primary worktree even when another worktree holds the default branch', () => {
+    const plan = buildCleanupPlan(
+      safeObservation({
+        worktrees: [
+          { path: '/repo-main', branch: 'main', oid: 'b'.repeat(40), main: false },
+          { ...worktree(1), main: true },
+        ],
+      }),
+    );
+
+    expect(plan.blockers).toContain('the main worktree is never a closeout target');
+    expect(plan.operations).toEqual([]);
   });
 
   it.each([
@@ -257,6 +360,22 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       'ambiguous worktree',
       { worktrees: [worktree(0), worktree(1), worktree(1)] },
       'the linked topic worktree is ambiguous',
+    ],
+    [
+      'missing default-branch worktree',
+      { worktrees: [worktree(1)] },
+      'exactly one surviving default-branch worktree is required',
+    ],
+    [
+      'ambiguous default-branch worktree',
+      {
+        worktrees: [
+          worktree(0),
+          { ...worktree(0), path: '/another-main', main: false },
+          worktree(1),
+        ],
+      },
+      'exactly one surviving default-branch worktree is required',
     ],
     [
       'stale verification',
@@ -566,14 +685,73 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     }
   });
 
-  it('accepts only transcript metadata bound to the exact session and repository', () => {
+  it('discovers a linked default-branch survivor after the primary worktree is detached', () => {
+    const sandbox = mkdtempSync(nodePath.join(tmpdir(), 'safeword-closeout-detached-main-'));
+    const primary = nodePath.join(sandbox, 'primary');
+    const surviving = nodePath.join(sandbox, 'surviving-main');
+    const topic = nodePath.join(sandbox, 'topic');
+    try {
+      runGit('init', '--initial-branch=main', primary);
+      runGit('-C', primary, 'config', 'user.email', 'closeout@example.test');
+      runGit('-C', primary, 'config', 'user.name', 'Closeout Test');
+      writeFileSync(nodePath.join(primary, 'README.md'), 'main\n');
+      runGit('-C', primary, 'add', 'README.md');
+      runGit('-C', primary, 'commit', '-m', 'main');
+      runGit('-C', primary, 'checkout', '--detach');
+      runGit('-C', primary, 'worktree', 'add', surviving, 'main');
+      runGit('-C', primary, 'worktree', 'add', '-b', 'feature/closeout', topic);
+
+      const worktrees = parseWorktrees(primary);
+      const survivingWorktree = {
+        path: realpathSync(surviving),
+        branch: 'main',
+        main: false,
+      };
+      const topicWorktree = {
+        path: realpathSync(topic),
+        branch: 'feature/closeout',
+        main: false,
+      };
+      expect(worktrees).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(survivingWorktree),
+          expect.objectContaining(topicWorktree),
+        ]),
+      );
+
+      const oid = runGit('-C', topic, 'rev-parse', 'HEAD');
+      const plan = buildCleanupPlan(
+        safeObservation({
+          deliveryWorktreePath: realpathSync(topic),
+          pullRequests: [{ ...pullRequest(), headRefOid: oid }],
+          localRefOid: oid,
+          remote: undefined,
+          remoteResolution: 'absent',
+          worktrees,
+          verification: { current: true, passed: true, headOid: oid, stateHash: 'detached-main' },
+        }),
+      );
+
+      expect(plan.blockers).toEqual([]);
+      expect(plan.operations.every(operation => operation.cwd === realpathSync(surviving))).toBe(
+        true,
+      );
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts an exact bound session after its original worktree is removed', () => {
     const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-closeout-transcript-'));
+    const otherRoot = mkdtempSync(nodePath.join(tmpdir(), 'safeword-closeout-other-'));
+    const originalWorktree = mkdtempSync(nodePath.join(tmpdir(), 'safeword-closeout-original-'));
     const transcript = nodePath.join(root, 'transcript.jsonl');
     mkdirSync(nodePath.join(root, '.project'));
     writeFileSync(
       transcript,
-      `${JSON.stringify({ type: 'user', sessionId: 'session-42', cwd: root })}\n`,
+      `${JSON.stringify({ type: 'user', sessionId: 'session-42', cwd: originalWorktree })}\n`,
     );
+    rmSync(originalWorktree, { recursive: true, force: true });
 
     expect(
       transcriptMatchesBinding(
@@ -593,7 +771,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       transcriptMatchesBinding(
         transcript,
         { runtime: 'claude', id: 'session-42', projectRoot: root },
-        '/other/repo',
+        otherRoot,
       ),
     ).toBe(false);
 

--- a/packages/cli/tests/manual-closeout-review.test.ts
+++ b/packages/cli/tests/manual-closeout-review.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
@@ -28,6 +29,28 @@ interface Review {
 
 function sha256(content: string | Buffer): string {
   return createHash('sha256').update(content).digest('hex');
+}
+
+function git(arguments_: string[]): { status: number; stdout: Buffer; stderr: Buffer } {
+  const result = spawnSync('git', arguments_, { cwd: repoRoot });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function sealedCommit(): string | undefined {
+  const relativeManifest = nodePath.relative(repoRoot, manifestPath);
+  const result = git(['log', '-1', '--format=%H', '--', relativeManifest]);
+  const commit = result.stdout.toString('utf8').trim();
+  return result.status === 0 && commit ? commit : undefined;
+}
+
+function reviewedInput(path: string, commit: string | undefined): Buffer {
+  if (!commit) return readFileSync(nodePath.join(repoRoot, path));
+  const result = git(['show', `${commit}:${path}`]);
+  return result.status === 0 ? result.stdout : readFileSync(nodePath.join(repoRoot, path));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -102,14 +125,17 @@ describe('hash-bound independent closeout review (93C14D)', () => {
     );
   });
 
-  it('binds every current artifact and expanded feature example to a passing fresh review', () => {
+  it('binds every sealed artifact and expanded feature example to a passing fresh review', () => {
     const manifestBytes = readFileSync(manifestPath, 'utf8');
     const manifest = JSON.parse(manifestBytes) as Manifest;
     const review = reviewJson(readFileSync(reviewPath, 'utf8'));
-    const featurePath = nodePath.join(repoRoot, 'features/close-completed-sessions-safely.feature');
-    const expectedScenarios = parseFeatureScenarios(readFileSync(featurePath, 'utf8')).map(
-      (scenario, index) => ({ id: String(index + 1).padStart(2, '0'), title: scenario.title }),
-    );
+    const commit = sealedCommit();
+    if (commit) {
+      expect(git(['merge-base', '--is-ancestor', commit, 'HEAD']).status).toBe(0);
+    }
+    const expectedScenarios = parseFeatureScenarios(
+      reviewedInput('features/close-completed-sessions-safely.feature', commit).toString('utf8'),
+    ).map((scenario, index) => ({ id: String(index + 1).padStart(2, '0'), title: scenario.title }));
 
     expect(manifest.ticket).toBe('93C14D');
     expect(manifest.expected_scenarios).toEqual(expectedScenarios);
@@ -155,9 +181,7 @@ describe('hash-bound independent closeout review (93C14D)', () => {
       '.project/tickets/93C14D-close-completed-sessions-safely/automated-review-results.json',
     ]);
     for (const input of manifest.inputs) {
-      const inputPath = nodePath.join(repoRoot, input.path);
-      const currentDigest = sha256(readFileSync(inputPath));
-      expect(input.sha256, input.path).toBe(currentDigest);
+      expect(input.sha256, input.path).toBe(sha256(reviewedInput(input.path, commit)));
     }
     expect(reviewIssues(manifest, manifestBytes, review)).toEqual([]);
   });

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.72.0",
   "hook_manifest_sha256": "79728d2f2251659a458208ac8d5ea45fe7aebe54e9204e4aaa108de491e39503",
-  "inventory_sha256": "223a941d19bd991fc5ffd761bd663de0c16e31ab4f5965cecc4013de9e83a10c"
+  "inventory_sha256": "6031e8b207875bca9d9a1b5ac084bf9bc8f27e1f6afc44c0fa32446c6173445f"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -87,7 +87,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "b2b6ed4428c784e2086fc2f7e9e6f95dbc2890c881f198a3ebf122026fed3962"
+      "sha256": "969603bb08719af367b53826307b41376d9659940fa422f4f6fdd045fe5cf744"
     },
     {
       "path": "resources/templates/adr-template.md",

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -150,10 +150,12 @@ function collectWorktreeBlockers(
   plan: CleanupPlan,
   pullRequest: PullRequestIdentity,
   topicWorktrees: WorktreeIdentity[],
-  mainWorktrees: WorktreeIdentity[],
+  defaultBranchWorktrees: WorktreeIdentity[],
   deliveryWorktreePath: string,
 ): void {
-  if (mainWorktrees.length !== 1) block(plan, 'exactly one surviving main worktree is required');
+  if (defaultBranchWorktrees.length !== 1) {
+    block(plan, 'exactly one surviving default-branch worktree is required');
+  }
   if (topicWorktrees.length > 1) block(plan, 'the linked topic worktree is ambiguous');
   const worktree = topicWorktrees[0];
   if (worktree && nodePath.resolve(worktree.path) !== nodePath.resolve(deliveryWorktreePath)) {
@@ -173,12 +175,12 @@ function assembleOperations(
   observation: CloseoutObservation,
   pullRequest: PullRequestIdentity,
   worktree: WorktreeIdentity | undefined,
-  mainWorktree: WorktreeIdentity,
+  survivingWorktree: WorktreeIdentity,
 ): void {
   if (worktree) {
     plan.operations.push({
       kind: 'remove-worktree',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       path: worktree.path,
       oid: pullRequest.headRefOid,
     });
@@ -188,7 +190,7 @@ function assembleOperations(
   if (observation.remote) {
     plan.operations.push({
       kind: 'delete-remote-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       remote: observation.remote.name,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
@@ -199,7 +201,7 @@ function assembleOperations(
   if (observation.localRefOid) {
     plan.operations.push({
       kind: 'delete-local-ref',
-      cwd: mainWorktree.path,
+      cwd: survivingWorktree.path,
       ref: `refs/heads/${pullRequest.headRefName}`,
       oid: pullRequest.headRefOid,
     });
@@ -230,17 +232,19 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
   const topicWorktrees = observation.worktrees.filter(
     worktree => worktree.branch === pullRequest.headRefName,
   );
-  const mainWorktrees = observation.worktrees.filter(worktree => worktree.main);
+  const defaultBranchWorktrees = observation.worktrees.filter(
+    worktree => worktree.branch === observation.defaultBranch,
+  );
   collectWorktreeBlockers(
     plan,
     pullRequest,
     topicWorktrees,
-    mainWorktrees,
+    defaultBranchWorktrees,
     observation.deliveryWorktreePath,
   );
-  const mainWorktree = mainWorktrees[0];
-  if (plan.blockers.length === 0 && mainWorktree) {
-    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], mainWorktree);
+  const survivingWorktree = defaultBranchWorktrees[0];
+  if (plan.blockers.length === 0 && survivingWorktree) {
+    assembleOperations(plan, observation, pullRequest, topicWorktrees[0], survivingWorktree);
   }
 
   return plan;
@@ -489,9 +493,8 @@ interface TranscriptMetadata {
   sessionId?: unknown;
   session_id?: unknown;
   conversation_id?: unknown;
-  cwd?: unknown;
   type?: unknown;
-  payload?: { id?: unknown; cwd?: unknown };
+  payload?: { id?: unknown };
 }
 
 function exactString(value: unknown): string | undefined {
@@ -532,12 +535,7 @@ export function transcriptMatchesBinding(
           exactString(record.session_id) ??
           exactString(record.conversation_id) ??
           exactString(codexMetadata?.id);
-        const cwd = exactString(record.cwd) ?? exactString(codexMetadata?.cwd);
-        if (sessionId !== binding.id || cwd === undefined) return false;
-        const resolvedCwd = realpathSync(cwd);
-        if (resolvedCwd === expectedRoot) return true;
-        const root = git(resolvedCwd, 'rev-parse', '--show-toplevel');
-        return root.status === 0 && nodePath.resolve(root.stdout.trim()) === expectedRoot;
+        return sessionId === binding.id;
       });
   } catch {
     return false;
@@ -769,7 +767,7 @@ interface GhPullRequest {
   headRepository?: { name?: string; nameWithOwner?: string };
 }
 
-function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
+export function pullRequestIdentity(value: GhPullRequest): PullRequestIdentity | undefined {
   const owner =
     value.headRepositoryOwner?.login ?? value.headRepository?.nameWithOwner?.split('/')[0];
   const repository =
@@ -881,11 +879,15 @@ function observeProtection(
     root,
   );
   const parsed = json<{ protected?: boolean }>(result);
-  return parsed?.protected === true
-    ? 'protected'
-    : parsed?.protected === false
-      ? 'unprotected'
-      : 'unknown';
+  return resolveProtection('matched', parsed?.protected);
+}
+
+export function resolveProtection(
+  remoteResolution: CloseoutObservation['remoteResolution'],
+  observed?: boolean,
+): CloseoutObservation['protection'] {
+  if (remoteResolution === 'absent') return 'unprotected';
+  return observed === true ? 'protected' : observed === false ? 'unprotected' : 'unknown';
 }
 
 export function defaultBranchArguments(identity: PullRequestIdentity): string[] {
@@ -935,7 +937,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection:
       identity && mutableTargets.remoteResolution === 'absent'
-        ? 'unprotected'
+        ? resolveProtection(mutableTargets.remoteResolution)
         : identity
           ? observeProtection(root, identity)
           : 'unknown',


### PR DESCRIPTION
## Summary

- authenticate resumed closeout by exact host binding and structured session ID without treating the transcript start cwd as permanent repository identity
- choose the unique observed default-branch checkout as the cleanup survivor while retaining the primary-worktree deletion guard
- preserve historical manual-review seals across follow-up patches and keep all installed/plugin script surfaces and integrity manifests in parity

Resolves #1849
Resolves #1850

## Verification

- 6,473/6,473 tests passed (5 skipped)
- 826 Gherkin scenarios passed/skipped as expected (823 passed, 3 skipped)
- build, ESLint, TypeScript, dependency audit, parity, diff-scoped audit: green
- cross-agent quality review: approved