### PR TITLE
Route Claude reviews through Opus then Sonnet

### DIFF
--- a/packages/cli/features/clarify-review-coverage.feature
+++ b/packages/cli/features/clarify-review-coverage.feature
@@ -175,10 +175,10 @@ Feature: Make review coverage clear without false alarms
 
     Examples:
       | case              | state           | status            | independence | actual | assigned | verdict         | keys                                                                                                                        |
-      | approved          | healthy         | approved          | degraded     | codex  | claude   | approve         | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status                                       |
-      | changes_requested | action_required | changes_requested | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status               |
-      | blocked_degraded  | action_required | blocked           | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,review_policy,reviewer_output,status |
-      | exhausted         | action_required | blocked           | none         | absent | claude   | absent          | alternate_model_failure,assigned_reviewer,author_agent,command,fallback_failure,independence,preferred_failure,review_policy,status                |
+      | approved          | healthy         | approved          | degraded     | codex  | claude   | approve         | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,preferred_model,reviewer_output,status                                                       |
+      | changes_requested | action_required | changes_requested | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,preferred_model,reviewer_output,status               |
+      | blocked_degraded  | action_required | blocked           | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,preferred_model,review_policy,reviewer_output,status |
+      | exhausted         | action_required | blocked           | none         | absent | claude   | absent          | alternate_model,alternate_model_failure,assigned_reviewer,author_agent,command,fallback_failure,independence,preferred_failure,preferred_model,review_policy,status                |
 
   @clarify-review-coverage.TBU1.R1 @surface.safeword-cli @rejection
   Scenario: Requested changes suppress optional coverage upgrades

--- a/packages/cli/features/clarify-review-coverage.feature
+++ b/packages/cli/features/clarify-review-coverage.feature
@@ -175,10 +175,10 @@ Feature: Make review coverage clear without false alarms
 
     Examples:
       | case              | state           | status            | independence | actual | assigned | verdict         | keys                                                                                                                        |
-      | approved          | healthy         | approved          | degraded     | codex  | claude   | approve         | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status                 |
-      | changes_requested | action_required | changes_requested | degraded     | codex  | claude   | request_changes | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status                 |
-      | blocked_degraded  | action_required | blocked           | degraded     | codex  | claude   | request_changes | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,review_policy,reviewer_output,status   |
-      | exhausted         | action_required | blocked           | none         | absent | claude   | absent          | assigned_reviewer,author_agent,command,fallback_failure,independence,preferred_failure,review_policy,status                  |
+      | approved          | healthy         | approved          | degraded     | codex  | claude   | approve         | actual_reviewer,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status                                       |
+      | changes_requested | action_required | changes_requested | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,reviewer_output,status               |
+      | blocked_degraded  | action_required | blocked           | degraded     | codex  | claude   | request_changes | actual_reviewer,alternate_model_failure,assigned_reviewer,author_agent,command,independence,preferred_failure,review_policy,reviewer_output,status |
+      | exhausted         | action_required | blocked           | none         | absent | claude   | absent          | alternate_model_failure,assigned_reviewer,author_agent,command,fallback_failure,independence,preferred_failure,review_policy,status                |
 
   @clarify-review-coverage.TBU1.R1 @surface.safeword-cli @rejection
   Scenario: Requested changes suppress optional coverage upgrades

--- a/packages/cli/features/reliable-reviews-for-real-packets.feature
+++ b/packages/cli/features/reliable-reviews-for-real-packets.feature
@@ -183,11 +183,11 @@ Feature: Keep independent reviews reliable for real ticket packets
   @reliable-reviews-for-real-packets.TBU3.R4 @surface.claude-code
   Rule: reliable-reviews-for-real-packets.TBU3.R4 — A later route starts only when the shared run bound can still fund a meaningful attempt
 
-    Scenario: A funded alternate-model route receives its attempt
-      Given a configured alternate model for the reviewer agent
-      And the reviewer agent's default model never answers
+    Scenario: A timed-out Claude Opus review leaves a funded Sonnet attempt
+      Given the default Claude Opus model never answers
       When the independent review runs
-      Then the alternate model still receives its own attempt
+      Then the Sonnet review returns an independent verdict
+      And the result names Opus as the timed-out primary model
 
     @rejection
     Scenario: An unfundable alternate-model route is not started

--- a/packages/cli/features/reliable-reviews-for-real-packets.feature
+++ b/packages/cli/features/reliable-reviews-for-real-packets.feature
@@ -165,7 +165,7 @@ Feature: Keep independent reviews reliable for real ticket packets
       Then the result does not report a full cross-agent check
 
   @reliable-reviews-for-real-packets.TBU3.R3 @surface.claude-code
-  Rule: reliable-reviews-for-real-packets.TBU3.R3 — With no alternate model configured, routing is exactly what it is today, and Safeword never supplies a model name of its own
+  Rule: reliable-reviews-for-real-packets.TBU3.R3 — Reviewer model overrides are validated before they can influence routing
 
     Scenario: A model value within the grammar is used as configured
       Given a configured alternate model within the accepted grammar
@@ -181,21 +181,20 @@ Feature: Keep independent reviews reliable for real ticket packets
       Then the reviewer is never asked for a review on an alternate model
 
   @reliable-reviews-for-real-packets.TBU3.R4 @surface.claude-code
-  Rule: reliable-reviews-for-real-packets.TBU3.R4 — The default first route leaves at least the 120-second floor for a configured independent retry; every later route remains capped by the shared run bound
+  Rule: reliable-reviews-for-real-packets.TBU3.R4 — A later route starts only when the shared run bound can still fund a meaningful attempt
 
-    Scenario: A route that uses its whole budget still leaves the next route its own
-      Given a configured alternate model for the reviewer agent
-      And the reviewer agent's default model never answers
-      And the reviewer agent's alternate model answers promptly
-      When the independent review runs
-      Then the review returns the alternate model's verdict
-
-    @rejection
-    Scenario: The preferred route leaves a fundable alternate-model retry
+    Scenario: A funded alternate-model route receives its attempt
       Given a configured alternate model for the reviewer agent
       And the reviewer agent's default model never answers
       When the independent review runs
       Then the alternate model still receives its own attempt
+
+    @rejection
+    Scenario: An unfundable alternate-model route is not started
+      Given a configured alternate model for the reviewer agent
+      And the run bound is reached while an early route is still working
+      When the independent review runs
+      Then the reviewer is never asked for a review on an alternate model
 
   @reliable-reviews-for-real-packets.TBU3.R5 @surface.claude-code
   Rule: reliable-reviews-for-real-packets.TBU3.R5 — Every route is tried in a fixed order; the run bound stops any route whose reviewer has not exited with valid output before its deadline

--- a/packages/cli/features/steps/clarify-review-coverage.steps.ts
+++ b/packages/cli/features/steps/clarify-review-coverage.steps.ts
@@ -887,7 +887,7 @@ function assertBlockedQuietMode(result: CliExecution): void {
   assert.deepEqual(result, {
     stdout:
       'Review incomplete — required independent coverage is unsatisfied.\n' +
-      'The independent reviewer (Claude) could not be run. The same reviewer on its alternate model (Claude) could not be run. The fallback review (Codex) could not be run. No independent check was recorded.\n',
+      'The independent reviewer using opus (Claude) could not be run. The same reviewer on its alternate model using sonnet (Claude) could not be run. The fallback review (Codex) could not be run. No independent check was recorded.\n',
     stderr: '',
     exitCode: 2,
   });

--- a/packages/cli/features/steps/clarify-review-coverage.steps.ts
+++ b/packages/cli/features/steps/clarify-review-coverage.steps.ts
@@ -715,7 +715,14 @@ function reviewerInvocationValidation(agent: 'claude' | 'codex'): string {
     return String.raw`[ "$#" -gt 0 ] && ${predicate} || { printf 'invalid ${agent} review argument at position ${position}\n' >&2; exit 64; }
 shift`;
   });
-  return `${checks.join('\n')}\n[ "$#" -eq 0 ] || { printf 'unexpected extra ${agent} review arguments\\n' >&2; exit 64; }`;
+  const trailingModel =
+    agent === 'claude'
+      ? String.raw`if [ "$#" -gt 0 ]; then
+[ "$#" -eq 2 ] && [ "$1" = "--model" ] && [ -n "$2" ] || { printf 'invalid claude model arguments\n' >&2; exit 64; }
+shift 2
+fi`
+      : '';
+  return `${checks.join('\n')}\n${trailingModel}\n[ "$#" -eq 0 ] || { printf 'unexpected extra ${agent} review arguments\\n' >&2; exit 64; }`;
 }
 
 function shellSingleQuoted(value: string): string {
@@ -880,7 +887,7 @@ function assertBlockedQuietMode(result: CliExecution): void {
   assert.deepEqual(result, {
     stdout:
       'Review incomplete — required independent coverage is unsatisfied.\n' +
-      'The independent reviewer (Claude) could not be run. The fallback review (Codex) could not be run. No independent check was recorded.\n',
+      'The independent reviewer (Claude) could not be run. The same reviewer on its alternate model (Claude) could not be run. The fallback review (Codex) could not be run. No independent check was recorded.\n',
     stderr: '',
     exitCode: 2,
   });

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -38,6 +38,8 @@ type Behaviour =
   | 'fails'
   | 'never answers'
   | 'answers only with a model'
+  | 'answers only with the expected model'
+  | 'times out on opus and answers on sonnet'
   | 'answers off contract'
   | 'answers after termination'
   | 'leaves a grandchild'
@@ -58,6 +60,27 @@ interface ReviewScenario {
 }
 
 type ReviewWorld = SafewordWorld & { review?: ReviewScenario };
+
+function modelSpecificBehaviour(behaviour: Behaviour, answer: string): string | undefined {
+  if (behaviour === 'answers only with a model') {
+    return `if ! printf '%s' "$*" | /usr/bin/grep -q -- '--model'; then\n  printf 'default model unavailable\\n' >&2\n  exit 7\nfi\n${answer}`;
+  }
+  if (behaviour === 'answers only with the expected model') {
+    return `model=''\nprevious=''\nfor argument in "$@"; do\n  if [ "$previous" = "--model" ]; then model="$argument"; fi\n  previous="$argument"\ndone\nif [ "$model" != "$SAFEWORD_REVIEW_BDD_EXPECTED_MODEL" ]; then\n  printf 'model unavailable: %s\\n' "$model" >&2\n  exit 7\nfi\n${answer}`;
+  }
+  if (behaviour === 'times out on opus and answers on sonnet') {
+    return String.raw`model=''
+previous=''
+for argument in "$@"; do
+  if [ "$previous" = "--model" ]; then model="$argument"; fi
+  previous="$argument"
+done
+if [ "$model" = "opus" ]; then exec /bin/sleep 3600; fi
+if [ "$model" != "sonnet" ]; then printf 'unexpected model: %s\n' "$model" >&2; exit 7; fi
+${answer}`;
+  }
+  return undefined;
+}
 
 function state(world: SafewordWorld): ReviewScenario {
   const world_ = world as ReviewWorld;
@@ -100,6 +123,8 @@ answer=$(printf '{"schema_version":1,"dispatch_id":"%s","reviewer_agent":"AGENT"
 printf '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"%s"}}\n' "$escaped"`
       : String.raw`printf '%s\n' "$answer"`;
   const answer = `${body}\n${emit}`;
+  const modelBehaviour = modelSpecificBehaviour(behaviour, answer);
+  if (modelBehaviour !== undefined) return modelBehaviour;
 
   if (behaviour === 'answers') return answer;
   if (behaviour === 'fails') return "printf 'reviewer unavailable\\n' >&2\nexit 7";
@@ -110,9 +135,6 @@ printf '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text"
   if (behaviour === 'leaves a grandchild') {
     return `/bin/sh -c 'printf "%s" "$$" > "$SAFEWORD_REVIEW_DESCENDANT_PID_FILE"; exec /bin/sleep 3600' &
 exec /bin/sleep 3600`;
-  }
-  if (behaviour === 'answers only with a model') {
-    return `if ! printf '%s' "$*" | /usr/bin/grep -q -- '--model'; then\n  printf 'default model unavailable\\n' >&2\n  exit 7\nfi\n${answer}`;
   }
   if (behaviour === 'emits a credential') {
     return `printf 'trace token=${CREDENTIAL}\\n' >&2\nprintf 'not-a-review\\n'`;
@@ -397,6 +419,14 @@ Given("the reviewer agent's default model never answers", function (this: Safewo
   installReviewer(state(this), 'codex', 'answers only with a model');
 });
 
+Given('the default Claude Opus model never answers', function (this: SafewordWorld) {
+  const current = state(this);
+  current.environment.SAFEWORD_AGENT_RUNTIME = 'codex';
+  current.environment.SAFEWORD_REVIEW_TIMEOUT_MS = '3000';
+  current.environment.SAFEWORD_REVIEW_RUN_BOUND_MS = '12000';
+  installReviewer(current, 'claude', 'times out on opus and answers on sonnet');
+});
+
 Given("the reviewer agent's alternate model answers promptly", function (this: SafewordWorld) {
   state(this);
 });
@@ -482,8 +512,9 @@ Given(
     const reviewer = reviewerName.toLowerCase() as Agent;
     assert.notEqual(author, reviewer);
     current.environment.SAFEWORD_AGENT_RUNTIME = author;
+    current.environment.SAFEWORD_REVIEW_BDD_EXPECTED_MODEL = model;
     writeConfig(current, { crossAgentReviewAlternateModel: { [reviewer]: model } });
-    installReviewer(current, reviewer, 'answers only with a model');
+    installReviewer(current, reviewer, 'answers only with the expected model');
   },
 );
 
@@ -728,6 +759,26 @@ Then('the alternate model still receives its own attempt', function (this: Safew
   // The first route being stopped at its own budget is what leaves the second
   // one able to answer at all.
   assert.equal(payload(this).data.reviewer_model, 'vendor-model-2');
+});
+
+Then('the Sonnet review returns an independent verdict', function (this: SafewordWorld) {
+  assert.deepEqual(
+    {
+      independence: payload(this).data.independence,
+      reviewerModel: payload(this).data.reviewer_model,
+    },
+    { independence: 'cross-agent', reviewerModel: 'sonnet' },
+  );
+});
+
+Then('the result names Opus as the timed-out primary model', function (this: SafewordWorld) {
+  assert.deepEqual(
+    {
+      preferredModel: payload(this).data.preferred_model,
+      preferredFailure: payload(this).data.preferred_failure,
+    },
+    { preferredModel: 'opus', preferredFailure: 'timed_out' },
+  );
 });
 
 Then('the routes were attempted in their fixed order', function (this: SafewordWorld) {

--- a/packages/cli/src/review/contract.ts
+++ b/packages/cli/src/review/contract.ts
@@ -11,6 +11,8 @@ export type ReviewFailure =
   | 'process_failed'
   | 'timed_out'
   | 'invalid_output'
+  | 'REVIEWER_PROVENANCE_MISSING'
+  | 'REVIEWER_PROVENANCE_CONTRADICTORY'
   | 'source_changed';
 
 interface ReviewFinding {

--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -11,7 +11,12 @@ import type {
   UnverifiedReviewerOutput,
 } from './contract.js';
 import { prepareReviewPacket } from './packet.js';
-import { oppositeReviewPair, readAlternateReviewerModel, readReviewPolicy } from './policy.js';
+import {
+  oppositeReviewPair,
+  readAlternateReviewerModel,
+  readPrimaryReviewerModel,
+  readReviewPolicy,
+} from './policy.js';
 import { minimumRouteMs, ReviewRuntimeError, runBoundMs, runHeadlessReviewer } from './runtime.js';
 
 /** The command runner owns reporter shutdown; review routing only updates it. */
@@ -770,6 +775,7 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
     });
   }
   const { reviewer } = pair;
+  const primaryModel = readPrimaryReviewerModel(input.cwd, reviewer);
 
   const prepared = preparePrimaryReview(input, reviewer);
   // One bound for reviewer work across the whole run. Initial packet sealing is
@@ -778,7 +784,7 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
   const { outcome, sourceChanged, snapshotChanged } = await executeReview(
     reviewer,
     prepared,
-    undefined,
+    primaryModel,
     runDeadline,
   );
   const changedResult = changedReviewResult({
@@ -823,12 +829,12 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
-      preferredFailure: 'invalid_output',
+      preferredFailure: provenance.code,
       policy,
       runDeadline,
     });
   }
   const output = provenance.output;
 
-  return independentReviewResult({ author: pair.author, reviewer, output });
+  return independentReviewResult({ author: pair.author, reviewer, output, model: primaryModel });
 }

--- a/packages/cli/src/review/coordinator.ts
+++ b/packages/cli/src/review/coordinator.ts
@@ -68,6 +68,7 @@ function independentReviewResult(input: {
   readonly reviewer: ReviewAgent;
   readonly output: ReviewerOutput;
   readonly model?: string;
+  readonly preferredModel?: string;
   readonly preferredFailure?: ReviewFailure;
 }): CliResult {
   return createResult({
@@ -90,6 +91,7 @@ function independentReviewResult(input: {
       assigned_reviewer: input.reviewer,
       actual_reviewer: input.output.reviewer_agent,
       ...(input.model !== undefined && { reviewer_model: input.model }),
+      ...(input.preferredModel !== undefined && { preferred_model: input.preferredModel }),
       ...(input.preferredFailure !== undefined && { preferred_failure: input.preferredFailure }),
       independence: 'cross-agent',
       reviewer_output: input.output,
@@ -223,12 +225,14 @@ function exhaustedExplanation(
   routes: readonly {
     readonly agent: ReviewAgent;
     readonly role: string;
+    readonly model?: string;
     readonly failure: string;
   }[],
 ): string {
-  const sentences = routes.map(
-    route => `The ${route.role} (${agentName(route.agent)}) ${causePhrase(route.failure)}.`,
-  );
+  const sentences = routes.map(route => {
+    const modelPhrase = route.model === undefined ? '' : ` using ${route.model}`;
+    return `The ${route.role}${modelPhrase} (${agentName(route.agent)}) ${causePhrase(route.failure)}.`;
+  });
   return [...sentences, 'No independent check was recorded.'].join(' ');
 }
 
@@ -366,10 +370,20 @@ function changedReviewResult(input: {
   });
 }
 
-function alternateFailureData(
-  failure: string | undefined,
-): Record<string, never> | { readonly alternate_model_failure: string } {
-  return failure === undefined ? {} : { alternate_model_failure: failure };
+function routeFailureData(input: {
+  readonly preferredFailure: ReviewFailure;
+  readonly preferredModel?: string;
+  readonly alternateFailure?: string;
+  readonly alternateModel?: string;
+}): Record<string, unknown> {
+  return {
+    ...(input.preferredModel !== undefined && { preferred_model: input.preferredModel }),
+    preferred_failure: input.preferredFailure,
+    ...(input.alternateFailure !== undefined && {
+      alternate_model_failure: input.alternateFailure,
+      ...(input.alternateModel !== undefined && { alternate_model: input.alternateModel }),
+    }),
+  };
 }
 
 function degradedNetworkEffects(
@@ -417,10 +431,12 @@ async function runDegradedFallback(
   input: ReviewRunInput & {
     readonly author: ReviewAgent;
     readonly assignedReviewer: ReviewAgent;
+    readonly preferredModel?: string;
     readonly preferredFailure: ReviewFailure;
     readonly policy: ReviewPolicy;
     readonly runDeadline: number;
     readonly alternateFailure?: string;
+    readonly alternateModel?: string;
   },
 ): Promise<CliResult> {
   const prepared = prepareFallbackReview(input, input.assignedReviewer, input.author);
@@ -457,6 +473,7 @@ async function runDegradedFallback(
             {
               agent: input.assignedReviewer,
               role: 'independent reviewer',
+              model: input.preferredModel,
               failure: input.preferredFailure,
             },
             ...(input.alternateFailure === undefined
@@ -465,6 +482,7 @@ async function runDegradedFallback(
                   {
                     agent: input.assignedReviewer,
                     role: 'same reviewer on its alternate model',
+                    model: input.alternateModel,
                     failure: input.alternateFailure,
                   },
                 ]),
@@ -492,8 +510,7 @@ async function runDegradedFallback(
         status: 'blocked',
         author_agent: input.author,
         assigned_reviewer: input.assignedReviewer,
-        preferred_failure: input.preferredFailure,
-        ...alternateFailureData(input.alternateFailure),
+        ...routeFailureData(input),
         fallback_failure: assessment.failure,
         review_policy: input.policy,
         independence: 'none',
@@ -533,8 +550,7 @@ async function runDegradedFallback(
         author_agent: input.author,
         assigned_reviewer: input.assignedReviewer,
         actual_reviewer: completedOutput.reviewer_agent,
-        preferred_failure: input.preferredFailure,
-        ...alternateFailureData(input.alternateFailure),
+        ...routeFailureData(input),
         review_policy: input.policy,
         independence: 'degraded',
         reviewer_output: completedOutput,
@@ -569,8 +585,7 @@ async function runDegradedFallback(
       author_agent: input.author,
       assigned_reviewer: input.assignedReviewer,
       actual_reviewer: completedOutput.reviewer_agent,
-      preferred_failure: input.preferredFailure,
-      ...alternateFailureData(input.alternateFailure),
+      ...routeFailureData(input),
       independence: 'degraded',
       reviewer_output: completedOutput,
     },
@@ -587,13 +602,19 @@ async function runAlternateModelRoute(
   input: ReviewRunInput & {
     readonly author: ReviewAgent;
     readonly reviewer: ReviewAgent;
+    readonly preferredModel?: string;
     readonly preferredFailure: ReviewFailure;
     readonly policy: ReviewPolicy;
     readonly runDeadline: number;
   },
 ): Promise<
   | { readonly kind: 'completed'; readonly result: CliResult }
-  | { readonly kind: 'failed'; readonly failure: string; readonly terminal: boolean }
+  | {
+      readonly kind: 'failed';
+      readonly failure: string;
+      readonly terminal: boolean;
+      readonly model: string;
+    }
   | { readonly kind: 'skipped' }
 > {
   const model = readAlternateReviewerModel(input.cwd, input.reviewer);
@@ -631,7 +652,7 @@ async function runAlternateModelRoute(
     // attempt or failure, so it must not displace the funded fallback route.
     if (assessment.failure === 'not_installed' || assessment.failure === 'unsupported')
       return { kind: 'skipped' };
-    return assessment;
+    return { ...assessment, model };
   }
   const output = assessment.output;
 
@@ -640,6 +661,7 @@ async function runAlternateModelRoute(
     reviewer: input.reviewer,
     output,
     model,
+    preferredModel: input.preferredModel,
     preferredFailure: input.preferredFailure,
   });
   return { kind: 'completed', result };
@@ -653,6 +675,7 @@ async function runRemainingRoutes(
   input: ReviewRunInput & {
     readonly author: ReviewAgent;
     readonly assignedReviewer: ReviewAgent;
+    readonly preferredModel?: string;
     readonly preferredFailure: ReviewFailure;
     readonly policy: ReviewPolicy;
     readonly runDeadline: number;
@@ -666,6 +689,7 @@ async function runRemainingRoutes(
     progress: input.progress,
     author: input.author,
     reviewer: input.assignedReviewer,
+    preferredModel: input.preferredModel,
     preferredFailure: input.preferredFailure,
     policy: input.policy,
     runDeadline: input.runDeadline,
@@ -674,23 +698,28 @@ async function runRemainingRoutes(
   // An attempted-and-failed alternate model is part of the story; a skipped one
   // never happened and must not be reported as a route that failed.
   const alternateFailure = alternate.kind === 'failed' ? alternate.failure : undefined;
+  const alternateModel = alternate.kind === 'failed' ? alternate.model : undefined;
   if (alternate.kind === 'failed' && alternate.terminal) {
-    return exhaustedRunResult({ ...input, alternateFailure });
+    return exhaustedRunResult({ ...input, alternateFailure, alternateModel });
   }
-  if (!canFundRoute(input.runDeadline)) return exhaustedRunResult({ ...input, alternateFailure });
-  return runDegradedFallback({ ...input, alternateFailure });
+  if (!canFundRoute(input.runDeadline)) {
+    return exhaustedRunResult({ ...input, alternateFailure, alternateModel });
+  }
+  return runDegradedFallback({ ...input, alternateFailure, alternateModel });
 }
 
 /** The run bound arrived before a later route could be funded. */
 function exhaustedRunResult(input: {
   readonly author: ReviewAgent;
   readonly assignedReviewer: ReviewAgent;
+  readonly preferredModel?: string;
   readonly preferredFailure: ReviewFailure;
   readonly kind: ReviewKind;
   readonly targets: readonly string[];
   readonly context?: readonly string[];
   readonly policy: ReviewPolicy;
   readonly alternateFailure?: string;
+  readonly alternateModel?: string;
 }): CliResult {
   return createResult({
     state: 'action_required',
@@ -701,6 +730,7 @@ function exhaustedRunResult(input: {
           {
             agent: input.assignedReviewer,
             role: 'independent reviewer',
+            model: input.preferredModel,
             failure: input.preferredFailure,
           },
           ...(input.alternateFailure === undefined
@@ -709,6 +739,7 @@ function exhaustedRunResult(input: {
                 {
                   agent: input.assignedReviewer,
                   role: 'same reviewer on its alternate model',
+                  model: input.alternateModel,
                   failure: input.alternateFailure,
                 },
               ]),
@@ -734,8 +765,7 @@ function exhaustedRunResult(input: {
       status: 'blocked',
       author_agent: input.author,
       assigned_reviewer: input.assignedReviewer,
-      preferred_failure: input.preferredFailure,
-      ...alternateFailureData(input.alternateFailure),
+      ...routeFailureData(input),
       review_policy: input.policy,
       independence: 'none',
     },
@@ -804,6 +834,7 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
         ...input,
         author: pair.author,
         assignedReviewer: reviewer,
+        preferredModel: primaryModel,
         preferredFailure: outcome.failure,
         policy,
       });
@@ -815,6 +846,7 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
+      preferredModel: primaryModel,
       preferredFailure: outcome.failure,
       policy,
       runDeadline,
@@ -829,6 +861,7 @@ export async function runReview(input: ReviewRunInput): Promise<CliResult> {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
+      preferredModel: primaryModel,
       preferredFailure: provenance.code,
       policy,
       runDeadline,

--- a/packages/cli/src/review/policy.ts
+++ b/packages/cli/src/review/policy.ts
@@ -25,30 +25,53 @@ export function oppositeReviewPair(author: ReviewAuthor): OppositeReviewPair | u
  */
 const MODEL_NAME = /^[\w.:/][\w.:/-]{0,199}$/u;
 
-/**
- * The model Safeword should retry the reviewer agent on when its default
- * cannot complete. Safeword never supplies a model of its own: an absent,
- * malformed, or unusable value reads as "none configured", which keeps routing
- * exactly as it is today.
- */
-export function readAlternateReviewerModel(cwd: string, reviewer: ReviewAgent): string | undefined {
-  // Each source is validated on its own, so an unusable environment override
-  // reads as "not set" and falls through to the configured value rather than
-  // silently masking it.
-  const sources = [
-    process.env[`SAFEWORD_REVIEW_ALTERNATE_MODEL_${reviewer.toUpperCase()}`],
-    readConfiguredAlternateModel(cwd, reviewer),
-  ];
-  return sources.find(value => value !== undefined && MODEL_NAME.test(value));
+const DEFAULT_PRIMARY_MODEL: Partial<Record<ReviewAgent, string>> = { claude: 'opus' };
+const DEFAULT_ALTERNATE_MODEL: Partial<Record<ReviewAgent, string>> = { claude: 'sonnet' };
+
+export function readPrimaryReviewerModel(cwd: string, reviewer: ReviewAgent): string | undefined {
+  return (
+    readReviewerModel(cwd, reviewer, 'PRIMARY', 'crossAgentReviewPrimaryModel') ??
+    DEFAULT_PRIMARY_MODEL[reviewer]
+  );
 }
 
-function readConfiguredAlternateModel(cwd: string, reviewer: ReviewAgent): string | undefined {
+/**
+ * The model Safeword should retry the reviewer agent on when its primary route
+ * cannot complete. Explicit values override the Claude default; agents without
+ * a default retain their authenticated profile behavior.
+ */
+export function readAlternateReviewerModel(cwd: string, reviewer: ReviewAgent): string | undefined {
+  return (
+    readReviewerModel(cwd, reviewer, 'ALTERNATE', 'crossAgentReviewAlternateModel') ??
+    DEFAULT_ALTERNATE_MODEL[reviewer]
+  );
+}
+
+function readReviewerModel(
+  cwd: string,
+  reviewer: ReviewAgent,
+  route: 'PRIMARY' | 'ALTERNATE',
+  configKey: 'crossAgentReviewPrimaryModel' | 'crossAgentReviewAlternateModel',
+): string | undefined {
+  const environmentValue = process.env[`SAFEWORD_REVIEW_${route}_MODEL_${reviewer.toUpperCase()}`];
+  if (environmentValue !== undefined && MODEL_NAME.test(environmentValue)) return environmentValue;
+  const configuredValue = readConfiguredModel(cwd, reviewer, configKey);
+  return configuredValue !== undefined && MODEL_NAME.test(configuredValue)
+    ? configuredValue
+    : undefined;
+}
+
+function readConfiguredModel(
+  cwd: string,
+  reviewer: ReviewAgent,
+  configKey: 'crossAgentReviewPrimaryModel' | 'crossAgentReviewAlternateModel',
+): string | undefined {
   try {
     const raw: unknown = JSON.parse(
       readFileSync(nodePath.join(cwd, '.safeword', 'config.json'), 'utf8'),
     );
     if (typeof raw !== 'object' || raw === null) return undefined;
-    const models = (raw as Record<string, unknown>).crossAgentReviewAlternateModel;
+    const models = (raw as Record<string, unknown>)[configKey];
     if (typeof models !== 'object' || models === null) return undefined;
     const value = (models as Record<string, unknown>)[reviewer];
     return typeof value === 'string' ? value : undefined;
@@ -60,8 +83,10 @@ function readConfiguredAlternateModel(cwd: string, reviewer: ReviewAgent): strin
 export function readReviewPolicy(cwd: string): ReviewPolicy {
   try {
     const raw = readFileSync(nodePath.join(cwd, '.safeword', 'config.json'), 'utf8');
+    const config: unknown = JSON.parse(raw);
+    if (typeof config !== 'object' || config === null || Array.isArray(config)) return 'require';
     return readCrossAgentReviewPolicy(raw);
-  } catch {
-    return 'prefer';
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? 'prefer' : 'require';
   }
 }

--- a/packages/cli/tests/cli-protocol/review-alternate-model.test.ts
+++ b/packages/cli/tests/cli-protocol/review-alternate-model.test.ts
@@ -42,6 +42,11 @@ if [ -z "$model" ]; then
   exit 7
 fi
 printf '%s\n' "$model" >> "$SAFEWORD_REVIEW_MODEL_LOG"
+accepted_model=$(printenv SAFEWORD_REVIEW_ACCEPTED_MODEL || true)
+if [ -n "$accepted_model" ] && [ "$model" != "$accepted_model" ]; then
+  printf 'model unavailable\n' >&2
+  exit 7
+fi
 payload=$(cat)
 dispatch_id=$(printf '%s' "$payload" | sed -n 's/.*"dispatch_id":"\([^"]*\)".*/\1/p')
 printf '{"schema_version":1,"dispatch_id":"%s","reviewer_agent":"${agent}","verdict":"approve","summary":"reviewed","findings":[]}\n' "$dispatch_id"
@@ -121,6 +126,7 @@ describe('alternate-model review route', () => {
             PATH: `${bin}:/usr/bin:/bin`,
             SAFEWORD_AGENT_RUNTIME: author,
             SAFEWORD_REVIEW_MODEL_LOG: modelLog,
+            SAFEWORD_REVIEW_ACCEPTED_MODEL: 'vendor-model-2',
             SAFEWORD_NO_UPDATE_CHECK: '1',
           },
         },
@@ -146,9 +152,93 @@ describe('alternate-model review route', () => {
         },
       });
       // The required cross-agent check is satisfied by the alternate model.
-      expect(readFileSync(modelLog, 'utf8').trim()).toBe('vendor-model-2');
+      expect(readFileSync(modelLog, 'utf8').trim().split('\n')).toEqual(
+        reviewer === 'claude' ? ['opus', 'vendor-model-2'] : ['vendor-model-2'],
+      );
     },
   );
+
+  it('uses Opus for the primary Claude review when no model is configured', async () => {
+    const directory = createTemporaryDirectory();
+    const modelLog = nodePath.join(directory, 'model.log');
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    writeConfig(directory, { crossAgentReview: 'require' });
+    const bin = installModelDependentReviewer(directory, 'claude');
+
+    const result = await runCli(
+      [
+        'review',
+        'run',
+        'quality-review',
+        'review-input.md',
+        '--json',
+        '--no-input',
+        '--cwd',
+        directory,
+      ],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'codex',
+          SAFEWORD_REVIEW_MODEL_LOG: modelLog,
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      data: {
+        actual_reviewer: 'claude',
+        reviewer_model: 'opus',
+        independence: 'cross-agent',
+      },
+    });
+    expect(readFileSync(modelLog, 'utf8').trim()).toBe('opus');
+  });
+
+  it('falls back from Opus to Sonnet without project configuration', async () => {
+    const directory = createTemporaryDirectory();
+    const modelLog = nodePath.join(directory, 'model.log');
+    writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
+    writeConfig(directory, { crossAgentReview: 'require' });
+    const bin = installModelDependentReviewer(directory, 'claude');
+
+    const result = await runCli(
+      [
+        'review',
+        'run',
+        'quality-review',
+        'review-input.md',
+        '--json',
+        '--no-input',
+        '--cwd',
+        directory,
+      ],
+      {
+        cwd: directory,
+        env: {
+          PATH: `${bin}:/usr/bin:/bin`,
+          SAFEWORD_AGENT_RUNTIME: 'codex',
+          SAFEWORD_REVIEW_MODEL_LOG: modelLog,
+          SAFEWORD_REVIEW_ACCEPTED_MODEL: 'sonnet',
+          SAFEWORD_NO_UPDATE_CHECK: '1',
+        },
+      },
+    );
+
+    expect(result.exitCode, result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      data: {
+        assigned_reviewer: 'claude',
+        actual_reviewer: 'claude',
+        reviewer_model: 'sonnet',
+        independence: 'cross-agent',
+      },
+    });
+    expect(readFileSync(modelLog, 'utf8').trim().split('\n')).toEqual(['opus', 'sonnet']);
+  });
 
   it('refuses to let the author reviewing itself satisfy a required check', async () => {
     const directory = createTemporaryDirectory();
@@ -180,9 +270,16 @@ describe('alternate-model review route', () => {
       },
     );
 
-    const payload = JSON.parse(result.stdout) as { data: Record<string, unknown> };
-    expect(payload.data.status).toBe('blocked');
-    expect(payload.data.independence).not.toBe('cross-agent');
+    const payload = JSON.parse(result.stdout) as {
+      findings: readonly { code: string }[];
+      data: Record<string, unknown>;
+    };
+    expect(payload.data).toMatchObject({
+      status: 'blocked',
+      actual_reviewer: 'claude',
+      independence: 'degraded',
+    });
+    expect(payload.findings.map(finding => finding.code)).toContain('REVIEW_INDEPENDENCE_REQUIRED');
   });
 
   it('passes no model at all when none is configured', async () => {
@@ -216,10 +313,12 @@ describe('alternate-model review route', () => {
       },
     );
 
-    // The reviewer refuses without a model, so no route completes — proving
-    // Safeword never supplied a model of its own choosing.
+    // The reviewer refuses without a model, so the exhausted result and absent
+    // model log together prove the real executable ran without `--model`.
     const payload = JSON.parse(result.stdout) as { data: Record<string, unknown> };
-    expect(payload.data.independence).not.toBe('cross-agent');
+    expect(payload.data).toMatchObject({ status: 'blocked', independence: 'none' });
+    expect(payload.data.preferred_failure).toBe('process_failed');
     expect(payload.data).not.toHaveProperty('reviewer_model');
+    expect(() => readFileSync(modelLog, 'utf8')).toThrow();
   });
 });

--- a/packages/cli/tests/cli-protocol/review-alternate-model.test.ts
+++ b/packages/cli/tests/cli-protocol/review-alternate-model.test.ts
@@ -44,6 +44,8 @@ fi
 printf '%s\n' "$model" >> "$SAFEWORD_REVIEW_MODEL_LOG"
 accepted_model=$(printenv SAFEWORD_REVIEW_ACCEPTED_MODEL || true)
 if [ -n "$accepted_model" ] && [ "$model" != "$accepted_model" ]; then
+  rejected_model_behaviour=$(printenv SAFEWORD_REVIEW_REJECTED_MODEL_BEHAVIOUR || true)
+  if [ "$rejected_model_behaviour" = "timeout" ]; then exec /bin/sleep 3600; fi
   printf 'model unavailable\n' >&2
   exit 7
 fi
@@ -223,6 +225,9 @@ describe('alternate-model review route', () => {
           SAFEWORD_AGENT_RUNTIME: 'codex',
           SAFEWORD_REVIEW_MODEL_LOG: modelLog,
           SAFEWORD_REVIEW_ACCEPTED_MODEL: 'sonnet',
+          SAFEWORD_REVIEW_REJECTED_MODEL_BEHAVIOUR: 'timeout',
+          SAFEWORD_REVIEW_TIMEOUT_MS: '1500',
+          SAFEWORD_REVIEW_RUN_BOUND_MS: '5000',
           SAFEWORD_NO_UPDATE_CHECK: '1',
         },
       },
@@ -234,6 +239,8 @@ describe('alternate-model review route', () => {
         assigned_reviewer: 'claude',
         actual_reviewer: 'claude',
         reviewer_model: 'sonnet',
+        preferred_model: 'opus',
+        preferred_failure: 'timed_out',
         independence: 'cross-agent',
       },
     });

--- a/packages/cli/tests/cli-protocol/review-three-route-explanation.test.ts
+++ b/packages/cli/tests/cli-protocol/review-three-route-explanation.test.ts
@@ -88,9 +88,14 @@ describe('when all three routes fail', () => {
     expect(explanation).toMatch(/ran out of time/i);
     expect(explanation).toMatch(/not signed in/i);
     expect(explanation).toMatch(/could not be accepted/i);
-    // The alternate-model attempt is named as such, without naming the model.
+    // The alternate-model attempt names the selected model so operators can
+    // distinguish a failed override from the primary route.
     expect(explanation).toMatch(/alternate model/i);
-    expect(explanation).not.toContain('vendor-model-2');
+    expect(explanation).toContain('vendor-model-2');
+    expect(payload.data).toMatchObject({
+      alternate_model: 'vendor-model-2',
+      alternate_model_failure: 'not_authenticated',
+    });
     expect(payload.data.independence).toBe('none');
   }, 30_000);
 });

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -1046,6 +1046,7 @@ describe('cross-agent review public-command wiring', () => {
       data: {
         status: 'approved',
         preferred_failure: 'process_failed',
+        alternate_model: 'vendor-model-2',
         alternate_model_failure: 'process_failed',
         independence: 'degraded',
       },

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -503,9 +503,12 @@ describe('cross-agent review public-command wiring', () => {
     });
   });
 
-  it.each([{ identity: 'missing' }, { identity: 'contradictory' }])(
+  it.each([
+    { identity: 'missing', failure: 'REVIEWER_PROVENANCE_MISSING' },
+    { identity: 'contradictory', failure: 'REVIEWER_PROVENANCE_CONTRADICTORY' },
+  ])(
     'rejects $identity reviewer provenance and continues through the bounded fallback routes',
-    async ({ identity }) => {
+    async ({ identity, failure }) => {
       const directory = createTemporaryDirectory();
       const log = nodePath.join(directory, 'review.log');
       writeFileSync(nodePath.join(directory, 'review-input.md'), 'bounded review input\n');
@@ -540,7 +543,7 @@ describe('cross-agent review public-command wiring', () => {
         state: 'action_required',
         findings: [{ code: 'REVIEW_ROUTES_EXHAUSTED' }],
         data: {
-          preferred_failure: 'invalid_output',
+          preferred_failure: failure,
           review_policy: 'prefer',
           independence: 'none',
         },

--- a/packages/cli/tests/review/alternate-model-grammar.test.ts
+++ b/packages/cli/tests/review/alternate-model-grammar.test.ts
@@ -4,7 +4,11 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { readAlternateReviewerModel } from '../../src/review/policy.js';
+import {
+  readAlternateReviewerModel,
+  readPrimaryReviewerModel,
+  readReviewPolicy,
+} from '../../src/review/policy.js';
 
 /**
  * Carries the model-grammar table that used to live as Gherkin example rows.
@@ -14,11 +18,18 @@ import { readAlternateReviewerModel } from '../../src/review/policy.js';
  */
 
 const originalEnvironment = process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX;
+const originalPrimaryClaude = process.env.SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE;
+const originalAlternateClaude = process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE;
 const directories: string[] = [];
 
 afterEach(() => {
   if (originalEnvironment === undefined) delete process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX;
   else process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX = originalEnvironment;
+  if (originalPrimaryClaude === undefined) delete process.env.SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE;
+  else process.env.SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE = originalPrimaryClaude;
+  if (originalAlternateClaude === undefined)
+    delete process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE;
+  else process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE = originalAlternateClaude;
   for (const directory of directories) {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -36,7 +47,68 @@ function projectConfiguring(model: unknown): string {
   return directory;
 }
 
+function projectConfiguringPrimary(model: unknown): string {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-primary-model-'));
+  directories.push(directory);
+  mkdirSync(nodePath.join(directory, '.safeword'), { recursive: true });
+  writeFileSync(
+    nodePath.join(directory, '.safeword', 'config.json'),
+    JSON.stringify({ crossAgentReviewPrimaryModel: { claude: model } }),
+  );
+  return directory;
+}
+
 describe('the alternate model grammar', () => {
+  it('defaults a missing config to prefer but fails closed when an existing config is malformed', () => {
+    const missing = mkdtempSync(nodePath.join(tmpdir(), 'safeword-missing-policy-'));
+    directories.push(missing);
+    const malformed = mkdtempSync(nodePath.join(tmpdir(), 'safeword-malformed-policy-'));
+    directories.push(malformed);
+    mkdirSync(nodePath.join(malformed, '.safeword'), { recursive: true });
+    writeFileSync(nodePath.join(malformed, '.safeword', 'config.json'), '{');
+
+    expect(readReviewPolicy(missing)).toBe('prefer');
+    expect(readReviewPolicy(malformed)).toBe('require');
+  });
+
+  it('defaults Claude reviews to Opus with a Sonnet fallback', () => {
+    const directory = projectConfiguring(undefined);
+
+    expect(readPrimaryReviewerModel(directory, 'claude')).toBe('opus');
+    expect(readAlternateReviewerModel(directory, 'claude')).toBe('sonnet');
+  });
+
+  it('leaves Codex model selection to its authenticated profile by default', () => {
+    const directory = projectConfiguring(undefined);
+
+    expect(readPrimaryReviewerModel(directory, 'codex')).toBeUndefined();
+    expect(readAlternateReviewerModel(directory, 'codex')).toBeUndefined();
+  });
+
+  it('allows the Claude defaults to be overridden independently', () => {
+    const directory = projectConfiguring(undefined);
+    process.env.SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE = 'custom-opus';
+    process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE = 'custom-sonnet';
+
+    expect(readPrimaryReviewerModel(directory, 'claude')).toBe('custom-opus');
+    expect(readAlternateReviewerModel(directory, 'claude')).toBe('custom-sonnet');
+  });
+
+  it('uses a configured primary Claude model', () => {
+    expect(readPrimaryReviewerModel(projectConfiguringPrimary('claude-opus-5'), 'claude')).toBe(
+      'claude-opus-5',
+    );
+  });
+
+  it('falls back to the Claude defaults when environment overrides are unusable', () => {
+    const directory = projectConfiguring(undefined);
+    process.env.SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE = '--help';
+    process.env.SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE = '--help';
+
+    expect(readPrimaryReviewerModel(directory, 'claude')).toBe('opus');
+    expect(readAlternateReviewerModel(directory, 'claude')).toBe('sonnet');
+  });
+
   it.each([
     ['a vendor-dated identifier', 'claude-sonnet-4-5-20250929'],
     ['a short identifier', 'gpt-5-codex'],

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -154,7 +154,9 @@ Safeword selects Claude's `opus` alias for the primary independent review and `s
 
 Each review attempt defaults to five minutes, with reviewer work across all routes bounded to nine minutes. Packet preparation happens before that shared reviewer-work deadline; final synchronous integrity checks and bounded process cleanup may finish after it. `SAFEWORD_REVIEW_TIMEOUT_MS` and `SAFEWORD_REVIEW_RUN_BOUND_MS` accept positive millisecond values when a caller needs shorter limits; neither can raise the nine-minute reviewer-work ceiling.
 
-Desktop and managed cloud sessions reuse each CLI's existing authentication; Safeword does not copy API keys between vendors or expose credential values. Install and sign in to both headless CLIs when you want independent coverage. Human output calls a validated same-agent result standard coverage and a validated opposite-agent result independent coverage; machine results retain the author, assigned and actual reviewer, selected model, and `cross-agent`, `degraded`, or `none` independence so stamps and automation can enforce the configured policy.
+Keep each review packet to the smallest coherent set of artifacts that lets the reviewer judge the change: include the implementation together with directly coupled tests, contracts, and documentation, but split unrelated subsystems into separate reviews. This preserves enough context for a meaningful verdict without making the primary route consume the alternate route's reserved time.
+
+Desktop and managed cloud sessions reuse each CLI's existing authentication; Safeword does not copy API keys between vendors or expose credential values. Install and sign in to both headless CLIs when you want independent coverage. Human output calls a validated same-agent result standard coverage and a validated opposite-agent result independent coverage; machine results retain the author, assigned and actual reviewer, successful `reviewer_model`, failed `preferred_model` or `alternate_model`, each route's classified failure, and `cross-agent`, `degraded`, or `none` independence so stamps and automation can enforce the configured policy.
 
 ### Advisory pull request review
 

--- a/packages/website/src/content/docs/reference/configuration.mdx
+++ b/packages/website/src/content/docs/reference/configuration.mdx
@@ -136,8 +136,11 @@ Adversarial reviews use `crossAgentReview` to choose their reviewer route:
 ```json
 {
   "crossAgentReview": "prefer",
+  "crossAgentReviewPrimaryModel": {
+    "claude": "opus"
+  },
   "crossAgentReviewAlternateModel": {
-    "claude": "claude-sonnet-4-5-20250929",
+    "claude": "sonnet",
     "codex": "gpt-5-codex"
   }
 }
@@ -147,11 +150,11 @@ Adversarial reviews use `crossAgentReview` to choose their reviewer route:
 - `require` — only an opposite-agent result satisfies the gate. A completed same-agent headless review returns the existing independence-required failure. If every CLI route fails, a foreground agent may still report useful host-native or self-review findings, but the result remains action required, recommends restoring an independent reviewer or explicitly choosing `prefer`, and never writes independent evidence.
 - `off` — retain the existing review route and do not create cross-agent evidence.
 
-`crossAgentReviewAlternateModel` is optional and has no Safeword-supplied default. Set `claude` and `codex` independently; environment variables `SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE` and `SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX` override their matching configured values. Model identifiers must be 1–200 characters using letters, digits, `.`, `_`, `:`, `/`, or `-`, and cannot begin with `-`. An unusable environment value falls through to the configured value.
+Safeword selects Claude's `opus` alias for the primary independent review and `sonnet` for its alternate attempt. This keeps adversarial review on Anthropic's complex-coding model while reserving the faster coding model as a fallback, independent of the user's ambient Claude profile. Codex continues to use its authenticated profile unless configured. Override either route per agent with `crossAgentReviewPrimaryModel` or `crossAgentReviewAlternateModel`; environment variables `SAFEWORD_REVIEW_PRIMARY_MODEL_CLAUDE`, `SAFEWORD_REVIEW_PRIMARY_MODEL_CODEX`, `SAFEWORD_REVIEW_ALTERNATE_MODEL_CLAUDE`, and `SAFEWORD_REVIEW_ALTERNATE_MODEL_CODEX` take precedence. Model identifiers must be 1–200 characters using letters, digits, `.`, `_`, `:`, `/`, or `-`, and cannot begin with `-`. An unusable override falls through to the configured value and then the Safeword default where one exists.
 
 Each review attempt defaults to five minutes, with reviewer work across all routes bounded to nine minutes. Packet preparation happens before that shared reviewer-work deadline; final synchronous integrity checks and bounded process cleanup may finish after it. `SAFEWORD_REVIEW_TIMEOUT_MS` and `SAFEWORD_REVIEW_RUN_BOUND_MS` accept positive millisecond values when a caller needs shorter limits; neither can raise the nine-minute reviewer-work ceiling.
 
-Desktop and managed cloud sessions reuse each CLI's existing authenticated profile; Safeword does not copy API keys between vendors or expose credential values. Install and sign in to both headless CLIs when you want independent coverage. Human output calls a validated same-agent result standard coverage and a validated opposite-agent result independent coverage; machine results retain the author, assigned and actual reviewer, and `cross-agent`, `degraded`, or `none` independence so stamps and automation can enforce the configured policy. Safeword records the configured alternate model only when that route actually runs and never invents a default model name.
+Desktop and managed cloud sessions reuse each CLI's existing authentication; Safeword does not copy API keys between vendors or expose credential values. Install and sign in to both headless CLIs when you want independent coverage. Human output calls a validated same-agent result standard coverage and a validated opposite-agent result independent coverage; machine results retain the author, assigned and actual reviewer, selected model, and `cross-agent`, `degraded`, or `none` independence so stamps and automation can enforce the configured policy.
 
 ### Advisory pull request review
 

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "d396cfc263eac0853251e999664c06757cb099b1657a293f8f04b560034f6fab"
+  "inventory_sha256": "11334e85fdf00745455a2a5608fb63544874307ac049d935021f9eb1cfa1cd50"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "0f8556846c78b52d16e990e792efcba192ef1053ed79f313a5b68869a3d3871e"
+      "sha256": "6a884468548e56408196ec5dc27826f85f54252244f2736a47de5805f84bb58d"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -42363,6 +42363,7 @@ function independentReviewResult(input) {
       assigned_reviewer: input.reviewer,
       actual_reviewer: input.output.reviewer_agent,
       ...input.model !== undefined && { reviewer_model: input.model },
+      ...input.preferredModel !== undefined && { preferred_model: input.preferredModel },
       ...input.preferredFailure !== undefined && { preferred_failure: input.preferredFailure },
       independence: "cross-agent",
       reviewer_output: input.output
@@ -42429,7 +42430,10 @@ function causePhrase(failure) {
   return FAILURE_CAUSES[failure] ?? "could not be run";
 }
 function exhaustedExplanation(routes) {
-  const sentences = routes.map((route) => `The ${route.role} (${agentName(route.agent)}) ${causePhrase(route.failure)}.`);
+  const sentences = routes.map((route) => {
+    const modelPhrase = route.model === undefined ? "" : ` using ${route.model}`;
+    return `The ${route.role}${modelPhrase} (${agentName(route.agent)}) ${causePhrase(route.failure)}.`;
+  });
   return [...sentences, "No independent check was recorded."].join(" ");
 }
 function nextStepFor(reviewer, failure) {
@@ -42538,8 +42542,15 @@ function changedReviewResult(input) {
     }
   });
 }
-function alternateFailureData(failure) {
-  return failure === undefined ? {} : { alternate_model_failure: failure };
+function routeFailureData(input) {
+  return {
+    ...input.preferredModel !== undefined && { preferred_model: input.preferredModel },
+    preferred_failure: input.preferredFailure,
+    ...input.alternateFailure !== undefined && {
+      alternate_model_failure: input.alternateFailure,
+      ...input.alternateModel !== undefined && { alternate_model: input.alternateModel }
+    }
+  };
 }
 function degradedNetworkEffects(assignedReviewer, author, alternateAttempted) {
   const preferred = { kind: "review", target: assignedReviewer, operation: "request" };
@@ -42592,12 +42603,14 @@ async function runDegradedFallback(input) {
             {
               agent: input.assignedReviewer,
               role: "independent reviewer",
+              model: input.preferredModel,
               failure: input.preferredFailure
             },
             ...input.alternateFailure === undefined ? [] : [
               {
                 agent: input.assignedReviewer,
                 role: "same reviewer on its alternate model",
+                model: input.alternateModel,
                 failure: input.alternateFailure
               }
             ],
@@ -42621,8 +42634,7 @@ async function runDegradedFallback(input) {
         status: "blocked",
         author_agent: input.author,
         assigned_reviewer: input.assignedReviewer,
-        preferred_failure: input.preferredFailure,
-        ...alternateFailureData(input.alternateFailure),
+        ...routeFailureData(input),
         fallback_failure: assessment.failure,
         review_policy: input.policy,
         independence: "none"
@@ -42657,8 +42669,7 @@ async function runDegradedFallback(input) {
         author_agent: input.author,
         assigned_reviewer: input.assignedReviewer,
         actual_reviewer: completedOutput.reviewer_agent,
-        preferred_failure: input.preferredFailure,
-        ...alternateFailureData(input.alternateFailure),
+        ...routeFailureData(input),
         review_policy: input.policy,
         independence: "degraded",
         reviewer_output: completedOutput
@@ -42684,8 +42695,7 @@ async function runDegradedFallback(input) {
       author_agent: input.author,
       assigned_reviewer: input.assignedReviewer,
       actual_reviewer: completedOutput.reviewer_agent,
-      preferred_failure: input.preferredFailure,
-      ...alternateFailureData(input.alternateFailure),
+      ...routeFailureData(input),
       independence: "degraded",
       reviewer_output: completedOutput
     }
@@ -42716,7 +42726,7 @@ async function runAlternateModelRoute(input) {
   if (assessment.kind === "failed") {
     if (assessment.failure === "not_installed" || assessment.failure === "unsupported")
       return { kind: "skipped" };
-    return assessment;
+    return { ...assessment, model };
   }
   const output = assessment.output;
   const result = independentReviewResult({
@@ -42724,6 +42734,7 @@ async function runAlternateModelRoute(input) {
     reviewer: input.reviewer,
     output,
     model,
+    preferredModel: input.preferredModel,
     preferredFailure: input.preferredFailure
   });
   return { kind: "completed", result };
@@ -42737,6 +42748,7 @@ async function runRemainingRoutes(input) {
     progress: input.progress,
     author: input.author,
     reviewer: input.assignedReviewer,
+    preferredModel: input.preferredModel,
     preferredFailure: input.preferredFailure,
     policy: input.policy,
     runDeadline: input.runDeadline
@@ -42744,12 +42756,14 @@ async function runRemainingRoutes(input) {
   if (alternate.kind === "completed")
     return alternate.result;
   const alternateFailure = alternate.kind === "failed" ? alternate.failure : undefined;
+  const alternateModel = alternate.kind === "failed" ? alternate.model : undefined;
   if (alternate.kind === "failed" && alternate.terminal) {
-    return exhaustedRunResult({ ...input, alternateFailure });
+    return exhaustedRunResult({ ...input, alternateFailure, alternateModel });
   }
-  if (!canFundRoute(input.runDeadline))
-    return exhaustedRunResult({ ...input, alternateFailure });
-  return runDegradedFallback({ ...input, alternateFailure });
+  if (!canFundRoute(input.runDeadline)) {
+    return exhaustedRunResult({ ...input, alternateFailure, alternateModel });
+  }
+  return runDegradedFallback({ ...input, alternateFailure, alternateModel });
 }
 function exhaustedRunResult(input) {
   return createResult({
@@ -42761,12 +42775,14 @@ function exhaustedRunResult(input) {
           {
             agent: input.assignedReviewer,
             role: "independent reviewer",
+            model: input.preferredModel,
             failure: input.preferredFailure
           },
           ...input.alternateFailure === undefined ? [] : [
             {
               agent: input.assignedReviewer,
               role: "same reviewer on its alternate model",
+              model: input.alternateModel,
               failure: input.alternateFailure
             }
           ]
@@ -42789,8 +42805,7 @@ function exhaustedRunResult(input) {
       status: "blocked",
       author_agent: input.author,
       assigned_reviewer: input.assignedReviewer,
-      preferred_failure: input.preferredFailure,
-      ...alternateFailureData(input.alternateFailure),
+      ...routeFailureData(input),
       review_policy: input.policy,
       independence: "none"
     }
@@ -42851,6 +42866,7 @@ async function runReview(input) {
         ...input,
         author: pair.author,
         assignedReviewer: reviewer,
+        preferredModel: primaryModel,
         preferredFailure: outcome.failure,
         policy
       });
@@ -42859,6 +42875,7 @@ async function runReview(input) {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
+      preferredModel: primaryModel,
       preferredFailure: outcome.failure,
       policy,
       runDeadline
@@ -42870,6 +42887,7 @@ async function runReview(input) {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
+      preferredModel: primaryModel,
       preferredFailure: provenance.code,
       policy,
       runDeadline

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -41684,19 +41684,25 @@ function oppositeReviewPair(author) {
     return { author, reviewer: "claude" };
   return;
 }
-function readAlternateReviewerModel(cwd, reviewer) {
-  const sources = [
-    process.env[`SAFEWORD_REVIEW_ALTERNATE_MODEL_${reviewer.toUpperCase()}`],
-    readConfiguredAlternateModel(cwd, reviewer)
-  ];
-  return sources.find((value) => value !== undefined && MODEL_NAME.test(value));
+function readPrimaryReviewerModel(cwd, reviewer) {
+  return readReviewerModel(cwd, reviewer, "PRIMARY", "crossAgentReviewPrimaryModel") ?? DEFAULT_PRIMARY_MODEL[reviewer];
 }
-function readConfiguredAlternateModel(cwd, reviewer) {
+function readAlternateReviewerModel(cwd, reviewer) {
+  return readReviewerModel(cwd, reviewer, "ALTERNATE", "crossAgentReviewAlternateModel") ?? DEFAULT_ALTERNATE_MODEL[reviewer];
+}
+function readReviewerModel(cwd, reviewer, route, configKey) {
+  const environmentValue = process.env[`SAFEWORD_REVIEW_${route}_MODEL_${reviewer.toUpperCase()}`];
+  if (environmentValue !== undefined && MODEL_NAME.test(environmentValue))
+    return environmentValue;
+  const configuredValue = readConfiguredModel(cwd, reviewer, configKey);
+  return configuredValue !== undefined && MODEL_NAME.test(configuredValue) ? configuredValue : undefined;
+}
+function readConfiguredModel(cwd, reviewer, configKey) {
   try {
     const raw = JSON.parse(readFileSync50(nodePath82.join(cwd, ".safeword", "config.json"), "utf8"));
     if (typeof raw !== "object" || raw === null)
       return;
-    const models = raw.crossAgentReviewAlternateModel;
+    const models = raw[configKey];
     if (typeof models !== "object" || models === null)
       return;
     const value = models[reviewer];
@@ -41708,15 +41714,20 @@ function readConfiguredAlternateModel(cwd, reviewer) {
 function readReviewPolicy(cwd) {
   try {
     const raw = readFileSync50(nodePath82.join(cwd, ".safeword", "config.json"), "utf8");
+    const config = JSON.parse(raw);
+    if (typeof config !== "object" || config === null || Array.isArray(config))
+      return "require";
     return readCrossAgentReviewPolicy(raw);
-  } catch {
-    return "prefer";
+  } catch (error2) {
+    return error2.code === "ENOENT" ? "prefer" : "require";
   }
 }
-var MODEL_NAME;
+var MODEL_NAME, DEFAULT_PRIMARY_MODEL, DEFAULT_ALTERNATE_MODEL;
 var init_policy = __esm(() => {
   init_review_ledger();
   MODEL_NAME = /^[\w.:/][\w.:/-]{0,199}$/u;
+  DEFAULT_PRIMARY_MODEL = { claude: "opus" };
+  DEFAULT_ALTERNATE_MODEL = { claude: "sonnet" };
 });
 
 // src/review/environment.ts
@@ -42818,9 +42829,10 @@ async function runReview(input) {
     });
   }
   const { reviewer } = pair;
+  const primaryModel = readPrimaryReviewerModel(input.cwd, reviewer);
   const prepared = preparePrimaryReview(input, reviewer);
   const runDeadline = Date.now() + runBoundMs();
-  const { outcome, sourceChanged, snapshotChanged } = await executeReview(reviewer, prepared, undefined, runDeadline);
+  const { outcome, sourceChanged, snapshotChanged } = await executeReview(reviewer, prepared, primaryModel, runDeadline);
   const changedResult = changedReviewResult({
     author: pair.author,
     reviewer,
@@ -42858,13 +42870,13 @@ async function runReview(input) {
       ...input,
       author: pair.author,
       assignedReviewer: reviewer,
-      preferredFailure: "invalid_output",
+      preferredFailure: provenance.code,
       policy,
       runDeadline
     });
   }
   const output = provenance.output;
-  return independentReviewResult({ author: pair.author, reviewer, output });
+  return independentReviewResult({ author: pair.author, reviewer, output, model: primaryModel });
 }
 var FAILURE_CAUSES;
 var init_coordinator = __esm(() => {


### PR DESCRIPTION
## Summary

- select Claude `opus` explicitly for the primary independent review
- default the funded Claude alternate route to `sonnet`
- allow project and environment overrides for both routes while leaving Codex defaults unchanged
- report the selected primary model and align timeout documentation with the current 120s/270s bounds

## Verification

- review routing suite: 161/161 tests across 16 files
- focused model policy/routing suite: 29/29 tests
- pre-push schema-drift gate: 790/790 tests
- targeted ESLint
- TypeScript typecheck
- Gherkin lint
- `git diff --check`

Closes #2587
