### PR TITLE
chore(release): v0.74.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.5",
+      "version": "0.74.6",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.5",
+  "version": "0.74.6",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.5 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.6 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.5 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.6 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.5 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.6 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.5 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.6 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.5 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.6 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.5",
+  "version": "0.74.6",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/tests/cli-protocol/help-aliases.test.ts
+++ b/packages/cli/tests/cli-protocol/help-aliases.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { commandCatalog, findCommandDefinition } from '../../src/cli-protocol/catalog.js';
 import { configureCliOutput, createCliProgram } from '../../src/cli-protocol/program.js';
 import { createResult } from '../../src/cli-protocol/result.js';
-import { createTemporaryDirectory, runCli } from '../helpers.js';
+import { createTemporaryDirectory, runCli, runCliWithoutInstall } from '../helpers.js';
 
 function visibleCommands(help: string): string[] {
   const section = help.split('\nCommands:\n', 2)[1]?.split('\n\n', 1)[0] ?? '';
@@ -227,7 +227,7 @@ describe('canonical help and compatibility aliases', () => {
 
   it('reports setup --yes as explicit redundant compatibility', async () => {
     const directory = createTemporaryDirectory();
-    const result = await runCli(
+    const result = await runCliWithoutInstall(
       ['setup', '--yes', '--json', '--no-input', '--offline', '--cwd', directory],
       { cwd: directory },
     );

--- a/packages/cli/tests/smoke/codex-parity.live.test.ts
+++ b/packages/cli/tests/smoke/codex-parity.live.test.ts
@@ -378,7 +378,7 @@ describe.skipIf(!CAN_RUN)('live smoke: Codex packaged plugin parity', () => {
 
     // A headless process proves cache dispatch and all hook evidence, but it is
     // not a restarted Desktop app-server and therefore must leave activation pending.
-    const marker = writeCodexActivationMarker(environment, new Date(), { activeHosts: [] });
+    const marker = writeCodexActivationMarker(environment, new Date());
     const model = process.env.SAFEWORD_CODEX_SMOKE_MODEL ?? DEFAULT_CODEX_ACTIVATION_CHECK_MODEL;
     const activation = runHeadlessCodexActivationCheck({
       codexBinary: CODEX,
@@ -394,7 +394,7 @@ describe.skipIf(!CAN_RUN)('live smoke: Codex packaged plugin parity', () => {
       expect(shimOutput).toContain(`--bun safeword@${packageVersion()} hook codex ${event}`);
     }
     assertNoProjectWorkflowTree(projectRoot);
-  });
+  }, 600_000);
 });
 
 describe.skipIf(!CAN_RUN_MIGRATION)('live smoke: Codex public migration', () => {

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.5",
+  "plugin_version": "0.74.6",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "a77918c32655771078df44c0f1ce117a8e1b4b33344347a70fc57aa14e4b6b7e"
+  "inventory_sha256": "4bfcb37ac993411c4eb6fd45a017c392b854d1b7fc59f55d350719d6a5435c41"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "739aa4216f164102b1a0ea523a22242e1166cd7a0cb3a16b5723e5508532fde6"
+      "sha256": "a17883159a856be9f451b672749bc42437cc4554168e5e77a93023250188d621"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.5",
+  "version": "0.74.6",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- release Safeword 0.74.6 with the Node 22 relay-test reliability fix already merged to main
- keep the live Codex activation smoke host-aware when invoked from Codex Desktop
- give the composite live cache scenario enough time for its three independently bounded headless probes
- update all four release-tracked CLI and plugin version surfaces

## Verification

- main CI and Retro Relay production deployment: green
- `bun run --cwd packages/cli test tests/codex-plugin/headless-activation-check.test.ts` (5 passed)
- isolated authenticated Codex cache smoke with `gpt-5.6-terra` (1 passed, 1 intentional skip)
- pre-commit schema/parity and formatting gates