### PR TITLE
chore(release): v0.74.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.1",
+      "version": "0.74.2",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.74.1",
+      "version": "0.74.2",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.1 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.2 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.1 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.2 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.1 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.2 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.1 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.2 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.1 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.2 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.1",
+  "plugin_version": "0.74.2",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "b2bb4e920df0175ed1a2d329c9e3c3d7de13b25e8ac32b2142ce63f41d7d4325"
+  "inventory_sha256": "68033623fb950330801ca84d857d3f21060bf0301a9188aa77c053f072a24cfa"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "c0c62ab94e73779aac74babf0a571460e62386b0a00ef69fae177ce6b85ab5bb"
+      "sha256": "f2e7c8022d02292f7e3a403608ac38934af9b3d25e2740d5bf57999eb6331cb3"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "type": "module"
 }


### PR DESCRIPTION
## Release\n\nCuts the corrected patch release from current main after #2241 made the unavailable live advisory smoke non-blocking.\n\n- bumps all CLI, Claude plugin, Codex plugin, hook, and lockfile release surfaces to `0.74.2`\n- regenerates Claude plugin identity and inventory seals\n\nVerification:\n\n- `node scripts/check-version-sync.ts`\n- `bun run --cwd packages/cli check:claude-plugin`\n- `bun run --cwd packages/cli test:release` (34/34)\n- `bun run --cwd packages/cli build`