### PR TITLE
Clarify profile-only legacy install aliases

### DIFF
--- a/packages/cli/src/cli-protocol/catalog.ts
+++ b/packages/cli/src/cli-protocol/catalog.ts
@@ -110,22 +110,27 @@ function alias(name: string, aliasFor: string): CommandDefinition {
 function scopedInstallAlias(name: string, agent: 'claude' | 'codex'): CommandDefinition {
   const canonical = canonicalDefinition('install');
   return {
-    ...command(name, `Deprecated alias for install --agents=${agent}`, canonical.effectClass, {
-      promptPolicy: canonical.promptPolicy,
-      networkPolicy: canonical.networkPolicy,
-      commandOptions: agent === 'claude' ? [claudeScopeOption()] : [],
-      // The retained spelling keeps its shipped safety guarantee: profile-only
-      // installation that leaves the repository untouched (main's Rule
-      // codex-plugin-install.TBU1.R2). `install --agents=<agent>` is the
-      // canonical route that also reconciles project configuration.
-      handler: publicHandler(name),
-    }),
+    ...command(
+      name,
+      `Deprecated profile-only install; install --agents=${agent} also reconciles the project`,
+      canonical.effectClass,
+      {
+        promptPolicy: canonical.promptPolicy,
+        networkPolicy: canonical.networkPolicy,
+        commandOptions: agent === 'claude' ? [claudeScopeOption()] : [],
+        // The retained spelling keeps its shipped safety guarantee: profile-only
+        // installation that leaves the repository untouched (main's Rule
+        // codex-plugin-install.TBU1.R2). `install --agents=<agent>` is the
+        // canonical route that also reconciles project configuration.
+        handler: publicHandler(name),
+      },
+    ),
     aliasFor: 'install',
     classification: 'retained-alias',
     visibility: 'hidden',
     compatibility: {
       ...RETAINED_ALIAS,
-      replacement: `install --agents=${agent}`,
+      replacement: `install --agents=${agent} (also reconciles the project)`,
     },
   };
 }

--- a/packages/cli/tests/cli-protocol/catalog.test.ts
+++ b/packages/cli/tests/cli-protocol/catalog.test.ts
@@ -187,12 +187,12 @@ describe('CLI command catalog', () => {
         { route: 'bare safeword', replacement: 'status', retention: 'indefinite' },
         {
           route: 'claude install',
-          replacement: 'install --agents=claude',
+          replacement: 'install --agents=claude (also reconciles the project)',
           retention: 'indefinite',
         },
         {
           route: 'codex install',
-          replacement: 'install --agents=codex',
+          replacement: 'install --agents=codex (also reconciles the project)',
           retention: 'indefinite',
         },
         {

--- a/packages/cli/tests/cli-protocol/help-aliases.test.ts
+++ b/packages/cli/tests/cli-protocol/help-aliases.test.ts
@@ -99,7 +99,9 @@ describe('canonical help and compatibility aliases', () => {
       ).toBe(false);
     }
     expect(result.stdout).toContain('Compatibility routes (retained indefinitely):');
-    expect(result.stdout).toContain('claude install -> install --agents=claude');
+    expect(result.stdout).toContain(
+      'claude install -> install --agents=claude (also reconciles the project)',
+    );
     expect(result.stdout).toContain(
       'project architecture --stage -> project architecture --from-index --stage-output',
     );

--- a/packages/website/src/content/docs/reference/cli.mdx
+++ b/packages/website/src/content/docs/reference/cli.mdx
@@ -99,7 +99,9 @@ leaving Cursor untouched.
 
 {/* safeword:compatibility:start */}
 
-`setup`, `upgrade`, `claude install`, and `codex install` remain deprecated aliases.
+`setup` and `upgrade` remain deprecated aliases for `install`. `claude install` and
+`codex install` remain profile-only legacy routes; use `install --agents=claude` or
+`install --agents=codex` when you also want project reconciliation.
 
 {/* safeword:compatibility:end */}
 
@@ -177,7 +179,7 @@ safeword claude cleanup
 safeword claude recover # only when status reports recovery-required
 ```
 
-`claude install` selects and verifies the official stable plugin at project scope by default, preserving unrelated settings and an explicit native-update opt-out. Pass `--scope user` for profile-wide activation without project-file changes. After install or update, `/reload-plugins` activates it in the current task; the next successful prompt records proof bound to the installed version and bundled hook manifest, then automatically retires exact catalogued legacy Safeword files and settings entries. Modified, malformed, unknown, and third-party content is preserved with a non-blocking advisory. `claude status` is read-only; `claude cleanup` remains an explicit diagnostic/repair path. Neither path installs, updates, enables, reloads, or trusts a plugin.
+The deprecated `claude install` route selects and verifies only the official stable plugin at project scope by default; it does not reconcile project configuration. Use `safeword install --agents=claude` for the canonical project-plus-Claude flow. Pass `--scope user` to the legacy route for profile-wide activation without project-file changes. After install or update, `/reload-plugins` activates it in the current task; the next successful prompt records proof bound to the installed version and bundled hook manifest, then automatically retires exact catalogued legacy Safeword files and settings entries. Modified, malformed, unknown, and third-party content is preserved with a non-blocking advisory. `claude status` is read-only; `claude cleanup` remains an explicit diagnostic/repair path. Neither path installs, updates, enables, reloads, or trusts a plugin.
 
 The **BDD acceptance lane is universal**: every project gets cucumber-js wired (`test:bdd` script, `features/` + `steps/` starters, `@cucumber/cucumber` + `tsx` + `@types/node` as devDependencies). Step definitions are always TypeScript — they test your app from the outside (shell out to `go test`, `cargo test`, or hit it over HTTP), so a pure Go/Python/Rust repo gets a minimal private `package.json` created to host the lane.
 
@@ -237,33 +239,33 @@ compatibility metadata.
 
 {/* safeword:generated-cli-compatibility:start */}
 
-| Retained route                        | Canonical replacement                              |
-| ------------------------------------- | -------------------------------------------------- |
-| bare `safeword`                       | `status`                                           |
-| `check`                               | `status`                                           |
-| `claude install`                      | `install --agents=claude`                          |
-| `codex install`                       | `install --agents=codex`                           |
-| `setup`                               | `install`                                          |
-| `upgrade`                             | `install`                                          |
-| `diff`                                | `plan`                                             |
-| `remove`                              | `uninstall --agents=none`                          |
-| `reset`                               | `uninstall --agents=none`                          |
-| `sync-config`                         | `project sync-config`                              |
-| `architecture`                        | `project architecture`                             |
-| `sync-learnings`                      | `project sync-learnings`                           |
-| `sync-tickets`                        | `project sync-tickets`                             |
-| `codify`                              | `project codify`                                   |
-| `test-plan`                           | `project test-plan`                                |
-| `lint-gherkin`                        | `project lint-gherkin`                             |
-| `sync-tracker`                        | `tracker sync`                                     |
-| `connect`                             | `tracker connect`                                  |
-| `self-report`                         | `retro signals`                                    |
-| `retro`                               | `retro run`                                        |
-| `retro-reconcile`                     | `retro reconcile`                                  |
-| `migrate codex-plugin`                | `codex migrate`                                    |
-| `project architecture --stage`        | `project architecture --from-index --stage-output` |
-| `project architecture --staged`       | `project architecture --from-index`                |
-| `codex migrate --remove-legacy-hooks` | `codex migrate --finalize`                         |
+| Retained route                        | Canonical replacement                                   |
+| ------------------------------------- | ------------------------------------------------------- |
+| bare `safeword`                       | `status`                                                |
+| `check`                               | `status`                                                |
+| `claude install`                      | `install --agents=claude (also reconciles the project)` |
+| `codex install`                       | `install --agents=codex (also reconciles the project)`  |
+| `setup`                               | `install`                                               |
+| `upgrade`                             | `install`                                               |
+| `diff`                                | `plan`                                                  |
+| `remove`                              | `uninstall --agents=none`                               |
+| `reset`                               | `uninstall --agents=none`                               |
+| `sync-config`                         | `project sync-config`                                   |
+| `architecture`                        | `project architecture`                                  |
+| `sync-learnings`                      | `project sync-learnings`                                |
+| `sync-tickets`                        | `project sync-tickets`                                  |
+| `codify`                              | `project codify`                                        |
+| `test-plan`                           | `project test-plan`                                     |
+| `lint-gherkin`                        | `project lint-gherkin`                                  |
+| `sync-tracker`                        | `tracker sync`                                          |
+| `connect`                             | `tracker connect`                                       |
+| `self-report`                         | `retro signals`                                         |
+| `retro`                               | `retro run`                                             |
+| `retro-reconcile`                     | `retro reconcile`                                       |
+| `migrate codex-plugin`                | `codex migrate`                                         |
+| `project architecture --stage`        | `project architecture --from-index --stage-output`      |
+| `project architecture --staged`       | `project architecture --from-index`                     |
+| `codex migrate --remove-legacy-hooks` | `codex migrate --finalize`                              |
 
 {/* safeword:generated-cli-compatibility:end */}
 

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.75.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "33510190f28119c47a87ac8afff2a87a11adea57d3eb57e612527b2519d4cee5"
+  "inventory_sha256": "89e52f05f0c7c6a78f2c5f4201982e04728c1610ec65afb063e5d0cb36d8b3b8"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "59a0d80884db3f938aa851b5297edba7052a5bfeb2d9ef94fe69ab6cd89c0631"
+      "sha256": "10f79bc3ddf032e096a0b829fe0a0a6f2e6e7754f7d3bd54efd42233943e57bb"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -58066,7 +58066,7 @@ function alias(name, aliasFor) {
 function scopedInstallAlias(name, agent) {
   const canonical = canonicalDefinition("install");
   return {
-    ...command(name, `Deprecated alias for install --agents=${agent}`, canonical.effectClass, {
+    ...command(name, `Deprecated profile-only install; install --agents=${agent} also reconciles the project`, canonical.effectClass, {
       promptPolicy: canonical.promptPolicy,
       networkPolicy: canonical.networkPolicy,
       commandOptions: agent === "claude" ? [claudeScopeOption()] : [],
@@ -58077,7 +58077,7 @@ function scopedInstallAlias(name, agent) {
     visibility: "hidden",
     compatibility: {
       ...RETAINED_ALIAS,
-      replacement: `install --agents=${agent}`
+      replacement: `install --agents=${agent} (also reconciles the project)`
     }
   };
 }


### PR DESCRIPTION
Fixes #2496.

Clarifies that legacy `claude install` and `codex install` are profile-only routes, while canonical `install --agents=…` also reconciles project configuration. Keeps every alias and its behavior intact.

Validation:
- focused CLI contract tests (33 CLI + 167 relay)
- CLI contract check
- Claude plugin release contract check