### PR TITLE
Keep agent-created pull requests in draft

### DIFF
--- a/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
+++ b/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
@@ -5,7 +5,8 @@ type: task
 phase: done
 status: done
 created: 2026-08-06T21:05:20.272Z
-last_modified: 2026-08-06T23:23:35Z
+last_modified: 2026-08-06T23:29:56Z
+external_prs: [https://github.com/ArcadeAI/safeword/pull/2117]
 ---
 
 # Keep agent-created pull requests in draft until approved
@@ -38,3 +39,4 @@ last_modified: 2026-08-06T23:23:35Z
 - 2026-08-06T21:57:34Z Isolated: moved the uncommitted feature from an unrelated detached branch onto `codex/keep-agent-created-prs-draft` from current `origin/main`; the feature diff now contains only its five scoped files.
 - 2026-08-06T22:12:05Z Verified: on the clean branch, 6,936 tests, 1,077 acceptance scenarios, build, lint, formatting, typecheck, and the diff-scoped audit passed. The dependency audit still reports the same six pre-existing advisories outside ticket scope.
 - 2026-08-06T23:23:35Z Done: User confirmed completion after the full Safe Word process; closed with verify and audit evidence recorded.
+- 2026-08-06T23:29:56Z Published: Opened draft pull request https://github.com/ArcadeAI/safeword/pull/2117 and confirmed it targets `main` with draft status.

--- a/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
+++ b/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
@@ -1,0 +1,39 @@
+---
+id: 2CQCAK
+slug: keep-agent-created-prs-draft
+type: task
+phase: verify
+status: in_progress
+created: 2026-08-06T21:05:20.272Z
+last_modified: 2026-08-06T22:12:05Z
+---
+
+# Keep agent-created pull requests in draft until approved
+
+**Goal:** Make every agent-created pull request start as a draft unless the user explicitly asks for a ready pull request.
+
+**Why:** Draft-first delivery prevents agents from signaling review readiness before the user has approved it.
+
+**Scope:** Add an always-on, cross-host instruction that agent-created pull requests start as drafts and become ready only after an explicit user request. Keep the canonical template and dogfood copy identical.
+
+**Out of Scope:** Blocking hooks, provider-specific PR creation automation, and changes to the merge-time `/closeout` checks.
+
+**Done When:**
+
+- [x] Installed Safe Word context tells every supported agent to create draft pull requests by default.
+- [x] The instruction preserves an explicit user override to create or mark a pull request ready.
+- [x] Canonical and dogfood copies remain in parity.
+
+**Tests:**
+
+- [x] A focused Vitest test asserts the default, the explicit override, and `gh pr create --draft` guidance in both context copies.
+
+## Work Log
+
+- 2026-08-06T21:05:20.272Z Started: Created ticket 2CQCAK
+- 2026-08-06T21:05:53Z Planned: Put the policy in always-loaded SAFEWORD.md rather than `/closeout` or a hard hook; use a parity test to cover both shipped and dogfood contexts.
+- 2026-08-06T21:07:25Z GREEN: focused draft-default checks passed for both the canonical and dogfood SAFEWORD contexts (2/2).
+- 2026-08-06T21:08:05Z Parity: release-only dogfood parity contract passed (1/1).
+- 2026-08-06T21:24:40Z Verified: 6,953 tests, 1,077 acceptance scenarios, build, lint, formatting, and typecheck passed. Dependency audit reported six pre-existing website/tooling advisories outside ticket scope.
+- 2026-08-06T21:57:34Z Isolated: moved the uncommitted feature from an unrelated detached branch onto `codex/keep-agent-created-prs-draft` from current `origin/main`; the feature diff now contains only its five scoped files.
+- 2026-08-06T22:12:05Z Verified: on the clean branch, 6,936 tests, 1,077 acceptance scenarios, build, lint, formatting, typecheck, and the diff-scoped audit passed. The dependency audit still reports the same six pre-existing advisories outside ticket scope.

--- a/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
+++ b/.project/tickets/2CQCAK-keep-agent-created-prs-draft/ticket.md
@@ -2,10 +2,10 @@
 id: 2CQCAK
 slug: keep-agent-created-prs-draft
 type: task
-phase: verify
-status: in_progress
+phase: done
+status: done
 created: 2026-08-06T21:05:20.272Z
-last_modified: 2026-08-06T22:12:05Z
+last_modified: 2026-08-06T23:23:35Z
 ---
 
 # Keep agent-created pull requests in draft until approved
@@ -37,3 +37,4 @@ last_modified: 2026-08-06T22:12:05Z
 - 2026-08-06T21:24:40Z Verified: 6,953 tests, 1,077 acceptance scenarios, build, lint, formatting, and typecheck passed. Dependency audit reported six pre-existing website/tooling advisories outside ticket scope.
 - 2026-08-06T21:57:34Z Isolated: moved the uncommitted feature from an unrelated detached branch onto `codex/keep-agent-created-prs-draft` from current `origin/main`; the feature diff now contains only its five scoped files.
 - 2026-08-06T22:12:05Z Verified: on the clean branch, 6,936 tests, 1,077 acceptance scenarios, build, lint, formatting, typecheck, and the diff-scoped audit passed. The dependency audit still reports the same six pre-existing advisories outside ticket scope.
+- 2026-08-06T23:23:35Z Done: User confirmed completion after the full Safe Word process; closed with verify and audit evidence recorded.

--- a/.project/tickets/2CQCAK-keep-agent-created-prs-draft/verify.md
+++ b/.project/tickets/2CQCAK-keep-agent-created-prs-draft/verify.md
@@ -1,0 +1,25 @@
+## Verify Checklist
+
+**Test Suite:** ✓ 6936/6936 tests pass
+**Gherkin:** ✅ Acceptance lane passes
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 1 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ✅ No new friction — walked the Non-Technical Builder through “push this PR”; worst step = none because draft status is automatic; new steps vs before = 0
+**Surface Evidence:** ✅ 3/3 affected surfaces have recorded proof
+**Evidence limits:** ✅ None
+**Supply Chain:** ⚠️ `bun audit` reports 6 pre-existing transitive advisories in website/tooling dependencies (1 high, 4 moderate, 1 low); dependency changes are outside this ticket.
+
+Audit passed — diff-scoped audit found 0 errors and 0 warnings.
+
+## Surface Evidence
+
+| Affected surface | Proof | Result |
+| --- | --- | --- |
+| Claude Code | Full Vitest/integration suite plus the shared SAFEWORD context assertion | Pass |
+| OpenAI Codex | Full Vitest/integration suite plus the shared SAFEWORD context assertion | Pass |
+| Cursor | Full Vitest/integration suite plus the shared SAFEWORD context assertion | Pass |

--- a/.safeword/SAFEWORD.md
+++ b/.safeword/SAFEWORD.md
@@ -193,6 +193,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Draft pull requests.** Create every pull request as a draft by default (`gh pr create --draft` on GitHub). Only create or mark a pull request ready for review when the user explicitly asks; a request to push, publish, or open a pull request does not count.
+
 **Worktree entry (all hosts).** At session start and after moving roots or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. Do not guess a package directory or probe a speculative path. Work from the reported repository root; use `<namespace-root>/architecture.generated.md` to find monorepo packages when present, otherwise inspect the root once. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
 
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword project sync-learnings` regenerates the index.

--- a/packages/cli/templates/SAFEWORD.md
+++ b/packages/cli/templates/SAFEWORD.md
@@ -193,6 +193,8 @@ Read the matching guide when its trigger fires:
 
 **Commit frequently.** After each GREEN phase, before and after refactors, when switching tasks. The LOC gate fires near 400 lines — commit to reset it.
 
+**Draft pull requests.** Create every pull request as a draft by default (`gh pr create --draft` on GitHub). Only create or mark a pull request ready for review when the user explicitly asks; a request to push, publish, or open a pull request does not count.
+
 **Worktree entry (all hosts).** At session start and after moving roots or creating a worktree, run `pwd && git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` before evidence gathering or edits. Do not guess a package directory or probe a speculative path. Work from the reported repository root; use `<namespace-root>/architecture.generated.md` to find monorepo packages when present, otherwise inspect the root once. If the path, repo root, branch, or commit is wrong, stop and fix the workspace before touching files.
 
 **Learnings.** Project-specific lessons live in `<namespace-root>/learnings/`. Before non-trivial work, scan `INDEX.md` or grep for your topic. When you solve something non-obvious, add `<slug>.md` with a `Covers:` line; `safeword project sync-learnings` regenerates the index.

--- a/packages/cli/tests/skills/draft-pull-request-default.test.ts
+++ b/packages/cli/tests/skills/draft-pull-request-default.test.ts
@@ -8,6 +8,12 @@ const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const readRepoFile = (relativePath: string): string =>
   readFileSync(nodePath.join(repoRoot, relativePath), 'utf8');
 
+const draftPullRequestPolicy =
+  '**Draft pull requests.** Create every pull request as a draft by default (' +
+  '`gh pr create --draft` on GitHub). Only create or mark a pull request ready ' +
+  'for review when the user explicitly asks; a request to push, publish, or open ' +
+  'a pull request does not count.';
+
 describe('draft pull request default', () => {
   it.each([
     ['canonical SAFEWORD template', 'packages/cli/templates/SAFEWORD.md'],
@@ -17,14 +23,7 @@ describe('draft pull request default', () => {
     (_label, path) => {
       const content = readRepoFile(path);
 
-      expect(content).toContain('**Draft pull requests.**');
-      expect(content).toContain('Create every pull request as a draft by default');
-      expect(content).toContain('`gh pr create --draft`');
-      expect(content).toContain('Only create or mark a pull request ready for review');
-      expect(content).toContain('explicitly asks');
-      expect(content).toContain(
-        'a request to push, publish, or open a pull request does not count',
-      );
+      expect(content).toContain(draftPullRequestPolicy);
     },
   );
 });

--- a/packages/cli/tests/skills/draft-pull-request-default.test.ts
+++ b/packages/cli/tests/skills/draft-pull-request-default.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
+
+const readRepoFile = (relativePath: string): string =>
+  readFileSync(nodePath.join(repoRoot, relativePath), 'utf8');
+
+describe('draft pull request default', () => {
+  it.each([
+    ['canonical SAFEWORD template', 'packages/cli/templates/SAFEWORD.md'],
+    ['dogfood SAFEWORD copy', '.safeword/SAFEWORD.md'],
+  ])(
+    '%s keeps agent-created pull requests in draft until the user says otherwise',
+    (_label, path) => {
+      const content = readRepoFile(path);
+
+      expect(content).toContain('**Draft pull requests.**');
+      expect(content).toContain('Create every pull request as a draft by default');
+      expect(content).toContain('`gh pr create --draft`');
+      expect(content).toContain('Only create or mark a pull request ready for review');
+      expect(content).toContain('explicitly asks');
+      expect(content).toContain(
+        'a request to push, publish, or open a pull request does not count',
+      );
+    },
+  );
+});


### PR DESCRIPTION
## What changed

- make agent-created pull requests draft by default in Safe Word’s standing instructions
- require an explicit user request before creating or marking a pull request ready for review
- clarify that “push,” “publish,” or “open a pull request” does not imply ready-for-review
- keep the canonical template and dogfood installation in sync

## Impact

Safe Word-enabled projects now preserve a review checkpoint by default across supported agents. Power users can still explicitly request a ready pull request.

## Validation

- focused contract: 2/2 passed
- full Vitest suite: 6,936 passed, 6 skipped
- repository BDD suite: 1,077 scenarios passed, 3 skipped
- build, typecheck, lint, and format checks passed
- Safe Word diff audit: 0 errors, 0 warnings
- release parity check: passed

## Known unrelated baseline

The dependency audit still reports six pre-existing advisories in documentation/build dependencies; this change does not alter dependencies.