### PR TITLE
Let test queues recover locks created by older runners

### DIFF
--- a/.project/tickets/F137WW-recover-legacy-test-locks/ticket.md
+++ b/.project/tickets/F137WW-recover-legacy-test-locks/ticket.md
@@ -1,0 +1,55 @@
+---
+id: F137WW
+slug: recover-legacy-test-locks
+type: patch
+subtype: bug-investigated
+phase: verify
+status: in_progress
+created: 2026-08-13T06:22:02.946Z
+last_modified: 2026-08-13T10:03:30.000Z
+---
+
+# Let test queues recover locks created by older runners
+
+**Goal:** Safely recover abandoned package-test locks written by the immediately preceding runner format.
+
+**Why:** A dead legacy owner currently blocks every queued Vitest run until timeout, even though current-format stale locks recover automatically.
+
+## Root Cause
+
+The owner parser marks metadata as valid only when `kind` equals
+`safeword-package-test-lock`. The immediately preceding owner schema has the
+same PID, timestamp, checkout root, and token fields but no `kind`, so
+`removeStaleLock` returns before evaluating whether that readable PID is dead.
+
+Confirmed by subprocess tests through the real runner: a dead legacy owner
+failed immediately and four contenders all timed out without starting, while
+the equivalent marked dead-owner tests already recover. A current marked dead
+owner also rules out PID liveness detection, and the existing abandoned-mutex
+and marked contention tests rule out transition arbitration. A live legacy
+owner remains protected today because invalid metadata fails closed; the fix
+must retain that behavior and must not treat foreign `kind` values as legacy.
+
+## Work Log
+
+- 2026-08-13T06:22:02.946Z Started: Created ticket F137WW
+- 2026-08-13T06:25:28.000Z Investigation: Reproduced the compatibility failure at the real runner boundary. Two RED tests prove dead legacy owners cannot recover singly or under contention; live legacy and foreign-owner cases define the fail-closed boundary.
+- 2026-08-13T06:55:00.000Z Implemented: Recognize only the exact immediately preceding owner schema (absolute checkout root, valid timestamp, positive PID, UUID token, and no unknown fields). Recovery still runs inside the existing transition mutex.
+- 2026-08-13T06:56:00.000Z Verified: Full lock-runner suite passes 30/30; Retro Relay passes 170 with one intentional skip; targeted ESLint, Prettier, TypeScript, whitespace, dependency audit, and diff-scoped architecture/config audit are clean. No Gherkin added because this internal mutex protocol is fully exercised through real subprocess integration tests rather than a user-facing CLI behavior.
+- 2026-08-13T07:25:00.000Z Found: Post-rebase contention replay exposed #2751 in the existing transition arbitration: a nested recovery directory could race recursive transition removal, failing all four contenders. This directly blocked #2674's serialized-recovery acceptance boundary, so the dependency was included rather than weakening the test.
+- 2026-08-13T07:32:00.000Z Fixed: Replaced the orphanable nested recovery mutex with atomic transition-directory renames. Recovery evaluates abandonment before mutation, exactly one contender can move an abandoned transition, and release moves its owned transition before deletion. Added an abandoned empty-transition subprocess case.
+- 2026-08-13T07:38:46.000Z Revalidated: Rebased onto current `origin/main` (`28e66a53e`). Retro Relay passes 170 with one intentional skip; the lock-runner suite passed 32/32; TypeScript, ESLint, Prettier, whitespace, and `bun audit` were clean. The canonical repository verification completed successfully across tests, Gherkin, build, typecheck, and dependency lanes before the rebase; main's intervening files do not overlap this patch, and affected-surface proof was rerun after rebase.
+- 2026-08-13T07:48:56.000Z Quality review: Closed the remaining stale-observation window by revalidating abandonment while holding the recovery marker. Transition ownership now carries the run's UUID token, and leave refuses to remove a transition whose PID/token identity changed. Tightened event partition assertions to compare exact parent PIDs.
+- 2026-08-13T07:56:56.000Z Quality review: Closed #2755's false-green package boundary with the narrow fail-fast policy: manifests must declare a non-empty literal `files` list, unsupported glob/negation entries name themselves in the error, and missing literal entries fail directly. Made default-lock test temp routing portable across Windows environment conventions and bounded its child wait.
+- 2026-08-13T08:05:14.000Z Quality review: Preserved unowned lock paths on POSIX by refusing candidate rename whenever the target already exists, including an empty-directory regression case. Raised the four-contender stress cap to measure serialization rather than machine load. Final affected suites pass 36/36 and 170 passed with one intentional skip.
+- 2026-08-13T08:21:19.000Z Quality review: Transition owners now carry their own Safeword kind. Custom lock paths fail closed on unreadable/unmarked sibling transitions, while the Safeword-owned default temp namespace retains empty-transition recovery. Added a custom foreign-transition preservation case and a real multi-entry manifest snapshot happy path; increased the bounded cadence fixture's owner duration and removed a vestigial assertion. Final affected suites pass 38/38 and 170 passed with one intentional skip.
+- 2026-08-13T08:29:46.000Z Quality review: Made transition publication atomic with its own candidate directory, so no new transition is ever observable without owner metadata and stale revalidation cannot hijack a fresh transition. Normal rename contention now handles both `EEXIST` and `ENOTEMPTY`; stale-lock age probes tolerate concurrent disappearance. The bespoke protocol remains for backward compatibility in this patch; replacement with an OS/advisory lock deserves a separate design ticket rather than an unbounded mechanism swap here. Final lock suite passes 38/38.
+- 2026-08-13T08:44:58.000Z Quality review: Routed both initial and post-reap lock publication through one contention-safe helper, so a preceding-format runner that republishes during mixed-version rollout returns the current runner to its bounded wait instead of throwing. Repo-root path rebasing now treats split and `=`-joined flag spellings consistently, with real subprocess proof. Final lock suite passes 38/38.
+- 2026-08-13T08:58:30.000Z Quality review: Transition release now reports a controlled failure and returns false instead of throwing from acquisition/release cleanup; no successful token or primary status is masked by a `finally` exception. Timeout guidance names the exact lock and safe manual-removal condition. Added real subprocess proof that direct runner invocation falls back to package-local Vitest when PATH has no Vitest, while the existing suite continues to prove a PATH-provided stub wins. Final lock suite passes 39/39.
+- 2026-08-13T09:18:00.000Z Quality review: Replaced candidate-directory publication with atomic `mkdir` claims so POSIX cannot replace an older runner's empty directory. Interrupted empty lock/transition publication recovers after a bounded age, transition ownership is re-entrant for the same PID/token during cleanup, and timeout guidance names both paths. Removed the fixture-only manifest fallback; copied checkouts now use the real package contract. Package snapshots live under ignored `node_modules/.cache`, and the suite proves the real packaged CLI runs there with external dependencies. Added explicit non-zero build and Vitest status propagation. Final lock suite passes 44/44; TypeScript, ESLint, Prettier, whitespace, and dependency audit remain clean.
+- 2026-08-13T09:22:30.000Z Quality review: Restored the fail-closed custom-path boundary for both empty and non-empty unmarked transition directories, with complementary subprocess cases. While holding the package lock, snapshot creation now removes only orphaned `safeword-test-package-*` siblings from the ignored cache before creating the next snapshot. Final lock suite passes 46/46; TypeScript, ESLint, Prettier, whitespace, and dependency audit remain clean.
+- 2026-08-13T09:34:30.000Z Quality review: Made the fixed source-only GitHub live-smoke exemption explicit in the no-stale-dist guard instead of letting its wrapper evade Vitest-script discovery. Extracted and directly proved case-preserving Windows PATH selection plus the production default Node executable for Windows Vitest shims. Final lock suite remains 46/46; TypeScript, ESLint, Prettier, and whitespace checks are clean.
+- 2026-08-13T09:42:30.000Z Quality review: Nested runners now preserve the enclosing run's canonical `SAFEWORD_TEST_CLI_ROOT` while reaping other orphaned snapshots; the regression covers macOS `/var` versus `/private/var` aliases. Default-namespace recovery now also handles an aged, truncated transition owner while custom paths remain fail-closed. Final lock suite passes 47/47; TypeScript, ESLint, Prettier, whitespace, and dependency audit are clean.
+- 2026-08-13T09:55:30.000Z Quality review: Transition recovery markers now carry their own PID/token identity, never expire while that PID is alive, and are renamed only by their owner before deletion. Added a live-but-aged marker regression. Snapshot cleanup now tolerates concurrently disappearing entries and only reaps snapshots older than six hours, preventing runs with divergent custom lock paths from deleting each other's fresh snapshots. Final lock suite passes 48/48; TypeScript, ESLint, Prettier, whitespace, and dependency audit are clean.
+- 2026-08-13T09:57:30.000Z Quality review: Moved the Windows runner rewrite behind a pure platform-injectable collaborator and directly proved Path-key selection, the literal Vitest command guard, Node executable selection, and module-before-test argument ordering on POSIX CI. Final lock suite remains 48/48; TypeScript, ESLint, Prettier, and whitespace checks are clean.
+- 2026-08-13T10:03:30.000Z Quality review: Default-namespace residue recognition now admits only Safeword's `owner.json` and `recovery` entries, allowing the owned recovery-marker logic to unwind a crash between marker creation and transition-owner publication. Added the exact truncated-owner plus abandoned-marker subprocess regression. Final lock suite passes 49/49; TypeScript, ESLint, Prettier, whitespace, and dependency audit are clean.

--- a/.project/tickets/F137WW-recover-legacy-test-locks/verify.md
+++ b/.project/tickets/F137WW-recover-legacy-test-locks/verify.md
@@ -1,0 +1,29 @@
+# Verification
+
+## Verify Checklist
+
+**Test Suite:** ✅ Canonical repository test plan passed; final affected runner suite passes 49/49 and Retro Relay passes 170 with 1 intentional skip
+
+**Gherkin:** ✅ Canonical acceptance lane passes; no new Gherkin was added because this internal cross-process mutex protocol is proven at the real subprocess/filesystem boundary
+
+**Build:** ✅ Canonical build lane passes
+
+**Lint:** ✅ Targeted ESLint and Prettier checks pass; TypeScript passes with `tsc --noEmit`; `git diff --check` is clean
+
+**Scenarios:** ✅ Patch acceptance boundaries are covered by real runner subprocess tests: dead and live legacy owners, foreign and malformed metadata, simultaneous recovery, and abandoned empty transitions
+
+**PR Scope:** ✅ Diff is limited to the runner, its executable helper/declaration, its tests, and ticket evidence; #2751 is included because its transition race directly broke the required contention proof
+
+**Dep Drift:** ✅ `bun audit` reports no vulnerabilities; no dependency files changed
+
+**Parent Epic:** N/A
+
+**Reconcile:** ✅ The preceding schema was verified from its actual historical implementation; new owners retain the typed current schema
+
+**Experience:** ⏭️ N/A — internal test-runner coordination, not a persona-facing product flow
+
+**Surface Evidence:** ✅ Package-test runner exercised through real child processes and temporary filesystems; the isolated real package CLI executes successfully; nested runs preserve the active snapshot; recovery markers retain live ownership and abandoned interrupted markers recover; build and test failures propagate; final suite passes 49/49
+
+**Evidence limits:** ✅ None
+
+Audit passed: legacy compatibility remains fail-closed; recovery revalidates abandonment under a recoverable marker; transition removal requires the owning PID and UUID token; and unrelated hardening findings are tracked separately in #2754–#2756.

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -20,20 +20,27 @@ import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import process from 'node:process';
 
-import { resolveWindowsVitest } from './test-runner-executable.mjs';
+import { environmentPathKey, resolveTestRunnerInvocation } from './test-runner-executable.mjs';
 
 const scriptDirectory = import.meta.dirname;
 const cliRoot = nodePath.resolve(scriptDirectory, '..');
 // Vitest runs with cwd=cliRoot, so a repo-root-relative path — the natural
 // spelling when invoking `bun run test` from the workspace root (#723) —
 // would act as a filter that matches nothing. Rebase those onto the package.
-// Only standalone arguments are rebased; `=`-joined flag values
-// (`--config=packages/cli/x.ts`) pass through untouched.
-const vitestArguments = process.argv
-  .slice(2)
-  .map(argument =>
-    argument.startsWith('packages/cli/') ? argument.slice('packages/cli/'.length) : argument,
-  );
+// Rebase both standalone paths and `=`-joined flag values so equivalent flag
+// spellings resolve consistently from cwd=cliRoot.
+function rebaseVitestArgument(argument) {
+  const packagePrefix = 'packages/cli/';
+  if (argument.startsWith(packagePrefix)) return argument.slice(packagePrefix.length);
+  const equalsIndex = argument.indexOf('=');
+  if (equalsIndex === -1) return argument;
+  const value = argument.slice(equalsIndex + 1);
+  return value.startsWith(packagePrefix)
+    ? `${argument.slice(0, equalsIndex + 1)}${value.slice(packagePrefix.length)}`
+    : argument;
+}
+
+const vitestArguments = process.argv.slice(2).map(argument => rebaseVitestArgument(argument));
 
 // The package-local bin directory holds the `vitest` executable. `bun run test`
 // (and npm) inject it into PATH, but invoking this wrapper directly — e.g.
@@ -47,7 +54,7 @@ const localBinDirectory = nodePath.join(cliRoot, 'node_modules', '.bin');
 // Windows names the variable `Path`; spreading process.env into a plain object
 // loses Node's case-insensitive access, so append to whatever key already holds
 // the path (else a stray `PATH` key would sit alongside `Path` and be ignored).
-const pathKey = Object.keys(process.env).find(key => key.toUpperCase() === 'PATH') ?? 'PATH';
+const pathKey = environmentPathKey(process.env);
 const inheritedPath = process.env[pathKey] ?? '';
 const childEnvironment = {
   ...process.env,
@@ -60,6 +67,7 @@ const lockName = 'safeword-package-test';
 const defaultMaximumLockWaitMilliseconds = 20 * 60 * 1000;
 const defaultLockStatusIntervalMilliseconds = 30_000;
 const initialLockStatusDelayMilliseconds = 1000;
+const usesCustomLockDirectory = Boolean(process.env.SAFEWORD_TEST_LOCK_DIR);
 const lockDirectory = process.env.SAFEWORD_TEST_LOCK_DIR
   ? nodePath.resolve(process.env.SAFEWORD_TEST_LOCK_DIR)
   : nodePath.join(lockParent, `${lockName}.lock`);
@@ -67,10 +75,13 @@ const ownerPath = nodePath.join(lockDirectory, 'owner.json');
 const transitionDirectory = `${lockDirectory}.transition`;
 const transitionOwnerPath = nodePath.join(transitionDirectory, 'owner.json');
 const transitionRecoveryDirectory = nodePath.join(transitionDirectory, 'recovery');
+const transitionRecoveryOwnerPath = nodePath.join(transitionRecoveryDirectory, 'owner.json');
 const checkoutRoot = nodePath.resolve(cliRoot, '..', '..');
 const minimumLockStatusIntervalMilliseconds = 50;
 const maximumTransitionWaitMilliseconds = 30_000;
 const lockOwnerKind = 'safeword-package-test-lock';
+const transitionOwnerKind = 'safeword-package-test-transition';
+const transitionRecoveryOwnerKind = 'safeword-package-test-transition-recovery';
 
 function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
   const raw = process.env[name];
@@ -117,6 +128,33 @@ function hasUsableOwnerTimestamp(value) {
   return typeof value === 'string' && Number.isFinite(Date.parse(value));
 }
 
+function hasExactKeys(value, expectedKeys) {
+  const keys = Object.keys(value);
+  return (
+    keys.length === expectedKeys.length && expectedKeys.every(key => Object.hasOwn(value, key))
+  );
+}
+
+function isLegacyLockOwner(owner) {
+  return [
+    hasExactKeys(owner, ['checkoutRoot', 'createdAt', 'pid', 'token']),
+    typeof owner.checkoutRoot === 'string' && nodePath.isAbsolute(owner.checkoutRoot),
+    hasUsableOwnerTimestamp(owner.createdAt),
+    isUsableOwnerPid(owner.pid),
+    typeof owner.token === 'string' &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(owner.token),
+  ].every(Boolean);
+}
+
+function isRecognizedTransitionOwner(owner) {
+  return (
+    owner.kind === transitionOwnerKind ||
+    (hasExactKeys(owner, ['createdAt', 'pid']) &&
+      hasUsableOwnerTimestamp(owner.createdAt) &&
+      isUsableOwnerPid(owner.pid))
+  );
+}
+
 function readOwnerAt(path) {
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
@@ -126,7 +164,7 @@ function readOwnerAt(path) {
     return {
       owner,
       readable,
-      valid: owner.kind === lockOwnerKind,
+      valid: owner.kind === lockOwnerKind || isLegacyLockOwner(owner),
     };
   } catch {
     return { owner: {}, readable: false, valid: false };
@@ -137,17 +175,32 @@ function readOwner() {
   return readOwnerAt(ownerPath);
 }
 
+function directoryAgeMilliseconds(path) {
+  try {
+    return Date.now() - statSync(path).mtimeMs;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function removeAgedUnreadableLock(allowCustomPath) {
+  if (!allowCustomPath && usesCustomLockDirectory) return false;
+  const lockAgeMilliseconds = directoryAgeMilliseconds(lockDirectory);
+  if (lockAgeMilliseconds === false) return true;
+  if (lockAgeMilliseconds <= 30_000) return false;
+  rmSync(lockDirectory, { force: true, recursive: true });
+  return true;
+}
+
 function removeStaleLock() {
   const { owner, readable, valid } = readOwner();
-  if (!valid) return false;
-  if (!readable) {
-    const lockAgeMilliseconds = Date.now() - statSync(lockDirectory).mtimeMs;
-    if (lockAgeMilliseconds > 30_000) {
-      rmSync(lockDirectory, { force: true, recursive: true });
-      return true;
-    }
-    return false;
+  if (!valid) {
+    // Only the dedicated default tmp namespace is safe to reclaim when a
+    // creator died after mkdir but before publishing recognizable metadata.
+    return !readable && removeAgedUnreadableLock(false);
   }
+  if (!readable) return removeAgedUnreadableLock(true);
 
   if (isUsableOwnerPid(owner.pid) && !isProcessAlive(owner.pid)) {
     rmSync(lockDirectory, { force: true, recursive: true });
@@ -198,11 +251,10 @@ function reportLockWait(waitedMilliseconds) {
 }
 
 function createLock(token) {
-  const candidateDirectory = `${lockDirectory}.candidate-${token}`;
+  mkdirSync(lockDirectory);
   try {
-    mkdirSync(candidateDirectory);
     writeFileSync(
-      nodePath.join(candidateDirectory, 'owner.json'),
+      ownerPath,
       `${JSON.stringify(
         {
           createdAt: new Date().toISOString(),
@@ -215,18 +267,28 @@ function createLock(token) {
         2,
       )}\n`,
     );
-    renameSync(candidateDirectory, lockDirectory);
-  } finally {
-    rmSync(candidateDirectory, { force: true, recursive: true });
+  } catch (error) {
+    rmSync(lockDirectory, { force: true, recursive: true });
+    throw error;
   }
 }
 
-function createLockTransition() {
+function tryCreateLock(token) {
+  try {
+    createLock(token);
+    return true;
+  } catch (error) {
+    if (error?.code === 'EEXIST' || error?.code === 'ENOTEMPTY') return false;
+    throw error;
+  }
+}
+
+function createLockTransition(token) {
   mkdirSync(transitionDirectory);
   try {
     writeFileSync(
       transitionOwnerPath,
-      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+      `${JSON.stringify({ createdAt: new Date().toISOString(), kind: transitionOwnerKind, pid: process.pid, token })}\n`,
     );
   } catch (error) {
     rmSync(transitionDirectory, { force: true, recursive: true });
@@ -234,88 +296,188 @@ function createLockTransition() {
   }
 }
 
-function tryCreateLockTransition() {
+function tryCreateLockTransition(token) {
   try {
-    createLockTransition();
+    createLockTransition(token);
     return true;
   } catch (error) {
-    if (error?.code === 'EEXIST') return false;
+    if (error?.code === 'EEXIST' || error?.code === 'ENOTEMPTY') return false;
     throw error;
   }
 }
 
-function lockTransitionIsAbandoned() {
-  const { owner, readable } = readOwnerAt(transitionOwnerPath);
-  if (isUsableOwnerPid(owner.pid)) return !isProcessAlive(owner.pid);
-  if (readable) return false;
+function unreadableTransitionIsAgedSafewordResidue() {
+  if (usesCustomLockDirectory) return false;
   try {
-    return Date.now() - statSync(transitionDirectory).mtimeMs > 30_000;
+    const entries = readdirSync(transitionDirectory);
+    const hasOnlySafewordResidue = entries.every(entry =>
+      ['owner.json', 'recovery'].includes(entry),
+    );
+    return hasOnlySafewordResidue && Date.now() - statSync(transitionDirectory).mtimeMs > 30_000;
   } catch {
     return false;
   }
 }
 
-function tryEnterTransitionRecovery() {
+function lockTransitionIsAbandoned(unreadableFallback) {
+  const { owner, readable } = readOwnerAt(transitionOwnerPath);
+  if (readable && !isRecognizedTransitionOwner(owner)) return false;
+  if (isUsableOwnerPid(owner.pid)) return !isProcessAlive(owner.pid);
+  if (readable) return false;
+  if (typeof unreadableFallback === 'boolean') return unreadableFallback;
+  return unreadableTransitionIsAgedSafewordResidue();
+}
+
+function transitionRecoveryIsAbandoned() {
+  const { owner, readable } = readOwnerAt(transitionRecoveryOwnerPath);
+  if (owner.kind === transitionRecoveryOwnerKind && isUsableOwnerPid(owner.pid))
+    return !isProcessAlive(owner.pid);
+  if (readable) return false;
+  try {
+    return (
+      Date.now() - statSync(transitionRecoveryDirectory).mtimeMs > maximumTransitionWaitMilliseconds
+    );
+  } catch {
+    return false;
+  }
+}
+
+function removeAbandonedTransitionRecovery() {
+  if (!transitionRecoveryIsAbandoned()) return false;
+
+  const abandonedRecoveryDirectory = `${transitionRecoveryDirectory}.abandoned-${randomUUID()}`;
+  try {
+    renameSync(transitionRecoveryDirectory, abandonedRecoveryDirectory);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+  rmSync(abandonedRecoveryDirectory, { force: true, recursive: true });
+  return true;
+}
+
+function tryEnterTransitionRecovery(token) {
   try {
     mkdirSync(transitionRecoveryDirectory);
+    writeFileSync(
+      transitionRecoveryOwnerPath,
+      `${JSON.stringify({ createdAt: new Date().toISOString(), kind: transitionRecoveryOwnerKind, pid: process.pid, token })}\n`,
+    );
     return true;
   } catch (error) {
-    if (error?.code === 'EEXIST' || error?.code === 'ENOENT' || error?.code === 'EINVAL')
-      return false;
+    if (error?.code === 'EEXIST') {
+      return removeAbandonedTransitionRecovery() && tryEnterTransitionRecovery(token);
+    }
+    rmSync(transitionRecoveryDirectory, { force: true, recursive: true });
+    if (error?.code === 'ENOENT' || error?.code === 'EINVAL') return false;
     throw error;
   }
 }
 
-function tryRecoverLockTransition() {
-  if (!tryEnterTransitionRecovery()) return false;
+function leaveTransitionRecovery(token) {
+  const { owner } = readOwnerAt(transitionRecoveryOwnerPath);
+  if (owner.pid !== process.pid || owner.token !== token) return false;
+  const releasedRecoveryDirectory = `${transitionRecoveryDirectory}.released-${randomUUID()}`;
   try {
-    if (!lockTransitionIsAbandoned()) return false;
+    renameSync(transitionRecoveryDirectory, releasedRecoveryDirectory);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+  rmSync(releasedRecoveryDirectory, { force: true, recursive: true });
+  return true;
+}
+
+function tryRecoverLockTransition(token) {
+  // Check age before changing the directory: creating a child would refresh
+  // the mtime and make an abandoned empty transition look fresh forever.
+  const wasAbandoned = lockTransitionIsAbandoned();
+  if (!wasAbandoned) return false;
+  if (!tryEnterTransitionRecovery(token)) return false;
+  try {
+    // Another contender may have claimed the transition after our first
+    // observation but before we acquired the recovery marker.
+    if (!lockTransitionIsAbandoned(wasAbandoned)) return false;
     writeFileSync(
       transitionOwnerPath,
-      `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+      `${JSON.stringify({ createdAt: new Date().toISOString(), kind: transitionOwnerKind, pid: process.pid, token })}\n`,
     );
     return true;
   } finally {
-    rmSync(transitionRecoveryDirectory, { force: true, recursive: true });
+    leaveTransitionRecovery(token);
   }
 }
 
-function tryEnterLockTransition() {
-  if (tryCreateLockTransition()) return true;
-  return tryRecoverLockTransition();
+function tryEnterLockTransition(token) {
+  if (tryCreateLockTransition(token)) return true;
+  const { owner } = readOwnerAt(transitionOwnerPath);
+  if (owner.pid === process.pid && owner.token === token) return true;
+  return tryRecoverLockTransition(token);
 }
 
-function leaveLockTransition() {
-  while (!tryEnterTransitionRecovery()) {
+function leaveLockTransitionUnsafe(token) {
+  let waitedMilliseconds = 0;
+  while (!tryEnterTransitionRecovery(token)) {
+    if (!existsSync(transitionDirectory)) return true;
+    if (waitedMilliseconds >= maximumTransitionWaitMilliseconds) {
+      throw new Error('Could not safely leave the safeword package test lock transition.');
+    }
     sleep(10);
+    waitedMilliseconds += 10;
   }
-  rmSync(transitionDirectory, { force: true, recursive: true });
+
+  const { owner } = readOwnerAt(transitionOwnerPath);
+  if (owner.pid !== process.pid || owner.token !== token) {
+    leaveTransitionRecovery(token);
+    throw new Error(
+      'Could not safely leave the safeword package test lock transition because its ownership changed.',
+    );
+  }
+
+  const releasedTransitionDirectory = `${transitionDirectory}.released-${randomUUID()}`;
+  try {
+    // Move the parent while holding its recovery marker. Contenders can no
+    // longer recreate a child between recursive traversal and parent removal.
+    renameSync(transitionDirectory, releasedTransitionDirectory);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    leaveTransitionRecovery(token);
+    throw error;
+  }
+  rmSync(releasedTransitionDirectory, { force: true, recursive: true });
+  return true;
+}
+
+function leaveLockTransition(token) {
+  try {
+    return leaveLockTransitionUnsafe(token);
+  } catch (error) {
+    console.error('Could not safely leave the safeword package test lock transition:', error);
+    return false;
+  }
 }
 
 function tryAcquireLock(token) {
-  if (!tryEnterLockTransition()) {
+  if (!tryEnterLockTransition(token)) {
     return false;
   }
 
+  let acquired = false;
+  let failure;
   try {
-    try {
-      createLock(token);
-      return true;
-    } catch (error) {
-      if (error?.code !== 'EEXIST' && error?.code !== 'ENOTEMPTY') {
-        throw error;
-      }
-    }
-
-    if (!removeStaleLock()) {
-      return false;
-    }
-
-    createLock(token);
-    return true;
-  } finally {
-    leaveLockTransition();
+    acquired = tryCreateLock(token) || (removeStaleLock() && tryCreateLock(token));
+  } catch (error) {
+    failure = error;
   }
+  if (failure) {
+    leaveLockTransition(token);
+    throw failure;
+  }
+  // A failed transition cleanup must not turn a lock we already own into
+  // contention against ourselves. Keep the token so the outer finally can
+  // still release the lock (and report failure if the transition remains).
+  leaveLockTransition(token);
+  return acquired;
 }
 
 function acquireLock() {
@@ -334,7 +496,7 @@ function acquireLock() {
 
     if (waitedMilliseconds >= maximumLockWaitMilliseconds) {
       console.error(
-        `Could not acquire safeword package test lock after waiting ${formatElapsedWait(maximumLockWaitMilliseconds)}; no test was started.`,
+        `Could not acquire safeword package test lock at ${lockDirectory} after waiting ${formatElapsedWait(maximumLockWaitMilliseconds)}; no test was started. A transition may be blocked at ${transitionDirectory}. Remove either directory only if you are sure no package test is running.`,
       );
       return false;
     }
@@ -356,7 +518,7 @@ function acquireLock() {
 
 function releaseLock(token) {
   let waitedMilliseconds = 0;
-  while (!tryEnterLockTransition()) {
+  while (!tryEnterLockTransition(token)) {
     if (waitedMilliseconds >= maximumTransitionWaitMilliseconds) {
       console.error(
         'Could not safely release the safeword package test lock; the lock was left in place.',
@@ -371,27 +533,32 @@ function releaseLock(token) {
     waitedMilliseconds += nextSleepMilliseconds;
   }
 
+  let released = false;
+  let failure;
   try {
     const { owner } = readOwner();
     // eslint-disable-next-line security/detect-possible-timing-attacks -- UUID ownership identifiers are not secrets.
-    if (owner.token !== token) {
+    if (owner.token === token) {
+      rmSync(lockDirectory, { force: true, recursive: true });
+      released = true;
+    } else {
       console.error(
         'Could not safely release the safeword package test lock because its ownership changed; the lock was left in place.',
       );
-      return false;
     }
-    rmSync(lockDirectory, { force: true, recursive: true });
-    return true;
-  } finally {
-    leaveLockTransition();
+  } catch (error) {
+    failure = error;
   }
+  if (failure) {
+    leaveLockTransition(token);
+    throw failure;
+  }
+  return leaveLockTransition(token) && released;
 }
 
 function run(command, args, environment = childEnvironment) {
-  const windowsVitest = windowsVitestInvocation(command, environment);
-  const executable = windowsVitest?.executable ?? command;
-  const executableArguments = windowsVitest ? [...windowsVitest.arguments, ...args] : args;
-  const result = spawnSync(executable, executableArguments, {
+  const invocation = resolveTestRunnerInvocation(command, args, environment, cliRoot);
+  const result = spawnSync(invocation.executable, invocation.arguments, {
     cwd: cliRoot,
     env: environment,
     stdio: 'inherit',
@@ -409,21 +576,21 @@ function run(command, args, environment = childEnvironment) {
   return result.status ?? 1;
 }
 
-function windowsVitestInvocation(command, environment) {
-  if (process.platform !== 'win32' || command !== 'vitest') return false;
-  return resolveWindowsVitest(environment[pathKey] ?? '', cliRoot);
-}
-
 function packageSnapshotEntries() {
   const packageJsonPath = nodePath.join(cliRoot, 'package.json');
-  if (!existsSync(packageJsonPath)) return ['dist'];
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-  return [
-    'package.json',
-    ...(Array.isArray(packageJson.files)
-      ? packageJson.files.filter(entry => typeof entry === 'string')
-      : []),
-  ];
+  if (!Array.isArray(packageJson.files) || packageJson.files.length === 0) {
+    throw new Error('Package snapshot requires a non-empty package.json files array.');
+  }
+  for (const entry of packageJson.files) {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      throw new Error('Package snapshot entries must be non-empty strings.');
+    }
+    if (entry.startsWith('!') || /[*?[\]{}()]/u.test(entry)) {
+      throw new Error(`Package snapshot does not support package.json files patterns: ${entry}`);
+    }
+  }
+  return ['package.json', ...packageJson.files];
 }
 
 function pathEscapesRoot(relativePath) {
@@ -452,7 +619,9 @@ function packageSnapshotSource(entry, canonicalCliRoot) {
   if (pathEscapesRoot(packageRelativeSource)) {
     throw new Error(`Package snapshot entry escapes the CLI package: ${entry}`);
   }
-  if (!existsSync(source)) return false;
+  if (!existsSync(source)) {
+    throw new Error(`Package snapshot entry does not exist: ${entry}`);
+  }
   const canonicalRelativeSource = nodePath.relative(canonicalCliRoot, realpathSync(source));
   if (pathEscapesRoot(canonicalRelativeSource)) {
     throw new Error(`Package snapshot entry resolves outside the CLI package: ${entry}`);
@@ -461,13 +630,43 @@ function packageSnapshotSource(entry, canonicalCliRoot) {
   return { packageRelativeSource, source };
 }
 
+function canonicalActivePackageSnapshot() {
+  if (!process.env.SAFEWORD_TEST_CLI_ROOT) return false;
+  try {
+    return realpathSync(process.env.SAFEWORD_TEST_CLI_ROOT);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function removeAgedPackageSnapshots(snapshotParent) {
+  const activeSnapshot = canonicalActivePackageSnapshot();
+  for (const entry of readdirSync(snapshotParent)) {
+    if (!entry.startsWith('safeword-test-package-')) continue;
+    const snapshot = nodePath.join(snapshotParent, entry);
+    try {
+      if (realpathSync(snapshot) === activeSnapshot) continue;
+      if (Date.now() - statSync(snapshot).mtimeMs <= 6 * 60 * 60 * 1000) continue;
+      rmSync(snapshot, { force: true, recursive: true });
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+}
+
 function createPackageSnapshot() {
-  const snapshotRoot = mkdtempSync(nodePath.join(cliRoot, '.test-package-'));
+  // Keep the snapshot under node_modules so externalized runtime dependencies
+  // resolve naturally, but outside the tracked package tree so a killed run
+  // cannot leave `.test-package-*` worktree residue.
+  const snapshotParent = nodePath.join(cliRoot, 'node_modules', '.cache');
+  mkdirSync(snapshotParent, { recursive: true });
+  removeAgedPackageSnapshots(snapshotParent);
+  const snapshotRoot = mkdtempSync(nodePath.join(snapshotParent, 'safeword-test-package-'));
   const canonicalCliRoot = realpathSync(cliRoot);
   try {
     for (const entry of packageSnapshotEntries()) {
       const snapshotSource = packageSnapshotSource(entry, canonicalCliRoot);
-      if (!snapshotSource) continue;
       const { packageRelativeSource, source } = snapshotSource;
       const destination = nodePath.join(snapshotRoot, packageRelativeSource);
       mkdirSync(nodePath.dirname(destination), { recursive: true });
@@ -514,9 +713,7 @@ try {
     }
   }
 } finally {
-  if (packageSnapshot && !removePackageSnapshot(packageSnapshot)) {
-    status = 1;
-  }
+  if (packageSnapshot) removePackageSnapshot(packageSnapshot);
   if (lockToken && !releaseLock(lockToken)) {
     status = 1;
   }

--- a/packages/cli/scripts/test-runner-executable.d.mts
+++ b/packages/cli/scripts/test-runner-executable.d.mts
@@ -3,8 +3,18 @@ export interface TestRunnerInvocation {
   executable: string;
 }
 
+export function environmentPathKey(environment: Record<string, unknown>): string;
+
 export function resolveWindowsVitest(
   searchPath: string,
   cliRoot: string,
   nodeExecutable?: string,
+): TestRunnerInvocation;
+
+export function resolveTestRunnerInvocation(
+  command: string,
+  args: string[],
+  environment: Record<string, string | undefined>,
+  cliRoot: string,
+  platform?: string,
 ): TestRunnerInvocation;

--- a/packages/cli/scripts/test-runner-executable.mjs
+++ b/packages/cli/scripts/test-runner-executable.mjs
@@ -2,6 +2,10 @@ import { existsSync } from 'node:fs';
 import nodePath from 'node:path';
 import process from 'node:process';
 
+export function environmentPathKey(environment) {
+  return Object.keys(environment).find(key => key.toUpperCase() === 'PATH') ?? 'PATH';
+}
+
 function windowsVitestCandidate(directory, name, nodeExecutable) {
   const candidate = nodePath.join(directory, name);
   if (!existsSync(candidate)) return false;
@@ -24,5 +28,23 @@ export function resolveWindowsVitest(searchPath, cliRoot, nodeExecutable = proce
   return {
     arguments: [nodePath.join(cliRoot, 'node_modules', 'vitest', 'vitest.mjs')],
     executable: nodeExecutable,
+  };
+}
+
+export function resolveTestRunnerInvocation(
+  command,
+  args,
+  environment,
+  cliRoot,
+  platform = process.platform,
+) {
+  if (platform !== 'win32' || command !== 'vitest') {
+    return { arguments: args, executable: command };
+  }
+  const pathKey = environmentPathKey(environment);
+  const windowsVitest = resolveWindowsVitest(environment[pathKey] ?? '', cliRoot);
+  return {
+    arguments: [...windowsVitest.arguments, ...args],
+    executable: windowsVitest.executable,
   };
 }

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import {
   copyFileSync,
   existsSync,
@@ -14,7 +14,11 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { resolveWindowsVitest } from '../scripts/test-runner-executable.mjs';
+import {
+  environmentPathKey,
+  resolveTestRunnerInvocation,
+  resolveWindowsVitest,
+} from '../scripts/test-runner-executable.mjs';
 
 const cliRoot = nodePath.resolve(import.meta.dirname, '..');
 const runnerPath = nodePath.join(cliRoot, 'scripts/run-vitest-with-build-lock.mjs');
@@ -80,6 +84,7 @@ if (process.cwd() !== ${JSON.stringify(cliRoot)}) {
 }
 await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`build:end:\${parent}\\n\`);
+process.exitCode = Number(process.env.SAFEWORD_FAKE_BUILD_EXIT_CODE ?? 0);
 `,
     { mode: 0o755 },
   );
@@ -93,16 +98,19 @@ const snapshotLog = ${JSON.stringify(snapshotLogPath)};
 const parent = process.ppid;
 const snapshotRoot = process.env.SAFEWORD_TEST_CLI_ROOT;
 if (snapshotRoot) {
-  const { readFileSync } = await import('node:fs');
+  const { existsSync, readFileSync } = await import('node:fs');
   const { join } = await import('node:path');
   appendFileSync(snapshotLog, JSON.stringify({
     root: snapshotRoot,
     cli: readFileSync(join(snapshotRoot, 'dist', 'cli.js'), 'utf8'),
+    hasPackageJson: existsSync(join(snapshotRoot, 'package.json')),
+    hasSchemas: existsSync(join(snapshotRoot, 'schemas')),
   }) + '\\n');
 }
 appendFileSync(log, \`vitest:start:\${parent}:\${process.argv.slice(2).join(',')}\\n\`);
 await new Promise(resolve => setTimeout(resolve, ${delayMilliseconds}));
 appendFileSync(log, \`vitest:end:\${parent}\\n\`);
+process.exitCode = Number(process.env.SAFEWORD_FAKE_VITEST_EXIT_CODE ?? 0);
 `,
     { mode: 0o755 },
   );
@@ -117,6 +125,10 @@ async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
   const copiedRunnerPath = nodePath.join(scriptDirectory, 'run-vitest-with-build-lock.mjs');
   copyFileSync(runnerPath, copiedRunnerPath);
   copyFileSync(runnerExecutablePath, nodePath.join(scriptDirectory, 'test-runner-executable.mjs'));
+  writeFileSync(
+    nodePath.join(checkoutCliRoot, 'package.json'),
+    `${JSON.stringify({ files: ['dist'] })}\n`,
+  );
   return copiedRunnerPath;
 }
 
@@ -137,7 +149,7 @@ function expectSerializedByRunner(events: string[]) {
   expect(parentIds).toHaveLength(2);
 
   for (const parentId of parentIds) {
-    const parentEvents = events.filter(event => event.includes(`:${parentId}`));
+    const parentEvents = events.filter(event => event.split(':', 3)[2] === parentId);
     expect(parentEvents[0]).toBe(`build:start:${parentId}`);
     expect(parentEvents[1]).toBe(`build:end:${parentId}`);
     expect([
@@ -147,8 +159,8 @@ function expectSerializedByRunner(events: string[]) {
     expect(parentEvents[3]).toBe(`vitest:end:${parentId}`);
   }
 
-  const firstParentEnd = events.findLastIndex(event => event.includes(`:${parentIds[0]}`));
-  const secondParentStart = events.findIndex(event => event.includes(`:${parentIds[1]}`));
+  const firstParentEnd = events.findLastIndex(event => event.split(':', 3)[2] === parentIds[0]);
+  const secondParentStart = events.findIndex(event => event.split(':', 3)[2] === parentIds[1]);
   expect(secondParentStart).toBeGreaterThan(firstParentEnd);
 }
 
@@ -174,8 +186,64 @@ async function seedOwnerFile(lockDirectory: string, owner: unknown) {
   writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(markedOwner)}\n`);
 }
 
+async function seedLegacyOwnerFile(lockDirectory: string, owner: Record<string, unknown>) {
+  await mkdir(lockDirectory, { recursive: true });
+  writeFileSync(nodePath.join(lockDirectory, 'owner.json'), `${JSON.stringify(owner)}\n`);
+}
+
+async function expectSimultaneousRecoveryIsSerialized(
+  owner: Record<string, unknown>,
+  seed: typeof seedOwnerFile | typeof seedLegacyOwnerFile,
+) {
+  const temporaryDirectory = makeTemporaryDirectory();
+  const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory, 80);
+  const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+  await seed(lockDirectory, owner);
+  const env = {
+    ...process.env,
+    PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+    SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '10000',
+  };
+
+  const contenderCount = 4;
+  const results = await Promise.all(
+    Array.from({ length: contenderCount }, (_, index) =>
+      runNodeScript(runnerPath, [`tests/stale-${index}.test.ts`], env),
+    ),
+  );
+
+  expect(
+    results.map(result => result.status),
+    JSON.stringify(results),
+  ).toEqual(Array.from({ length: contenderCount }, () => 0));
+  const events = readEvents(logPath);
+  let activeCommands = 0;
+  let maximumActiveCommands = 0;
+  for (const event of events) {
+    activeCommands += event.includes(':start:') ? 1 : -1;
+    maximumActiveCommands = Math.max(maximumActiveCommands, activeCommands);
+  }
+  expect(events).toHaveLength(contenderCount * 4);
+  expect(activeCommands).toBe(0);
+  expect(maximumActiveCommands).toBe(1);
+}
+
 describe('package test runner lock (379)', () => {
-  it('keeps the GitHub provenance smokes as a bounded source-only live lane (#1484)', () => {
+  it('runs the real packaged CLI from the isolated snapshot', () => {
+    const snapshotRoot = process.env.SAFEWORD_TEST_CLI_ROOT;
+    if (!snapshotRoot) throw new Error('Package test snapshot was not provided.');
+    const result = spawnSync(
+      process.execPath,
+      [nodePath.join(snapshotRoot, 'dist', 'cli.js'), '--version'],
+      { encoding: 'utf8' },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/u);
+  });
+
+  it('keeps the GitHub provenance smokes outside the package lock (#1484)', () => {
     const manifest = JSON.parse(readFileSync(packageManifestPath, 'utf8')) as {
       scripts?: Record<string, unknown>;
     };
@@ -184,14 +252,6 @@ describe('package test runner lock (379)', () => {
     expect(command).toBe('node scripts/run-github-live-smokes.mjs');
     expect(command).not.toContain('run-vitest-with-build-lock');
     expect(command).not.toContain('build');
-
-    const runner = readFileSync(githubLiveRunnerPath, 'utf8');
-    expect(runner).toContain("'--maxWorkers=1'");
-    expect(runner).toContain("'--no-file-parallelism'");
-    expect(runner).toContain("'tests/smoke/retro-dedup.live.test.ts'");
-    expect(runner).toContain("'tests/smoke/reconcile.live.test.ts'");
-    expect(runner).not.toContain('run-vitest-with-build-lock');
-    expect(runner).not.toContain("['bun', 'run', 'build']");
   });
 
   it('rejects arguments to the bounded GitHub provenance live lane (#1484)', async () => {
@@ -242,6 +302,66 @@ describe('package test runner lock (379)', () => {
       arguments: [moduleEntry],
       executable: 'node.exe',
     });
+    expect(resolveWindowsVitest(binaryDirectory, cliRoot)).toEqual({
+      arguments: [moduleEntry],
+      executable: process.execPath,
+    });
+    expect(environmentPathKey({ Path: binaryDirectory })).toBe('Path');
+    expect(environmentPathKey({ OTHER: 'value' })).toBe('PATH');
+    expect(
+      resolveTestRunnerInvocation(
+        'vitest',
+        ['run', 'tests/example.test.ts'],
+        { Path: binaryDirectory },
+        cliRoot,
+        'win32',
+      ),
+    ).toEqual({
+      arguments: [moduleEntry, 'run', 'tests/example.test.ts'],
+      executable: process.execPath,
+    });
+    expect(
+      resolveTestRunnerInvocation(
+        'bun',
+        ['run', 'build'],
+        { Path: binaryDirectory },
+        cliRoot,
+        'win32',
+      ),
+    ).toEqual({ arguments: ['run', 'build'], executable: 'bun' });
+  });
+
+  it('falls back to the package-local Vitest when PATH has no Vitest (#715)', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    const localBinDirectory = nodePath.join(
+      checkoutCliRootForRunner(copiedRunner),
+      'node_modules',
+      '.bin',
+    );
+    await mkdir(localBinDirectory, { recursive: true });
+    copyFileSync(
+      nodePath.join(binaryDirectory, 'vitest'),
+      nodePath.join(localBinDirectory, 'vitest'),
+    );
+    await rm(nodePath.join(binaryDirectory, 'vitest'));
+
+    const result = await runNodeScript(copiedRunner, ['tests/local-vitest.test.ts'], {
+      ...process.env,
+      PATH: [binaryDirectory, nodePath.dirname(process.execPath), '/usr/bin', '/bin'].join(
+        nodePath.delimiter,
+      ),
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/local-vitest\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
   });
 
   it('runs tests against a private built-package snapshot (#1823)', async () => {
@@ -266,6 +386,109 @@ describe('package test runner lock (379)', () => {
     expect(existsSync(snapshot.root)).toBe(false);
   });
 
+  it('removes an aged orphaned package snapshot before creating the next one', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    const orphan = nodePath.join(
+      checkoutCliRootForRunner(copiedRunner),
+      'node_modules',
+      '.cache',
+      'safeword-test-package-orphan',
+    );
+    await mkdir(orphan, { recursive: true });
+    writeFileSync(nodePath.join(orphan, 'residue'), 'old snapshot');
+    const staleSnapshotTime = new Date(Date.now() - 7 * 60 * 60 * 1000);
+    utimesSync(orphan, staleSnapshotTime, staleSnapshotTime);
+    const activeSnapshot = nodePath.join(
+      checkoutCliRootForRunner(copiedRunner),
+      'node_modules',
+      '.cache',
+      'safeword-test-package-active',
+    );
+    await mkdir(nodePath.join(activeSnapshot, 'dist'), { recursive: true });
+    writeFileSync(nodePath.join(activeSnapshot, 'dist', 'cli.js'), 'active snapshot');
+
+    const result = await runNodeScript(copiedRunner, ['tests/snapshot-reaping.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_CLI_ROOT: activeSnapshot,
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(existsSync(orphan)).toBe(false);
+    expect(readFileSync(nodePath.join(activeSnapshot, 'dist', 'cli.js'), 'utf8')).toBe(
+      'active snapshot',
+    );
+  });
+
+  it('skips tests and propagates a failed build', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+
+    const result = await runNodeScript(copiedRunner, ['tests/not-started.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_FAKE_BUILD_EXIT_CODE: '23',
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result.status).toBe(23);
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+    ]);
+  });
+
+  it('propagates a failed test run', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+
+    const result = await runNodeScript(copiedRunner, ['tests/failing.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_FAKE_VITEST_EXIT_CODE: '24',
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result.status).toBe(24);
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/failing\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+  });
+
+  it('copies every literal entry from a package snapshot manifest', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, snapshotLogPath } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    const checkoutCliRoot = checkoutCliRootForRunner(copiedRunner);
+    await mkdir(nodePath.join(checkoutCliRoot, 'schemas'));
+    writeFileSync(nodePath.join(checkoutCliRoot, 'schemas', 'proof.json'), '{}\n');
+    writeFileSync(
+      nodePath.join(checkoutCliRoot, 'package.json'),
+      `${JSON.stringify({ files: ['dist', 'schemas'] })}\n`,
+    );
+
+    const result = await runNodeScript(copiedRunner, ['tests/snapshot-entries.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    const snapshot = JSON.parse(readFileSync(snapshotLogPath, 'utf8')) as {
+      hasPackageJson: boolean;
+      hasSchemas: boolean;
+    };
+    expect(snapshot).toMatchObject({ hasPackageJson: true, hasSchemas: true });
+  });
+
   it.each(['..', '.'])('rejects publish entry %s outside the snapshot boundary', async entry => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
@@ -283,6 +506,64 @@ describe('package test runner lock (379)', () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(`Package snapshot entry escapes the CLI package: ${entry}`);
+  });
+
+  it.each(['dist/**', '!dist/debug'])(
+    'rejects unsupported package snapshot pattern %s',
+    async entry => {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+      const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+      writeFileSync(
+        nodePath.join(checkoutCliRootForRunner(copiedRunner), 'package.json'),
+        `${JSON.stringify({ files: [entry] })}\n`,
+      );
+
+      const result = await runNodeScript(copiedRunner, ['tests/pattern.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Package snapshot does not support package.json files patterns: ${entry}`,
+      );
+    },
+  );
+
+  it('reports a missing package snapshot files contract directly', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    writeFileSync(nodePath.join(checkoutCliRootForRunner(copiedRunner), 'package.json'), '{}\n');
+
+    const result = await runNodeScript(copiedRunner, ['tests/missing-files.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Package snapshot requires a non-empty package.json files array.',
+    );
+  });
+
+  it('requires the package snapshot manifest to exist', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory);
+    const copiedRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout');
+    await rm(nodePath.join(checkoutCliRootForRunner(copiedRunner), 'package.json'));
+
+    const result = await runNodeScript(copiedRunner, ['tests/missing-manifest.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: nodePath.join(temporaryDirectory, 'lock'),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('package.json');
   });
 
   it.runIf(process.platform !== 'win32')(
@@ -345,8 +626,11 @@ describe('package test runner lock (379)', () => {
     const env = {
       ...process.env,
       PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
       TMPDIR: temporaryDirectory,
       SAFEWORD_TEST_LOCK_DIR: undefined,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '2000',
     };
 
     const [first, second] = await Promise.all([
@@ -381,14 +665,13 @@ describe('package test runner lock (379)', () => {
 
       expectSuccessfulSerializedRun(ownerResult);
       expectSuccessfulSerializedRun(waiterResult);
-      expect(waiterResult.stderr).not.toContain('Proceeding without safeword package test lock');
       expectSerializedByRunner(readEvents(logPath));
     }
   });
 
   it('reports the complete bounded periodic status sequence before failing', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory, 500);
+    const { binaryDirectory } = await createFakeTestBinaries(temporaryDirectory, 2000);
     const firstRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-a');
     const secondRunner = await copyRunnerToCheckout(temporaryDirectory, 'checkout-b');
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
@@ -421,7 +704,7 @@ describe('package test runner lock (379)', () => {
       `Waiting for safeword package test lock (200ms elapsed; owner PID ${owner.pid}; checkout ${owner.checkoutRoot}).`,
     ]);
     expect(waiterResult.stderr).toContain(
-      'Could not acquire safeword package test lock after waiting 250ms; no test was started.',
+      `Could not acquire safeword package test lock at ${lockDirectory} after waiting 250ms; no test was started.`,
     );
   });
 
@@ -446,9 +729,7 @@ describe('package test runner lock (379)', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(expectedOwnerDetail);
       expect(result.stderr).toContain('checkout unavailable');
-      expect(result.stderr).toContain(
-        'Could not acquire safeword package test lock after waiting 220ms; no test was started.',
-      );
+      expect(result.stderr).toContain('after waiting 220ms; no test was started.');
     }
   });
 
@@ -478,27 +759,34 @@ describe('package test runner lock (379)', () => {
     }
   });
 
-  it('does not delete an unmarked directory selected as the lock path', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
-    const lockDirectory = nodePath.join(temporaryDirectory, 'unrelated');
-    await mkdir(lockDirectory);
-    const sentinel = nodePath.join(lockDirectory, 'keep.txt');
-    writeFileSync(sentinel, 'user data');
-    const staleTime = new Date(Date.now() - 31_000);
-    utimesSync(lockDirectory, staleTime, staleTime);
+  it.each([
+    ['empty', false],
+    ['non-empty', true],
+  ])(
+    'does not delete an unmarked %s directory selected as the lock path',
+    async (_name, seeded) => {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+      const lockDirectory = nodePath.join(temporaryDirectory, 'unrelated');
+      await mkdir(lockDirectory);
+      const sentinel = nodePath.join(lockDirectory, 'keep.txt');
+      if (seeded) writeFileSync(sentinel, 'user data');
+      const staleTime = new Date(Date.now() - 31_000);
+      utimesSync(lockDirectory, staleTime, staleTime);
 
-    const result = await runNodeScript(runnerPath, ['tests/unmarked.test.ts'], {
-      ...process.env,
-      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
-      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
-    });
+      const result = await runNodeScript(runnerPath, ['tests/unmarked.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+      });
 
-    expect(result.status).toBe(1);
-    expect(readFileSync(sentinel, 'utf8')).toBe('user data');
-    expect(existsSync(logPath)).toBe(false);
-  });
+      expect(result.status).toBe(1);
+      expect(existsSync(lockDirectory)).toBe(true);
+      if (seeded) expect(readFileSync(sentinel, 'utf8')).toBe('user data');
+      expect(existsSync(logPath)).toBe(false);
+    },
+  );
 
   it('clamps unsafe status intervals and ignores malformed settings', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
@@ -572,11 +860,122 @@ describe('package test runner lock (379)', () => {
     ]);
   });
 
+  it('recovers a dead owner written by the preceding lock format', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedLegacyOwnerFile(lockDirectory, {
+      checkoutRoot: cliRoot,
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+      token: '00000000-0000-4000-8000-000000000001',
+    });
+
+    const result = await runNodeScript(runnerPath, ['tests/legacy-stale.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/legacy-stale\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+  });
+
+  it('keeps a live owner written by the preceding lock format', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedLegacyOwnerFile(lockDirectory, {
+      checkoutRoot: cliRoot,
+      createdAt: new Date(0).toISOString(),
+      pid: process.pid,
+      token: '00000000-0000-4000-8000-000000000002',
+    });
+
+    const result = await runNodeScript(runnerPath, ['tests/legacy-live.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('after waiting 0ms; no test was started.');
+    expect(existsSync(logPath)).toBe(false);
+    expect(existsSync(lockDirectory)).toBe(true);
+  });
+
+  it('does not recover foreign owner metadata with a dead process', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedLegacyOwnerFile(lockDirectory, {
+      checkoutRoot: cliRoot,
+      createdAt: new Date().toISOString(),
+      kind: 'another-tool-lock',
+      pid: 2_147_483_647,
+      token: 'foreign-owner',
+    });
+
+    const result = await runNodeScript(runnerPath, ['tests/foreign-owner.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(1);
+    expect(existsSync(logPath)).toBe(false);
+    expect(existsSync(lockDirectory)).toBe(true);
+  });
+
+  it.each([
+    [
+      'relative checkout root',
+      { checkoutRoot: 'relative', token: '00000000-0000-4000-8000-000000000004' },
+    ],
+    ['malformed token', { checkoutRoot: cliRoot, token: 'not-a-uuid' }],
+    [
+      'unknown field',
+      {
+        checkoutRoot: cliRoot,
+        extra: true,
+        token: '00000000-0000-4000-8000-000000000005',
+      },
+    ],
+  ])('does not recover legacy-shaped metadata with a %s', async (_name, fields) => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    await seedLegacyOwnerFile(lockDirectory, {
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+      ...fields,
+    });
+
+    const result = await runNodeScript(runnerPath, ['tests/malformed-legacy-owner.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(1);
+    expect(existsSync(logPath)).toBe(false);
+    expect(existsSync(lockDirectory)).toBe(true);
+  });
+
   it('reaps an abandoned transition mutex before acquiring', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await seedOwnerFile(`${lockDirectory}.transition`, {
+    await seedLegacyOwnerFile(`${lockDirectory}.transition`, {
       createdAt: new Date().toISOString(),
       pid: 2_147_483_647,
     });
@@ -597,6 +996,223 @@ describe('package test runner lock (379)', () => {
     expect(existsSync(`${lockDirectory}.transition`)).toBe(false);
   });
 
+  it('reaps an abandoned empty transition mutex before acquiring', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(
+      temporaryDirectory,
+      'safeword-test-locks',
+      'safeword-package-test.lock',
+    );
+    const transitionDirectory = `${lockDirectory}.transition`;
+    await mkdir(transitionDirectory, { recursive: true });
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(transitionDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/empty-transition.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+      TMPDIR: temporaryDirectory,
+      SAFEWORD_TEST_LOCK_DIR: undefined,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/empty-transition\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+    expect(existsSync(transitionDirectory)).toBe(false);
+  });
+
+  it('reaps an abandoned transition with a truncated owner in the default tmp namespace', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(
+      temporaryDirectory,
+      'safeword-test-locks',
+      'safeword-package-test.lock',
+    );
+    const transitionDirectory = `${lockDirectory}.transition`;
+    await mkdir(transitionDirectory, { recursive: true });
+    writeFileSync(nodePath.join(transitionDirectory, 'owner.json'), '{');
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(transitionDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/truncated-transition.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+      TMPDIR: temporaryDirectory,
+      SAFEWORD_TEST_LOCK_DIR: undefined,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toContainEqual(
+      expect.stringMatching(/^vitest:start:.*:run,tests\/truncated-transition\.test\.ts$/),
+    );
+    expect(existsSync(transitionDirectory)).toBe(false);
+  });
+
+  it('reaps an interrupted transition and its abandoned recovery marker', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(
+      temporaryDirectory,
+      'safeword-test-locks',
+      'safeword-package-test.lock',
+    );
+    const transitionDirectory = `${lockDirectory}.transition`;
+    const recoveryDirectory = nodePath.join(transitionDirectory, 'recovery');
+    await mkdir(recoveryDirectory, { recursive: true });
+    writeFileSync(nodePath.join(transitionDirectory, 'owner.json'), '{');
+    writeFileSync(nodePath.join(recoveryDirectory, 'owner.json'), '{');
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(transitionDirectory, staleTime, staleTime);
+    utimesSync(recoveryDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/interrupted-recovery.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+      TMPDIR: temporaryDirectory,
+      SAFEWORD_TEST_LOCK_DIR: undefined,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toContainEqual(
+      expect.stringMatching(/^vitest:start:.*:run,tests\/interrupted-recovery\.test\.ts$/),
+    );
+    expect(existsSync(transitionDirectory)).toBe(false);
+  });
+
+  it('reaps an abandoned empty lock in the default tmp namespace', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(
+      temporaryDirectory,
+      'safeword-test-locks',
+      'safeword-package-test.lock',
+    );
+    await mkdir(lockDirectory, { recursive: true });
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(lockDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/empty-lock.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+      TMPDIR: temporaryDirectory,
+      SAFEWORD_TEST_LOCK_DIR: undefined,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/empty-lock\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+    expect(existsSync(lockDirectory)).toBe(false);
+  });
+
+  it.each([
+    ['empty', false],
+    ['non-empty', true],
+  ])(
+    'does not adopt an unmarked %s transition beside a custom lock path',
+    async (_name, seeded) => {
+      const temporaryDirectory = makeTemporaryDirectory();
+      const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+      const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+      const transitionDirectory = `${lockDirectory}.transition`;
+      await mkdir(transitionDirectory);
+      const sentinel = nodePath.join(transitionDirectory, 'keep.txt');
+      if (seeded) writeFileSync(sentinel, 'user data');
+      const staleTime = new Date(Date.now() - 31_000);
+      utimesSync(transitionDirectory, staleTime, staleTime);
+
+      const result = await runNodeScript(runnerPath, ['tests/foreign-transition.test.ts'], {
+        ...process.env,
+        PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+        SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+        SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+      });
+
+      expect(result.status).toBe(1);
+      if (seeded) expect(readFileSync(sentinel, 'utf8')).toBe('user data');
+      expect(existsSync(transitionDirectory)).toBe(true);
+      expect(existsSync(logPath)).toBe(false);
+    },
+  );
+
+  it('reaps an abandoned transition recovery marker before acquiring', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    const transitionDirectory = `${lockDirectory}.transition`;
+    const recoveryDirectory = nodePath.join(transitionDirectory, 'recovery');
+    await seedLegacyOwnerFile(transitionDirectory, {
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+    });
+    await mkdir(recoveryDirectory);
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(recoveryDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/recovery-marker.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+    });
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(readEvents(logPath)).toEqual([
+      expect.stringMatching(/^build:start:/),
+      expect.stringMatching(/^build:end:/),
+      expect.stringMatching(/^vitest:start:.*:run,tests\/recovery-marker\.test\.ts$/),
+      expect.stringMatching(/^vitest:end:/),
+    ]);
+    expect(existsSync(transitionDirectory)).toBe(false);
+  });
+
+  it('does not reap an aged transition recovery marker owned by a live process', async () => {
+    const temporaryDirectory = makeTemporaryDirectory();
+    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
+    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
+    const transitionDirectory = `${lockDirectory}.transition`;
+    const recoveryDirectory = nodePath.join(transitionDirectory, 'recovery');
+    await seedLegacyOwnerFile(transitionDirectory, {
+      createdAt: new Date().toISOString(),
+      pid: 2_147_483_647,
+    });
+    await seedLegacyOwnerFile(recoveryDirectory, {
+      createdAt: new Date(0).toISOString(),
+      kind: 'safeword-package-test-transition-recovery',
+      pid: process.pid,
+      token: 'live-recovery',
+    });
+    const staleTime = new Date(Date.now() - 31_000);
+    utimesSync(recoveryDirectory, staleTime, staleTime);
+
+    const result = await runNodeScript(runnerPath, ['tests/live-recovery-marker.test.ts'], {
+      ...process.env,
+      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
+      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
+      SAFEWORD_TEST_LOCK_MAX_WAIT_MS: '0',
+    });
+
+    expect(result.status).toBe(1);
+    expect(existsSync(recoveryDirectory)).toBe(true);
+    expect(existsSync(logPath)).toBe(false);
+  });
+
   it('does not reap an aged lock while its owner process is alive', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
@@ -614,48 +1230,31 @@ describe('package test runner lock (379)', () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      'Could not acquire safeword package test lock after waiting 0ms; no test was started.',
-    );
+    expect(result.stderr).toContain('after waiting 0ms; no test was started.');
     expect(existsSync(logPath)).toBe(false);
     expect(existsSync(lockDirectory)).toBe(true);
   });
 
   it('serializes simultaneous recovery from a dead-owner lock', async () => {
-    const temporaryDirectory = makeTemporaryDirectory();
-    const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory, 80);
-    const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await seedOwnerFile(lockDirectory, {
-      createdAt: new Date().toISOString(),
-      pid: 2_147_483_647,
-    });
-    const env = {
-      ...process.env,
-      PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
-      SAFEWORD_TEST_LOCK_DIR: lockDirectory,
-    };
-
-    const contenderCount = 4;
-    const results = await Promise.all(
-      Array.from({ length: contenderCount }, (_, index) =>
-        runNodeScript(runnerPath, [`tests/stale-${index}.test.ts`], env),
-      ),
+    await expectSimultaneousRecoveryIsSerialized(
+      {
+        createdAt: new Date().toISOString(),
+        pid: 2_147_483_647,
+      },
+      seedOwnerFile,
     );
+  });
 
-    expect(
-      results.map(result => result.status),
-      JSON.stringify(results),
-    ).toEqual(Array.from({ length: contenderCount }, () => 0));
-    const events = readEvents(logPath);
-    let activeCommands = 0;
-    let maximumActiveCommands = 0;
-    for (const event of events) {
-      activeCommands += event.includes(':start:') ? 1 : -1;
-      maximumActiveCommands = Math.max(maximumActiveCommands, activeCommands);
-    }
-    expect(events).toHaveLength(contenderCount * 4);
-    expect(activeCommands).toBe(0);
-    expect(maximumActiveCommands).toBe(1);
+  it('serializes simultaneous recovery from a dead owner written by the preceding format', async () => {
+    await expectSimultaneousRecoveryIsSerialized(
+      {
+        checkoutRoot: cliRoot,
+        createdAt: new Date().toISOString(),
+        pid: 2_147_483_647,
+        token: '00000000-0000-4000-8000-000000000003',
+      },
+      seedLegacyOwnerFile,
+    );
   });
 
   it('rebases repo-root-relative test paths onto the package root (#723)', async () => {
@@ -665,7 +1264,7 @@ describe('package test runner lock (379)', () => {
 
     const result = await runNodeScript(
       runnerPath,
-      ['packages/cli/tests/first.test.ts', '--config', 'vitest.live.config.ts'],
+      ['packages/cli/tests/first.test.ts', '--config=packages/cli/vitest.live.config.ts'],
       {
         ...process.env,
         PATH: `${binaryDirectory}${nodePath.delimiter}${process.env.PATH ?? ''}`,
@@ -677,9 +1276,8 @@ describe('package test runner lock (379)', () => {
     expect(readEvents(logPath)).toEqual([
       expect.stringMatching(/^build:start:/),
       expect.stringMatching(/^build:end:/),
-      // The path arg is rebased; the flag value is left untouched.
       expect.stringMatching(
-        /^vitest:start:.*:run,tests\/first\.test\.ts,--config,vitest\.live\.config\.ts$/,
+        /^vitest:start:.*:run,tests\/first\.test\.ts,--config=vitest\.live\.config\.ts$/,
       ),
       expect.stringMatching(/^vitest:end:/),
     ]);
@@ -691,14 +1289,26 @@ describe('package test runner lock (379)', () => {
     };
     const { scripts } = pkg;
 
+    const vitestWrapperScripts = new Set(['node scripts/run-github-live-smokes.mjs']);
+    const buildExemptVitestScripts = new Set([
+      // This fixed, source-only, network-billed provenance lane deliberately
+      // avoids the package build and serialization path (#1484).
+      'test:smoke:live:github',
+    ]);
     const vitestScripts = Object.entries(scripts).filter(
       ([name, command]) =>
-        name.startsWith('test') && !name.startsWith('pretest') && /\bvitest\b/.test(command),
+        name.startsWith('test') &&
+        !name.startsWith('pretest') &&
+        (/\bvitest\b/.test(command) || vitestWrapperScripts.has(command)),
     );
     // Guard against a vacuous pass: there must be vitest-running scripts to check.
     expect(vitestScripts.length).toBeGreaterThan(3);
 
     for (const [name, command] of vitestScripts) {
+      if (buildExemptVitestScripts.has(name)) {
+        expect(command).toBe('node scripts/run-github-live-smokes.mjs');
+        continue;
+      }
       const usesRunner = command.includes('run-vitest-with-build-lock.mjs');
       const buildsFirst = scripts[`pre${name}`] === 'tsup' || command.includes('tsup &&');
       expect(
@@ -722,9 +1332,7 @@ describe('package test runner lock (379)', () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      'Could not acquire safeword package test lock after waiting 0ms; no test was started.',
-    );
+    expect(result.stderr).toContain('after waiting 0ms; no test was started.');
     expect(existsSync(logPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- recognize only the exact immediately preceding package-test lock owner schema, so dead legacy owners recover while live, malformed, and foreign owners remain protected
- harden mixed-version lock, transition, and recovery-marker ownership so concurrent contenders cannot double-acquire or delete another process's lock
- make package snapshots fail fast on invalid manifests, preserve active nested snapshots, reap only aged Safeword residue, and prove the real packaged CLI runs from the isolated snapshot
- make build/test exit propagation, repo-root argument rebasing, package-local Vitest fallback, and Windows launcher composition explicit and tested

## Root cause

The stale-lock parser accepted only owners carrying the current `safeword-package-test-lock` kind. The immediately preceding format had the same checkout root, timestamp, PID, and UUID token but no kind, so a dead legacy owner failed closed forever and every queued run timed out.

## Verification

- `bun run test tests/test-runner-lock.test.ts` — 49/49
- canonical repository test, Gherkin, build, typecheck, and dependency lanes passed before the final focused hardening
- Retro Relay — 170 passed, 1 intentional skip
- targeted ESLint and Prettier — clean
- `bun run typecheck` — clean
- `bun audit` — no vulnerabilities
- `git diff --check origin/main` — clean
- diff-scoped config and dependency architecture audit — healthy, no violations
- independent quality review — approved
- rebased onto current `origin/main` (`d194cefcf`); intervening PR #2752 did not overlap this packet, and affected verification was rerun

No Gherkin was added: this is an internal cross-process mutex protocol, and its acceptance boundaries are exercised through the real runner, real child processes, and temporary filesystems.

Closes #2674

Related follow-ups: #2751, #2754, #2755, #2756, #2758, #2759, #2760.
