### PR TITLE
Stop a Codex migration-safety scenario from proving nothing (#1973)

### DIFF
--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -103,7 +103,7 @@ Feature: Test Codex plugin migration
     Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback
       Given a repo installed with today's project-local Codex assets
       And the repo contains user-owned tickets and learnings under the namespace root
-      When the plugin migration upgrade runs
+      When the plugin migration upgrade runs without profile enrollment available
       Then the upgrade reports profile enrollment failure loudly
       And the user-owned tickets and learnings remain byte-identical
       And Safe Word keeps repo-local `.agents/skills` available during the compatibility window
@@ -111,7 +111,7 @@ Feature: Test Codex plugin migration
 
     Scenario: User-authored Codex skills survive the migration
       Given an old project-local Codex install with a user-authored `.agents/skills/company-workflow/SKILL.md`
-      When the plugin migration upgrade runs
+      When the plugin migration upgrade runs without profile enrollment available
       Then the user-authored skill remains byte-identical
       And Safe Word-owned Codex skill files remain beside the user-authored skill until finalization
 
@@ -119,7 +119,7 @@ Feature: Test Codex plugin migration
     Scenario: Customized Codex config is not clobbered while stale Safe Word hooks await explicit migration
       Given an old project-local Codex install with user-authored Codex config entries
       And the config also contains old Safe Word hook commands pointing at `.safeword/hooks/codex`
-      When the plugin migration upgrade runs
+      When the plugin migration upgrade runs without profile enrollment available
       Then the user-authored Codex config entries remain
       And the stale Safe Word project-local hook commands remain until explicit migration
 

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -1611,18 +1611,36 @@ When(
   },
 );
 
-When('the plugin migration upgrade runs', function (this: CodexPluginMigrationWorld) {
-  const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
-  this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
-    cwd: repoRoot,
-    env: {
-      // SAFEWORD_SKIP_INSTALL only skips project dependencies; hide profile tools too.
-      PATH: '',
-      SAFEWORD_SKIP_INSTALL: '1',
-    },
-    timeout: 120_000,
-  });
-});
+/**
+ * Every scenario in this rule runs the upgrade with profile enrollment made
+ * unavailable, and each one asserts the decline it produces (#1973). The
+ * decline is the point: it proves the upgrade ran, reached the Codex handoff,
+ * and preserved the project on the way out. Without that assertion these
+ * scenarios pass whether or not anything executed, because untouched files
+ * look identical to files nothing reached.
+ *
+ * Enrollment stays unavailable on purpose rather than being made to succeed.
+ * `installCodexPlugin` shells out to the real `bun` and `codex` binaries and
+ * clones the `ArcadeAI/safeword` marketplace at ref `stable`; the automatic
+ * migration path takes no local-source override. Succeeding here would mean a
+ * network clone per scenario and mutating whatever Codex profile is ambient.
+ * Hermetic coverage of a *successful* handoff is tracked separately.
+ */
+When(
+  'the plugin migration upgrade runs without profile enrollment available',
+  function (this: CodexPluginMigrationWorld) {
+    const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
+      cwd: repoRoot,
+      env: {
+        // SAFEWORD_SKIP_INSTALL only skips project dependencies; hide profile tools too.
+        PATH: '',
+        SAFEWORD_SKIP_INSTALL: '1',
+      },
+      timeout: 120_000,
+    });
+  },
+);
 
 Then(
   'the hook output denies the edit with the existing Safe Word phase-gate reason',
@@ -1769,13 +1787,31 @@ Then(
   },
 );
 
+/**
+ * Non-vacuity guard for every scenario under this rule (#1973). Survival
+ * assertions only mean something once the upgrade is known to have run and
+ * reached the Codex handoff; a migration that never started leaves the same
+ * files untouched and proves nothing.
+ */
+function assertMigrationRanAndDeclined(world: CodexPluginMigrationWorld): void {
+  const result = world.codexPluginMigrationResult;
+  assert.ok(result, 'migration result was not captured');
+  assert.equal(
+    result.exitCode,
+    2,
+    `expected a declined migration: ${result.stdout}${result.stderr}`,
+  );
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /legacy project protection was retained/iu,
+    'upgrade did not reach the Codex handoff decline',
+  );
+}
+
 Then(
   'the upgrade reports profile enrollment failure loudly',
   function (this: CodexPluginMigrationWorld) {
-    const result = this.codexPluginMigrationResult;
-    assert.ok(result, 'migration result was not captured');
-    assert.equal(result.exitCode, 2);
-    assert.match(`${result.stdout}\n${result.stderr}`, /Codex|plugin|profile/iu);
+    assertMigrationRanAndDeclined(this);
   },
 );
 
@@ -1823,6 +1859,7 @@ Then('the user-authored skill remains byte-identical', function (this: CodexPlug
 Then(
   'Safe Word-owned Codex skill files remain beside the user-authored skill until finalization',
   function (this: CodexPluginMigrationWorld) {
+    assertMigrationRanAndDeclined(this);
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
     assert.deepEqual(readdirSync(nodePath.join(repoRoot, '.agents/skills')).sort(), [
       'bdd',
@@ -1833,6 +1870,7 @@ Then(
 );
 
 Then('the user-authored Codex config entries remain', function (this: CodexPluginMigrationWorld) {
+  assertMigrationRanAndDeclined(this);
   const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
   const config = readFileSync(nodePath.join(repoRoot, '.codex/config.toml'), 'utf8');
   const lines = config.split(/\r?\n/u);


### PR DESCRIPTION
Fixes #1973. Second attempt — #1975 was the first and was reverted by #1981; see below for why this one is shaped differently.

## The problem

The three scenarios under `test-codex-plugin-migration.TB1.R4` shared one step that ran the upgrade with an empty `PATH`. With no tools reachable, "User-authored Codex skills survive the migration" passed whether or not anything ran — the files it asserted were byte-identical because nothing had reached them.

## The fix

Assert the decline rather than make enrollment succeed. Each of the three scenarios now guards on the upgrade exiting 2 with the `CODEX_PLUGIN_HANDOFF_DEFERRED` message. That proves the upgrade ran, reached the Codex handoff, and preserved the project on the way out — survival now means something. The feature file names that boundary in all three scenarios instead of hiding it inside one shared step.

## Why not make enrollment actually succeed

That was #1975's approach and it was wrong twice over:

- `installCodexPlugin` runs `bun --version` and `codex --version` before anything else. On CI, `bun` lives in setup-bun's tool cache, not `/usr/local/bin`, so the hand-rolled PATH had no `bun` and the handoff deferred — red CI. It passed locally only because this container has `/usr/local/bin/bun` as a symlink.
- Even with both binaries present, enrollment clones the `ArcadeAI/safeword` marketplace at ref `stable`, and the automatic migration path takes no local-source override. Succeeding would mean a network clone per scenario and mutating whatever Codex profile is ambient on the developer's machine.

Hermetic coverage of a *successful* handoff is filed as #1989, including the `marketplaceSource` plumbing it would need.

## Correction to #1973 as filed

Only the skills scenario was vacuous. The customized-config scenario declines on config inspection before any Codex call, so it behaved identically with or without tools on PATH.

## Verification

- Guards falsified: neutered the upgrade to a no-op, confirmed all three scenarios fail on the guard rather than passing empty. Restored, all three pass.
- Rule `TB1.R4`: 3/3 scenarios pass.
- lint, typecheck, format: clean.
- Full BDD lane: 955 passed / 3 skipped / 1 failed. The failure is `Interrupted proof write cannot become current` in `keep-codex-protection-continuous.feature` — a file this PR doesn't touch, which passes in isolation. Letting CI arbitrate rather than asserting it's unrelated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPpTdcLAj7JkXzSpigWk1v)_