### PR TITLE
Release v0.74.3-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.2",
+      "version": "0.74.3-rc.1",
       "source": "./plugin",
       "author": {
         "name": "safeword"

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.74.2",
+      "version": "0.74.3-rc.1",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.2",
+  "version": "0.74.3-rc.1",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.2 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.1 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.2 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.1 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.2 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.1 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.2 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.1 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.2 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.1 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.2",
+  "version": "0.74.3-rc.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/tests/claude-plugin/profile-install.test.ts
+++ b/packages/cli/tests/claude-plugin/profile-install.test.ts
@@ -110,7 +110,7 @@ describe('Claude marketplace update enrollment', () => {
   });
 
   it('does not migrate a stale marketplace while native auto-update is explicitly disabled', () => {
-    const { log, project, settingsPath } = fixture(false, `v${SAFEWORD_SCHEMA.version}`);
+    const { log, project, settingsPath } = fixture(false, 'v0.0.0');
     const before = readFileSync(settingsPath, 'utf8');
 
     const result = installClaudePlugin(project);

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.2",
+  "plugin_version": "0.74.3-rc.1",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "8e99b70f066e525533d551f7bc8f4150a69dbc96d975af1f335b10c7ee341185"
+  "inventory_sha256": "23e2b77d4533405c82d25894ea1cfeff8a336531dffd038facd40897246c87dd"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "f2e7c8022d02292f7e3a403608ac38934af9b3d25e2740d5bf57999eb6331cb3"
+      "sha256": "a0f2eb9b8b7145f655bd5c59cba248066f930c24e4cccd50f593bbcea6c90571"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.2",
+  "version": "0.74.3-rc.1",
   "type": "module"
 }

--- a/steps/native-claude-plugin.steps.ts
+++ b/steps/native-claude-plugin.steps.ts
@@ -70,7 +70,9 @@ interface NativeClaudePluginWorld {
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '..');
 const PLUGIN_ROOT = nodePath.join(REPO_ROOT, 'plugin');
 const EXPECTED_VERSION = SAFEWORD_SCHEMA.version;
-const OFFICIAL_MARKETPLACE_SOURCE = 'https://github.com/ArcadeAI/safeword.git#stable';
+const OFFICIAL_MARKETPLACE_REF = EXPECTED_VERSION.includes('-') ? `v${EXPECTED_VERSION}` : 'stable';
+const OFFICIAL_MARKETPLACE_SOURCE = `https://github.com/ArcadeAI/safeword.git#${OFFICIAL_MARKETPLACE_REF}`;
+const MARKETPLACE_REGISTRATION_KIND = EXPECTED_VERSION.includes('-') ? 'add' : 'update';
 
 function pluginCachePath(root: string): string {
   return nodePath.join(root, 'cache', 'safeword', EXPECTED_VERSION);
@@ -2825,7 +2827,7 @@ Then(
       state.marketplaceDeclarations.some(
         marketplace =>
           marketplace.name === 'safeword' &&
-          marketplace.ref === 'stable' &&
+          marketplace.ref === OFFICIAL_MARKETPLACE_REF &&
           marketplace.scope === scope &&
           (scope !== 'project' || marketplace.projectPath === this.lifecycle?.project),
       ),
@@ -2950,7 +2952,7 @@ Then(
       source: {
         source: 'git',
         url: OFFICIAL_MARKETPLACE_SOURCE.split('#')[0],
-        ref: 'stable',
+        ref: OFFICIAL_MARKETPLACE_REF,
       },
     });
     assert.equal(settings.env?.CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE, '1');
@@ -3043,7 +3045,7 @@ Then(
       effects?: { configuration?: unknown[] };
     };
     assert.deepEqual(result.effects?.configuration, [
-      { kind: 'update', target: 'safeword', operation: 'project' },
+      { kind: MARKETPLACE_REGISTRATION_KIND, target: 'safeword', operation: 'project' },
       { kind: 'enable', target: 'safeword marketplace auto-update', operation: 'project' },
       {
         kind: 'enable',
@@ -3079,7 +3081,7 @@ Then(
       completedEffects === 'no mutation'
         ? []
         : [
-            { kind: 'update', target: 'safeword', operation: 'user' },
+            { kind: MARKETPLACE_REGISTRATION_KIND, target: 'safeword', operation: 'user' },
             { kind: 'enable', target: 'safeword marketplace auto-update', operation: 'user' },
             {
               kind: 'enable',
@@ -3287,7 +3289,7 @@ Then(
         name: 'safeword',
         source: 'git',
         url: 'https://github.com/ArcadeAI/safeword.git',
-        ref: 'stable',
+        ref: OFFICIAL_MARKETPLACE_REF,
       },
     ]);
     assert.deepEqual(state.plugins, [


### PR DESCRIPTION
## Summary

- bump CLI, Claude plugin, and Codex plugin contracts to 0.74.3-rc.1
- regenerate the published Claude plugin identity and inventory
- publish a release candidate for the required previous-stable-to-candidate real-host acceptance gate

## Verification

- Claude plugin release contract
- release-gate suite: 34/34
- repository formatting

## Release plan

After CI passes, admin-merge and tag this merge commit as v0.74.3-rc.1. The release workflow will publish it under npm dist-tag `next`. Then run the isolated Claude 0.74.2 → 0.74.3-rc.1 acceptance gate before preparing stable 0.74.3.