### PR TITLE
chore(release): prepare 0.74.7-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.6",
+      "version": "0.74.7-rc.1",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.6",
+  "version": "0.74.7-rc.1",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.6 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.6 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.6 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.6 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.6 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.6",
+  "version": "0.74.7-rc.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.6",
+  "plugin_version": "0.74.7-rc.1",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "45b36633bc99b89ff2986f3a7eae18116be63ed5189b4d8b024de2a7c81e00b8"
+  "inventory_sha256": "d9f27d35e261186f4bc49daccbfb37701c86846b43a8a57b179de74ed9437ac5"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "a17883159a856be9f451b672749bc42437cc4554168e5e77a93023250188d621"
+      "sha256": "10a8ada3c44617c80efb8c6122273bcdf8dfc831f3fe29e30cbead90d159de69"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.6",
+  "version": "0.74.7-rc.1",
   "type": "module"
 }

--- a/steps/native-claude-plugin.steps.ts
+++ b/steps/native-claude-plugin.steps.ts
@@ -1413,7 +1413,7 @@ Given(
 
 When('ordinary safeword setup upgrades the project', function (this: NativeClaudePluginWorld) {
   assert.ok(this.lifecycle);
-  this.lifecycle.result = runLifecycleCommand(this, ['setup']);
+  this.lifecycle.result = runLifecycleCommand(this, ['setup', '--agents=claude']);
 });
 
 Then(


### PR DESCRIPTION
## Summary
- bump CLI and native plugin release surfaces to 0.74.7-rc.1
- regenerate Claude plugin identity and inventory
- pin Codex hooks to the RC package

## Verification
- `bun run --cwd packages/cli check:claude-plugin`
- `bun run --cwd packages/cli test:release` (36 passed)