### PR TITLE
Prevent lint formatting flags from reaching Prettier

### DIFF
--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -35,7 +35,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/.cursor/commands/lint.md
+++ b/.cursor/commands/lint.md
@@ -30,7 +30,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/.safeword/skills/lint/SKILL.md
+++ b/.safeword/skills/lint/SKILL.md
@@ -35,7 +35,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
     "file-type": "^21.3.2",
     "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "turbo": "2.9.18",
     "yaml": "^2.9.0",
@@ -1986,7 +1986,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fast-uri": "3.1.5",
     "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "turbo": "2.9.18",
     "yaml": "^2.9.0",

--- a/packages/cli/codex-plugin/skills/lint/SKILL.md
+++ b/packages/cli/codex-plugin/skills/lint/SKILL.md
@@ -33,7 +33,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -44,7 +44,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/finish-review/SKILL.md':
         'e9ed5d198994b6cca12c62b1a4c13a1db2d82d65fc8a9173a41c5b5cf312cd52',
       '.claude/skills/lint/SKILL.md':
-        '208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66',
+        'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
         'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
       '.claude/skills/refactor/SKILL.md':

--- a/packages/cli/templates/commands/lint.md
+++ b/packages/cli/templates/commands/lint.md
@@ -30,7 +30,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/packages/cli/templates/skills/lint/SKILL.md
+++ b/packages/cli/templates/skills/lint/SKILL.md
@@ -35,7 +35,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }

--- a/packages/cli/tests/skills/lint-skill-exit-status.test.ts
+++ b/packages/cli/tests/skills/lint-skill-exit-status.test.ts
@@ -18,6 +18,7 @@ const REPOSITORY_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 const LINT_SURFACES = [
   'packages/cli/templates/skills/lint/SKILL.md',
   'packages/cli/templates/commands/lint.md',
+  '.safeword/skills/lint/SKILL.md',
   '.claude/skills/lint/SKILL.md',
   '.cursor/commands/lint.md',
   'packages/cli/codex-plugin/skills/lint/SKILL.md',
@@ -39,9 +40,10 @@ function writeExecutable(directory: string, name: string, body: string): void {
 function runLintInstructions(
   relativePath: string,
   options: { hasGoManifest?: boolean } = {},
-): { status: number | null; goCommands: string[] } {
+): { status: number | null; bunCommands: string[]; goCommands: string[] } {
   const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-lint-skill-'));
   const binDirectory = nodePath.join(projectDirectory, 'fake-bin');
+  const bunCommandsPath = nodePath.join(projectDirectory, 'bun-commands.log');
   const goCommandsPath = nodePath.join(projectDirectory, 'go-commands.log');
 
   try {
@@ -50,7 +52,7 @@ function runLintInstructions(
     if (options.hasGoManifest)
       writeFileSync(nodePath.join(projectDirectory, 'go.mod'), 'module example\n');
 
-    writeExecutable(binDirectory, 'bun', 'exit 0');
+    writeExecutable(binDirectory, 'bun', String.raw`printf '%s\n' "$*" >> "${bunCommandsPath}"`);
     writeExecutable(binDirectory, 'bunx', 'exit 0');
     writeExecutable(
       binDirectory,
@@ -66,6 +68,9 @@ function runLintInstructions(
 
     return {
       status: result.status,
+      bunCommands: existsSync(bunCommandsPath)
+        ? readFileSync(bunCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
+        : [],
       goCommands: existsSync(goCommandsPath)
         ? readFileSync(goCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
         : [],
@@ -75,11 +80,12 @@ function runLintInstructions(
   }
 }
 
-describe('lint instructions exit status (#1701)', () => {
+describe('lint instruction command behavior (#1701, #2060)', () => {
   it.each(LINT_SURFACES)('%s succeeds for a JavaScript-only project', relativePath => {
     const result = runLintInstructions(relativePath);
 
     expect(result.status).toBe(0);
+    expect(result.bunCommands).toContain('run --if-present format');
     expect(result.goCommands).toEqual([]);
   });
 

--- a/packages/cli/tests/skills/lint-skill-exit-status.test.ts
+++ b/packages/cli/tests/skills/lint-skill-exit-status.test.ts
@@ -37,6 +37,12 @@ function writeExecutable(directory: string, name: string, body: string): void {
   chmodSync(executablePath, 0o755);
 }
 
+function readCommandLog(logPath: string): string[] {
+  return existsSync(logPath)
+    ? readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+}
+
 function runLintInstructions(
   relativePath: string,
   options: { hasGoManifest?: boolean } = {},
@@ -68,12 +74,8 @@ function runLintInstructions(
 
     return {
       status: result.status,
-      bunCommands: existsSync(bunCommandsPath)
-        ? readFileSync(bunCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
-        : [],
-      goCommands: existsSync(goCommandsPath)
-        ? readFileSync(goCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
-        : [],
+      bunCommands: readCommandLog(bunCommandsPath),
+      goCommands: readCommandLog(goCommandsPath),
     };
   } finally {
     rmSync(projectDirectory, { recursive: true, force: true });

--- a/packages/cli/tests/skills/lint-skill-exit-status.test.ts
+++ b/packages/cli/tests/skills/lint-skill-exit-status.test.ts
@@ -43,6 +43,20 @@ function readCommandLog(logPath: string): string[] {
     : [];
 }
 
+function installFakeLintTools(
+  binDirectory: string,
+  bunCommandsPath: string,
+  goCommandsPath: string,
+): void {
+  writeExecutable(binDirectory, 'bun', String.raw`printf '%s\n' "$*" >> "${bunCommandsPath}"`);
+  writeExecutable(binDirectory, 'bunx', 'exit 0');
+  writeExecutable(
+    binDirectory,
+    'golangci-lint',
+    String.raw`printf '%s\n' "$*" >> "${goCommandsPath}"`,
+  );
+}
+
 function runLintInstructions(
   relativePath: string,
   options: { hasGoManifest?: boolean } = {},
@@ -58,13 +72,7 @@ function runLintInstructions(
     if (options.hasGoManifest)
       writeFileSync(nodePath.join(projectDirectory, 'go.mod'), 'module example\n');
 
-    writeExecutable(binDirectory, 'bun', String.raw`printf '%s\n' "$*" >> "${bunCommandsPath}"`);
-    writeExecutable(binDirectory, 'bunx', 'exit 0');
-    writeExecutable(
-      binDirectory,
-      'golangci-lint',
-      String.raw`printf '%s\n' "$*" >> "${goCommandsPath}"`,
-    );
+    installFakeLintTools(binDirectory, bunCommandsPath, goCommandsPath);
 
     const result = spawnSync('bash', ['-c', extractLintBlock(relativePath)], {
       cwd: projectDirectory,

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "f6591677db751d8d3c06502a89251d32f662ca5935971190ad665cfa84b95b3b"
+  "inventory_sha256": "191d728f161ca6a89284d4d3bcd27492a9909be6dc5dfc3e8004506ed1fb67aa"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,11 +139,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "3b94425f06f6bb7ff67811d8c45bc315babe05cac353cdfc9afdbbb452996d9b"
+      "sha256": "fdc64fe4a2f04aecbea42f8a67382bc33057dd4a3346f890f55a6ca069317b26"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "603cd7b51bdb52688423e49cabbb1a3fc8b82256c380689d35af490a1f72b8f4"
+      "sha256": "9538359bfae1979fb8cb9181186ff8804bb5f70e8d9bf0c277c2eb99198e5dff"
     },
     {
       "path": "runtime/event-groups.json",
@@ -655,7 +655,7 @@
     },
     {
       "path": "skills/lint/SKILL.md",
-      "sha256": "208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66"
+      "sha256": "fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19"
     },
     {
       "path": "skills/quality-review/SKILL.md",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -6110,7 +6110,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/figure-it-out/SKILL.md": "18e2b44e9a91562079b3e1f52fcd9f952b5f57a0f0e7647b0273809848a75c0d",
         ".claude/skills/finish-review/REVIEWER.md": "0ecee21a63f91e09d3136f62cf8f7590ba9a640b85cad7b7b35c1ae334ff43c2",
         ".claude/skills/finish-review/SKILL.md": "e9ed5d198994b6cca12c62b1a4c13a1db2d82d65fc8a9173a41c5b5cf312cd52",
-        ".claude/skills/lint/SKILL.md": "208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66",
+        ".claude/skills/lint/SKILL.md": "fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19",
         ".claude/skills/quality-review/SKILL.md": "b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a",
         ".claude/skills/refactor/SKILL.md": "a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e",
         ".claude/skills/retro-filer/SKILL.md": "ea126f3805a2befefb4db2011439f075ebfd6eca31b78bd5f284ac11d667b4f0",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1798,7 +1798,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/finish-review/SKILL.md':
         'e9ed5d198994b6cca12c62b1a4c13a1db2d82d65fc8a9173a41c5b5cf312cd52',
       '.claude/skills/lint/SKILL.md':
-        '208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66',
+        'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
         'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
       '.claude/skills/refactor/SKILL.md':

--- a/plugin/skills/lint/SKILL.md
+++ b/plugin/skills/lint/SKILL.md
@@ -35,7 +35,7 @@ Run these commands based on project type. All detected languages run for polyglo
     bun run lint 2>&1 || true
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  bun run --if-present format 2>&1 || true
   # TypeScript type check (if tsconfig.json exists)
   [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
 }


### PR DESCRIPTION
Closes #2060.

## What changed

- move Bun's `--if-present` option before the `format` script name across every managed lint surface
- add regression coverage that executes all six shipped lint surfaces and records Bun's received arguments
- refactor the regression harness with shared command-log parsing and isolated fake-tool setup
- regenerate the Claude plugin catalogue after the canonical skill change
- update `nanoid` from 3.3.17 to 3.3.18 to clear the dependency-audit advisory

## Root cause

`bun run format --if-present` places the option after the script name, so Bun forwards it to the `format` script. In projects where `format` runs Prettier, Prettier receives the unknown option and prints a warning. `bun run --if-present format` keeps the option scoped to Bun.

## Audit and refactor

- diff-scoped Safeword audit: 0 errors and 0 warnings after remediation
- dependency audit: no vulnerabilities found
- refactor pass: applied both justified behavior-preserving test-harness extractions; no production refactor warranted
- documentation impact: none; this is an implementation-level command-order correction

## Validation

- focused lint-surface regression: 12/12 passed after each refactor
- lint, formatting, typecheck, build, dependency architecture, plugin freshness, CLI contract, and parity checks passed locally
- dependency architecture: 0 errors; one pre-existing orphan warning
- current-head GitHub Actions: https://github.com/ArcadeAI/safeword/actions/runs/31870475040
- template parity: 254 pairs and 8 contracts in sync
