### PR TITLE
Tighten BDD scenario proof fidelity

### DIFF
--- a/.claude/skills/bdd/TDD.md
+++ b/.claude/skills/bdd/TDD.md
@@ -45,6 +45,15 @@ same actor-facing entry point and actor-visible result that the `When` and
   `Then` names an actor or typed result, assert those fields in the emitted
   output. Assert attempt order only when that order is part of the promised
   behavior.
+- **Prove the whole scenario in its primary test.** Material `Given`, `When`,
+  and `Then` clauses must hold together at the claimed boundary; evidence
+  scattered across separate tests does not prove their interaction.
+- **Preserve timing and cardinality.** If the scenario promises behavior within
+  the same invocation, attempt, or session, a retry or second call is not
+  equivalent proof.
+- **Prove every material outline row.** A `Scenario Outline` is complete only
+  when each behaviorally distinct example traverses the claimed boundary;
+  otherwise narrow the scenario or add the missing proof.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/.safeword/skills/bdd/TDD.md
+++ b/.safeword/skills/bdd/TDD.md
@@ -45,6 +45,15 @@ same actor-facing entry point and actor-visible result that the `When` and
   `Then` names an actor or typed result, assert those fields in the emitted
   output. Assert attempt order only when that order is part of the promised
   behavior.
+- **Prove the whole scenario in its primary test.** Material `Given`, `When`,
+  and `Then` clauses must hold together at the claimed boundary; evidence
+  scattered across separate tests does not prove their interaction.
+- **Preserve timing and cardinality.** If the scenario promises behavior within
+  the same invocation, attempt, or session, a retry or second call is not
+  equivalent proof.
+- **Prove every material outline row.** A `Scenario Outline` is complete only
+  when each behaviorally distinct example traverses the claimed boundary;
+  otherwise narrow the scenario or add the missing proof.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/packages/cli/codex-plugin/skills/bdd/references/TDD.md
+++ b/packages/cli/codex-plugin/skills/bdd/references/TDD.md
@@ -45,6 +45,15 @@ same actor-facing entry point and actor-visible result that the `When` and
   `Then` names an actor or typed result, assert those fields in the emitted
   output. Assert attempt order only when that order is part of the promised
   behavior.
+- **Prove the whole scenario in its primary test.** Material `Given`, `When`,
+  and `Then` clauses must hold together at the claimed boundary; evidence
+  scattered across separate tests does not prove their interaction.
+- **Preserve timing and cardinality.** If the scenario promises behavior within
+  the same invocation, attempt, or session, a retry or second call is not
+  equivalent proof.
+- **Prove every material outline row.** A `Scenario Outline` is complete only
+  when each behaviorally distinct example traverses the claimed boundary;
+  otherwise narrow the scenario or add the missing proof.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -22,7 +22,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/bdd/SPLITTING.md':
         'e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708',
       '.claude/skills/bdd/TDD.md':
-        '319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5',
+        '9cb3e98b453fd3ca4378a43b07e4bd389aa1c6fb40875f9fb50d04319cb8b72b',
       '.claude/skills/bdd/VERIFY.md':
         '85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31',
       '.claude/skills/brainstorm/SKILL.md':

--- a/packages/cli/templates/skills/bdd/TDD.md
+++ b/packages/cli/templates/skills/bdd/TDD.md
@@ -45,6 +45,15 @@ same actor-facing entry point and actor-visible result that the `When` and
   `Then` names an actor or typed result, assert those fields in the emitted
   output. Assert attempt order only when that order is part of the promised
   behavior.
+- **Prove the whole scenario in its primary test.** Material `Given`, `When`,
+  and `Then` clauses must hold together at the claimed boundary; evidence
+  scattered across separate tests does not prove their interaction.
+- **Preserve timing and cardinality.** If the scenario promises behavior within
+  the same invocation, attempt, or session, a retry or second call is not
+  equivalent proof.
+- **Prove every material outline row.** A `Scenario Outline` is complete only
+  when each behaviorally distinct example traverses the claimed boundary;
+  otherwise narrow the scenario or add the missing proof.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "cb1f41e043abccc84b6148cbf619b933fecd394de0fbea5c477f9e677e7e98bc"
+  "inventory_sha256": "6b3436960cd6b841b90fbea6388e5687de35ddac2d853b18436cbe2270be0735"
 }

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "6b3436960cd6b841b90fbea6388e5687de35ddac2d853b18436cbe2270be0735"
+  "inventory_sha256": "6ec47191536a8a0343dd97a2475a3b0b5d4274519760d720797430c226c80f00"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,11 +139,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "f72b490f4fb747550c0965e9254f7d5bad53e22f583fa094df61ad6f0bfb113b"
+      "sha256": "3bfc4f3e3effc1bf45c785a5ee7b30470aeb6bd1094481409d17a8c318329744"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "73d8d26f8e5d9690c5864a1b9227a375ffa3b661ce547a3f7efd565b7fbaf28e"
+      "sha256": "aa7c3d35f7cf14023d4664fd3f4ad5cee075c602b1299b2d9c59e13d0d58b556"
     },
     {
       "path": "runtime/event-groups.json",

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -607,7 +607,7 @@
     },
     {
       "path": "skills/bdd/TDD.md",
-      "sha256": "623bf5e2f73cb5b211a936d3f858eae28d2d4c873602344a124bd567fd8121f8"
+      "sha256": "bbba8b95ca9accf44e7a3b9c84d749610f2b876ef0457af7b9e9be92a007765f"
     },
     {
       "path": "skills/bdd/VERIFY.md",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -6062,7 +6062,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/bdd/SCENARIOS.md": "2cf7c403e6a50c5ee1574f6e0a0965ee4afcbda9d0ec4580b425723ec5d4f83d",
         ".claude/skills/bdd/SKILL.md": "53b66c5ee888c6d9a1dc05119ee9d197d3d6b01d36b747fe62d686852e3715c9",
         ".claude/skills/bdd/SPLITTING.md": "e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708",
-        ".claude/skills/bdd/TDD.md": "319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5",
+        ".claude/skills/bdd/TDD.md": "9cb3e98b453fd3ca4378a43b07e4bd389aa1c6fb40875f9fb50d04319cb8b72b",
         ".claude/skills/bdd/VERIFY.md": "85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31",
         ".claude/skills/brainstorm/SKILL.md": "fe99638bd1621cbd5fe3780a8d39023d4b175e3be2aef2e60d0ebe7558848f2e",
         ".claude/skills/cleanup-zombies/SKILL.md": "e0af9635774767cf36eb69726e11c642ec1dad42839c11407ea8ef60f89fc289",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1803,7 +1803,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/bdd/SPLITTING.md':
         'e232a37a4d76f0dfc51e65965c1e1b7f1572e0dedce0fb8c031e75bd6544a708',
       '.claude/skills/bdd/TDD.md':
-        '319a0b4430a60c23be095c703f5405c14f63c5ad9ed932992c7f846a096618e5',
+        '9cb3e98b453fd3ca4378a43b07e4bd389aa1c6fb40875f9fb50d04319cb8b72b',
       '.claude/skills/bdd/VERIFY.md':
         '85abadfe756a3f391779fe500cd5c66597a33e0cab7fcef55f6b633b30818f31',
       '.claude/skills/brainstorm/SKILL.md':

--- a/plugin/skills/bdd/TDD.md
+++ b/plugin/skills/bdd/TDD.md
@@ -45,6 +45,15 @@ same actor-facing entry point and actor-visible result that the `When` and
   `Then` names an actor or typed result, assert those fields in the emitted
   output. Assert attempt order only when that order is part of the promised
   behavior.
+- **Prove the whole scenario in its primary test.** Material `Given`, `When`,
+  and `Then` clauses must hold together at the claimed boundary; evidence
+  scattered across separate tests does not prove their interaction.
+- **Preserve timing and cardinality.** If the scenario promises behavior within
+  the same invocation, attempt, or session, a retry or second call is not
+  equivalent proof.
+- **Prove every material outline row.** A `Scenario Outline` is complete only
+  when each behaviorally distinct example traverses the claimed boundary;
+  otherwise narrow the scenario or add the missing proof.
 - **Keep evidence limits explicit.** When the real boundary cannot be automated
   reliably, use the existing `@manual` or `@live` path and perform and record
   that check separately. A tag, skip reason, or narrower automated test does


### PR DESCRIPTION
## What changed

- require a primary test to prove the material Given, When, and Then together
- preserve invocation, attempt, and session timing/cardinality in scenario proof
- require every behaviorally distinct Scenario Outline row to traverse the claimed boundary
- synchronize the canonical, Claude, Codex, and dogfood BDD guidance

## Why

The closeout reliability work exposed cases where nominal scenario-to-test mappings overstated proof: fragments were split across tests, retries substituted for same-invocation behavior, and one outline example stood in for materially different rows. These compact rules close that gap without adding a phase or artifact.

## Validation

- `bun run test:release tests/codex-plugin-catalogue.release.test.ts` — 8 passed
- `git diff --check`
- pre-commit template parity and Markdown checks