### PR TITLE
Run GitHub live smokes without waiting for builds

### DIFF
--- a/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/spec.md
+++ b/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/spec.md
@@ -1,0 +1,26 @@
+# Run GitHub live smokes without waiting for builds
+
+## Intent
+
+Let a maintainer run the two proven GitHub API source-only smoke tests while an
+unrelated normal package test owns the build-and-Vitest lock.
+
+## Primary user
+
+**TBU — maintainer validating GitHub provenance behavior.**
+
+## Surface
+
+Safeword CLI package scripts.
+
+## Rules
+
+- **github-live-smokes.TBU1.R1:** `bun run test:smoke:live:github` runs only
+  `retro-dedup.live.test.ts` and `reconcile.live.test.ts`, with one Vitest
+  worker and file parallelism disabled. It neither builds nor uses the normal
+  package-test lock, and accepts no caller-supplied arguments.
+
+## Out of scope
+
+- General parallel test capacity, scheduling, cancellation, or remote test
+  execution. Those remain the separate `2RZDMP` design.

--- a/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/test-definitions.md
+++ b/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/test-definitions.md
@@ -6,12 +6,16 @@ Feature source: `packages/cli/features/run-github-live-smokes-without-waiting-fo
 
 ### Scenario: GitHub live smokes start while the normal package-test lock is held
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: the runner and regression proof were added before this ticket ledger existed, so no pre-change failure can be reconstructed honestly.
+- [x] GREEN 896b049b0
+- [x] REFACTOR skip: the fixed-argument launcher is already a single-purpose boundary; review found no behavior-preserving simplification.
 
 ### Scenario: GitHub live smokes reject arbitrary extra arguments
 
-- [ ] RED
-- [ ] GREEN
-- [ ] REFACTOR
+- [x] RED skip: the runner and regression proof were added before this ticket ledger existed, so no pre-change failure can be reconstructed honestly.
+- [x] GREEN 896b049b0
+- [x] REFACTOR skip: the fixed-argument launcher is already a single-purpose boundary; review found no behavior-preserving simplification.
+
+## Feature-level cross-scenario refactor
+
+- [x] cross-scenario skip: both scenarios exercise the same intentionally tiny launcher; review found no shared abstraction or cleanup worth adding.

--- a/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/test-definitions.md
+++ b/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/test-definitions.md
@@ -1,0 +1,17 @@
+# Test Definitions: Run GitHub live smokes without waiting for builds
+
+Feature source: `packages/cli/features/run-github-live-smokes-without-waiting-for-builds.feature`
+
+## Rule: github-live-smokes.TBU1.R1
+
+### Scenario: GitHub live smokes start while the normal package-test lock is held
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: GitHub live smokes reject arbitrary extra arguments
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/ticket.md
+++ b/.project/tickets/Y1484A-run-github-live-smokes-without-waiting-for-builds/ticket.md
@@ -1,0 +1,21 @@
+---
+id: Y1484A
+slug: run-github-live-smokes-without-waiting-for-builds
+type: task
+phase: scenario-gate
+status: in_progress
+scope:
+  - Keep the two source-only GitHub live smokes runnable during an unrelated locked package test.
+out_of_scope:
+  - General concurrent Vitest execution, process cancellation, and shared test capacity.
+done_when:
+  - The fixed live-smoke lane is BDD-specified and cannot accept arbitrary Vitest arguments.
+created: 2026-08-11T00:00:00Z
+last_modified: 2026-08-11T00:00:00Z
+---
+
+# Run GitHub live smokes without waiting for builds
+
+**Goal:** Let maintainers run the two proven source-only GitHub smokes while an unrelated package test owns the normal build-and-Vitest lock.
+
+**Feature:** `packages/cli/features/run-github-live-smokes-without-waiting-for-builds.feature`

--- a/packages/cli/features/run-github-live-smokes-without-waiting-for-builds.feature
+++ b/packages/cli/features/run-github-live-smokes-without-waiting-for-builds.feature
@@ -1,0 +1,17 @@
+@wip @surface.safeword-cli
+Feature: Run GitHub live smokes without waiting for builds
+
+  Rule: The proven source-only GitHub smokes stay a narrow exception to package-test serialization
+
+    @github-live-smokes.TBU1.R1 @wiring
+    Scenario: GitHub live smokes start while the normal package-test lock is held
+      Given a normal package-test wrapper holds the shared lock with build and Vitest collaborators active
+      When the builder runs `bun run test:smoke:live:github`
+      Then only `retro-dedup.live.test.ts` and `reconcile.live.test.ts` start through Vitest with one worker and no file parallelism
+      And the live-smoke command neither runs a build nor waits for or acquires the package-test lock
+
+    @github-live-smokes.TBU1.R1 @rejection
+    Scenario: GitHub live smokes reject arbitrary extra arguments
+      Given the bounded GitHub live-smoke command is available
+      When the builder appends an extra Vitest argument
+      Then it exits 2 before starting Vitest and explains that the command accepts no arguments

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "test:smoke:fast": "node scripts/run-vitest-with-build-lock.mjs tests/hooks/ tests/schema.test.ts tests/integration/quality-gates.test.ts tests/integration/jtbd-gate.test.ts tests/smoke/hook-coverage.test.ts",
     "test:smoke": "node scripts/run-vitest-with-build-lock.mjs tests/hooks/ tests/schema.test.ts tests/integration/quality-gates.test.ts tests/integration/jtbd-gate.test.ts tests/smoke/hook-coverage.test.ts tests/integration/phase0-walkthrough.test.ts tests/integration/golden-path.test.ts",
     "test:smoke:live": "node scripts/run-vitest-with-build-lock.mjs --config vitest.live.config.ts",
+    "test:smoke:live:github": "node scripts/run-github-live-smokes.mjs",
     "test:release": "node scripts/run-vitest-with-build-lock.mjs --config vitest.release.config.ts",
     "test:slow": "node scripts/run-vitest-with-build-lock.mjs --config vitest.slow.config.ts",
     "test:slow:install-proof": "node scripts/run-vitest-with-build-lock.mjs --config vitest.slow.config.ts tests/integration/non-git-install-proof.slow.test.ts",

--- a/packages/cli/scripts/run-github-live-smokes.mjs
+++ b/packages/cli/scripts/run-github-live-smokes.mjs
@@ -1,0 +1,41 @@
+import { spawnSync } from 'node:child_process';
+import console from 'node:console';
+import nodePath from 'node:path';
+import process from 'node:process';
+
+const scriptDirectory = import.meta.dirname;
+const cliRoot = nodePath.resolve(scriptDirectory, '..');
+const liveSmokeArguments = [
+  'run',
+  '--config',
+  'vitest.live.config.ts',
+  '--maxWorkers=1',
+  '--no-file-parallelism',
+  'tests/smoke/retro-dedup.live.test.ts',
+  'tests/smoke/reconcile.live.test.ts',
+];
+
+if (process.argv.length === 2) {
+  const localBinDirectory = nodePath.join(cliRoot, 'node_modules', '.bin');
+  const pathKey = Object.keys(process.env).find(key => key.toUpperCase() === 'PATH') ?? 'PATH';
+  const result = spawnSync('vitest', liveSmokeArguments, {
+    cwd: cliRoot,
+    env: {
+      ...process.env,
+      [pathKey]: `${process.env[pathKey] ?? ''}${nodePath.delimiter}${localBinDirectory}`,
+    },
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  if (result.signal) {
+    console.error(`vitest terminated with signal ${result.signal}`);
+    process.exitCode = 1;
+  } else {
+    process.exitCode = result.status ?? 1;
+  }
+} else {
+  console.error('test:smoke:live:github accepts no arguments.');
+  process.exitCode = 2;
+}

--- a/packages/cli/tests/smoke/reconcile.live.test.ts
+++ b/packages/cli/tests/smoke/reconcile.live.test.ts
@@ -22,6 +22,8 @@
  *
  * It is token-gated and opt-in: the assertion runs only in the live lane and only
  * when a real GitHub token is resolvable (env `GITHUB_TOKEN` or `gh auth token`).
+ * The two source-only GitHub smokes may run via `bun run test:smoke:live:github`
+ * without a fresh build or the package-test lock (#1484).
  * (One edge: in an environment with `gh` auth but no `api.github.com` egress, the
  * gate passes and the fetch fails closed → the assertion fails rather than skips;
  * that is the right signal for a deliberately-invoked manual lane.)

--- a/packages/cli/tests/smoke/retro-dedup.live.test.ts
+++ b/packages/cli/tests/smoke/retro-dedup.live.test.ts
@@ -23,7 +23,9 @@
  * so no pinned issue number goes stale when an issue is closed.
  *
  * Token-gated and opt-in, like reconcile.live.test.ts: the assertions run only in
- * the live lane and only when a real GitHub token resolves.
+ * the live lane and only when a real GitHub token resolves. The two source-only
+ * GitHub smokes may run via `bun run test:smoke:live:github` without a fresh build
+ * or the package-test lock (#1484).
  *
  * Without a token the lane FAILS rather than skipping quietly. An earlier version
  * warned via a module-scope `console.warn` and called that "skipping loudly" — it

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -15,6 +15,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const cliRoot = nodePath.resolve(import.meta.dirname, '..');
 const runnerPath = nodePath.join(cliRoot, 'scripts/run-vitest-with-build-lock.mjs');
+const githubLiveRunnerPath = nodePath.join(cliRoot, 'scripts/run-github-live-smokes.mjs');
+const packageManifestPath = nodePath.join(cliRoot, 'package.json');
 
 const temporaryDirectories: string[] = [];
 
@@ -144,6 +146,58 @@ async function seedOwnerFile(lockDirectory: string, owner: unknown) {
 }
 
 describe('package test runner lock (379)', () => {
+  it('keeps the GitHub provenance smokes as a bounded source-only live lane (#1484)', () => {
+    const manifest = JSON.parse(readFileSync(packageManifestPath, 'utf8')) as {
+      scripts?: Record<string, unknown>;
+    };
+    const command = manifest.scripts?.['test:smoke:live:github'];
+
+    expect(command).toBe('node scripts/run-github-live-smokes.mjs');
+    expect(command).not.toContain('run-vitest-with-build-lock');
+    expect(command).not.toContain('build');
+
+    const runner = readFileSync(githubLiveRunnerPath, 'utf8');
+    expect(runner).toContain("'--maxWorkers=1'");
+    expect(runner).toContain("'--no-file-parallelism'");
+    expect(runner).toContain("'tests/smoke/retro-dedup.live.test.ts'");
+    expect(runner).toContain("'tests/smoke/reconcile.live.test.ts'");
+    expect(runner).not.toContain('run-vitest-with-build-lock');
+    expect(runner).not.toContain("['bun', 'run', 'build']");
+  });
+
+  it('rejects arguments to the bounded GitHub provenance live lane (#1484)', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const result = await runNodeScript(githubLiveRunnerPath, ['tests/other.live.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('test:smoke:live:github accepts no arguments.');
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  it('runs only the fixed GitHub provenance live-smoke arguments without the package lock (#1484)', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'held-package-test-lock');
+    await seedOwnerFile(lockDirectory, { pid: process.pid });
+    const result = await runNodeScript(githubLiveRunnerPath, [], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    });
+
+    expect(result.status).toBe(0);
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(
+        /^vitest:start:\d+:run,--config,vitest\.live\.config\.ts,--maxWorkers=1,--no-file-parallelism,tests\/smoke\/retro-dedup\.live\.test\.ts,tests\/smoke\/reconcile\.live\.test\.ts$/,
+      ),
+      expect.stringMatching(/^vitest:end:\d+$/),
+    ]);
+  });
+
   it('serializes build and vitest for concurrent focused test commands', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -92,16 +92,14 @@ const log = ${JSON.stringify(logPath)};
 const snapshotLog = ${JSON.stringify(snapshotLogPath)};
 const parent = process.ppid;
 const snapshotRoot = process.env.SAFEWORD_TEST_CLI_ROOT;
-if (!snapshotRoot) {
-  process.stderr.write('SAFEWORD_TEST_CLI_ROOT was not provided\\n');
-  process.exit(2);
+if (snapshotRoot) {
+  const { readFileSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  appendFileSync(snapshotLog, JSON.stringify({
+    root: snapshotRoot,
+    cli: readFileSync(join(snapshotRoot, 'dist', 'cli.js'), 'utf8'),
+  }) + '\\n');
 }
-const { readFileSync } = await import('node:fs');
-const { join } = await import('node:path');
-appendFileSync(snapshotLog, JSON.stringify({
-  root: snapshotRoot,
-  cli: readFileSync(join(snapshotRoot, 'dist', 'cli.js'), 'utf8'),
-}) + '\\n');
 appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')}\\n\`);
 await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`vitest:end:\${parent}\\n\`);


### PR DESCRIPTION
## What changed
- Adds a fixed-argument GitHub live-smoke command that bypasses the package build/test lock.
- Runs the two networked smoke files serially through the live Vitest configuration.
- Rejects arbitrary arguments so this lane cannot become a general test runner.

## Why
GitHub-backed smoke tests do not need a fresh package build, yet previously waited behind the shared package-test lock. The dedicated lane preserves the normal lock for build-dependent tests while allowing these independent checks to start immediately.

## Validation
- Focused runner contract: 16 tests passed.
- Build, typecheck, Gherkin lint, syntax checks, and diff hygiene passed before this follow-up evidence commit.
- Canonical full package suite was run under a clean lock; its child exited after about 13 minutes, but this environment dropped the final exit status, so CI remains the aggregate authority.

## Scope
Only commits 896b049b0 and fb7b744e6 are included. Unrelated 2RZDMP working-tree edits are excluded.