### PR TITLE
Stop advisory smoke from blocking unrelated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
     name: Build + test + pack
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    outputs:
-      advisory_smoke_required: ${{ steps.advisory-smoke-scope.outputs.required }}
     permissions:
       contents: read
 
@@ -49,31 +47,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # full history so tag metadata is available
-
-      - name: Determine whether the live advisory smoke is required
-        id: advisory-smoke-scope
-        shell: bash
-        run: |
-          # Stable advances only after a successful stable publish, so it is the
-          # last known-good production baseline. Missing/uncertain evidence fails
-          # closed by requiring the live proof.
-          git fetch origin refs/heads/stable:refs/remotes/origin/stable || true
-          if ! git show-ref --verify --quiet refs/remotes/origin/stable; then
-            REQUIRED=true
-          elif git diff --quiet refs/remotes/origin/stable "$GITHUB_SHA" -- \
-            .github/workflows/release.yml \
-            .github/workflows/advisory-pr-review-canary.yml \
-            packages/cli/scripts/run-pr-review-disposable-smoke.ts \
-            packages/cli/src/pr-review \
-            packages/cli/templates/workflows/pr-review-publisher.yml \
-            packages/cli/templates/workflows/pr-review-worker.yml \
-            packages/cli/templates/workflows/pr-review.yml; then
-            REQUIRED=false
-          else
-            REQUIRED=true
-          fi
-          echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
-          echo "Live advisory compatibility smoke required: $REQUIRED"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -121,35 +94,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  advisory-pr-review-smoke:
-    name: Advisory PR review compatibility smoke
-    needs: build
-    if: ${{ needs.build.outputs.advisory_smoke_required == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: pr-review-smoke
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout qualified release
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version-file: package.json
-
-      - name: Install dependencies without repository authority
-        run: bun install --frozen-lockfile
-
-      - name: Prove fork-event and scheduled advisory semantics
-        run: bun run --cwd packages/cli smoke:pr-review:disposable
-        env:
-          GH_TOKEN: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_TOKEN }}
-          SAFEWORD_PR_REVIEW_SMOKE_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_OWNER }}
-          SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER }}
-
   # --------------------------------------------------------------------------
   # publish: runs ONLY `npm publish` against the artifact built above.
   # No project code, no test code, no install scripts execute here. Minimal
@@ -160,12 +104,7 @@ jobs:
   # --------------------------------------------------------------------------
   publish:
     name: Publish to npm
-    needs: [build, advisory-pr-review-smoke]
-    if: >-
-      ${{ always() && needs.build.result == 'success' &&
-      (needs['advisory-pr-review-smoke'].result == 'success' ||
-      (needs['advisory-pr-review-smoke'].result == 'skipped' &&
-      needs.build.outputs.advisory_smoke_required == 'false')) }}
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:

--- a/README.md
+++ b/README.md
@@ -464,15 +464,14 @@ trusted `workflow_run` publisher from the base branch; it never checks out pull
 request code and receives no model secret. GitHub currently requires
 `pull-requests: write` for an ordinary pull-request conversation comment, so the
 publisher is additionally constrained by Safeword's fixed issue-comment-only
-boundary and the release smoke verifies that it creates no review, check,
+boundary and the compatibility smoke verifies that it creates no review, check,
 status, or merge change.
 
-Deterministic release tests always validate the advisory workflow contract. A
-disposable-repository smoke test additionally blocks a release when that
-workflow or its compatibility harness changed since the last successful stable
-release. A daily canary and default-branch manual dispatch watch for GitHub
-environment-secret, fork-event, and concurrency drift between releases. Keep
-the customer workflow disabled until a live smoke passes where it will run.
+Deterministic release tests always validate the advisory workflow contract.
+Live GitHub compatibility is monitored separately so sandbox availability or
+credentials cannot block unrelated releases. A daily canary and default-branch
+manual dispatch watch for environment-secret, fork-event, and concurrency drift.
+Keep the customer workflow disabled until a live smoke passes where it will run.
 
 ### Maintainer compatibility proof
 
@@ -492,7 +491,7 @@ Run the same proof locally with:
 bun run --cwd packages/cli smoke:pr-review:disposable
 ```
 
-Each change-scoped release run, daily canary, or manual proof creates
+Each daily canary or manual proof creates
 `safeword-pr-review-smoke-<unique-id>` in both owners, exercises a real fork pull
 request plus the canonical scheduled-call projection, and then permanently
 deletes both repositories. Set

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -62,25 +62,15 @@ describe('Claude plugin release contract', () => {
     expect(workflow).not.toMatch(/git push[^\n]*(?:--force|-f\b)/u);
   });
 
-  it('blocks changed advisory surfaces on the disposable compatibility proof', () => {
+  it('does not block publication on the live advisory compatibility proof', () => {
     const workflow = readFileSync(
       nodePath.join(REPO_ROOT, '.github/workflows/release.yml'),
       'utf8',
     );
-    expect(workflow).toContain('advisory-pr-review-smoke:');
-    expect(workflow).toContain(
-      'advisory_smoke_required: ${{ steps.advisory-smoke-scope.outputs.required }}',
-    );
-    expect(workflow).toContain('git fetch origin refs/heads/stable:refs/remotes/origin/stable');
-    expect(workflow).toContain('git diff --quiet refs/remotes/origin/stable "$GITHUB_SHA"');
-    expect(workflow).toContain('packages/cli/src/pr-review');
-    expect(workflow).toContain("needs.build.outputs.advisory_smoke_required == 'true'");
-    expect(workflow).toContain('environment: pr-review-smoke');
-    expect(workflow).toContain('needs: [build, advisory-pr-review-smoke]');
-    expect(workflow).toContain("needs['advisory-pr-review-smoke'].result == 'skipped'");
-    expect(workflow).toContain("needs.build.outputs.advisory_smoke_required == 'false'");
-    expect(workflow).toContain('secrets.SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
-    expect(workflow).toContain('smoke:pr-review:disposable');
+    expect(workflow).toContain('publish:\n    name: Publish to npm\n    needs: build');
+    expect(workflow).not.toContain('advisory-pr-review-smoke:');
+    expect(workflow).not.toContain('pr-review-smoke');
+    expect(workflow).not.toContain('SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
   });
 
   it('watches platform drift with a sandbox-only advisory canary', () => {


### PR DESCRIPTION
## Outcome

Unrelated Safeword releases no longer depend on the live advisory-review sandbox. Publication remains gated by build, release-contract tests, packaging, and npm OIDC; the disposable GitHub proof remains on its daily/manual canary.

## Changes

- remove the live disposable smoke from the release dependency graph
- make `publish` depend only on the successful build artifact
- retain the daily and manually dispatched compatibility canary
- update the release contract and maintainer documentation

## Verification

- `bun run --cwd packages/cli test:release` — 34 passed
- `bun run --cwd packages/cli check:pr-review-workflows` — generated workflows passed actionlint and invalid control failed
- targeted ESLint and Prettier checks passed
- `git diff --check` passed