### PR TITLE
Let merged deliveries close out without repeating verification or retro filing

### DIFF
--- a/.project/tickets/93C14D-close-completed-sessions-safely/test-definitions.md
+++ b/.project/tickets/93C14D-close-completed-sessions-safely/test-definitions.md
@@ -28,14 +28,11 @@ required `Scenario:` heading grammar.
 
 ## Rule: close-completed-sessions-safely.NTB1.R2 — Retrospective capture is a mandatory prerequisite to destructive cleanup
 
-### Scenario Outline: Retro extraction runs in the bound host runtime
+### Scenario: Retro extraction runs in the bound host runtime
 
-- [x] RED — closeout's mandatory retro subprocess did not carry the bound host,
-      so Codex and Cursor could fall back to Claude extraction
-- [x] GREEN — the guard forwards `SAFEWORD_RETRO_AGENT` from the exact fresh
-      Claude/Codex/Cursor binding; each runtime has a checked headless extractor
-- [x] REFACTOR — runtime selection is a small pure mapping while the real
-      subprocess boundary test proves the environment is forwarded
+- [x] RED skip: legacy scenario did not retain its original red commit metadata
+- [x] GREEN 15c1d9dc3
+- [x] REFACTOR skip: runtime selection is a small pure mapping while the real subprocess boundary test proves the environment is forwarded
 
 ### Scenario: A completed retro permits cleanup
 
@@ -48,6 +45,12 @@ required `Scenario:` heading grammar.
 - [x] RED 0170c9663
 - [x] GREEN 4e7238eff
 - [x] REFACTOR skip: failure states share one fail-closed boundary and recovery contract
+
+### Scenario: Filing completed retro drafts resumes without re-extraction
+
+- [x] RED skip: the receipt behavior shipped before this scenario was added to the ledger
+- [x] GREEN f6622f29d
+- [x] REFACTOR skip: the recovery test keeps the runner boundary explicit and proves one extraction across filing recovery
 
 ### Scenario: A request to skip retro does not create a bypass
 
@@ -62,6 +65,18 @@ required `Scenario:` heading grammar.
 - [x] RED af86a036e
 - [x] GREEN e0bce09f1
 - [x] REFACTOR skip: reviewed the concise state-transition guidance; no structural change improved it
+
+### Scenario: Exact evidence is reused through preview, replay, and approved apply
+
+- [x] RED skip: the receipt behavior shipped before this scenario was added to the ledger
+- [x] GREEN f6622f29d
+- [x] REFACTOR skip: the host-adapter test names each verification lane and proves the same workflow across every local runtime
+
+### Scenario: Changed evidence invalidates the matching cached prerequisite
+
+- [x] RED skip: the receipt behavior shipped before this scenario was added to the ledger
+- [x] GREEN f6622f29d
+- [x] REFACTOR skip: a focused rewrite test proves altered session context re-runs extraction while append-only continuation remains reusable
 
 ### Scenario: A local merge-command error after remote success is partial success
 

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -660,18 +660,18 @@ function cleanWorkingStateHash(headOid: string): string {
 }
 
 function verificationReceiptPath(root: string): string | undefined {
-  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
-  const path = commonDirectory.stdout.trim();
-  return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
-    : undefined;
+  return closeoutReceiptPath(root, 'closeout-verification.json');
 }
 
 function retroReceiptPath(root: string): string | undefined {
+  return closeoutReceiptPath(root, 'closeout-retro.json');
+}
+
+function closeoutReceiptPath(root: string, filename: string): string | undefined {
   const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
   const path = commonDirectory.stdout.trim();
   return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', filename)
     : undefined;
 }
 

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -572,6 +572,8 @@ export function runBoundRetro(
 ): CloseoutObservation['retro'] {
   const transcript = resolveTranscript(binding, root);
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0 };
+  const cached = readRetroReceipt(root, binding, transcript);
+  if (cached) return retroObservationFromReceipt(root, binding.id, cached);
   const retro = runner(
     root,
     [
@@ -592,11 +594,9 @@ export function runBoundRetro(
     errors?: { message?: string }[];
   }>(retro);
   const pendingDrafts = readSpooledDrafts(root, binding.id).length;
-  const complete =
-    retro.status === 0 &&
-    (result?.state === 'healthy' || result?.state === 'changed') &&
-    result.data?.agent_filing_needed === false &&
-    pendingDrafts === 0;
+  const successful =
+    retro.status === 0 && (result?.state === 'healthy' || result?.state === 'changed');
+  const complete = successful && result.data?.agent_filing_needed === false && pendingDrafts === 0;
   const errorText = result?.errors?.map(error => error.message ?? '').join('\n') ?? '';
   const failure = classifyRetroFailure({
     complete,
@@ -604,6 +604,17 @@ export function runBoundRetro(
     agentFilingNeeded: result?.data?.agent_filing_needed,
     pendingDrafts,
   });
+  if (successful) {
+    writeRetroReceipt(root, {
+      runtime: binding.runtime,
+      id: binding.id,
+      projectRoot: realpathSync(binding.projectRoot),
+      snapshot: transcriptSnapshot(transcript),
+      agentFilingNeeded: result.data?.agent_filing_needed === true,
+      pendingDrafts,
+      recordedAt: new Date().toISOString(),
+    });
+  }
   return {
     bound: true,
     complete,
@@ -625,6 +636,23 @@ interface VerificationReceipt {
   recordedAt: string;
 }
 
+interface TranscriptSnapshot {
+  path: string;
+  byteLength: number;
+  digest: string;
+}
+
+interface RetroReceipt {
+  version: 1;
+  runtime: CloseoutBinding['runtime'];
+  id: string;
+  projectRoot: string;
+  snapshot: TranscriptSnapshot;
+  agentFilingNeeded: boolean;
+  pendingDrafts: number;
+  recordedAt: string;
+}
+
 const VERIFICATION_RECEIPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function cleanWorkingStateHash(headOid: string): string {
@@ -637,6 +665,102 @@ function verificationReceiptPath(root: string): string | undefined {
   return commonDirectory.status === 0 && path !== ''
     ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
     : undefined;
+}
+
+function retroReceiptPath(root: string): string | undefined {
+  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
+  const path = commonDirectory.stdout.trim();
+  return commonDirectory.status === 0 && path !== ''
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    : undefined;
+}
+
+function transcriptSnapshot(path: string): TranscriptSnapshot {
+  const content = readFileSync(path);
+  return {
+    path: realpathSync(path),
+    byteLength: content.byteLength,
+    digest: createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
+  try {
+    const content = readFileSync(snapshot.path);
+    return (
+      content.byteLength >= snapshot.byteLength &&
+      createHash('sha256').update(content.subarray(0, snapshot.byteLength)).digest('hex') ===
+        snapshot.digest
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readRetroReceipt(
+  root: string,
+  binding: CloseoutBinding,
+  transcript: string,
+  now = new Date(),
+): RetroReceipt | undefined {
+  const path = retroReceiptPath(root);
+  if (!path || !existsSync(path)) return undefined;
+  try {
+    const receipt = JSON.parse(readFileSync(path, 'utf8')) as Partial<RetroReceipt>;
+    const recordedAt =
+      typeof receipt.recordedAt === 'string' ? Date.parse(receipt.recordedAt) : Number.NaN;
+    return receipt.version === 1 &&
+      receipt.runtime === binding.runtime &&
+      receipt.id === binding.id &&
+      receipt.projectRoot === realpathSync(binding.projectRoot) &&
+      receipt.snapshot?.path === realpathSync(transcript) &&
+      typeof receipt.snapshot.byteLength === 'number' &&
+      receipt.snapshot.byteLength >= 0 &&
+      typeof receipt.snapshot.digest === 'string' &&
+      Number.isFinite(recordedAt) &&
+      recordedAt <= now.getTime() &&
+      now.getTime() - recordedAt <= VERIFICATION_RECEIPT_MAX_AGE_MS &&
+      snapshotStillMatches(receipt.snapshot)
+      ? (receipt as RetroReceipt)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>): boolean {
+  const path = retroReceiptPath(root);
+  if (!path) return false;
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    mkdirSync(nodePath.dirname(path), { recursive: true });
+    writeFileSync(temporaryPath, `${JSON.stringify({ version: 1, ...receipt })}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, path);
+    return true;
+  } catch {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    return false;
+  }
+}
+
+function retroObservationFromReceipt(
+  root: string,
+  sessionId: string,
+  receipt: RetroReceipt,
+): CloseoutObservation['retro'] {
+  const pendingDrafts = readSpooledDrafts(root, sessionId).length;
+  const filingRecovered =
+    receipt.agentFilingNeeded && receipt.pendingDrafts > 0 && pendingDrafts === 0;
+  const complete = (!receipt.agentFilingNeeded || filingRecovered) && pendingDrafts === 0;
+  return {
+    bound: true,
+    complete,
+    pendingDrafts,
+    failure: complete ? undefined : 'filing',
+  };
 }
 
 function readVerificationReceipt(
@@ -702,8 +826,17 @@ function workingStateHash(root: string, headOid: string): string {
 
 function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
+  const observedStateHash = workingStateHash(root, observedHead);
+  const receipt = readVerificationReceipt(root, expectedOid);
+  if (receipt && observedHead === expectedOid && observedStateHash === receipt.stateHash) {
+    return {
+      current: true,
+      passed: true,
+      headOid: receipt.headOid,
+      stateHash: receipt.stateHash,
+    };
+  }
   if (observedHead !== expectedOid) {
-    const receipt = readVerificationReceipt(root, expectedOid);
     return receipt
       ? {
           current: true,

--- a/features/close-completed-sessions-safely.feature
+++ b/features/close-completed-sessions-safely.feature
@@ -79,6 +79,12 @@ Feature: Close completed sessions safely
         | failed filing                 | resolve the filing failure         |
         | pending drafts in the spool   | drain the filing spool             |
 
+    @surface.claude-code @surface.openai-codex @surface.cursor
+    Scenario: Filing completed retro drafts resumes without re-extraction
+      Given retrospective extraction completed and left filing drafts for the bound session
+      When the user files every pending draft and closeout resumes
+      Then it treats the retrospective as complete without re-running extraction and validates cleanup
+
     @rejection @surface.claude-code @surface.openai-codex @surface.cursor
     Scenario: A request to skip retro does not create a bypass
       Given retro is incomplete
@@ -103,6 +109,30 @@ Feature: Close completed sessions safely
         | entry into the merge queue                  | already exercised     | wait for a confirmed merged state                      |
         | confirmed merge and completed retro         | already exercised     | clean the exact targets                                |
         | worktree removal and remote branch removal  | already exercised     | remove the exact local branch                          |
+
+    @surface.claude-code @surface.openai-codex @surface.cursor
+    Scenario Outline: Exact evidence is reused through preview, replay, and approved apply
+      Given the exact clean merged head has current verification and a completed retrospective snapshot bound to "<runtime>"
+      When closeout is previewed, replayed, and approved with unchanged evidence
+      Then it runs each verification lane and the retrospective once before applying cleanup
+
+      Examples:
+        | runtime       |
+        | Claude Code   |
+        | OpenAI Codex  |
+        | Cursor        |
+
+    @surface.claude-code @surface.openai-codex @surface.cursor
+    Scenario Outline: Changed evidence invalidates the matching cached prerequisite
+      Given the exact clean merged head has completed closeout evidence
+      And "<change>" changes after its snapshot
+      When closeout resumes
+      Then it does not reuse the cached "<prerequisite>" and does not clean up until it passes again
+
+      Examples:
+        | change                      | prerequisite   |
+        | the working tree             | verification   |
+        | the bound session transcript is rewritten | retrospective  |
 
     @surface.claude-code @surface.openai-codex @surface.cursor
     Scenario: A local merge-command error after remote success is partial success

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -660,18 +660,18 @@ function cleanWorkingStateHash(headOid: string): string {
 }
 
 function verificationReceiptPath(root: string): string | undefined {
-  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
-  const path = commonDirectory.stdout.trim();
-  return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
-    : undefined;
+  return closeoutReceiptPath(root, 'closeout-verification.json');
 }
 
 function retroReceiptPath(root: string): string | undefined {
+  return closeoutReceiptPath(root, 'closeout-retro.json');
+}
+
+function closeoutReceiptPath(root: string, filename: string): string | undefined {
   const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
   const path = commonDirectory.stdout.trim();
   return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', filename)
     : undefined;
 }
 

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -572,6 +572,8 @@ export function runBoundRetro(
 ): CloseoutObservation['retro'] {
   const transcript = resolveTranscript(binding, root);
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0 };
+  const cached = readRetroReceipt(root, binding, transcript);
+  if (cached) return retroObservationFromReceipt(root, binding.id, cached);
   const retro = runner(
     root,
     [
@@ -592,11 +594,9 @@ export function runBoundRetro(
     errors?: { message?: string }[];
   }>(retro);
   const pendingDrafts = readSpooledDrafts(root, binding.id).length;
-  const complete =
-    retro.status === 0 &&
-    (result?.state === 'healthy' || result?.state === 'changed') &&
-    result.data?.agent_filing_needed === false &&
-    pendingDrafts === 0;
+  const successful =
+    retro.status === 0 && (result?.state === 'healthy' || result?.state === 'changed');
+  const complete = successful && result.data?.agent_filing_needed === false && pendingDrafts === 0;
   const errorText = result?.errors?.map(error => error.message ?? '').join('\n') ?? '';
   const failure = classifyRetroFailure({
     complete,
@@ -604,6 +604,17 @@ export function runBoundRetro(
     agentFilingNeeded: result?.data?.agent_filing_needed,
     pendingDrafts,
   });
+  if (successful) {
+    writeRetroReceipt(root, {
+      runtime: binding.runtime,
+      id: binding.id,
+      projectRoot: realpathSync(binding.projectRoot),
+      snapshot: transcriptSnapshot(transcript),
+      agentFilingNeeded: result.data?.agent_filing_needed === true,
+      pendingDrafts,
+      recordedAt: new Date().toISOString(),
+    });
+  }
   return {
     bound: true,
     complete,
@@ -625,6 +636,23 @@ interface VerificationReceipt {
   recordedAt: string;
 }
 
+interface TranscriptSnapshot {
+  path: string;
+  byteLength: number;
+  digest: string;
+}
+
+interface RetroReceipt {
+  version: 1;
+  runtime: CloseoutBinding['runtime'];
+  id: string;
+  projectRoot: string;
+  snapshot: TranscriptSnapshot;
+  agentFilingNeeded: boolean;
+  pendingDrafts: number;
+  recordedAt: string;
+}
+
 const VERIFICATION_RECEIPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function cleanWorkingStateHash(headOid: string): string {
@@ -637,6 +665,102 @@ function verificationReceiptPath(root: string): string | undefined {
   return commonDirectory.status === 0 && path !== ''
     ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
     : undefined;
+}
+
+function retroReceiptPath(root: string): string | undefined {
+  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
+  const path = commonDirectory.stdout.trim();
+  return commonDirectory.status === 0 && path !== ''
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    : undefined;
+}
+
+function transcriptSnapshot(path: string): TranscriptSnapshot {
+  const content = readFileSync(path);
+  return {
+    path: realpathSync(path),
+    byteLength: content.byteLength,
+    digest: createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
+  try {
+    const content = readFileSync(snapshot.path);
+    return (
+      content.byteLength >= snapshot.byteLength &&
+      createHash('sha256').update(content.subarray(0, snapshot.byteLength)).digest('hex') ===
+        snapshot.digest
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readRetroReceipt(
+  root: string,
+  binding: CloseoutBinding,
+  transcript: string,
+  now = new Date(),
+): RetroReceipt | undefined {
+  const path = retroReceiptPath(root);
+  if (!path || !existsSync(path)) return undefined;
+  try {
+    const receipt = JSON.parse(readFileSync(path, 'utf8')) as Partial<RetroReceipt>;
+    const recordedAt =
+      typeof receipt.recordedAt === 'string' ? Date.parse(receipt.recordedAt) : Number.NaN;
+    return receipt.version === 1 &&
+      receipt.runtime === binding.runtime &&
+      receipt.id === binding.id &&
+      receipt.projectRoot === realpathSync(binding.projectRoot) &&
+      receipt.snapshot?.path === realpathSync(transcript) &&
+      typeof receipt.snapshot.byteLength === 'number' &&
+      receipt.snapshot.byteLength >= 0 &&
+      typeof receipt.snapshot.digest === 'string' &&
+      Number.isFinite(recordedAt) &&
+      recordedAt <= now.getTime() &&
+      now.getTime() - recordedAt <= VERIFICATION_RECEIPT_MAX_AGE_MS &&
+      snapshotStillMatches(receipt.snapshot)
+      ? (receipt as RetroReceipt)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>): boolean {
+  const path = retroReceiptPath(root);
+  if (!path) return false;
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    mkdirSync(nodePath.dirname(path), { recursive: true });
+    writeFileSync(temporaryPath, `${JSON.stringify({ version: 1, ...receipt })}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, path);
+    return true;
+  } catch {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    return false;
+  }
+}
+
+function retroObservationFromReceipt(
+  root: string,
+  sessionId: string,
+  receipt: RetroReceipt,
+): CloseoutObservation['retro'] {
+  const pendingDrafts = readSpooledDrafts(root, sessionId).length;
+  const filingRecovered =
+    receipt.agentFilingNeeded && receipt.pendingDrafts > 0 && pendingDrafts === 0;
+  const complete = (!receipt.agentFilingNeeded || filingRecovered) && pendingDrafts === 0;
+  return {
+    bound: true,
+    complete,
+    pendingDrafts,
+    failure: complete ? undefined : 'filing',
+  };
 }
 
 function readVerificationReceipt(
@@ -702,8 +826,17 @@ function workingStateHash(root: string, headOid: string): string {
 
 function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
+  const observedStateHash = workingStateHash(root, observedHead);
+  const receipt = readVerificationReceipt(root, expectedOid);
+  if (receipt && observedHead === expectedOid && observedStateHash === receipt.stateHash) {
+    return {
+      current: true,
+      passed: true,
+      headOid: receipt.headOid,
+      stateHash: receipt.stateHash,
+    };
+  }
   if (observedHead !== expectedOid) {
-    const receipt = readVerificationReceipt(root, expectedOid);
     return receipt
       ? {
           current: true,

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -14,6 +14,7 @@ import nodePath from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { rememberCloseoutBinding } from '../templates/hooks/lib/closeout-binding.ts';
+import { draftSpoolPath, markDraftsFiled } from '../templates/hooks/lib/retro-draft-spool.ts';
 import {
   applyCleanupPlan,
   buildCleanupPlan,
@@ -185,6 +186,55 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       }
     },
   );
+
+  it('reuses a completed extraction after the user files its pending drafts', () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), 'closeout-retro-filing-recovery-'));
+    const id = 'claude-filing-recovery';
+    const transcript = nodePath.join(root, 'transcript.jsonl');
+    try {
+      spawnSync('git', ['init', '--quiet', root], { encoding: 'utf8' });
+      writeFileSync(transcript, `${JSON.stringify({ session_id: id, cwd: root })}\n`);
+      const spool = draftSpoolPath(root, id);
+      mkdirSync(nodePath.dirname(spool), { recursive: true });
+      writeFileSync(
+        spool,
+        `${JSON.stringify({
+          signature: 'retro:filing-recovery',
+          title: 'File the completed retrospective',
+          body: 'A safe, already-extracted finding.',
+          labels: ['retro'],
+        })}\n`,
+      );
+      const binding = {
+        runtime: 'claude' as const,
+        id,
+        projectRoot: root,
+        transcriptPath: transcript,
+      };
+      let runs = 0;
+      const runner = () => {
+        runs += 1;
+        return {
+          status: 0,
+          stdout: JSON.stringify({ state: 'changed', data: { agent_filing_needed: true } }),
+          stderr: '',
+        };
+      };
+
+      expect(runBoundRetro(root, binding, runner)).toMatchObject({
+        complete: false,
+        failure: 'filing',
+      });
+      markDraftsFiled(root, id, ['retro:filing-recovery']);
+      expect(runBoundRetro(root, binding, runner)).toMatchObject({
+        complete: true,
+        pendingDrafts: 0,
+      });
+      expect(runs).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
   it.each([
     [true, '', false, 0, undefined],
     [false, 'Retro extraction failed.', false, 0, 'extraction'],

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -235,6 +235,45 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('reruns extraction when the bound transcript is rewritten after its snapshot', () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), 'closeout-retro-snapshot-invalidation-'));
+    const id = 'claude-retro-snapshot-invalidation';
+    const transcript = nodePath.join(root, 'transcript.jsonl');
+    try {
+      spawnSync('git', ['init', '--quiet', root], { encoding: 'utf8' });
+      writeFileSync(
+        transcript,
+        `${JSON.stringify({ session_id: id, cwd: root, message: 'close this delivery' })}\n`,
+      );
+      const binding = {
+        runtime: 'claude' as const,
+        id,
+        projectRoot: root,
+        transcriptPath: transcript,
+      };
+      let runs = 0;
+      const runner = () => {
+        runs += 1;
+        return {
+          status: 0,
+          stdout: JSON.stringify({ state: 'healthy', data: { agent_filing_needed: false } }),
+          stderr: '',
+        };
+      };
+
+      expect(runBoundRetro(root, binding, runner).complete).toBe(true);
+      writeFileSync(
+        transcript,
+        `${JSON.stringify({ session_id: id, cwd: root, message: 'rewritten closeout context' })}\n`,
+      );
+      expect(runBoundRetro(root, binding, runner).complete).toBe(true);
+      expect(runs).toBe(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     [true, '', false, 0, undefined],
     [false, 'Retro extraction failed.', false, 0, 'extraction'],

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -386,6 +386,85 @@ describe('closeout production host adapters (93C14D TBU1.R4)', () => {
     30_000,
   );
 
+  it('reuses one exact-head verification and retrospective snapshot from preview through apply', () => {
+    const fixture = deliveryFixture();
+    installBoundaryFakes(fixture);
+    const sandbox = nodePath.dirname(fixture.bare);
+    const id = 'claude-closeout-snapshot';
+    const transcript = nodePath.join(sandbox, `${id}.jsonl`);
+    const counter = nodePath.join(sandbox, 'safeword-invocations.txt');
+    const cli = nodePath.join(fixture.bin, 'counting-safeword.ts');
+    writeFileSync(
+      transcript,
+      [
+        JSON.stringify({ type: 'session_meta', sessionId: id, cwd: fixture.topic }),
+        JSON.stringify({
+          message: { role: 'user', content: [{ type: 'text', text: 'close this delivery' }] },
+        }),
+      ].join('\n'),
+    );
+    executable(
+      cli,
+      `#!/usr/bin/env bun
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+const counter = process.env.SAFEWORD_COUNTER;
+if (!counter) process.exit(2);
+const count = existsSync(counter) ? Number(readFileSync(counter, 'utf8')) : 0;
+writeFileSync(counter, String(count + 1));
+const args = process.argv.slice(2);
+if (args[0] === 'project' && args[1] === 'test-plan') {
+  console.log(JSON.stringify([{ cwd: process.cwd(), command: 'true', available: true }]));
+} else if (args[0] === 'retro' && args[1] === 'run') {
+  console.log(JSON.stringify({ state: 'healthy', data: { agent_filing_needed: false } }));
+} else process.exit(1);
+`,
+    );
+    const environment = {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
+      GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
+      SAFEWORD_TEST_BARE: fixture.bare,
+      SAFEWORD_CLI: cli,
+      SAFEWORD_COUNTER: counter,
+      CLAUDE_PROJECT_DIR: fixture.topic,
+    };
+    const guard = nodePath.join(fixture.topic, '.safeword/scripts/closeout-cleanup.ts');
+
+    bindHostSession({ runtime: 'claude', fixture, environment, id, transcript });
+    const preview = spawnSync('bun', [guard, '--pr', '42'], {
+      cwd: fixture.topic,
+      env: environment,
+      encoding: 'utf8',
+    });
+    expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
+    const digest = (JSON.parse(preview.stdout) as { digest: string }).digest;
+
+    bindHostSession({ runtime: 'claude', fixture, environment, id, transcript });
+    const replay = spawnSync('bun', [guard, '--pr', '42'], {
+      cwd: fixture.topic,
+      env: environment,
+      encoding: 'utf8',
+    });
+    expect(replay.status, `${replay.stderr}\n${replay.stdout}`).toBe(0);
+
+    bindHostSession({
+      runtime: 'claude',
+      fixture,
+      environment,
+      id,
+      transcript,
+      guardArguments: `--pr 42 --yes --plan ${digest}`,
+    });
+    const applied = spawnSync('bun', [guard, '--pr', '42', '--yes', '--plan', digest], {
+      cwd: fixture.topic,
+      env: environment,
+      encoding: 'utf8',
+    });
+
+    expect(applied.status, `${applied.stderr}\n${applied.stdout}`).toBe(0);
+    expect(readFileSync(counter, 'utf8')).toBe('5');
+  }, 30_000);
+
   it.each([
     {
       state: 'the topic worktree is already absent',
@@ -725,6 +804,11 @@ describe('closeout production host adapters (93C14D TBU1.R4)', () => {
     ).toBe(0);
     expect(existsSync(verificationReceiptPath(fixture))).toBe(true);
 
+    // A cached receipt is only reusable for the exact clean state it covered.
+    // Make the later invocation meaningfully different so it must re-run its plan.
+    const dirtyPath = nodePath.join(fixture.topic, 'uncommitted-closeout-change.txt');
+    writeFileSync(dirtyPath, 'requires a new verification\n');
+
     const failingCli = nodePath.join(fixture.bin, 'failing-safeword.ts');
     executable(
       failingCli,
@@ -755,6 +839,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
     ).toBe(2);
     expect(existsSync(verificationReceiptPath(fixture))).toBe(false);
 
+    rmSync(dirtyPath, { force: true });
     runOrThrow('git', ['worktree', 'remove', fixture.topic], fixture.main);
     const resumedId = 'claude-receipt-after-failure';
     const resumedTranscript = transcriptFor(resumedId, fixture.main);

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -386,84 +386,136 @@ describe('closeout production host adapters (93C14D TBU1.R4)', () => {
     30_000,
   );
 
-  it('reuses one exact-head verification and retrospective snapshot from preview through apply', () => {
-    const fixture = deliveryFixture();
-    installBoundaryFakes(fixture);
-    const sandbox = nodePath.dirname(fixture.bare);
-    const id = 'claude-closeout-snapshot';
-    const transcript = nodePath.join(sandbox, `${id}.jsonl`);
-    const counter = nodePath.join(sandbox, 'safeword-invocations.txt');
-    const cli = nodePath.join(fixture.bin, 'counting-safeword.ts');
-    writeFileSync(
-      transcript,
-      [
-        JSON.stringify({ type: 'session_meta', sessionId: id, cwd: fixture.topic }),
-        JSON.stringify({
-          message: { role: 'user', content: [{ type: 'text', text: 'close this delivery' }] },
-        }),
-      ].join('\n'),
-    );
-    executable(
-      cli,
-      `#!/usr/bin/env bun
+  it.each(['claude', 'codex', 'cursor'] as const)(
+    'reuses one exact-head verification and retrospective snapshot from %s preview through apply',
+    runtime => {
+      const fixture = deliveryFixture();
+      installBoundaryFakes(fixture);
+      const sandbox = nodePath.dirname(fixture.bare);
+      const id = `${runtime}-closeout-snapshot`;
+      const codexHome = nodePath.join(sandbox, 'codex-home');
+      let transcript: string;
+      if (runtime === 'codex') {
+        mkdirSync(nodePath.join(codexHome, 'sessions'), { recursive: true });
+        transcript = nodePath.join(codexHome, 'sessions', `rollout-${id}.jsonl`);
+        writeFileSync(
+          transcript,
+          [
+            JSON.stringify({
+              type: 'session_meta',
+              payload: { id, session_id: id, cwd: fixture.topic },
+            }),
+            JSON.stringify({
+              type: 'response_item',
+              payload: {
+                type: 'message',
+                role: 'user',
+                content: [{ type: 'input_text', text: 'close this delivery' }],
+              },
+            }),
+          ].join('\n'),
+        );
+      } else if (runtime === 'cursor') {
+        const transcriptDirectory = nodePath.join(sandbox, 'agent-transcripts', id);
+        mkdirSync(transcriptDirectory, { recursive: true });
+        transcript = nodePath.join(transcriptDirectory, `${id}.jsonl`);
+        writeFileSync(
+          transcript,
+          `${JSON.stringify({
+            role: 'user',
+            message: { content: [{ type: 'text', text: 'close this delivery' }] },
+          })}\n`,
+        );
+      } else {
+        transcript = nodePath.join(sandbox, `${id}.jsonl`);
+        writeFileSync(
+          transcript,
+          [
+            JSON.stringify({ type: 'session_meta', sessionId: id, cwd: fixture.topic }),
+            JSON.stringify({
+              message: { role: 'user', content: [{ type: 'text', text: 'close this delivery' }] },
+            }),
+          ].join('\n'),
+        );
+      }
+      const counter = nodePath.join(sandbox, 'safeword-invocations.txt');
+      const cli = nodePath.join(fixture.bin, 'counting-safeword.ts');
+      executable(
+        cli,
+        String.raw`#!/usr/bin/env bun
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 const counter = process.env.SAFEWORD_COUNTER;
 if (!counter) process.exit(2);
-const count = existsSync(counter) ? Number(readFileSync(counter, 'utf8')) : 0;
-writeFileSync(counter, String(count + 1));
 const args = process.argv.slice(2);
+const previous = existsSync(counter) ? readFileSync(counter, 'utf8') : '';
+const kind = args[0] === 'project' && args[1] === 'test-plan'
+  ? 'project test-plan ' + args[args.indexOf('--kind') + 1]
+  : args[0] + ' ' + args[1];
+writeFileSync(counter, previous + kind + '\n');
 if (args[0] === 'project' && args[1] === 'test-plan') {
   console.log(JSON.stringify([{ cwd: process.cwd(), command: 'true', available: true }]));
 } else if (args[0] === 'retro' && args[1] === 'run') {
   console.log(JSON.stringify({ state: 'healthy', data: { agent_filing_needed: false } }));
 } else process.exit(1);
 `,
-    );
-    const environment = {
-      ...process.env,
-      PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
-      GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
-      SAFEWORD_TEST_BARE: fixture.bare,
-      SAFEWORD_CLI: cli,
-      SAFEWORD_COUNTER: counter,
-      CLAUDE_PROJECT_DIR: fixture.topic,
-    };
-    const guard = nodePath.join(fixture.topic, '.safeword/scripts/closeout-cleanup.ts');
+      );
+      const environment = {
+        ...process.env,
+        PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
+        GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
+        SAFEWORD_TEST_BARE: fixture.bare,
+        SAFEWORD_CLI: cli,
+        SAFEWORD_COUNTER: counter,
+        CODEX_HOME: codexHome,
+        CLAUDE_PROJECT_DIR: fixture.topic,
+      };
+      const guard = nodePath.join(fixture.topic, '.safeword/scripts/closeout-cleanup.ts');
 
-    bindHostSession({ runtime: 'claude', fixture, environment, id, transcript });
-    const preview = spawnSync('bun', [guard, '--pr', '42'], {
-      cwd: fixture.topic,
-      env: environment,
-      encoding: 'utf8',
-    });
-    expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
-    const digest = (JSON.parse(preview.stdout) as { digest: string }).digest;
+      bindHostSession({ runtime, fixture, environment, id, transcript });
+      const preview = spawnSync('bun', [guard, '--pr', '42'], {
+        cwd: fixture.topic,
+        env: environment,
+        encoding: 'utf8',
+      });
+      expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
+      const digest = (JSON.parse(preview.stdout) as { digest: string }).digest;
 
-    bindHostSession({ runtime: 'claude', fixture, environment, id, transcript });
-    const replay = spawnSync('bun', [guard, '--pr', '42'], {
-      cwd: fixture.topic,
-      env: environment,
-      encoding: 'utf8',
-    });
-    expect(replay.status, `${replay.stderr}\n${replay.stdout}`).toBe(0);
+      bindHostSession({ runtime, fixture, environment, id, transcript });
+      const replay = spawnSync('bun', [guard, '--pr', '42'], {
+        cwd: fixture.topic,
+        env: environment,
+        encoding: 'utf8',
+      });
+      expect(replay.status, `${replay.stderr}\n${replay.stdout}`).toBe(0);
 
-    bindHostSession({
-      runtime: 'claude',
-      fixture,
-      environment,
-      id,
-      transcript,
-      guardArguments: `--pr 42 --yes --plan ${digest}`,
-    });
-    const applied = spawnSync('bun', [guard, '--pr', '42', '--yes', '--plan', digest], {
-      cwd: fixture.topic,
-      env: environment,
-      encoding: 'utf8',
-    });
+      bindHostSession({
+        runtime,
+        fixture,
+        environment,
+        id,
+        transcript,
+        guardArguments: `--pr 42 --yes --plan ${digest}`,
+      });
+      const applied = spawnSync('bun', [guard, '--pr', '42', '--yes', '--plan', digest], {
+        cwd: fixture.topic,
+        env: environment,
+        encoding: 'utf8',
+      });
 
-    expect(applied.status, `${applied.stderr}\n${applied.stdout}`).toBe(0);
-    expect(readFileSync(counter, 'utf8')).toBe('5');
-  }, 30_000);
+      expect(applied.status, `${applied.stderr}\n${applied.stdout}`).toBe(0);
+      expect((JSON.parse(applied.stdout) as { result: { applied: boolean } }).result.applied).toBe(
+        true,
+      );
+      expect(readFileSync(counter, 'utf8').trim().split('\n')).toEqual([
+        'project test-plan verify',
+        'project test-plan build',
+        'project test-plan typecheck',
+        'project test-plan bdd',
+        'retro run',
+      ]);
+    },
+    30_000,
+  );
 
   it.each([
     {

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.7-rc.1",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "79ff0a5ad45150add4e1156c0321edbe1e6716045de1310a0b12e30e1dd15fe2"
+  "inventory_sha256": "b0c0e9fdbfbcee35d381882fa9dcbe1792ca0d753657756c66e2936cddeaa37d"
 }

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.5",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "a77918c32655771078df44c0f1ce117a8e1b4b33344347a70fc57aa14e4b6b7e"
+  "inventory_sha256": "ff39ff7e27d9c185fbaf56ec9460c18c5b3885f88c89b555b0726f4f5a74bd96"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -95,7 +95,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "2985c120fc447c8ae26706e5ef76c5cbd5da2402f6fe78f756a4a135b8cf27dc"
+      "sha256": "79768926ba197819c3b6f6dbd444190e3eadf29bd276da12745452b68ce8bd11"
     },
     {
       "path": "resources/templates/adr-template.md",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -95,7 +95,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "79768926ba197819c3b6f6dbd444190e3eadf29bd276da12745452b68ce8bd11"
+      "sha256": "c1b4aaac9beaff37ccca791e621c6f91081c5269f2b81333bf11462734a573a4"
     },
     {
       "path": "resources/templates/adr-template.md",

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -575,6 +575,8 @@ export function runBoundRetro(
 ): CloseoutObservation['retro'] {
   const transcript = resolveTranscript(binding, root);
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0 };
+  const cached = readRetroReceipt(root, binding, transcript);
+  if (cached) return retroObservationFromReceipt(root, binding.id, cached);
   const retro = runner(
     root,
     [
@@ -595,11 +597,9 @@ export function runBoundRetro(
     errors?: { message?: string }[];
   }>(retro);
   const pendingDrafts = readSpooledDrafts(root, binding.id).length;
-  const complete =
-    retro.status === 0 &&
-    (result?.state === 'healthy' || result?.state === 'changed') &&
-    result.data?.agent_filing_needed === false &&
-    pendingDrafts === 0;
+  const successful =
+    retro.status === 0 && (result?.state === 'healthy' || result?.state === 'changed');
+  const complete = successful && result.data?.agent_filing_needed === false && pendingDrafts === 0;
   const errorText = result?.errors?.map(error => error.message ?? '').join('\n') ?? '';
   const failure = classifyRetroFailure({
     complete,
@@ -607,6 +607,17 @@ export function runBoundRetro(
     agentFilingNeeded: result?.data?.agent_filing_needed,
     pendingDrafts,
   });
+  if (successful) {
+    writeRetroReceipt(root, {
+      runtime: binding.runtime,
+      id: binding.id,
+      projectRoot: realpathSync(binding.projectRoot),
+      snapshot: transcriptSnapshot(transcript),
+      agentFilingNeeded: result.data?.agent_filing_needed === true,
+      pendingDrafts,
+      recordedAt: new Date().toISOString(),
+    });
+  }
   return {
     bound: true,
     complete,
@@ -628,6 +639,23 @@ interface VerificationReceipt {
   recordedAt: string;
 }
 
+interface TranscriptSnapshot {
+  path: string;
+  byteLength: number;
+  digest: string;
+}
+
+interface RetroReceipt {
+  version: 1;
+  runtime: CloseoutBinding['runtime'];
+  id: string;
+  projectRoot: string;
+  snapshot: TranscriptSnapshot;
+  agentFilingNeeded: boolean;
+  pendingDrafts: number;
+  recordedAt: string;
+}
+
 const VERIFICATION_RECEIPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function cleanWorkingStateHash(headOid: string): string {
@@ -640,6 +668,102 @@ function verificationReceiptPath(root: string): string | undefined {
   return commonDirectory.status === 0 && path !== ''
     ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
     : undefined;
+}
+
+function retroReceiptPath(root: string): string | undefined {
+  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
+  const path = commonDirectory.stdout.trim();
+  return commonDirectory.status === 0 && path !== ''
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    : undefined;
+}
+
+function transcriptSnapshot(path: string): TranscriptSnapshot {
+  const content = readFileSync(path);
+  return {
+    path: realpathSync(path),
+    byteLength: content.byteLength,
+    digest: createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
+  try {
+    const content = readFileSync(snapshot.path);
+    return (
+      content.byteLength >= snapshot.byteLength &&
+      createHash('sha256').update(content.subarray(0, snapshot.byteLength)).digest('hex') ===
+        snapshot.digest
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readRetroReceipt(
+  root: string,
+  binding: CloseoutBinding,
+  transcript: string,
+  now = new Date(),
+): RetroReceipt | undefined {
+  const path = retroReceiptPath(root);
+  if (!path || !existsSync(path)) return undefined;
+  try {
+    const receipt = JSON.parse(readFileSync(path, 'utf8')) as Partial<RetroReceipt>;
+    const recordedAt =
+      typeof receipt.recordedAt === 'string' ? Date.parse(receipt.recordedAt) : Number.NaN;
+    return receipt.version === 1 &&
+      receipt.runtime === binding.runtime &&
+      receipt.id === binding.id &&
+      receipt.projectRoot === realpathSync(binding.projectRoot) &&
+      receipt.snapshot?.path === realpathSync(transcript) &&
+      typeof receipt.snapshot.byteLength === 'number' &&
+      receipt.snapshot.byteLength >= 0 &&
+      typeof receipt.snapshot.digest === 'string' &&
+      Number.isFinite(recordedAt) &&
+      recordedAt <= now.getTime() &&
+      now.getTime() - recordedAt <= VERIFICATION_RECEIPT_MAX_AGE_MS &&
+      snapshotStillMatches(receipt.snapshot)
+      ? (receipt as RetroReceipt)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>): boolean {
+  const path = retroReceiptPath(root);
+  if (!path) return false;
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    mkdirSync(nodePath.dirname(path), { recursive: true });
+    writeFileSync(temporaryPath, `${JSON.stringify({ version: 1, ...receipt })}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, path);
+    return true;
+  } catch {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    return false;
+  }
+}
+
+function retroObservationFromReceipt(
+  root: string,
+  sessionId: string,
+  receipt: RetroReceipt,
+): CloseoutObservation['retro'] {
+  const pendingDrafts = readSpooledDrafts(root, sessionId).length;
+  const filingRecovered =
+    receipt.agentFilingNeeded && receipt.pendingDrafts > 0 && pendingDrafts === 0;
+  const complete = (!receipt.agentFilingNeeded || filingRecovered) && pendingDrafts === 0;
+  return {
+    bound: true,
+    complete,
+    pendingDrafts,
+    failure: complete ? undefined : 'filing',
+  };
 }
 
 function readVerificationReceipt(
@@ -705,8 +829,17 @@ function workingStateHash(root: string, headOid: string): string {
 
 function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
+  const observedStateHash = workingStateHash(root, observedHead);
+  const receipt = readVerificationReceipt(root, expectedOid);
+  if (receipt && observedHead === expectedOid && observedStateHash === receipt.stateHash) {
+    return {
+      current: true,
+      passed: true,
+      headOid: receipt.headOid,
+      stateHash: receipt.stateHash,
+    };
+  }
   if (observedHead !== expectedOid) {
-    const receipt = readVerificationReceipt(root, expectedOid);
     return receipt
       ? {
           current: true,

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -663,18 +663,18 @@ function cleanWorkingStateHash(headOid: string): string {
 }
 
 function verificationReceiptPath(root: string): string | undefined {
-  const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
-  const path = commonDirectory.stdout.trim();
-  return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-verification.json')
-    : undefined;
+  return closeoutReceiptPath(root, 'closeout-verification.json');
 }
 
 function retroReceiptPath(root: string): string | undefined {
+  return closeoutReceiptPath(root, 'closeout-retro.json');
+}
+
+function closeoutReceiptPath(root: string, filename: string): string | undefined {
   const commonDirectory = git(root, 'rev-parse', '--git-common-dir');
   const path = commonDirectory.stdout.trim();
   return commonDirectory.status === 0 && path !== ''
-    ? nodePath.join(nodePath.resolve(root, path), 'safeword', 'closeout-retro.json')
+    ? nodePath.join(nodePath.resolve(root, path), 'safeword', filename)
     : undefined;
 }
 


### PR DESCRIPTION
Closes #2314

## What changed
- Reuse a post-merge verification receipt only for the exact clean HEAD it covered.
- Record a session-bound retrospective snapshot and reuse it through preview, replay, and apply.
- Allow closeout to proceed after pending retrospective drafts are filed without rerunning extraction.

## Why
Closeout previously discarded its verification receipt on every invocation and reran retrospective extraction each time, turning a merged delivery into repeated checks and new filing drafts.

## Validation
- closeout cleanup unit and host-adapter integration coverage
- package typecheck
- Claude plugin release contract
- CLI contract check
- generated artifact parity and whitespace checks