### PR TITLE
Keep committed plugin builds reproducible across Bun releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       - name: Ticket closure rides ready PR
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/retro-reconcile.yml
+++ b/.github/workflows/retro-reconcile.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/upstream-changelog-monitor.yml
+++ b/.github/workflows/upstream-changelog-monitor.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
 
       - name: Run monitor
         run: bun packages/cli/src/upstream-monitor/run.ts

--- a/packages/cli/scripts/generate-claude-plugin.ts
+++ b/packages/cli/scripts/generate-claude-plugin.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import nodePath from 'node:path';
 
+import rootPackageJson from '../../../package.json' with { type: 'json' };
 import packageJson from '../package.json' with { type: 'json' };
 import {
   sealClaudePluginCatalogue,
@@ -10,13 +11,22 @@ import {
 const packageRoot = nodePath.resolve(import.meta.dirname, '..');
 const repoRoot = nodePath.resolve(packageRoot, '../..');
 
-// Run this under the bun version pinned in the root package.json's
-// `packageManager`. `plugin/runtime/cli.js` comes out of Bun.build below, so its
-// bytes depend on the bun that runs this script — different versions emit
-// different code for identical source. CI's catalogue-freshness gate regenerates
-// and rejects any diff, so a bundle built with another bun can never pass it.
-// Note that `bun run generate:claude-plugin` re-invokes `bun` from PATH: the
-// pinned version has to be FIRST ON PATH, not merely the binary you launched.
+const expectedBunVersion = /^bun@(.+)$/.exec(rootPackageJson.packageManager)?.[1];
+if (expectedBunVersion === undefined) {
+  throw new Error('Root package.json must pin Bun with `"packageManager": "bun@<version>"`.');
+}
+// @ts-expect-error -- this production generator executes under Bun; the CLI's
+// Node-targeted tsconfig intentionally does not expose Bun globals elsewhere.
+const actualBunVersion = Bun.version;
+if (actualBunVersion !== expectedBunVersion) {
+  throw new Error(
+    `Claude plugin generation requires Bun ${expectedBunVersion} from root package.json; ` +
+      `found ${actualBunVersion}. Install the pinned version and ensure it is first on PATH.`,
+  );
+}
+
+// `plugin/runtime/cli.js` comes out of Bun.build below, so its bytes depend on
+// the Bun version. Check before writing any generated or sealed plugin files.
 // @ts-expect-error -- this production generator executes under Bun; the CLI's
 // Node-targeted tsconfig intentionally does not expose Bun globals elsewhere.
 const cliBuild = await Bun.build({


### PR DESCRIPTION
## Summary

- make every GitHub Actions Bun setup resolve the version from the root `package.json`
- fail Claude plugin generation before writing files when the active Bun runtime does not match the repository pin
- keep the committed plugin bundle and its catalogue/manual-review seals unchanged

## Root cause

`plugin/runtime/cli.js` is committed output from `Bun.build()`, whose emitted bytes can change between Bun versions. CI compares regenerated bytes with the committed bundle, while contributors could run the generator with a different Bun release and be told to commit incompatible output.

The repository already declares `"packageManager": "bun@1.3.14"`. This change makes that declaration the explicit single source of truth for all `setup-bun` steps and enforces the same version at the generator boundary.

## Impact

This affects only Safeword development, CI, and release tooling. It does not impose a Bun version on customer projects or change the shipped plugin bundle.

## Validation

- `bun run --cwd packages/cli generate:claude-plugin` (zero `plugin/` diff)
- `bun run --cwd packages/cli check:claude-plugin`
- `bun scripts/parity-check.ts --mode=all` (241 pairs and 8 contracts in sync)
- `bun run lint`
- `bun run test` (440 CLI files / 6,746 passed; 8 relay files / 167 passed)
- `git diff --check`