### PR TITLE
Keep CLI status reliable for large Claude plugin inventories

### DIFF
--- a/.project/tickets/6GMJAV-reliable-large-claude-plugin-inventories/ticket.md
+++ b/.project/tickets/6GMJAV-reliable-large-claude-plugin-inventories/ticket.md
@@ -1,0 +1,27 @@
+---
+id: 6GMJAV
+slug: reliable-large-claude-plugin-inventories
+type: patch
+phase: intake
+status: in_progress
+created: 2026-08-09T02:54:59.550Z
+last_modified: 2026-08-09T02:54:59.550Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/2291
+---
+
+# Keep CLI status reliable for large Claude plugin inventories
+
+**Goal:** Capture and parse valid large Claude plugin inventories without turning status into a failure.
+
+**Why:** Claude plugin output can exceed the host call buffer and be truncated into invalid JSON.
+
+## Work Log
+
+- 2026-08-09T02:54:59.550Z Started: Created ticket 6GMJAV
+- 2026-08-09T03:00:00.000Z Found: A valid 65,700-byte `claude plugin list --json` response is truncated at 65,536 bytes by `runClaude`, causing status to fail with `CLAUDE_PROFILE_OUTPUT_INVALID`.
+- 2026-08-09T03:00:00.000Z Planned: Prove the public Claude observation boundary with a large valid inventory, then add a documented bounded capture size and isolate CLI status tests from the developer profile.
+- 2026-08-09T03:05:00.000Z Implemented: Claude stdout is captured through a temporary regular file, bounded at 10 MiB before parsing, and always cleaned up.
+- 2026-08-09T03:05:00.000Z Verified: Large and oversized host-output cases plus both formerly host-dependent status suites pass (23 tests); targeted ESLint, Prettier, TypeScript, and whitespace checks pass.
+- 2026-08-09T03:25:00.000Z Review: Corrected operational-error classification, normalized omitted user scope across observation and verification, added a 30-second host timeout, and expanded focused coverage to 26 passing tests.
+- 2026-08-09T03:25:00.000Z Scoped: Filed follow-up #2293 for the reviewer-raised installed-payload trust-root question; it predates and is independent of this host-output patch.
+- 2026-08-09T03:50:00.000Z Verified: Full repository tests pass (CLI 7,109 passed/5 skipped; relay 167 passed/1 skipped), full lint/format/typecheck pass, dependency audit reports no vulnerabilities, and whitespace is clean.

--- a/.safeword/logs/ticket-6GMJAV-reliable-large-claude-plugin-inventories.md
+++ b/.safeword/logs/ticket-6GMJAV-reliable-large-claude-plugin-inventories.md
@@ -1,0 +1,21 @@
+# Work Log: Keep CLI status reliable for large Claude plugin inventories
+
+**Anchored to:** `.project/tickets/6GMJAV-reliable-large-claude-plugin-inventories/ticket.md`
+
+---
+
+## Session: 2026-08-08
+
+- [16:52] Full verification for PR #2290 failed two bare-status assertions with exit code 1 instead of 2.
+- [16:54] Confirmed the failures reproduce in isolation, excluding full-suite ordering pollution.
+- [16:55] Confirmed Claude emits 65,700 bytes of valid JSON while Safeword receives a response truncated at 65,536 bytes.
+- [16:56] Created GitHub issue #2291 before adopting it as local ticket 6GMJAV.
+- [17:00] Test plan: use the real `claude` subprocess boundary with a fake executable returning a valid inventory above 64 KiB; assert observation remains current. Then rerun the two user-facing status tests to prove the original failure is gone.
+- [17:01] RED: the >64 KiB public-observer test returned `errored` when its fake host reproduced Claude pipe truncation.
+- [17:02] GREEN: redirecting stdout to a temporary regular file returned the complete inventory; output above 10 MiB is rejected before parsing.
+- [17:03] Found: status tests also inherited real Claude/Codex profile state. Replaced that dependency with supported fake host executables at the process boundary.
+- [17:05] Focused verification passed: 23 tests across profile observation and both CLI status suites; targeted lint, format, typecheck, and whitespace gates also passed.
+- [17:13] Quality review found operational version-probe failures were mislabeled unsupported. Added error-code-specific mapping and coverage for oversized stdout and stderr.
+- [17:20] Quality re-review found inconsistent default user-scope handling. Centralized scope normalization across matching, public observation, and install verification; added omitted-scope coverage.
+- [17:25] Final degraded review raised a pre-existing payload trust-root concern without authoritative provenance. Filed GitHub #2293 for separate threat-model investigation; no trust-model changes were folded into #2291.
+- [17:50] Full verification passed: CLI 7,109 tests passed/5 skipped; relay 167 passed/1 skipped; repository lint, format, typecheck, dependency audit, and whitespace gates are green.

--- a/packages/cli/src/claude-plugin/profile.ts
+++ b/packages/cli/src/claude-plugin/profile.ts
@@ -1,7 +1,17 @@
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
 import { parse, type ParseError } from 'jsonc-parser';
@@ -21,6 +31,8 @@ import { canonicalClaudeProjectRoot } from './project-root.js';
 export { canonicalClaudeProjectRoot } from './project-root.js';
 
 const MINIMUM_CLAUDE_VERSION = [2, 1, 170] as const;
+const CLAUDE_COMMAND_TIMEOUT_MS = 30_000;
+const MAXIMUM_CLAUDE_OUTPUT_BYTES = 10 * 1024 * 1024;
 const MARKETPLACE_NAME = 'safeword';
 const MARKETPLACE_BASE = 'https://github.com/ArcadeAI/safeword.git';
 
@@ -64,24 +76,67 @@ class ClaudeProfileError extends Error {
 }
 
 function runClaude(cwd: string, arguments_: readonly string[], effects: readonly Effect[]): string {
-  const result = spawnSync('claude', arguments_, { cwd, encoding: 'utf8' });
-  if (result.error !== undefined) {
-    throw new ClaudeProfileError(
-      'CLAUDE_HOST_UNAVAILABLE',
-      `Claude Code could not be started: ${result.error.message}`,
-      effects,
-    );
+  const outputDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-claude-output-'));
+  const outputPath = nodePath.join(outputDirectory, 'stdout');
+  const outputDescriptor = openSync(outputPath, 'w');
+  let outputOpen = true;
+
+  try {
+    const result = spawnSync('claude', arguments_, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: MAXIMUM_CLAUDE_OUTPUT_BYTES,
+      stdio: ['ignore', outputDescriptor, 'pipe'],
+      timeout: CLAUDE_COMMAND_TIMEOUT_MS,
+    });
+    closeSync(outputDescriptor);
+    outputOpen = false;
+
+    if (result.error !== undefined) {
+      const errorCode = (result.error as NodeJS.ErrnoException).code;
+      if (errorCode === 'ENOBUFS') {
+        throw new ClaudeProfileError(
+          'CLAUDE_PROFILE_OUTPUT_TOO_LARGE',
+          `Claude command output exceeded ${MAXIMUM_CLAUDE_OUTPUT_BYTES} bytes: claude ${arguments_.join(' ')}`,
+          effects,
+        );
+      }
+      if (errorCode !== 'ENOENT') {
+        throw new ClaudeProfileError(
+          'CLAUDE_PROFILE_COMMAND_FAILED',
+          `Claude command could not complete: claude ${arguments_.join(' ')} (${result.error.message})`,
+          effects,
+        );
+      }
+      throw new ClaudeProfileError(
+        'CLAUDE_HOST_UNAVAILABLE',
+        `Claude Code could not be started: ${result.error.message}`,
+        effects,
+      );
+    }
+    const outputBytes = statSync(outputPath).size;
+    if (outputBytes > MAXIMUM_CLAUDE_OUTPUT_BYTES) {
+      throw new ClaudeProfileError(
+        'CLAUDE_PROFILE_OUTPUT_TOO_LARGE',
+        `Claude command output exceeded ${MAXIMUM_CLAUDE_OUTPUT_BYTES} bytes: claude ${arguments_.join(' ')}`,
+        effects,
+      );
+    }
+    const output = readFileSync(outputPath, 'utf8');
+    if (result.status !== 0) {
+      const detail = `${result.stderr ?? ''}${output}`.trim();
+      const detailSuffix = detail === '' ? '' : ` (${detail})`;
+      throw new ClaudeProfileError(
+        'CLAUDE_PROFILE_COMMAND_FAILED',
+        `Claude command failed: claude ${arguments_.join(' ')}${detailSuffix}`,
+        effects,
+      );
+    }
+    return output;
+  } finally {
+    if (outputOpen) closeSync(outputDescriptor);
+    rmSync(outputDirectory, { recursive: true, force: true });
   }
-  if (result.status !== 0) {
-    const detail = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim();
-    const detailSuffix = detail === '' ? '' : ` (${detail})`;
-    throw new ClaudeProfileError(
-      'CLAUDE_PROFILE_COMMAND_FAILED',
-      `Claude command failed: claude ${arguments_.join(' ')}${detailSuffix}`,
-      effects,
-    );
-  }
-  return result.stdout ?? '';
 }
 
 function parseJsonArray(output: string, command: string, effects: readonly Effect[]): JsonObject[] {
@@ -359,8 +414,13 @@ function pluginEntries(cwd: string, effects: readonly Effect[]): JsonObject[] {
   );
 }
 
+function pluginScope(entry: JsonObject): ClaudePluginScope | undefined {
+  const scope = entry.scope ?? 'user';
+  return scope === 'project' || scope === 'user' ? scope : undefined;
+}
+
 function entryMatchesScope(entry: JsonObject, scope: ClaudePluginScope, cwd: string): boolean {
-  if ((entry.scope ?? 'user') !== scope) return false;
+  if (pluginScope(entry) !== scope) return false;
   return scope === 'user' || canonicalDirectory(entry.projectPath) === cwd;
 }
 
@@ -379,12 +439,13 @@ function safewordPlugin(
 }
 
 function applicableSafewordPlugins(entries: readonly JsonObject[], cwd: string): JsonObject[] {
-  return entries.filter(
-    entry =>
+  return entries.filter(entry => {
+    const scope = pluginScope(entry);
+    return (
       entry.id === CLAUDE_PLUGIN_ID &&
-      (entry.scope === 'user' ||
-        (entry.scope === 'project' && canonicalDirectory(entry.projectPath) === cwd)),
-  );
+      (scope === 'user' || (scope === 'project' && canonicalDirectory(entry.projectPath) === cwd))
+    );
+  });
 }
 
 const DIAGNOSTIC_FAILURES: Readonly<
@@ -665,6 +726,14 @@ export function observeApplicableClaudePlugins(cwd: string): ClaudeApplicablePlu
     assertSupportedHost(projectRoot);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (!isUnsupportedHostError(error)) {
+      return {
+        status: 'errored',
+        installations: [],
+        message,
+        nextAction: 'repair the reported Claude host error',
+      };
+    }
     return {
       status: 'unsupported-host',
       installations: [],
@@ -687,7 +756,7 @@ export function observeApplicableClaudePlugins(cwd: string): ClaudeApplicablePlu
   return {
     status: 'observed',
     installations: plugins.map(plugin => ({
-      scope: plugin.scope as ClaudePluginScope,
+      scope: pluginScope(plugin) ?? 'user',
       plugin,
       ...observeInstalledPlugin(plugin),
     })),
@@ -717,6 +786,13 @@ function unsupportedHostNextAction(error: unknown, message: string): string {
     return 'install Claude Code';
   }
   return message.startsWith('Could not parse') ? 'reinstall Claude Code' : 'update Claude Code';
+}
+
+function isUnsupportedHostError(error: unknown): boolean {
+  return (
+    error instanceof ClaudeProfileError &&
+    ['CLAUDE_HOST_UNAVAILABLE', 'CLAUDE_VERSION_UNSUPPORTED'].includes(error.code)
+  );
 }
 
 function assertNativePayload(plugin: JsonObject, effects: readonly Effect[]): void {
@@ -750,7 +826,7 @@ function verifyPlugin(
   if (
     plugin?.version === SAFEWORD_SCHEMA.version &&
     plugin.enabled === true &&
-    plugin.scope === scope
+    pluginScope(plugin) === scope
   ) {
     assertNativePayload(plugin, effects);
     return entries;

--- a/packages/cli/tests/claude-plugin/profile-install.test.ts
+++ b/packages/cli/tests/claude-plugin/profile-install.test.ts
@@ -23,9 +23,14 @@ const originalProjectDirectory = process.env.CLAUDE_PROJECT_DIR;
 interface FixtureState {
   readonly healthyPayload?: boolean;
   readonly installedVersion?: string | false;
+  readonly largePluginInventory?: boolean;
   readonly marketplaceAddPersists?: boolean;
   readonly marketplaceDeclared?: boolean;
   readonly marketplaceListedReference?: string | false;
+  readonly omittedUserScope?: boolean;
+  readonly oversizedPluginInventory?: boolean;
+  readonly oversizedVersionOutput?: boolean;
+  readonly oversizedVersionStderr?: boolean;
   readonly pluginEnabled?: boolean;
 }
 
@@ -50,6 +55,62 @@ function initializeFixtureState(root: string, ref: string, state: FixtureState) 
   return { enabledState, installedState, installPath, marketplaceState };
 }
 
+function writePluginListOverride(
+  path: string,
+  state: FixtureState,
+  installPath: string,
+  project: string,
+): void {
+  if (state.omittedUserScope === true) {
+    writeFileSync(
+      path,
+      `${JSON.stringify([
+        {
+          id: 'safeword@safeword',
+          version: SAFEWORD_SCHEMA.version,
+          enabled: true,
+          installPath,
+        },
+      ])}\n`,
+    );
+    return;
+  }
+  if (
+    state.oversizedPluginInventory === true ||
+    state.oversizedVersionOutput === true ||
+    state.oversizedVersionStderr === true
+  ) {
+    writeFileSync(
+      path,
+      `${JSON.stringify([{ id: 'oversized@example', detail: 'x'.repeat(10 * 1024 * 1024) }])}\n`,
+    );
+    return;
+  }
+  if (state.largePluginInventory !== true) return;
+  const plugins: Record<string, unknown>[] = Array.from({ length: 400 }, (_, index) => ({
+    id: `unrelated-${index}@example`,
+    scope: 'user',
+    version: '1.0.0',
+    enabled: true,
+    installPath: `/tmp/${'x'.repeat(180)}-${index}`,
+  }));
+  plugins.push({
+    id: 'safeword@safeword',
+    scope: 'project',
+    version: SAFEWORD_SCHEMA.version,
+    enabled: true,
+    installPath,
+    projectPath: project,
+  });
+  writeFileSync(path, `${JSON.stringify(plugins)}\n`);
+}
+
+function versionCommand(state: FixtureState, outputPath: string): string {
+  if (state.oversizedVersionOutput === true) return `cat ${JSON.stringify(outputPath)}`;
+  if (state.oversizedVersionStderr === true) return `cat ${JSON.stringify(outputPath)} >&2`;
+  return "echo '2.1.170'";
+}
+
 function fixture(
   autoUpdate: boolean | undefined,
   ref = 'stable',
@@ -60,6 +121,7 @@ function fixture(
   const project = nodePath.join(root, 'project');
   const bin = nodePath.join(root, 'bin');
   const log = nodePath.join(root, 'claude.log');
+  const pluginListOverride = nodePath.join(root, 'plugin-list.json');
   const settingsPath = nodePath.join(project, '.claude/settings.json');
   directories.push(root);
   mkdirSync(nodePath.dirname(settingsPath), { recursive: true });
@@ -69,6 +131,7 @@ function fixture(
     ref,
     state,
   );
+  writePluginListOverride(pluginListOverride, state, installPath, project);
   const declaration: Record<string, unknown> = {
     source: { source: 'git', url: 'https://github.com/ArcadeAI/safeword.git', ref },
   };
@@ -101,7 +164,7 @@ function fixture(
 set -eu
 printf '%s\n' "$*" >> ${JSON.stringify(log)}
 case "$*" in
-  '--version') echo '2.1.170' ;;
+  '--version') ${versionCommand(state, pluginListOverride)} ;;
   'plugin marketplace list --json')
     if [ -f ${JSON.stringify(marketplaceState)} ]; then
       marketplace_ref=$(cat ${JSON.stringify(marketplaceState)})
@@ -112,7 +175,13 @@ case "$*" in
     ;;
   'plugin marketplace add https://github.com/ArcadeAI/safeword.git#${OFFICIAL_MARKETPLACE_REF} --scope project') ${persistMarketplace} ;;
   'plugin list --json')
-    if [ -f ${JSON.stringify(installedState)} ]; then
+    if [ -f ${JSON.stringify(pluginListOverride)} ]; then
+      if [ -p /dev/fd/1 ] || [ -S /dev/fd/1 ]; then
+        head -c 65536 ${JSON.stringify(pluginListOverride)}
+      else
+        cat ${JSON.stringify(pluginListOverride)}
+      fi
+    elif [ -f ${JSON.stringify(installedState)} ]; then
       plugin_version=$(cat ${JSON.stringify(installedState)})
       plugin_enabled=false
       if [ -f ${JSON.stringify(enabledState)} ]; then plugin_enabled=true; fi
@@ -241,6 +310,49 @@ describe('Claude marketplace update enrollment', () => {
       installations: [{ scope: 'project', health: 'current' }],
     });
   });
+
+  it('treats an omitted Claude plugin scope as the default user scope', () => {
+    const { project } = fixture(true, 'stable', undefined, { omittedUserScope: true });
+
+    expect(observeApplicableClaudePlugins(project)).toMatchObject({
+      status: 'observed',
+      installations: [{ scope: 'user', health: 'current' }],
+    });
+  });
+
+  it('observes a valid Claude plugin inventory larger than 64 KiB', () => {
+    const { project } = fixture(true, 'stable', undefined, { largePluginInventory: true });
+
+    expect(observeApplicableClaudePlugins(project)).toMatchObject({
+      status: 'observed',
+      installations: [{ scope: 'project', health: 'current' }],
+    });
+  });
+
+  it('reports an actionable error when Claude output exceeds the safety limit', () => {
+    const { project } = fixture(true, 'stable', undefined, { oversizedPluginInventory: true });
+
+    expect(observeApplicableClaudePlugins(project)).toMatchObject({
+      status: 'errored',
+      installations: [],
+      message: expect.stringContaining('Claude command output exceeded 10485760 bytes'),
+      nextAction: 'repair the reported Claude plugin error',
+    });
+  });
+
+  it.each([{ oversizedVersionOutput: true }, { oversizedVersionStderr: true }])(
+    'reports an operational error when the Claude version probe exceeds its limit',
+    state => {
+      const { project } = fixture(true, 'stable', undefined, state);
+
+      expect(observeApplicableClaudePlugins(project)).toMatchObject({
+        status: 'errored',
+        installations: [],
+        message: expect.stringContaining('Claude command output exceeded 10485760 bytes'),
+        nextAction: 'repair the reported Claude host error',
+      });
+    },
+  );
 
   it('enables native auto-update for an eligible stable marketplace without disturbing other settings', () => {
     const { log, project, settingsPath } = fixture(undefined);

--- a/packages/cli/tests/cli-protocol/cli-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/cli-wiring.test.ts
@@ -3,6 +3,10 @@ import { readdirSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import { createTemporaryDirectory, runCli } from '../helpers.js';
+import {
+  installEmptyClaudeRuntime,
+  installFakeCodexRuntime,
+} from '../helpers/fake-codex-runtime.js';
 
 describe('predictable CLI wiring', () => {
   it('publishes capabilities as JSON-only stdout', async () => {
@@ -50,9 +54,19 @@ describe('predictable CLI wiring', () => {
 
   it('uses bare Safeword as read-only status with one next action', async () => {
     const directory = createTemporaryDirectory();
+    const runtime = installFakeCodexRuntime(createTemporaryDirectory(), {
+      pluginEnabled: false,
+      pluginInitiallyInstalled: false,
+    });
+    installEmptyClaudeRuntime(runtime.bin);
     const before = readdirSync(directory);
     const result = await runCli(['--json', '--no-input', '--offline', '--cwd', directory], {
       cwd: directory,
+      env: {
+        CODEX_HOME: runtime.codexHome,
+        SAFEWORD_CODEX_LOG: runtime.logPath,
+        PATH: `${runtime.bin}:${process.env.PATH ?? ''}`,
+      },
     });
 
     expect(result.exitCode).toBe(2);

--- a/packages/cli/tests/commands/cli.test.ts
+++ b/packages/cli/tests/commands/cli.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { runCli, runCliSync } from '../helpers';
+import { createTemporaryDirectory, runCli, runCliSync } from '../helpers';
+import {
+  installEmptyClaudeRuntime,
+  installFakeCodexRuntime,
+} from '../helpers/fake-codex-runtime.js';
 
 describe('Test Suite 1: Version and Help', () => {
   describe('Test 1.1: --version flag shows CLI version', () => {
@@ -75,7 +79,20 @@ describe('Test Suite 1: Version and Help', () => {
 
   describe('Test 1.3: Bare command reports status', () => {
     it('should report an actionable status when run with no arguments', async () => {
-      const bareResult = await runCli([]);
+      const directory = createTemporaryDirectory();
+      const runtime = installFakeCodexRuntime(createTemporaryDirectory(), {
+        pluginEnabled: false,
+        pluginInitiallyInstalled: false,
+      });
+      installEmptyClaudeRuntime(runtime.bin);
+      const bareResult = await runCli([], {
+        cwd: directory,
+        env: {
+          CODEX_HOME: runtime.codexHome,
+          SAFEWORD_CODEX_LOG: runtime.logPath,
+          PATH: `${runtime.bin}:${process.env.PATH ?? ''}`,
+        },
+      });
 
       expect(bareResult.exitCode).toBe(2);
       expect(bareResult.stdout).toContain('Needs attention');

--- a/packages/cli/tests/helpers/fake-codex-runtime.ts
+++ b/packages/cli/tests/helpers/fake-codex-runtime.ts
@@ -20,6 +20,21 @@ function writeExecutable(path: string, content: string): void {
   chmodSync(path, 0o755);
 }
 
+/** Install a supported Claude host with no applicable Safeword plugins. */
+export function installEmptyClaudeRuntime(bin: string): void {
+  writeExecutable(
+    nodePath.join(bin, 'claude'),
+    `#!/bin/sh
+set -eu
+if [ "$*" = "--version" ]; then
+  printf '%s\n' '2.1.170'
+else
+  printf '%s\n' '[]'
+fi
+`,
+  );
+}
+
 export function installFakeCodexRuntime(
   directory: string,
   { pluginEnabled, pluginInitiallyInstalled, pluginVersion }: FakeCodexRuntimeOptions,

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.4",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "6464094765b3d3711d395a5c9fceb50e079c0079302be3fe2448534dd2df9af1"
+  "inventory_sha256": "ca38ebf981c9289a156ad665e68c8451e8c396e8b8cd41f8c5a731b4b48a8206"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "d7d9641c877d917c2428a0f635642f7115fcfa81ca1c2fe258a17390e6cc5142"
+      "sha256": "3b7ac734bee660915e315485c11809fd99eea3c5b0f82c210dcd3eef377c9e57"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -30192,20 +30192,60 @@ __export(exports_profile, {
 });
 import { spawnSync as spawnSync3 } from "child_process";
 import { createHash as createHash8 } from "crypto";
-import { existsSync as existsSync28, lstatSync as lstatSync5, readFileSync as readFileSync22, realpathSync as realpathSync2, statSync as statSync4 } from "fs";
-import { homedir as homedir3 } from "os";
+import {
+  closeSync as closeSync2,
+  existsSync as existsSync28,
+  lstatSync as lstatSync5,
+  mkdtempSync as mkdtempSync3,
+  openSync as openSync2,
+  readFileSync as readFileSync22,
+  realpathSync as realpathSync2,
+  rmSync as rmSync5,
+  statSync as statSync4
+} from "fs";
+import { homedir as homedir3, tmpdir } from "os";
 import nodePath43 from "path";
 function runClaude(cwd, arguments_, effects) {
-  const result = spawnSync3("claude", arguments_, { cwd, encoding: "utf8" });
-  if (result.error !== undefined) {
-    throw new ClaudeProfileError("CLAUDE_HOST_UNAVAILABLE", `Claude Code could not be started: ${result.error.message}`, effects);
+  const outputDirectory = mkdtempSync3(nodePath43.join(tmpdir(), "safeword-claude-output-"));
+  const outputPath = nodePath43.join(outputDirectory, "stdout");
+  const outputDescriptor = openSync2(outputPath, "w");
+  let outputOpen = true;
+  try {
+    const result = spawnSync3("claude", arguments_, {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: MAXIMUM_CLAUDE_OUTPUT_BYTES,
+      stdio: ["ignore", outputDescriptor, "pipe"],
+      timeout: CLAUDE_COMMAND_TIMEOUT_MS
+    });
+    closeSync2(outputDescriptor);
+    outputOpen = false;
+    if (result.error !== undefined) {
+      const errorCode = result.error.code;
+      if (errorCode === "ENOBUFS") {
+        throw new ClaudeProfileError("CLAUDE_PROFILE_OUTPUT_TOO_LARGE", `Claude command output exceeded ${MAXIMUM_CLAUDE_OUTPUT_BYTES} bytes: claude ${arguments_.join(" ")}`, effects);
+      }
+      if (errorCode !== "ENOENT") {
+        throw new ClaudeProfileError("CLAUDE_PROFILE_COMMAND_FAILED", `Claude command could not complete: claude ${arguments_.join(" ")} (${result.error.message})`, effects);
+      }
+      throw new ClaudeProfileError("CLAUDE_HOST_UNAVAILABLE", `Claude Code could not be started: ${result.error.message}`, effects);
+    }
+    const outputBytes = statSync4(outputPath).size;
+    if (outputBytes > MAXIMUM_CLAUDE_OUTPUT_BYTES) {
+      throw new ClaudeProfileError("CLAUDE_PROFILE_OUTPUT_TOO_LARGE", `Claude command output exceeded ${MAXIMUM_CLAUDE_OUTPUT_BYTES} bytes: claude ${arguments_.join(" ")}`, effects);
+    }
+    const output = readFileSync22(outputPath, "utf8");
+    if (result.status !== 0) {
+      const detail = `${result.stderr ?? ""}${output}`.trim();
+      const detailSuffix = detail === "" ? "" : ` (${detail})`;
+      throw new ClaudeProfileError("CLAUDE_PROFILE_COMMAND_FAILED", `Claude command failed: claude ${arguments_.join(" ")}${detailSuffix}`, effects);
+    }
+    return output;
+  } finally {
+    if (outputOpen)
+      closeSync2(outputDescriptor);
+    rmSync5(outputDirectory, { recursive: true, force: true });
   }
-  if (result.status !== 0) {
-    const detail = `${result.stderr ?? ""}${result.stdout ?? ""}`.trim();
-    const detailSuffix = detail === "" ? "" : ` (${detail})`;
-    throw new ClaudeProfileError("CLAUDE_PROFILE_COMMAND_FAILED", `Claude command failed: claude ${arguments_.join(" ")}${detailSuffix}`, effects);
-  }
-  return result.stdout ?? "";
 }
 function parseJsonArray(output, command, effects) {
   try {
@@ -30413,8 +30453,12 @@ function marketplaceEntries(cwd, effects) {
 function pluginEntries(cwd, effects) {
   return parseJsonArray(runClaude(cwd, ["plugin", "list", "--json"], effects), "plugin list --json", effects);
 }
+function pluginScope(entry) {
+  const scope = entry.scope ?? "user";
+  return scope === "project" || scope === "user" ? scope : undefined;
+}
 function entryMatchesScope(entry, scope, cwd) {
-  if ((entry.scope ?? "user") !== scope)
+  if (pluginScope(entry) !== scope)
     return false;
   return scope === "user" || canonicalDirectory2(entry.projectPath) === cwd;
 }
@@ -30425,7 +30469,10 @@ function safewordPlugin(entries, scope, cwd) {
   return entries.find((entry) => entry.id === CLAUDE_PLUGIN_ID && entryMatchesScope(entry, scope, cwd));
 }
 function applicableSafewordPlugins(entries, cwd) {
-  return entries.filter((entry) => entry.id === CLAUDE_PLUGIN_ID && (entry.scope === "user" || entry.scope === "project" && canonicalDirectory2(entry.projectPath) === cwd));
+  return entries.filter((entry) => {
+    const scope = pluginScope(entry);
+    return entry.id === CLAUDE_PLUGIN_ID && (scope === "user" || scope === "project" && canonicalDirectory2(entry.projectPath) === cwd);
+  });
 }
 function failedResult(error2, scope) {
   let failure;
@@ -30617,6 +30664,14 @@ function observeApplicableClaudePlugins(cwd) {
     assertSupportedHost(projectRoot);
   } catch (error2) {
     const message = error2 instanceof Error ? error2.message : String(error2);
+    if (!isUnsupportedHostError(error2)) {
+      return {
+        status: "errored",
+        installations: [],
+        message,
+        nextAction: "repair the reported Claude host error"
+      };
+    }
     return {
       status: "unsupported-host",
       installations: [],
@@ -30638,7 +30693,7 @@ function observeApplicableClaudePlugins(cwd) {
   return {
     status: "observed",
     installations: plugins.map((plugin) => ({
-      scope: plugin.scope,
+      scope: pluginScope(plugin) ?? "user",
       plugin,
       ...observeInstalledPlugin(plugin)
     }))
@@ -30669,6 +30724,9 @@ function unsupportedHostNextAction(error2, message) {
   }
   return message.startsWith("Could not parse") ? "reinstall Claude Code" : "update Claude Code";
 }
+function isUnsupportedHostError(error2) {
+  return error2 instanceof ClaudeProfileError && ["CLAUDE_HOST_UNAVAILABLE", "CLAUDE_VERSION_UNSUPPORTED"].includes(error2.code);
+}
 function assertNativePayload(plugin, effects) {
   try {
     validateNativePayload(plugin);
@@ -30684,7 +30742,7 @@ function verifyPlugin(cwd, scope, effects) {
     throw new ClaudeProfileError("CLAUDE_PLUGIN_POSTCONDITION_UNVERIFIED", `Claude completed the selected-scope mutations, but the final plugin state could not be observed: ${error2 instanceof Error ? error2.message : String(error2)}`, effects);
   }
   const plugin = safewordPlugin(entries, scope, cwd);
-  if (plugin?.version === SAFEWORD_SCHEMA.version && plugin.enabled === true && plugin.scope === scope) {
+  if (plugin?.version === SAFEWORD_SCHEMA.version && plugin.enabled === true && pluginScope(plugin) === scope) {
     assertNativePayload(plugin, effects);
     return entries;
   }
@@ -30798,7 +30856,7 @@ function uninstallClaudePlugin(cwd, scope = "project") {
     });
   }
 }
-var MINIMUM_CLAUDE_VERSION, MARKETPLACE_NAME = "safeword", MARKETPLACE_BASE = "https://github.com/ArcadeAI/safeword.git", ClaudeProfileError, DIAGNOSTIC_FAILURES;
+var MINIMUM_CLAUDE_VERSION, CLAUDE_COMMAND_TIMEOUT_MS = 30000, MAXIMUM_CLAUDE_OUTPUT_BYTES, MARKETPLACE_NAME = "safeword", MARKETPLACE_BASE = "https://github.com/ArcadeAI/safeword.git", ClaudeProfileError, DIAGNOSTIC_FAILURES;
 var init_profile = __esm(() => {
   init_main();
   init_result();
@@ -30808,6 +30866,7 @@ var init_profile = __esm(() => {
   init_project_root();
   init_project_root();
   MINIMUM_CLAUDE_VERSION = [2, 1, 170];
+  MAXIMUM_CLAUDE_OUTPUT_BYTES = 10 * 1024 * 1024;
   ClaudeProfileError = class ClaudeProfileError extends Error {
     code;
     effects;
@@ -32600,7 +32659,7 @@ var init_migration = __esm(() => {
 
 // src/codex-plugin/profile-lock.ts
 import { randomUUID as randomUUID3 } from "crypto";
-import { mkdirSync as mkdirSync7, readFileSync as readFileSync26, rmSync as rmSync5, statSync as statSync5, writeFileSync as writeFileSync9 } from "fs";
+import { mkdirSync as mkdirSync7, readFileSync as readFileSync26, rmSync as rmSync6, statSync as statSync5, writeFileSync as writeFileSync9 } from "fs";
 import { homedir as homedir5 } from "os";
 import nodePath47 from "path";
 function profileDirectory(environment) {
@@ -32657,16 +32716,16 @@ function acquireCodexProfileLock(environment = process.env, options = {}) {
       return acquired;
     if (lockAge(path4, now) <= (options.maxAgeMs ?? DEFAULT_MAX_AGE_MS))
       return;
-    rmSync5(path4, { recursive: true, force: true });
+    rmSync6(path4, { recursive: true, force: true });
     return createLock(path4, owner, now);
   } finally {
-    rmSync5(gate, { recursive: true, force: true });
+    rmSync6(gate, { recursive: true, force: true });
   }
 }
 function releaseCodexProfileLock(lock) {
   if (readRecord(lock.path)?.owner !== lock.owner)
     return false;
-  rmSync5(lock.path, { recursive: true, force: true });
+  rmSync6(lock.path, { recursive: true, force: true });
   return true;
 }
 var DEFAULT_MAX_AGE_MS;
@@ -32770,7 +32829,7 @@ var init_host_process = () => {};
 
 // src/codex-plugin/profile-proof.ts
 import { createHash as createHash10, randomUUID as randomUUID4 } from "crypto";
-import { existsSync as existsSync30, readFileSync as readFileSync27, realpathSync as realpathSync4, rmSync as rmSync6 } from "fs";
+import { existsSync as existsSync30, readFileSync as readFileSync27, realpathSync as realpathSync4, rmSync as rmSync7 } from "fs";
 import { homedir as homedir6 } from "os";
 import nodePath48 from "path";
 function codexProfileDirectory(environment = process.env) {
@@ -32842,18 +32901,18 @@ function writeCodexActivationMarker(environment = process.env, now = new Date, o
   };
   writeAtomicJson(path4, marker);
   for (const event of CODEX_PLUGIN_HOOK_EVENTS)
-    rmSync6(codexProofPath(environment, event), { force: true });
-  rmSync6(nodePath48.join(codexProfileDirectory(environment), "safeword/hook-proof-v1"), {
+    rmSync7(codexProofPath(environment, event), { force: true });
+  rmSync7(nodePath48.join(codexProfileDirectory(environment), "safeword/hook-proof-v1"), {
     recursive: true,
     force: true
   });
-  rmSync6(nodePath48.join(codexProfileDirectory(environment), "safeword/session-proof-v1"), {
+  rmSync7(nodePath48.join(codexProfileDirectory(environment), "safeword/session-proof-v1"), {
     recursive: true,
     force: true
   });
-  rmSync6(codexActivationReceiptPath(environment), { force: true });
-  rmSync6(legacyCodexActivationMarkerPath(environment), { force: true });
-  rmSync6(legacyCodexRestartMarkerPath(environment), { force: true });
+  rmSync7(codexActivationReceiptPath(environment), { force: true });
+  rmSync7(legacyCodexActivationMarkerPath(environment), { force: true });
+  rmSync7(legacyCodexRestartMarkerPath(environment), { force: true });
   return marker;
 }
 function hostObservationForOverride(current = null) {
@@ -32886,7 +32945,7 @@ function recordCodexHookProof(event, environment = process.env, now = new Date, 
     if (restartedReceipt !== null) {
       receipt = restartedReceipt;
       writeAtomicJson(codexActivationReceiptPath(environment), receipt);
-      rmSync6(codexActivationMarkerPath(environment), { force: true });
+      rmSync7(codexActivationMarkerPath(environment), { force: true });
     }
   }
   const proof = {
@@ -36518,7 +36577,7 @@ import {
   readdirSync as readdirSync22,
   readFileSync as readFileSync38,
   rmdirSync as rmdirSync4,
-  rmSync as rmSync7
+  rmSync as rmSync8
 } from "fs";
 import nodePath64 from "path";
 function sha2564(content) {
@@ -36618,7 +36677,7 @@ function pruneEmptyAncestors(root, path4) {
 }
 function writeImage(root, path4, content, mode) {
   if (content === null) {
-    rmSync7(path4, { force: true });
+    rmSync8(path4, { force: true });
     pruneEmptyAncestors(root, path4);
     return;
   }
@@ -36827,7 +36886,7 @@ function performAutomaticMigration(projectRoot, options, now) {
     };
   }
   writeAutomaticPluginMode(projectRoot, transaction);
-  rmSync7(transactionPath(projectRoot), { force: true });
+  rmSync8(transactionPath(projectRoot), { force: true });
   return { state: "complete", advisory, unresolvedPaths: unresolved };
 }
 function parseTransaction(cwd) {
@@ -36863,7 +36922,7 @@ function completedRecoveryResult(projectRoot, transaction) {
   if (transaction.disposition === "complete-forward") {
     writeAutomaticPluginMode(projectRoot, transaction);
   }
-  rmSync7(transactionPath(projectRoot), { force: true });
+  rmSync8(transactionPath(projectRoot), { force: true });
   return createResult({
     state: "changed",
     data: {
@@ -38470,14 +38529,14 @@ import {
   copyFileSync as copyFileSync2,
   lstatSync as lstatSync12,
   mkdirSync as mkdirSync10,
-  mkdtempSync as mkdtempSync3,
+  mkdtempSync as mkdtempSync4,
   readFileSync as readFileSync41,
   realpathSync as realpathSync5,
   renameSync as renameSync5,
-  rmSync as rmSync8,
+  rmSync as rmSync9,
   writeFileSync as writeFileSync14
 } from "fs";
-import { tmpdir } from "os";
+import { tmpdir as tmpdir2 } from "os";
 import nodePath70 from "path";
 import process9 from "process";
 function architectureMode(options) {
@@ -38588,13 +38647,13 @@ function architectureStage(cwd, reporter = defaultReporter) {
   });
 }
 function persistWorktreeRecoveryCopy(destination, content) {
-  const directory = mkdtempSync3(nodePath70.join(tmpdir(), "safeword-architecture-recovery-"));
+  const directory = mkdtempSync4(nodePath70.join(tmpdir2(), "safeword-architecture-recovery-"));
   const path4 = nodePath70.join(directory, `${nodePath70.basename(destination)}.recovery`);
   try {
     writeFileSync14(path4, content, { mode: 384 });
     return { directory, path: path4 };
   } catch (error_) {
-    rmSync8(directory, { recursive: true, force: true });
+    rmSync9(directory, { recursive: true, force: true });
     throw error_;
   }
 }
@@ -38605,7 +38664,7 @@ function restoreWorktreeAfterStaging(cwd, result, recoveryCopy, staged, reporter
   try {
     replaceArchitectureDocumentContent(result.restoreWorktreeContent, result.path, cwd);
     if (recoveryCopy !== undefined) {
-      rmSync8(recoveryCopy.directory, { recursive: true, force: true });
+      rmSync9(recoveryCopy.directory, { recursive: true, force: true });
     }
     reporter.warn(`Preserved unstaged worktree architecture edits: ${result.path}`);
   } catch (error_) {
@@ -38675,7 +38734,7 @@ function architectureStaged(cwd, reporter = defaultReporter) {
   });
 }
 function withGitIndexSnapshot(cwd, gitContext, useSnapshot) {
-  const snapshotDirectory = mkdtempSync3(nodePath70.join(tmpdir(), "safeword-architecture-index-"));
+  const snapshotDirectory = mkdtempSync4(nodePath70.join(tmpdir2(), "safeword-architecture-index-"));
   const sourceIndexFile = process9.env[ARCHITECTURE_SOURCE_INDEX_ENV];
   const sourceIndexEnvironment = sourceIndexFile === undefined ? undefined : { ...process9.env, GIT_INDEX_FILE: sourceIndexFile };
   try {
@@ -38695,7 +38754,7 @@ function withGitIndexSnapshot(cwd, gitContext, useSnapshot) {
     prepareSnapshotProjectRoot(cwd, snapshotProjectDirectory);
     return useSnapshot(snapshotProjectDirectory);
   } finally {
-    rmSync8(snapshotDirectory, { recursive: true, force: true });
+    rmSync9(snapshotDirectory, { recursive: true, force: true });
   }
 }
 function assertNoGitlinks(gitContext, sourceIndexEnvironment) {
@@ -38802,17 +38861,17 @@ function replaceArchitectureDocumentWith(destination, allowedRoot, writeTemporar
   const destinationDirectory = nodePath70.dirname(destination);
   assertPhysicalContainment(allowedRoot, destination);
   mkdirSync10(destinationDirectory, { recursive: true });
-  let temporaryDirectory = mkdtempSync3(nodePath70.join(tmpdir(), "safeword-architecture-replacement-"));
+  let temporaryDirectory = mkdtempSync4(nodePath70.join(tmpdir2(), "safeword-architecture-replacement-"));
   if (lstatSync12(temporaryDirectory).dev !== lstatSync12(destinationDirectory).dev) {
-    rmSync8(temporaryDirectory, { recursive: true, force: true });
-    temporaryDirectory = mkdtempSync3(nodePath70.join(destinationDirectory, ".safeword-architecture-"));
+    rmSync9(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = mkdtempSync4(nodePath70.join(destinationDirectory, ".safeword-architecture-"));
   }
   try {
     const temporaryPath = nodePath70.join(temporaryDirectory, nodePath70.basename(destination));
     writeTemporaryFile(temporaryPath);
     renameSync5(temporaryPath, destination);
   } finally {
-    rmSync8(temporaryDirectory, { recursive: true, force: true });
+    rmSync9(temporaryDirectory, { recursive: true, force: true });
   }
 }
 function replaceArchitectureDocument(source, destination, allowedRoot) {
@@ -38931,7 +38990,7 @@ function restoreMaterializationPlans(cwd, plans) {
         replaceArchitectureDocumentContent(priorState.content, plan.destination, cwd);
       } else {
         assertPhysicalContainment(cwd, plan.destination);
-        rmSync8(plan.destination, { force: true });
+        rmSync9(plan.destination, { force: true });
       }
     } catch (error_) {
       errors.push(error_);
@@ -39967,20 +40026,20 @@ var init_run_identity = __esm(() => {
 // src/review/packet.ts
 import { createHash as createHash18, randomUUID as randomUUID6 } from "crypto";
 import {
-  closeSync as closeSync2,
+  closeSync as closeSync3,
   constants as constants2,
   fstatSync,
   lstatSync as lstatSync13,
   mkdirSync as mkdirSync11,
-  mkdtempSync as mkdtempSync4,
-  openSync as openSync2,
+  mkdtempSync as mkdtempSync5,
+  openSync as openSync3,
   readdirSync as readdirSync27,
   readFileSync as readFileSync46,
   realpathSync as realpathSync6,
-  rmSync as rmSync9,
+  rmSync as rmSync10,
   writeFileSync as writeFileSync17
 } from "fs";
-import { tmpdir as tmpdir2 } from "os";
+import { tmpdir as tmpdir3 } from "os";
 import nodePath76 from "path";
 function digest2(content) {
   return createHash18("sha256").update(content).digest("hex");
@@ -39993,7 +40052,7 @@ function fileDigest(path4) {
   }
 }
 function readContainedText(root, source, target) {
-  const descriptor = openSync2(source, constants2.O_RDONLY | (constants2.O_NOFOLLOW ?? 0));
+  const descriptor = openSync3(source, constants2.O_RDONLY | (constants2.O_NOFOLLOW ?? 0));
   try {
     const opened = fstatSync(descriptor);
     if (!opened.isFile())
@@ -40014,7 +40073,7 @@ function readContainedText(root, source, target) {
     }
     return { bytes, content };
   } finally {
-    closeSync2(descriptor);
+    closeSync3(descriptor);
   }
 }
 function escapes(root, candidate) {
@@ -40037,7 +40096,7 @@ function prepareReviewPacket(cwd, kind, targets) {
   if (targets.length > MAX_FILE_COUNT) {
     throw new Error(`Review packet exceeds the ${MAX_FILE_COUNT}-file limit`);
   }
-  const workspace = mkdtempSync4(nodePath76.join(tmpdir2(), "safeword-review-"));
+  const workspace = mkdtempSync5(nodePath76.join(tmpdir3(), "safeword-review-"));
   const canonicalRoot = realpathSync6(cwd);
   const tracked = [];
   const expectedSnapshotEntries = new Set;
@@ -40076,7 +40135,7 @@ function prepareReviewPacket(cwd, kind, targets) {
       return { path: relative, content };
     });
   } catch (error2) {
-    rmSync9(workspace, { recursive: true, force: true });
+    rmSync10(workspace, { recursive: true, force: true });
     throw error2;
   }
   const packet = {
@@ -40097,7 +40156,7 @@ function prepareReviewPacket(cwd, kind, targets) {
       return actualEntries.length !== expectedSnapshotEntries.size || actualEntries.some((entry2) => !expectedSnapshotEntries.has(entry2));
     },
     cleanup: () => {
-      rmSync9(workspace, { recursive: true, force: true });
+      rmSync10(workspace, { recursive: true, force: true });
     }
   };
 }
@@ -40230,8 +40289,8 @@ var init_environment = __esm(() => {
 
 // src/review/runtime.ts
 import { spawn } from "child_process";
-import { accessSync as accessSync2, constants as constants3, mkdtempSync as mkdtempSync5, realpathSync as realpathSync7, rmSync as rmSync10, writeFileSync as writeFileSync18 } from "fs";
-import { tmpdir as tmpdir3 } from "os";
+import { accessSync as accessSync2, constants as constants3, mkdtempSync as mkdtempSync6, realpathSync as realpathSync7, rmSync as rmSync11, writeFileSync as writeFileSync18 } from "fs";
+import { tmpdir as tmpdir4 } from "os";
 import nodePath78 from "path";
 function reviewerArguments(reviewer, model, schemaPath) {
   const base = [...ARGUMENTS[reviewer]];
@@ -40643,13 +40702,13 @@ async function runHeadlessReviewer(reviewer, packet, cwd, untrustedRoot = proces
   }
 }
 function writeContractFile() {
-  const directory = mkdtempSync5(nodePath78.join(tmpdir3(), "safeword-review-contract-"));
+  const directory = mkdtempSync6(nodePath78.join(tmpdir4(), "safeword-review-contract-"));
   const path4 = nodePath78.join(directory, "review-result.schema.json");
   writeFileSync18(path4, REVIEW_OUTPUT_SCHEMA, { mode: 384 });
   return {
     path: path4,
     cleanup: () => {
-      rmSync10(directory, { recursive: true, force: true });
+      rmSync11(directory, { recursive: true, force: true });
     }
   };
 }
@@ -51440,13 +51499,13 @@ __export(exports_retro, {
 import { spawnSync as spawnSync7 } from "child_process";
 import {
   mkdirSync as mkdirSync14,
-  mkdtempSync as mkdtempSync6,
+  mkdtempSync as mkdtempSync7,
   readFileSync as readFileSync54,
   realpathSync as realpathSync8,
   statSync as statSync6,
   writeFileSync as writeFileSync22
 } from "fs";
-import { tmpdir as tmpdir4 } from "os";
+import { tmpdir as tmpdir5 } from "os";
 import nodePath86 from "path";
 import process16 from "process";
 function buildProvenanceResolver(options) {
@@ -51683,7 +51742,7 @@ async function buildAutoExtractor(projectDirectory, dependencies = {}) {
   const spawnClaude = dependencies.spawn ?? spawnClaudeExtractor;
   const spawnCodex = dependencies.spawn ?? spawnCodexExtractor;
   const spawnCursor = dependencies.spawn ?? spawnCursorExtractor;
-  const workDirectory = mkdtempSync6(nodePath86.join(tmpdir4(), "safeword-retro-"));
+  const workDirectory = mkdtempSync7(nodePath86.join(tmpdir5(), "safeword-retro-"));
   if (agent === "codex") {
     return async (transcript) => {
       const result = await runCodexHeadlessExtractionChecked2(transcript, {
@@ -52929,13 +52988,13 @@ import {
   cpSync,
   existsSync as existsSync46,
   mkdirSync as mkdirSync16,
-  mkdtempSync as mkdtempSync7,
+  mkdtempSync as mkdtempSync8,
   readFileSync as readFileSync56,
   renameSync as renameSync7,
-  rmSync as rmSync11,
+  rmSync as rmSync12,
   writeFileSync as writeFileSync23
 } from "fs";
-import { tmpdir as tmpdir5 } from "os";
+import { tmpdir as tmpdir6 } from "os";
 import nodePath91 from "path";
 import process21 from "process";
 async function readStdin() {
@@ -53173,7 +53232,7 @@ function runPackagedHook(relativePath, rawInput, projectDirectory) {
   let temporaryHookDirectory;
   try {
     if (relativePath === "session-codex-start.ts") {
-      temporaryHookDirectory = mkdtempSync7(nodePath91.join(tmpdir5(), "safeword-codex-hook-"));
+      temporaryHookDirectory = mkdtempSync8(nodePath91.join(tmpdir6(), "safeword-codex-hook-"));
       cpSync(nodePath91.dirname(hookPath), temporaryHookDirectory, { recursive: true });
       writeFileSync23(nodePath91.join(temporaryHookDirectory, "lib", "owned-paths.ts"), generateOwnedPathsModule(SAFEWORD_SCHEMA, packagedNamespaceRootLabel(projectDirectory)), "utf8");
       executableHookPath = nodePath91.join(temporaryHookDirectory, nodePath91.basename(hookPath));
@@ -53182,7 +53241,7 @@ function runPackagedHook(relativePath, rawInput, projectDirectory) {
     return runHookFile(executableHookPath, rawInput, projectDirectory, packagedContextPath);
   } finally {
     if (temporaryHookDirectory)
-      rmSync11(temporaryHookDirectory, { recursive: true, force: true });
+      rmSync12(temporaryHookDirectory, { recursive: true, force: true });
   }
 }
 function snapshotPackagedHook(relativePath) {
@@ -53190,7 +53249,7 @@ function snapshotPackagedHook(relativePath) {
   if (!packagedHooksDirectory) {
     return { error: new Error(`Safe Word packaged hook is missing: ${relativePath}`) };
   }
-  const directory = mkdtempSync7(nodePath91.join(tmpdir5(), `safeword-codex-hook-snapshot-${process21.pid}-`));
+  const directory = mkdtempSync8(nodePath91.join(tmpdir6(), `safeword-codex-hook-snapshot-${process21.pid}-`));
   const stagingHooksDirectory = nodePath91.join(directory, "hooks-copying");
   const snapshotHooksDirectory = nodePath91.join(directory, "hooks");
   try {
@@ -53309,7 +53368,7 @@ async function runPreToolUse() {
   const rawInput = await readStdin();
   const qualityResult = snapshot.hookPath ? runHookFile(snapshot.hookPath, rawInput, projectDirectory) : { error: snapshot.error, stderr: "", stdout: "" };
   if (snapshot.directory)
-    rmSync11(snapshot.directory, { recursive: true, force: true });
+    rmSync12(snapshot.directory, { recursive: true, force: true });
   runEnrolledPreToolUse(rawInput, projectDirectory, qualityResult);
 }
 async function runSessionStart() {


### PR DESCRIPTION
## What changed

- capture Claude host stdout through a temporary regular file so large plugin inventories are not truncated at the host pipe boundary
- reject responses above 10 MiB, bound host commands to 30 seconds, and classify operational failures separately from unsupported hosts
- normalize omitted Claude plugin scope as the default user scope across discovery, status, and verification
- isolate bare-status tests from developer-installed Claude and Codex profiles

## Why

A valid 65,700-byte `claude plugin list --json` response was truncated to 65,536 bytes when captured through the existing process pipe. Safeword then reported `CLAUDE_ERRORED` for otherwise valid host state, making status dependent on profile size and breaking local verification.

## Impact

Large valid Claude plugin inventories are parsed reliably. Empty-project status tests are deterministic across developer and CI machines. Oversized or stalled host commands fail actionably instead of hanging or being mislabeled as an unsupported installation.

## Validation

- full repository tests: CLI 7,109 passed / 5 skipped; retro relay 167 passed / 1 skipped
- focused exact behavior: 26 tests passed across Claude profile and CLI status wiring
- repository ESLint, Prettier, and TypeScript checks passed
- `bun audit`: no vulnerabilities
- `git diff --check`: clean

Closes #2291

Follow-up trust-boundary investigation: #2293