### PR TITLE
Release 0.74.3-rc.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.3-rc.2",
+      "version": "0.74.3-rc.3",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.74.3-rc.2",
+      "version": "0.74.3-rc.3",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.2",
+  "version": "0.74.3-rc.3",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.2 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.2 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.2 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.2 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.2 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.2",
+  "version": "0.74.3-rc.3",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.3-rc.2",
+  "plugin_version": "0.74.3-rc.3",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "d609a87548acf54004d8310c3116b7677d23ecdc716668242d222c3d973a84ca"
+  "inventory_sha256": "5fd10df0d40de7ee1e2d9bcaf3b1df306bd10720d20c49a7e17a1a42064cc73d"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "b5b336464436f40eece199872aa0ae224c40952ec0322186d7fe3ac36823493b"
+      "sha256": "4adeb1eed70be8041a8a913dd66b59fcbb6828beb4f31b1b9f465ad931a9ecb8"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.2",
+  "version": "0.74.3-rc.3",
   "type": "module"
 }


### PR DESCRIPTION
## Release candidate

Publishes `0.74.3-rc.3` from current `main`, including #2249's native Claude skill-discovery fix.

## Validation

- deterministic Codex headless activation: 5/5 passed
- release-gate suite: 36/36 passed
- Claude plugin regenerated and version/inventory identity aligned
- all four release-tracked version surfaces and `bun.lock` aligned at `0.74.3-rc.3`

After merge, the annotated tag will publish through the OIDC release workflow. Stable `0.74.3` remains blocked on the authenticated disposable-profile Claude native-host acceptance gate.
