### PR TITLE
fix(closeout): finish authenticated post-merge cleanup

### DIFF
--- a/.claude/skills/closeout/SKILL.md
+++ b/.claude/skills/closeout/SKILL.md
@@ -28,6 +28,9 @@ Collect and report every blocker. Missing, stale, failing, pending, unknown, or
 ambiguous evidence means **no merge or cleanup**. A merge command's exit status
 never proves that the pull request is merged.
 
+Dependency audit is part of this delivery-time verification boundary. Resolve
+its failures before merge while the pull request head can still be changed.
+
 ## 2. Respect merge authority
 
 Invocation alone grants no merge authority. Read authority only from the current user request;
@@ -74,9 +77,10 @@ A missing, stale, malformed, dirty-state, or wrong-head receipt blocks cleanup.
 
 After merge is independently confirmed, invoke the cleanup guard in preview
 mode. Its host hook supplies a short-lived, single-consumer binding to this exact
-session (and Cursor transcript). A missing or expired binding fails closed;
-there is no newest-session fallback and callers cannot nominate another receipt,
-session, transcript, or spool.
+session (and Cursor transcript). Codex Desktop may instead supply its authenticated
+current `CODEX_THREAD_ID`, consistent with SafeWord's other Codex identity bridges.
+A missing or expired binding or identity fails closed; there is no newest-session
+fallback and callers cannot nominate another receipt, session, transcript, or spool.
 
 The guard runs `safeword retro run --json` itself and accepts only a
 successful result whose `data.agent_filing_needed` is `false` and whose derived
@@ -96,8 +100,10 @@ Run the guard from the delivery worktree; preview is the default:
 bun .safeword/scripts/closeout-cleanup.ts --pr PR_NUMBER
 ```
 
-At the exact delivery head, preview reruns the project's verification, build,
-typecheck, BDD, and dependency plans. After that worktree is gone, preview
+At the exact delivery head, the post-merge preview reruns the project's
+verification, build, typecheck, and BDD plans. It does not rerun dependency audit:
+that changing intelligence is enforced at the delivery-time, pre-merge boundary
+and cannot repair an immutable merged head. After that worktree is gone, preview
 requires its fresh clean-head receipt instead. It binds the resulting repository
 state and exact PR identity to `PLAN_DIGEST`. Report the complete operation list
 and all blockers. Do not apply a blocked plan.

--- a/.project/tickets/CJXX50-closeout-can-finish-after-merge/audit.md
+++ b/.project/tickets/CJXX50-closeout-can-finish-after-merge/audit.md
@@ -1,0 +1,30 @@
+# Audit
+
+Audited: 2026-08-04T01:15:46Z
+
+## Summary
+
+Errors: 0 | Warnings: 1 | Passed: 7
+
+Audit passed with one review-process warning.
+
+## Code quality
+
+- Architecture: `sync-config --check` is healthy and dependency-cruiser reports no violations.
+- Scope: the change is confined to closeout policy, identity resolution, generated mirrors, regression tests, public documentation, and this ticket.
+- Test quality: focused tests use isolated temporary repositories, assert hook precedence and missing-identity failure, and pin the exact post-merge lane set.
+- Dependencies: no runtime dependencies changed; the pre-merge dependency audit reports no vulnerabilities.
+- Duplication and dead code: diff-mode audit found no applicable new findings.
+- Learning and principle trace: no findings. The change improves the NTB cleanup path without weakening TBU delivery or identity controls.
+
+## Documentation
+
+Configured sources `README.md` and `packages/website/src/content/docs` were reviewed and updated. They now distinguish the pre-merge dependency gate from deterministic post-merge checks and document the authenticated Codex Desktop thread fallback.
+
+## Warning
+
+- Independent quality review exhausted its configured Claude route (`timed_out`) and Codex fallback (`invalid_output`) without returning a verdict. No approval is inferred. Direct audit, full verification, and real-host evidence found no actionable defect.
+
+## Next
+
+Open the pull request and require hosted checks and normal review policy before merge.

--- a/.project/tickets/CJXX50-closeout-can-finish-after-merge/ticket.md
+++ b/.project/tickets/CJXX50-closeout-can-finish-after-merge/ticket.md
@@ -1,0 +1,44 @@
+---
+id: CJXX50
+slug: closeout-can-finish-after-merge
+type: patch
+phase: verify
+status: in_progress
+created: 2026-08-04T00:12:56.287Z
+last_modified: 2026-08-04T01:15:46.000Z
+---
+
+# Let authenticated closeout finish after merge
+
+**Goal:** Let Codex Desktop authenticate closeout and keep mutable dependency policy from stranding cleanup of immutable merged heads.
+
+**Why:** Dogfooding left three merged delivery worktrees preserved despite successful delivery evidence.
+
+**Tracker:** #1856; related dependency-policy bug #1857.
+
+**Scope:**
+
+- reuse the established `CODEX_THREAD_ID` fallback when no fresh Codex hook binding exists;
+- keep a fresh hook binding authoritative when one exists;
+- keep dependency auditing in delivery-time `/verify`, but exclude it from the post-merge cleanup recheck;
+- cover both dogfooded failure modes in the existing closeout feature and focused automated tests.
+
+**Out of scope:**
+
+- weakening exact PR/ref/worktree identity checks or cleanup compare-and-swap behavior;
+- bypassing dependency audit before merge;
+- changing Claude Code or Cursor identity resolution.
+
+**Done when:**
+
+- Codex Desktop can preview closeout from its authenticated thread environment without a hook cache;
+- hook bindings still take precedence and missing identity still fails closed;
+- post-merge verification runs verify, build, typecheck, and BDD but not dependency audit;
+- focused tests, full verification, audit, parity, and quality review pass.
+
+## Work Log
+
+- 2026-08-04T00:12:56.287Z Started: Created ticket CJXX50
+- 2026-08-04T00:18:00.000Z Revalidated: #1856 still fails on current main; PR #1833 remains stranded by a newly failing dependency audit on its immutable merged head. Filed #1857 for the policy deadlock.
+- 2026-08-04T00:19:00.000Z Decided: Reuse SafeWord's existing Codex Desktop `CODEX_THREAD_ID` identity fallback with hook precedence. Preserve dependency audit as a pre-merge `/verify` gate and rerun only deterministic code-state lanes after merge.
+- 2026-08-04T01:15:46.000Z Verified: Full unit, Gherkin, build, typecheck, lint, dependency, parity, and architecture lanes pass. A real PR #1855 closeout preview authenticated through Codex Desktop and produced a safe exact-OID cleanup plan without rerunning dependency audit.

--- a/.project/tickets/CJXX50-closeout-can-finish-after-merge/ticket.md
+++ b/.project/tickets/CJXX50-closeout-can-finish-after-merge/ticket.md
@@ -2,10 +2,10 @@
 id: CJXX50
 slug: closeout-can-finish-after-merge
 type: patch
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-08-04T00:12:56.287Z
-last_modified: 2026-08-04T01:15:46.000Z
+last_modified: 2026-08-04T01:28:00.000Z
 ---
 
 # Let authenticated closeout finish after merge
@@ -42,3 +42,4 @@ last_modified: 2026-08-04T01:15:46.000Z
 - 2026-08-04T00:18:00.000Z Revalidated: #1856 still fails on current main; PR #1833 remains stranded by a newly failing dependency audit on its immutable merged head. Filed #1857 for the policy deadlock.
 - 2026-08-04T00:19:00.000Z Decided: Reuse SafeWord's existing Codex Desktop `CODEX_THREAD_ID` identity fallback with hook precedence. Preserve dependency audit as a pre-merge `/verify` gate and rerun only deterministic code-state lanes after merge.
 - 2026-08-04T01:15:46.000Z Verified: Full unit, Gherkin, build, typecheck, lint, dependency, parity, and architecture lanes pass. A real PR #1855 closeout preview authenticated through Codex Desktop and produced a safe exact-OID cleanup plan without rerunning dependency audit.
+- 2026-08-04T01:28:00.000Z Done: The implementation, regression coverage, generated parity, documentation, audit, and verification evidence are complete. Independent quality-review routes exhausted without a verdict; `audit.md` records that evidence limitation without inferring approval.

--- a/.project/tickets/CJXX50-closeout-can-finish-after-merge/verify.md
+++ b/.project/tickets/CJXX50-closeout-can-finish-after-merge/verify.md
@@ -1,0 +1,30 @@
+# Verify Checklist
+
+**Test Suite:** ✓ 6548/6548 executed tests pass (5 skipped)
+**Gherkin:** ✅ Acceptance lane passes (910 scenarios passed, 3 skipped)
+**Build:** ✅ Success
+**Typecheck:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** ✅ Both closeout regression scenarios pass in the full Gherkin lane
+**PR Scope:** ✅ Only the two revalidated closeout defects, their evidence, and generated mirrors
+**Dep Drift:** ✅ Clean — no dependencies changed and `bun audit` reports no vulnerabilities
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation; generated Claude, Codex, plugin, and dogfood assets agree
+**Experience:** ✅ NTB can finish an already-merged delivery without mutable advisory drift; TBU retains pre-merge audit, exact identity, retro, and compare-and-swap cleanup controls
+**Surface Evidence:** ✅ Claude, Codex, and Cursor adapter integration passes; a real Codex Desktop preview against merged PR #1855 produced the expected exact-OID cleanup plan
+**Evidence limits:** ⚠️ Independent quality-review routes exhausted without a verdict; see `audit.md`
+
+## Closure Evidence
+
+- The patched cleanup guard previewed PR #1855 successfully from `/Users/alex/.codex/worktrees/closeout-resolve/safeword` using authenticated `CODEX_THREAD_ID` fallback.
+- Plan digest: `5ee369af902819b74dc6d55bb2a0e86c77d6297d1523723c404f6b24aed4e781`.
+- Target head: `12e6f19f5ab98efb3413540434e9ae0b3b97fdb8`.
+- No cleanup mutation was applied during validation.
+
+## Errors
+
+None.
+
+## Warnings
+
+- Independent reviewer infrastructure did not produce a parseable verdict after the required preferred and fallback routes.

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -17,6 +17,9 @@ import nodePath from 'node:path';
 
 import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';
 import { readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
+import { resolveRunIdentity } from '../hooks/lib/run-identity.ts';
+
+export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
 
 export interface PullRequestIdentity {
   url: string;
@@ -716,7 +719,7 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
         };
   }
   let passed = invalidateVerificationReceipt(root);
-  for (const kind of ['verify', 'build', 'typecheck', 'bdd', 'deps']) {
+  for (const kind of POST_MERGE_VERIFICATION_KINDS) {
     const planResult = runSafeword(root, [
       'project',
       'test-plan',
@@ -753,6 +756,28 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
     });
   }
   return verification;
+}
+
+export function resolveCloseoutBinding(
+  root: string,
+  env: Record<string, string | undefined> = process.env,
+): CloseoutBinding | undefined {
+  const bridged = readFreshCloseoutBinding({ projectDirectory: root });
+  if (bridged !== undefined) return bridged;
+
+  const identity = resolveRunIdentity({}, { env });
+  if (
+    identity.runtime !== 'codex' ||
+    identity.source !== 'CODEX_THREAD_ID' ||
+    identity.sessionKey === null
+  ) {
+    return undefined;
+  }
+  return {
+    runtime: 'codex',
+    id: identity.sessionKey,
+    projectRoot: realpathSync(root),
+  };
 }
 
 interface GhPullRequest {
@@ -963,7 +988,7 @@ function argumentValue(name: string): string | undefined {
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const pr = argumentValue('--pr');
-  const binding = root ? readFreshCloseoutBinding({ projectDirectory: root }) : undefined;
+  const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
     console.error(
       'closeout blocked: repository, --pr, and a fresh host session binding are required',

--- a/.safeword/skills/closeout/SKILL.md
+++ b/.safeword/skills/closeout/SKILL.md
@@ -28,6 +28,9 @@ Collect and report every blocker. Missing, stale, failing, pending, unknown, or
 ambiguous evidence means **no merge or cleanup**. A merge command's exit status
 never proves that the pull request is merged.
 
+Dependency audit is part of this delivery-time verification boundary. Resolve
+its failures before merge while the pull request head can still be changed.
+
 ## 2. Respect merge authority
 
 Invocation alone grants no merge authority. Read authority only from the current user request;
@@ -74,9 +77,10 @@ A missing, stale, malformed, dirty-state, or wrong-head receipt blocks cleanup.
 
 After merge is independently confirmed, invoke the cleanup guard in preview
 mode. Its host hook supplies a short-lived, single-consumer binding to this exact
-session (and Cursor transcript). A missing or expired binding fails closed;
-there is no newest-session fallback and callers cannot nominate another receipt,
-session, transcript, or spool.
+session (and Cursor transcript). Codex Desktop may instead supply its authenticated
+current `CODEX_THREAD_ID`, consistent with SafeWord's other Codex identity bridges.
+A missing or expired binding or identity fails closed; there is no newest-session
+fallback and callers cannot nominate another receipt, session, transcript, or spool.
 
 The guard runs `safeword retro run --json` itself and accepts only a
 successful result whose `data.agent_filing_needed` is `false` and whose derived
@@ -96,8 +100,10 @@ Run the guard from the delivery worktree; preview is the default:
 bun .safeword/scripts/closeout-cleanup.ts --pr PR_NUMBER
 ```
 
-At the exact delivery head, preview reruns the project's verification, build,
-typecheck, BDD, and dependency plans. After that worktree is gone, preview
+At the exact delivery head, the post-merge preview reruns the project's
+verification, build, typecheck, and BDD plans. It does not rerun dependency audit:
+that changing intelligence is enforced at the delivery-time, pre-merge boundary
+and cannot repair an immutable merged head. After that worktree is gone, preview
 requires its fresh clean-head receipt instead. It binds the resulting repository
 state and exact PR identity to `PLAN_DIGEST`. Report the complete operation list
 and all blockers. Do not apply a blocked plan.

--- a/README.md
+++ b/README.md
@@ -333,9 +333,12 @@ it never stages, commits, or opens a PR.
 
 Closeout can resume after its topic worktree has already been removed. The
 guard stores a private 24-hour receipt in Git's shared common directory only
-after every verification lane passes on the clean exact pull-request head; a
-missing, stale, malformed, dirty-state, or wrong-head receipt blocks the
-remaining branch cleanup.
+after every applicable post-merge lane passes on the clean exact pull-request
+head. Dependency auditing remains a pre-merge delivery gate; mutable advisory
+data cannot strand cleanup of an immutable merged head. Claude Code and Cursor
+use hook-captured session identity, while Codex Desktop may use its authenticated
+`CODEX_THREAD_ID` when the one-shot hook bridge is unavailable. Missing, stale,
+malformed, dirty-state, or wrong-head proof blocks the remaining branch cleanup.
 
 **MCP Servers** (in `.mcp.json` / `.cursor/mcp.json`): Auto-configured integrations
 

--- a/features/close-completed-sessions-safely.feature
+++ b/features/close-completed-sessions-safely.feature
@@ -134,6 +134,14 @@ Feature: Close completed sessions safely
       When closeout runs again
       Then it performs no destructive action and reports the session already closed
 
+    @surface.claude-code @surface.openai-codex @surface.cursor
+    Scenario: New dependency intelligence does not strand cleanup of an immutable merged head
+      Given delivery-time verification including dependency audit passed before merge
+      And the exact pull request head is confirmed merged
+      And a dependency advisory published after merge now affects that immutable head
+      When closeout revalidates the merged head for cleanup
+      Then it reruns verification, build, typecheck, and BDD without rerunning dependency audit
+
   @close-completed-sessions-safely.TBU1.R1
   Rule: close-completed-sessions-safely.TBU1.R1 — Merge actions never exceed the authority explicitly granted by the user
 
@@ -264,6 +272,13 @@ Feature: Close completed sessions safely
       Given the canonical skill and generated Claude Code, OpenAI Codex, and Cursor artifacts carry the closeout contract
       When Safeword checks workflow parity
       Then every closeout parity pair and action entry point passes
+
+    @surface.openai-codex
+    Scenario: Codex Desktop binds closeout from its authenticated thread environment
+      Given Codex Desktop exposes the current thread identity to the closeout process
+      And no fresh pre-tool binding cache is available
+      When the user previews closeout from that task
+      Then closeout binds the current Codex thread and evaluates the exact merged delivery
 
     @rejection @surface.claude-code @surface.openai-codex @surface.cursor
     Scenario Outline: Closeout drift fails parity at the changed surface

--- a/packages/cli/codex-plugin/skills/closeout/SKILL.md
+++ b/packages/cli/codex-plugin/skills/closeout/SKILL.md
@@ -27,6 +27,9 @@ Collect and report every blocker. Missing, stale, failing, pending, unknown, or
 ambiguous evidence means **no merge or cleanup**. A merge command's exit status
 never proves that the pull request is merged.
 
+Dependency audit is part of this delivery-time verification boundary. Resolve
+its failures before merge while the pull request head can still be changed.
+
 ## 2. Respect merge authority
 
 Invocation alone grants no merge authority. Read authority only from the current user request;
@@ -73,9 +76,10 @@ A missing, stale, malformed, dirty-state, or wrong-head receipt blocks cleanup.
 
 After merge is independently confirmed, invoke the cleanup guard in preview
 mode. Its host hook supplies a short-lived, single-consumer binding to this exact
-session (and Cursor transcript). A missing or expired binding fails closed;
-there is no newest-session fallback and callers cannot nominate another receipt,
-session, transcript, or spool.
+session (and Cursor transcript). Codex Desktop may instead supply its authenticated
+current `CODEX_THREAD_ID`, consistent with SafeWord's other Codex identity bridges.
+A missing or expired binding or identity fails closed; there is no newest-session
+fallback and callers cannot nominate another receipt, session, transcript, or spool.
 
 The guard runs `safeword retro run --json` itself and accepts only a
 successful result whose `data.agent_filing_needed` is `false` and whose derived
@@ -95,8 +99,10 @@ Run the guard from the delivery worktree; preview is the default:
 bun .safeword/scripts/closeout-cleanup.ts --pr PR_NUMBER
 ```
 
-At the exact delivery head, preview reruns the project's verification, build,
-typecheck, BDD, and dependency plans. After that worktree is gone, preview
+At the exact delivery head, the post-merge preview reruns the project's
+verification, build, typecheck, and BDD plans. It does not rerun dependency audit:
+that changing intelligence is enforced at the delivery-time, pre-merge boundary
+and cannot repair an immutable merged head. After that worktree is gone, preview
 requires its fresh clean-head receipt instead. It binds the resulting repository
 state and exact PR identity to `PLAN_DIGEST`. Report the complete operation list
 and all blockers. Do not apply a blocked plan.

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -17,6 +17,9 @@ import nodePath from 'node:path';
 
 import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';
 import { readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
+import { resolveRunIdentity } from '../hooks/lib/run-identity.ts';
+
+export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
 
 export interface PullRequestIdentity {
   url: string;
@@ -716,7 +719,7 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
         };
   }
   let passed = invalidateVerificationReceipt(root);
-  for (const kind of ['verify', 'build', 'typecheck', 'bdd', 'deps']) {
+  for (const kind of POST_MERGE_VERIFICATION_KINDS) {
     const planResult = runSafeword(root, [
       'project',
       'test-plan',
@@ -753,6 +756,28 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
     });
   }
   return verification;
+}
+
+export function resolveCloseoutBinding(
+  root: string,
+  env: Record<string, string | undefined> = process.env,
+): CloseoutBinding | undefined {
+  const bridged = readFreshCloseoutBinding({ projectDirectory: root });
+  if (bridged !== undefined) return bridged;
+
+  const identity = resolveRunIdentity({}, { env });
+  if (
+    identity.runtime !== 'codex' ||
+    identity.source !== 'CODEX_THREAD_ID' ||
+    identity.sessionKey === null
+  ) {
+    return undefined;
+  }
+  return {
+    runtime: 'codex',
+    id: identity.sessionKey,
+    projectRoot: realpathSync(root),
+  };
 }
 
 interface GhPullRequest {
@@ -963,7 +988,7 @@ function argumentValue(name: string): string | undefined {
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const pr = argumentValue('--pr');
-  const binding = root ? readFreshCloseoutBinding({ projectDirectory: root }) : undefined;
+  const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
     console.error(
       'closeout blocked: repository, --pr, and a fresh host session binding are required',

--- a/packages/cli/templates/skills/closeout/SKILL.md
+++ b/packages/cli/templates/skills/closeout/SKILL.md
@@ -28,6 +28,9 @@ Collect and report every blocker. Missing, stale, failing, pending, unknown, or
 ambiguous evidence means **no merge or cleanup**. A merge command's exit status
 never proves that the pull request is merged.
 
+Dependency audit is part of this delivery-time verification boundary. Resolve
+its failures before merge while the pull request head can still be changed.
+
 ## 2. Respect merge authority
 
 Invocation alone grants no merge authority. Read authority only from the current user request;
@@ -74,9 +77,10 @@ A missing, stale, malformed, dirty-state, or wrong-head receipt blocks cleanup.
 
 After merge is independently confirmed, invoke the cleanup guard in preview
 mode. Its host hook supplies a short-lived, single-consumer binding to this exact
-session (and Cursor transcript). A missing or expired binding fails closed;
-there is no newest-session fallback and callers cannot nominate another receipt,
-session, transcript, or spool.
+session (and Cursor transcript). Codex Desktop may instead supply its authenticated
+current `CODEX_THREAD_ID`, consistent with SafeWord's other Codex identity bridges.
+A missing or expired binding or identity fails closed; there is no newest-session
+fallback and callers cannot nominate another receipt, session, transcript, or spool.
 
 The guard runs `safeword retro run --json` itself and accepts only a
 successful result whose `data.agent_filing_needed` is `false` and whose derived
@@ -96,8 +100,10 @@ Run the guard from the delivery worktree; preview is the default:
 bun .safeword/scripts/closeout-cleanup.ts --pr PR_NUMBER
 ```
 
-At the exact delivery head, preview reruns the project's verification, build,
-typecheck, BDD, and dependency plans. After that worktree is gone, preview
+At the exact delivery head, the post-merge preview reruns the project's
+verification, build, typecheck, and BDD plans. It does not rerun dependency audit:
+that changing intelligence is enforced at the delivery-time, pre-merge boundary
+and cannot repair an immutable merged head. After that worktree is gone, preview
 requires its fresh clean-head receipt instead. It binds the resulting repository
 state and exact PR identity to `PLAN_DIGEST`. Report the complete operation list
 and all blockers. Do not apply a blocked plan.

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -13,6 +13,7 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { rememberCloseoutBinding } from '../templates/hooks/lib/closeout-binding.ts';
 import {
   applyCleanupPlan,
   buildCleanupPlan,
@@ -23,7 +24,9 @@ import {
   executeCleanupOperation,
   operationCommand,
   parseWorktrees,
+  POST_MERGE_VERIFICATION_KINDS,
   pullRequestIdentity,
+  resolveCloseoutBinding,
   resolveProtection,
   resolveRemoteRef as resolveRemoteReference,
   retroAgentForRuntime,
@@ -40,7 +43,8 @@ function normalizedCloseoutScript(path: string): string {
       /import \{\s*type CloseoutBinding,\s*readFreshCloseoutBinding,\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/closeout-binding\.ts';/u,
       "import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';",
     )
-    .replace('../../runtime/hooks/lib/retro-draft-spool.ts', '../hooks/lib/retro-draft-spool.ts');
+    .replace('../../runtime/hooks/lib/retro-draft-spool.ts', '../hooks/lib/retro-draft-spool.ts')
+    .replace('../../runtime/hooks/lib/run-identity.ts', '../hooks/lib/run-identity.ts');
 }
 
 function safeObservation(overrides: Partial<CloseoutObservation> = {}): CloseoutObservation {
@@ -95,6 +99,41 @@ function runGit(...arguments_: string[]): string {
 }
 
 describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
+  it('revalidates immutable merged code without rerunning mutable dependency intelligence', () => {
+    expect(POST_MERGE_VERIFICATION_KINDS).toEqual(['verify', 'build', 'typecheck', 'bdd']);
+    expect(POST_MERGE_VERIFICATION_KINDS).not.toContain('deps');
+  });
+
+  it('uses Codex Desktop thread identity when the one-shot hook bridge is unavailable', () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-closeout-codex-desktop-'));
+    try {
+      mkdirSync(nodePath.join(root, '.safeword'));
+      writeFileSync(nodePath.join(root, '.safeword', 'SAFEWORD.md'), '# SafeWord\n');
+
+      expect(resolveCloseoutBinding(root, { CODEX_THREAD_ID: 'desktop-thread-42' })).toEqual({
+        runtime: 'codex',
+        id: 'desktop-thread-42',
+        projectRoot: realpathSync(root),
+      });
+      expect(resolveCloseoutBinding(root, {})).toBeUndefined();
+
+      rememberCloseoutBinding({
+        projectDirectory: root,
+        runtime: 'claude',
+        id: 'hook-session-42',
+        transcriptPath: '/exact/hook-session-42.jsonl',
+      });
+      expect(resolveCloseoutBinding(root, { CODEX_THREAD_ID: 'desktop-thread-42' })).toEqual({
+        runtime: 'claude',
+        id: 'hook-session-42',
+        projectRoot: realpathSync(root),
+        transcriptPath: '/exact/hook-session-42.jsonl',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('selects the mandatory retro extractor from the bound host runtime', () => {
     expect(retroAgentForRuntime('claude')).toBe('claude');
     expect(retroAgentForRuntime('codex')).toBe('codex');

--- a/packages/cli/tests/closeout-skill.test.ts
+++ b/packages/cli/tests/closeout-skill.test.ts
@@ -70,6 +70,15 @@ describe('closeout observed resumption (93C14D NTB1.R3)', () => {
     expect(skill).toContain('unfinished suffix');
     expect(skill).toContain('already closed');
   });
+
+  it('keeps dependency audit in delivery readiness without rerunning it after merge', () => {
+    const skill = canonicalSkill();
+
+    expect(skill).toMatch(/Run `\/verify`[\s\S]*before[\s\S]*merge/i);
+    expect(skill).toMatch(/dependency audit[\s\S]*delivery-time/i);
+    expect(skill).toMatch(/post-merge[\s\S]*verification, build, typecheck, and BDD/i);
+    expect(skill).toMatch(/does not rerun[\s\S]*dependency audit/i);
+  });
 });
 
 describe('closeout retrospective boundary (93C14D NTB1.R2)', () => {
@@ -86,7 +95,7 @@ describe('closeout retrospective boundary (93C14D NTB1.R2)', () => {
     expect(skill).toContain('empty filing spool');
     expect(skill).toMatch(/skip.*retro.*does not/i);
     expect(skill).toMatch(/missing.*expired.*binding/i);
-    expect(skill).toContain('no newest-session fallback');
+    expect(skill).toMatch(/no\s+newest-session\s+fallback/i);
     expect(skill).toMatch(/failed extraction.*failed filing.*pending drafts/is);
     expect(skill).toMatch(/no cleanup/i);
   });

--- a/packages/website/src/content/docs/reference/hooks-and-skills.mdx
+++ b/packages/website/src/content/docs/reference/hooks-and-skills.mdx
@@ -163,11 +163,21 @@ removes only the exact linked worktree, remote branch, and local branch—in tha
 order. Dirty, locked, protected, changed, default, main, ambiguous, or otherwise
 unverifiable targets are preserved and reported with recovery actions.
 
+The dependency audit is a delivery-readiness gate and must pass before merge.
+After merge, closeout rechecks the immutable head's verification, build,
+typecheck, and BDD lanes, but does not rerun mutable dependency intelligence
+that could make an already-merged head impossible to clean up later.
+
+Claude Code and Cursor bind closeout to the session captured by their hooks.
+Codex uses the same hook binding when available; in Codex Desktop it can use the
+authenticated `CODEX_THREAD_ID` supplied by the host when the one-shot hook
+bridge is unavailable. Missing or expired identity still fails closed.
+
 If cleanup is interrupted after removing the topic worktree, the guard can
 resume from a surviving worktree using a private verification receipt in Git's
-shared common directory. It creates that receipt only after every lane passes on
-a clean exact PR head, accepts it for 24 hours, and rejects stale, malformed,
-dirty-state, or wrong-head proof.
+shared common directory. It creates that receipt only after every applicable
+post-merge lane passes on a clean exact PR head, accepts it for 24 hours, and
+rejects stale, malformed, dirty-state, or wrong-head proof.
 
 | Skill             | Triggers on                                                                                                         |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.72.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "69f281e43ef2ccb244afe7c461ba72948579819eee131b184744f77ccd532190"
+  "inventory_sha256": "968cae1e82977822d6036630afe19728ca171601535060a71e64f545ffd142e6"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -87,7 +87,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "969603bb08719af367b53826307b41376d9659940fa422f4f6fdd045fe5cf744"
+      "sha256": "2985c120fc447c8ae26706e5ef76c5cbd5da2402f6fe78f756a4a135b8cf27dc"
     },
     {
       "path": "resources/templates/adr-template.md",
@@ -591,7 +591,7 @@
     },
     {
       "path": "skills/closeout/SKILL.md",
-      "sha256": "6837f21a58aa88b759c300a9c17822a7a7bc703707c825a6407e60fad7b11513"
+      "sha256": "4880f44b0bcfaaaf743c5b31b9fbcb507aa884897158c53471bbf06a1ca82425"
     },
     {
       "path": "skills/debug/SKILL.md",

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -20,6 +20,9 @@ import {
   readFreshCloseoutBinding,
 } from '../../runtime/hooks/lib/closeout-binding.ts';
 import { readSpooledDrafts } from '../../runtime/hooks/lib/retro-draft-spool.ts';
+import { resolveRunIdentity } from '../../runtime/hooks/lib/run-identity.ts';
+
+export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
 
 export interface PullRequestIdentity {
   url: string;
@@ -719,7 +722,7 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
         };
   }
   let passed = invalidateVerificationReceipt(root);
-  for (const kind of ['verify', 'build', 'typecheck', 'bdd', 'deps']) {
+  for (const kind of POST_MERGE_VERIFICATION_KINDS) {
     const planResult = runSafeword(root, [
       'project',
       'test-plan',
@@ -756,6 +759,28 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
     });
   }
   return verification;
+}
+
+export function resolveCloseoutBinding(
+  root: string,
+  env: Record<string, string | undefined> = process.env,
+): CloseoutBinding | undefined {
+  const bridged = readFreshCloseoutBinding({ projectDirectory: root });
+  if (bridged !== undefined) return bridged;
+
+  const identity = resolveRunIdentity({}, { env });
+  if (
+    identity.runtime !== 'codex' ||
+    identity.source !== 'CODEX_THREAD_ID' ||
+    identity.sessionKey === null
+  ) {
+    return undefined;
+  }
+  return {
+    runtime: 'codex',
+    id: identity.sessionKey,
+    projectRoot: realpathSync(root),
+  };
 }
 
 interface GhPullRequest {
@@ -966,7 +991,7 @@ function argumentValue(name: string): string | undefined {
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const pr = argumentValue('--pr');
-  const binding = root ? readFreshCloseoutBinding({ projectDirectory: root }) : undefined;
+  const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
     console.error(
       'closeout blocked: repository, --pr, and a fresh host session binding are required',

--- a/plugin/skills/closeout/SKILL.md
+++ b/plugin/skills/closeout/SKILL.md
@@ -28,6 +28,9 @@ Collect and report every blocker. Missing, stale, failing, pending, unknown, or
 ambiguous evidence means **no merge or cleanup**. A merge command's exit status
 never proves that the pull request is merged.
 
+Dependency audit is part of this delivery-time verification boundary. Resolve
+its failures before merge while the pull request head can still be changed.
+
 ## 2. Respect merge authority
 
 Invocation alone grants no merge authority. Read authority only from the current user request;
@@ -74,9 +77,10 @@ A missing, stale, malformed, dirty-state, or wrong-head receipt blocks cleanup.
 
 After merge is independently confirmed, invoke the cleanup guard in preview
 mode. Its host hook supplies a short-lived, single-consumer binding to this exact
-session (and Cursor transcript). A missing or expired binding fails closed;
-there is no newest-session fallback and callers cannot nominate another receipt,
-session, transcript, or spool.
+session (and Cursor transcript). Codex Desktop may instead supply its authenticated
+current `CODEX_THREAD_ID`, consistent with SafeWord's other Codex identity bridges.
+A missing or expired binding or identity fails closed; there is no newest-session
+fallback and callers cannot nominate another receipt, session, transcript, or spool.
 
 The guard runs `safeword retro run --json` itself and accepts only a
 successful result whose `data.agent_filing_needed` is `false` and whose derived
@@ -96,8 +100,10 @@ Run the guard from the delivery worktree; preview is the default:
 bun "${CLAUDE_PLUGIN_ROOT}"/resources/scripts/closeout-cleanup.ts --pr PR_NUMBER
 ```
 
-At the exact delivery head, preview reruns the project's verification, build,
-typecheck, BDD, and dependency plans. After that worktree is gone, preview
+At the exact delivery head, the post-merge preview reruns the project's
+verification, build, typecheck, and BDD plans. It does not rerun dependency audit:
+that changing intelligence is enforced at the delivery-time, pre-merge boundary
+and cannot repair an immutable merged head. After that worktree is gone, preview
 requires its fresh clean-head receipt instead. It binds the resulting repository
 state and exact PR identity to `PLAN_DIGEST`. Report the complete operation list
 and all blockers. Do not apply a blocked plan.


### PR DESCRIPTION
Closes #1856.
Closes #1857.

## Summary
- authenticate Codex Desktop closeout with the host-provided thread identity when the hook bridge is unavailable
- keep dependency auditing as a pre-merge delivery gate while limiting post-merge revalidation to immutable code-state lanes
- add regression coverage, public documentation, and generated host/plugin parity

## Verification
- 6,548 executed unit tests passed (5 skipped)
- 910 Gherkin scenarios passed (3 skipped)
- build, typecheck, lint, dependency audit, parity, and architecture audit passed
- real Claude, Codex, and Cursor Git cleanup adapters passed
- real merged PR #1855 preview produced a safe exact-OID cleanup plan

## Review note
Independent quality-review routes were attempted as required but exhausted (Claude timeout, Codex invalid output). Direct audit found no actionable defect; the limitation is recorded in the ticket audit.