### PR TITLE
Release safeword 0.74.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.4",
+      "version": "0.74.5",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.4",
+  "version": "0.74.5",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.4 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.5 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.4 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.5 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.4 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.5 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.4 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.5 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.4 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.5 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.4",
+  "version": "0.74.5",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -17,7 +17,7 @@ describe('Claude plugin release contract', () => {
       'Claude plugin release contract is aligned',
     );
     expect(result.status).toBe(0);
-  });
+  }, 15_000);
 
   it('documents the real-host upgrade gate in the maintainer release path', () => {
     const readme = readFileSync(nodePath.join(REPO_ROOT, 'README.md'), 'utf8');

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.4",
+  "plugin_version": "0.74.5",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "ace10f0b6a8b125ceb5c31b9b22290427451aed6ae07e790fc565103dae394c8"
+  "inventory_sha256": "eb6e6b4ff6c4fed7048abad56c2bed282ebf72427671c283141489366c050d46"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "34fe841a13fff2acb2632d79bae99b3c9a77b39c649f6071afcb2d235624de30"
+      "sha256": "739aa4216f164102b1a0ea523a22242e1166cd7a0cb3a16b5723e5508532fde6"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.4",
+  "version": "0.74.5",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- bump the CLI, Claude marketplace, Codex plugin, and all Codex hook pins to 0.74.5
- regenerate and seal the committed Claude plugin package for 0.74.5
- give the CPU-bound Claude plugin seal test an explicit 15-second budget so parallel release verification measures the contract rather than host contention

## Verification

- Claude plugin release checker: aligned at 0.74.5
- release contract suite: 36 passed
- feature PR #2296: full GitHub CI green on Node 22 and Node 24 before admin merge
