### PR TITLE
Review the turns that edited files, even when tool output carries a trailing note

### DIFF
--- a/.project/tickets/S0RYNS-review-turns-that-edited-files/ticket.md
+++ b/.project/tickets/S0RYNS-review-turns-that-edited-files/ticket.md
@@ -1,0 +1,25 @@
+---
+id: S0RYNS
+slug: review-turns-that-edited-files
+type: task
+phase: verify
+status: in_progress
+created: 2026-08-07T18:22:54.585Z
+last_modified: 2026-08-07T18:40:00Z
+---
+
+# Review the turns that edited files, even when tool output carries a trailing note
+
+**Goal:** Stop treating a tool-result message as the start of a human turn, so the quality review still fires on turns that changed files.
+
+**Why:** A user message may carry text blocks after its tool_result blocks. That trailing text is read as a human prompt, so the backward scan stops there and the Stop review is skipped on a turn that did edit files.
+
+## Work Log
+
+- 2026-08-07T18:22:54.585Z Started: Created ticket S0RYNS
+- 2026-08-07T18:24:00Z RED: `tests/integration/stop-hook-transcript-format.test.ts` — an edited turn whose tool result carries a trailing note (`[tool_result, text]`) exits silently instead of blocking. The hook printed nothing, so the review was skipped on a turn that did edit files.
+- 2026-08-07T18:25:00Z GREEN: `humanPromptText` returns '' when the message contains any `tool_result` block — such a message answers a tool call and belongs to the turn already running, whatever text follows. 17/17 in the file. Template, `.safeword` mirror, and generated `plugin/` mirror all synced.
+- 2026-08-07T18:27:00Z Mutation check: forcing the new guard to fire on every user message fails exactly the four boundary-detection cases (string-form follow-up, genuine follow-up, reminder-prefixed, notification-prefixed) and leaves the new case green. The guard is scoped, not a blanket short-circuit.
+- 2026-08-07T18:45:00Z Verify: full suite 6992 passed / 11 skipped / 12 failed. Ten failures are pre-existing on clean `main` (chmod-based negative paths that cannot fail as uid 0, plus four review-subsystem timing/permission cases from #2003). The remaining two — `setup-convergence` and `rust-golden-path` — pass in isolation both with and without this change and fail only under full-suite parallelism; treated as load flakes, not verified in a full clean-`main` run. Lint, Gherkin lint, `tsc --noEmit`, and build all clean.
+- 2026-08-07T18:46:00Z Source check: the API allows text blocks after `tool_result` blocks in one user message — "in the user message containing tool results, the tool_result blocks must come FIRST in the content array. Any text must come AFTER all tool results" (platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls, fetched this session). That shape is what this ticket fixes.
+- 2026-08-07T18:50:38.110Z Phase: intake → verify

--- a/.safeword/hooks/stop-quality.ts
+++ b/.safeword/hooks/stop-quality.ts
@@ -480,7 +480,15 @@ function normalizeContentItems(content: ContentItem[] | string | undefined): Con
 function userMessageText(message: TranscriptMessage): string {
   if (message.type !== 'user' || message.isMeta) return '';
 
-  return normalizeContentItems(message.message?.content)
+  const content = normalizeContentItems(message.message?.content);
+
+  // A message that answers a tool call belongs to the turn already running, even
+  // when text follows the results — the API allows that ordering and the harness
+  // uses it to append notes to tool output. Reading such a note as a human prompt
+  // would end the turn early and skip the review on a turn that did edit files.
+  if (content.some(item => item.type === 'tool_result')) return '';
+
+  return content
     .filter((item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text)
     .map(item => item.text)
     .join('\n')

--- a/packages/cli/templates/hooks/stop-quality.ts
+++ b/packages/cli/templates/hooks/stop-quality.ts
@@ -480,7 +480,15 @@ function normalizeContentItems(content: ContentItem[] | string | undefined): Con
 function userMessageText(message: TranscriptMessage): string {
   if (message.type !== 'user' || message.isMeta) return '';
 
-  return normalizeContentItems(message.message?.content)
+  const content = normalizeContentItems(message.message?.content);
+
+  // A message that answers a tool call belongs to the turn already running, even
+  // when text follows the results — the API allows that ordering and the harness
+  // uses it to append notes to tool output. Reading such a note as a human prompt
+  // would end the turn early and skip the review on a turn that did edit files.
+  if (content.some(item => item.type === 'tool_result')) return '';
+
+  return content
     .filter((item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text)
     .map(item => item.text)
     .join('\n')

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -401,53 +401,57 @@ describe('Stop Hook: Ticket Resolution Context', () => {
     expect(result.stdout.trim()).toBe('');
   });
 
-  it('still reviews an edited turn whose tool result carries a trailing note (S0RYNS)', () => {
-    // A user message may legally carry text blocks after its tool_result blocks,
-    // and the harness uses that to append notes to tool output. Those notes are
-    // not a human prompt: reading one as a turn start ends the turn early and
-    // skips the review on a turn that did edit files.
-    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
-    writeFileSync(
-      transcriptPath,
-      [
-        JSON.stringify({
-          type: 'user',
-          message: { role: 'user', content: [{ type: 'text', text: 'Refactor the parser.' }] },
-        }),
-        JSON.stringify({
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
-          },
-        }),
-        JSON.stringify({
-          type: 'user',
-          message: {
-            role: 'user',
-            content: [
-              { type: 'tool_result', tool_use_id: 'edit-1' },
-              { type: 'text', text: 'Shell cwd was reset to /home/user/project' },
-            ],
-          },
-        }),
-        JSON.stringify({
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'text', text: 'Parser refactored.' }],
-          },
-        }),
-      ].join('\n'),
-    );
+  it.each(['Write', 'Edit', 'MultiEdit', 'NotebookEdit'])(
+    'still reviews a turn with %s when its tool result carries a trailing note (S0RYNS)',
+    editToolName => {
+      // A user message may legally carry text blocks after its tool_result blocks,
+      // and the harness uses that to append notes to tool output. Those notes are
+      // not a human prompt: reading one as a turn start ends the turn early and
+      // skips the review on a turn that did edit files.
+      const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+      writeFileSync(
+        transcriptPath,
+        [
+          JSON.stringify({
+            type: 'user',
+            message: { role: 'user', content: [{ type: 'text', text: 'Refactor the parser.' }] },
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'tool_use', name: editToolName, id: 'edit-1' }],
+            },
+          }),
+          JSON.stringify({
+            type: 'user',
+            message: {
+              role: 'user',
+              content: [
+                { type: 'tool_result', tool_use_id: 'edit-1' },
+                { type: 'text', text: 'Shell cwd was reset to /home/user/project' },
+              ],
+            },
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'text', text: 'Parser refactored.' }],
+            },
+          }),
+        ].join('\n'),
+      );
 
-    const result = runStopHook(state.projectDirectory, transcriptPath);
+      const result = runStopHook(state.projectDirectory, transcriptPath);
 
-    expect(result.status).toBe(0);
-    const block = JSON.parse(result.stdout.trim()) as { decision?: string; reason?: string };
-    expect(block.decision).toBe('block');
-    expect(block.reason).toMatch(/\*\*CONFIDENT\*\*|decision brief/i);
-  });
+      expect(result.status).toBe(0);
+      const block = JSON.parse(result.stdout.trim()) as { decision?: string; reason?: string };
+      expect(block.decision).toBe('block');
+      expect(block.reason).toMatch(/quality review|\*\*CONFIDENT\*\*/i);
+      expect(block.reason).not.toMatch(/verify\.md/i);
+    },
+  );
 
   it('skips the review prompt when the user follow-up leads with a task notification', () => {
     const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');

--- a/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
+++ b/packages/cli/tests/integration/stop-hook-transcript-format.test.ts
@@ -401,6 +401,54 @@ describe('Stop Hook: Ticket Resolution Context', () => {
     expect(result.stdout.trim()).toBe('');
   });
 
+  it('still reviews an edited turn whose tool result carries a trailing note (S0RYNS)', () => {
+    // A user message may legally carry text blocks after its tool_result blocks,
+    // and the harness uses that to append notes to tool output. Those notes are
+    // not a human prompt: reading one as a turn start ends the turn early and
+    // skips the review on a turn that did edit files.
+    const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: [{ type: 'text', text: 'Refactor the parser.' }] },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'Edit', id: 'edit-1' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'edit-1' },
+              { type: 'text', text: 'Shell cwd was reset to /home/user/project' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Parser refactored.' }],
+          },
+        }),
+      ].join('\n'),
+    );
+
+    const result = runStopHook(state.projectDirectory, transcriptPath);
+
+    expect(result.status).toBe(0);
+    const block = JSON.parse(result.stdout.trim()) as { decision?: string; reason?: string };
+    expect(block.decision).toBe('block');
+    expect(block.reason).toMatch(/\*\*CONFIDENT\*\*|decision brief/i);
+  });
+
   it('skips the review prompt when the user follow-up leads with a task notification', () => {
     const transcriptPath = nodePath.join(state.projectDirectory, 'transcript.jsonl');
     writeFileSync(

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.75.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "33510190f28119c47a87ac8afff2a87a11adea57d3eb57e612527b2519d4cee5"
+  "inventory_sha256": "b8c3811f8cee8b24358cd241a0ff4a9f17e5adf272079d74416725223985e7ce"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -551,7 +551,7 @@
     },
     {
       "path": "runtime/hooks/stop-quality.ts",
-      "sha256": "f1f50fb9c5df53f65e496fc0815bf8766569e5f6deaa3b35404ef4e168f94e51"
+      "sha256": "2a375c66ccc0a2b8a0ee5fbc9c6717fc8f07e60515573c47a48273ae30452b88"
     },
     {
       "path": "runtime/hooks/stop-reentry.ts",

--- a/plugin/runtime/hooks/stop-quality.ts
+++ b/plugin/runtime/hooks/stop-quality.ts
@@ -480,7 +480,15 @@ function normalizeContentItems(content: ContentItem[] | string | undefined): Con
 function userMessageText(message: TranscriptMessage): string {
   if (message.type !== 'user' || message.isMeta) return '';
 
-  return normalizeContentItems(message.message?.content)
+  const content = normalizeContentItems(message.message?.content);
+
+  // A message that answers a tool call belongs to the turn already running, even
+  // when text follows the results — the API allows that ordering and the harness
+  // uses it to append notes to tool output. Reading such a note as a human prompt
+  // would end the turn early and skip the review on a turn that did edit files.
+  if (content.some(item => item.type === 'tool_result')) return '';
+
+  return content
     .filter((item): item is ContentItem & { text: string } => item.type === 'text' && !!item.text)
     .map(item => item.text)
     .join('\n')


### PR DESCRIPTION
Ticket S0RYNS. Closes the mixed-content gap the #2233 scenario review asked for.

## Problem

A user message may carry text blocks **after** its `tool_result` blocks. That is not an edge case — the API mandates the ordering, and the harness uses it to append notes to tool output:

> In the user message containing tool results, the tool_result blocks must come FIRST in the content array. Any text must come AFTER all tool results.
> — [handle-tool-calls](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls)

`humanPromptText` filters to text blocks and ignores the `tool_result` blocks entirely, so that trailing note reads as a human prompt. The backward scan in `detectEditToolsUsedInCurrentUserTurn` treats a mid-turn tool result as the start of a turn, stops there, and never reaches the edit that came before it.

Net effect: **the Stop quality review is skipped on a turn that did edit files** — the mirror image of the false positive #2233 fixed.

## Fix

A message containing any `tool_result` block answers a tool call and belongs to the turn already running, whatever text follows it. `humanPromptText` returns `''` for it.

## Tests

`tests/integration/stop-hook-transcript-format.test.ts` — one case: prompt → `Edit` → tool result with a trailing note → reply. The review must still fire. It exits silently before the fix (no stdout at all) and blocks after.

**Mutation-checked.** Forcing the new guard to fire on *every* user message fails exactly the four boundary-detection cases — string-form follow-up, genuine follow-up, reminder-prefixed, notification-prefixed — and leaves the new case green. The guard is scoped, not a blanket short-circuit that would make the new test pass for the wrong reason.

## Verification

- Full suite **6992 passed / 11 skipped / 12 failed**
- **Ten** failures reproduce on clean `main`: the `chmod`-based negative paths that cannot fail as uid 0, plus four review-subsystem timing/permission cases introduced by #2003
- **Two** — `setup-convergence` and `rust-golden-path` — pass in isolation both with and without this change, and fail only under full-suite parallelism. Treated as load flakes; I did not verify them in a full clean-`main` run, so that is an evidence limit rather than a cleared result
- `bun run lint` clean (eslint, lint-gherkin, `tsc --noEmit`), build clean
- Parity contracts in sync; `plugin/` mirror regenerated with pinned Bun 1.3.14

## Not fixed here

Three items from the #2233 scenario review remain open and are test-strengthening rather than behavior: mutation-tool parity across `Write`/`MultiEdit`/`NotebookEdit`, a discriminating notification-classification pair, and assertions that exclude competing gate reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SQCNKRNgwUQRcKc8Ck92h)_