### PR TITLE
docs: explain relay volume recovery

### DIFF
--- a/packages/retro-relay/README.md
+++ b/packages/retro-relay/README.md
@@ -51,6 +51,20 @@ The runtime image resolves its exact `gosu` package from a dated Debian
 snapshot, so the pinned package cannot disappear when the mutable Bookworm
 archive rotates.
 
+### Recovering an incompatible Railway volume
+
+If startup reports that the SQLite schema is partial or incompatible, leave the
+affected volume intact. Do not delete database files or selectively restore
+SQLite, WAL, or spool files: the relay's receipts are its duplicate-prevention
+authority.
+
+For a health-only `spike`, retain and detach the failed volume, attach a new
+empty persistent volume at `/data`, redeploy, and confirm `GET /health` is 200
+while `POST /v1/retro-filings` remains unavailable. For `production`, do not
+resume routing on a blank replacement volume. Keep filing disabled and restore
+the complete compatible volume (or follow an explicit, reviewed migration and
+recovery plan) before allowing requests again.
+
 Node 22 documents `node:sqlite` as active development and Node 24 documents it
 as release candidate. The relay keeps the API behind `src/sqlite.ts`, qualifies
 the built artifact on the deployed runtime, and may emit Node's experimental

--- a/packages/retro-relay/README.md
+++ b/packages/retro-relay/README.md
@@ -58,12 +58,11 @@ affected volume intact. Do not delete database files or selectively restore
 SQLite, WAL, or spool files: the relay's receipts are its duplicate-prevention
 authority.
 
-For a health-only `spike`, retain and detach the failed volume, attach a new
-empty persistent volume at `/data`, redeploy, and confirm `GET /health` is 200
-while `POST /v1/retro-filings` remains unavailable. For `production`, do not
-resume routing on a blank replacement volume. Keep filing disabled and restore
-the complete compatible volume (or follow an explicit, reviewed migration and
-recovery plan) before allowing requests again.
+For a health-only `spike`, retain and detach the failed volume, then attach a
+[new empty persistent volume](https://docs.railway.com/volumes) at `/data` and
+redeploy. Confirm `GET /health` returns 200 and `POST /v1/retro-filings` returns 503. For `production`, do not resume routing on a blank replacement volume.
+Keep filing disabled and restore the complete compatible volume (or follow an
+explicit, reviewed migration and recovery plan) before allowing requests again.
 
 Node 22 documents `node:sqlite` as active development and Node 24 documents it
 as release candidate. The relay keeps the API behind `src/sqlite.ts`, qualifies


### PR DESCRIPTION
## What changed

Adds a focused Railway recovery runbook for an incompatible relay SQLite volume.

## Why

The health-only deployment demonstrated that the relay correctly fails closed on partial schema state. Operators need an explicit distinction: a fresh volume is safe only for a health-only spike; production routing must retain or restore the complete durable receipt store.

## Validation

- `bunx prettier --check packages/retro-relay/README.md`
- `bunx markdownlint-cli2 packages/retro-relay/README.md`
- `git diff --check`

The repository-wide Markdown lint also reports two pre-existing generated-index MD022 findings in `.project/tickets/INDEX.md`.