### PR TITLE
Keep concurrent relay coverage reliable on Node 22

### DIFF
--- a/packages/retro-relay/tests/relay.integration.test.ts
+++ b/packages/retro-relay/tests/relay.integration.test.ts
@@ -585,7 +585,7 @@ describe('retry-safe retro relay', () => {
     );
     expect(statuses.filter(status => status === 201)).toHaveLength(60);
     expect(statuses.filter(status => status === 429)).toHaveLength(1);
-  });
+  }, 15_000);
 
   it('reuses the filed receipt after response delivery is lost', async () => {
     let responseDropped = false;


### PR DESCRIPTION
## Summary

- give the 61-request relay rate-limit integration test its own 15-second budget
- retain the default 5-second budget everywhere else and leave all relay behavior unchanged

## Why

Post-merge Node 22 CI timed out at Vitest’s default 5 seconds while the identical commit passed Node 24, pre-merge CI, and release validation. This is a real concurrent integration scenario, not a unit test.

## Verification

- focused rate-limit integration test: passed
- complete retro-relay suite: 167 passed, 1 skipped
- official Vitest guidance supports a per-test timeout for legitimately longer operations
