### PR TITLE
Move Codex migration acceptance coverage to setup

### DIFF
--- a/features/test-codex-plugin-migration.feature
+++ b/features/test-codex-plugin-migration.feature
@@ -97,14 +97,14 @@ Feature: Test Codex plugin migration
       And each command invokes a packaged Safe Word command entrypoint
 
   @test-codex-plugin-migration.TB1.R4 @surface.openai-codex
-  Rule: test-codex-plugin-migration.TB1.R4 — Upgrading an old project-local Codex install leaves user-owned project data and fallback assets intact until an explicit proven handoff
+  Rule: test-codex-plugin-migration.TB1.R4 — Setting up an old project-local Codex install leaves user-owned project data and fallback assets intact until an explicit proven handoff
 
     @rejection
     Scenario: Unavailable profile enrollment preserves an old project's authored data and fallback
       Given a repo installed with today's project-local Codex assets
       And the repo contains user-owned tickets and learnings under the namespace root
-      When the plugin migration upgrade runs without profile enrollment available
-      Then the upgrade reports profile enrollment failure loudly
+      When the plugin migration setup runs without profile enrollment available
+      Then setup reports profile enrollment failure loudly
       And the user-owned tickets and learnings remain byte-identical
       And Safe Word keeps repo-local `.agents/skills` available during the compatibility window
       And legacy Safe Word Codex hook runtime files remain until explicit handoff cleanup
@@ -113,7 +113,7 @@ Feature: Test Codex plugin migration
       Given a repo installed with today's project-local Codex assets
       And the repo contains user-owned tickets and learnings under the namespace root
       And the repo contains a user-authored `.agents/skills/company-workflow/SKILL.md`
-      When the plugin migration upgrade runs with profile enrollment available
+      When the plugin migration setup runs with profile enrollment available
       Then Safe Word is enrolled in the Codex profile
       And the user-owned tickets and learnings remain byte-identical
       And the user-authored skill remains byte-identical
@@ -122,7 +122,7 @@ Feature: Test Codex plugin migration
 
     Scenario: User-authored Codex skills survive the migration
       Given an old project-local Codex install with a user-authored `.agents/skills/company-workflow/SKILL.md`
-      When the plugin migration upgrade runs without profile enrollment available
+      When the plugin migration setup runs without profile enrollment available
       Then the user-authored skill remains byte-identical
       And Safe Word-owned Codex skill files remain beside the user-authored skill until finalization
 
@@ -130,7 +130,7 @@ Feature: Test Codex plugin migration
     Scenario: Customized Codex config is not clobbered while stale Safe Word hooks await explicit migration
       Given an old project-local Codex install with user-authored Codex config entries
       And the config also contains old Safe Word hook commands pointing at `.safeword/hooks/codex`
-      When the plugin migration upgrade runs without profile enrollment available
+      When the plugin migration setup runs without profile enrollment available
       Then the user-authored Codex config entries remain
       And the stale Safe Word project-local hook commands remain until explicit migration
 

--- a/steps/test-codex-plugin-migration.steps.ts
+++ b/steps/test-codex-plugin-migration.steps.ts
@@ -1628,9 +1628,9 @@ When(
 );
 
 /**
- * Rejection scenarios in this rule run the upgrade with profile enrollment
+ * Rejection scenarios in this rule run setup with profile enrollment
  * made unavailable, and each one asserts the decline it produces (#1973). The
- * decline is the point: it proves the upgrade ran, reached the Codex handoff,
+ * decline is the point: it proves setup ran, reached the Codex handoff,
  * and preserved the project on the way out. Without that assertion these
  * scenarios pass whether or not anything executed, because untouched files
  * look identical to files nothing reached.
@@ -1641,10 +1641,10 @@ When(
  * CODEX_HOME.
  */
 When(
-  'the plugin migration upgrade runs without profile enrollment available',
+  'the plugin migration setup runs without profile enrollment available',
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
-    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
+    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'setup'], {
       cwd: repoRoot,
       env: {
         // SAFEWORD_SKIP_INSTALL only skips project dependencies; hide profile tools too.
@@ -1657,7 +1657,7 @@ When(
 );
 
 When(
-  'the plugin migration upgrade runs with profile enrollment available',
+  'the plugin migration setup runs with profile enrollment available',
   function (this: CodexPluginMigrationWorld) {
     const repoRoot = requirePath(this.codexPluginRepoRoot, 'repo root');
     const runtimeRoot = createTemporaryDirectory('safeword-codex-migration-runtime-');
@@ -1668,7 +1668,7 @@ When(
     this.codexPluginRuntimeRoot = runtimeRoot;
     this.codexPluginCodexHome = runtime.codexHome;
     this.codexPluginMigrationLogPath = runtime.logPath;
-    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'upgrade'], {
+    this.codexPluginMigrationResult = runCommand(process.execPath, [SAFEWORD_CLI_PATH, 'setup'], {
       cwd: repoRoot,
       env: {
         PATH: `${runtime.bin}:${process.env.PATH ?? ''}`,
@@ -1847,12 +1847,9 @@ function assertMigrationRanAndDeclined(world: CodexPluginMigrationWorld): void {
   );
 }
 
-Then(
-  'the upgrade reports profile enrollment failure loudly',
-  function (this: CodexPluginMigrationWorld) {
-    assertMigrationRanAndDeclined(this);
-  },
-);
+Then('setup reports profile enrollment failure loudly', function (this: CodexPluginMigrationWorld) {
+  assertMigrationRanAndDeclined(this);
+});
 
 Then(
   'the user-owned tickets and learnings remain byte-identical',


### PR DESCRIPTION
## What changed

- Exercise the supported `setup` command throughout the Codex migration `TB1.R4` acceptance rule.
- Rename the matching Gherkin steps and explanatory comments so the contract consistently describes `setup`.

## Why

The migration acceptance rule invoked `upgrade`, which is only a deprecated alias for `setup`. That coupled migration coverage to a compatibility alias and would make eventual alias removal look like a migration regression.

This keeps deprecated-alias coverage in the CLI protocol tests and lets the migration rule verify the supported product path.

## Impact

No production behavior changes. The four migration scenarios now validate the canonical command users should run.

## Validation

- `NODE_OPTIONS='--import tsx' packages/cli/node_modules/.bin/cucumber-js features/test-codex-plugin-migration.feature --tags '@test-codex-plugin-migration.TB1.R4'` — 4 scenarios, 165 steps passed
- `bun run lint:gherkin`
- `packages/cli/node_modules/.bin/prettier --check steps/test-codex-plugin-migration.steps.ts`
- `bun run --cwd packages/cli typecheck`
- Pre-commit parity, ESLint, Prettier, and Gherkin gates

Closes #2062
