### PR TITLE
Strengthen independent-review BDD proof outcomes

### DIFF
--- a/packages/cli/features/reliable-reviews-for-real-packets.feature
+++ b/packages/cli/features/reliable-reviews-for-real-packets.feature
@@ -47,6 +47,7 @@ Feature: Keep independent reviews reliable for real ticket packets
       And the second executable answers promptly
       When the independent review runs
       Then the review returns the second executable's verdict
+      And the stale executable was tried before the working executable
 
     @rejection
     Scenario: Every reviewer executable failing still reports a timeout

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -286,7 +286,9 @@ Given(
   'two installed reviewer executables that both accept the review contract',
   function (this: SafewordWorld) {
     const current = state(this);
-    current.environment.SAFEWORD_REVIEW_TIMEOUT_MS = '4000';
+    // The first candidate may consume its five-second capability probe budget;
+    // leave the second candidate enough time to probe and return a real review.
+    current.environment.SAFEWORD_REVIEW_TIMEOUT_MS = '12000';
     installReviewer(current, 'codex', 'never answers', 'stale');
   },
 );

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -761,9 +761,10 @@ Then(
 Then(
   'the explanation contains neither that output nor the credential',
   function (this: SafewordWorld) {
-    const rendered = JSON.stringify(payload(this));
-    assert.ok(!rendered.includes(CREDENTIAL));
-    assert.ok(!rendered.includes('not-a-review'));
+    for (const output of [this.result.stdout, this.result.stderr]) {
+      assert.ok(!output.includes(CREDENTIAL));
+      assert.ok(!output.includes('not-a-review'));
+    }
   },
 );
 

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -55,6 +55,7 @@ interface ReviewScenario {
   binaries: string[];
   environment: Record<string, string>;
   launchLog: string;
+  elapsedMs?: number;
   targets: string[];
   context: string[];
 }
@@ -119,6 +120,9 @@ exec /bin/sleep 3600`;
   if (behaviour === 'emits a credential') {
     return `printf 'trace token=${CREDENTIAL}\\n' >&2\nprintf 'not-a-review\\n'`;
   }
+  if (behaviour === 'answers off contract') {
+    return `${body}\nanswer=$(printf '{"schema_version":1,"dispatch_id":"%s","reviewer_agent":"${agent}","verdict":"approve","summary":"reviewed","findings":[{"severity":"fatal","message":"invalid severity"}]}' "$dispatch_id")\n${emit}`;
+  }
   return String.raw`printf 'not-a-review\n'`;
 }
 function installReviewer(
@@ -159,6 +163,7 @@ function writeConfig(current: ReviewScenario, config: Record<string, unknown>): 
 
 async function runReview(world: SafewordWorld): Promise<void> {
   const current = state(world);
+  const startedAt = performance.now();
   const environment: Record<string, string> = {
     ...current.environment,
     SAFEWORD_REVIEW_LAUNCH_LOG: current.launchLog,
@@ -190,6 +195,8 @@ async function runReview(world: SafewordWorld): Promise<void> {
       stderr: failure.stderr ?? '',
       exitCode: failure.code ?? 1,
     };
+  } finally {
+    current.elapsedMs = performance.now() - startedAt;
   }
 }
 
@@ -531,6 +538,8 @@ Then('the command rejects the packet through a typed result', function (this: Sa
 Then('the configured deadline is used', function (this: SafewordWorld) {
   assert.equal(payload(this).data.preferred_failure, 'timed_out');
   assert.equal(reviewerLaunches(this).length, 1);
+  const elapsedMs = state(this).elapsedMs;
+  assert.ok(elapsedMs !== undefined && elapsedMs >= 2600 && elapsedMs < 4500);
 });
 
 Then('the assigned reviewer route is reported as timed out', function (this: SafewordWorld) {

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -708,6 +708,11 @@ Then(
   'the reviewer is never asked for a review on an alternate model',
   function (this: SafewordWorld) {
     assert.equal(payload(this).data.reviewer_model, undefined);
+    assert.ok(
+      reviewerLaunches(this).every(
+        launch => !launch.includes('--model') && !launch.includes('--help'),
+      ),
+    );
   },
 );
 

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -221,6 +221,23 @@ function reviewerLaunches(world: SafewordWorld): string[] {
   return existsSync(launchLog) ? readFileSync(launchLog, 'utf8').split('\n').filter(Boolean) : [];
 }
 
+function reviewerOutput(world: SafewordWorld): Record<string, unknown> {
+  const output = payload(world).data.reviewer_output;
+  assert.ok(output !== null && typeof output === 'object' && !Array.isArray(output));
+  return output as Record<string, unknown>;
+}
+
+function assertApprovedCodexVerdict(world: SafewordWorld): void {
+  const data = payload(world).data;
+  assert.equal(data.independence, 'cross-agent');
+  assert.equal(data.actual_reviewer, 'codex');
+  assert.equal(data.status, 'approved');
+
+  const output = reviewerOutput(world);
+  assert.equal(output.reviewer_agent, 'codex');
+  assert.equal(output.verdict, 'approve');
+}
+
 After(function (this: SafewordWorld) {
   const current = (this as ReviewWorld).review;
   if (current === undefined) return;
@@ -264,7 +281,9 @@ Given('no later route can complete either', function (this: SafewordWorld) {
 Given(
   'two installed reviewer executables that both accept the review contract',
   function (this: SafewordWorld) {
-    installReviewer(state(this), 'codex', 'never answers', 'stale');
+    const current = state(this);
+    current.environment.SAFEWORD_REVIEW_TIMEOUT_MS = '4000';
+    installReviewer(current, 'codex', 'never answers', 'stale');
   },
 );
 
@@ -491,7 +510,7 @@ When('the exhausted-route result is reported', async function (this: SafewordWor
 // ----------------------------------------------------------------- Then
 
 Then("the review returns the reviewer's verdict", function (this: SafewordWorld) {
-  assert.equal(payload(this).data.independence, 'cross-agent');
+  assertApprovedCodexVerdict(this);
 });
 
 Then('no reviewer is asked to review it', function (this: SafewordWorld) {
@@ -519,7 +538,11 @@ Then('the assigned reviewer route is reported as timed out', function (this: Saf
 });
 
 Then("the review returns the second executable's verdict", function (this: SafewordWorld) {
-  assert.equal(payload(this).data.independence, 'cross-agent');
+  assertApprovedCodexVerdict(this);
+  assert.deepEqual(
+    reviewerLaunches(this).map(launch => launch.split('\t', 1)[0]),
+    ['stale', 'working'],
+  );
 });
 
 Then(

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -567,11 +567,17 @@ Then('the assigned reviewer route is reported as timed out', function (this: Saf
 
 Then("the review returns the second executable's verdict", function (this: SafewordWorld) {
   assertApprovedCodexVerdict(this);
-  assert.deepEqual(
-    reviewerLaunches(this).map(launch => launch.split('\t', 1)[0]),
-    ['stale', 'working'],
-  );
 });
+
+Then(
+  'the stale executable was tried before the working executable',
+  function (this: SafewordWorld) {
+    assert.deepEqual(
+      reviewerLaunches(this).map(launch => launch.split('\t', 1)[0]),
+      ['stale', 'working'],
+    );
+  },
+);
 
 Then(
   'no process grouped with that reviewer is still running afterwards',

--- a/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
+++ b/packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts
@@ -14,16 +14,13 @@ import nodePath from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
 
-import { After, Given, setDefaultTimeout, Then, When } from '@cucumber/cucumber';
+import { After, Given, Then, When } from '@cucumber/cucumber';
 
 import type { SafewordWorld } from './world.js';
 
-// Cucumber's built-in step timeout is 5000ms. A route-exhaustion scenario can
-// legitimately wait through three sequential real subprocess timeouts (up to
-// SAFEWORD_REVIEW_TIMEOUT_MS each) before the run bound settles it — 3 × 2000ms
-// alone already exceeds the default, before process-spawn and cleanup
-// overhead. This is real subprocess wall-clock time, not a hang to tighten.
-setDefaultTimeout(20_000);
+// Review scenarios use real subprocess timeouts. Scope their longer budget to
+// the steps that invoke the CLI so unrelated Cucumber scenarios still fail fast.
+const REVIEW_STEP_TIMEOUT_MS = 20_000;
 
 const execFileAsync = promisify(execFile);
 const CLI_PATH = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
@@ -490,29 +487,49 @@ Given(
 
 // ----------------------------------------------------------------- When
 
-When('the independent review runs', async function (this: SafewordWorld) {
-  await runReview(this);
-});
+When(
+  'the independent review runs',
+  { timeout: REVIEW_STEP_TIMEOUT_MS },
+  async function (this: SafewordWorld) {
+    await runReview(this);
+  },
+);
 
-When('a builder runs the public review command', async function (this: SafewordWorld) {
-  await runReview(this);
-});
+When(
+  'a builder runs the public review command',
+  { timeout: REVIEW_STEP_TIMEOUT_MS },
+  async function (this: SafewordWorld) {
+    await runReview(this);
+  },
+);
 
-When('the attempt deadline is derived', async function (this: SafewordWorld) {
-  await runReview(this);
-});
+When(
+  'the attempt deadline is derived',
+  { timeout: REVIEW_STEP_TIMEOUT_MS },
+  async function (this: SafewordWorld) {
+    await runReview(this);
+  },
+);
 
-When('the answer is checked', async function (this: SafewordWorld) {
-  await runReview(this);
-});
+When(
+  'the answer is checked',
+  { timeout: REVIEW_STEP_TIMEOUT_MS },
+  async function (this: SafewordWorld) {
+    await runReview(this);
+  },
+);
 
 When('the review result is reported', function (this: SafewordWorld) {
   state(this);
 });
 
-When('the exhausted-route result is reported', async function (this: SafewordWorld) {
-  await runReview(this);
-});
+When(
+  'the exhausted-route result is reported',
+  { timeout: REVIEW_STEP_TIMEOUT_MS },
+  async function (this: SafewordWorld) {
+    await runReview(this);
+  },
+);
 
 // ----------------------------------------------------------------- Then
 


### PR DESCRIPTION
## Summary

Strengthens the independent-review BDD proofs without changing product behavior.

- Assert the returned reviewer identity, approval status, and typed verdict.
- Prove the stale executable is attempted before the working fallback.
- Give the two-executable fixture enough test-only time for its split budget.

## Why

The previous scenarios established only that the result was cross-agent. They could pass without proving which executable supplied the verdict or whether its typed approval payload was preserved.

## Validation

- `NODE_OPTIONS='--import tsx' bunx cucumber-js packages/cli/features/reliable-reviews-for-real-packets.feature --format summary`
- `bunx eslint packages/cli/features/steps/reliable-reviews-for-real-packets.steps.ts`
- `bun run --cwd packages/cli typecheck`
