### PR TITLE
Clarify verification cadence

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -14,10 +14,12 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 ## Closing Check, Not Fast Feedback
 
-`/verify` is the closing gate: it resolves and runs the authoritative test plan,
-not a fast subset. While implementing, use focused tests and relevant static
-checks; before handing work back, run the project's smoke lane when it has one.
-Do not substitute smoke for `/verify` when proving ticket completion.
+`/verify` is the closing gate: it prefers the project's authoritative suite over
+a fast subset. If the project exposes only `test:done`, record that limited
+evidence rather than calling it a full run. While implementing, use focused
+tests and relevant static checks; before handing work back, run the project's
+smoke lane when it has one. Do not substitute smoke for `/verify` when proving
+ticket completion.
 
 ## Invocation log
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -12,6 +12,13 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 **Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
+## Closing Check, Not Fast Feedback
+
+`/verify` is the closing gate: it resolves and runs the authoritative test plan,
+not a fast subset. While implementing, use focused tests and relevant static
+checks; before handing work back, run the project's smoke lane when it has one.
+Do not substitute smoke for `/verify` when proving ticket completion.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/.safeword/guides/verification-lanes-guide.md
+++ b/.safeword/guides/verification-lanes-guide.md
@@ -482,15 +482,15 @@ That cannot fail deterministically.
 
 Use this default cadence unless the project has a stronger local convention.
 
-| Event             | Recommended Lanes                   |
-| ----------------- | ----------------------------------- |
-| During coding     | Focused                             |
-| Before handoff    | Focused + relevant static gates     |
-| Pull request      | Static gates + smoke + affected BDD |
-| Before release    | Release + migration + full smoke    |
-| Scheduled nightly | Slow/performance + broader matrices |
-| Manual high-risk  | Live-fire                           |
-| After deployment  | Smoke + selected live-fire health   |
+| Event             | Recommended Lanes                       |
+| ----------------- | --------------------------------------- |
+| During coding     | Focused                                 |
+| Before handoff    | Focused + relevant static gates + smoke |
+| Pull request      | Static gates + smoke + affected BDD     |
+| Before release    | Release + migration + full smoke        |
+| Scheduled nightly | Slow/performance + broader matrices     |
+| Manual high-risk  | Live-fire                               |
+| After deployment  | Smoke + selected live-fire health       |
 
 **Tie-breaker:** move a lane earlier only when the failure is cheap to diagnose
 there. Expensive checks that frequently fail for environmental reasons belong

--- a/.safeword/skills/verify/SKILL.md
+++ b/.safeword/skills/verify/SKILL.md
@@ -14,10 +14,12 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 ## Closing Check, Not Fast Feedback
 
-`/verify` is the closing gate: it resolves and runs the authoritative test plan,
-not a fast subset. While implementing, use focused tests and relevant static
-checks; before handing work back, run the project's smoke lane when it has one.
-Do not substitute smoke for `/verify` when proving ticket completion.
+`/verify` is the closing gate: it prefers the project's authoritative suite over
+a fast subset. If the project exposes only `test:done`, record that limited
+evidence rather than calling it a full run. While implementing, use focused
+tests and relevant static checks; before handing work back, run the project's
+smoke lane when it has one. Do not substitute smoke for `/verify` when proving
+ticket completion.
 
 ## Invocation log
 

--- a/.safeword/skills/verify/SKILL.md
+++ b/.safeword/skills/verify/SKILL.md
@@ -12,6 +12,13 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 **Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
+## Closing Check, Not Fast Feedback
+
+`/verify` is the closing gate: it resolves and runs the authoritative test plan,
+not a fast subset. While implementing, use focused tests and relevant static
+checks; before handing work back, run the project's smoke lane when it has one.
+Do not substitute smoke for `/verify` when proving ticket completion.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/packages/cli/codex-plugin/skills/verify/SKILL.md
+++ b/packages/cli/codex-plugin/skills/verify/SKILL.md
@@ -13,10 +13,12 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 ## Closing Check, Not Fast Feedback
 
-`$safeword:verify` is the closing gate: it resolves and runs the authoritative test plan,
-not a fast subset. While implementing, use focused tests and relevant static
-checks; before handing work back, run the project's smoke lane when it has one.
-Do not substitute smoke for `$safeword:verify` when proving ticket completion.
+`$safeword:verify` is the closing gate: it prefers the project's authoritative suite over
+a fast subset. If the project exposes only `test:done`, record that limited
+evidence rather than calling it a full run. While implementing, use focused
+tests and relevant static checks; before handing work back, run the project's
+smoke lane when it has one. Do not substitute smoke for `$safeword:verify` when proving
+ticket completion.
 
 ## Invocation log
 

--- a/packages/cli/codex-plugin/skills/verify/SKILL.md
+++ b/packages/cli/codex-plugin/skills/verify/SKILL.md
@@ -11,6 +11,13 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 **Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
+## Closing Check, Not Fast Feedback
+
+`$safeword:verify` is the closing gate: it resolves and runs the authoritative test plan,
+not a fast subset. While implementing, use focused tests and relevant static
+checks; before handing work back, run the project's smoke lane when it has one.
+Do not substitute smoke for `$safeword:verify` when proving ticket completion.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify $safeword:verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/packages/cli/templates/guides/verification-lanes-guide.md
+++ b/packages/cli/templates/guides/verification-lanes-guide.md
@@ -482,15 +482,15 @@ That cannot fail deterministically.
 
 Use this default cadence unless the project has a stronger local convention.
 
-| Event             | Recommended Lanes                   |
-| ----------------- | ----------------------------------- |
-| During coding     | Focused                             |
-| Before handoff    | Focused + relevant static gates     |
-| Pull request      | Static gates + smoke + affected BDD |
-| Before release    | Release + migration + full smoke    |
-| Scheduled nightly | Slow/performance + broader matrices |
-| Manual high-risk  | Live-fire                           |
-| After deployment  | Smoke + selected live-fire health   |
+| Event             | Recommended Lanes                       |
+| ----------------- | --------------------------------------- |
+| During coding     | Focused                                 |
+| Before handoff    | Focused + relevant static gates + smoke |
+| Pull request      | Static gates + smoke + affected BDD     |
+| Before release    | Release + migration + full smoke        |
+| Scheduled nightly | Slow/performance + broader matrices     |
+| Manual high-risk  | Live-fire                               |
+| After deployment  | Smoke + selected live-fire health       |
 
 **Tie-breaker:** move a lane earlier only when the failure is cheap to diagnose
 there. Expensive checks that frequently fail for environmental reasons belong

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -14,10 +14,12 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 ## Closing Check, Not Fast Feedback
 
-`/verify` is the closing gate: it resolves and runs the authoritative test plan,
-not a fast subset. While implementing, use focused tests and relevant static
-checks; before handing work back, run the project's smoke lane when it has one.
-Do not substitute smoke for `/verify` when proving ticket completion.
+`/verify` is the closing gate: it prefers the project's authoritative suite over
+a fast subset. If the project exposes only `test:done`, record that limited
+evidence rather than calling it a full run. While implementing, use focused
+tests and relevant static checks; before handing work back, run the project's
+smoke lane when it has one. Do not substitute smoke for `/verify` when proving
+ticket completion.
 
 ## Invocation log
 

--- a/packages/cli/templates/skills/verify/SKILL.md
+++ b/packages/cli/templates/skills/verify/SKILL.md
@@ -12,6 +12,13 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 **Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
+## Closing Check, Not Fast Feedback
+
+`/verify` is the closing gate: it resolves and runs the authoritative test plan,
+not a fast subset. While implementing, use focused tests and relevant static
+checks; before handing work back, run the project's smoke lane when it has one.
+Do not substitute smoke for `/verify` when proving ticket completion.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.2",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "68033623fb950330801ca84d857d3f21060bf0301a9188aa77c053f072a24cfa"
+  "inventory_sha256": "789651b690018b7c1c49daf6aef3ce97466f68d3488bfa211c68ce0d9cd81189"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -71,7 +71,7 @@
     },
     {
       "path": "resources/guides/verification-lanes-guide.md",
-      "sha256": "4a2e5cdc98f55a022e4888eb98e9ed6f63ed3e3ec8dd0934f3e118249d85fa78"
+      "sha256": "139dfff44444e7e13aa90cfbbd1acf2a9375fdb12222d31152eac3377ce1a385"
     },
     {
       "path": "resources/guides/zombie-process-cleanup.md",
@@ -671,7 +671,7 @@
     },
     {
       "path": "skills/verify/SKILL.md",
-      "sha256": "4de3ce6df69d23b5abbcda93785b2eff432f889c0f09bd0a6c7ecdb8c2a44342"
+      "sha256": "a39c2d67f90588aefb820f58a9aad718e7baa972ae257a33747c99eac9dabe82"
     }
   ]
 }

--- a/plugin/resources/guides/verification-lanes-guide.md
+++ b/plugin/resources/guides/verification-lanes-guide.md
@@ -482,15 +482,15 @@ That cannot fail deterministically.
 
 Use this default cadence unless the project has a stronger local convention.
 
-| Event             | Recommended Lanes                   |
-| ----------------- | ----------------------------------- |
-| During coding     | Focused                             |
-| Before handoff    | Focused + relevant static gates     |
-| Pull request      | Static gates + smoke + affected BDD |
-| Before release    | Release + migration + full smoke    |
-| Scheduled nightly | Slow/performance + broader matrices |
-| Manual high-risk  | Live-fire                           |
-| After deployment  | Smoke + selected live-fire health   |
+| Event             | Recommended Lanes                       |
+| ----------------- | --------------------------------------- |
+| During coding     | Focused                                 |
+| Before handoff    | Focused + relevant static gates + smoke |
+| Pull request      | Static gates + smoke + affected BDD     |
+| Before release    | Release + migration + full smoke        |
+| Scheduled nightly | Slow/performance + broader matrices     |
+| Manual high-risk  | Live-fire                               |
+| After deployment  | Smoke + selected live-fire health       |
 
 **Tie-breaker:** move a lane earlier only when the failure is cheap to diagnose
 there. Expensive checks that frequently fail for environmental reasons belong

--- a/plugin/skills/verify/SKILL.md
+++ b/plugin/skills/verify/SKILL.md
@@ -12,6 +12,15 @@ Prove a ticket meets its criteria. Works with or without an active ticket.
 
 **Reviewer class:** _class-2 — independent observation_: the test suite and parsers are the independent party, so no fresh-context or cross-model reviewer applies.
 
+## Closing Check, Not Fast Feedback
+
+`/verify` is the closing gate: it prefers the project's authoritative suite over
+a fast subset. If the project exposes only `test:done`, record that limited
+evidence rather than calling it a full run. While implementing, use focused
+tests and relevant static checks; before handing work back, run the project's
+smoke lane when it has one. Do not substitute smoke for `/verify` when proving
+ticket completion.
+
 ## Invocation log
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.


### PR DESCRIPTION
## What changed

Clarifies the two-speed verification workflow:

- Use focused tests, static checks, and smoke coverage for fast handoff feedback.
- Keep `/verify` as the ticket-closing check, preferring the authoritative suite.
- Record limited evidence when a project exposes only `test:done`, rather than describing it as a full run.

## Why

The prior wording could blur fast feedback with completion evidence and overstate the `test:done` fallback.

## Validation

- Diff-scoped Safe Word audit: clean; no changed source or manifest files.
- Template parity: 241 pairs and 8 contracts in sync.
- Markdown lint and formatting passed in pre-commit.