### PR TITLE
chore(release): prepare 0.74.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.7-rc.1",
+      "version": "0.74.7",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.7-rc.1",
+  "version": "0.74.7",
   "description": "Safe Word workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safe Word standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safe Word edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safe Word post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safe Word prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7-rc.1 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.74.7 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safe Word stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.7-rc.1",
+  "version": "0.74.7",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.7-rc.1",
+  "plugin_version": "0.74.7",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "6a1320c20cb8e9d147171c3582b2bb744e08790614f08b02fa4a2c98653512f7"
+  "inventory_sha256": "33b66ec4c3e8779e481f8673f2077e6bb263f3c55c7d03177c95b2b07ddacbcf"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "10a8ada3c44617c80efb8c6122273bcdf8dfc831f3fe29e30cbead90d159de69"
+      "sha256": "154d7a85d10285fc8f5c789063e65994d3052ab77b1bef79e719ae4df22b3ba5"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.7-rc.1",
+  "version": "0.74.7",
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- promote the accepted 0.74.7 release candidate to stable
- regenerate Claude plugin identity and inventory
- pin Codex hooks to stable 0.74.7

## RC acceptance
- public `0.74.7-rc.1` published with provenance
- same-name marketplace upgraded from `v0.74.6` to `v0.74.7-rc.1` in an isolated authenticated profile
- exact plugin identity/inventory and candidate cache root verified
- unrelated profile state and persistent plugin-data sentinel preserved byte-for-byte
- real Claude hooks succeeded and `/quality-review` loaded its helper from the candidate cache
- `claude status --json` healthy; idempotent reinstall returned `changed: false`
- documented deviation: 0.74.6 PreToolUse blocked Bash inside the old task, so the candidate CLI upgrade ran directly against the same isolated authenticated profile before real-task proof

## Verification
- `bun run --cwd packages/cli check:claude-plugin`
- `bun run --cwd packages/cli test:release` (36 passed)