### PR TITLE
Make review contract distribution tests self-describing

### DIFF
--- a/features/native-claude-plugin.feature
+++ b/features/native-claude-plugin.feature
@@ -130,11 +130,11 @@ Feature: Ship Safeword as a native Claude Code plugin
       Then cleanup refuses to contract that project
       And the unknown content and every unrelated project file remain byte-identical
 
-    Scenario: Ordinary setup preserves an existing legacy project and its Claude profile
+    Scenario: Ordinary setup preserves an existing legacy project and unrelated Claude profile state
       Given an existing project has viable legacy Claude protection and arbitrary profile state
       When ordinary safeword setup upgrades the project
-      Then every viable legacy asset and the complete Claude profile are byte-identical
-      And the result recommends the canonical Claude install command without invoking it
+      Then every viable legacy asset and unrelated Claude profile state are preserved
+      And the result records the project plugin install and recommends reloading it
 
   @native-claude-plugin.TBU1.R3 @surface.claude-code @surface.safeword-cli
   Rule: native-claude-plugin.TBU1.R3 — Framework code executes from the installed versioned plugin while project state remains in the repository

--- a/packages/cli/features/steps/clarify-review-coverage.steps.ts
+++ b/packages/cli/features/steps/clarify-review-coverage.steps.ts
@@ -1,17 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import { promisify } from 'node:util';
@@ -75,31 +65,16 @@ const fixtureControlVariables = new Set([
   'SAFEWORD_REVIEW_COVERAGE_FAIL_CODEX',
   'SAFEWORD_REVIEW_COVERAGE_VERDICT',
   'SAFEWORD_REVIEW_COVERAGE_FINDING',
+  'SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE',
+  'SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX',
 ]);
 const CHANGE_REQUEST_VERDICT = 'request_changes';
 const CHANGE_REQUEST_FINDING = 'Needs work.';
 const fixtureDirectories = new Set<string>();
 
-BeforeAll(() => {
+BeforeAll(async () => {
   const cliRoot = nodePath.join(repoRoot, 'packages/cli');
-  const builtCli = nodePath.join(cliRoot, 'dist/cli.js');
-  assert.ok(
-    existsSync(builtCli),
-    'Missing packages/cli/dist/cli.js; run bun run pretest:bdd before cucumber-js.',
-  );
-  let newestInput = 0;
-  for (const input of [
-    nodePath.join(cliRoot, 'src'),
-    nodePath.join(cliRoot, 'package.json'),
-    nodePath.join(cliRoot, 'tsconfig.json'),
-    nodePath.join(cliRoot, 'tsup.config.ts'),
-  ]) {
-    newestInput = Math.max(newestInput, newestModifiedTime(input));
-  }
-  assert.ok(
-    statSync(builtCli).mtimeMs >= newestInput,
-    'Stale packages/cli/dist/cli.js; run bun run pretest:bdd before cucumber-js.',
-  );
+  await execFileAsync('bun', ['run', 'build'], { cwd: cliRoot });
   productionCliBuild.completed = true;
 });
 
@@ -112,17 +87,6 @@ function createFixtureDirectory(prefix: string): string {
   const directory = mkdtempSync(nodePath.join(tmpdir(), prefix));
   fixtureDirectories.add(directory);
   return directory;
-}
-
-function newestModifiedTime(path: string): number {
-  const status = statSync(path);
-  if (!status.isDirectory()) return status.mtimeMs;
-  let latest = status.mtimeMs;
-  const entries = readdirSync(path, { withFileTypes: true });
-  for (const entry of entries) {
-    latest = Math.max(latest, newestModifiedTime(nodePath.join(path, entry.name)));
-  }
-  return latest;
 }
 
 function sanitizedFixtureEnvironment(): NodeJS.ProcessEnv {
@@ -710,66 +674,53 @@ function createCliFixture(): CliFixture {
 }
 
 function reviewerInvocationValidation(agent: 'claude' | 'codex'): string {
-  if (agent === 'claude') {
-    return String.raw`prompt_mode=0
-output_json=0
-schema=0
-isolated_session=0
-slash_commands=0
-setting_sources=0
-strict_mcp=0
-tools=0
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -p) prompt_mode=1; shift ;;
-    --output-format) [ "$#" -ge 2 ] && [ "$2" = "json" ] || exit 64; output_json=1; shift 2 ;;
-    --json-schema) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; schema=1; shift 2 ;;
-    --no-session-persistence) isolated_session=1; shift ;;
-    --disable-slash-commands) slash_commands=1; shift ;;
-    --setting-sources) [ "$#" -ge 2 ] && [ -z "$2" ] || exit 64; setting_sources=1; shift 2 ;;
-    --strict-mcp-config) strict_mcp=1; shift ;;
-    --tools) [ "$#" -ge 2 ] && [ -z "$2" ] || exit 64; tools=1; shift 2 ;;
-    --model) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; shift 2 ;;
-    *) printf 'unsupported claude review argument: %s\n' "$1" >&2; exit 64 ;;
-  esac
-done
-[ "$prompt_mode$output_json$schema$isolated_session$slash_commands$setting_sources$strict_mcp$tools" = "11111111" ] || {
-  printf 'incomplete claude review arguments\n' >&2
-  exit 64
-}`;
-  }
-  return String.raw`exec_mode=0
-json=0
-sandbox=0
-git_check=0
-ephemeral=0
-user_config=0
-rules=0
-hooks=0
-mcp=0
-schema=0
-stdin_marker=0
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    exec) exec_mode=1; shift ;;
-    --json) json=1; shift ;;
-    --sandbox) [ "$#" -ge 2 ] && [ "$2" = "read-only" ] || exit 64; sandbox=1; shift 2 ;;
-    --skip-git-repo-check) git_check=1; shift ;;
-    --ephemeral) ephemeral=1; shift ;;
-    --ignore-user-config) user_config=1; shift ;;
-    --ignore-rules) rules=1; shift ;;
-    --disable) [ "$#" -ge 2 ] && [ "$2" = "hooks" ] || exit 64; hooks=1; shift 2 ;;
-    --config) [ "$#" -ge 2 ] && [ "$2" = "mcp_servers={}" ] || exit 64; mcp=1; shift 2 ;;
-    --output-schema) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; schema=1; shift 2 ;;
-    --model) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; shift 2 ;;
-    -) stdin_marker=1; shift; [ "$#" -eq 0 ] || exit 64 ;;
-    *) printf 'unsupported codex review argument: %s\n' "$1" >&2; exit 64 ;;
-  esac
-done
-[ "$exec_mode$json$sandbox$git_check$ephemeral$user_config$rules$hooks$mcp$schema$stdin_marker" = "11111111111" ] || {
-  printf 'incomplete codex review arguments\n' >&2
-  exit 64
-}`;
+  const dynamic = undefined;
+  const expected: readonly (string | undefined)[] =
+    agent === 'claude'
+      ? [
+          '-p',
+          '--output-format',
+          'json',
+          '--json-schema',
+          dynamic,
+          '--no-session-persistence',
+          '--disable-slash-commands',
+          '--setting-sources',
+          '',
+          '--strict-mcp-config',
+          '--tools',
+          '',
+        ]
+      : [
+          'exec',
+          '--json',
+          '--sandbox',
+          'read-only',
+          '--skip-git-repo-check',
+          '--ephemeral',
+          '--ignore-user-config',
+          '--ignore-rules',
+          '--disable',
+          'hooks',
+          '--config',
+          'mcp_servers={}',
+          '--output-schema',
+          dynamic,
+          '-',
+        ];
+  const checks = expected.map((argument, index) => {
+    const position = index + 1;
+    const predicate =
+      argument === undefined ? '[ -n "$1" ]' : `[ "$1" = ${shellSingleQuoted(argument)} ]`;
+    return String.raw`[ "$#" -gt 0 ] && ${predicate} || { printf 'invalid ${agent} review argument at position ${position}\n' >&2; exit 64; }
+shift`;
+  });
+  return `${checks.join('\n')}\n[ "$#" -eq 0 ] || { printf 'unexpected extra ${agent} review arguments\\n' >&2; exit 64; }`;
+}
+
+function shellSingleQuoted(value: string): string {
+  const escapedQuote = ["'", '"', "'", '"', "'"].join('');
+  return `'${value.split("'").join(escapedQuote)}'`;
 }
 
 function installStandardReviewerFixture(): CliFixture {

--- a/packages/cli/features/steps/clarify-review-coverage.steps.ts
+++ b/packages/cli/features/steps/clarify-review-coverage.steps.ts
@@ -1,12 +1,24 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import { promisify } from 'node:util';
 
-import { BeforeAll, Given, Then, When } from '@cucumber/cucumber';
+import { AfterAll, BeforeAll, Given, Then, When } from '@cucumber/cucumber';
+import { AstBuilder, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin';
+import { IdGenerator } from '@cucumber/messages';
 
 import { generateClaudePluginAssets } from '../../src/claude-plugin/catalogue.js';
 import {
@@ -50,7 +62,7 @@ interface ReviewWorld {
     result: CliExecution;
   };
   requiredOutcome?: { name: string; result: CliExecution };
-  blockedMode?: { name: string; result: { stdout: string; stderr: string; exitCode: number } };
+  blockedMode?: { name: string; result: CliExecution };
   originalRecovery?: unknown;
 }
 
@@ -66,13 +78,52 @@ const fixtureControlVariables = new Set([
 ]);
 const CHANGE_REQUEST_VERDICT = 'request_changes';
 const CHANGE_REQUEST_FINDING = 'Needs work.';
+const fixtureDirectories = new Set<string>();
 
-BeforeAll(async () => {
-  await execFileAsync('bun', ['run', 'build'], {
-    cwd: nodePath.join(repoRoot, 'packages/cli'),
-  });
+BeforeAll(() => {
+  const cliRoot = nodePath.join(repoRoot, 'packages/cli');
+  const builtCli = nodePath.join(cliRoot, 'dist/cli.js');
+  assert.ok(
+    existsSync(builtCli),
+    'Missing packages/cli/dist/cli.js; run bun run pretest:bdd before cucumber-js.',
+  );
+  let newestInput = 0;
+  for (const input of [
+    nodePath.join(cliRoot, 'src'),
+    nodePath.join(cliRoot, 'package.json'),
+    nodePath.join(cliRoot, 'tsconfig.json'),
+    nodePath.join(cliRoot, 'tsup.config.ts'),
+  ]) {
+    newestInput = Math.max(newestInput, newestModifiedTime(input));
+  }
+  assert.ok(
+    statSync(builtCli).mtimeMs >= newestInput,
+    'Stale packages/cli/dist/cli.js; run bun run pretest:bdd before cucumber-js.',
+  );
   productionCliBuild.completed = true;
 });
+
+AfterAll(() => {
+  for (const directory of fixtureDirectories) rmSync(directory, { force: true, recursive: true });
+  fixtureDirectories.clear();
+});
+
+function createFixtureDirectory(prefix: string): string {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), prefix));
+  fixtureDirectories.add(directory);
+  return directory;
+}
+
+function newestModifiedTime(path: string): number {
+  const status = statSync(path);
+  if (!status.isDirectory()) return status.mtimeMs;
+  let latest = status.mtimeMs;
+  const entries = readdirSync(path, { withFileTypes: true });
+  for (const entry of entries) {
+    latest = Math.max(latest, newestModifiedTime(nodePath.join(path, entry.name)));
+  }
+  return latest;
+}
 
 function sanitizedFixtureEnvironment(): NodeJS.ProcessEnv {
   return Object.fromEntries(
@@ -402,15 +453,23 @@ Given('reviewer prose mentions {string}', function (this: ReviewWorld, prose: st
   };
 });
 
+function renderOrdinaryReview(world: ReviewWorld): void {
+  assert.ok(world.reviewResult);
+  world.human = renderHumanResult(world.reviewResult);
+}
+
+function renderOrdinaryAndVerboseReview(world: ReviewWorld): void {
+  renderOrdinaryReview(world);
+  assert.ok(world.reviewResult);
+  world.verbose = renderHumanResult(world.reviewResult, { verbose: true });
+}
+
 When('the typed review result is rendered for a person', function (this: ReviewWorld) {
-  assert.ok(this.reviewResult);
-  this.human = renderHumanResult(this.reviewResult);
+  renderOrdinaryReview(this);
 });
 
 When('verbose review details are rendered', function (this: ReviewWorld) {
-  assert.ok(this.reviewResult);
-  this.human = renderHumanResult(this.reviewResult);
-  this.verbose = renderHumanResult(this.reviewResult, { verbose: true });
+  renderOrdinaryAndVerboseReview(this);
 });
 
 When('human and JSON review results are rendered', function (this: ReviewWorld) {
@@ -509,7 +568,7 @@ Then('review policy is absent', function (this: ReviewWorld) {
 });
 
 Then('no completed coverage phrase is shown', function (this: ReviewWorld) {
-  const presentation = (this.human ?? '').replace(
+  const presentation = (this.human ?? '').replaceAll(
     'required independent coverage is unsatisfied',
     '',
   );
@@ -524,16 +583,26 @@ Then('the declared inconsistent cases exactly match the executable rejection dom
     nodePath.join(repoRoot, 'packages/cli/features/clarify-review-coverage.feature'),
     'utf8',
   );
-  const scenarioBody = feature.split(
-    'Scenario Outline: Presentation rejects inconsistent policy and status as completed coverage',
-    2,
-  )[1];
-  const section = scenarioBody?.split('@clarify-review-coverage', 2)[0];
-  assert.ok(section);
-  const declared = section
-    .split('\n')
-    .map(line => /^\s*\|\s*([a-z][\w-]+)\s*\|\s*$/u.exec(line)?.[1])
-    .filter((value): value is string => value !== undefined && value !== 'case')
+  const parser = new Parser(
+    new AstBuilder(IdGenerator.incrementing()),
+    new GherkinClassicTokenMatcher(),
+  );
+  const document = parser.parse(feature);
+  const scenario = document.feature?.children
+    .map(child => child.scenario)
+    .find(
+      candidate =>
+        candidate?.name ===
+        'Presentation rejects inconsistent policy and status as completed coverage',
+    );
+  assert.ok(scenario, 'Missing inconsistent-policy presentation scenario outline');
+  const declared = scenario.examples
+    .flatMap(example => {
+      const caseColumn = example.tableHeader?.cells.findIndex(cell => cell.value === 'case') ?? -1;
+      assert.notEqual(caseColumn, -1, 'Missing case column in inconsistent-policy examples');
+      return example.tableBody.map(row => row.cells[caseColumn]?.value);
+    })
+    .filter((value): value is string => value !== undefined)
     .toSorted((left, right) => left.localeCompare(right));
   assert.deepEqual(
     declared,
@@ -633,10 +702,79 @@ Then('requested changes remain the first review line', function (this: ReviewWor
   assert.equal(this.verbose?.split('\n', 1)[0], 'Review changes requested — standard coverage.');
 });
 
-function installStandardReviewerFixture(): CliFixture {
-  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-coverage-bdd-'));
-  const bin = mkdtempSync(nodePath.join(tmpdir(), 'safeword-coverage-bin-'));
+function createCliFixture(): CliFixture {
+  const directory = createFixtureDirectory('safeword-coverage-bdd-');
+  const bin = createFixtureDirectory('safeword-coverage-bin-');
   writeFileSync(nodePath.join(directory, 'spec.md'), `bounded review input ${directory}\n`);
+  return { directory, bin };
+}
+
+function reviewerInvocationValidation(agent: 'claude' | 'codex'): string {
+  if (agent === 'claude') {
+    return String.raw`prompt_mode=0
+output_json=0
+schema=0
+isolated_session=0
+slash_commands=0
+setting_sources=0
+strict_mcp=0
+tools=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) prompt_mode=1; shift ;;
+    --output-format) [ "$#" -ge 2 ] && [ "$2" = "json" ] || exit 64; output_json=1; shift 2 ;;
+    --json-schema) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; schema=1; shift 2 ;;
+    --no-session-persistence) isolated_session=1; shift ;;
+    --disable-slash-commands) slash_commands=1; shift ;;
+    --setting-sources) [ "$#" -ge 2 ] && [ -z "$2" ] || exit 64; setting_sources=1; shift 2 ;;
+    --strict-mcp-config) strict_mcp=1; shift ;;
+    --tools) [ "$#" -ge 2 ] && [ -z "$2" ] || exit 64; tools=1; shift 2 ;;
+    --model) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; shift 2 ;;
+    *) printf 'unsupported claude review argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+[ "$prompt_mode$output_json$schema$isolated_session$slash_commands$setting_sources$strict_mcp$tools" = "11111111" ] || {
+  printf 'incomplete claude review arguments\n' >&2
+  exit 64
+}`;
+  }
+  return String.raw`exec_mode=0
+json=0
+sandbox=0
+git_check=0
+ephemeral=0
+user_config=0
+rules=0
+hooks=0
+mcp=0
+schema=0
+stdin_marker=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    exec) exec_mode=1; shift ;;
+    --json) json=1; shift ;;
+    --sandbox) [ "$#" -ge 2 ] && [ "$2" = "read-only" ] || exit 64; sandbox=1; shift 2 ;;
+    --skip-git-repo-check) git_check=1; shift ;;
+    --ephemeral) ephemeral=1; shift ;;
+    --ignore-user-config) user_config=1; shift ;;
+    --ignore-rules) rules=1; shift ;;
+    --disable) [ "$#" -ge 2 ] && [ "$2" = "hooks" ] || exit 64; hooks=1; shift 2 ;;
+    --config) [ "$#" -ge 2 ] && [ "$2" = "mcp_servers={}" ] || exit 64; mcp=1; shift 2 ;;
+    --output-schema) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; schema=1; shift 2 ;;
+    --model) [ "$#" -ge 2 ] && [ -n "$2" ] || exit 64; shift 2 ;;
+    -) stdin_marker=1; shift; [ "$#" -eq 0 ] || exit 64 ;;
+    *) printf 'unsupported codex review argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+[ "$exec_mode$json$sandbox$git_check$ephemeral$user_config$rules$hooks$mcp$schema$stdin_marker" = "11111111111" ] || {
+  printf 'incomplete codex review arguments\n' >&2
+  exit 64
+}`;
+}
+
+function installStandardReviewerFixture(): CliFixture {
+  const fixture = createCliFixture();
+  const { bin } = fixture;
   const executable = nodePath.join(bin, 'codex');
   writeFileSync(
     executable,
@@ -647,6 +785,7 @@ if printf '%s' "$*" | /usr/bin/grep -q -- '--help'; then
   printf '%s\n' '--json --sandbox --skip-git-repo-check --ephemeral --ignore-user-config --ignore-rules --disable --config --output-schema --model'
   exit 0
 fi
+${reviewerInvocationValidation('codex')}
 payload=$(cat)
 dispatch_id=$(printf '%s' "$payload" | sed -n 's/.*"dispatch_id":"\([^"]*\)".*/\1/p')
 printf '{"schema_version":1,"dispatch_id":"%s","reviewer_agent":"codex","verdict":"approve","summary":"reviewed","findings":[]}\n' "$dispatch_id"
@@ -654,7 +793,7 @@ printf '{"schema_version":1,"dispatch_id":"%s","reviewer_agent":"codex","verdict
     { mode: 0o755 },
   );
   chmodSync(executable, 0o755);
-  return { directory, bin };
+  return fixture;
 }
 
 function installCoverageReviewer(bin: string, agent: 'claude' | 'codex'): void {
@@ -669,6 +808,7 @@ function installCoverageReviewer(bin: string, agent: 'claude' | 'codex'): void {
 set -eu
 if [ "$#" -gt 0 ] && [ "$1" = "--version" ]; then printf '${agent} 1.0.0\n'; exit 0; fi
 if printf '%s' "$*" | /usr/bin/grep -q -- '--help'; then printf '%s\n' '${capabilities}'; exit 0; fi
+${reviewerInvocationValidation(agent)}
 failure=$(printenv SAFEWORD_REVIEW_COVERAGE_FAIL_${agent.toUpperCase()} || printenv SAFEWORD_REVIEW_COVERAGE_FAIL || true)
 if [ "$failure" = "1" ]; then printf 'review failed\n' >&2; exit 7; fi
 payload=$(cat)
@@ -691,7 +831,7 @@ async function runFixtureCli(
   fixture: CliFixture,
   arguments_: string[],
   environment: Record<string, string> = {},
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+): Promise<CliExecution> {
   try {
     const result = await execFileAsync(
       process.execPath,
@@ -709,11 +849,23 @@ async function runFixtureCli(
     );
     return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
   } catch (error) {
-    const failed = error as { stdout?: string; stderr?: string; code?: number };
+    const failed = error as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string | null;
+      signal?: NodeJS.Signals | null;
+    };
+    const diagnostics = [
+      failed.stderr,
+      typeof failed.code === 'string' ? `Spawn error: ${failed.code}` : undefined,
+      failed.signal === undefined || failed.signal === null
+        ? undefined
+        : `Process terminated by signal: ${failed.signal}`,
+    ].filter((value): value is string => value !== undefined && value.length > 0);
     return {
       stdout: failed.stdout ?? '',
-      stderr: failed.stderr ?? '',
-      exitCode: failed.code ?? 1,
+      stderr: diagnostics.join('\n'),
+      exitCode: typeof failed.code === 'number' ? failed.code : 1,
     };
   }
 }
@@ -756,7 +908,8 @@ function fixtureArguments(name: string, directory: string): string[] {
   }
   if (name === 'quiet') return ['--quiet', '--verbose', ...suffix];
   if (name === 'json') return ['--json', '--verbose', ...suffix];
-  return ['review', 'run', '--help'];
+  if (name === 'help') return ['review', 'run', '--help'];
+  assert.fail(`Unknown review fixture mode: ${name}`);
 }
 
 function assertBlockedJsonMode(result: CliExecution): void {
@@ -782,11 +935,7 @@ function assertBlockedQuietMode(result: CliExecution): void {
   });
 }
 
-function assertOneVerboseSuggestion(result: {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}): void {
+function assertOneVerboseSuggestion(result: CliExecution): void {
   const suggestion = 'To add independent coverage, install or update Claude, then retry review.';
   assert.equal(result.exitCode, 0);
   assert.equal(result.stdout.split('\n', 1)[0], 'Review complete — standard coverage.');
@@ -948,9 +1097,7 @@ Given(
 );
 
 When('ordinary and verbose review content is rendered', function (this: ReviewWorld) {
-  assert.ok(this.reviewResult);
-  this.human = renderHumanResult(this.reviewResult);
-  this.verbose = renderHumanResult(this.reviewResult, { verbose: true });
+  renderOrdinaryAndVerboseReview(this);
 });
 
 Then(
@@ -978,7 +1125,7 @@ function installRequiredReviewerFixture(): CliFixture {
 }
 
 function installPreferredReviewerFixture(policy?: 'require'): CliFixture {
-  const fixture = installStandardReviewerFixture();
+  const fixture = createCliFixture();
   installCoverageReviewer(fixture.bin, 'codex');
   installCoverageReviewer(fixture.bin, 'claude');
   if (policy !== undefined) {
@@ -994,7 +1141,7 @@ function installPreferredReviewerFixture(policy?: 'require'): CliFixture {
 async function runRequiredFixture(
   environment: Record<string, string> = {},
   mode: 'json' | 'quiet' = 'json',
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+): Promise<CliExecution> {
   const fixture = installRequiredReviewerFixture();
   return runFixtureCli(
     fixture,
@@ -1357,24 +1504,46 @@ function assertNoContradictoryPolicyClaims(content: string, relativePath: string
   }
 }
 
-function distributedContractContent(relativePath: string): string {
+function contractBody(content: string): string {
+  if (!content.startsWith('---\n')) return content.trim();
+  const body = content.split('---', 3)[2]?.trim();
+  assert.ok(body, 'Contract frontmatter must be followed by a body');
+  return body;
+}
+
+function distributedContractContent(
+  relativePath: string,
+  expectedContract: ReviewContractName,
+): string {
   const content = readFileSync(nodePath.join(repoRoot, relativePath), 'utf8');
   const pointer = contractPointerTarget(content);
+  if (pointer !== undefined) {
+    assert.ok(
+      pointer.includes(`/skills/${expectedContract}/`),
+      `${relativePath} points to the wrong review contract: ${pointer}`,
+    );
+  }
   return pointer === undefined ? content : readFileSync(nodePath.join(repoRoot, pointer), 'utf8');
 }
 
 function contractPointerTarget(content: string): string | undefined {
-  return /(?:Read and follow the instructions in |@)(\.safeword\/skills\/(?:finish-review|quality-review)\/SKILL\.md)/u.exec(
-    content,
+  return /^(?:Read and follow the instructions in |@)(\.safeword\/skills\/(?:finish-review|quality-review)\/SKILL\.md)$/u.exec(
+    contractBody(content),
   )?.[1];
 }
 
-function assertPointerOnlyWrapper(relativePath: string): void {
+function assertPointerOnlyWrapper(
+  relativePath: string,
+  expectedContract: ReviewContractName,
+): void {
   const content = readFileSync(nodePath.join(repoRoot, relativePath), 'utf8');
   const pointer = contractPointerTarget(content);
   if (pointer === undefined) return;
-  const body = content.split('---', 3)[2]?.trim();
-  assert.ok(body, relativePath);
+  assert.ok(
+    pointer.includes(`/skills/${expectedContract}/`),
+    `${relativePath} points to the wrong review contract: ${pointer}`,
+  );
+  const body = contractBody(content);
   assert.equal(
     body,
     body.startsWith('@') ? `@${pointer}` : `Read and follow the instructions in ${pointer}`,
@@ -1397,7 +1566,10 @@ Then(
     assert.ok(this.distributedContract);
     const contractPaths = distributedContractPaths(this.distributedContract);
     for (const relativePath of contractPaths) {
-      assert.ok(distributedContractContent(relativePath).includes(expected), relativePath);
+      assert.ok(
+        distributedContractContent(relativePath, this.distributedContract).includes(expected),
+        relativePath,
+      );
     }
   },
 );
@@ -1406,11 +1578,13 @@ Then('every surface preserves its policy boundary clauses', function (this: Revi
   assert.ok(this.distributedContract);
   const contractPaths = distributedContractPaths(this.distributedContract);
   for (const relativePath of contractPaths) {
-    assertPointerOnlyWrapper(relativePath);
-    const content = normalizeContract(distributedContractContent(relativePath));
+    assertPointerOnlyWrapper(relativePath, this.distributedContract);
+    const content = normalizeContract(
+      distributedContractContent(relativePath, this.distributedContract),
+    );
     const mandatoryBlock = mandatoryPolicyBlock(this.distributedContract);
     assert.ok(content.includes(mandatoryBlock), relativePath);
-    const remainder = content.replace(mandatoryBlock, '');
+    const remainder = content.replaceAll(mandatoryBlock, '');
     assertNoContradictoryPolicyClaims(remainder, relativePath);
   }
 });
@@ -1426,8 +1600,8 @@ Then(
       'Never describe either supplemental route as completed standard or independent coverage, and never write an independent review stamp from this workflow.',
     ];
     for (const relativePath of contractPaths) {
-      assertPointerOnlyWrapper(relativePath);
-      const content = normalizeContract(distributedContractContent(relativePath));
+      assertPointerOnlyWrapper(relativePath, 'finish-review');
+      const content = normalizeContract(distributedContractContent(relativePath, 'finish-review'));
       let remainder = content;
       for (const clause of allowedClauses) {
         assert.ok(content.includes(clause), relativePath);
@@ -1438,7 +1612,7 @@ Then(
         /\b(?:standard(?: or independent)?|independent|completed standard(?: or independent)?|completed machine|machine-validated) coverage\b/iu,
         relativePath,
       );
-      const policyRemainder = remainder.replace(mandatoryPolicyBlock('finish-review'), '');
+      const policyRemainder = remainder.replaceAll(mandatoryPolicyBlock('finish-review'), '');
       assertNoContradictoryPolicyClaims(policyRemainder, relativePath);
     }
   },
@@ -1581,10 +1755,12 @@ function assertReviewManifests(): void {
     ),
   ) as { skills?: string };
   assert.deepEqual(claudeManifest.skills, ['./skills']);
+  const claudeSkillsRoot = claudeManifest.skills?.[0];
+  assert.ok(claudeSkillsRoot);
   assert.equal(codexManifest.skills, './skills/');
   for (const name of contractNames) {
     const claudeSkill: string = readFileSync(
-      nodePath.join(repoRoot, 'plugin', claudeManifest.skills[0] ?? '', name, 'SKILL.md'),
+      nodePath.join(repoRoot, 'plugin', claudeSkillsRoot, name, 'SKILL.md'),
       'utf8',
     );
     const codexSkill: string = readFileSync(

--- a/packages/cli/features/steps/clarify-review-coverage.steps.ts
+++ b/packages/cli/features/steps/clarify-review-coverage.steps.ts
@@ -1266,12 +1266,16 @@ const distributedContracts = {
       'packages/cli/codex-plugin/skills/finish-review/SKILL.md',
     ],
     dogfood: ['.safeword/skills/finish-review/SKILL.md', '.claude/skills/finish-review/SKILL.md'],
-    cursor: [
-      'packages/cli/templates/commands/finish-review.md',
-      '.cursor/commands/finish-review.md',
-      'packages/cli/templates/cursor/rules/safeword-finish-review.mdc',
-      '.cursor/rules/safeword-finish-review.mdc',
-    ],
+    cursor: {
+      command: {
+        source: 'packages/cli/templates/commands/finish-review.md',
+        destination: '.cursor/commands/finish-review.md',
+      },
+      rule: {
+        source: 'packages/cli/templates/cursor/rules/safeword-finish-review.mdc',
+        destination: '.cursor/rules/safeword-finish-review.mdc',
+      },
+    },
   },
   'quality-review': {
     canonical: 'packages/cli/templates/skills/quality-review/SKILL.md',
@@ -1280,18 +1284,27 @@ const distributedContracts = {
       'packages/cli/codex-plugin/skills/quality-review/SKILL.md',
     ],
     dogfood: ['.safeword/skills/quality-review/SKILL.md', '.claude/skills/quality-review/SKILL.md'],
-    cursor: [
-      'packages/cli/templates/commands/quality-review.md',
-      '.cursor/commands/quality-review.md',
-      'packages/cli/templates/cursor/rules/safeword-quality-reviewing.mdc',
-      '.cursor/rules/safeword-quality-reviewing.mdc',
-    ],
+    cursor: {
+      command: {
+        source: 'packages/cli/templates/commands/quality-review.md',
+        destination: '.cursor/commands/quality-review.md',
+      },
+      rule: {
+        source: 'packages/cli/templates/cursor/rules/safeword-quality-reviewing.mdc',
+        destination: '.cursor/rules/safeword-quality-reviewing.mdc',
+      },
+    },
   },
 } as const;
 
 function distributedContractPaths(name: ReviewContractName): readonly string[] {
   const contract = distributedContracts[name];
-  return [contract.canonical, ...contract.generated, ...contract.dogfood, ...contract.cursor];
+  return [
+    contract.canonical,
+    ...contract.generated,
+    ...contract.dogfood,
+    ...Object.values(contract.cursor).flatMap(edge => [edge.source, edge.destination]),
+  ];
 }
 
 const mandatoryFinishPolicyBlock = `Under \`prefer\`, map \`approve\` to \`State: approved\` and \`request_changes\` to
@@ -1468,12 +1481,10 @@ function assertDogfoodContractEdges(): void {
 }
 
 function assertCursorContractEdges(): void {
-  const cursorEdges = Object.values(distributedContracts).flatMap(contract => [
-    [contract.cursor[0], contract.cursor[1]],
-    [contract.cursor[2], contract.cursor[3]],
-  ]);
-  for (const [source, destination] of cursorEdges) {
-    assert.ok(source && destination);
+  const cursorEdges = Object.values(distributedContracts).flatMap(contract =>
+    Object.values(contract.cursor),
+  );
+  for (const { source, destination } of cursorEdges) {
     assert.equal(
       readFileSync(nodePath.join(repoRoot, destination), 'utf8'),
       readFileSync(nodePath.join(repoRoot, source), 'utf8'),

--- a/packages/cli/src/claude-plugin/inventory.ts
+++ b/packages/cli/src/claude-plugin/inventory.ts
@@ -37,6 +37,9 @@ export function claudeNativePayloadFiles(root: string): string[] {
   const visit = (physicalDirectory: string, logicalDirectory: string): void => {
     const entries = readdirSync(physicalDirectory, { withFileTypes: true });
     for (const entry of entries) {
+      // Claude owns this root-level lease directory and rotates PID markers
+      // while sessions use the cached plugin. It is host metadata, not payload.
+      if (logicalDirectory === '' && entry.isDirectory() && entry.name === '.in_use') continue;
       const physicalPath = nodePath.join(physicalDirectory, entry.name);
       const logicalPath =
         logicalDirectory === '' ? entry.name : nodePath.posix.join(logicalDirectory, entry.name);

--- a/packages/cli/tests/claude-plugin/inventory.test.ts
+++ b/packages/cli/tests/claude-plugin/inventory.test.ts
@@ -1,0 +1,19 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { claudeNativePayloadFiles } from '../../src/claude-plugin/inventory.js';
+import { createTemporaryDirectory } from '../helpers.js';
+
+describe('Claude native plugin inventory', () => {
+  it('ignores Claude host lease markers only at the payload root', () => {
+    const root = createTemporaryDirectory();
+    mkdirSync(nodePath.join(root, '.in_use'));
+    writeFileSync(nodePath.join(root, '.in_use/12345'), '');
+    mkdirSync(nodePath.join(root, 'skills/.in_use'), { recursive: true });
+    writeFileSync(nodePath.join(root, 'skills/.in_use/unlisted'), 'untrusted\n');
+
+    expect(claudeNativePayloadFiles(root)).toEqual(['skills/.in_use/unlisted']);
+  });
+});

--- a/packages/cli/tests/claude-plugin/inventory.test.ts
+++ b/packages/cli/tests/claude-plugin/inventory.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -15,5 +15,14 @@ describe('Claude native plugin inventory', () => {
     writeFileSync(nodePath.join(root, 'skills/.in_use/unlisted'), 'untrusted\n');
 
     expect(claudeNativePayloadFiles(root)).toEqual(['skills/.in_use/unlisted']);
+  });
+
+  it('keeps a root lease-marker symlink visible as an untrusted leaf', () => {
+    const root = createTemporaryDirectory();
+    const external = createTemporaryDirectory();
+    writeFileSync(nodePath.join(external, '12345'), 'outside payload\n');
+    symlinkSync(external, nodePath.join(root, '.in_use'), 'dir');
+
+    expect(claudeNativePayloadFiles(root)).toEqual(['.in_use']);
   });
 });

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.74.6",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "4bfcb37ac993411c4eb6fd45a017c392b854d1b7fc59f55d350719d6a5435c41"
+  "inventory_sha256": "45b36633bc99b89ff2986f3a7eae18116be63ed5189b4d8b024de2a7c81e00b8"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,11 +139,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "6a8244b9a6431b16c6fcb212a60b6382c88c283f648e3b37448aef6d4b6a21fc"
+      "sha256": "a591a6f502eb82ac2bae70a40af9a33b9f38576d33a72273f4d09546fae9cbf2"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "6953daa3b78140fb9ab8350fc13474fb4a8436e172da2aeb619f9f9f8af401ae"
+      "sha256": "0b92bcd9f6221d16163107a4b02e3840e59565d2bec9d6b73eb9f464f2cffa31"
     },
     {
       "path": "runtime/event-groups.json",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -15882,6 +15882,8 @@ function claudeNativePayloadFiles(root) {
   const visit = (physicalDirectory, logicalDirectory) => {
     const entries = readdirSync8(physicalDirectory, { withFileTypes: true });
     for (const entry of entries) {
+      if (logicalDirectory === "" && entry.isDirectory() && entry.name === ".in_use")
+        continue;
       const physicalPath = nodePath24.join(physicalDirectory, entry.name);
       const logicalPath = logicalDirectory === "" ? entry.name : nodePath24.posix.join(logicalDirectory, entry.name);
       if (entry.isDirectory())

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1734,6 +1734,7 @@ function claudeNativePayloadFiles(root) {
   const visit3 = (physicalDirectory, logicalDirectory) => {
     const entries = readdirSync(physicalDirectory, { withFileTypes: true });
     for (const entry of entries) {
+      if (logicalDirectory === '' && entry.isDirectory() && entry.name === '.in_use') continue;
       const physicalPath = nodePath3.join(physicalDirectory, entry.name);
       const logicalPath =
         logicalDirectory === '' ? entry.name : nodePath3.posix.join(logicalDirectory, entry.name);

--- a/steps/native-claude-plugin.steps.ts
+++ b/steps/native-claude-plugin.steps.ts
@@ -1437,10 +1437,17 @@ Then(
 Then(
   'the result records the project plugin install and recommends reloading it',
   function (this: NativeClaudePluginWorld) {
+    assert.equal(this.lifecycle?.result?.status, 2, this.lifecycle?.result?.output);
     const result = JSON.parse(this.lifecycle?.result?.output ?? '') as {
+      ok?: boolean;
+      state?: string;
+      errors?: unknown[];
       next_actions?: { command?: string }[];
       effects?: { configuration?: { kind?: string; operation?: string; target?: string }[] };
     };
+    assert.equal(result.ok, true);
+    assert.equal(result.state, 'action_required');
+    assert.deepEqual(result.errors, []);
     assert.ok(
       result.effects?.configuration?.some(
         effect =>

--- a/steps/native-claude-plugin.steps.ts
+++ b/steps/native-claude-plugin.steps.ts
@@ -1413,30 +1413,11 @@ Given(
 
 When('ordinary safeword setup upgrades the project', function (this: NativeClaudePluginWorld) {
   assert.ok(this.lifecycle);
-  const result = spawnSync(
-    'bun',
-    [
-      nodePath.join(REPO_ROOT, 'packages/cli/src/cli.ts'),
-      'setup',
-      '--json',
-      '--no-input',
-      '--cwd',
-      this.lifecycle.project,
-    ],
-    {
-      cwd: REPO_ROOT,
-      env: { ...process.env, SAFEWORD_SKIP_INSTALL: '1', SAFEWORD_SKIP_SKILLS: '1' },
-      encoding: 'utf8',
-    },
-  );
-  this.lifecycle.result = {
-    status: result.status ?? 1,
-    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
-  };
+  this.lifecycle.result = runLifecycleCommand(this, ['setup']);
 });
 
 Then(
-  'every viable legacy asset and the complete Claude profile are byte-identical',
+  'every viable legacy asset and unrelated Claude profile state are preserved',
   function (this: NativeClaudePluginWorld) {
     assert.ok(this.lifecycle);
     assert.equal(
@@ -1446,21 +1427,31 @@ Then(
         'utf8',
       ),
     );
-    assert.equal(readFileSync(this.lifecycle.statePath, 'utf8'), this.lifecycle.profileSnapshot);
+    const state = JSON.parse(readFileSync(this.lifecycle.statePath, 'utf8')) as {
+      unrelated?: unknown;
+    };
+    assert.deepEqual(state.unrelated, this.lifecycle.unrelatedProfile);
   },
 );
 
 Then(
-  'the result recommends the canonical Claude install command without invoking it',
+  'the result records the project plugin install and recommends reloading it',
   function (this: NativeClaudePluginWorld) {
     const result = JSON.parse(this.lifecycle?.result?.output ?? '') as {
       next_actions?: { command?: string }[];
+      effects?: { configuration?: { kind?: string; operation?: string; target?: string }[] };
     };
     assert.ok(
-      result.next_actions?.some(action => action.command === 'safeword install --agents=claude'),
+      result.effects?.configuration?.some(
+        effect =>
+          effect.kind === 'install' &&
+          effect.target === 'safeword@safeword' &&
+          effect.operation === 'project',
+      ),
+      JSON.stringify(result),
     );
+    assert.ok(result.next_actions?.some(action => action.command === '/reload-plugins'));
     assert.ok(this.lifecycle);
-    assert.equal(readFileSync(this.lifecycle.statePath, 'utf8'), this.lifecycle.profileSnapshot);
   },
 );
 


### PR DESCRIPTION
## What changed

- replace positional Cursor contract paths with named command and rule edges
- harden the review-coverage BDD fixtures: controlled CLI builds, isolated temp cleanup, exact ordered Claude/Codex argv validation, Gherkin AST parsing, and explicit contract-pointer checks
- ignore only Claude host-owned root `.in_use/<pid>` lease markers while continuing to reject nested or symlinked unlisted content
- isolate the ordinary native-Claude setup scenario from the real user profile and align its vocabulary with unified install plus `/reload-plugins`

## Review findings resolved

- stale or incomplete build artifacts could satisfy the fixture freshness gate
- fake reviewers accepted duplicated or reordered collaborator arguments
- root `.in_use/<pid>` host leases made plugin health and machine output nondeterministic
- the native-Claude BDD scenario called the real Claude CLI and could pass against user-specific state
- the activation-required success scenario lacked an explicit outcome assertion

Independent review requested changes on each gap above. Every finding was fixed and re-reviewed. Final verdict: approve, no findings. The generated plugin runtime mirrors and full identity/inventory hash chain were also independently verified.

## Verification

- lint, Gherkin lint, formatting, and TypeScript typecheck passed
- dependency audit: 0 errors; one pre-existing `packages/cli/src/codex-plugin/hooks.ts` orphan warning
- review vocabulary feature: 127 scenarios, 2,042 steps passed
- Claude inventory, dispatch security, and machine contract: 21 tests passed
- full Vitest: Relay 167 passed / 1 skipped; CLI 7,187 passed / 5 skipped across 476 files
- full BDD completed 1,485 passed / 3 skipped with one stale native-Claude scenario exposed; after fixing it, that scenario passed all 43 steps and the final commit is running through GitHub CI
