### PR TITLE
chore(release): v0.74.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.73.0",
+      "version": "0.74.0",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.73.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.73.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.73.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.73.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.73.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.73.0",
+  "plugin_version": "0.74.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "95d5760bf2a0ff89ac7113620e963c1fee1510f14a2b863915f237219e15ef87"
+  "inventory_sha256": "c8454fd6bbbd36f826f0236fa7d44254eff320599b1404528ab3adf8c5c96ce2"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -11,7 +11,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "44c13567262ae5bcd88a9243478d642cdfc2e170f2e1c8cd887b167b529bc629"
+      "sha256": "555b3604b4d67ece67e7675b0044dc03ba642c9b430bc846980ed9e846bb075a"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "type": "module"
 }


### PR DESCRIPTION
## Release

Bumps Safeword from 0.73.0 to 0.74.0.

## Highlights

- Make retro delivery retry-safe across harnesses without self-filing the filing lane as a broken transport.
- Let dependency recovery unblock Safeword commands and preserve user data through Codex handoffs.
- Keep BDD verification reliable and make independent-review fallback advisory rather than blocking.
- Keep generated plugin builds reproducible and move Codex migration acceptance coverage onto the supported setup path.
- Document relay-volume recovery for operators.

## Verification

- Current-tip `main` CI passed on exact base `12b4cb72ef7e97fd0b258f3f28bfad3f14624f93` before the bump.
- Release contract: 30 of 30 tests passed.
- Version-sync and Claude plugin release-contract checks passed at 0.74.0.
- Frozen-lockfile install passed with no dependency-resolution changes.
- Generated Claude plugin package, identity, inventory, and catalogue align at 0.74.0.
- `git diff --check` passed.

## Known audit findings

`bun audit` reports six pre-existing website/tooling advisories: one high-severity `js-yaml` advisory plus four moderate and one low Mermaid advisories. This release changes no dependencies or lockfile entries, so remediation is intentionally kept out of the release-only diff.

After merge, an annotated `v0.74.0` tag will trigger the OIDC Release workflow and npm publication.