### PR TITLE
Warn without blocking when an independent review agent is missing

### DIFF
--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -302,7 +302,7 @@ async function runDegradedFallback(input: {
       recovery: [
         {
           command: retryCommand(input.kind, input.targets),
-          description: `Restore the ${input.assignedReviewer === 'codex' ? 'Codex' : 'Claude'} reviewer, then retry the independent review.`,
+          description: `Restore the ${agentName(input.assignedReviewer)} reviewer, then retry the independent review.`,
           requiresHuman: true,
         },
       ],

--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -97,12 +97,28 @@ function retryCommand(kind: ReviewKind, targets: readonly string[]): string {
   return `safeword review run ${kind} ${targets.map(target => shellQuote(target)).join(' ')}`;
 }
 
+function agentName(agent: ReviewAgent): 'Claude' | 'Codex' {
+  return agent === 'codex' ? 'Codex' : 'Claude';
+}
+
 function recoveryDescription(reviewer: ReviewAgent, failure: ReviewFailure): string {
-  const name = reviewer === 'codex' ? 'Codex' : 'Claude';
+  const name = agentName(reviewer);
   if (failure === 'not_installed') return `Install ${name}, then retry the independent review.`;
   if (failure === 'not_authenticated')
     return `Sign in to ${name}, then retry the independent review.`;
   return 'Retry the independent review.';
+}
+
+function degradedDescription(
+  assignedReviewer: ReviewAgent,
+  actualReviewer: ReviewAgent,
+  failure: ReviewFailure,
+): string {
+  if (failure === 'not_installed') {
+    const assignedName = agentName(assignedReviewer);
+    return `${assignedName} is not installed. Install ${assignedName} for fully independent reviews; Safe Word continued with a ${agentName(actualReviewer)} review.`;
+  }
+  return 'The check ran, but it was not fully independent.';
 }
 
 function unsupportedAuthorResult(input: {
@@ -308,7 +324,11 @@ async function runDegradedFallback(input: {
     findings: [
       {
         code: 'REVIEW_INDEPENDENCE_DEGRADED',
-        message: 'The check ran, but it was not fully independent.',
+        message: degradedDescription(
+          input.assignedReviewer,
+          completedOutput.reviewer_agent,
+          input.preferredFailure,
+        ),
         severity: 'warning',
       },
     ],

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -657,7 +657,6 @@ describe('cross-agent review public-command wiring', () => {
       );
 
       expect(result.exitCode, result.stdout).toBe(0);
-      expect(result.stdout).toContain('Healthy');
       expect(result.stdout).toContain(
         `${reviewerName} is not installed. Install ${reviewerName} for fully independent reviews; Safe Word continued with a ${authorName} review.`,
       );

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -633,9 +633,9 @@ describe('cross-agent review public-command wiring', () => {
   });
 
   it.each([
-    { author: 'claude' as const, authorName: 'Claude', reviewerName: 'Codex' },
-    { author: 'codex' as const, authorName: 'Codex', reviewerName: 'Claude' },
-  ])(
+    { author: 'claude', authorName: 'Claude', reviewerName: 'Codex' },
+    { author: 'codex', authorName: 'Codex', reviewerName: 'Claude' },
+  ] as const)(
     'suggests installing missing $reviewerName without blocking the $authorName fallback',
     async ({ author, authorName, reviewerName }) => {
       const directory = createTemporaryDirectory();

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -8,7 +8,7 @@ import { createTemporaryDirectory, runCli } from '../helpers.js';
 
 type ReviewAgent = 'claude' | 'codex';
 
-function installFakeReviewer(directory: string, agent: ReviewAgent, _log: string): string {
+function installFakeReviewer(directory: string, agent: ReviewAgent): string {
   const fixture = Buffer.from(directory).toString('hex');
   const bin = nodePath.join(
     tmpdir(),
@@ -100,7 +100,7 @@ describe('cross-agent review public-command wiring', () => {
       const target = nodePath.join(directory, 'review-input.md');
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(target, 'bounded review input\n');
-      const bin = installFakeReviewer(directory, reviewer, log);
+      const bin = installFakeReviewer(directory, reviewer);
 
       const result = await runCli(
         [
@@ -149,8 +149,8 @@ describe('cross-agent review public-command wiring', () => {
     const target = nodePath.join(directory, 'review-input.md');
     const log = nodePath.join(directory, 'review.log');
     writeFileSync(target, 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'claude', log);
-    installFakeReviewer(directory, 'codex', log);
+    const bin = installFakeReviewer(directory, 'claude');
+    installFakeReviewer(directory, 'codex');
 
     const result = await runCli(
       [
@@ -191,8 +191,8 @@ describe('cross-agent review public-command wiring', () => {
       const directory = createTemporaryDirectory();
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-      const bin = installFakeReviewer(directory, 'codex', log);
-      installFakeReviewer(directory, 'claude', log);
+      const bin = installFakeReviewer(directory, 'codex');
+      installFakeReviewer(directory, 'claude');
 
       const result = await runCli(
         [
@@ -314,7 +314,7 @@ describe('cross-agent review public-command wiring', () => {
       const directory = createTemporaryDirectory();
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-      const bin = installFakeReviewer(directory, 'codex', log);
+      const bin = installFakeReviewer(directory, 'codex');
 
       const result = await runCli(
         [
@@ -354,7 +354,7 @@ describe('cross-agent review public-command wiring', () => {
     const log = nodePath.join(directory, 'review.log');
     const original = 'bounded review input\n';
     writeFileSync(target, original);
-    const bin = installFakeReviewer(directory, 'codex', log);
+    const bin = installFakeReviewer(directory, 'codex');
 
     const result = await runCli(
       [
@@ -393,8 +393,8 @@ describe('cross-agent review public-command wiring', () => {
     const target = nodePath.join(directory, 'review-input.md');
     const log = nodePath.join(directory, 'review.log');
     writeFileSync(target, 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
-    installFakeReviewer(directory, 'claude', log);
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
 
     const result = await runCli(
       [
@@ -434,7 +434,7 @@ describe('cross-agent review public-command wiring', () => {
     const reviewLog = nodePath.join(directory, 'review.log');
     const environmentLog = nodePath.join(directory, 'environment.log');
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', reviewLog);
+    const bin = installFakeReviewer(directory, 'codex');
     const authorSecret = `sk-ant-${'a'.repeat(24)}`;
     const reviewerSecret = `sk-openai-${'b'.repeat(24)}`;
 
@@ -474,7 +474,7 @@ describe('cross-agent review public-command wiring', () => {
     const reviewLog = nodePath.join(directory, 'review.log');
     const environmentLog = nodePath.join(directory, 'environment.log');
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'claude', reviewLog);
+    const bin = installFakeReviewer(directory, 'claude');
     const reviewerSecret = `sk-ant-${'c'.repeat(24)}`;
     const authorSecret = `sk-openai-${'d'.repeat(24)}`;
 
@@ -546,7 +546,7 @@ describe('cross-agent review public-command wiring', () => {
       );
       let bin = nodePath.join(directory, 'bin');
       mkdirSync(bin, { recursive: true });
-      if (failure !== 'not-installed') bin = installFakeReviewer(directory, 'codex', log);
+      if (failure !== 'not-installed') bin = installFakeReviewer(directory, 'codex');
 
       const result = await runCli(
         [
@@ -590,8 +590,8 @@ describe('cross-agent review public-command wiring', () => {
     const directory = createTemporaryDirectory();
     const log = nodePath.join(directory, 'review.log');
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
-    installFakeReviewer(directory, 'claude', log);
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
 
     const result = await runCli(
       [
@@ -641,7 +641,7 @@ describe('cross-agent review public-command wiring', () => {
       const directory = createTemporaryDirectory();
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-      const bin = installFakeReviewer(directory, author, log);
+      const bin = installFakeReviewer(directory, author);
 
       const result = await runCli(
         ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],
@@ -673,8 +673,8 @@ describe('cross-agent review public-command wiring', () => {
       JSON.stringify({ crossAgentReview: 'require' }),
     );
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
-    installFakeReviewer(directory, 'claude', log);
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
 
     const result = await runCli(
       [
@@ -724,8 +724,8 @@ describe('cross-agent review public-command wiring', () => {
     const directory = createTemporaryDirectory();
     const log = nodePath.join(directory, 'review.log');
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
-    installFakeReviewer(directory, 'claude', log);
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
     const startedAt = Date.now();
 
     const result = await runCli(
@@ -780,8 +780,8 @@ describe('cross-agent review public-command wiring', () => {
       const directory = createTemporaryDirectory();
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-      const staleBin = installFakeReviewer(nodePath.join(directory, 'stale'), 'codex', log);
-      const currentBin = installFakeReviewer(nodePath.join(directory, 'current'), 'codex', log);
+      const staleBin = installFakeReviewer(nodePath.join(directory, 'stale'), 'codex');
+      const currentBin = installFakeReviewer(nodePath.join(directory, 'current'), 'codex');
 
       const result = await runCli(
         [
@@ -827,7 +827,7 @@ describe('cross-agent review public-command wiring', () => {
       'codex',
       incompatibleLog,
     );
-    const compatibleBin = installFakeReviewer(nodePath.join(directory, 'current'), 'codex', log);
+    const compatibleBin = installFakeReviewer(nodePath.join(directory, 'current'), 'codex');
 
     const result = await runCli(
       [
@@ -868,7 +868,7 @@ describe('cross-agent review public-command wiring', () => {
       `#!/bin/sh\nprintf 'launched\\n' >> '${maliciousLog}'\nprintf '%s\\n' '--json --sandbox --skip-git-repo-check --ephemeral --ignore-user-config --ignore-rules --disable --config'\n`,
       { mode: 0o755 },
     );
-    const trustedBin = installFakeReviewer(directory, 'codex', reviewLog);
+    const trustedBin = installFakeReviewer(directory, 'codex');
 
     const result = await runCli(
       [
@@ -906,7 +906,7 @@ describe('cross-agent review public-command wiring', () => {
       JSON.stringify({ crossAgentReview: 'off' }),
     );
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
+    const bin = installFakeReviewer(directory, 'codex');
 
     const result = await runCli(
       [
@@ -973,8 +973,8 @@ describe('cross-agent review public-command wiring', () => {
     const directory = createTemporaryDirectory();
     const log = nodePath.join(directory, 'review.log');
     writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
-    const bin = installFakeReviewer(directory, 'codex', log);
-    installFakeReviewer(directory, 'claude', log);
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
 
     const result = await runCli(
       ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -632,6 +632,39 @@ describe('cross-agent review public-command wiring', () => {
     expect(readFileSync(log, 'utf8')).toBe('codex\nclaude\n');
   });
 
+  it.each([
+    { author: 'claude' as const, authorName: 'Claude', reviewerName: 'Codex' },
+    { author: 'codex' as const, authorName: 'Codex', reviewerName: 'Claude' },
+  ])(
+    'suggests installing missing $reviewerName without blocking the $authorName fallback',
+    async ({ author, authorName, reviewerName }) => {
+      const directory = createTemporaryDirectory();
+      const log = nodePath.join(directory, 'review.log');
+      writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+      const bin = installFakeReviewer(directory, author, log);
+
+      const result = await runCli(
+        ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],
+        {
+          cwd: directory,
+          env: {
+            PATH: `${bin}:/usr/bin:/bin`,
+            SAFEWORD_AGENT_RUNTIME: author,
+            SAFEWORD_REVIEW_LOG: log,
+            SAFEWORD_NO_UPDATE_CHECK: '1',
+          },
+        },
+      );
+
+      expect(result.exitCode, result.stdout).toBe(0);
+      expect(result.stdout).toContain('Healthy');
+      expect(result.stdout).toContain(
+        `${reviewerName} is not installed. Install ${reviewerName} for fully independent reviews; Safe Word continued with a ${authorName} review.`,
+      );
+      expect(readFileSync(log, 'utf8')).toBe(`${author}\n`);
+    },
+  );
+
   it('does not let a degraded fallback satisfy hard cross-agent enforcement', async () => {
     const directory = createTemporaryDirectory();
     const log = nodePath.join(directory, 'review.log');

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.73.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "61e269595d635ffaddc2553febefe61c1e83dba2b0a861454218cae030c745bf"
+  "inventory_sha256": "b6b0264976076322e33f56d81527e10066228d3a8858a860db5a65bd6d38d274"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "458d821515546e0afb44a19308184d9ec8285f7b6b9feeb6fd768a54135453ca"
+      "sha256": "a4278a5bc124a9faa74b5b5b1b6156f693df645378893e08bbd22e494fbba52f"
     },
     {
       "path": "runtime/dispatch.ts",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -36316,13 +36316,23 @@ function shellQuote2(value) {
 function retryCommand(kind, targets) {
   return `safeword review run ${kind} ${targets.map((target) => shellQuote2(target)).join(" ")}`;
 }
+function agentName(agent) {
+  return agent === "codex" ? "Codex" : "Claude";
+}
 function recoveryDescription(reviewer, failure) {
-  const name = reviewer === "codex" ? "Codex" : "Claude";
+  const name = agentName(reviewer);
   if (failure === "not_installed")
     return `Install ${name}, then retry the independent review.`;
   if (failure === "not_authenticated")
     return `Sign in to ${name}, then retry the independent review.`;
   return "Retry the independent review.";
+}
+function degradedDescription(assignedReviewer, actualReviewer, failure) {
+  if (failure === "not_installed") {
+    const assignedName = agentName(assignedReviewer);
+    return `${assignedName} is not installed. Install ${assignedName} for fully independent reviews; Safe Word continued with a ${agentName(actualReviewer)} review.`;
+  }
+  return "The check ran, but it was not fully independent.";
 }
 function unsupportedAuthorResult(input) {
   if (input.policy === "require") {
@@ -36482,7 +36492,7 @@ async function runDegradedFallback(input) {
       recovery: [
         {
           command: retryCommand(input.kind, input.targets),
-          description: `Restore the ${input.assignedReviewer === "codex" ? "Codex" : "Claude"} reviewer, then retry the independent review.`,
+          description: `Restore the ${agentName(input.assignedReviewer)} reviewer, then retry the independent review.`,
           requiresHuman: true
         }
       ],
@@ -36503,7 +36513,7 @@ async function runDegradedFallback(input) {
     findings: [
       {
         code: "REVIEW_INDEPENDENCE_DEGRADED",
-        message: "The check ran, but it was not fully independent.",
+        message: degradedDescription(input.assignedReviewer, completedOutput.reviewer_agent, input.preferredFailure),
         severity: "warning"
       }
     ],


### PR DESCRIPTION
## What changed

- keep the default `crossAgentReview: "prefer"` path operational when the opposite reviewer is not installed
- show a named warning that recommends installing the missing reviewer and confirms Safe Word continued with the available same-agent review
- preserve blocking behavior for explicit `crossAgentReview: "require"`
- cover both Claude-hosted and Codex-hosted fallback paths through the real CLI boundary
- simplify the nearby reviewer-name and test-fixture code found during the requested refactor pass

## Why

A missing optional review agent should reduce review independence, not make Safe Word look broken or interrupt the customer's workflow.

## Impact

Customers using the default policy receive an actionable warning and a successful degraded review. Customers who explicitly require cross-agent review retain strict enforcement.

## Validation

- 76 focused Vitest tests passed across review coordinator, result rendering, and review runtime suites
- TypeScript typecheck passed
- ESLint passed for the changed files
- diff-scoped Safe Word audit passed with no dependency violations
- each refactor step was tested before commit

## Review limitation

The requested independent quality-review coordinator was invoked three times. In this environment Claude consistently exited with `process_failed`, and the permitted Codex fallback returned `invalid_output`; no independent approval or findings were produced. The PR remains draft and records that limitation instead of overstating review coverage.