### PR TITLE
chore(release): v0.76.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.74.7-rc.1",
+      "version": "0.76.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.75.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.76.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.75.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.76.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.75.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.76.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.75.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.76.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.75.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.76.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.75.0",
+  "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "b795418d71120705a154fee16c75920084f4ebb9eff48512b74c8b00c8628c21"
+  "inventory_sha256": "be2d6e689d7dcd46f1c832cb5f595d3b74ffbef3b6123c211bfefb36a865e417"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "5e7804cfb1647392fafca0762d4605bedca5500b6f2b55332f89977a67701549"
+      "sha256": "6030e2db88687a057cb6e9c44391a108a184a5be121aa02d971dd1961acba48f"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "type": "module"
 }


### PR DESCRIPTION
## Release

Minor release for additive workflows and reliability improvements merged since v0.75.0.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/cli check:claude-plugin`
- `bun run --cwd packages/cli build`
- Codex activation and full release Vitest gates are queued behind the repository-wide single-Vitest lock and will run in CI.