### PR TITLE
Keep BDD verification reliable for maintainers

### DIFF
--- a/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
+++ b/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
@@ -3,10 +3,10 @@ id: 6XQESF
 slug: keep-bdd-verification-reliable
 type: task
 subtype: bug-investigated
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-08-06T18:51:26.130Z
-last_modified: 2026-08-06T19:56:05Z
+last_modified: 2026-08-07T00:04:23Z
 scope: "Make the two existing full-BDD failures deterministic: preserve the relay proof hook's intended timeout despite step-import order, and isolate each public-command fixture's Codex profile state."
 out_of_scope: "Changing Cucumber's global scheduler or timeout defaults, relaxing machine JSON comparisons, and changing production proof timestamps or Codex status semantics."
 done_when:
@@ -63,6 +63,7 @@ Ruled out: an intrinsically slow relay proof (the direct proof completed in unde
 
 ## Work Log
 
+- 2026-08-07T00:04:23Z Complete: Marked the ticket done after confirming the current PR head carries passing canonical verification, full BDD evidence, and a clean diff-scoped audit.
 - 2026-08-06T19:56:05Z PR: Opened draft [#2110](https://github.com/ArcadeAI/safeword/pull/2110) to fix GitHub issues [#2101](https://github.com/ArcadeAI/safeword/issues/2101) and [#2102](https://github.com/ArcadeAI/safeword/issues/2102).
 - 2026-08-06T19:52:20Z Verified: Canonical verification and the diff-scoped audit passed. Build and type checks succeeded for both packages; Bun audit found no vulnerabilities. The audit found no dependency, architecture, or scope violations.
 - 2026-08-06T19:24:00Z Verified: `bun run test` passed on this branch. Retro Relay: 167 passed / 1 skipped. CLI: 441 files, 6,768 passed / 5 skipped; 716.69s.

--- a/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
+++ b/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
@@ -1,0 +1,70 @@
+---
+id: 6XQESF
+slug: keep-bdd-verification-reliable
+type: task
+subtype: bug-investigated
+phase: verify
+status: in_progress
+created: 2026-08-06T18:51:26.130Z
+last_modified: 2026-08-06T19:52:20Z
+scope: "Make the two existing full-BDD failures deterministic: preserve the relay proof hook's intended timeout despite step-import order, and isolate each public-command fixture's Codex profile state."
+out_of_scope: "Changing Cucumber's global scheduler or timeout defaults, relaxing machine JSON comparisons, and changing production proof timestamps or Codex status semantics."
+done_when:
+  - "Relay proof hooks retain their intended 180-second budget regardless of other step files' defaults."
+  - "The public-command machine-contract scenario compares outputs from an isolated Codex profile."
+  - "Focused and full BDD verification pass on the implementation commit."
+external_issue: https://github.com/ArcadeAI/safeword/issues/2101
+---
+
+# Keep BDD verification reliable for maintainers
+
+**Goal:** Let maintainers run the full BDD lane without unrelated timeouts or unstable machine-output assertions.
+
+**Why:** Shared test-process state currently makes otherwise-correct verification flaky and blocks narrow changes.
+
+**Related:** [#2102](https://github.com/ArcadeAI/safeword/issues/2102) tracks the relay-specific manifestation.
+
+## Scope
+
+**In scope:** The relay proof hook at `steps/operate-retry-safe-retro-relay.steps.ts` and the fixture environment at `packages/cli/features/steps/predictable-safeword-cli.steps.ts`.
+
+**Out of scope:** Cucumber scheduler changes, broad timeout increases, timestamp normalization, and any production Codex-profile behavior.
+
+## Done When
+
+- [x] The relay proof hook has its own 180-second timeout.
+- [x] Every public-command fixture uses its own empty `CODEX_HOME`.
+- [x] The affected scenarios and full BDD lane pass.
+
+## Tests
+
+- [x] Unit: public-command fixtures replace inherited `CODEX_HOME` and `NODE_OPTIONS`.
+- [x] Acceptance: the machine-contract scenario remains deterministic when Codex proof state exists outside its fixture.
+- [x] Acceptance: the relay proof scenario loads with a local 180-second budget despite another step module's 60-second default.
+
+## Decision
+
+**Options considered:** (1) raise or reorder the global Cucumber timeout; (2) set the relay hook's timeout directly; (3) redesign the proof runner. The selected local hook timeout is correct because Cucumber's support-code builder stores one mutable default, so another imported step module can overwrite it. An explicit hook timeout preserves the intended 180-second budget without changing unrelated scenarios. The upstream Cucumber project also documents serial execution as the default and treats each scenario as independently scoped, reinforcing local rather than global state ([discussion #2357](https://github.com/cucumber/cucumber-js/discussions/2357)).
+
+For the machine-contract failure, (1) remove `recorded_at` before comparing output, (2) make production status omit timestamps, or (3) isolate `CODEX_HOME`. The third option wins: `recorded_at` is true status data, and the test's defect is reading the developer's mutable Codex profile. Existing Codex fixtures already use a temporary `CODEX_HOME`.
+
+**Premortem:** This local repair could miss a second external profile variable; the focused scenario will run with a deliberate external Codex proof to prove the fixture never reads it.
+
+**Next:** review the isolated BDD reliability change and merge its dedicated PR.
+
+## Root Cause
+
+The relay `Before` hook relies on `setDefaultTimeout(180_000)`, but `steps/retry-safe-retro-filing.steps.ts` is also loaded and later calls `setDefaultTimeout(60_000)`. The Cucumber support-code builder stores that setting as one mutable default, so the relay hook actually times out at 60 seconds. The direct relay proof passed in 328 ms, ruling out a consistently slow Vitest test. Its seven full-lane failures all reported the 60-second hook timeout.
+
+The machine-contract scenario passes the parent process's `CODEX_HOME` into every child CLI command. `codex status` reads hook proof metadata from that mutable real profile, including `recorded_at`; a concurrently running Codex hook can therefore change only one of the two compared JSON values. The isolated rerun passed when the external profile did not change, which rules out a deterministic product JSON defect.
+
+Ruled out: an intrinsically slow relay proof (the direct proof completed in under one second); Cucumber intra-lane parallelism (the checked-in runner does not configure `--parallel`); and a need to alter production timestamps (the nondeterminism enters through test-fixture environment leakage).
+
+## Work Log
+
+- 2026-08-06T19:52:20Z Verified: Canonical verification and the diff-scoped audit passed. Build and type checks succeeded for both packages; Bun audit found no vulnerabilities. The audit found no dependency, architecture, or scope violations.
+- 2026-08-06T19:24:00Z Verified: `bun run test` passed on this branch. Retro Relay: 167 passed / 1 skipped. CLI: 441 files, 6,768 passed / 5 skipped; 716.69s.
+- 2026-08-06T19:11:00Z Verified: `bun run test:bdd` passed on this branch: 1,077 scenarios and 41,946 steps passed; 3 scenarios and 4 steps skipped; 9m 11.928s.
+- 2026-08-06T19:00:00Z Green: Added the dependency-free public fixture environment helper and a focused unit test. The unit test, machine-contract BDD scenario with an inherited temporary profile, and relay setup scenario all pass.
+- 2026-08-06T18:54:00Z Decided: Use an explicit local relay-hook timeout and per-fixture CODEX_HOME isolation; rejected global timeout changes and production timestamp normalization. Confirmed direct relay proof passes in 328 ms and isolated machine-contract scenario passes when external profile state is stable.
+- 2026-08-06T18:51:26.130Z Started: Created ticket 6XQESF

--- a/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
+++ b/.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md
@@ -6,7 +6,7 @@ subtype: bug-investigated
 phase: verify
 status: in_progress
 created: 2026-08-06T18:51:26.130Z
-last_modified: 2026-08-06T19:52:20Z
+last_modified: 2026-08-06T19:56:05Z
 scope: "Make the two existing full-BDD failures deterministic: preserve the relay proof hook's intended timeout despite step-import order, and isolate each public-command fixture's Codex profile state."
 out_of_scope: "Changing Cucumber's global scheduler or timeout defaults, relaxing machine JSON comparisons, and changing production proof timestamps or Codex status semantics."
 done_when:
@@ -14,6 +14,7 @@ done_when:
   - "The public-command machine-contract scenario compares outputs from an isolated Codex profile."
   - "Focused and full BDD verification pass on the implementation commit."
 external_issue: https://github.com/ArcadeAI/safeword/issues/2101
+external_prs: [https://github.com/ArcadeAI/safeword/pull/2110]
 ---
 
 # Keep BDD verification reliable for maintainers
@@ -62,6 +63,7 @@ Ruled out: an intrinsically slow relay proof (the direct proof completed in unde
 
 ## Work Log
 
+- 2026-08-06T19:56:05Z PR: Opened draft [#2110](https://github.com/ArcadeAI/safeword/pull/2110) to fix GitHub issues [#2101](https://github.com/ArcadeAI/safeword/issues/2101) and [#2102](https://github.com/ArcadeAI/safeword/issues/2102).
 - 2026-08-06T19:52:20Z Verified: Canonical verification and the diff-scoped audit passed. Build and type checks succeeded for both packages; Bun audit found no vulnerabilities. The audit found no dependency, architecture, or scope violations.
 - 2026-08-06T19:24:00Z Verified: `bun run test` passed on this branch. Retro Relay: 167 passed / 1 skipped. CLI: 441 files, 6,768 passed / 5 skipped; 716.69s.
 - 2026-08-06T19:11:00Z Verified: `bun run test:bdd` passed on this branch: 1,077 scenarios and 41,946 steps passed; 3 scenarios and 4 steps skipped; 9m 11.928s.

--- a/.project/tickets/6XQESF-keep-bdd-verification-reliable/verify.md
+++ b/.project/tickets/6XQESF-keep-bdd-verification-reliable/verify.md
@@ -1,0 +1,21 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 6,935/6,941 tests pass (Retro Relay: 167 passed / 1 skipped; CLI: 6,768 passed / 5 skipped)
+**Gherkin:** ✅ Acceptance lane passes — 1,077 scenarios and 41,946 steps passed; 3 scenarios and 4 steps skipped
+**Build:** ✅ Success — both packages built
+**Lint:** ✅ Clean — ESLint, Gherkin lint, and `tsc --noEmit` passed
+**Scenarios:** All 6 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean — no dependency declarations changed; Bun audit found no vulnerabilities
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation — explicit Cucumber hook configuration and fixture-scoped profile state follow existing local-isolation patterns
+**Experience:** ⏭️ N/A — internal verification harness
+**Surface Evidence:** ✅ 2/2 affected surfaces have recorded proof
+**Evidence limits:** ✅ None
+
+| Affected surface | Proof | Result |
+| --- | --- | --- |
+| Safeword CLI | Machine-contract acceptance scenario with an inherited external Codex profile; full BDD lane | Pass |
+| Railway Hosted Relay | Relay-unavailability acceptance scenario; full BDD lane | Pass |
+
+Audit passed — diff-scoped audit found no errors or warnings in the changed code, tests, or ticket evidence.

--- a/.safeword/logs/ticket-6XQESF-keep-bdd-verification-reliable.md
+++ b/.safeword/logs/ticket-6XQESF-keep-bdd-verification-reliable.md
@@ -1,0 +1,15 @@
+# Work Log: Keep BDD verification reliable for maintainers
+
+**Anchored to:** `.project/tickets/6XQESF-keep-bdd-verification-reliable/ticket.md`
+
+---
+
+## Session: 2026-08-06
+
+- [08:54] Confirmed the relay's direct Vitest proof completes in 328 ms; the full-lane 60-second failure comes from a second imported step module overwriting the global Cucumber default.
+- [08:54] Confirmed `codex status` reads mutable `CODEX_HOME` proof metadata; the public-command fixture inherits that profile instead of using isolated state.
+- [08:54] Selected an explicit hook timeout and a per-fixture `CODEX_HOME`, keeping production status payloads unchanged.
+- [09:00] GREEN: The public-fixture environment unit test passes; the machine-contract scenario passes while an inherited temporary profile contains real `recorded_at` proof metadata; and a relay scenario passes with the explicit 180-second hook budget.
+- [09:11] Full BDD: `bun run test:bdd` passed with 1,077 scenarios and 41,946 steps passed; 3 scenarios and 4 steps skipped.
+- [09:24] Full units: `bun run test` passed. Retro Relay: 167 passed / 1 skipped. CLI: 441 files, 6,768 passed / 5 skipped.
+- [09:52] Canonical verification passed: full unit and BDD suites, builds, type checks, and Bun audit. The diff-scoped audit found no dependency, architecture, or scope violations.

--- a/.safeword/logs/ticket-6XQESF-keep-bdd-verification-reliable.md
+++ b/.safeword/logs/ticket-6XQESF-keep-bdd-verification-reliable.md
@@ -13,3 +13,4 @@
 - [09:11] Full BDD: `bun run test:bdd` passed with 1,077 scenarios and 41,946 steps passed; 3 scenarios and 4 steps skipped.
 - [09:24] Full units: `bun run test` passed. Retro Relay: 167 passed / 1 skipped. CLI: 441 files, 6,768 passed / 5 skipped.
 - [09:52] Canonical verification passed: full unit and BDD suites, builds, type checks, and Bun audit. The diff-scoped audit found no dependency, architecture, or scope violations.
+- [09:56] Opened draft PR #2110 with `codex` and `codex-automation` labels; it closes GitHub issues #2101 and #2102 when merged.

--- a/packages/cli/features/steps/predictable-safeword-cli.steps.ts
+++ b/packages/cli/features/steps/predictable-safeword-cli.steps.ts
@@ -36,6 +36,7 @@ import {
   renderJsonResult,
 } from '../../src/cli-protocol/result.ts';
 import { convergeSetup } from '../../src/commands/converge-setup.ts';
+import { publicFixtureEnvironment } from './public-fixture-environment.js';
 import type { SafewordWorld } from './world.js';
 
 const CLI_PATH = fileURLToPath(new URL('../../dist/cli.js', import.meta.url));
@@ -126,7 +127,7 @@ function runPublicFixture(world: PredictableCliWorld, definition: CommandDefinit
     {
       cwd,
       encoding: 'utf8',
-      env: { ...childEnvironment(), ...definition.fixture.environment },
+      env: publicFixtureEnvironment(cwd, definition.fixture.environment),
     },
   );
   return {

--- a/packages/cli/features/steps/public-fixture-environment.ts
+++ b/packages/cli/features/steps/public-fixture-environment.ts
@@ -1,0 +1,17 @@
+import nodePath from 'node:path';
+
+export function publicFixtureEnvironment(
+  fixtureDirectory: string,
+  fixtureOverrides: Readonly<NodeJS.ProcessEnv>,
+  inheritedEnvironment: Readonly<NodeJS.ProcessEnv> = process.env,
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    ...inheritedEnvironment,
+    SAFEWORD_NO_UPDATE_CHECK: '1',
+    SAFEWORD_SKIP_INSTALL: '1',
+    ...fixtureOverrides,
+    CODEX_HOME: nodePath.join(fixtureDirectory, 'codex-profile'),
+  };
+  delete environment.NODE_OPTIONS;
+  return environment;
+}

--- a/packages/cli/tests/features/public-fixture-environment.test.ts
+++ b/packages/cli/tests/features/public-fixture-environment.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { publicFixtureEnvironment } from '../../features/steps/public-fixture-environment.js';
+
+describe('public CLI BDD fixture environment', () => {
+  it('replaces an inherited Codex profile with fixture-scoped state', () => {
+    const environment = publicFixtureEnvironment(
+      '/tmp/safeword-cli-bdd-fixture',
+      { SAFEWORD_NO_UPDATE_CHECK: '1' },
+      { CODEX_HOME: '/Users/developer/.codex', NODE_OPTIONS: '--inspect' },
+    );
+
+    expect(environment).toMatchObject({
+      CODEX_HOME: '/tmp/safeword-cli-bdd-fixture/codex-profile',
+      SAFEWORD_NO_UPDATE_CHECK: '1',
+      SAFEWORD_SKIP_INSTALL: '1',
+    });
+    expect(environment.NODE_OPTIONS).toBeUndefined();
+  });
+});

--- a/steps/operate-retry-safe-retro-relay.steps.ts
+++ b/steps/operate-retry-safe-retro-relay.steps.ts
@@ -3,12 +3,12 @@ import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 
-import { Before, defineStep, setDefaultTimeout } from '@cucumber/cucumber';
+import { Before, defineStep } from '@cucumber/cucumber';
 
 import type { SafewordWorld } from './world.js';
 
 const execFileAsync = promisify(execFile);
-setDefaultTimeout(180_000);
+const RELAY_PROOF_TIMEOUT_MS = 180_000;
 
 type ScenarioProof = { packageDirectory: string; pattern: string; testFile: string };
 
@@ -248,7 +248,7 @@ async function runProof(
 }
 
 Before(
-  { tags: '@operate-retry-safe-retro-relay' },
+  { tags: '@operate-retry-safe-retro-relay', timeout: RELAY_PROOF_TIMEOUT_MS },
   async function (this: SafewordWorld, scenario: { pickle: { name: string } }) {
     const scenarioName = scenario.pickle.name;
     proofCache.set(scenarioName, proofCache.get(scenarioName) ?? runProof(scenarioName));


### PR DESCRIPTION
## What changed

- Give the relay proof hook an explicit 180-second timeout so later step imports cannot overwrite it.
- Run public CLI BDD fixtures with a fixture-scoped `CODEX_HOME`, keeping their machine-output comparisons independent of mutable developer state.
- Add focused fixture-environment coverage and ticket verification evidence.

## Why

Cucumber's global default timeout was overwritten by another step module, and public command fixtures inherited the real Codex profile. Together those shared states made the full BDD lane fail intermittently.

## Impact

Maintainers can run full BDD verification without unrelated timeout failures or mutable profile data changing JSON comparisons.

## Validation

- `bun run test`
- `bun run test:bdd`
- `bun run lint`
- Canonical test-plan verification: tests, BDD, build, typecheck, and Bun audit
- Diff-scoped architecture and test-quality audit

Fixes #2101
Fixes #2102