### PR TITLE
Clarify BDD proof assertions

### DIFF
--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -41,6 +41,10 @@ same actor-facing entry point and actor-visible result that the `When` and
 - **Observe the `Then` as the actor-visible result.** Store, editor, or component
   state is supporting evidence; it does not prove a visible UI result, emitted
   CLI output, or external API response.
+- **Assert the result's material values.** A proxy property is not enough: when a
+  `Then` names an actor or typed result, assert those fields in the emitted
+  output. Assert attempt order only when that order is part of the promised
+  behavior.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/.safeword/skills/bdd/TDD.md
+++ b/.safeword/skills/bdd/TDD.md
@@ -41,6 +41,10 @@ same actor-facing entry point and actor-visible result that the `When` and
 - **Observe the `Then` as the actor-visible result.** Store, editor, or component
   state is supporting evidence; it does not prove a visible UI result, emitted
   CLI output, or external API response.
+- **Assert the result's material values.** A proxy property is not enough: when a
+  `Then` names an actor or typed result, assert those fields in the emitted
+  output. Assert attempt order only when that order is part of the promised
+  behavior.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/packages/cli/codex-plugin/skills/bdd/references/TDD.md
+++ b/packages/cli/codex-plugin/skills/bdd/references/TDD.md
@@ -41,6 +41,10 @@ same actor-facing entry point and actor-visible result that the `When` and
 - **Observe the `Then` as the actor-visible result.** Store, editor, or component
   state is supporting evidence; it does not prove a visible UI result, emitted
   CLI output, or external API response.
+- **Assert the result's material values.** A proxy property is not enough: when a
+  `Then` names an actor or typed result, assert those fields in the emitted
+  output. Assert attempt order only when that order is part of the promised
+  behavior.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -22,7 +22,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/bdd/SPLITTING.md':
         'e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708',
       '.claude/skills/bdd/TDD.md':
-        '8c73a7a57a3df8c834e77462e2d7ca8a824e15b6ecadf15ba64e0e1c9227a09a',
+        '319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5',
       '.claude/skills/bdd/VERIFY.md':
         '85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31',
       '.claude/skills/brainstorm/SKILL.md':

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -41,6 +41,10 @@ same actor-facing entry point and actor-visible result that the `When` and
 - **Observe the `Then` as the actor-visible result.** Store, editor, or component
   state is supporting evidence; it does not prove a visible UI result, emitted
   CLI output, or external API response.
+- **Assert the result's material values.** A proxy property is not enough: when a
+  `Then` names an actor or typed result, assert those fields in the emitted
+  output. Assert attempt order only when that order is part of the promised
+  behavior.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/packages/cli/tests/hooks/scenario-proof-fidelity-documentation.test.ts
+++ b/packages/cli/tests/hooks/scenario-proof-fidelity-documentation.test.ts
@@ -40,6 +40,9 @@ describe('scenario proof fidelity documentation (issue #1698)', () => {
 
     expect(content).toContain('actor-visible result');
     expect(content).toMatch(/Store, editor, or component\s+state is supporting evidence/);
+    expect(content).toContain("Assert the result's material values");
+    expect(content).toContain('A proxy property is not enough');
+    expect(content).toContain('Assert attempt order only when that order is part of the promised');
   });
 
   it.each(bddTddCopies)('%s keeps setup and lower-level checks proportionate', path => {

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "be2d6e689d7dcd46f1c832cb5f595d3b74ffbef3b6123c211bfefb36a865e417"
+  "inventory_sha256": "0b8e76231eb56fcd47c48bcef62fccde089c4f2fc854b927f4348cfc3ae25e61"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,11 +139,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "72246338cc0c8f32920cb86b9a2faf1547a863f65a3d38ae7676d4685c473325"
+      "sha256": "a6b4b15b1da2fd8e352d26b29bc3086ec33d18d7ed413ac5b12a2d2517817771"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "887cfb565c0cd1f68d82d30adbd97293c09818f9ba5de948e95c0e40592e6cf6"
+      "sha256": "f9be3468d81b2694d54806eddc2fbb323572c121bebf547d5d849042446f8eaf"
     },
     {
       "path": "runtime/event-groups.json",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -603,7 +603,7 @@
     },
     {
       "path": "skills/bdd/TDD.md",
-      "sha256": "1b450ed34f67ce6ee107e3b304f7e3ce2c56a4fc09dd8823e9b84e060eff7b63"
+      "sha256": "623bf5e2f73cb5b211a936d3f858eae28d2d4c873602344a124bd567fd8121f8"
     },
     {
       "path": "skills/bdd/VERIFY.md",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -6062,7 +6062,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/bdd/SCENARIOS.md": "2cf7c403e6a50c5ee1574f6e0a0965ee4afcbda9d0ec4580b425723ec5d4f83d",
         ".claude/skills/bdd/SKILL.md": "53b66c5ee888c6d9a1dc05119ee9d197d3d6b01d36b747fe62d686852e3715c9",
         ".claude/skills/bdd/SPLITTING.md": "e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708",
-        ".claude/skills/bdd/TDD.md": "8c73a7a57a3df8c834e77462e2d7ca8a824e15b6ecadf15ba64e0e1c9227a09a",
+        ".claude/skills/bdd/TDD.md": "319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5",
         ".claude/skills/bdd/VERIFY.md": "85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31",
         ".claude/skills/brainstorm/SKILL.md": "fe99638bd1621cbd5fe3780a8d39023d4b175e3be2aef2e60d0ebe7558848f2e",
         ".claude/skills/cleanup-zombies/SKILL.md": "e0af9635774767cf36eb69726e11c642ec1dad42839c11407ea8ef60f89fc289",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1803,7 +1803,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/bdd/SPLITTING.md':
         'e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708',
       '.claude/skills/bdd/TDD.md':
-        '8c73a7a57a3df8c834e77462e2d7ca8a824e15b6ecadf15ba64e0e1c9227a09a',
+        '319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5',
       '.claude/skills/bdd/VERIFY.md':
         '85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31',
       '.claude/skills/brainstorm/SKILL.md':

--- a/plugin/skills/bdd/TDD.md
+++ b/plugin/skills/bdd/TDD.md
@@ -41,6 +41,10 @@ same actor-facing entry point and actor-visible result that the `When` and
 - **Observe the `Then` as the actor-visible result.** Store, editor, or component
   state is supporting evidence; it does not prove a visible UI result, emitted
   CLI output, or external API response.
+- **Assert the result's material values.** A proxy property is not enough: when a
+  `Then` names an actor or typed result, assert those fields in the emitted
+  output. Assert attempt order only when that order is part of the promised
+  behavior.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does


### PR DESCRIPTION
## Summary

Clarifies that BDD step definitions must assert the material fields promised by a `Then`, not merely a proxy status.

It permits assertion of execution order only when the order is part of the stated behavior.

## Validation

- Template, Claude, dogfood, and Codex-plugin copies are identical.
- Prettier and diff hygiene pass.
- Focused documentation test is queued behind the repository-wide single-Vitest lock; CI will run the full matrix.