### PR TITLE
chore(release): v0.74.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.3-rc.3",
+      "version": "0.74.3",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.3",
+  "version": "0.74.3",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.3-rc.3 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.3 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.3",
+  "version": "0.74.3",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/tests/cli-protocol/plan-remove-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/plan-remove-wiring.test.ts
@@ -8,6 +8,9 @@ import { createTemporaryDirectory, runCli } from '../helpers.js';
 import { installFakeCodexRuntime } from '../helpers/fake-codex-runtime.js';
 
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+const CURRENT_MARKETPLACE_REF = SAFEWORD_SCHEMA.version.includes('-')
+  ? `v${SAFEWORD_SCHEMA.version}`
+  : 'stable';
 
 function configureMinimalProject(directory: string): void {
   mkdirSync(nodePath.join(directory, '.safeword'), { recursive: true });
@@ -55,7 +58,7 @@ function createUserScopedClaudeHost(
             source: {
               source: 'git',
               url: 'https://github.com/ArcadeAI/safeword.git',
-              ref: `v${SAFEWORD_SCHEMA.version}`,
+              ref: CURRENT_MARKETPLACE_REF,
             },
             autoUpdate,
           },
@@ -72,7 +75,7 @@ printf '%s\n' "$*" >> ${JSON.stringify(log)}
 case "$*" in
   '--version') echo '2.1.170' ;;
   'plugin marketplace list --json')
-    ${marketplaceCurrent ? `echo '[{"name":"safeword","source":{"url":"https://github.com/ArcadeAI/safeword.git","ref":"v${SAFEWORD_SCHEMA.version}"}}]'` : "echo '[]'"}
+    ${marketplaceCurrent ? `echo '[{"name":"safeword","source":{"url":"https://github.com/ArcadeAI/safeword.git","ref":"${CURRENT_MARKETPLACE_REF}"}}]'` : "echo '[]'"}
     ;;
   'plugin list --json')
     if [ -f ${JSON.stringify(removed)} ]; then

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.3-rc.3",
+  "plugin_version": "0.74.3",
   "hook_manifest_sha256": "e2919a15d4ab1838c26d5679dd0167a119960a74752b1dd1a3f404d6e500fef0",
-  "inventory_sha256": "5fd10df0d40de7ee1e2d9bcaf3b1df306bd10720d20c49a7e17a1a42064cc73d"
+  "inventory_sha256": "6806f217145b4276acc909b8efa4f2fbeb66baa21d2bfc46446e5054e6512a2a"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "4adeb1eed70be8041a8a913dd66b59fcbb6828beb4f31b1b9f465ad931a9ecb8"
+      "sha256": "ff5b582d80d501edc76a7d520be238097c9e6e23ba0c3088f27f853d99aac208"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.3-rc.3",
+  "version": "0.74.3",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- promote the accepted 0.74.3-rc.3 payload to stable 0.74.3
- align npm, Claude plugin, Codex plugin, pinned hook commands, and generated Claude plugin identity

## Verification

- release suite: 10 files, 36 tests passed
- native Claude Code upgrade acceptance passed against 0.74.3-rc.3 in an isolated profile
- candidate source, cache root, execution proof, sentinel preservation, reload, skill activation, and idempotent reinstall all verified
- RC release workflow: https://github.com/ArcadeAI/safeword/actions/runs/31264522577

Stable publication remains tag-driven after this PR merges.