### PR TITLE
Show review progress during long checks

### DIFF
--- a/packages/cli/src/cli-protocol/handler.ts
+++ b/packages/cli/src/cli-protocol/handler.ts
@@ -1,15 +1,18 @@
 import type { CliResult } from './result.js';
 
+export interface ProgressReporter {
+  readonly start: (message: string) => void;
+  readonly heartbeat?: (message: string) => void;
+  readonly stop: () => void;
+}
+
 export interface CommandInvocation {
   readonly cwd: string;
   readonly noInput: boolean;
   readonly offline: boolean;
   readonly options: Readonly<Record<string, unknown>>;
   readonly operands: readonly unknown[];
-  readonly progress?: {
-    readonly start: (message: string) => void;
-    readonly stop: () => void;
-  };
+  readonly progress?: ProgressReporter;
 }
 
 export type CommandHandler = (invocation: CommandInvocation) => Promise<CliResult>;

--- a/packages/cli/src/cli-protocol/policy.ts
+++ b/packages/cli/src/cli-protocol/policy.ts
@@ -1,4 +1,5 @@
 import type { CommandDefinition } from './catalog.js';
+import type { ProgressReporter } from './handler.js';
 import type { CliResult, Effects } from './result.js';
 
 function firstNonEmptyEffect(effects: Effects): keyof Effects | undefined {
@@ -54,24 +55,37 @@ interface ProgressAdapters {
 
 /** Operations finishing faster than this are not worth announcing. */
 const PROGRESS_ANNOUNCE_DELAY_MS = 100;
+/** A long wait needs proof that the coordinator is still responsive. */
+const PROGRESS_HEARTBEAT_INTERVAL_MS = 30_000;
 
-export function createProgressReporter(adapters: ProgressAdapters): {
-  start: (message: string) => void;
-  stop: () => void;
-} {
-  let scheduledHandle: unknown;
+export function createProgressReporter(adapters: ProgressAdapters): ProgressReporter {
+  let announcementHandle: unknown;
+  let heartbeatHandle: unknown;
+
+  function scheduleHeartbeat(message: string): void {
+    heartbeatHandle = adapters.schedule(() => {
+      adapters.emit(message);
+      scheduleHeartbeat(message);
+    }, PROGRESS_HEARTBEAT_INTERVAL_MS);
+  }
+
   return {
     start(message: string): void {
-      if (scheduledHandle !== undefined) adapters.cancel(scheduledHandle);
-      scheduledHandle = adapters.schedule(() => {
+      if (announcementHandle !== undefined) adapters.cancel(announcementHandle);
+      announcementHandle = adapters.schedule(() => {
         adapters.emit(message);
-        scheduledHandle = undefined;
+        announcementHandle = undefined;
       }, PROGRESS_ANNOUNCE_DELAY_MS);
     },
+    heartbeat(message: string): void {
+      if (heartbeatHandle !== undefined) adapters.cancel(heartbeatHandle);
+      scheduleHeartbeat(message);
+    },
     stop(): void {
-      if (scheduledHandle === undefined) return;
-      adapters.cancel(scheduledHandle);
-      scheduledHandle = undefined;
+      if (announcementHandle !== undefined) adapters.cancel(announcementHandle);
+      if (heartbeatHandle !== undefined) adapters.cancel(heartbeatHandle);
+      announcementHandle = undefined;
+      heartbeatHandle = undefined;
     },
   };
 }

--- a/packages/cli/src/cli-protocol/policy.ts
+++ b/packages/cli/src/cli-protocol/policy.ts
@@ -58,15 +58,32 @@ const PROGRESS_ANNOUNCE_DELAY_MS = 100;
 /** A long wait needs proof that the coordinator is still responsive. */
 const PROGRESS_HEARTBEAT_INTERVAL_MS = 30_000;
 
+/**
+ * Shorten the heartbeat so a test can observe a real one without waiting 30
+ * seconds. Internal: a value outside 1ms..30s is ignored.
+ */
+export function resolveHeartbeatIntervalMs(environment: NodeJS.ProcessEnv = process.env): number {
+  const override = Number(environment.SAFEWORD_PROGRESS_HEARTBEAT_MS);
+  if (
+    !Number.isSafeInteger(override) ||
+    override < 1 ||
+    override > PROGRESS_HEARTBEAT_INTERVAL_MS
+  ) {
+    return PROGRESS_HEARTBEAT_INTERVAL_MS;
+  }
+  return override;
+}
+
 export function createProgressReporter(adapters: ProgressAdapters): ProgressReporter {
   let announcementHandle: unknown;
   let heartbeatHandle: unknown;
+  const heartbeatIntervalMs = resolveHeartbeatIntervalMs();
 
   function scheduleHeartbeat(message: string): void {
     heartbeatHandle = adapters.schedule(() => {
       adapters.emit(message);
       scheduleHeartbeat(message);
-    }, PROGRESS_HEARTBEAT_INTERVAL_MS);
+    }, heartbeatIntervalMs);
   }
 
   return {

--- a/packages/cli/src/cli-protocol/public-handlers.ts
+++ b/packages/cli/src/cli-protocol/public-handlers.ts
@@ -555,7 +555,7 @@ async function reviewRunHandler(invocation: CommandInvocation): Promise<CliResul
     ? rawTargets.filter((target): target is string => typeof target === 'string')
     : [];
   const { runReview } = await import('../review/coordinator.js');
-  return runReview({ cwd: invocation.cwd, kind: rawKind, targets });
+  return runReview({ cwd: invocation.cwd, kind: rawKind, targets, progress: invocation.progress });
 }
 
 async function codexStatusHandler(invocation: CommandInvocation): Promise<CliResult> {

--- a/packages/cli/src/commands/codex-hook.ts
+++ b/packages/cli/src/commands/codex-hook.ts
@@ -81,7 +81,7 @@ const WRITE_REVIEW_STAMP_SCRIPT = '.safeword/hooks/write-review-stamp.ts';
 const REVIEW_STAMP_CACHE_KEY = 'review-stamp';
 const SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/u;
 const SHELL_SEPARATORS = ';&|';
-const SHELL_WHITESPACE = String.raw` \n\r\t\v\f`;
+const SHELL_WHITESPACE = [' ', '\n', '\r', '\t', '\v', '\f'].join('');
 const SUPPORTED_CODEX_HOOK_EVENTS: ReadonlySet<string> = new Set([
   'post-tool-use',
   'pre-tool-use',

--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -231,16 +231,41 @@ function changedReviewResult(input: {
   });
 }
 
-async function runDegradedFallback(input: {
+type ReviewProgress = {
+  readonly start: (message: string) => void;
+  readonly heartbeat?: (message: string) => void;
+};
+
+type ReviewRunInput = {
   readonly cwd: string;
   readonly kind: ReviewKind;
   readonly targets: readonly string[];
-  readonly author: ReviewAgent;
-  readonly assignedReviewer: ReviewAgent;
-  readonly preferredFailure: ReviewFailure;
-  readonly policy: ReviewPolicy;
-}): Promise<CliResult> {
+  readonly progress?: ReviewProgress;
+};
+
+function preparePrimaryReview(input: ReviewRunInput, reviewer: ReviewAgent) {
+  input.progress?.start(`Preparing the review packet for ${agentName(reviewer)}…`);
   const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.start(`Requesting an independent ${agentName(reviewer)} review…`);
+  input.progress?.heartbeat?.(`Still waiting for a response from ${agentName(reviewer)}…`);
+  return prepared;
+}
+
+async function runDegradedFallback(
+  input: ReviewRunInput & {
+    readonly author: ReviewAgent;
+    readonly assignedReviewer: ReviewAgent;
+    readonly preferredFailure: ReviewFailure;
+    readonly policy: ReviewPolicy;
+  },
+): Promise<CliResult> {
+  input.progress?.start(
+    `${agentName(input.assignedReviewer)} did not complete; trying a ${agentName(input.author)} fallback…`,
+  );
+  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.heartbeat?.(
+    `Still waiting for a response from the ${agentName(input.author)} fallback…`,
+  );
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(input.author, prepared);
   const changedResult = changedReviewResult({
     author: input.author,
@@ -351,11 +376,7 @@ async function runDegradedFallback(input: {
   });
 }
 
-export async function runReview(input: {
-  readonly cwd: string;
-  readonly kind: ReviewKind;
-  readonly targets: readonly string[];
-}): Promise<CliResult> {
+export async function runReview(input: ReviewRunInput): Promise<CliResult> {
   const author = resolveRunIdentity({}, { env: process.env }).runtime;
   const policy = readReviewPolicy(input.cwd);
   if (policy === 'off') {
@@ -383,7 +404,7 @@ export async function runReview(input: {
   }
   const { reviewer } = pair;
 
-  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  const prepared = preparePrimaryReview(input, reviewer);
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(reviewer, prepared);
   const changedResult = changedReviewResult({
     author: pair.author,

--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -1,4 +1,5 @@
 import { resolveRunIdentity } from '../../templates/hooks/lib/run-identity.js';
+import type { ProgressReporter } from '../cli-protocol/handler.js';
 import { type CliResult, createResult } from '../cli-protocol/result.js';
 import type {
   ReviewAgent,
@@ -231,10 +232,11 @@ function changedReviewResult(input: {
   });
 }
 
-type ReviewProgress = {
-  readonly start: (message: string) => void;
-  readonly heartbeat?: (message: string) => void;
-};
+/**
+ * The coordinator announces and keeps a wait visible, but never ends the
+ * reporter — the command runner owns `stop()` in its `finally`.
+ */
+type ReviewProgress = Pick<ProgressReporter, 'start' | 'heartbeat'>;
 
 type ReviewRunInput = {
   readonly cwd: string;
@@ -243,11 +245,37 @@ type ReviewRunInput = {
   readonly progress?: ReviewProgress;
 };
 
-function preparePrimaryReview(input: ReviewRunInput, reviewer: ReviewAgent) {
-  input.progress?.start(`Preparing the review packet for ${agentName(reviewer)}…`);
+/**
+ * Prepare the primary reviewer's packet while narrating the wait.
+ *
+ * The dispatch announcement supersedes the preparation one: the reporter emits
+ * only an announcement still pending after 100ms, so packet preparation is
+ * announced when it is slow enough to matter and stays silent otherwise.
+ */
+function preparePrimaryReview(
+  input: ReviewRunInput,
+  reviewer: ReviewAgent,
+): ReturnType<typeof prepareReviewPacket> {
+  const name = agentName(reviewer);
+  input.progress?.start(`Preparing the review packet for ${name}…`);
   const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
-  input.progress?.start(`Requesting an independent ${agentName(reviewer)} review…`);
-  input.progress?.heartbeat?.(`Still waiting for a response from ${agentName(reviewer)}…`);
+  input.progress?.start(`Requesting an independent ${name} review…`);
+  input.progress?.heartbeat?.(`Still waiting for a response from ${name}…`);
+  return prepared;
+}
+
+/** Narrate the fallback the same way, so both routes read identically. */
+function prepareFallbackReview(
+  input: ReviewRunInput,
+  assignedReviewer: ReviewAgent,
+  author: ReviewAgent,
+): ReturnType<typeof prepareReviewPacket> {
+  const fallbackName = agentName(author);
+  input.progress?.start(
+    `${agentName(assignedReviewer)} did not complete; trying a ${fallbackName} fallback…`,
+  );
+  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.heartbeat?.(`Still waiting for a response from the ${fallbackName} fallback…`);
   return prepared;
 }
 
@@ -259,13 +287,7 @@ async function runDegradedFallback(
     readonly policy: ReviewPolicy;
   },
 ): Promise<CliResult> {
-  input.progress?.start(
-    `${agentName(input.assignedReviewer)} did not complete; trying a ${agentName(input.author)} fallback…`,
-  );
-  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
-  input.progress?.heartbeat?.(
-    `Still waiting for a response from the ${agentName(input.author)} fallback…`,
-  );
+  const prepared = prepareFallbackReview(input, input.assignedReviewer, input.author);
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(input.author, prepared);
   const changedResult = changedReviewResult({
     author: input.author,

--- a/packages/cli/tests/cli-protocol/policy.test.ts
+++ b/packages/cli/tests/cli-protocol/policy.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { commandCatalog } from '../../src/cli-protocol/catalog.js';
-import { assertEffectPolicy, createProgressReporter } from '../../src/cli-protocol/policy.js';
+import {
+  assertEffectPolicy,
+  createProgressReporter,
+  resolveHeartbeatIntervalMs,
+} from '../../src/cli-protocol/policy.js';
 import { createResult } from '../../src/cli-protocol/result.js';
 
 function definition(name: string) {
@@ -102,5 +106,35 @@ describe('CLI execution policy', () => {
 
     progress.stop();
     expect(cancel).toHaveBeenCalledWith(2);
+  });
+
+  it('cancels a pending announcement as well as the heartbeat when the command ends', () => {
+    const emit = vi.fn();
+    const cancel = vi.fn();
+    let nextHandle = 0;
+    const progress = createProgressReporter({
+      schedule: () => {
+        nextHandle += 1;
+        return nextHandle;
+      },
+      cancel,
+      emit,
+    });
+
+    progress.start('Requesting an independent Codex review…');
+    progress.heartbeat?.('Still waiting for a response from Codex…');
+    progress.stop();
+
+    expect(cancel).toHaveBeenCalledWith(1);
+    expect(cancel).toHaveBeenCalledWith(2);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('ignores a heartbeat interval override that is not a positive value under the default', () => {
+    for (const value of ['0', '-5', 'soon', '', '30001', '1.5']) {
+      expect(resolveHeartbeatIntervalMs({ SAFEWORD_PROGRESS_HEARTBEAT_MS: value })).toBe(30_000);
+    }
+    expect(resolveHeartbeatIntervalMs({})).toBe(30_000);
+    expect(resolveHeartbeatIntervalMs({ SAFEWORD_PROGRESS_HEARTBEAT_MS: '250' })).toBe(250);
   });
 });

--- a/packages/cli/tests/cli-protocol/policy.test.ts
+++ b/packages/cli/tests/cli-protocol/policy.test.ts
@@ -76,4 +76,31 @@ describe('CLI execution policy', () => {
     expect(emit).toHaveBeenCalledWith('Applying the confirmed plan…');
     progress.stop();
   });
+
+  it('keeps a long-running operation visibly alive without claiming completion progress', () => {
+    const scheduled = new Map<number, () => void>();
+    const delays = new Map<number, number>();
+    const emit = vi.fn();
+    const cancel = vi.fn();
+    let nextHandle = 0;
+    const progress = createProgressReporter({
+      schedule: (callback, delay) => {
+        nextHandle += 1;
+        scheduled.set(nextHandle, callback);
+        delays.set(nextHandle, delay);
+        return nextHandle;
+      },
+      cancel,
+      emit,
+    });
+
+    progress.heartbeat?.('Still waiting for a response from Codex…');
+    expect(delays.get(1)).toBe(30_000);
+    scheduled.get(1)?.();
+    expect(emit).toHaveBeenCalledWith('Still waiting for a response from Codex…');
+    expect(delays.get(2)).toBe(30_000);
+
+    progress.stop();
+    expect(cancel).toHaveBeenCalledWith(2);
+  });
 });

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -33,12 +33,14 @@ printf '%s\n' '${agent}' >> "$SAFEWORD_REVIEW_LOG"
 failure=$(printenv SAFEWORD_REVIEW_FAKE_FAILURE_${agent.toUpperCase()} || printenv SAFEWORD_REVIEW_FAKE_FAILURE || true)
 failure_agent=$(printenv SAFEWORD_REVIEW_FAKE_FAILURE_AGENT || true)
 failure_path=$(printenv SAFEWORD_REVIEW_FAKE_FAIL_PATH_CONTAINS || true)
+delay_agent=$(printenv SAFEWORD_REVIEW_FAKE_DELAY_AGENT || true)
 if [ "$failure" = "auth" ] && { [ -z "$failure_agent" ] || [ "$failure_agent" = "${agent}" ]; } && { [ -z "$failure_path" ] || printf '%s' "$0" | /usr/bin/grep -q "$failure_path"; }; then
   printf 'not logged in\n' >&2
   exit 1
 fi
 payload=$(cat)
 dispatch_id=$(printf '%s' "$payload" | sed -n 's/.*"dispatch_id":"\([^"]*\)".*/\1/p')
+if [ "$delay_agent" = "${agent}" ]; then /bin/sleep 1; fi
 if { [ -z "$failure_agent" ] || [ "$failure_agent" = "${agent}" ]; } && { [ -z "$failure_path" ] || printf '%s' "$0" | /usr/bin/grep -q "$failure_path"; }; then
   if [ "$failure" = "process" ]; then printf 'review crashed\n' >&2; exit 7; fi
   if [ "$failure" = "timeout" ]; then /bin/sleep 1; fi
@@ -772,6 +774,56 @@ describe('cross-agent review public-command wiring', () => {
     });
     expect(output.data).not.toHaveProperty('reviewer_output');
     expect(readFileSync(log, 'utf8')).toBe('codex\nclaude\n');
+  });
+
+  it('reports the assigned reviewer while a long independent check is running', async () => {
+    const directory = createTemporaryDirectory();
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    const log = nodePath.join(directory, 'review.log');
+    const bin = installFakeReviewer(directory, 'codex');
+
+    const result = await runCli(
+      ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'claude',
+          SAFEWORD_REVIEW_FAKE_DELAY_AGENT: 'codex',
+          SAFEWORD_REVIEW_LOG: log,
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    expect(result.stderr).toContain('Requesting an independent Codex review…');
+  });
+
+  it('reports when an unavailable independent reviewer moves to a fallback', async () => {
+    const directory = createTemporaryDirectory();
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    const log = nodePath.join(directory, 'review.log');
+    const bin = installFakeReviewer(directory, 'codex');
+    installFakeReviewer(directory, 'claude');
+
+    const result = await runCli(
+      ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'claude',
+          SAFEWORD_REVIEW_FAKE_FAILURE_CODEX: 'process',
+          SAFEWORD_REVIEW_FAKE_DELAY_AGENT: 'claude',
+          SAFEWORD_REVIEW_LOG: log,
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    expect(result.stderr).toContain('Codex did not complete; trying a Claude fallback…');
   });
 
   it.each(['process', 'auth'])(

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -826,6 +826,69 @@ describe('cross-agent review public-command wiring', () => {
     expect(result.stderr).toContain('Codex did not complete; trying a Claude fallback…');
   });
 
+  it('repeats a waiting heartbeat while the independent reviewer has not answered', async () => {
+    const directory = createTemporaryDirectory();
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    const log = nodePath.join(directory, 'review.log');
+    const bin = installFakeReviewer(directory, 'codex');
+
+    const result = await runCli(
+      ['review', 'run', 'quality-review', 'review-input.md', '--no-input', '--cwd', directory],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'claude',
+          SAFEWORD_REVIEW_FAKE_DELAY_AGENT: 'codex',
+          SAFEWORD_PROGRESS_HEARTBEAT_MS: '150',
+          SAFEWORD_REVIEW_LOG: log,
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    const heartbeats = result.stderr
+      .split('\n')
+      .filter(line => line.includes('Still waiting for a response from Codex…'));
+    expect(heartbeats.length).toBeGreaterThan(1);
+  });
+
+  it('stays silent on stderr when the caller asked for machine output', async () => {
+    const directory = createTemporaryDirectory();
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    const log = nodePath.join(directory, 'review.log');
+    const bin = installFakeReviewer(directory, 'codex');
+
+    const result = await runCli(
+      [
+        'review',
+        'run',
+        'quality-review',
+        'review-input.md',
+        '--json',
+        '--no-input',
+        '--cwd',
+        directory,
+      ],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'claude',
+          SAFEWORD_REVIEW_FAKE_DELAY_AGENT: 'codex',
+          SAFEWORD_PROGRESS_HEARTBEAT_MS: '150',
+          SAFEWORD_REVIEW_LOG: log,
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    expect(result.stderr).not.toContain('Requesting an independent Codex review…');
+    expect(result.stderr).not.toContain('Still waiting for a response from Codex…');
+  });
+
   it.each(['process', 'auth'])(
     'skips a reviewer candidate that fails with %s and runs the next compatible installation',
     async failure => {

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.73.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "95d5760bf2a0ff89ac7113620e963c1fee1510f14a2b863915f237219e15ef87"
+  "inventory_sha256": "867b0e5d8ac4fd771076a6cf32c158457cac414bd25d5b05ee096139d16e7928"
 }

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.73.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "867b0e5d8ac4fd771076a6cf32c158457cac414bd25d5b05ee096139d16e7928"
+  "inventory_sha256": "88613e69eba5c0f78e2531b5e20b3e2a2fe953c2c61e55c702c32de9a241261a"
 }

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "2d61a6035505b4d7362d7847650233e25b3555184e9a9c5024e18ca111c237a2"
+  "inventory_sha256": "669eee3d915e14d0b7b1cf535f32319b0249c94c1470477888f8281b7e013c7c"
 }

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.0",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "010445fe71a55c5a2e2e7ba421028d1bd5d3686f4901d1293c37229611c4e249"
+  "inventory_sha256": "2d61a6035505b4d7362d7847650233e25b3555184e9a9c5024e18ca111c237a2"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "8923c89fa2939ac6194b4a891cbfce3b25eabc72840c42b51d97209ff7e0fc66"
+      "sha256": "67cc50d57ba088391c320490e58455c5d9ab171436263ba3b8d13d60a5d389c4"
     },
     {
       "path": "runtime/dispatch.ts",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "5f5cfd51f237ea963c72f1c68ff82fe7aec629b60ddcd0976db590266d241ada"
+      "sha256": "b1743a49f4e2d86c03c4ac39d6bc5961742e49d3fde11c7aee001fb68d4f32f4"
     },
     {
       "path": "runtime/dispatch.ts",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "5773cc534abd0d6b91a9de40660c7e91d2d1c7a28eca06cc9c7fd0524fc923ab"
+      "sha256": "8923c89fa2939ac6194b4a891cbfce3b25eabc72840c42b51d97209ff7e0fc66"
     },
     {
       "path": "runtime/dispatch.ts",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "b1743a49f4e2d86c03c4ac39d6bc5961742e49d3fde11c7aee001fb68d4f32f4"
+      "sha256": "bf3673f1c72c1933b229ff6e4c8d7b33ec02a376f3a127af94de244e1c5665ad"
     },
     {
       "path": "runtime/dispatch.ts",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -36430,8 +36430,17 @@ function changedReviewResult(input) {
     }
   });
 }
-async function runDegradedFallback(input) {
+function preparePrimaryReview(input, reviewer) {
+  input.progress?.start(`Preparing the review packet for ${agentName(reviewer)}\u2026`);
   const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.start(`Requesting an independent ${agentName(reviewer)} review\u2026`);
+  input.progress?.heartbeat?.(`Still waiting for a response from ${agentName(reviewer)}\u2026`);
+  return prepared;
+}
+async function runDegradedFallback(input) {
+  input.progress?.start(`${agentName(input.assignedReviewer)} did not complete; trying a ${agentName(input.author)} fallback\u2026`);
+  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.heartbeat?.(`Still waiting for a response from the ${agentName(input.author)} fallback\u2026`);
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(input.author, prepared);
   const changedResult = changedReviewResult({
     author: input.author,
@@ -36562,7 +36571,7 @@ async function runReview(input) {
     return unsupportedAuthorResult({ author, policy, kind: input.kind, targets: input.targets });
   }
   const { reviewer } = pair;
-  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  const prepared = preparePrimaryReview(input, reviewer);
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(reviewer, prepared);
   const changedResult = changedReviewResult({
     author: pair.author,
@@ -50580,7 +50589,7 @@ async function reviewRunHandler(invocation) {
   }
   const targets = Array.isArray(rawTargets) ? rawTargets.filter((target) => typeof target === "string") : [];
   const { runReview: runReview2 } = await Promise.resolve().then(() => (init_coordinator(), exports_coordinator));
-  return runReview2({ cwd: invocation.cwd, kind: rawKind, targets });
+  return runReview2({ cwd: invocation.cwd, kind: rawKind, targets, progress: invocation.progress });
 }
 async function codexStatusHandler(invocation) {
   const { observeCodexMigration: observeCodexMigration2 } = await Promise.resolve().then(() => (init_migrate_codex_plugin(), exports_migrate_codex_plugin));
@@ -51725,22 +51734,37 @@ function assertEffectPolicy(definition, result, options) {
   }
 }
 var PROGRESS_ANNOUNCE_DELAY_MS = 100;
+var PROGRESS_HEARTBEAT_INTERVAL_MS = 30000;
 function createProgressReporter(adapters) {
-  let scheduledHandle;
+  let announcementHandle;
+  let heartbeatHandle;
+  function scheduleHeartbeat(message) {
+    heartbeatHandle = adapters.schedule(() => {
+      adapters.emit(message);
+      scheduleHeartbeat(message);
+    }, PROGRESS_HEARTBEAT_INTERVAL_MS);
+  }
   return {
     start(message) {
-      if (scheduledHandle !== undefined)
-        adapters.cancel(scheduledHandle);
-      scheduledHandle = adapters.schedule(() => {
+      if (announcementHandle !== undefined)
+        adapters.cancel(announcementHandle);
+      announcementHandle = adapters.schedule(() => {
         adapters.emit(message);
-        scheduledHandle = undefined;
+        announcementHandle = undefined;
       }, PROGRESS_ANNOUNCE_DELAY_MS);
     },
+    heartbeat(message) {
+      if (heartbeatHandle !== undefined)
+        adapters.cancel(heartbeatHandle);
+      scheduleHeartbeat(message);
+    },
     stop() {
-      if (scheduledHandle === undefined)
-        return;
-      adapters.cancel(scheduledHandle);
-      scheduledHandle = undefined;
+      if (announcementHandle !== undefined)
+        adapters.cancel(announcementHandle);
+      if (heartbeatHandle !== undefined)
+        adapters.cancel(heartbeatHandle);
+      announcementHandle = undefined;
+      heartbeatHandle = undefined;
     }
   };
 }

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -36431,16 +36431,22 @@ function changedReviewResult(input) {
   });
 }
 function preparePrimaryReview(input, reviewer) {
-  input.progress?.start(`Preparing the review packet for ${agentName(reviewer)}\u2026`);
+  const name = agentName(reviewer);
+  input.progress?.start(`Preparing the review packet for ${name}\u2026`);
   const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
-  input.progress?.start(`Requesting an independent ${agentName(reviewer)} review\u2026`);
-  input.progress?.heartbeat?.(`Still waiting for a response from ${agentName(reviewer)}\u2026`);
+  input.progress?.start(`Requesting an independent ${name} review\u2026`);
+  input.progress?.heartbeat?.(`Still waiting for a response from ${name}\u2026`);
+  return prepared;
+}
+function prepareFallbackReview(input, assignedReviewer, author) {
+  const fallbackName = agentName(author);
+  input.progress?.start(`${agentName(assignedReviewer)} did not complete; trying a ${fallbackName} fallback\u2026`);
+  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
+  input.progress?.heartbeat?.(`Still waiting for a response from the ${fallbackName} fallback\u2026`);
   return prepared;
 }
 async function runDegradedFallback(input) {
-  input.progress?.start(`${agentName(input.assignedReviewer)} did not complete; trying a ${agentName(input.author)} fallback\u2026`);
-  const prepared = prepareReviewPacket(input.cwd, input.kind, input.targets);
-  input.progress?.heartbeat?.(`Still waiting for a response from the ${agentName(input.author)} fallback\u2026`);
+  const prepared = prepareFallbackReview(input, input.assignedReviewer, input.author);
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(input.author, prepared);
   const changedResult = changedReviewResult({
     author: input.author,
@@ -51735,14 +51741,22 @@ function assertEffectPolicy(definition, result, options) {
 }
 var PROGRESS_ANNOUNCE_DELAY_MS = 100;
 var PROGRESS_HEARTBEAT_INTERVAL_MS = 30000;
+function resolveHeartbeatIntervalMs(environment = process.env) {
+  const override = Number(environment.SAFEWORD_PROGRESS_HEARTBEAT_MS);
+  if (!Number.isSafeInteger(override) || override < 1 || override > PROGRESS_HEARTBEAT_INTERVAL_MS) {
+    return PROGRESS_HEARTBEAT_INTERVAL_MS;
+  }
+  return override;
+}
 function createProgressReporter(adapters) {
   let announcementHandle;
   let heartbeatHandle;
+  const heartbeatIntervalMs = resolveHeartbeatIntervalMs();
   function scheduleHeartbeat(message) {
     heartbeatHandle = adapters.schedule(() => {
       adapters.emit(message);
       scheduleHeartbeat(message);
-    }, PROGRESS_HEARTBEAT_INTERVAL_MS);
+    }, heartbeatIntervalMs);
   }
   return {
     start(message) {

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -39035,7 +39035,7 @@ var require_browser = __commonJS((exports, module) => {
   };
 });
 
-// ../../node_modules/.bun/supports-color@10.2.2/node_modules/supports-color/index.js
+// ../../node_modules/.bun/supports-color@11.0.0/node_modules/supports-color/index.js
 var exports_supports_color = {};
 __export(exports_supports_color, {
   default: () => supports_color_default,
@@ -39063,7 +39063,10 @@ function envForceColor() {
   if (env.FORCE_COLOR.length === 0) {
     return 1;
   }
-  const level = Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+  if (!/^\d+$/v.test(env.FORCE_COLOR)) {
+    return;
+  }
+  const level = Math.min(Number(env.FORCE_COLOR), 3);
   if (![0, 1, 2, 3].includes(level)) {
     return;
   }
@@ -39097,6 +39100,9 @@ function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
       return 2;
     }
   }
+  if (forceColor !== undefined && /^\d+$/v.test(env.FORCE_COLOR)) {
+    return forceColor;
+  }
   if ("TF_BUILD" in env && "AGENT_NAME" in env) {
     return 1;
   }
@@ -39115,16 +39121,16 @@ function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
     return 1;
   }
   if ("CI" in env) {
-    if (["GITHUB_ACTIONS", "GITEA_ACTIONS", "CIRCLECI"].some((key) => (key in env))) {
+    if (["GITHUB_ACTIONS", "GITEA_ACTIONS", "CIRCLECI"].some((key) => Object.hasOwn(env, key))) {
       return 3;
     }
-    if (["TRAVIS", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"].some((sign) => (sign in env)) || env.CI_NAME === "codeship") {
+    if (["TRAVIS", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"].some((sign) => Object.hasOwn(env, sign)) || env.CI_NAME === "codeship") {
       return 1;
     }
     return min;
   }
   if ("TEAMCITY_VERSION" in env) {
-    return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
+    return /^(?:9\.0*[1-9]\d*\.|\d{2,}\.)/v.test(env.TEAMCITY_VERSION) ? 1 : 0;
   }
   if (env.COLORTERM === "truecolor") {
     return 3;
@@ -39139,7 +39145,7 @@ function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
     return 3;
   }
   if ("TERM_PROGRAM" in env) {
-    const version2 = Number.parseInt((env.TERM_PROGRAM_VERSION || "").split(".")[0], 10);
+    const version2 = Number((env.TERM_PROGRAM_VERSION || "").split(".", 1)[0]);
     switch (env.TERM_PROGRAM) {
       case "iTerm.app": {
         return version2 >= 3 ? 3 : 2;
@@ -39149,10 +39155,10 @@ function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
       }
     }
   }
-  if (/-256(color)?$/i.test(env.TERM)) {
+  if (/-256(?:color)?$/iv.test(env.TERM)) {
     return 2;
   }
-  if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+  if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/iv.test(env.TERM)) {
     return 1;
   }
   if ("COLORTERM" in env) {

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -47934,7 +47934,7 @@ async function codexHook(event, options = {}) {
   }
   await CODEX_HOOK_RUNNERS[normalized]();
 }
-var EXPLAIN_HINT = "Run `$explain` for a plain-English version of this block.", EXIT_CODE_DENY_MODE = "exit-code", PRE_TOOL_QUALITY_HOOK_PATH = "codex/pre-tool-quality.ts", REQUIRED_INTAKE_FIELDS, MODULE_DIRECTORY, TEMPLATE_DIRECTORIES, POST_TOOL_GUIDANCE_PATH = ".project/codex-post-tool-guidance.txt", PROMPT_CONTEXT_PATH = ".project/codex-prompt-context.txt", STOP_CONTINUATION_PATH = ".project/codex-stop-continuation.txt", CODEX_RUN_IDENTITY_CACHE = "codex-run-identity.json", CODEX_REVIEW_STAMP_IDENTITY_CACHE = "codex-review-stamp-identity.json", RECORD_SKILL_INVOCATION_SCRIPT = ".safeword/hooks/record-skill-invocation.ts", WRITE_REVIEW_STAMP_SCRIPT = ".safeword/hooks/write-review-stamp.ts", REVIEW_STAMP_CACHE_KEY = "review-stamp", SKILL_NAME_PATTERN, SHELL_SEPARATORS = ";&|", SHELL_WHITESPACE = " \\n\\r\\t\\v\\f", SUPPORTED_CODEX_HOOK_EVENTS, stdinCache, CODEX_HOOK_RUNNERS;
+var EXPLAIN_HINT = "Run `$explain` for a plain-English version of this block.", EXIT_CODE_DENY_MODE = "exit-code", PRE_TOOL_QUALITY_HOOK_PATH = "codex/pre-tool-quality.ts", REQUIRED_INTAKE_FIELDS, MODULE_DIRECTORY, TEMPLATE_DIRECTORIES, POST_TOOL_GUIDANCE_PATH = ".project/codex-post-tool-guidance.txt", PROMPT_CONTEXT_PATH = ".project/codex-prompt-context.txt", STOP_CONTINUATION_PATH = ".project/codex-stop-continuation.txt", CODEX_RUN_IDENTITY_CACHE = "codex-run-identity.json", CODEX_REVIEW_STAMP_IDENTITY_CACHE = "codex-review-stamp-identity.json", RECORD_SKILL_INVOCATION_SCRIPT = ".safeword/hooks/record-skill-invocation.ts", WRITE_REVIEW_STAMP_SCRIPT = ".safeword/hooks/write-review-stamp.ts", REVIEW_STAMP_CACHE_KEY = "review-stamp", SKILL_NAME_PATTERN, SHELL_SEPARATORS = ";&|", SHELL_WHITESPACE, SUPPORTED_CODEX_HOOK_EVENTS, stdinCache, CODEX_HOOK_RUNNERS;
 var init_codex_hook = __esm(() => {
   init_legacy_authority();
   init_profile_proof();
@@ -47948,6 +47948,8 @@ var init_codex_hook = __esm(() => {
     nodePath84.resolve(MODULE_DIRECTORY, "../../templates")
   ];
   SKILL_NAME_PATTERN = /^[a-z][a-z0-9-]*$/u;
+  SHELL_WHITESPACE = [" ", `
+`, "\r", "\t", "\v", "\f"].join("");
   SUPPORTED_CODEX_HOOK_EVENTS = new Set([
     "post-tool-use",
     "pre-tool-use",


### PR DESCRIPTION
## What changed

- Announce reviewer dispatch and fallback transitions on stderr.
- Announce review-packet preparation when preparation is slow enough to matter — the dispatch announcement supersedes it below the 100ms announce delay.
- Emit a truthful 30-second waiting heartbeat for long independent reviews.
- Keep JSON and quiet output unchanged.

## Why

Long review routes previously emitted no output during their 120-second timeout window, leaving users unable to distinguish a running reviewer from a stalled route.

## Review follow-ups (0091b979d)

Applied after `/review-spec`, `/quality-review`, and `/refactor` — see [the review](https://github.com/ArcadeAI/safeword/pull/2204#pullrequestreview-4880880458) for the reasoning.

- **The 30s heartbeat had no end-to-end proof.** `heartbeat` is optional on `ProgressReporter`, so deleting the coordinator's call typechecked and left the suite green. Added a clamped internal `SAFEWORD_PROGRESS_HEARTBEAT_MS` override (1ms..30s, otherwise ignored) and a scenario asserting more than one heartbeat line reaches stderr.
- **"Keep JSON and quiet output unchanged" was unbound.** Added a scenario asserting `--json` emits neither the dispatch line nor a heartbeat.
- **`stop()` was half-asserted.** This PR made it cancel both handles; only the heartbeat handle was covered. Added coverage for the pending announcement.
- **Deduped the progress contract.** `ReviewProgress` was a hand-copied structural twin of `ProgressReporter`; it is now `Pick<ProgressReporter, 'start' | 'heartbeat'>`, with `stop` excluded on purpose — the command runner owns `stop()` in its `finally`.
- **Made the two routes symmetric.** The fallback inlined its own announce block; extracted `prepareFallbackReview` to match the primary.

Known trade-off: on the fallback path the primary's heartbeat stays armed across the fallback's packet preparation, so a heartbeat can briefly name the reviewer that already failed. Bounded by prep duration and re-armed immediately after — cosmetic, left as-is.

## Validation

- `bun run lint` (eslint + gherkin + `tsc --noEmit`)
- `bun run test tests/cli-protocol/policy.test.ts tests/cli-protocol/review-wiring.test.ts` — 43 passed (was 39)

Closes #2115.
