### PR TITLE
Keep built CLI stable during package tests

### DIFF
--- a/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/ticket.md
+++ b/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/ticket.md
@@ -1,0 +1,50 @@
+---
+id: JZ6PNV
+slug: keep-built-cli-stable-during-tests
+type: patch
+subtype: bug-investigated
+phase: intake
+status: in_progress
+external_issue: https://github.com/ArcadeAI/safeword/issues/1823
+created: 2026-08-12T22:13:03.364Z
+last_modified: 2026-08-12T22:13:03.364Z
+---
+
+# Keep package tests from deleting the CLI they exercise
+
+**Goal:** Keep the built CLI and preset artifacts stable for the full lifetime of every package test run.
+
+**Why:** Concurrent build-producing tests can clean packages/cli/dist while other tests execute the CLI, creating false-red verification and CI failures.
+
+## Root Cause
+
+The test runner built the CLI under `packages/cli/dist`, then left every CLI subprocess and every
+fixture `file:` dependency pointed at that live package directory for the full parallel suite. The
+same mutable directory was therefore serving three incompatible roles: build output, executable
+under test, and package-install source. The cross-worktree lock serialized wrapper invocations but
+did not make those artifacts immutable after the build.
+
+The original issue's cross-worktree deletion theory was too narrow: Git worktrees have separate
+`dist` directories, and the Node 24 CI failure happened in one checkout with no second wrapper.
+Install-heavy focused runs also passed without mutation. The durable defect is the missing
+isolation boundary, regardless of which concurrent source-tree operation exposes it.
+
+## Done When
+
+- The runner snapshots the built publishable package before Vitest starts.
+- CLI subprocesses and `file:` package fixtures use that snapshot, while source-oriented tests can
+  continue to inspect or mutate the live checkout deliberately.
+- The snapshot is removed after success or failure.
+- A regression test proves Vitest receives a private snapshot containing the built CLI.
+- The install-backed TypeScript validation remains green even if live `dist` disappears after the
+  suite starts.
+
+## Work Log
+
+- 2026-08-12T22:13:03.364Z Started: Created ticket JZ6PNV
+- 2026-08-12T22:28:00.000Z Investigated: Ruled out overlapping wrapper builds inside the failing Node 24 job and failed to reproduce mutation with the three install-heavy fixtures alone. Confirmed that the full suite executed and installed from the live mutable package directory.
+- 2026-08-12T22:28:00.000Z RED: The runner contract failed because `SAFEWORD_TEST_CLI_ROOT` was absent, proving there was no private built-package boundary.
+- 2026-08-12T22:29:00.000Z GREEN: The runner now copies the publishable package entries after building, supplies the private root to Vitest, and removes it in `finally`. Shared helpers route both CLI execution and `file:` dependencies through that root.
+- 2026-08-12T22:30:00.000Z Regression proof: Temporarily moved the live generated `dist` after Vitest started; all 11 TypeScript install/ESLint tests still passed from the snapshot, then the live directory was restored.
+- 2026-08-13T00:20:00.000Z Quality review: Hardened stale-transition recovery, typed lock ownership, snapshot path/symlink containment, argv-safe synchronous CLI execution, timeout classification, and shell-free Windows Vitest resolution. Focused runner/helper suite passed 31/31.
+- 2026-08-13T00:20:00.000Z Full verification: 490 files and 7,595 tests passed; 1,469 BDD scenarios/64,549 steps plus 50 proof scenarios/240 proof steps passed; builds, TypeScript, Bun audit, and govulncheck passed. The aggregate verifier exits 2 only because the repository-wide generated type plan incorrectly runs `mypy .` where no Python files exist.

--- a/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/ticket.md
+++ b/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/ticket.md
@@ -3,11 +3,11 @@ id: JZ6PNV
 slug: keep-built-cli-stable-during-tests
 type: patch
 subtype: bug-investigated
-phase: intake
-status: in_progress
+phase: done
+status: done
 external_issue: https://github.com/ArcadeAI/safeword/issues/1823
 created: 2026-08-12T22:13:03.364Z
-last_modified: 2026-08-12T22:13:03.364Z
+last_modified: 2026-08-13T00:23:00.000Z
 ---
 
 # Keep package tests from deleting the CLI they exercise
@@ -48,3 +48,4 @@ isolation boundary, regardless of which concurrent source-tree operation exposes
 - 2026-08-12T22:30:00.000Z Regression proof: Temporarily moved the live generated `dist` after Vitest started; all 11 TypeScript install/ESLint tests still passed from the snapshot, then the live directory was restored.
 - 2026-08-13T00:20:00.000Z Quality review: Hardened stale-transition recovery, typed lock ownership, snapshot path/symlink containment, argv-safe synchronous CLI execution, timeout classification, and shell-free Windows Vitest resolution. Focused runner/helper suite passed 31/31.
 - 2026-08-13T00:20:00.000Z Full verification: 490 files and 7,595 tests passed; 1,469 BDD scenarios/64,549 steps plus 50 proof scenarios/240 proof steps passed; builds, TypeScript, Bun audit, and govulncheck passed. The aggregate verifier exits 2 only because the repository-wide generated type plan incorrectly runs `mypy .` where no Python files exist.
+- 2026-08-13T00:23:00.000Z Completed: Verification evidence recorded and PR #2659 opened to close GitHub issue #1823.

--- a/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/verify.md
+++ b/.project/tickets/JZ6PNV-keep-built-cli-stable-during-tests/verify.md
@@ -1,0 +1,19 @@
+# Verification
+
+**PR Scope:** Passed — the diff is limited to the package-test runner, its shared test helpers and consumers, regression tests, and this ticket evidence.
+
+**Test Suite:** Passed — 490 files, 7,595 tests passed (5 skipped). After quality-review hardening, the focused runner/helper suite passed 31/31 and retro-relay passed 170/171 (1 intentional skip).
+
+**BDD:** Passed — 1,469 scenarios/64,549 steps passed with expected skips; the proof lane passed 50 scenarios/240 steps.
+
+**Build:** Passed — CLI and retro-relay builds completed successfully.
+
+**Typecheck:** Passed for the changed TypeScript (`packages/cli` `tsc --noEmit`). The aggregate repository verifier exits 2 because its generated plan runs `mypy .` in a repository with no Python files; that detector defect is unrelated to this diff.
+
+**Dependencies:** Passed — `bun audit` reported no vulnerabilities and `govulncheck` reported zero reachable vulnerabilities; `pip-audit` was unavailable and explicitly skipped.
+
+**Audit:** Passed — diff-scoped health and dependency-boundary checks were clean; no changed agent configuration, learning, domain-document, or architecture dependency required reconciliation.
+
+**Manual regression:** Passed — after Vitest started, the live CLI `dist` directory was moved away; all 11 install-backed TypeScript validation tests continued from the private snapshot, then the live directory was restored.
+
+**Quality review:** Multiple reviewer passes were run. The preferred Claude reviewer timed out each time, so independence was degraded; every fallback finding was implemented and covered by focused tests.

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -1,10 +1,26 @@
 import { spawnSync } from 'node:child_process';
 import console from 'node:console';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import process from 'node:process';
+
+import { resolveWindowsVitest } from './test-runner-executable.mjs';
 
 const scriptDirectory = import.meta.dirname;
 const cliRoot = nodePath.resolve(scriptDirectory, '..');
@@ -32,9 +48,12 @@ const localBinDirectory = nodePath.join(cliRoot, 'node_modules', '.bin');
 // loses Node's case-insensitive access, so append to whatever key already holds
 // the path (else a stray `PATH` key would sit alongside `Path` and be ignored).
 const pathKey = Object.keys(process.env).find(key => key.toUpperCase() === 'PATH') ?? 'PATH';
+const inheritedPath = process.env[pathKey] ?? '';
 const childEnvironment = {
   ...process.env,
-  [pathKey]: `${process.env[pathKey] ?? ''}${nodePath.delimiter}${localBinDirectory}`,
+  [pathKey]: inheritedPath
+    ? `${inheritedPath}${nodePath.delimiter}${localBinDirectory}`
+    : localBinDirectory,
 };
 const lockParent = nodePath.join(tmpdir(), 'safeword-test-locks');
 const lockName = 'safeword-package-test';
@@ -46,9 +65,12 @@ const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
   : nodePath.join(lockParent, `${lockName}.lock`);
 const ownerPath = nodePath.join(lockDirectory, 'owner.json');
 const transitionDirectory = `${lockDirectory}.transition`;
+const transitionOwnerPath = nodePath.join(transitionDirectory, 'owner.json');
+const transitionRecoveryDirectory = nodePath.join(transitionDirectory, 'recovery');
 const checkoutRoot = nodePath.resolve(cliRoot, '..', '..');
 const minimumLockStatusIntervalMilliseconds = 50;
 const maximumTransitionWaitMilliseconds = 30_000;
+const lockOwnerKind = 'safeword-package-test-lock';
 
 function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
   const raw = process.env[name];
@@ -95,23 +117,29 @@ function hasUsableOwnerTimestamp(value) {
   return typeof value === 'string' && Number.isFinite(Date.parse(value));
 }
 
-function readOwner() {
+function readOwnerAt(path) {
   try {
-    const parsed = JSON.parse(readFileSync(ownerPath, 'utf8'));
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
     const owner =
       typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : {};
     const readable = isUsableOwnerPid(owner.pid) || hasUsableOwnerTimestamp(owner.createdAt);
     return {
       owner,
       readable,
+      valid: owner.kind === lockOwnerKind,
     };
   } catch {
-    return { owner: {}, readable: false };
+    return { owner: {}, readable: false, valid: false };
   }
 }
 
+function readOwner() {
+  return readOwnerAt(ownerPath);
+}
+
 function removeStaleLock() {
-  const { owner, readable } = readOwner();
+  const { owner, readable, valid } = readOwner();
+  if (!valid) return false;
   if (!readable) {
     const lockAgeMilliseconds = Date.now() - statSync(lockDirectory).mtimeMs;
     if (lockAgeMilliseconds > 30_000) {
@@ -170,35 +198,97 @@ function reportLockWait(waitedMilliseconds) {
 }
 
 function createLock(token) {
-  mkdirSync(lockDirectory);
-  writeFileSync(
-    ownerPath,
-    `${JSON.stringify(
-      {
-        createdAt: new Date().toISOString(),
-        checkoutRoot,
-        pid: process.pid,
-        token,
-      },
-      undefined,
-      2,
-    )}\n`,
-  );
+  const candidateDirectory = `${lockDirectory}.candidate-${token}`;
+  try {
+    mkdirSync(candidateDirectory);
+    writeFileSync(
+      nodePath.join(candidateDirectory, 'owner.json'),
+      `${JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          checkoutRoot,
+          kind: lockOwnerKind,
+          pid: process.pid,
+          token,
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+    renameSync(candidateDirectory, lockDirectory);
+  } finally {
+    rmSync(candidateDirectory, { force: true, recursive: true });
+  }
 }
 
-function tryEnterLockTransition() {
+function createLockTransition() {
+  mkdirSync(transitionDirectory);
   try {
-    mkdirSync(transitionDirectory);
-    return true;
+    writeFileSync(
+      transitionOwnerPath,
+      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+    );
   } catch (error) {
-    if (error?.code === 'EEXIST') {
-      return false;
-    }
+    rmSync(transitionDirectory, { force: true, recursive: true });
     throw error;
   }
 }
 
+function tryCreateLockTransition() {
+  try {
+    createLockTransition();
+    return true;
+  } catch (error) {
+    if (error?.code === 'EEXIST') return false;
+    throw error;
+  }
+}
+
+function lockTransitionIsAbandoned() {
+  const { owner, readable } = readOwnerAt(transitionOwnerPath);
+  if (isUsableOwnerPid(owner.pid)) return !isProcessAlive(owner.pid);
+  if (readable) return false;
+  try {
+    return Date.now() - statSync(transitionDirectory).mtimeMs > 30_000;
+  } catch {
+    return false;
+  }
+}
+
+function tryEnterTransitionRecovery() {
+  try {
+    mkdirSync(transitionRecoveryDirectory);
+    return true;
+  } catch (error) {
+    if (error?.code === 'EEXIST' || error?.code === 'ENOENT' || error?.code === 'EINVAL')
+      return false;
+    throw error;
+  }
+}
+
+function tryRecoverLockTransition() {
+  if (!tryEnterTransitionRecovery()) return false;
+  try {
+    if (!lockTransitionIsAbandoned()) return false;
+    writeFileSync(
+      transitionOwnerPath,
+      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+    );
+    return true;
+  } finally {
+    rmSync(transitionRecoveryDirectory, { force: true, recursive: true });
+  }
+}
+
+function tryEnterLockTransition() {
+  if (tryCreateLockTransition()) return true;
+  return tryRecoverLockTransition();
+}
+
 function leaveLockTransition() {
+  while (!tryEnterTransitionRecovery()) {
+    sleep(10);
+  }
   rmSync(transitionDirectory, { force: true, recursive: true });
 }
 
@@ -212,7 +302,7 @@ function tryAcquireLock(token) {
       createLock(token);
       return true;
     } catch (error) {
-      if (error?.code !== 'EEXIST') {
+      if (error?.code !== 'EEXIST' && error?.code !== 'ENOTEMPTY') {
         throw error;
       }
     }
@@ -297,11 +387,13 @@ function releaseLock(token) {
   }
 }
 
-function run(command, args) {
-  const result = spawnSync(command, args, {
+function run(command, args, environment = childEnvironment) {
+  const windowsVitest = windowsVitestInvocation(command, environment);
+  const executable = windowsVitest?.executable ?? command;
+  const executableArguments = windowsVitest ? [...windowsVitest.arguments, ...args] : args;
+  const result = spawnSync(executable, executableArguments, {
     cwd: cliRoot,
-    env: childEnvironment,
-    shell: process.platform === 'win32',
+    env: environment,
     stdio: 'inherit',
   });
 
@@ -317,17 +409,114 @@ function run(command, args) {
   return result.status ?? 1;
 }
 
+function windowsVitestInvocation(command, environment) {
+  if (process.platform !== 'win32' || command !== 'vitest') return false;
+  return resolveWindowsVitest(environment[pathKey] ?? '', cliRoot);
+}
+
+function packageSnapshotEntries() {
+  const packageJsonPath = nodePath.join(cliRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) return ['dist'];
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  return [
+    'package.json',
+    ...(Array.isArray(packageJson.files)
+      ? packageJson.files.filter(entry => typeof entry === 'string')
+      : []),
+  ];
+}
+
+function pathEscapesRoot(relativePath) {
+  return (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${nodePath.sep}`) ||
+    nodePath.isAbsolute(relativePath)
+  );
+}
+
+function assertSnapshotTreeHasNoSymlinks(path, entry) {
+  const stats = lstatSync(path);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Package snapshot entry contains a symbolic link: ${entry}`);
+  }
+  if (!stats.isDirectory()) return;
+  for (const child of readdirSync(path)) {
+    assertSnapshotTreeHasNoSymlinks(nodePath.join(path, child), entry);
+  }
+}
+
+function packageSnapshotSource(entry, canonicalCliRoot) {
+  const source = nodePath.resolve(cliRoot, entry);
+  const packageRelativeSource = nodePath.relative(cliRoot, source);
+  if (pathEscapesRoot(packageRelativeSource)) {
+    throw new Error(`Package snapshot entry escapes the CLI package: ${entry}`);
+  }
+  if (!existsSync(source)) return false;
+  const canonicalRelativeSource = nodePath.relative(canonicalCliRoot, realpathSync(source));
+  if (pathEscapesRoot(canonicalRelativeSource)) {
+    throw new Error(`Package snapshot entry resolves outside the CLI package: ${entry}`);
+  }
+  assertSnapshotTreeHasNoSymlinks(source, entry);
+  return { packageRelativeSource, source };
+}
+
+function createPackageSnapshot() {
+  const snapshotRoot = mkdtempSync(nodePath.join(cliRoot, '.test-package-'));
+  const canonicalCliRoot = realpathSync(cliRoot);
+  try {
+    for (const entry of packageSnapshotEntries()) {
+      const snapshotSource = packageSnapshotSource(entry, canonicalCliRoot);
+      if (!snapshotSource) continue;
+      const { packageRelativeSource, source } = snapshotSource;
+      const destination = nodePath.join(snapshotRoot, packageRelativeSource);
+      mkdirSync(nodePath.dirname(destination), { recursive: true });
+      if (statSync(source).isDirectory()) {
+        cpSync(source, destination, { recursive: true });
+      } else {
+        copyFileSync(source, destination);
+      }
+    }
+    const snapshotCli = nodePath.join(snapshotRoot, 'dist', 'cli.js');
+    if (!existsSync(snapshotCli)) {
+      throw new Error(`Built CLI is missing from the package test snapshot: ${snapshotCli}`);
+    }
+    return snapshotRoot;
+  } catch (error) {
+    rmSync(snapshotRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+function removePackageSnapshot(snapshotRoot) {
+  try {
+    rmSync(snapshotRoot, { force: true, recursive: true });
+    return true;
+  } catch (error) {
+    console.error(`Could not remove package test snapshot ${snapshotRoot}:`, error);
+    return false;
+  }
+}
+
 let lockToken;
+let packageSnapshot;
 let status = 1;
 try {
   lockToken = acquireLock();
   if (lockToken) {
     status = run('bun', ['run', 'build']);
     if (status === 0) {
-      status = run('vitest', ['run', ...vitestArguments]);
+      packageSnapshot = createPackageSnapshot();
+      status = run('vitest', ['run', ...vitestArguments], {
+        ...childEnvironment,
+        SAFEWORD_TEST_CLI_ROOT: packageSnapshot,
+      });
     }
   }
 } finally {
+  if (packageSnapshot && !removePackageSnapshot(packageSnapshot)) {
+    status = 1;
+  }
   if (lockToken && !releaseLock(lockToken)) {
     status = 1;
   }

--- a/packages/cli/scripts/test-runner-executable.d.mts
+++ b/packages/cli/scripts/test-runner-executable.d.mts
@@ -1,0 +1,10 @@
+export interface TestRunnerInvocation {
+  arguments: string[];
+  executable: string;
+}
+
+export function resolveWindowsVitest(
+  searchPath: string,
+  cliRoot: string,
+  nodeExecutable?: string,
+): TestRunnerInvocation;

--- a/packages/cli/scripts/test-runner-executable.mjs
+++ b/packages/cli/scripts/test-runner-executable.mjs
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+function windowsVitestCandidate(directory, name, nodeExecutable) {
+  const candidate = nodePath.join(directory, name);
+  if (!existsSync(candidate)) return false;
+  if (name === 'vitest.exe') return { arguments: [], executable: candidate };
+  if (name !== 'vitest.cmd') {
+    return { arguments: [candidate], executable: nodeExecutable };
+  }
+  const moduleEntry = nodePath.resolve(directory, '..', 'vitest', 'vitest.mjs');
+  return existsSync(moduleEntry) ? { arguments: [moduleEntry], executable: nodeExecutable } : false;
+}
+
+export function resolveWindowsVitest(searchPath, cliRoot, nodeExecutable = process.execPath) {
+  const directories = searchPath.split(nodePath.delimiter).filter(Boolean);
+  const names = ['vitest.exe', 'vitest.cmd', 'vitest.mjs', 'vitest.js'];
+  const candidates = directories.flatMap(directory => names.map(name => ({ directory, name })));
+  for (const { directory, name } of candidates) {
+    const invocation = windowsVitestCandidate(directory, name, nodeExecutable);
+    if (invocation) return invocation;
+  }
+  return {
+    arguments: [nodePath.join(cliRoot, 'node_modules', 'vitest', 'vitest.mjs')],
+    executable: nodeExecutable,
+  };
+}

--- a/packages/cli/tests/codex-plugin/headless-activation-check.test.ts
+++ b/packages/cli/tests/codex-plugin/headless-activation-check.test.ts
@@ -22,8 +22,9 @@ import {
   type CodexHostProcessIdentity,
   writeCodexActivationMarker,
 } from '../../src/codex-plugin/profile-proof.js';
+import { testCliPath } from '../helpers.js';
 
-const CLI_PATH = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
+const CLI_PATH = testCliPath;
 const OLD_HOST: CodexHostProcessIdentity = {
   pid: 9001,
   started_at: '2026-08-03T00:00:00.000Z',

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,4 +1,10 @@
-import { execFile, execSync, spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import {
+  execFile,
+  execFileSync,
+  execSync,
+  spawnSync,
+  type SpawnSyncReturns,
+} from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -51,16 +57,17 @@ export const TIMEOUT_ACCEPTANCE_LANE = 120_000;
 export const TIMEOUT_BUN_INSTALL = 120_000;
 
 const __dirname = import.meta.dirname;
+export const testCliRoot = process.env.SAFEWORD_TEST_CLI_ROOT ?? nodePath.join(__dirname, '..');
 
 /**
  * Path to the CLI entry point (built)
  */
-const CLI_PATH = nodePath.join(__dirname, '../dist/cli.js');
+export const testCliPath = nodePath.join(testCliRoot, 'dist/cli.js');
 
 /**
  * Path to the local safeword CLI package (for file: references in tests)
  */
-const SAFEWORD_PATH = nodePath.join(__dirname, '..');
+const SAFEWORD_PATH = testCliRoot;
 
 /**
  * safeword reference for test package.json files.
@@ -317,7 +324,7 @@ export function wasKilledByTimeout(execError: {
   killed?: boolean;
   signal?: string | null;
 }): boolean {
-  return execError.killed === true || (execError.signal !== undefined && execError.signal !== null);
+  return execError.killed === true && execError.signal !== undefined && execError.signal !== null;
 }
 
 const SOURCE_DIRECTORY = nodePath.join(__dirname, '../src');
@@ -381,7 +388,7 @@ function warnIfDistributionStale(): void {
   distributionStaleness.checked = true;
   let distributionMtime;
   try {
-    distributionMtime = statSync(CLI_PATH).mtimeMs;
+    distributionMtime = statSync(testCliPath).mtimeMs;
   } catch {
     return;
   }
@@ -434,12 +441,16 @@ async function executeCli(cliArguments: string[], options: RunCliOptions): Promi
   warnIfDistributionStale();
 
   try {
-    const { stdout, stderr } = await execFileAsync(process.execPath, [CLI_PATH, ...cliArguments], {
-      cwd,
-      env: { ...process.env, ...env },
-      timeout,
-      maxBuffer: CLI_MACHINE_OUTPUT_LIMIT_BYTES,
-    });
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [testCliPath, ...cliArguments],
+      {
+        cwd,
+        env: { ...process.env, ...env },
+        timeout,
+        maxBuffer: CLI_MACHINE_OUTPUT_LIMIT_BYTES,
+      },
+    );
     return { stdout, stderr, exitCode: 0, timedOut: false };
   } catch (error: unknown) {
     const execError = error as {
@@ -542,10 +553,8 @@ export function runCliSync(
   const cliArguments = projectFixtureArguments(args);
   warnIfDistributionStale();
 
-  const command = `${process.execPath} ${CLI_PATH} ${cliArguments.join(' ')}`;
-
   try {
-    const stdout = execSync(command, {
+    const stdout = execFileSync(process.execPath, [testCliPath, ...cliArguments], {
       cwd,
       env: { ...process.env, ...env },
       timeout,

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -34,6 +34,7 @@ import {
   repoRoot,
   sealedRetroDraft,
   setupOrThrow,
+  testCliPath,
 } from '../helpers.js';
 
 const temporaryProjects: string[] = [];
@@ -235,13 +236,7 @@ function bindHostSession(input_: BindHostSessionInput): void {
       tool_input: { command },
     };
   } else if (runtime === 'codex') {
-    hook = [
-      process.execPath,
-      nodePath.join(repoRoot, 'packages/cli/dist/cli.js'),
-      'hook',
-      'codex',
-      'pre-tool-use',
-    ];
+    hook = [process.execPath, testCliPath, 'hook', 'codex', 'pre-tool-use'];
     hookInput = { session_id: id, tool_name: 'Bash', tool_input: { command } };
   } else {
     hook = [
@@ -1472,19 +1467,15 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
 
   it('binds the exact Codex session through the shipped pre-tool hook', () => {
     const directory = project();
-    const result = spawnSync(
-      process.execPath,
-      [nodePath.join(repoRoot, 'packages/cli/dist/cli.js'), 'hook', 'codex', 'pre-tool-use'],
-      {
-        cwd: directory,
-        input: JSON.stringify({
-          session_id: 'codex-closeout-42',
-          tool_name: 'Bash',
-          tool_input: { command: closeoutCommand(directory) },
-        }),
-        encoding: 'utf8',
-      },
-    );
+    const result = spawnSync(process.execPath, [testCliPath, 'hook', 'codex', 'pre-tool-use'], {
+      cwd: directory,
+      input: JSON.stringify({
+        session_id: 'codex-closeout-42',
+        tool_name: 'Bash',
+        tool_input: { command: closeoutCommand(directory) },
+      }),
+      encoding: 'utf8',
+    });
 
     expect(result.status, result.stderr).toBe(0);
     expect(readFreshCloseoutBinding({ projectDirectory: directory })).toEqual({

--- a/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
+++ b/packages/cli/tests/integration/codex-cursor-skill-fallback.test.ts
@@ -32,8 +32,8 @@ import {
   initGitRepo,
   INSTALL_DEPENDENCIES_ENV,
   removeTemporaryDirectory,
-  repoRoot,
   setupOrThrow,
+  testCliPath,
 } from '../helpers.js';
 import { runDoneGate, writeFeatureTicketAtDone } from './done-gate-harness.js';
 
@@ -86,20 +86,16 @@ function logContents(projectDirectory: string): string {
 // the short-lived cache the fallback then reads — no env var, no explicit arg.
 function bindCodexSession(projectDirectory: string, skill: string, sessionId: string): void {
   const command = `bun "${projectDirectory}/.safeword/hooks/record-skill-invocation.ts" "${projectDirectory}" ${skill}`;
-  const result = spawnSync(
-    process.execPath,
-    [nodePath.join(repoRoot, 'packages/cli/dist/cli.js'), 'hook', 'codex', 'pre-tool-use'],
-    {
-      cwd: projectDirectory,
-      input: JSON.stringify({
-        session_id: sessionId,
-        tool_name: 'Bash',
-        tool_input: { command },
-      }),
-      env: fallbackEnvironment(projectDirectory),
-      encoding: 'utf8',
-    },
-  );
+  const result = spawnSync(process.execPath, [testCliPath, 'hook', 'codex', 'pre-tool-use'], {
+    cwd: projectDirectory,
+    input: JSON.stringify({
+      session_id: sessionId,
+      tool_name: 'Bash',
+      tool_input: { command },
+    }),
+    env: fallbackEnvironment(projectDirectory),
+    encoding: 'utf8',
+  });
   expect(result.status ?? 0).toBe(0);
 }
 

--- a/packages/cli/tests/npm-package.test.ts
+++ b/packages/cli/tests/npm-package.test.ts
@@ -10,6 +10,8 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { testCliRoot } from './helpers.js';
+
 const __dirname = import.meta.dirname;
 const cliRoot = nodePath.join(__dirname, '..');
 
@@ -23,7 +25,7 @@ describe('NPM Package Structure', () => {
   });
 
   it('should have dist directory with CLI entry point', () => {
-    const distributionPath = nodePath.join(cliRoot, 'dist');
+    const distributionPath = nodePath.join(testCliRoot, 'dist');
     expect(existsSync(distributionPath)).toBe(true);
     expect(existsSync(nodePath.join(distributionPath, 'cli.js'))).toBe(true);
   });
@@ -104,7 +106,7 @@ describe('NPM Package Structure', () => {
 
   it('should resolve templates from dist context', () => {
     // Simulate the path resolution that getTemplatesDirectory() does
-    const distributionDirectory = nodePath.join(cliRoot, 'dist');
+    const distributionDirectory = nodePath.join(testCliRoot, 'dist');
     const templatesFromDistribution = nodePath.join(distributionDirectory, '..', 'templates');
 
     expect(existsSync(templatesFromDistribution)).toBe(true);

--- a/packages/cli/tests/presets/lazy-config-loading.test.ts
+++ b/packages/cli/tests/presets/lazy-config-loading.test.ts
@@ -29,6 +29,8 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { testCliRoot } from '../helpers.js';
+
 const CLI_ROOT = nodePath.resolve(__dirname, '../..');
 
 /** Source file → package name it must lazy-load. */
@@ -120,7 +122,7 @@ describe('Lazy config array semantics (Proxy preserves array shape)', () => {
 
 describe('Lazy ESLint plugin loading (behavioral)', () => {
   it('does not eagerly load CJS-detectable plugins when eslintPlugin is imported', () => {
-    const distributionEntry = nodePath.join(CLI_ROOT, 'dist/presets/typescript/index.js');
+    const distributionEntry = nodePath.join(testCliRoot, 'dist/presets/typescript/index.js');
     const script = `
       import { eslintPlugin } from ${JSON.stringify(distributionEntry)};
       if (!eslintPlugin) throw new Error('eslintPlugin import failed');

--- a/packages/cli/tests/setup-or-throw.test.ts
+++ b/packages/cli/tests/setup-or-throw.test.ts
@@ -210,4 +210,8 @@ describe('wasKilledByTimeout', () => {
     const spawnFailure = { killed: false, code: 'ENOENT' };
     expect(wasKilledByTimeout(spawnFailure)).toBe(false);
   });
+
+  it('is false for a signal termination that the caller did not initiate', () => {
+    expect(wasKilledByTimeout({ killed: false, signal: 'SIGTERM' })).toBe(false);
+  });
 });

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -13,8 +14,11 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { resolveWindowsVitest } from '../scripts/test-runner-executable.mjs';
+
 const cliRoot = nodePath.resolve(import.meta.dirname, '..');
 const runnerPath = nodePath.join(cliRoot, 'scripts/run-vitest-with-build-lock.mjs');
+const runnerExecutablePath = nodePath.join(cliRoot, 'scripts/test-runner-executable.mjs');
 
 const temporaryDirectories: string[] = [];
 
@@ -58,14 +62,20 @@ async function createFakeTestBinaries(temporaryDirectory: string, delayMilliseco
   const binaryDirectory = nodePath.join(temporaryDirectory, 'bin');
   await mkdir(binaryDirectory, { recursive: true });
   const logPath = nodePath.join(temporaryDirectory, 'events.log');
+  const snapshotLogPath = nodePath.join(temporaryDirectory, 'snapshot.log');
 
   writeFileSync(
     nodePath.join(binaryDirectory, 'bun'),
     `#!/usr/bin/env node
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 const log = ${JSON.stringify(logPath)};
 const parent = process.ppid;
 appendFileSync(log, \`build:start:\${parent}\\n\`);
+if (process.cwd() !== ${JSON.stringify(cliRoot)}) {
+  mkdirSync(path.join(process.cwd(), 'dist'), { recursive: true });
+  writeFileSync(path.join(process.cwd(), 'dist', 'cli.js'), 'built-cli');
+}
 await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`build:end:\${parent}\\n\`);
 `,
@@ -77,7 +87,19 @@ appendFileSync(log, \`build:end:\${parent}\\n\`);
     `#!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
 const log = ${JSON.stringify(logPath)};
+const snapshotLog = ${JSON.stringify(snapshotLogPath)};
 const parent = process.ppid;
+const snapshotRoot = process.env.SAFEWORD_TEST_CLI_ROOT;
+if (!snapshotRoot) {
+  process.stderr.write('SAFEWORD_TEST_CLI_ROOT was not provided\\n');
+  process.exit(2);
+}
+const { readFileSync } = await import('node:fs');
+const { join } = await import('node:path');
+appendFileSync(snapshotLog, JSON.stringify({
+  root: snapshotRoot,
+  cli: readFileSync(join(snapshotRoot, 'dist', 'cli.js'), 'utf8'),
+}) + '\\n');
 appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')}\\n\`);
 await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`vitest:end:\${parent}\\n\`);
@@ -85,7 +107,7 @@ appendFileSync(log, \`vitest:end:\${parent}\\n\`);
     { mode: 0o755 },
   );
 
-  return { binaryDirectory, logPath };
+  return { binaryDirectory, logPath, snapshotLogPath };
 }
 
 async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
@@ -94,7 +116,12 @@ async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
   await mkdir(scriptDirectory, { recursive: true });
   const copiedRunnerPath = nodePath.join(scriptDirectory, 'run-vitest-with-build-lock.mjs');
   copyFileSync(runnerPath, copiedRunnerPath);
+  copyFileSync(runnerExecutablePath, nodePath.join(scriptDirectory, 'test-runner-executable.mjs'));
   return copiedRunnerPath;
+}
+
+function checkoutCliRootForRunner(copiedRunner: string): string {
+  return nodePath.resolve(nodePath.dirname(copiedRunner), '..');
 }
 
 function readEvents(logPath: string): string[] {
@@ -140,10 +167,101 @@ function waitStatusLines(stderr: string): string[] {
 
 async function seedOwnerFile(lockDirectory: string, owner: unknown) {
   await mkdir(lockDirectory, { recursive: true });
-  writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(owner)}\n`);
+  const markedOwner =
+    typeof owner === 'object' && owner !== null && !Array.isArray(owner)
+      ? { kind: 'safeword-package-test-lock', ...owner }
+      : owner;
+  writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(markedOwner)}\n`);
 }
 
 describe('package test runner lock (379)', () => {
+  it('resolves a Windows npm Vitest shim without selecting the POSIX shim', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const moduleDirectory = nodePath.join(temporaryDirectory, 'node_modules', 'vitest');
+    const binaryDirectory = nodePath.join(temporaryDirectory, 'node_modules', '.bin');
+    await mkdir(moduleDirectory, { recursive: true });
+    await mkdir(binaryDirectory, { recursive: true });
+    writeFileSync(nodePath.join(binaryDirectory, 'vitest'), '#!/bin/sh\n');
+    writeFileSync(nodePath.join(binaryDirectory, 'vitest.cmd'), '@echo off\r\n');
+    const moduleEntry = nodePath.join(moduleDirectory, 'vitest.mjs');
+    writeFileSync(moduleEntry, 'export {};\n');
+
+    expect(resolveWindowsVitest(binaryDirectory, cliRoot, 'node.exe')).toEqual({
+      arguments: [moduleEntry],
+      executable: 'node.exe',
+    });
+  });
+
+  it('runs tests against a private built-package snapshot (#1823)', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, snapshotLogPath } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+
+    const result = await runNodeScript(copiedRunner, ['tests/first.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    const snapshot = JSON.parse(readFileSync(snapshotLogPath, 'utf8')) as {
+      cli: string;
+      root: string;
+    };
+    expect(snapshot.cli).toBe('built-cli');
+    expect(snapshot.root).not.toBe(cliRoot);
+    expect(existsSync(snapshot.root)).toBe(false);
+  });
+
+  it.each(['..', '.'])('rejects publish entry %s outside the snapshot boundary', async entry => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    writeFileSync(
+      nodePath.join(checkoutCliRootForRunner(copiedRunner), 'package.json'),
+      `${JSON.stringify({ files: [entry] })}\n`,
+    );
+
+    const result = await runNodeScript(copiedRunner, ['tests/escape.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`Package snapshot entry escapes the CLI package: ${entry}`);
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'rejects symbolic links inside publishable snapshot entries',
+    async () => {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+      const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+      const checkoutCliRoot = checkoutCliRootForRunner(copiedRunner);
+      const publishDirectory = nodePath.join(checkoutCliRoot, 'publish');
+      await mkdir(publishDirectory);
+      symlinkSync(
+        nodePath.join(temporaryDirectory, 'outside'),
+        nodePath.join(publishDirectory, 'link'),
+      );
+      writeFileSync(
+        nodePath.join(checkoutCliRoot, 'package.json'),
+        `${JSON.stringify({ files: ['publish'] })}\n`,
+      );
+
+      const result = await runNodeScript(copiedRunner, ['tests/symlink.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Package snapshot entry contains a symbolic link: publish');
+    },
+  );
+
   it('serializes build and vitest for concurrent focused test commands', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
@@ -282,8 +400,8 @@ describe('package test runner lock (379)', () => {
     }
   });
 
-  it('reaps stale locks when owner metadata is unusable or expired', async () => {
-    for (const owner of ['not owner metadata', {}, { createdAt: new Date(0).toISOString() }]) {
+  it('reaps marked stale locks when owner metadata is incomplete or expired', async () => {
+    for (const owner of [{}, { createdAt: new Date(0).toISOString() }]) {
       const temporaryDirectory = makeTemporaryDirectory();
       const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
       const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
@@ -306,6 +424,28 @@ describe('package test runner lock (379)', () => {
         expect.stringMatching(/^vitest:end:/),
       ]);
     }
+  });
+
+  it('does not delete an unmarked directory selected as the lock path', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'unrelated');
+    await mkdir(lockDirectory);
+    const sentinel = nodePath.join(lockDirectory, 'keep.txt');
+    writeFileSync(sentinel, 'user data');
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(lockDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/unmarked.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(sentinel, 'utf8')).toBe('user data');
+    expect(existsSync(logPath)).toBe(false);
   });
 
   it('clamps unsafe status intervals and ignores malformed settings', async () => {
@@ -380,6 +520,31 @@ describe('package test runner lock (379)', () => {
     ]);
   });
 
+  it('reaps an abandoned transition mutex before acquiring', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedOwnerFile(`${lockDirectory}.transition`, {
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+    });
+
+    const result = await runNodeScript(runnerPath, ['tests/abandoned-transition.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/abandoned-transition\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+    expect(existsSync(`${lockDirectory}.transition`)).toBe(false);
+  });
+
   it('does not reap an aged lock while its owner process is alive', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
@@ -418,13 +583,17 @@ describe('package test runner lock (379)', () => {
       SAFEWORD_TEST_LOCK_DIR: lockDirectory,
     };
 
+    const contenderCount = 4;
     const results = await Promise.all(
-      Array.from({ length: 8 }, (_, index) =>
+      Array.from({ length: contenderCount }, (_, index) =>
         runNodeScript(runnerPath, [`tests/stale-${index}.test.ts`], env),
       ),
     );
 
-    expect(results.map(result => result.status)).toEqual(Array.from({ length: 8 }, () => 0));
+    expect(
+      results.map(result => result.status),
+      JSON.stringify(results),
+    ).toEqual(Array.from({ length: contenderCount }, () => 0));
     const events = readEvents(logPath);
     let activeCommands = 0;
     let maximumActiveCommands = 0;
@@ -432,7 +601,7 @@ describe('package test runner lock (379)', () => {
       activeCommands += event.includes(':start:') ? 1 : -1;
       maximumActiveCommands = Math.max(maximumActiveCommands, activeCommands);
     }
-    expect(events).toHaveLength(32);
+    expect(events).toHaveLength(contenderCount * 4);
     expect(activeCommands).toBe(0);
     expect(maximumActiveCommands).toBe(1);
   });


### PR DESCRIPTION
Fixes #1823

## Summary
- snapshot the publishable CLI package before Vitest starts and route CLI/file dependencies through it
- harden cross-worktree lock ownership and abandoned transition recovery
- keep Windows Vitest execution shell-free and PATH-aware
- add regression coverage for snapshot isolation, cleanup, containment, and lock recovery

## Verification
- 7,595 tests passed across 490 files before final hardening
- 1,469 BDD scenarios / 64,549 steps passed; proof lane 50 scenarios / 240 steps
- post-review focused suite: 31/31 passed
- CLI typecheck, lint, build, bun audit, govulncheck, and diff audit passed

The aggregate local verify command still exits 2 because the generated repository type plan runs `mypy .` despite there being no Python files; all changed-stack gates pass.