### PR TITLE
Fix Claude skill invocation hooks

### DIFF
--- a/packages/cli/src/claude-plugin/catalogue.ts
+++ b/packages/cli/src/claude-plugin/catalogue.ts
@@ -85,6 +85,24 @@ function adaptWorkflowReference(content: string): string {
   return adaptProjectFrameworkDirectory(adapted, 'skills', 'skills');
 }
 
+/**
+ * Claude Code evaluates a skill's `!` command before it expands it. Recent
+ * clients reject command substitution there, so the host-neutral project-root
+ * fallback (`$(git rev-parse … || pwd)`) never reaches the proof helper.
+ * Native Claude plugin sessions always provide CLAUDE_PROJECT_DIR; rewrite only
+ * inline skill commands to use that host contract directly.
+ */
+function adaptClaudeSkill(content: string): string {
+  const adapted = adaptWorkflowReference(content).replaceAll(
+    '!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && ',
+    '!`',
+  );
+  return adapted.replaceAll(
+    /^!`([^`\n]*)`$/gmu,
+    (_line, command: string) => `!\`${command.replaceAll('$PROJECT_DIR', '$CLAUDE_PROJECT_DIR')}\``,
+  );
+}
+
 function adaptPluginScriptReference(content: string): string {
   return adaptWorkflowReference(content).replaceAll(
     "from '../hooks/",
@@ -421,7 +439,7 @@ export function generateClaudePluginAssets(
       relativePath: 'package.json',
       content: `${JSON.stringify({ name: 'safeword', version, type: 'module' }, undefined, 2)}\n`,
     },
-    ...directoryAssets(nodePath.join(templatesRoot, 'skills'), 'skills', adaptWorkflowReference),
+    ...directoryAssets(nodePath.join(templatesRoot, 'skills'), 'skills', adaptClaudeSkill),
     ...directoryAssets(nodePath.join(templatesRoot, 'agents'), 'agents', adaptWorkflowReference),
     ...claudeHookAssets(templatesRoot),
     {

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -55,7 +55,7 @@ describe('Claude plugin release contract', () => {
     );
 
     expect(skill).toContain(
-      '!`bun "${CLAUDE_PLUGIN_ROOT}"/runtime/hooks/record-skill-invocation.ts "$CLAUDE_PROJECT_DIR" quality-review',
+      '!`bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$CLAUDE_PROJECT_DIR" quality-review',
     );
     expect(skill).not.toContain('$(git rev-parse');
   });

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -57,7 +57,7 @@ describe('Claude plugin release contract', () => {
     expect(skill).toContain(
       '!`bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$CLAUDE_PROJECT_DIR" quality-review',
     );
-    expect(skill).not.toContain('$(git rev-parse');
+    expect(skill).not.toMatch(/^!`[^`\n]*\$\(/mu);
   });
 
   it('promotes one monotonic stable channel only after stable publication', () => {

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -48,6 +48,18 @@ describe('Claude plugin release contract', () => {
     }
   });
 
+  it('uses Claude project metadata directly for inline native skill commands', () => {
+    const skill = readFileSync(
+      nodePath.join(REPO_ROOT, 'plugin/skills/quality-review/SKILL.md'),
+      'utf8',
+    );
+
+    expect(skill).toContain(
+      '!`bun "${CLAUDE_PLUGIN_ROOT}"/runtime/hooks/record-skill-invocation.ts "$CLAUDE_PROJECT_DIR" quality-review',
+    );
+    expect(skill).not.toContain('$(git rev-parse');
+  });
+
   it('promotes one monotonic stable channel only after stable publication', () => {
     const workflow = readFileSync(
       nodePath.join(REPO_ROOT, '.github/workflows/release.yml'),

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.3-rc.1",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "23e2b77d4533405c82d25894ea1cfeff8a336531dffd038facd40897246c87dd"
+  "inventory_sha256": "bbea7ebc049ce51e4ca6fd3b015d9d5267eaf102ccd9af14f0b6c423c989bfc1"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -555,7 +555,7 @@
     },
     {
       "path": "skills/audit/SKILL.md",
-      "sha256": "7cd41e819a8bc372c86526b588c1434bb080f1cadf63a9b6d86ddeed09b169b6"
+      "sha256": "dd9e73adc108072a1d1ff50669e0861af37c51e147286f4888aeb03948b435f2"
     },
     {
       "path": "skills/bdd/DISCOVERY.md",
@@ -631,7 +631,7 @@
     },
     {
       "path": "skills/quality-review/SKILL.md",
-      "sha256": "c1a5a0f2235464e50e0d0c38a2e8e1c0330b0161d81e7401231e86c2159689ee"
+      "sha256": "154c4587a4388b916a775afc1f18a476d688a77a399d258f6fcb0c76c8fe44f8"
     },
     {
       "path": "skills/refactor/SKILL.md",
@@ -651,7 +651,7 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "sha256": "eb3c417c7a4e218efc92d58e60e32d077eb4556803a1aed5c0d32af86817c060"
+      "sha256": "0e10e88553bca93ffc15f798ee8c6642dc65a9045296208d759afb9984279bf1"
     },
     {
       "path": "skills/spike/SKILL.md",
@@ -671,7 +671,7 @@
     },
     {
       "path": "skills/verify/SKILL.md",
-      "sha256": "a39c2d67f90588aefb820f58a9aad718e7baa972ae257a33747c99eac9dabe82"
+      "sha256": "762012f71db24e177ecca779c23c77f642e875d95a7d1cf1e2e7aeb6b77b47c2"
     }
   ]
 }

--- a/plugin/skills/audit/SKILL.md
+++ b/plugin/skills/audit/SKILL.md
@@ -16,7 +16,7 @@ Run a diff-scoped code audit. Execute checks and report results by severity.
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /audit was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing audit results cannot produce this feature-gate proof.
 
-!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$PROJECT_DIR" audit "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
+!`bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$CLAUDE_PROJECT_DIR" audit "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
 
 If no `[skill-invocation-log] audit ✓` line appears above, run this fallback before continuing:
 

--- a/plugin/skills/quality-review/SKILL.md
+++ b/plugin/skills/quality-review/SKILL.md
@@ -16,7 +16,7 @@ Deep review with research to verify a work-product — code, docs, specs, plans,
 
 Required at the done-gate for tickets with **two or more RGR loops** (W610WW). The line below logs a current-run entry to `skill-invocations.log` under the project namespace root so the done-gate hook can verify /quality-review actually ran; Claude Code expands the `!` line automatically. On Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id, so the fallback runs on all three runtimes without hand-picking one. Hand-writing review notes cannot produce this gate proof.
 
-!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$PROJECT_DIR" quality-review "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
+!`bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$CLAUDE_PROJECT_DIR" quality-review "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
 
 If no `[skill-invocation-log] quality-review ✓` line appears above, run this fallback before continuing:
 

--- a/plugin/skills/self-review/SKILL.md
+++ b/plugin/skills/self-review/SKILL.md
@@ -26,7 +26,7 @@ content** and appends it to `skill-invocations.log` under the project namespace 
 per-asset gate reads it back. Invoking this skill is what writes the stamp —
 hand-editing the log is the gameable floor this tier deliberately accepts.
 
-!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && CLAUDE_PROJECT_DIR="$PROJECT_DIR" bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/write-review-stamp.ts" spec`
+!`CLAUDE_PROJECT_DIR="$CLAUDE_PROJECT_DIR" bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/write-review-stamp.ts" spec`
 
 If no `[skill-invocation-log] ... ✓` line appears above, run this fallback before stopping:
 

--- a/plugin/skills/verify/SKILL.md
+++ b/plugin/skills/verify/SKILL.md
@@ -25,7 +25,7 @@ ticket completion.
 
 This skill is required at the feature-ticket done-gate (ticket 147). The line below appends a current-run entry to `skill-invocations.log` under the project namespace root (`.project/`, or legacy `.safeword-project/` where that exists) so the done-gate hook can verify /verify was actually invoked. Claude Code expands the `!` line automatically and passes `${CLAUDE_SESSION_ID}` when available. The helper also resolves Claude remote-container ids from the runtime environment, and on Cursor and Codex the pre-shell hook (beforeShellExecution / PreToolUse) bridges the session id to the helper — so on all three runtimes the fallback runs without hand-picking an id. Hand-writing verify.md cannot produce this feature-gate proof.
 
-!`PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}" && bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$PROJECT_DIR" verify "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
+!`bun "${CLAUDE_PLUGIN_ROOT}/runtime/hooks/record-skill-invocation.ts" "$CLAUDE_PROJECT_DIR" verify "${CLAUDE_SESSION_ID:-}" || echo "[skill-invocation-log] FAILED - no current-run proof logged"`
 
 If no `[skill-invocation-log] verify ✓` line appears above, run this fallback before continuing:
 


### PR DESCRIPTION
## Summary\n- remove command substitution from generated native-Claude inline skill invocations\n- use Claude's guaranteed project directory environment instead\n- add a release-contract guard for the generated command\n\n## Validation\n- CLI Building entry: src/index.ts, src/main.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/alex/.codex/worktrees/4e4a/safeword/packages/retro-relay/tsup.config.ts
CLI Target: node22
CLI Cleaning output folder
ESM Build start
ESM dist/index.js              3.30 KB
ESM dist/main.js               848.00 B
ESM dist/chunk-32UTR6LA.js     86.69 KB
ESM dist/main.js.map           1.56 KB
ESM dist/index.js.map          6.01 KB
ESM dist/chunk-32UTR6LA.js.map 160.97 KB
ESM ⚡️ Build success in 110ms
DTS Build start
DTS ⚡️ Build success in 19385ms
DTS dist/main.d.ts  13.00 B
DTS dist/index.d.ts 9.42 KB

 RUN  v4.1.10 /Users/alex/.codex/worktrees/4e4a/safeword/packages/retro-relay

 ❯ tests/runtime-qualification.test.ts (10 tests | 1 failed | 1 skipped) 11010ms
     × allows only one process to acquire the released lock database 6148ms
 ❯ tests/spike-safety.test.ts (8 tests | 1 failed) 27916ms
     × rejects incomplete or secret-bearing reports 12441ms

 Test Files  2 failed | 6 passed (8)
      Tests  2 failed | 165 passed | 1 skipped (168)
   Start at  11:58:02
   Duration  48.42s (transform 68.14s, setup 0ms, import 99.13s, tests 85.45s, environment 10ms)\n- \n- real Claude 2.1.170 candidate acceptance reproduced the prior failure and showed the canonical candidate helper path\n\nThis unblocks the required public-candidate host acceptance retry before stable 0.74.3 publication.