### PR TITLE
Guard the Bun plugin bundler pin

### DIFF
--- a/packages/cli/tests/claude-plugin-bun-version-contract.test.ts
+++ b/packages/cli/tests/claude-plugin-bun-version-contract.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Reproducibility contract: Bun.build output is toolchain-sensitive, so every
+ * workflow and the committed Claude plugin generator must share one exact Bun
+ * version from the root package.json.
+ *
+ * setup-bun's package.json reader resolves packageManager:
+ * https://github.com/oven-sh/setup-bun/blob/main/src/utils.ts
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../..');
+const generatorPath = nodePath.join(repoRoot, 'packages/cli/scripts/generate-claude-plugin.ts');
+
+interface Workflow {
+  jobs?: Record<string, { steps?: { uses?: string; with?: Record<string, unknown> }[] }>;
+}
+
+describe('Claude plugin Bun version contract', () => {
+  it('declares one exact Bun version at the repository root', () => {
+    const packageJson = JSON.parse(
+      readFileSync(nodePath.join(repoRoot, 'package.json'), 'utf8'),
+    ) as {
+      packageManager?: string;
+    };
+
+    expect(packageJson.packageManager).toMatch(/^bun@\d+\.\d+\.\d+$/);
+  });
+
+  it('makes every setup-bun step read the root version declaration', () => {
+    const workflowsRoot = nodePath.join(repoRoot, '.github/workflows');
+    const setupSteps = readdirSync(workflowsRoot)
+      .filter(file => /\.ya?ml$/.test(file))
+      .flatMap(file => {
+        const workflow = parse(
+          readFileSync(nodePath.join(workflowsRoot, file), 'utf8'),
+        ) as Workflow;
+        return Object.values(workflow.jobs ?? {}).flatMap(job => job.steps ?? []);
+      })
+      .filter(step => step.uses?.startsWith('oven-sh/setup-bun@'));
+
+    expect(setupSteps.length).toBeGreaterThan(0);
+    for (const step of setupSteps) {
+      expect(step.with?.['bun-version-file']).toBe('package.json');
+      expect(step.with?.['bun-version']).toBeUndefined();
+    }
+  });
+
+  it('refuses a mismatched Bun before writing generated plugin files', () => {
+    const fixtureRoot = mkdtempSync(nodePath.join(tmpdir(), 'safeword-bun-pin-'));
+    try {
+      const fixturePackageRoot = nodePath.join(fixtureRoot, 'packages/cli');
+      const fixtureGeneratorPath = nodePath.join(
+        fixturePackageRoot,
+        'scripts/generate-claude-plugin.ts',
+      );
+      mkdirSync(nodePath.join(fixturePackageRoot, 'scripts'), { recursive: true });
+      mkdirSync(nodePath.join(fixturePackageRoot, 'src/claude-plugin'), { recursive: true });
+      mkdirSync(nodePath.join(fixtureRoot, 'plugin'), { recursive: true });
+      cpSync(generatorPath, fixtureGeneratorPath);
+      writeFileSync(nodePath.join(fixtureRoot, 'package.json'), '{"packageManager":"bun@0.0.0"}\n');
+      writeFileSync(nodePath.join(fixturePackageRoot, 'package.json'), '{"version":"0.0.0"}\n');
+      writeFileSync(
+        nodePath.join(fixturePackageRoot, 'src/claude-plugin/catalogue.js'),
+        'export const sealClaudePluginCatalogue = () => {};\n' +
+          'export const writeClaudePluginCatalogue = () => [];\n',
+      );
+      const sentinelPath = nodePath.join(fixtureRoot, 'plugin/sentinel');
+      writeFileSync(sentinelPath, 'untouched');
+
+      const result = spawnSync('bun', [fixtureGeneratorPath], {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('Claude plugin generation requires Bun 0.0.0');
+      expect(readFileSync(sentinelPath, 'utf8')).toBe('untouched');
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a regression contract requiring an exact root `packageManager` Bun version
- require every `setup-bun` workflow step to read that root version and reject competing `bun-version` inputs
- exercise the real generator in a fixture to prove a mismatched Bun fails before plugin files are written

## Context

Follow-up quality/refactor/audit hardening for #2015. The implementation review passed; this adds the missing regression tripwire required by the repository testing guidance for toolchain pins.

## Validation

- independent cross-agent quality review: approved
- diff-scoped audit: clean
- `bun run lint`
- `bun install --frozen-lockfile`
- `bun run --cwd packages/cli generate:claude-plugin` (zero plugin diff)
- `bun scripts/parity-check.ts --mode=all` (241 pairs + 8 contracts)
- direct contract execution under Bun 1.3.14

The focused Vitest runner was intentionally not started locally because another safeword worktree already had an active Vitest process; CI is the isolated test proof.