### PR TITLE
Prove user data survives a Codex handoff that succeeds (#1989)

### DIFF
--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/spec.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/spec.md
@@ -79,7 +79,7 @@ Unaffected:
 
 #### test-codex-plugin-migration.TB1.R3 — Safe Word Codex hooks execute the packaged CLI entrypoints and preserve the existing deny, allow, context, and continuation semantics
 
-#### test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data intact while removing or ignoring obsolete Safe Word implementation assets
+#### test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and working fallback assets intact until an explicit proven handoff
 
 ### test-codex-plugin-migration.SM1 — Trust the migration through targeted evidence, not a fragile monolith
 
@@ -110,7 +110,7 @@ future change safe.
 - A maintainer can run an isolated local Codex plugin install test without mutating their real `~/.codex`.
 - A maintainer can run deterministic hook-entrypoint tests that fail before any live model run is needed.
 - A maintainer can opt into one live Codex smoke that proves Codex itself loads the plugin and invokes the hooks.
-- A technical builder upgrading from the old Codex install shape keeps project-owned data and no longer depends on bulky repo-local Safe Word implementation files.
+- A technical builder's authored project data survives both a declined handoff and a successful proven handoff; fallback assets remain until success, then managed assets are removed.
 
 ## Open Questions
 

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/spec.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/spec.md
@@ -79,7 +79,7 @@ Unaffected:
 
 #### test-codex-plugin-migration.TB1.R3 — Safe Word Codex hooks execute the packaged CLI entrypoints and preserve the existing deny, allow, context, and continuation semantics
 
-#### test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and working fallback assets intact until an explicit proven handoff
+#### test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and fallback assets intact until an explicit proven handoff
 
 ### test-codex-plugin-migration.SM1 — Trust the migration through targeted evidence, not a fragile monolith
 

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
@@ -76,13 +76,19 @@ test-definitions.md is the R/G/R ledger.
 - [x] GREEN 011cb21d
 - [x] REFACTOR skip: hook manifest is intentionally explicit per Codex event
 
-## Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data intact while removing or ignoring obsolete Safe Word implementation assets
+## Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and working fallback assets intact until an explicit proven handoff
 
-### Scenario: Old project-local Codex install migrates to plugin-backed Codex support
+### Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback
 
 - [x] RED 76e61756
 - [x] GREEN d38dba27
 - [x] REFACTOR skip: migration cleanup is already file-scoped for shared skill dirs and source-only for legacy hook templates
+
+### Scenario: Successful handoff preserves authored project data while removing managed fallback
+
+- [x] RED #1989
+- [ ] GREEN pending
+- [x] REFACTOR 7352a6dcd
 
 ### Scenario: User-authored Codex skills survive the migration
 
@@ -90,7 +96,7 @@ test-definitions.md is the R/G/R ledger.
 - [x] GREEN ba64937a
 - [x] REFACTOR skip: deprecated file and empty-dir cleanup both derive from the canonical Codex skill list
 
-### Scenario: Customized Codex config is not clobbered while stale Safe Word hooks are removed
+### Scenario: Customized Codex config is not clobbered while stale Safe Word hooks await explicit migration
 
 - [x] RED eb760fa5
 - [x] GREEN cb6cc277

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
@@ -86,8 +86,8 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Successful handoff preserves authored project data while removing managed fallback
 
-- [x] RED #1989
-- [ ] GREEN pending
+- [x] RED ae935d66b
+- [x] GREEN bf5e436ec
 - [x] REFACTOR 7352a6dcd
 
 ### Scenario: User-authored Codex skills survive the migration

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/test-definitions.md
@@ -76,7 +76,7 @@ test-definitions.md is the R/G/R ledger.
 - [x] GREEN 011cb21d
 - [x] REFACTOR skip: hook manifest is intentionally explicit per Codex event
 
-## Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and working fallback assets intact until an explicit proven handoff
+## Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and fallback assets intact until an explicit proven handoff
 
 ### Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback
 
@@ -86,9 +86,9 @@ test-definitions.md is the R/G/R ledger.
 
 ### Scenario: Successful handoff preserves authored project data while removing managed fallback
 
-- [x] RED ae935d66b
-- [x] GREEN bf5e436ec
-- [x] REFACTOR 7352a6dcd
+- [x] RED ae935d66
+- [x] GREEN bf5e436e
+- [x] REFACTOR 7352a6dc
 
 ### Scenario: User-authored Codex skills survive the migration
 

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/ticket.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/ticket.md
@@ -28,7 +28,7 @@ done_when:
   - Plugin hook commands invoke package-runner or packaged CLI entrypoints and contain no dependency on repo-local `.safeword/hooks` paths
   - Existing Codex hook deny/allow/continuation semantics are covered through packaged CLI entrypoints with exact Codex hook JSON fixtures
   - The opt-in live smoke exercises plugin-installed hooks through real `codex exec --json --dangerously-bypass-hook-trust` and records any known Codex interception boundary
-  - A declined migration preserves working fallback assets; a successful proven handoff removes managed Codex skill/hook assets while preserving user-owned project data
+  - A declined migration preserves fallback assets; a successful proven handoff removes managed Codex skill/hook assets while preserving user-owned project data
 created: 2026-07-09T01:04:07.604Z
 last_modified: 2026-07-09T20:10:04Z
 ---

--- a/.project/tickets/4DK9H4-test-codex-plugin-migration/ticket.md
+++ b/.project/tickets/4DK9H4-test-codex-plugin-migration/ticket.md
@@ -28,7 +28,7 @@ done_when:
   - Plugin hook commands invoke package-runner or packaged CLI entrypoints and contain no dependency on repo-local `.safeword/hooks` paths
   - Existing Codex hook deny/allow/continuation semantics are covered through packaged CLI entrypoints with exact Codex hook JSON fixtures
   - The opt-in live smoke exercises plugin-installed hooks through real `codex exec --json --dangerously-bypass-hook-trust` and records any known Codex interception boundary
-  - A migration fixture starting from today's project-local Codex install shape ends with no bulky Safe Word Codex skill/hook dependency in the repo, while user-owned project data is preserved
+  - A declined migration preserves working fallback assets; a successful proven handoff removes managed Codex skill/hook assets while preserving user-owned project data
 created: 2026-07-09T01:04:07.604Z
 last_modified: 2026-07-09T20:10:04Z
 ---

--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -97,7 +97,7 @@ Feature: Test Codex plugin migration
       And each command invokes a packaged Safe Word command entrypoint
 
   @test-codex-plugin-migration.TB1.R4 @surface.openai-codex
-  Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and working fallback assets intact until an explicit proven handoff
+  Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and fallback assets intact until an explicit proven handoff
 
     @rejection
     Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback

--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -109,6 +109,17 @@ Feature: Test Codex plugin migration
       And Safe Word keeps repo-local `.agents/skills` available during the compatibility window
       And legacy Safe Word Codex hook runtime files remain until explicit handoff cleanup
 
+    Scenario: Successful handoff preserves authored project data while removing managed fallback
+      Given a repo installed with today's project-local Codex assets
+      And the repo contains user-owned tickets and learnings under the namespace root
+      And the repo contains a user-authored `.agents/skills/company-workflow/SKILL.md`
+      When the plugin migration handoff succeeds under an isolated Codex profile
+      Then the handoff installs the Safe Word plugin through the fake Codex boundary
+      And the user-owned tickets and learnings remain byte-identical
+      And the user-authored skill remains byte-identical
+      And Safe Word-owned Codex skill files are removed after finalization
+      And legacy Safe Word Codex hook runtime files are removed after finalization
+
     Scenario: User-authored Codex skills survive the migration
       Given an old project-local Codex install with a user-authored `.agents/skills/company-workflow/SKILL.md`
       When the plugin migration upgrade runs without profile enrollment available

--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -113,8 +113,8 @@ Feature: Test Codex plugin migration
       Given a repo installed with today's project-local Codex assets
       And the repo contains user-owned tickets and learnings under the namespace root
       And the repo contains a user-authored `.agents/skills/company-workflow/SKILL.md`
-      When the plugin migration handoff succeeds under an isolated Codex profile
-      Then the handoff installs the Safe Word plugin through the fake Codex boundary
+      When the plugin migration upgrade runs with profile enrollment available
+      Then Safe Word is enrolled in the Codex profile
       And the user-owned tickets and learnings remain byte-identical
       And the user-authored skill remains byte-identical
       And Safe Word-owned Codex skill files are removed after finalization

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -88,12 +88,11 @@ describe('migrate codex-plugin command', () => {
     const configPath = nodePath.join(directory, '.codex/config.toml');
     writeFileSync(configPath, config);
 
-    const runtime = installFakeCodexRuntime(
-      directory,
+    const runtime = installFakeCodexRuntime(directory, {
       pluginEnabled,
       pluginInitiallyInstalled,
       pluginVersion,
-    );
+    });
     return {
       directory,
       configPath,

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -346,7 +346,7 @@ describe('migrate codex-plugin command', () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
     const userOwned = {
       '.project/tickets/ABC123/spec.md': '# Authored spec\n\nOwned by the user, not Safeword.\n',
-      '.project/learnings/INDEX.md': '# Learnings\n\n- Do not clobber authored notes.\n',
+      '.project/learnings/handoff-notes.md': '# Handoff notes\n\nDo not clobber authored notes.\n',
       '.agents/skills/company-workflow/SKILL.md': 'User-authored company workflow skill\n',
     };
     for (const [relativePath, contents] of Object.entries(userOwned)) {

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable unicorn/no-null -- migration JSON uses null for unavailable profile facts */
 
 import {
-  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -29,6 +28,7 @@ import {
 } from '../../src/commands/migrate-codex-plugin.js';
 import { SAFEWORD_SCHEMA } from '../../src/schema.js';
 import { createTemporaryDirectory, removeTemporaryDirectory, runCli } from '../helpers';
+import { installFakeCodexRuntime } from '../helpers/fake-codex-runtime.js';
 
 const LEGACY_HOOK_CONFIG = `# Safeword Codex project configuration.
 
@@ -71,109 +71,6 @@ type = "command"
 command = 'echo "keep this user hook"'
 `;
 
-function writeExecutable(path: string, content: string): void {
-  writeFileSync(path, content, { mode: 0o755 });
-  chmodSync(path, 0o755);
-}
-
-function installFakeRuntime(
-  directory: string,
-  pluginEnabled: boolean,
-  pluginInitiallyInstalled: boolean,
-  pluginVersion?: string,
-): string {
-  const bin = nodePath.join(directory, 'bin');
-  const pluginState = nodePath.join(directory, 'profile/plugin-state');
-  const pluginVersionState = nodePath.join(directory, 'profile/plugin-version');
-  mkdirSync(bin, { recursive: true });
-  mkdirSync(nodePath.dirname(pluginState), { recursive: true });
-  let initialPluginState = 'absent';
-  if (pluginInitiallyInstalled) initialPluginState = pluginEnabled ? 'enabled' : 'disabled';
-  writeFileSync(pluginState, initialPluginState);
-  writeFileSync(pluginVersionState, pluginVersion ?? '');
-  writeExecutable(nodePath.join(bin, 'bun'), '#!/bin/sh\nexit 0\n');
-  writeExecutable(
-    nodePath.join(bin, 'codex'),
-    String.raw`#!/bin/sh
-set -eu
-printf '%s\n' "$*" >> "$SAFEWORD_CODEX_LOG"
-if [ "$(printenv SAFEWORD_MUTATE_CONFIG 2>/dev/null || true)" = "1" ] && [ "$*" = "plugin list --json" ]; then
-  printf '# concurrent config update\\n' >> "$SAFEWORD_CONFIG_PATH"
-fi
-if [ -n "$(printenv SAFEWORD_LEGACY_ASSET_PATH 2>/dev/null || true)" ] && [ "$*" = "plugin list --json" ]; then
-  printf '# appeared after confirmation\n' > "$SAFEWORD_LEGACY_ASSET_PATH"
-fi
-case "$*" in
-  '--version') echo 'codex 0.141.0' ;;
-  'plugin marketplace list --json')
-    if [ "$(printenv SAFEWORD_FAIL_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
-      echo 'marketplace observation failed' >&2
-      exit 7
-    fi
-    if [ "$(printenv SAFEWORD_MALFORMED_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
-      echo '{bad json'
-    elif [ "$(printenv SAFEWORD_UNSUPPORTED_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
-      echo '{"marketplaces":[null]}'
-    elif [ "$(printenv SAFEWORD_MARKETPLACE_SOURCE_TYPE 2>/dev/null || true)" = "local" ]; then
-      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"local","source":"/tmp/safeword"}}]}'
-    elif [ "$(printenv SAFEWORD_MISMATCHED_GIT_MARKETPLACE 2>/dev/null || true)" = "1" ]; then
-      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"https://example.com/untrusted/safeword.git"}}]}'
-    elif [ "$(printenv SAFEWORD_SSH_GIT_MARKETPLACE 2>/dev/null || true)" = "1" ]; then
-      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"git@github.com:ArcadeAI/safeword.git"}}]}'
-    elif [ '${pluginInitiallyInstalled}' = 'true' ]; then
-      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"https://github.com/ArcadeAI/safeword.git"}}]}'
-    else
-      echo '{"marketplaces":[]}'
-    fi
-    ;;
-  'plugin marketplace upgrade safeword --json')
-    if [ "$(printenv SAFEWORD_FAIL_MARKETPLACE_UPGRADE 2>/dev/null || true)" = "1" ]; then
-      echo 'marketplace refresh failed' >&2
-      exit 6
-    fi
-    echo '{"marketplaceName":"safeword"}'
-    ;;
-  'plugin marketplace remove safeword --json')
-    echo '{"marketplaceName":"safeword"}'
-    ;;
-  'plugin marketplace add '* )
-    if [ "$(printenv SAFEWORD_FAIL_PLUGIN_INSTALL 2>/dev/null || true)" = "1" ]; then
-      echo 'marketplace unavailable' >&2
-      exit 9
-    fi
-    echo '{"marketplaceName":"safeword"}'
-    ;;
-  'plugin add safeword@safeword --json')
-    printf 'enabled' > '${pluginState}'
-    printf '${SAFEWORD_SCHEMA.version}' > '${pluginVersionState}'
-    echo '{"pluginId":"safeword@safeword"}'
-    ;;
-  'plugin list --json')
-    if [ "$(printenv SAFEWORD_FAIL_PLUGIN_VERIFY 2>/dev/null || true)" = "1" ]; then
-      echo 'profile observation failed' >&2
-      exit 8
-    fi
-    mode="$(cat '${pluginState}')"
-    if [ "$mode" = "absent" ]; then
-      echo '{"installed":[]}'
-    elif [ "$mode" = "disabled" ]; then
-      echo '{"installed":[{"pluginId":"safeword@safeword","enabled":false}]}'
-    else
-      version="$(cat '${pluginVersionState}')"
-      if [ -n "$version" ]; then
-        echo "{\"installed\":[{\"pluginId\":\"safeword@safeword\",\"enabled\":true,\"version\":\"$version\"}]}"
-      else
-        echo '{"installed":[{"pluginId":"safeword@safeword","enabled":true}]}'
-      fi
-    fi
-    ;;
-  *) exit 2 ;;
-esac
-`,
-  );
-  return bin;
-}
-
 describe('migrate codex-plugin command', () => {
   const directories: string[] = [];
 
@@ -191,10 +88,16 @@ describe('migrate codex-plugin command', () => {
     const configPath = nodePath.join(directory, '.codex/config.toml');
     writeFileSync(configPath, config);
 
+    const runtime = installFakeCodexRuntime(
+      directory,
+      pluginEnabled,
+      pluginInitiallyInstalled,
+      pluginVersion,
+    );
     return {
       directory,
       configPath,
-      bin: installFakeRuntime(directory, pluginEnabled, pluginInitiallyInstalled, pluginVersion),
+      bin: runtime.bin,
     };
   }
 

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -339,6 +339,44 @@ describe('migrate codex-plugin command', () => {
     ).toBe(true);
   });
 
+  // The declining handoff is covered by the acceptance lane's TB1.R4 rule. The
+  // succeeding one is where files actually move and get rewritten, so it is the
+  // path where survival is least obvious and most worth pinning.
+  it('preserves user-owned project data and authored skills through a successful handoff', () => {
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const userOwned = {
+      '.project/tickets/ABC123/spec.md': '# Authored spec\n\nOwned by the user, not Safeword.\n',
+      '.project/learnings/INDEX.md': '# Learnings\n\n- Do not clobber authored notes.\n',
+      '.agents/skills/company-workflow/SKILL.md': 'User-authored company workflow skill\n',
+    };
+    for (const [relativePath, contents] of Object.entries(userOwned)) {
+      const absolutePath = nodePath.join(fixture.directory, relativePath);
+      mkdirSync(nodePath.dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, contents);
+    }
+    // A Safeword-owned skill sharing the directory the authored one lives in:
+    // removing it is what proves the migration reached and rewrote this tree,
+    // so the survival assertions below are not just describing an inert repo.
+    const safewordSkill = nodePath.join(fixture.directory, '.agents/skills/audit/SKILL.md');
+    mkdirSync(nodePath.dirname(safewordSkill), { recursive: true });
+    writeFileSync(safewordSkill, 'legacy audit skill\n');
+    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
+    vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
+    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
+    vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
+
+    expect(automaticallyMigrateLegacyCodex(fixture.directory, environment)).toBe(true);
+
+    expect(existsSync(safewordSkill)).toBe(false);
+    expect(existsSync(nodePath.join(fixture.directory, '.safeword/codex-plugin.json'))).toBe(true);
+    for (const [relativePath, contents] of Object.entries(userOwned)) {
+      expect(
+        readFileSync(nodePath.join(fixture.directory, relativePath), 'utf8'),
+        relativePath,
+      ).toBe(contents);
+    }
+  });
+
   it('retains complete legacy state when automatic plugin installation fails', () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
     const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -96,7 +96,7 @@ function installFakeRuntime(
     nodePath.join(bin, 'codex'),
     String.raw`#!/bin/sh
 set -eu
-printf '%s\\n' "$*" >> "$SAFEWORD_CODEX_LOG"
+printf '%s\n' "$*" >> "$SAFEWORD_CODEX_LOG"
 if [ "$(printenv SAFEWORD_MUTATE_CONFIG 2>/dev/null || true)" = "1" ] && [ "$*" = "plugin list --json" ]; then
   printf '# concurrent config update\\n' >> "$SAFEWORD_CONFIG_PATH"
 fi

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -76,9 +76,15 @@ describe('migrate codex-plugin command', () => {
 
   function createMigrationFixture(
     config: string,
-    pluginEnabled = true,
-    pluginInitiallyInstalled = true,
-    pluginVersion?: string,
+    {
+      pluginEnabled = true,
+      pluginInitiallyInstalled = true,
+      pluginVersion,
+    }: {
+      pluginEnabled?: boolean;
+      pluginInitiallyInstalled?: boolean;
+      pluginVersion?: string;
+    } = {},
   ) {
     const directory = createTemporaryDirectory();
     directories.push(directory);
@@ -227,7 +233,9 @@ describe('migrate codex-plugin command', () => {
   });
 
   it('automatically installs the plugin and transactionally removes recognized legacy state', () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const legacySkill = nodePath.join(fixture.directory, '.agents/skills/audit/SKILL.md');
     mkdirSync(nodePath.dirname(legacySkill), { recursive: true });
     writeFileSync(legacySkill, 'legacy audit skill\n');
@@ -251,7 +259,9 @@ describe('migrate codex-plugin command', () => {
   // succeeding one is where files actually move and get rewritten, so it is the
   // path where survival is least obvious and most worth pinning.
   it('preserves user-owned project data and authored skills through a successful handoff', () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const userOwnedFiles = {
       '.project/tickets/ABC123/spec.md': '# Authored spec\n\nOwned by the user, not Safeword.\n',
       '.project/learnings/handoff-notes.md': '# Handoff notes\n\nDo not clobber authored notes.\n',
@@ -284,7 +294,9 @@ describe('migrate codex-plugin command', () => {
   });
 
   it('retains complete legacy state when automatic plugin installation fails', () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const environment = stubAutomaticMigrationEnvironment(fixture);
     vi.stubEnv('SAFEWORD_FAIL_PLUGIN_INSTALL', '1');
 
@@ -607,7 +619,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('re-enables a disabled profile plugin while retaining legacy hooks', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, { pluginEnabled: false });
     const { configPath } = fixture;
     const before = readFileSync(configPath, 'utf8');
 
@@ -629,7 +641,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('updates an enabled older profile plugin while retaining legacy hooks', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, true, '0.68.0');
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, { pluginVersion: '0.68.0' });
     const before = readFileSync(fixture.configPath, 'utf8');
 
     const result = await runCodexCommand(fixture, ['codex', 'install', '--json']);
@@ -661,7 +673,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('does not install from stale metadata when marketplace refresh fails', async () => {
-    const fixture = createMigrationFixture('', true, true, '0.68.0');
+    const fixture = createMigrationFixture('', { pluginVersion: '0.68.0' });
 
     const result = await runCodexCommand(fixture, ['codex', 'install', '--json'], {
       SAFEWORD_FAIL_MARKETPLACE_UPGRADE: '1',
@@ -683,7 +695,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('leaves the profile unchanged when another task is installing the plugin', async () => {
-    const fixture = createMigrationFixture('', true, false);
+    const fixture = createMigrationFixture('', { pluginInitiallyInstalled: false });
     const profileEnvironment = { CODEX_HOME: fixture.codexHome };
     expect(
       acquireCodexProfileLock(profileEnvironment, { owner: 'another-codex-task' }),
@@ -709,7 +721,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('rejects a Git marketplace that reuses the Safeword name for another source', async () => {
-    const fixture = createMigrationFixture('', true, true, '0.68.0');
+    const fixture = createMigrationFixture('', { pluginVersion: '0.68.0' });
 
     const result = await runCodexCommand(fixture, ['codex', 'install', '--json'], {
       SAFEWORD_MISMATCHED_GIT_MARKETPLACE: '1',
@@ -731,7 +743,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('refreshes the official Safeword marketplace when configured with an SSH Git URL', async () => {
-    const fixture = createMigrationFixture('', true, true, '0.68.0');
+    const fixture = createMigrationFixture('', { pluginVersion: '0.68.0' });
 
     const result = await runCodexCommand(fixture, ['codex', 'install'], {
       SAFEWORD_SSH_GIT_MARKETPLACE: '1',
@@ -744,7 +756,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('moves an official main-branch marketplace onto the stable channel before installing', async () => {
-    const fixture = createMigrationFixture('', true, true, '0.68.0');
+    const fixture = createMigrationFixture('', { pluginVersion: '0.68.0' });
     writeFileSync(
       nodePath.join(fixture.directory, 'profile/config.toml'),
       '[marketplaces.safeword]\nsource = "https://github.com/ArcadeAI/safeword.git"\nref = "main"\n',
@@ -766,7 +778,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('preserves a newer explicit marketplace pin without profile mutation', async () => {
-    const fixture = createMigrationFixture('', true, true, '0.68.0');
+    const fixture = createMigrationFixture('', { pluginVersion: '0.68.0' });
     writeFileSync(
       nodePath.join(fixture.directory, 'profile/config.toml'),
       '[marketplaces.safeword]\nsource = "ArcadeAI/safeword"\nref = "v9.0.0"\n',
@@ -791,7 +803,7 @@ command = 'echo "keep this user hook"'
     ['malformed', { SAFEWORD_MALFORMED_MARKETPLACE_LIST: '1' }],
     ['unsupported', { SAFEWORD_UNSUPPORTED_MARKETPLACE_LIST: '1' }],
   ])('fails closed when marketplace discovery is %s', async (_name, environment) => {
-    const fixture = createMigrationFixture('', true, false);
+    const fixture = createMigrationFixture('', { pluginInitiallyInstalled: false });
 
     const result = await runCodexCommand(fixture, ['codex', 'install', '--json'], environment);
 
@@ -806,7 +818,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('uses the supported add fallback for a configured non-Git marketplace', async () => {
-    const fixture = createMigrationFixture('', true, false);
+    const fixture = createMigrationFixture('', { pluginInitiallyInstalled: false });
 
     const result = await runCodexCommand(fixture, ['codex', 'install'], {
       SAFEWORD_MARKETPLACE_SOURCE_TYPE: 'local',
@@ -819,7 +831,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('refuses finalization when proof and the installed plugin version differ', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, true, '0.68.0');
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, { pluginVersion: '0.68.0' });
     recordCurrentProof(fixture);
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate', '--finalize', '--json']);
@@ -834,7 +846,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('uses manifest-bound proof when an older Codex omits installed plugin version metadata', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, true);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG);
     recordCurrentProof(fixture);
 
     const result = await finalizeCodex(fixture, {}, true);
@@ -852,7 +864,7 @@ command = 'echo "keep this user hook"'
   });
 
   it('installs and verifies the profile plugin without creating project Codex configuration', async () => {
-    const fixture = createMigrationFixture('', true, false);
+    const fixture = createMigrationFixture('', { pluginInitiallyInstalled: false });
     const { directory, logPath } = fixture;
     rmSync(nodePath.join(directory, '.codex'), { recursive: true });
 
@@ -874,7 +886,9 @@ command = 'echo "keep this user hook"'
   });
 
   it('expands to the profile plugin without removing legacy hooks', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const { configPath } = fixture;
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate']);
@@ -886,7 +900,9 @@ command = 'echo "keep this user hook"'
   });
 
   it('leaves recognized legacy protection unchanged when plugin installation fails', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const legacySkillPath = nodePath.join(fixture.directory, '.agents/skills/review-spec/SKILL.md');
     mkdirSync(nodePath.dirname(legacySkillPath), { recursive: true });
     writeFileSync(legacySkillPath, '# legacy protection\n');
@@ -904,7 +920,9 @@ command = 'echo "keep this user hook"'
   });
 
   it('reports unknown enablement without changing the repository after partial installation', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const beforeConfig = readFileSync(fixture.configPath, 'utf8');
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate', '--json'], {
@@ -1134,7 +1152,9 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
   });
 
   it('records restart-required state after successful profile installation', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const codexHome = fixture.codexHome;
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate'], {
@@ -1660,7 +1680,9 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
   });
 
   it('returns one schema result for JSON migration, finalization, and recovery', async () => {
-    const installing = createMigrationFixture(LEGACY_HOOK_CONFIG, false, false);
+    const installing = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const install = await runCodexCommand(installing, ['codex', 'migrate', '--json']);
     expect(install.stderr).toBe('');
     expect(JSON.parse(install.stdout)).toMatchObject({
@@ -1706,7 +1728,9 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
   });
 
   it('returns a schema error instead of prose when JSON migration fails', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, false, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate', '--json'], {
       SAFEWORD_FAIL_PLUGIN_INSTALL: '1',
@@ -1790,7 +1814,9 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
   });
 
   it('reinstalls an absent plugin even when a stale activation marker remains', async () => {
-    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, false, false);
+    const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, {
+      pluginInitiallyInstalled: false,
+    });
     const environment = {
       CODEX_HOME: fixture.codexHome,
     };

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -97,6 +97,8 @@ describe('migrate codex-plugin command', () => {
       directory,
       configPath,
       bin: runtime.bin,
+      codexHome: runtime.codexHome,
+      logPath: runtime.logPath,
     };
   }
 
@@ -118,8 +120,8 @@ describe('migrate codex-plugin command', () => {
         cwd: fixture.directory,
         env: {
           PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
-          SAFEWORD_CODEX_LOG: nodePath.join(fixture.directory, 'codex.log'),
-          CODEX_HOME: nodePath.join(fixture.directory, 'profile'),
+          SAFEWORD_CODEX_LOG: fixture.logPath,
+          CODEX_HOME: fixture.codexHome,
           ...environment,
         },
       },
@@ -135,8 +137,8 @@ describe('migrate codex-plugin command', () => {
       cwd: fixture.directory,
       env: {
         PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
-        SAFEWORD_CODEX_LOG: nodePath.join(fixture.directory, 'codex.log'),
-        CODEX_HOME: nodePath.join(fixture.directory, 'profile'),
+        SAFEWORD_CODEX_LOG: fixture.logPath,
+        CODEX_HOME: fixture.codexHome,
         ...environment,
       },
     });
@@ -145,15 +147,15 @@ describe('migrate codex-plugin command', () => {
   function stubAutomaticMigrationEnvironment(
     fixture: ReturnType<typeof createMigrationFixture>,
   ): NodeJS.ProcessEnv {
-    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
+    const environment = { CODEX_HOME: fixture.codexHome };
     vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
-    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
+    vi.stubEnv('SAFEWORD_CODEX_LOG', fixture.logPath);
     vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
     return environment;
   }
 
   function recordCurrentProof(fixture: ReturnType<typeof createMigrationFixture>): void {
-    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
+    const environment = { CODEX_HOME: fixture.codexHome };
     for (const event of CODEX_PLUGIN_HOOK_EVENTS) {
       recordCodexHookProof(event, environment);
     }
@@ -209,8 +211,7 @@ describe('migrate codex-plugin command', () => {
 
   it('leaves legacy hooks untouched and explains the reviewed-plugin handoff', async () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG);
-    const { directory, configPath } = fixture;
-    const log = nodePath.join(directory, 'codex.log');
+    const { directory, configPath, logPath: log } = fixture;
 
     const result = await runMigration(fixture);
 
@@ -271,9 +272,7 @@ describe('migrate codex-plugin command', () => {
 
     expect(automaticallyMigrateLegacyCodex(fixture.directory, environment)).toBe(true);
 
-    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).toContain(
-      'plugin add safeword@safeword --json',
-    );
+    expect(readFileSync(fixture.logPath, 'utf8')).toContain('plugin add safeword@safeword --json');
     expect(existsSync(safewordSkill)).toBe(false);
     expect(existsSync(nodePath.join(fixture.directory, '.safeword/codex-plugin.json'))).toBe(true);
     for (const [relativePath, contents] of Object.entries(userOwned)) {
@@ -348,7 +347,7 @@ describe('migrate codex-plugin command', () => {
 
     expect(result.exitCode, result.stderr).toBe(0);
     expect(readFileSync(configPath, 'utf8')).not.toContain('safeword hook codex pre-tool-use');
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin list --json');
     expect(calls).not.toContain('plugin marketplace add');
     expect(calls).not.toContain('plugin add safeword@safeword --json');
@@ -539,8 +538,7 @@ command = """npx --yes safeword hook codex pre-tool-use"""
   it('refuses explicit cleanup when the Codex configuration is malformed', async () => {
     const original = `${LEGACY_HOOK_CONFIG}\n[broken\n`;
     const fixture = createMigrationFixture(original);
-    const { directory, configPath } = fixture;
-    const codexLogPath = nodePath.join(directory, 'codex.log');
+    const { directory, configPath, logPath: codexLogPath } = fixture;
     const legacyRuntimeHookPath = nodePath.join(
       directory,
       '.safeword/hooks/codex/pre-tool-quality.ts',
@@ -559,9 +557,8 @@ command = """npx --yes safeword hook codex pre-tool-use"""
 
   it('refuses cleanup before profile mutation when the Codex configuration is a symbolic link', async () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG);
-    const { directory, configPath } = fixture;
+    const { directory, configPath, logPath: codexLogPath } = fixture;
     const targetPath = nodePath.join(directory, 'dotfiles-config.toml');
-    const codexLogPath = nodePath.join(directory, 'codex.log');
     writeFileSync(targetPath, LEGACY_HOOK_CONFIG);
     rmSync(configPath);
     symlinkSync('dotfiles-config.toml', configPath);
@@ -654,7 +651,7 @@ command = 'echo "keep this user hook"'
       },
     });
     expect(readFileSync(fixture.configPath, 'utf8')).toBe(before);
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin marketplace list --json');
     expect(calls).toContain('plugin marketplace upgrade safeword --json');
     expect(calls).toContain('plugin add safeword@safeword --json');
@@ -680,14 +677,14 @@ command = 'echo "keep this user hook"'
         },
       ],
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin marketplace upgrade safeword --json');
     expect(calls).not.toContain('plugin add safeword@safeword --json');
   });
 
   it('leaves the profile unchanged when another task is installing the plugin', async () => {
     const fixture = createMigrationFixture('', true, false);
-    const profileEnvironment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
+    const profileEnvironment = { CODEX_HOME: fixture.codexHome };
     expect(
       acquireCodexProfileLock(profileEnvironment, { owner: 'another-codex-task' }),
     ).toBeDefined();
@@ -705,7 +702,7 @@ command = 'echo "keep this user hook"'
         },
       ],
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin list --json');
     expect(calls).not.toContain('plugin marketplace');
     expect(calls).not.toContain('plugin add safeword@safeword --json');
@@ -728,7 +725,7 @@ command = 'echo "keep this user hook"'
         },
       ],
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).not.toContain('plugin marketplace upgrade safeword --json');
     expect(calls).not.toContain('plugin add safeword@safeword --json');
   });
@@ -741,7 +738,7 @@ command = 'echo "keep this user hook"'
     });
 
     expect(result.exitCode).toBe(2);
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin marketplace upgrade safeword --json');
     expect(calls).toContain('plugin add safeword@safeword --json');
   });
@@ -756,7 +753,7 @@ command = 'echo "keep this user hook"'
     const result = await runCodexCommand(fixture, ['codex', 'install']);
 
     expect(result.exitCode).toBe(2);
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin marketplace remove safeword --json');
     expect(calls).toContain('plugin marketplace add ArcadeAI/safeword --ref stable');
     expect(calls).not.toContain('plugin marketplace upgrade safeword --json');
@@ -783,7 +780,7 @@ command = 'echo "keep this user hook"'
       changed: false,
       errors: [{ code: 'PLUGIN_NEWER_PIN_PRESERVED' }],
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).not.toContain('plugin marketplace remove');
     expect(calls).not.toContain('plugin marketplace add');
     expect(calls).not.toContain('plugin add safeword@safeword');
@@ -803,7 +800,7 @@ command = 'echo "keep this user hook"'
       state: 'failed',
       errors: [{ code: 'PLUGIN_MARKETPLACE_FAILED' }],
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).not.toContain('plugin marketplace add');
     expect(calls).not.toContain('plugin add safeword@safeword --json');
   });
@@ -816,7 +813,7 @@ command = 'echo "keep this user hook"'
     });
 
     expect(result.exitCode).toBe(2);
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin marketplace add ArcadeAI/safeword');
     expect(calls).not.toContain('plugin marketplace upgrade safeword --json');
   });
@@ -856,7 +853,7 @@ command = 'echo "keep this user hook"'
 
   it('installs and verifies the profile plugin without creating project Codex configuration', async () => {
     const fixture = createMigrationFixture('', true, false);
-    const { directory } = fixture;
+    const { directory, logPath } = fixture;
     rmSync(nodePath.join(directory, '.codex'), { recursive: true });
 
     const result = await runCodexCommand(fixture, ['codex', 'install']);
@@ -868,7 +865,7 @@ command = 'echo "keep this user hook"'
     expect(`${result.stdout}\n${result.stderr}`).toContain('Restart Codex');
     expect(`${result.stdout}\n${result.stderr}`).toContain('start a new task');
     expect(existsSync(nodePath.join(directory, '.codex'))).toBe(false);
-    const calls = readFileSync(nodePath.join(directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(logPath, 'utf8');
     expect(calls).toContain(
       'plugin marketplace add ArcadeAI/safeword --ref stable --sparse .agents/plugins --sparse packages/cli/codex-plugin --json',
     );
@@ -885,9 +882,7 @@ command = 'echo "keep this user hook"'
     expect(result.exitCode, result.stderr).toBe(2);
     expect(`${result.stdout}\n${result.stderr}`).toContain('Restart Codex');
     expect(readFileSync(configPath, 'utf8')).toBe(LEGACY_HOOK_CONFIG);
-    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).toContain(
-      'plugin marketplace add',
-    );
+    expect(readFileSync(fixture.logPath, 'utf8')).toContain('plugin marketplace add');
   });
 
   it('leaves recognized legacy protection unchanged when plugin installation fails', async () => {
@@ -938,7 +933,7 @@ command = 'echo "keep this user hook"'
 
   it('reports an enabled plugin without current hook proof as unproven', async () => {
     const fixture = createMigrationFixture('');
-    const codexHome = nodePath.join(fixture.directory, 'profile');
+    const codexHome = fixture.codexHome;
     mkdirSync(codexHome, { recursive: true });
 
     const result = await runCodexCommand(fixture, ['codex', 'status'], {
@@ -1140,7 +1135,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
 
   it('records restart-required state after successful profile installation', async () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
-    const codexHome = nodePath.join(fixture.directory, 'profile');
+    const codexHome = fixture.codexHome;
 
     const result = await runCodexCommand(fixture, ['codex', 'migrate'], {
       CODEX_HOME: codexHome,
@@ -1213,7 +1208,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     try {
       await expect(
         removeLegacyCodexHooks(fixture.directory, {
-          environment: { CODEX_HOME: nodePath.join(fixture.directory, 'profile') },
+          environment: { CODEX_HOME: fixture.codexHome },
           confirm,
         }),
       ).resolves.toBe(false);
@@ -1224,7 +1219,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
 
     expect(confirm).not.toHaveBeenCalled();
     expect(readFileSync(fixture.configPath, 'utf8')).toBe(before);
-    expect(existsSync(nodePath.join(fixture.directory, 'codex.log'))).toBe(false);
+    expect(existsSync(fixture.logPath)).toBe(false);
 
     const result = await runCodexCommand(fixture, [
       'codex',
@@ -1242,7 +1237,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
       next_actions: [{ command: 'safeword codex recover' }],
     });
     expect(readFileSync(fixture.configPath, 'utf8')).toBe(before);
-    expect(existsSync(nodePath.join(fixture.directory, 'codex.log'))).toBe(false);
+    expect(existsSync(fixture.logPath)).toBe(false);
   });
 
   it('passes exact config blocks and paths from the real planner to confirmation', async () => {
@@ -1251,7 +1246,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     let displayedPlan = '';
 
     await removeLegacyCodexHooks(fixture.directory, {
-      environment: { CODEX_HOME: nodePath.join(fixture.directory, 'profile') },
+      environment: { CODEX_HOME: fixture.codexHome },
       confirm: plan => {
         displayedPlan = plan;
         return Promise.resolve(false);
@@ -1517,8 +1512,8 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG);
     recordCurrentProof(fixture);
     vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
-    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
-    vi.stubEnv('CODEX_HOME', nodePath.join(fixture.directory, 'profile'));
+    vi.stubEnv('SAFEWORD_CODEX_LOG', fixture.logPath);
+    vi.stubEnv('CODEX_HOME', fixture.codexHome);
     const handler = publicHandler('codex migrate');
     const preview = await handler({
       cwd: fixture.directory,
@@ -1753,7 +1748,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
   it('converges repeated migration while app-restart activation is pending', async () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG);
     writeCodexActivationMarker({
-      CODEX_HOME: nodePath.join(fixture.directory, 'profile'),
+      CODEX_HOME: fixture.codexHome,
     });
     const first = await runCodexCommand(fixture, ['codex', 'migrate']);
     expect(first.exitCode, first.stderr).toBe(2);
@@ -1777,7 +1772,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
       },
     });
     expect(readFileSync(markerPath, 'utf8')).toBe(marker);
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).not.toContain('plugin marketplace add');
   });
 
@@ -1791,15 +1786,13 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     expect(
       existsSync(nodePath.join(fixture.directory, 'profile/safeword/activation-pending-v2.json')),
     ).toBe(false);
-    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).not.toContain(
-      'plugin marketplace add',
-    );
+    expect(readFileSync(fixture.logPath, 'utf8')).not.toContain('plugin marketplace add');
   });
 
   it('reinstalls an absent plugin even when a stale activation marker remains', async () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, false, false);
     const environment = {
-      CODEX_HOME: nodePath.join(fixture.directory, 'profile'),
+      CODEX_HOME: fixture.codexHome,
     };
     writeCodexActivationMarker(environment);
 
@@ -1809,9 +1802,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
       changed: true,
       data: { plugin: { installed: true, enabled: true } },
     });
-    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).toContain(
-      'plugin add safeword@safeword --json',
-    );
+    expect(readFileSync(fixture.logPath, 'utf8')).toContain('plugin add safeword@safeword --json');
   });
 
   it('does not regress compatibility mode to app-restart-required on repeated migration', async () => {
@@ -1825,9 +1816,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     expect(
       existsSync(nodePath.join(fixture.directory, 'profile/safeword/activation-pending-v2.json')),
     ).toBe(false);
-    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).not.toContain(
-      'plugin marketplace add',
-    );
+    expect(readFileSync(fixture.logPath, 'utf8')).not.toContain('plugin marketplace add');
   });
 
   it('blocks migration while recovery evidence is unresolved', async () => {
@@ -1847,7 +1836,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
     expect(result.stdout).toContain('Next: safeword codex recover');
     expect(result.stdout.match(/^Next:/gm)).toHaveLength(1);
     expect(readFileSync(fixture.configPath, 'utf8')).toBe(before);
-    expect(existsSync(nodePath.join(fixture.directory, 'codex.log'))).toBe(false);
+    expect(existsSync(fixture.logPath)).toBe(false);
 
     const preview = await runCodexCommand(fixture, ['codex', 'migrate', '--finalize', '--json']);
     expect(preview.exitCode).toBe(2);
@@ -1858,7 +1847,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
       errors: [],
       next_actions: [{ command: 'safeword codex recover' }],
     });
-    expect(existsSync(nodePath.join(fixture.directory, 'codex.log'))).toBe(false);
+    expect(existsSync(fixture.logPath)).toBe(false);
   });
 
   it('reports linked or dangling reserved backup roots as recovery required', async () => {
@@ -1977,7 +1966,7 @@ command = 'bun "$(git rev-parse --show-toplevel)/.safeword/hooks/codex/pre-tool-
       transaction_id: marker.transaction_id,
       plan_sha256: marker.plan_sha256,
     });
-    const calls = readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8');
+    const calls = readFileSync(fixture.logPath, 'utf8');
     expect(calls).toContain('plugin list --json');
     expect(calls).not.toContain('plugin marketplace add');
     expect(calls).not.toContain('plugin add safeword@safeword --json');

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -252,12 +252,12 @@ describe('migrate codex-plugin command', () => {
   // path where survival is least obvious and most worth pinning.
   it('preserves user-owned project data and authored skills through a successful handoff', () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
-    const userOwned = {
+    const userOwnedFiles = {
       '.project/tickets/ABC123/spec.md': '# Authored spec\n\nOwned by the user, not Safeword.\n',
       '.project/learnings/handoff-notes.md': '# Handoff notes\n\nDo not clobber authored notes.\n',
       '.agents/skills/company-workflow/SKILL.md': 'User-authored company workflow skill\n',
     };
-    for (const [relativePath, contents] of Object.entries(userOwned)) {
+    for (const [relativePath, contents] of Object.entries(userOwnedFiles)) {
       const absolutePath = nodePath.join(fixture.directory, relativePath);
       mkdirSync(nodePath.dirname(absolutePath), { recursive: true });
       writeFileSync(absolutePath, contents);
@@ -275,7 +275,7 @@ describe('migrate codex-plugin command', () => {
     expect(readFileSync(fixture.logPath, 'utf8')).toContain('plugin add safeword@safeword --json');
     expect(existsSync(safewordSkill)).toBe(false);
     expect(existsSync(nodePath.join(fixture.directory, '.safeword/codex-plugin.json'))).toBe(true);
-    for (const [relativePath, contents] of Object.entries(userOwned)) {
+    for (const [relativePath, contents] of Object.entries(userOwnedFiles)) {
       expect(
         readFileSync(nodePath.join(fixture.directory, relativePath), 'utf8'),
         relativePath,

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -240,6 +240,16 @@ describe('migrate codex-plugin command', () => {
     });
   }
 
+  function stubAutomaticMigrationEnvironment(
+    fixture: ReturnType<typeof createMigrationFixture>,
+  ): NodeJS.ProcessEnv {
+    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
+    vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
+    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
+    vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
+    return environment;
+  }
+
   function recordCurrentProof(fixture: ReturnType<typeof createMigrationFixture>): void {
     const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
     for (const event of CODEX_PLUGIN_HOOK_EVENTS) {
@@ -318,12 +328,7 @@ describe('migrate codex-plugin command', () => {
     const legacySkill = nodePath.join(fixture.directory, '.agents/skills/audit/SKILL.md');
     mkdirSync(nodePath.dirname(legacySkill), { recursive: true });
     writeFileSync(legacySkill, 'legacy audit skill\n');
-    const environment = {
-      CODEX_HOME: nodePath.join(fixture.directory, 'profile'),
-    };
-    vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
-    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
-    vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
+    const environment = stubAutomaticMigrationEnvironment(fixture);
 
     expect(automaticallyMigrateLegacyCodex(fixture.directory, environment)).toBe(true);
 
@@ -360,10 +365,7 @@ describe('migrate codex-plugin command', () => {
     const safewordSkill = nodePath.join(fixture.directory, '.agents/skills/audit/SKILL.md');
     mkdirSync(nodePath.dirname(safewordSkill), { recursive: true });
     writeFileSync(safewordSkill, 'legacy audit skill\n');
-    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
-    vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
-    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
-    vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
+    const environment = stubAutomaticMigrationEnvironment(fixture);
 
     expect(automaticallyMigrateLegacyCodex(fixture.directory, environment)).toBe(true);
 
@@ -379,11 +381,8 @@ describe('migrate codex-plugin command', () => {
 
   it('retains complete legacy state when automatic plugin installation fails', () => {
     const fixture = createMigrationFixture(LEGACY_HOOK_CONFIG, true, false);
-    const environment = { CODEX_HOME: nodePath.join(fixture.directory, 'profile') };
-    vi.stubEnv('PATH', `${fixture.bin}:${process.env.PATH ?? ''}`);
-    vi.stubEnv('SAFEWORD_CODEX_LOG', nodePath.join(fixture.directory, 'codex.log'));
+    const environment = stubAutomaticMigrationEnvironment(fixture);
     vi.stubEnv('SAFEWORD_FAIL_PLUGIN_INSTALL', '1');
-    vi.stubEnv('CODEX_HOME', environment.CODEX_HOME);
 
     expect(() => automaticallyMigrateLegacyCodex(fixture.directory, environment)).toThrow(
       'marketplace unavailable',

--- a/packages/cli/tests/commands/migrate-codex-plugin.test.ts
+++ b/packages/cli/tests/commands/migrate-codex-plugin.test.ts
@@ -369,6 +369,9 @@ describe('migrate codex-plugin command', () => {
 
     expect(automaticallyMigrateLegacyCodex(fixture.directory, environment)).toBe(true);
 
+    expect(readFileSync(nodePath.join(fixture.directory, 'codex.log'), 'utf8')).toContain(
+      'plugin add safeword@safeword --json',
+    );
     expect(existsSync(safewordSkill)).toBe(false);
     expect(existsSync(nodePath.join(fixture.directory, '.safeword/codex-plugin.json'))).toBe(true);
     for (const [relativePath, contents] of Object.entries(userOwned)) {

--- a/packages/cli/tests/helpers/fake-codex-runtime.ts
+++ b/packages/cli/tests/helpers/fake-codex-runtime.ts
@@ -42,7 +42,7 @@ export function installFakeCodexRuntime(
 set -eu
 printf '%s\n' "$*" >> "$SAFEWORD_CODEX_LOG"
 if [ "$(printenv SAFEWORD_MUTATE_CONFIG 2>/dev/null || true)" = "1" ] && [ "$*" = "plugin list --json" ]; then
-  printf '# concurrent config update\\n' >> "$SAFEWORD_CONFIG_PATH"
+  printf '# concurrent config update\n' >> "$SAFEWORD_CONFIG_PATH"
 fi
 if [ -n "$(printenv SAFEWORD_LEGACY_ASSET_PATH 2>/dev/null || true)" ] && [ "$*" = "plugin list --json" ]; then
   printf '# appeared after confirmation\n' > "$SAFEWORD_LEGACY_ASSET_PATH"

--- a/packages/cli/tests/helpers/fake-codex-runtime.ts
+++ b/packages/cli/tests/helpers/fake-codex-runtime.ts
@@ -1,0 +1,116 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { SAFEWORD_SCHEMA } from '../../src/schema.js';
+
+export interface FakeCodexRuntime {
+  bin: string;
+  codexHome: string;
+  logPath: string;
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+export function installFakeCodexRuntime(
+  directory: string,
+  pluginEnabled: boolean,
+  pluginInitiallyInstalled: boolean,
+  pluginVersion?: string,
+): FakeCodexRuntime {
+  const bin = nodePath.join(directory, 'bin');
+  const codexHome = nodePath.join(directory, 'profile');
+  const logPath = nodePath.join(directory, 'codex.log');
+  const pluginState = nodePath.join(codexHome, 'plugin-state');
+  const pluginVersionState = nodePath.join(codexHome, 'plugin-version');
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  let initialPluginState = 'absent';
+  if (pluginInitiallyInstalled) initialPluginState = pluginEnabled ? 'enabled' : 'disabled';
+  writeFileSync(pluginState, initialPluginState);
+  writeFileSync(pluginVersionState, pluginVersion ?? '');
+  writeExecutable(nodePath.join(bin, 'bun'), '#!/bin/sh\nexit 0\n');
+  writeExecutable(
+    nodePath.join(bin, 'codex'),
+    String.raw`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$SAFEWORD_CODEX_LOG"
+if [ "$(printenv SAFEWORD_MUTATE_CONFIG 2>/dev/null || true)" = "1" ] && [ "$*" = "plugin list --json" ]; then
+  printf '# concurrent config update\\n' >> "$SAFEWORD_CONFIG_PATH"
+fi
+if [ -n "$(printenv SAFEWORD_LEGACY_ASSET_PATH 2>/dev/null || true)" ] && [ "$*" = "plugin list --json" ]; then
+  printf '# appeared after confirmation\n' > "$SAFEWORD_LEGACY_ASSET_PATH"
+fi
+case "$*" in
+  '--version') echo 'codex 0.141.0' ;;
+  'plugin marketplace list --json')
+    if [ "$(printenv SAFEWORD_FAIL_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
+      echo 'marketplace observation failed' >&2
+      exit 7
+    fi
+    if [ "$(printenv SAFEWORD_MALFORMED_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
+      echo '{bad json'
+    elif [ "$(printenv SAFEWORD_UNSUPPORTED_MARKETPLACE_LIST 2>/dev/null || true)" = "1" ]; then
+      echo '{"marketplaces":[null]}'
+    elif [ "$(printenv SAFEWORD_MARKETPLACE_SOURCE_TYPE 2>/dev/null || true)" = "local" ]; then
+      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"local","source":"/tmp/safeword"}}]}'
+    elif [ "$(printenv SAFEWORD_MISMATCHED_GIT_MARKETPLACE 2>/dev/null || true)" = "1" ]; then
+      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"https://example.com/untrusted/safeword.git"}}]}'
+    elif [ "$(printenv SAFEWORD_SSH_GIT_MARKETPLACE 2>/dev/null || true)" = "1" ]; then
+      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"git@github.com:ArcadeAI/safeword.git"}}]}'
+    elif [ '${pluginInitiallyInstalled}' = 'true' ]; then
+      echo '{"marketplaces":[{"name":"safeword","marketplaceSource":{"sourceType":"git","source":"https://github.com/ArcadeAI/safeword.git"}}]}'
+    else
+      echo '{"marketplaces":[]}'
+    fi
+    ;;
+  'plugin marketplace upgrade safeword --json')
+    if [ "$(printenv SAFEWORD_FAIL_MARKETPLACE_UPGRADE 2>/dev/null || true)" = "1" ]; then
+      echo 'marketplace refresh failed' >&2
+      exit 6
+    fi
+    echo '{"marketplaceName":"safeword"}'
+    ;;
+  'plugin marketplace remove safeword --json')
+    echo '{"marketplaceName":"safeword"}'
+    ;;
+  'plugin marketplace add '* )
+    if [ "$(printenv SAFEWORD_FAIL_PLUGIN_INSTALL 2>/dev/null || true)" = "1" ]; then
+      echo 'marketplace unavailable' >&2
+      exit 9
+    fi
+    echo '{"marketplaceName":"safeword"}'
+    ;;
+  'plugin add safeword@safeword --json')
+    printf 'enabled' > '${pluginState}'
+    printf '${SAFEWORD_SCHEMA.version}' > '${pluginVersionState}'
+    echo '{"pluginId":"safeword@safeword"}'
+    ;;
+  'plugin list --json')
+    if [ "$(printenv SAFEWORD_FAIL_PLUGIN_VERIFY 2>/dev/null || true)" = "1" ]; then
+      echo 'profile observation failed' >&2
+      exit 8
+    fi
+    mode="$(cat '${pluginState}')"
+    if [ "$mode" = "absent" ]; then
+      echo '{"installed":[]}'
+    elif [ "$mode" = "disabled" ]; then
+      echo '{"installed":[{"pluginId":"safeword@safeword","enabled":false}]}'
+    else
+      version="$(cat '${pluginVersionState}')"
+      if [ -n "$version" ]; then
+        echo "{\"installed\":[{\"pluginId\":\"safeword@safeword\",\"enabled\":true,\"version\":\"$version\"}]}"
+      else
+        echo '{"installed":[{"pluginId":"safeword@safeword","enabled":true}]}'
+      fi
+    fi
+    ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+
+  return { bin, codexHome, logPath };
+}

--- a/packages/cli/tests/helpers/fake-codex-runtime.ts
+++ b/packages/cli/tests/helpers/fake-codex-runtime.ts
@@ -9,6 +9,12 @@ export interface FakeCodexRuntime {
   logPath: string;
 }
 
+interface FakeCodexRuntimeOptions {
+  pluginEnabled: boolean;
+  pluginInitiallyInstalled: boolean;
+  pluginVersion?: string;
+}
+
 function writeExecutable(path: string, content: string): void {
   writeFileSync(path, content, { mode: 0o755 });
   chmodSync(path, 0o755);
@@ -16,9 +22,7 @@ function writeExecutable(path: string, content: string): void {
 
 export function installFakeCodexRuntime(
   directory: string,
-  pluginEnabled: boolean,
-  pluginInitiallyInstalled: boolean,
-  pluginVersion?: string,
+  { pluginEnabled, pluginInitiallyInstalled, pluginVersion }: FakeCodexRuntimeOptions,
 ): FakeCodexRuntime {
   const bin = nodePath.join(directory, 'bin');
   const codexHome = nodePath.join(directory, 'profile');

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -1661,7 +1661,7 @@ When(
 );
 
 When(
-  'the plugin migration handoff succeeds under an isolated Codex profile',
+  'the plugin migration upgrade runs with profile enrollment available',
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
     const runtimeRoot = createTemporaryDirectory('safeword-codex-migration-runtime-');
@@ -1870,27 +1870,24 @@ Then(
   },
 );
 
-Then(
-  'the handoff installs the Safe Word plugin through the fake Codex boundary',
-  function (this: CodexPluginMigrationWorld) {
-    const result = this.codexPluginMigrationResult;
-    assert.ok(result, 'migration result was not captured');
-    assert.equal(result.exitCode, 0, `${result.stdout}\n${result.stderr}`);
-    assert.match(
-      readFileSync(requirePath(this.codexPluginMigrationLogPath, 'migration log'), 'utf8'),
-      /plugin add safeword@safeword --json/u,
-    );
-    assert.equal(
-      existsSync(
-        nodePath.join(
-          requirePath(this.codexPluginRepoRoot, 'repo root'),
-          '.safeword/codex-plugin.json',
-        ),
+Then('Safe Word is enrolled in the Codex profile', function (this: CodexPluginMigrationWorld) {
+  const result = this.codexPluginMigrationResult;
+  assert.ok(result, 'migration result was not captured');
+  assert.equal(result.exitCode, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(
+    readFileSync(requirePath(this.codexPluginMigrationLogPath, 'migration log'), 'utf8'),
+    /plugin add safeword@safeword --json/u,
+  );
+  assert.equal(
+    existsSync(
+      nodePath.join(
+        requirePath(this.codexPluginRepoRoot, 'repo root'),
+        '.safeword/codex-plugin.json',
       ),
-      true,
-    );
-  },
-);
+    ),
+    true,
+  );
+});
 
 Then(
   /^Safe Word keeps repo-local `\.agents\/skills` available during the compatibility window$/,

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -16,6 +16,8 @@ import process from 'node:process';
 
 import { After, Given, Then, When } from '@cucumber/cucumber';
 
+import { installFakeCodexRuntime } from '../packages/cli/tests/helpers/fake-codex-runtime.js';
+
 import type { CommandResult, SafewordWorld } from './world.js';
 
 const SAFEWORD_CODEX_PLUGIN_ROOT = nodePath.resolve(
@@ -56,6 +58,8 @@ interface CodexPluginMigrationWorld extends SafewordWorld {
   codexPluginHookContractResults?: CodexHookContractResult[];
   codexPluginMalformedHookCommandName?: CodexHookCommandName;
   codexPluginMigrationResult?: CommandResult;
+  codexPluginMigrationLogPath?: string;
+  codexPluginRuntimeRoot?: string;
   codexPluginUserDataSnapshot?: Record<string, string>;
   codexPluginSelfReportSnapshot?: Record<string, string>;
   codexPluginUserSkillSnapshot?: string;
@@ -1367,6 +1371,22 @@ Given(
   },
 );
 
+Given(
+  /^the repo contains a user-authored `\.agents\/skills\/company-workflow\/SKILL\.md`$/,
+  function (this: CodexPluginMigrationWorld) {
+    const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    const skillPath = nodePath.join(repoRoot, '.agents/skills/company-workflow/SKILL.md');
+    mkdirSync(nodePath.dirname(skillPath), { recursive: true });
+    writeFileSync(
+      skillPath,
+      ['---', 'name: company-workflow', '---', '', '# Company Workflow', 'Use local process.'].join(
+        '\n',
+      ),
+    );
+    this.codexPluginUserSkillSnapshot = readFileSync(skillPath, 'utf8');
+  },
+);
+
 When(
   "the packaged Codex PreToolUse entrypoint receives a supported edit payload for that ticket's `test-definitions.md`",
   function (this: CodexPluginMigrationWorld) {
@@ -1612,19 +1632,17 @@ When(
 );
 
 /**
- * Every scenario in this rule runs the upgrade with profile enrollment made
- * unavailable, and each one asserts the decline it produces (#1973). The
+ * Rejection scenarios in this rule run the upgrade with profile enrollment
+ * made unavailable, and each one asserts the decline it produces (#1973). The
  * decline is the point: it proves the upgrade ran, reached the Codex handoff,
  * and preserved the project on the way out. Without that assertion these
  * scenarios pass whether or not anything executed, because untouched files
  * look identical to files nothing reached.
  *
- * Enrollment stays unavailable on purpose rather than being made to succeed.
- * `installCodexPlugin` shells out to the real `bun` and `codex` binaries and
- * clones the `ArcadeAI/safeword` marketplace at ref `stable`; the automatic
- * migration path takes no local-source override. Succeeding here would mean a
- * network clone per scenario and mutating whatever Codex profile is ambient.
- * Hermetic coverage of a *successful* handoff is tracked separately.
+ * Enrollment stays unavailable in those cases so they cannot clone a network
+ * marketplace or mutate an ambient Codex profile. The successful case below
+ * crosses the same subprocess boundary through a temp-bin fake and isolated
+ * CODEX_HOME.
  */
 When(
   'the plugin migration upgrade runs without profile enrollment available',
@@ -1636,6 +1654,28 @@ When(
         // SAFEWORD_SKIP_INSTALL only skips project dependencies; hide profile tools too.
         PATH: '',
         SAFEWORD_SKIP_INSTALL: '1',
+      },
+      timeout: 120_000,
+    });
+  },
+);
+
+When(
+  'the plugin migration handoff succeeds under an isolated Codex profile',
+  function (this: CodexPluginMigrationWorld) {
+    const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    const runtimeRoot = createTemporaryDirectory('safeword-codex-migration-runtime-');
+    const runtime = installFakeCodexRuntime(runtimeRoot, true, false);
+    this.codexPluginRuntimeRoot = runtimeRoot;
+    this.codexPluginCodexHome = runtime.codexHome;
+    this.codexPluginMigrationLogPath = runtime.logPath;
+    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
+      cwd: repoRoot,
+      env: {
+        PATH: `${runtime.bin}:${process.env.PATH ?? ''}`,
+        SAFEWORD_CODEX_LOG: runtime.logPath,
+        SAFEWORD_SKIP_INSTALL: '1',
+        CODEX_HOME: runtime.codexHome,
       },
       timeout: 120_000,
     });
@@ -1828,6 +1868,28 @@ Then(
 );
 
 Then(
+  'the handoff installs the Safe Word plugin through the fake Codex boundary',
+  function (this: CodexPluginMigrationWorld) {
+    const result = this.codexPluginMigrationResult;
+    assert.ok(result, 'migration result was not captured');
+    assert.equal(result.exitCode, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(
+      readFileSync(requirePath(this.codexPluginMigrationLogPath, 'migration log'), 'utf8'),
+      /plugin add safeword@safeword --json/u,
+    );
+    assert.equal(
+      existsSync(
+        nodePath.join(
+          requirePath(this.codexPluginRepoRoot, 'repo root'),
+          '.safeword/codex-plugin.json',
+        ),
+      ),
+      true,
+    );
+  },
+);
+
+Then(
   /^Safe Word keeps repo-local `\.agents\/skills` available during the compatibility window$/,
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
@@ -1855,6 +1917,23 @@ Then('the user-authored skill remains byte-identical', function (this: CodexPlug
     this.codexPluginUserSkillSnapshot,
   );
 });
+
+Then(
+  'Safe Word-owned Codex skill files are removed after finalization',
+  function (this: CodexPluginMigrationWorld) {
+    const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    assert.equal(existsSync(nodePath.join(repoRoot, '.agents/skills/bdd/SKILL.md')), false);
+    assert.equal(existsSync(nodePath.join(repoRoot, '.agents/skills/verify/SKILL.md')), false);
+  },
+);
+
+Then(
+  'legacy Safe Word Codex hook runtime files are removed after finalization',
+  function (this: CodexPluginMigrationWorld) {
+    const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
+    assert.equal(existsSync(nodePath.join(repoRoot, '.safeword/hooks/codex')), false);
+  },
+);
 
 Then(
   'Safe Word-owned Codex skill files remain beside the user-authored skill until finalization',
@@ -2130,6 +2209,7 @@ After(function (this: CodexPluginMigrationWorld) {
     this.codexPluginMarketplaceRoot,
     this.codexPluginPackageRoot,
     this.codexPluginDefaultVerificationReportRoot,
+    this.codexPluginRuntimeRoot,
   ]) {
     if (directory) rmSync(directory, { recursive: true, force: true });
   }

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -140,6 +140,18 @@ function requirePath(value: string | undefined, label: string): string {
   return value;
 }
 
+function writeCompanyWorkflowSkill(repoRoot: string): string {
+  const skillPath = nodePath.join(repoRoot, '.agents/skills/company-workflow/SKILL.md');
+  mkdirSync(nodePath.dirname(skillPath), { recursive: true });
+  writeFileSync(
+    skillPath,
+    ['---', 'name: company-workflow', '---', '', '# Company Workflow', 'Use local process.'].join(
+      '\n',
+    ),
+  );
+  return readFileSync(skillPath, 'utf8');
+}
+
 function runCommand(
   command: string,
   args: string[],
@@ -1283,17 +1295,9 @@ Given(
   /^an old project-local Codex install with a user-authored `\.agents\/skills\/company-workflow\/SKILL\.md`$/,
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = createProjectLocalCodexInstallFixture();
-    const skillPath = nodePath.join(repoRoot, '.agents/skills/company-workflow/SKILL.md');
-    mkdirSync(nodePath.dirname(skillPath), { recursive: true });
-    writeFileSync(
-      skillPath,
-      ['---', 'name: company-workflow', '---', '', '# Company Workflow', 'Use local process.'].join(
-        '\n',
-      ),
-    );
 
     this.codexPluginRepoRoot = repoRoot;
-    this.codexPluginUserSkillSnapshot = readFileSync(skillPath, 'utf8');
+    this.codexPluginUserSkillSnapshot = writeCompanyWorkflowSkill(repoRoot);
   },
 );
 
@@ -1375,15 +1379,7 @@ Given(
   /^the repo contains a user-authored `\.agents\/skills\/company-workflow\/SKILL\.md`$/,
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
-    const skillPath = nodePath.join(repoRoot, '.agents/skills/company-workflow/SKILL.md');
-    mkdirSync(nodePath.dirname(skillPath), { recursive: true });
-    writeFileSync(
-      skillPath,
-      ['---', 'name: company-workflow', '---', '', '# Company Workflow', 'Use local process.'].join(
-        '\n',
-      ),
-    );
-    this.codexPluginUserSkillSnapshot = readFileSync(skillPath, 'utf8');
+    this.codexPluginUserSkillSnapshot = writeCompanyWorkflowSkill(repoRoot);
   },
 );
 

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -1665,7 +1665,10 @@ When(
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
     const runtimeRoot = createTemporaryDirectory('safeword-codex-migration-runtime-');
-    const runtime = installFakeCodexRuntime(runtimeRoot, true, false);
+    const runtime = installFakeCodexRuntime(runtimeRoot, {
+      pluginEnabled: true,
+      pluginInitiallyInstalled: false,
+    });
     this.codexPluginRuntimeRoot = runtimeRoot;
     this.codexPluginCodexHome = runtime.codexHome;
     this.codexPluginMigrationLogPath = runtime.logPath;
@@ -1931,7 +1934,11 @@ Then(
   'legacy Safe Word Codex hook runtime files are removed after finalization',
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
-    assert.equal(existsSync(nodePath.join(repoRoot, '.safeword/hooks/codex')), false);
+    assert.equal(
+      existsSync(nodePath.join(repoRoot, '.safeword/hooks/codex/pre-tool-quality.ts')),
+      false,
+    );
+    assert.equal(existsSync(nodePath.join(repoRoot, '.safeword/hooks/codex/stop.ts')), false);
   },
 );
 


### PR DESCRIPTION
Fixes #1989.

## Gap

All three `TB1.R4` acceptance scenarios covered a handoff that **declines** — non-vacuously, since #1973. Nothing covered user-owned tickets, learnings, or authored `.agents/skills` surviving a handoff that **succeeds**. That is the path where files actually move and get rewritten, so it is where survival is least obvious.

## Change

Two proof lanes, no production change:

- The focused Vitest regression exercises the real automatic-migration and transactional-finalization collaborators against a temporary filesystem.
- The executable acceptance scenario drives the packaged CLI through a successful handoff, proving the plugin install crosses the fake `codex` process boundary, authored project data remains byte-identical, and managed fallback assets are removed.
- A shared hermetic fake Codex runtime isolates `CODEX_HOME` and fakes only the external `codex`/`bun` boundary; no network or ambient profile is used.
- The feature, spec, ticket done criteria, and scenario ledger now agree on the successful-handoff behavior.

## On the marketplace-source override

#1989 proposed threading a `marketplaceSource` override through `automaticallyMigrateLegacyCodex` so the acceptance lane could point at a local marketplace, and flagged that it was worth confirming production actually needs it. It does not:

- The fake-runtime harness reaches the success path hermetically, which is what the issue requires.
- Adding an override for *where plugin code is fetched from* widens the supply-chain surface for a test-only benefit. This repo already refuses repo-local reviewer binaries on the same reasoning, so a new redirect seam would cut against that.

Real-`codex` enrollment remains covered by `TB1.R1`/`R2`, which drive the actual binary against a local marketplace.

## Verification

Falsified in both directions before trusting the proof:

- Treating a managed file as user-owned fails the byte-identity assertion, proving the preservation check has teeth.
- Blocking plugin installation fails the successful-handoff scenario, so it cannot pass vacuously.
- Focused migration Vitest: **77/77 passed**.
- Successful-handoff acceptance: **1 scenario, 44/44 steps passed**.
- Full CLI Vitest: **6,749 passed, 5 skipped**; relay: **167 passed, 1 skipped**.
- Build, ESLint, TypeScript, diff hygiene, dependency audit, and `bun audit`: clean.
- The full acceptance run reached **1,077 passed / 3 skipped** and reproduced one base-branch failure: the public-command determinism scenario compares two generated `codex status` `recorded_at` timestamps. #1991 does not change that scenario or implementation; the focused rerun reproduces it independently of this PR's migration path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPpTdcLAj7JkXzSpigWk1v)_
