### PR TITLE
Prove the Codex migration safety scenario actually tests a migration (#1973)

### DIFF
--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -103,7 +103,7 @@ Feature: Test Codex plugin migration
     Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback
       Given a repo installed with today's project-local Codex assets
       And the repo contains user-owned tickets and learnings under the namespace root
-      When the plugin migration upgrade runs
+      When the plugin migration upgrade runs without profile tools
       Then the upgrade reports profile enrollment failure loudly
       And the user-owned tickets and learnings remain byte-identical
       And Safe Word keeps repo-local `.agents/skills` available during the compatibility window

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -25,6 +25,27 @@ const SAFEWORD_CODEX_PLUGIN_ROOT = nodePath.resolve(
 );
 const CODEX_PLUGIN_MANIFEST_PATH = '.codex-plugin/plugin.json';
 const SAFEWORD_CLI_PATH = nodePath.resolve(import.meta.dirname, '..', 'packages/cli/dist/cli.js');
+
+/**
+ * Deterministic tool boundary for migration scenarios.
+ *
+ * These scenarios must not inherit the runner's ambient `PATH`. Doing so made
+ * them measure whichever Codex happened to be installed: the "unavailable
+ * enrollment" scenario silently exercised the *available* path wherever Codex
+ * existed, and the survival scenarios flipped with the environment (#1973).
+ *
+ * `CODEX_AVAILABLE_PATH` puts the repo's pinned `@openai/codex` first, so a
+ * migration genuinely runs and the survival scenarios assert against real work
+ * rather than a migration that never happened. The system directories keep
+ * git/node resolvable; the pinned binary shadows any system Codex, so the
+ * result does not depend on the developer's machine.
+ */
+const CODEX_AVAILABLE_PATH = [
+  nodePath.resolve(import.meta.dirname, '..', 'node_modules/.bin'),
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+].join(nodePath.delimiter);
 const CODEX_TEST_TICKET_ID = 'ABC123';
 const REPO_LOCAL_SAFEWORD_SENTINEL = 'REPO LOCAL SAFEWORD SHOULD NOT APPEAR';
 const POST_TOOL_GUIDANCE_LINE =
@@ -1611,18 +1632,34 @@ When(
   },
 );
 
-When('the plugin migration upgrade runs', function (this: CodexPluginMigrationWorld) {
-  const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
-  this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
+function runCodexMigrationUpgrade(
+  world: CodexPluginMigrationWorld,
+  toolPath: string,
+): CommandResult {
+  const repoRoot = requirePath(world.codexPluginRepoRoot, 'repo root');
+  return runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
     cwd: repoRoot,
-    env: {
-      // SAFEWORD_SKIP_INSTALL only skips project dependencies; hide profile tools too.
-      PATH: '',
-      SAFEWORD_SKIP_INSTALL: '1',
-    },
+    // SAFEWORD_SKIP_INSTALL only skips project dependencies, so the tool
+    // boundary has to be set explicitly rather than inherited.
+    env: { PATH: toolPath, SAFEWORD_SKIP_INSTALL: '1' },
     timeout: 120_000,
   });
+}
+
+When('the plugin migration upgrade runs', function (this: CodexPluginMigrationWorld) {
+  this.codexPluginMigrationResult = runCodexMigrationUpgrade(this, CODEX_AVAILABLE_PATH);
 });
+
+// Separate step, not a flag on the shared one: the scenario name promises no
+// profile tools, so the fixture that makes that true belongs where a reader of
+// the feature file can see it. Folding it into the shared step is what made
+// three scenarios share one boundary and two of them stop testing anything.
+When(
+  'the plugin migration upgrade runs without profile tools',
+  function (this: CodexPluginMigrationWorld) {
+    this.codexPluginMigrationResult = runCodexMigrationUpgrade(this, '');
+  },
+);
 
 Then(
   'the hook output denies the edit with the existing Safe Word phase-gate reason',
@@ -1824,9 +1861,16 @@ Then(
   'Safe Word-owned Codex skill files remain beside the user-authored skill until finalization',
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    // The migration actually ran here, so the bootstrap skill it writes is
+    // expected. Guarding that first keeps this from passing vacuously if the
+    // migration ever silently stops running again (#1973).
+    const migration = this.codexPluginMigrationResult;
+    assert.ok(migration, 'migration result was not captured');
+    assert.equal(migration.exitCode, 0, `migration did not run: ${migration.stderr}`);
     assert.deepEqual(readdirSync(nodePath.join(repoRoot, '.agents/skills')).sort(), [
       'bdd',
       'company-workflow',
+      'safeword-plugin-setup',
       'verify',
     ]);
   },
@@ -1834,6 +1878,19 @@ Then(
 
 Then('the user-authored Codex config entries remain', function (this: CodexPluginMigrationWorld) {
   const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+  // Survival is only meaningful if the migration actually evaluated this repo.
+  // Here it runs, finds the stale Safe Word hook commands, and deliberately
+  // declines — so the config survives because the decline path preserved it,
+  // not because nothing ran. Asserting the decline reason keeps that
+  // distinction: a migration that never started would leave the config equally
+  // untouched and prove nothing (#1973).
+  const migration = this.codexPluginMigrationResult;
+  assert.ok(migration, 'migration result was not captured');
+  assert.equal(migration.exitCode, 2, `expected a declined migration: ${migration.stderr}`);
+  assert.match(
+    `${migration.stdout}\n${migration.stderr}`,
+    /legacy project protection was retained/iu,
+  );
   const config = readFileSync(nodePath.join(repoRoot, '.codex/config.toml'), 'utf8');
   const lines = config.split(/\r?\n/u);
   for (const line of this.codexPluginUserCodexConfigLines ?? []) {


### PR DESCRIPTION
Fixes #1973.

## What was wrong

Three scenarios in `features/test-codex-plugin-migration.feature` shared one Cucumber step (`When the plugin migration upgrade runs`) that ran the upgrade with an empty `PATH`. With no tools reachable, the "user-authored Codex skills survive the migration" scenario passed without a migration ever running — the files it asserted were byte-identical because nothing touched them. A vacuous pass.

Correction to #1973 as filed: only the *skills* scenario was vacuous. The customized-config scenario declines on config inspection before any Codex call, so it behaves identically with or without tools on PATH.

## The fix

- New step `When the plugin migration upgrade runs without profile tools` (`PATH: ''`), used only by the rejection scenario at feature line 103 that genuinely needs enrollment to be unavailable.
- The shared step now runs with `CODEX_AVAILABLE_PATH` — the repo's pinned `node_modules/.bin` first, then system dirs — so the migration actually executes and does so deterministically rather than depending on ambient PATH.
- Skill-list expectation updated to include `safeword-plugin-setup`, which is correct once the migration really runs.
- Non-vacuity guards added to both survival scenarios: the skills scenario asserts `exitCode === 0`, the config scenario asserts `exitCode === 2` and a legacy-protection message. Verified by re-hiding the tools — the skills scenario then fails on the guard instead of passing empty.

## Verification

- Migration feature: 22/22 scenarios pass
- Full BDD lane: 956 passed, 3 skipped, 0 failed
- lint, typecheck, format: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPpTdcLAj7JkXzSpigWk1v)_