### PR TITLE
chore(release): v0.75.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.74.7",
+      "version": "0.75.0",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.7",
+  "version": "0.75.0",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.75.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.75.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.75.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.75.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.74.7 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.75.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.74.7",
+  "version": "0.75.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.74.7",
+  "plugin_version": "0.75.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "151b38e002e9fb7819bf9f250afddb3809de2a5ba2e6713151033bd9fcdddd05"
+  "inventory_sha256": "33510190f28119c47a87ac8afff2a87a11adea57d3eb57e612527b2519d4cee5"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "154d7a85d10285fc8f5c789063e65994d3052ab77b1bef79e719ae4df22b3ba5"
+      "sha256": "5e7804cfb1647392fafca0762d4605bedca5500b6f2b55332f89977a67701549"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.74.7",
+  "version": "0.75.0",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- release Safeword 0.75.0 as an additive minor version
- synchronize CLI, Claude plugin, Codex plugin, and pinned Codex hooks
- regenerate the committed Claude plugin catalogue

## Verification

- deterministic Codex headless activation check: 5 passed
- release contract suite: 36 passed
- ESLint
- TypeScript typecheck
- diff hygiene