### PR TITLE
chore(release): v0.77.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.76.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.77.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.76.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.77.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.76.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.77.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.76.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.77.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.76.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.77.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.76.0",
+  "plugin_version": "0.77.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "8887b976c91e114b9864475b6cfaea47c10f56e90cad717640ec41faa91f5692"
+  "inventory_sha256": "e12c55bfd2c026877b7e15b882aafd6be83158f03ff39e678415e4deaf851aaa"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "6030e2db88687a057cb6e9c44391a108a184a5be121aa02d971dd1961acba48f"
+      "sha256": "7d18236896c04691fe7628a61c0affa21016833815b2c1adf1e7ee64f5ea66e0"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "type": "module"
 }


### PR DESCRIPTION
## Release

- Publish durable independent review jobs and review status/cancel commands.
- Improve BDD/TDD adversarial review guidance and cross-host parity.
- Harden reviewer lifecycle cleanup, source binding, offline collection, and persisted evidence validation.

## Version

Minor release: additive capability with no intentional breaking changes.

## Verification

- `bun install` completed and build passed.
- Release-contract and full matrix checks run in CI.