### PR TITLE
Make closeout resilient across Codex restarts

### DIFF
--- a/.project/tickets/07VEZF-resume-closeout-after-upgrade/dimensions.md
+++ b/.project/tickets/07VEZF-resume-closeout-after-upgrade/dimensions.md
@@ -1,0 +1,9 @@
+# Dimensions: Resume interrupted closeout after a Codex upgrade
+
+| Dimension | Partitions |
+| --- | --- |
+| Repository identity | exact match; foreign repository; unreadable repository |
+| Receipt lifecycle | fresh unclaimed; claimed by current task; claimed by another task; expired; malformed; completed |
+| Pull-request identity | unchanged exact target; changed head; closed or absent target |
+| Authority | advisory only; attempted inherited merge or cleanup authority |
+| Restart boundary | old task records; new matching SessionStart claims; failed resume; successful cleanup |

--- a/.project/tickets/07VEZF-resume-closeout-after-upgrade/spec.md
+++ b/.project/tickets/07VEZF-resume-closeout-after-upgrade/spec.md
@@ -1,0 +1,89 @@
+# Spec: Resume interrupted closeout after a Codex upgrade
+
+<!-- safeword:inspiration-contract:v1 -->
+
+## Intent
+
+Make the required Codex restart a safe continuation boundary instead of a dead end for already-merged deliveries.
+
+## Intake Brief
+
+- **Requested by:** Safeword maintainer after dogfood upgrades stranded merged PR cleanup
+- **Cost of inaction:** Users must remember PR numbers and reconstruct destructive cleanup context after the original task loses Safeword protection.
+- **Reversibility:** Two-way door; the handoff is an expiring advisory receipt and carries no cleanup authority.
+
+## References
+
+- GitHub issue #2802
+- Existing profile-scoped Codex activation marker and SessionStart proof
+- Parent epic KMB053
+
+## Personas
+
+- Non-Technical Builder (NTB)
+- Technical Builder (TBU)
+
+## Surfaces
+
+Affected:
+
+- OpenAI Codex
+- Closeout Cleanup Guard
+
+Unaffected:
+
+- Claude Code — does not require the Codex profile-plugin restart boundary
+- Cursor — does not require the Codex profile-plugin restart boundary
+
+## Vocabulary
+
+- **Closeout handoff:** A repository-bound advisory receipt naming an observed pull request identity, expiring exactly 24 hours after its millisecond-precision write timestamp. It grants no cleanup or merge authority.
+- **Structural decoding:** Parsing the expected JSON object and required field types; it does not make persisted values or timestamps trusted.
+- **Identity validation:** Rejecting values that are not a bounded positive pull-request integer, canonical repository identity, exact 40-character lowercase hexadecimal commit head, or current-profile provenance after structural decoding.
+- **Profile provenance:** Proof that the current Codex profile wrote the handoff. It is bound to the profile installation identity, not the Safeword plugin version, so an ordinary plugin upgrade preserves trust while a different profile does not.
+
+## Product Inspiration
+
+### Product Unsuccessful Search
+
+| Customer job | Framed question | Products attempted | Source categories | Queries attempted | Search date | Sources inspected | Why none transfers | Decision retained |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Resume guarded destructive work after a mandatory host restart | Which established product safely transfers a session-bound destructive workflow across a forced AI-agent restart? | Git worktree recovery; GitHub merge queues; Codex activation receipts | Repository source; installed CLI documentation | Existing restart and receipt patterns in this repository | 2026-08-13 | Codex activation marker and SessionStart proof; closeout guard receipts | Available patterns cover durable identity or resumable work, but not both without weakening session-bound retrospective evidence | Reuse the profile-scoped activation boundary while keeping closeout revalidation and authority in the existing guard |
+
+## Jobs To Be Done
+
+### resume-closeout-after-upgrade.NTB1 — Trust that a restart does not lose unfinished delivery work
+
+**Persona:** Non-Technical Builder (NTB)
+
+> When Safeword requires a new Codex task after an upgrade, I want the next protected task to discover unfinished closeout work, so I do not need to remember technical cleanup details.
+
+#### resume-closeout-after-upgrade.NTB1.R1 — Blocked closeout records one bounded handoff and the first matching protected task receives its continuation
+
+#### resume-closeout-after-upgrade.NTB1.R2 — Expired, malformed, or foreign handoffs never surface as current work
+
+### resume-closeout-after-upgrade.TBU1 — Resume without transferring destructive authority
+
+**Persona:** Technical Builder (TBU)
+
+> When closeout crosses a required Codex restart, I want every persisted target revalidated under the new task, so stale state or a second consumer cannot delete the wrong branch or worktree.
+
+#### resume-closeout-after-upgrade.TBU1.R1 — A handoff is bound to one repository and claimed by at most one current Codex task
+
+#### resume-closeout-after-upgrade.TBU1.R2 — Resumption re-observes pull-request and repository state and never carries merge or cleanup authority
+
+## Rave Moment
+
+skip: table-stakes — safe recovery after a required restart is baseline reliability.
+
+## Outcomes
+
+- A blocked closeout can persist its observed PR identity before directing the user to restart.
+- The next matching protected Codex task receives one concrete closeout command without choosing a transcript, branch, or worktree.
+- Foreign, malformed, expired, concurrently claimed, or changed targets receive no destructive action and are reported.
+- Successful guarded cleanup removes the handoff; failed attempts remain recoverable until expiry.
+- Expired records may remain inert until the same repository next writes a handoff; background garbage collection is out of scope.
+
+## Open Questions
+
+None.

--- a/.project/tickets/07VEZF-resume-closeout-after-upgrade/test-definitions.md
+++ b/.project/tickets/07VEZF-resume-closeout-after-upgrade/test-definitions.md
@@ -1,0 +1,503 @@
+# Test Definitions: Resume interrupted closeout after a Codex upgrade
+
+Feature source: `features/resume-closeout-after-upgrade.feature`
+
+## Rule: resume-closeout-after-upgrade.NTB1.R1 — Blocked closeout records one bounded handoff and the first matching protected task receives its continuation
+
+### Scenario: A blocked old task records the one observed pending pull request
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A normally protected closeout does not create a handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An ambiguous closeout target does not create a handoff [zero]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An ambiguous closeout target does not create a handoff [two]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [a flag-shaped pull request value]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A traversal-shaped repository identity cannot escape the handoff store
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [a non-hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [pull request zero]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [an overflowing pull request value]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [a shortened hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Hostile observed identities are not persisted [an overlong hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Concurrent blocked closeouts create only one handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A second pending handoff does not overwrite the first
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Re-recording the same pending pull request is idempotent
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A changed head does not rewrite a saved pull request
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An ambiguous existing store is not rewritten
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An expired handoff can be replaced
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An expired claimed handoff can be replaced
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: A handoff at its expiry boundary can be replaced [no claim]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: A handoff at its expiry boundary can be replaced [a claim record]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff claimed by a current task is not overwritten
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A blocked former claim owner cannot rewrite its handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A fresh handoff with a stale claim is preserved for restart discovery
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Closeout without one canonical repository does not create a handoff [zero]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Closeout without one canonical repository does not create a handoff [two]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The matching restarted task receives one concrete continuation
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The handoff written by blocked closeout is consumed after restart
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff written before a profile upgrade is consumed afterward
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Equivalent repository remote spellings match one handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff-store failure still tells the user how to recover
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Unaffected hosts do not create Codex restart handoffs [Claude Code]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Unaffected hosts do not create Codex restart handoffs [Cursor]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: resume-closeout-after-upgrade.NTB1.R2 — Expired, malformed, or foreign handoffs never surface as current work
+
+### Scenario: An expired handoff is not presented as current work
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A malformed handoff is not presented as current work
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A foreign handoff is not presented as current work
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff expires at the exact lifetime boundary
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An expired claimed handoff is not presented as current work
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff with an excessive lifetime is not presented as current work
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An impossible handoff clock is not presented as current work [a write time in the future]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An impossible handoff clock is not presented as current work [an expiry at its write time]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An impossible handoff clock is not presented as current work [an expiry before its write time]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: An impossible handoff clock is not presented as current work [an expiry less than 24 hours after its write time]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An unreadable handoff store does not break protected startup
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Discovery without one canonical repository cannot claim a handoff [zero]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Discovery without one canonical repository cannot claim a handoff [two]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Multiple matching handoffs are rejected as ambiguous
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: resume-closeout-after-upgrade.TBU1.R1 — A handoff is bound to one repository and claimed by at most one current Codex task
+
+### Scenario: The first matching task atomically claims the handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A different task cannot consume a live claim
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A task reclaims a claim whose owner is no longer current
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A superseded claim owner cannot resume after reclaim
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: A malformed claim record cannot trigger reclaim [a truncated owner claim record]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: A malformed claim record cannot trigger reclaim [a structurally valid claim record with an invalid owner identity]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A failed atomic claim does not emit a continuation
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Repeated discovery by the current claim owner is idempotent
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An orphan claim record cannot trigger discovery
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff symlink escaping the store is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A claim-record symlink escaping the store is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff without current-profile provenance is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A handoff from a different profile installation is rejected
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [a flag-shaped pull request value]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [a repository identity with path traversal]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [a non-hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [pull request zero]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [an overflowing pull request value]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [a shortened hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Injection-shaped handoff identities are rejected [an overlong hexadecimal observed head]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An unprotected Codex task cannot discover or claim a handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Unaffected agent hosts cannot discover or claim a Codex handoff [Claude Code]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Unaffected agent hosts cannot discover or claim a Codex handoff [Cursor]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: resume-closeout-after-upgrade.TBU1.R2 — Resumption re-observes pull-request and repository state and never carries merge or cleanup authority
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a different pull-request head | head changed since handoff]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a pull request that is not merged | pull request is not merged]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a changed canonical repository remote | repository identity changed]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a missing branch target | branch target is missing]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a recreated branch target | branch target identity changed]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a missing worktree target | worktree target is missing]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a recreated worktree target | worktree target identity changed]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario Outline: Changed closeout targets remain untouched after restart [a pull request that no longer resolves | pull request is unavailable]
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Successful guarded cleanup clears the handoff
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Cleared closeout is absent from later discovery
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Receipt removal failure leaves an inert recoverable record
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Failed guarded cleanup preserves the handoff until expiry
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Restarted closeout cannot remove its current branch or worktree
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR

--- a/.project/tickets/07VEZF-resume-closeout-after-upgrade/ticket.md
+++ b/.project/tickets/07VEZF-resume-closeout-after-upgrade/ticket.md
@@ -1,0 +1,41 @@
+---
+id: 07VEZF
+slug: resume-closeout-after-upgrade
+type: feature
+phase: scenario-gate
+status: in_progress
+scope:
+  - persist an observed closeout PR identity when the current Codex task cannot supply a protected closeout binding
+  - surface and atomically claim the repository-bound handoff in the next matching protected Codex SessionStart
+  - expire stale handoffs and remove them only after successful guarded cleanup
+  - prove real persistence, restart discovery, repository binding, single-consumer behavior, and fresh target revalidation
+out_of_scope:
+  - carrying merge or cleanup authority across tasks
+  - selecting or impersonating the original task transcript
+  - general Codex task persistence or handoff of arbitrary work
+  - Claude Code, Cursor, or cloud-agent restart semantics
+done_when:
+  - a matching new Codex task discovers the exact pending PR without user-supplied identifiers
+  - foreign, expired, malformed, or already-claimed handoffs do not authorize or trigger cleanup
+  - resumed closeout uses the existing guard to re-observe every target and authority boundary
+  - successful cleanup clears the handoff while failed attempts remain recoverable until expiry
+inspiration_contract: v1
+inspiration_contract_scaffold: v1
+parent: KMB053
+created: 2026-08-13T18:15:59.751Z
+last_modified: 2026-08-13T18:15:59.751Z
+---
+
+# Resume interrupted closeout after a Codex upgrade
+
+**Goal:** Carry exact pending closeout targets safely into the next protected Codex task.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-08-13T18:15:59.751Z Started: Created ticket 07VEZF
+- 2026-08-13T18:26:00.000Z Intake: Confirmed NTB and TBU restart-continuation jobs, repository-bound single-consumer rules, expiry, fresh target revalidation, and no transferred authority; advanced to define behavior.
+- 2026-08-13T18:35:00.000Z Scenario gate: Defined restart, expiry, repository isolation, atomic claim, target drift, and recovery behaviors for independent review.
+- 2026-08-13T19:00:00.000Z Scenario gate: Cross-agent review requested stronger single-deviation rejection proofs, exact expiry, stale-claim recovery, normal-path non-persistence, and observable non-destructive reporting; revised the feature and ledger.
+- 2026-08-13T19:05:00.000Z Scenario gate: Added current-profile provenance, hostile identity rejection, protected-host isolation, exact contention and split-brain outcomes, unambiguous target drift observations, dedup boundaries, and claim cleanup after two further adversarial passes.

--- a/.project/tickets/0RDXVD-trust-green-hosted-ci/ticket.md
+++ b/.project/tickets/0RDXVD-trust-green-hosted-ci/ticket.md
@@ -1,0 +1,20 @@
+---
+id: 0RDXVD
+slug: trust-green-hosted-ci
+type: task
+phase: intake
+status: in_progress
+parent: KMB053
+created: 2026-08-13T18:15:54.710Z
+last_modified: 2026-08-13T18:15:54.710Z
+---
+
+# Use complete hosted CI evidence during closeout
+
+**Goal:** Skip redundant local verification only when exact hosted evidence covers the clean delivery head.
+
+**Why:** Issue #2384 shows closeout ignores trustworthy CI and can hang or fail in mutable local lanes.
+
+## Work Log
+
+- 2026-08-13T18:15:54.710Z Started: Created ticket 0RDXVD

--- a/.project/tickets/CFK8P4-bound-closeout-retro/ticket.md
+++ b/.project/tickets/CFK8P4-bound-closeout-retro/ticket.md
@@ -1,0 +1,20 @@
+---
+id: CFK8P4
+slug: bound-closeout-retro
+type: task
+phase: intake
+status: in_progress
+parent: KMB053
+created: 2026-08-13T18:15:54.765Z
+last_modified: 2026-08-13T18:15:54.765Z
+---
+
+# Keep closeout retrospective bounded to meaningful session work
+
+**Goal:** Let Codex closeout ignore only its positively attributed bookkeeping while preserving fail-closed review of genuine additions.
+
+**Why:** Issue #2805 shows live closeout progress recursively extends the transcript and prevents convergence.
+
+## Work Log
+
+- 2026-08-13T18:15:54.765Z Started: Created ticket CFK8P4

--- a/.project/tickets/KMB053-resilient-closeout/ticket.md
+++ b/.project/tickets/KMB053-resilient-closeout/ticket.md
@@ -1,0 +1,20 @@
+---
+id: KMB053
+slug: resilient-closeout
+type: epic
+phase: intake
+status: in_progress
+children: ['0RDXVD', 'CFK8P4', '07VEZF']
+created: 2026-08-13T18:15:45.346Z
+last_modified: 2026-08-13T18:15:45.346Z
+---
+
+# Finish closeout reliably across verification and restarts
+
+**Goal:** Let closeout finish safely using exact evidence across CI, live transcripts, and required Codex restarts.
+
+**Why:** Merged deliveries are currently stranded by redundant verification, recursive transcript growth, and activation handoff gaps.
+
+## Work Log
+
+- 2026-08-13T18:15:45.346Z Started: Created ticket KMB053

--- a/.safeword/hooks/lib/closeout-binding.ts
+++ b/.safeword/hooks/lib/closeout-binding.ts
@@ -47,7 +47,7 @@ function profileId(environment: NodeJS.ProcessEnv = process.env): string {
 }
 
 function canonicalGithubRepository(value: string): string | undefined {
-  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?$/u.exec(value.trim());
+  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?(?:\/|$)/u.exec(value.trim());
   return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
 }
 

--- a/.safeword/hooks/lib/closeout-binding.ts
+++ b/.safeword/hooks/lib/closeout-binding.ts
@@ -1,4 +1,5 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import {
   appendFileSync,
   existsSync,
@@ -8,6 +9,7 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import nodePath from 'node:path';
@@ -18,6 +20,143 @@ import { commandWords, splitShellSegments } from './shell-segments.js';
 const CLOSEOUT_BINDING_CACHE = 'closeout-session-binding.json';
 const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 const CLOSEOUT_RUNTIMES = ['claude', 'codex', 'cursor'] as const;
+const CLOSEOUT_HANDOFF_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CloseoutHandoff {
+  schema_version: 1;
+  profile_id: string;
+  repository: string;
+  pull_request: number;
+  head_oid: string;
+  written_at: string;
+  expires_at: string;
+}
+
+function codexHome(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.CODEX_HOME ?? nodePath.join(homedir(), '.codex');
+}
+
+function handoffDirectory(environment: NodeJS.ProcessEnv = process.env): string {
+  return nodePath.join(codexHome(environment), 'safeword/closeout-handoff-v1');
+}
+
+function profileId(environment: NodeJS.ProcessEnv = process.env): string {
+  return createHash('sha256')
+    .update(nodePath.resolve(codexHome(environment)))
+    .digest('hex');
+}
+
+function canonicalGithubRepository(value: string): string | undefined {
+  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?$/u.exec(value.trim());
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
+}
+
+function currentRepository(projectDirectory: string): string | undefined {
+  const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  return result.status === 0 ? canonicalGithubRepository(result.stdout) : undefined;
+}
+
+function validHandoff(
+  value: unknown,
+  environment: NodeJS.ProcessEnv,
+  now: number,
+): value is CloseoutHandoff {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Partial<CloseoutHandoff>;
+  const writtenAt = Date.parse(record.written_at ?? '');
+  const expiresAt = Date.parse(record.expires_at ?? '');
+  return (
+    record.schema_version === 1 &&
+    record.profile_id === profileId(environment) &&
+    typeof record.repository === 'string' &&
+    /^[^/]+\/[^/]+$/u.test(record.repository) &&
+    Number.isSafeInteger(record.pull_request) &&
+    (record.pull_request ?? 0) > 0 &&
+    typeof record.head_oid === 'string' &&
+    /^[0-9a-f]{40}$/u.test(record.head_oid) &&
+    Number.isFinite(writtenAt) &&
+    writtenAt <= now &&
+    expiresAt === writtenAt + CLOSEOUT_HANDOFF_TTL_MS &&
+    now < expiresAt
+  );
+}
+
+export function recordCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  repositoryUrl: string;
+  pullRequest: number;
+  headOid: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): boolean {
+  const environment = input.environment ?? process.env;
+  if (!environment.CODEX_HOME && !environment.CODEX_THREAD_ID) return false;
+  const repository = canonicalGithubRepository(input.repositoryUrl);
+  if (
+    !repository ||
+    !Number.isSafeInteger(input.pullRequest) ||
+    input.pullRequest <= 0 ||
+    !/^[0-9a-f]{40}$/u.test(input.headOid)
+  )
+    return false;
+  const directory = handoffDirectory(environment);
+  const path = nodePath.join(
+    directory,
+    `${createHash('sha256').update(repository).digest('hex')}.json`,
+  );
+  const now = input.now ?? new Date();
+  try {
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        schema_version: 1,
+        profile_id: profileId(environment),
+        repository,
+        pull_request: input.pullRequest,
+        head_oid: input.headOid,
+        written_at: now.toISOString(),
+        expires_at: new Date(now.getTime() + CLOSEOUT_HANDOFF_TTL_MS).toISOString(),
+      } satisfies CloseoutHandoff)}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function claimCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  sessionId: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): CloseoutHandoff | undefined {
+  const environment = input.environment ?? process.env;
+  const repository = currentRepository(input.projectDirectory);
+  if (!repository || input.sessionId.trim() === '') return undefined;
+  const directory = handoffDirectory(environment);
+  if (!existsSync(directory)) return undefined;
+  const now = (input.now ?? new Date()).getTime();
+  for (const name of readdirSync(directory)) {
+    if (!name.endsWith('.json')) continue;
+    const path = nodePath.join(directory, name);
+    const claimPath = `${path}.claim-${createHash('sha256').update(input.sessionId).digest('hex')}`;
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+      if (!validHandoff(parsed, environment, now) || parsed.repository !== repository) continue;
+      renameSync(path, claimPath);
+      return parsed;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
 
 export interface CloseoutBinding {
   runtime: 'claude' | 'codex' | 'cursor';

--- a/.safeword/hooks/lib/safeword-context.ts
+++ b/.safeword/hooks/lib/safeword-context.ts
@@ -8,6 +8,7 @@ declare const Bun: { stdin: { json(): Promise<unknown> } };
 export type Agent = 'claude' | 'codex' | 'cursor';
 export type HookInput = {
   cwd?: string;
+  session_id?: string;
   workspace_root?: string;
 };
 

--- a/.safeword/hooks/session-codex-start.ts
+++ b/.safeword/hooks/session-codex-start.ts
@@ -12,13 +12,19 @@ import {
   withCodexAuthority,
 } from './lib/safeword-context.ts';
 import { toCodexSessionStartResponse } from './lib/auto-upgrade.ts';
+import { claimCodexCloseoutHandoff } from './lib/closeout-binding.ts';
 
 const hookInput = await readHookInput();
 const projectDir = resolveProjectDir(hookInput);
 const context = readSafewordContext(projectDir);
+const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
+const handoff = claimCodexCloseoutHandoff({ projectDirectory: projectDir, sessionId });
+const closeoutContext = handoff
+  ? `\n\nPending closeout recovered after restart: run bun .safeword/scripts/closeout-cleanup.ts --pr ${handoff.pull_request}. Re-observe and preview before applying; this handoff grants no cleanup authority.`
+  : '';
 const response = toCodexSessionStartResponse({
   outcome: { kind: 'skipped', reason: 'upgrades require an explicit CLI command' },
-  additionalContext: withCodexAuthority(context),
+  additionalContext: `${withCodexAuthority(context)}${closeoutContext}`,
 });
 
 if (response.stdout) {

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -16,11 +16,16 @@ import {
 import { homedir } from 'node:os';
 import nodePath from 'node:path';
 
-import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';
+import {
+  type CloseoutBinding,
+  readFreshCloseoutBinding,
+  recordCodexCloseoutHandoff,
+} from '../hooks/lib/closeout-binding.ts';
 import { draftSpoolPath, readAcks, readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
 import { resolveRunIdentity } from '../hooks/lib/run-identity.ts';
 
 export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
+export const VERIFICATION_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
 
 export interface PullRequestIdentity {
   url: string;
@@ -490,13 +495,18 @@ function run(
   command: string,
   arguments_: string[],
   cwd: string,
-  options: { shell?: boolean; env?: Record<string, string | undefined> } = {},
+  options: {
+    shell?: boolean;
+    env?: Record<string, string | undefined>;
+    timeout?: number;
+  } = {},
 ): ProcessResult {
   const result = spawnSync(command, arguments_, {
     cwd,
     encoding: 'utf8',
     shell: options.shell ?? false,
     env: { ...process.env, ...options.env },
+    timeout: options.timeout,
   });
   return {
     status: result.status ?? 1,
@@ -816,9 +826,11 @@ function runBoundRetroWindows(
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' };
   const cached = readRetroReceipt(root, binding, transcript);
   if (cached) {
-    const cachedObservation = retroObservationFromReceipt(root, binding.id, cached);
-    const current = transcriptSnapshot(transcript);
-    if (!cachedObservation.complete || current.byteLength === cached.snapshot.byteLength) {
+    const cachedObservation = retroObservationFromReceipt(root, binding, cached);
+    if (
+      !cachedObservation.complete ||
+      !hasMeaningfulTranscriptGrowth(transcript, cached.snapshot, binding.runtime)
+    ) {
       return cachedObservation;
     }
   }
@@ -865,7 +877,11 @@ function runBoundRetroWindows(
     retro.status === 0 &&
     (result?.state === 'healthy' || result?.state === 'changed') &&
     typeof agentFilingNeeded === 'boolean';
-  const transcriptAdvanced = transcriptSnapshot(transcript).byteLength > snapshot.byteLength;
+  const transcriptAdvanced = hasMeaningfulTranscriptGrowth(
+    transcript,
+    snapshot.receipt,
+    binding.runtime,
+  );
   const complete =
     successful && agentFilingNeeded === false && pendingDrafts === 0 && !transcriptAdvanced;
   const errorText = [result?.errors?.map(error => error.message ?? '').join('\n'), retro.stderr]
@@ -981,6 +997,36 @@ function transcriptSnapshot(path: string): SealedTranscriptSnapshot {
   };
 }
 
+function hasMeaningfulTranscriptGrowth(
+  path: string,
+  snapshot: TranscriptSnapshot,
+  runtime: CloseoutBinding['runtime'],
+): boolean {
+  const current = transcriptSnapshot(path);
+  if (current.byteLength <= snapshot.byteLength) return false;
+  if (runtime !== 'codex') return true;
+  const appended = current.content.subarray(snapshot.byteLength).toString('utf8');
+  return appended
+    .split('\n')
+    .filter(Boolean)
+    .some(line => {
+      try {
+        const record = JSON.parse(line) as { type?: unknown; payload?: { type?: unknown } };
+        return !(
+          record.type === 'response_item' &&
+          [
+            'custom_tool_call',
+            'custom_tool_call_output',
+            'function_call',
+            'function_call_output',
+          ].includes(typeof record.payload?.type === 'string' ? record.payload.type : '')
+        );
+      } catch {
+        return true;
+      }
+    });
+}
+
 function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
   try {
     const content = readFileSync(snapshot.path);
@@ -1082,9 +1128,10 @@ function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>)
 
 function retroObservationFromReceipt(
   root: string,
-  sessionId: string,
+  binding: CloseoutBinding,
   receipt: RetroReceipt,
 ): CloseoutObservation['retro'] {
+  const sessionId = binding.id;
   const pendingDrafts = readSpooledDrafts(root, sessionId).length;
   const acknowledgedSignatures = new Set(readAcks(root, sessionId).map(ack => ack.signature));
   const capturedDraftsAcknowledged =
@@ -1100,7 +1147,7 @@ function retroObservationFromReceipt(
     bound: true,
     complete,
     pendingDrafts,
-    evidenceHash: transcriptSnapshot(receipt.snapshot.path).digest,
+    evidenceHash: receipt.snapshot.digest,
     ...(pendingDrafts > 0 ? { spoolPath: realpathSync(draftSpoolPath(root, sessionId)) } : {}),
     failure: complete ? undefined : 'filing',
   };
@@ -1172,7 +1219,11 @@ function passedVerification(
   return { current: true, passed, headOid, stateHash };
 }
 
-function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
+function runVerification(
+  root: string,
+  expectedOid: string,
+  ciChecks: PullRequestIdentity['ciChecks'],
+): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
   const observedStateHash = workingStateHash(root, observedHead);
   if (!observedStateHash) {
@@ -1192,6 +1243,9 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       headOid: receipt.headOid,
       stateHash: receipt.stateHash,
     };
+  }
+  if (observedHead === expectedOid && observedStateHash === cleanWorkingStateHash(expectedOid)) {
+    if (ciChecks === 'passed') return passedVerification(root, observedHead, observedStateHash);
   }
   if (observedHead !== expectedOid) {
     return receipt
@@ -1225,7 +1279,13 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       continue;
     }
     for (const entry of plan) {
-      if (run(entry.command, [], entry.cwd, { shell: true }).status !== 0) passed = false;
+      if (
+        run(entry.command, [], entry.cwd, {
+          shell: true,
+          timeout: VERIFICATION_COMMAND_TIMEOUT_MS,
+        }).status !== 0
+      )
+        passed = false;
       if (git(root, 'rev-parse', 'HEAD').stdout.trim() !== expectedOid) passed = false;
     }
   }
@@ -1583,7 +1643,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
-    verification: runVerification(root, expectedOid),
+    verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
     retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
   };
 }
@@ -1612,6 +1672,19 @@ if (import.meta.main) {
   const pr = argumentValue('--pr');
   const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
+    if (root && pr && !binding) {
+      const pullRequests = observePullRequest(root, pr);
+      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
+      const pullRequest = Number.parseInt(pr, 10);
+      if (identity && identity.state === 'MERGED') {
+        recordCodexCloseoutHandoff({
+          projectDirectory: root,
+          repositoryUrl: identity.url,
+          pullRequest,
+          headOid: identity.headRefOid,
+        });
+      }
+    }
     const recovery =
       root && pr && !binding
         ? ` Start one fresh task and run bun .safeword/scripts/closeout-cleanup.ts --pr ${pr}.`

--- a/features/resume-closeout-after-upgrade.feature
+++ b/features/resume-closeout-after-upgrade.feature
@@ -1,4 +1,11 @@
-@surface.openai-codex @surface.closeout-cleanup-guard
+# Behavior source for 07VEZF. Executable proof lives in
+# packages/cli/tests/hooks/closeout-session-binding.test.ts and
+# packages/cli/tests/commands/codex-hook.test.ts. Those suites exercise the
+# profile handoff store and shipped SessionStart hook at their real boundaries.
+#
+# Reproducing the same filesystem, profile, and hook fixtures as Cucumber steps
+# would duplicate the integration harness without adding confidence.
+@proof.vitest @surface.openai-codex @surface.closeout-cleanup-guard
 Feature: Resume interrupted closeout after a Codex upgrade
 
   @resume-closeout-after-upgrade.NTB1.R1

--- a/features/resume-closeout-after-upgrade.feature
+++ b/features/resume-closeout-after-upgrade.feature
@@ -1,0 +1,500 @@
+@surface.openai-codex @surface.closeout-cleanup-guard
+Feature: Resume interrupted closeout after a Codex upgrade
+
+  @resume-closeout-after-upgrade.NTB1.R1
+  Rule: resume-closeout-after-upgrade.NTB1.R1 — Blocked closeout records one bounded handoff and the first matching protected task receives its continuation
+
+    Scenario: A blocked old task records the one observed pending pull request
+      Given closeout has observed one exact pull request at a controlled write time in a Codex task that must restart
+      When closeout cannot obtain a protected current-task binding
+      Then one advisory handoff records current-profile provenance, the canonical repository identity, numeric pull request, observed head, the millisecond-precision write time, and an expiry exactly 24 hours later
+      And no claim record exists for the new handoff
+      And the current task output directs the user to start a new protected Codex task
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario: A normally protected closeout does not create a handoff
+      Given closeout has observed one exact pull request in a protected Codex task
+      When closeout obtains the protected current-task binding
+      Then no restart handoff is stored
+      And closeout proceeds with its normal protected binding
+
+    @rejection
+    Scenario Outline: An ambiguous closeout target does not create a handoff
+      Given closeout observes <count> pull requests in a Codex task that must restart
+      When closeout cannot obtain a protected current-task binding
+      Then no restart handoff is stored
+      And the current task output reports that one exact pull request is required
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+      Examples:
+        | count |
+        | zero |
+        | two |
+
+    @rejection
+    Scenario Outline: Hostile observed identities are not persisted
+      Given blocked closeout observes <hostile identity>
+      When closeout cannot obtain a protected current-task binding
+      Then no handoff exists in the profile store
+      And the current task output reports invalid observed closeout identity
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+      Examples:
+        | hostile identity |
+        | a flag-shaped pull request value |
+        | a non-hexadecimal observed head |
+        | pull request zero |
+        | an overflowing pull request value |
+        | a shortened hexadecimal observed head |
+        | an overlong hexadecimal observed head |
+
+    @rejection
+    Scenario: A traversal-shaped repository identity cannot escape the handoff store
+      Given blocked closeout observes a repository identity whose normalized key targets a known path outside the profile store
+      When closeout cannot obtain a protected current-task binding
+      Then no handoff exists in the profile store or at that known external target
+      And the current task output reports invalid repository identity
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    Scenario: Concurrent blocked closeouts create only one handoff
+      Given two blocked closeouts with distinct pull-request identities reach handoff creation for the same repository before either write commits at a controlled time
+      When both writes are released to commit concurrently
+      Then exactly one handoff exists for that repository
+      And it is schema-valid and names exactly one complete observed pull request identity
+      And the winning task receives the normal blocked-closeout output
+      And the losing task output reports the existing pending closeout
+
+    @rejection
+    Scenario: A second pending handoff does not overwrite the first
+      Given one fresh unclaimed handoff exists for one pull request and observed head in the current repository at a controlled time
+      When blocked closeout attempts to record a different pull request for that repository
+      Then the original handoff bytes remain unchanged
+      And the current task output reports the existing pending closeout
+
+    Scenario: Re-recording the same pending pull request is idempotent
+      Given one fresh unclaimed handoff exists for the same pull request, observed head, and repository at a controlled time
+      When blocked closeout attempts to record that identical pull request identity again
+      Then the original handoff bytes remain unchanged
+      And the current task output reports that the pending closeout is already saved
+
+    @rejection
+    Scenario: A changed head does not rewrite a saved pull request
+      Given one fresh unclaimed handoff exists for a pull request and its original observed head at a controlled time
+      When blocked closeout observes the same pull request number with a different head
+      Then the original handoff bytes remain unchanged
+      And the current task output reports that the saved pull request head changed
+
+    @rejection
+    Scenario: An ambiguous existing store is not rewritten
+      Given two distinct handoff records normalize to the current canonical repository
+      When blocked closeout attempts to record another pull request for that repository
+      Then both existing handoff bytes remain unchanged
+      And no third handoff is created
+      And the current task output reports ambiguous pending closeout state
+
+    Scenario: An expired handoff can be replaced
+      Given one expired handoff exists for the current repository at a controlled time
+      When blocked closeout records one exact pull request for that repository
+      Then exactly one fresh handoff contains the newly observed pull request identity
+
+    Scenario: An expired claimed handoff can be replaced
+      Given one expired handoff and claim record exist for the current repository at a controlled time
+      When blocked closeout records one exact pull request for that repository
+      Then exactly one fresh handoff contains the newly observed pull request identity
+      And the expired claim record is removed
+
+    Scenario Outline: A handoff at its expiry boundary can be replaced
+      Given one handoff with <claim state> reaches its exact expiry at a controlled millisecond
+      When blocked closeout records one exact pull request for that repository
+      Then exactly one fresh handoff contains the newly observed pull request identity
+      And no expired claim record remains
+
+      Examples:
+        | claim state |
+        | no claim |
+        | a claim record |
+
+    @rejection
+    Scenario: A handoff claimed by a current task is not overwritten
+      Given one fresh handoff is claimed by a different current task and blocked closeout never held that claim at a controlled time
+      When blocked closeout attempts to record another pull request for that repository
+      Then the claimed handoff and claim record bytes remain unchanged
+      And the current task output reports the existing pending closeout
+
+    @rejection
+    Scenario: A blocked former claim owner cannot rewrite its handoff
+      Given blocked closeout previously owned a fresh handoff claim that now belongs to the current task
+      When blocked closeout attempts to record that pull request again
+      Then the handoff and current claim record bytes remain unchanged
+      And the blocked task output reports that its claim is no longer current
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario: A fresh handoff with a stale claim is preserved for restart discovery
+      Given one fresh handoff is claimed by a task whose profile activation marker is no longer current at a controlled time
+      When blocked closeout attempts to record another pull request for that repository
+      Then the original handoff and stale claim record bytes remain unchanged
+      And the current task output reports the existing pending closeout
+
+    @rejection
+    Scenario Outline: Closeout without one canonical repository does not create a handoff
+      Given blocked closeout resolves <repository count> canonical repository identities
+      When closeout cannot obtain a protected current-task binding
+      Then no restart handoff is stored
+      And the current task output directs the user to retry with the numeric pull request from a canonical repository checkout
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+      Examples:
+        | repository count |
+        | zero |
+        | two |
+
+    Scenario: The matching restarted task receives one concrete continuation
+      Given an unclaimed handoff for the current repository is one tick before expiry at a controlled time
+      When a protected Codex task starts in that repository
+      Then SessionStart output contains one command naming only the numeric pending pull request
+      And SessionStart output requests no transcript, branch, or worktree selection
+      And the existing protected SessionStart proof is still emitted
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    Scenario: The handoff written by blocked closeout is consumed after restart
+      Given blocked protected closeout writes its observed numeric pull request at a controlled time
+      When the next protected Codex task starts in the same canonical repository before expiry
+      Then SessionStart output contains one command naming that same numeric pull request
+      And the resulting claim record names the new current task
+      And the existing protected SessionStart proof is still emitted
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    Scenario: A handoff written before a profile upgrade is consumed afterward
+      Given blocked protected closeout writes its observed numeric pull request under the current profile identity and old plugin version
+      When the plugin version is upgraded and the next protected Codex task starts in the same canonical repository before expiry
+      Then SessionStart output contains one command naming that same numeric pull request
+      And SessionStart output contains no untrusted-provenance notice
+      And the existing protected SessionStart proof is still emitted
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    Scenario: Equivalent repository remote spellings match one handoff
+      Given a fresh handoff records the canonical identity derived from an HTTPS remote at a controlled time
+      When a protected Codex task starts from the same repository using its equivalent SSH remote
+      Then SessionStart output contains one continuation naming the numeric pending pull request
+      And the existing protected SessionStart proof is still emitted
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario: A handoff-store failure still tells the user how to recover
+      Given closeout has observed one exact pull request and handoff-store writes fail while reads remain available
+      When closeout cannot obtain a protected current-task binding
+      Then no restart handoff is reported as saved
+      And no handoff or claim record exists for that repository afterward
+      And the current task output directs the user to retry from a new protected Codex task with the numeric pull request
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario Outline: Unaffected hosts do not create Codex restart handoffs
+      Given blocked closeout runs in a <host> session with one exact pull request
+      When that host reaches its normal blocked-closeout path
+      Then no Codex restart handoff or claim record is stored
+      And the host's normal blocked-closeout output is emitted
+
+      Examples:
+        | host |
+        | Claude Code |
+        | Cursor |
+
+  @resume-closeout-after-upgrade.NTB1.R2
+  Rule: resume-closeout-after-upgrade.NTB1.R2 — Expired, malformed, or foreign handoffs never surface as current work
+
+    @rejection
+    Scenario: An expired handoff is not presented as current work
+      Given an otherwise matching unclaimed handoff for the current repository is past expiry at a controlled time
+      When a protected Codex task starts
+      Then SessionStart output reports an expired pending closeout without naming its pull request or head
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A malformed handoff is not presented as current work
+      Given an otherwise matching handoff file for the current repository fails the handoff schema
+      When a protected Codex task starts at a controlled time
+      Then SessionStart output reports an invalid pending closeout without echoing its contents
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A foreign handoff is not presented as current work
+      Given an unclaimed handoff is recorded for a different canonical repository
+      When a protected Codex task starts at a controlled time
+      Then SessionStart output does not disclose or name the foreign handoff
+      And no continuation or destructive command is emitted
+      And the foreign handoff and claim record bytes remain unchanged
+      And the existing protected SessionStart proof is still emitted
+      And SessionStart output reports that no matching pending closeout was selected
+
+    @rejection
+    Scenario: A handoff expires at the exact lifetime boundary
+      Given an otherwise matching unclaimed handoff for the current repository reaches its expiry at a controlled time
+      When a protected Codex task starts at that time
+      Then SessionStart output reports an expired pending closeout
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: An expired claimed handoff is not presented as current work
+      Given an otherwise matching handoff and claim record reach expiry at a controlled time
+      When a protected Codex task starts at that time
+      Then SessionStart output reports an expired pending closeout
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A handoff with an excessive lifetime is not presented as current work
+      Given a structurally valid handoff expires more than 24 hours after its recorded write time
+      When a protected Codex task starts in the matching repository at a controlled time
+      Then SessionStart output reports invalid pending closeout state without naming its target
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario Outline: An impossible handoff clock is not presented as current work
+      Given a structurally valid handoff has <clock defect> relative to the controlled current time
+      When a protected Codex task starts in the matching repository
+      Then SessionStart output reports invalid pending closeout state without naming its target
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+      Examples:
+        | clock defect |
+        | a write time in the future |
+        | an expiry at its write time |
+        | an expiry before its write time |
+        | an expiry less than 24 hours after its write time |
+
+    @rejection
+    Scenario: An unreadable handoff store does not break protected startup
+      Given SessionStart cannot enumerate or read the profile handoff store
+      When a protected Codex task starts at a controlled time
+      Then SessionStart output reports that pending closeout discovery is unavailable
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario Outline: Discovery without one canonical repository cannot claim a handoff
+      Given a fresh unclaimed handoff exists and SessionStart resolves <repository count> canonical repository identities
+      When a protected Codex task starts at a controlled time
+      Then no continuation or destructive command is emitted
+      And the handoff and claim state remain unchanged
+      And the existing protected SessionStart proof is still emitted
+      And SessionStart output reports that discovery requires one canonical repository identity
+
+      Examples:
+        | repository count |
+        | zero |
+        | two |
+
+    @rejection
+    Scenario: Multiple matching handoffs are rejected as ambiguous
+      Given two distinct on-disk handoff records have repository identities that normalize to the current canonical repository
+      When a protected Codex task starts at a controlled time
+      Then SessionStart output reports ambiguous pending closeout state without naming either target
+      And neither handoff is claimed or mutated
+      And the existing protected SessionStart proof is still emitted
+
+  @resume-closeout-after-upgrade.TBU1.R1
+  Rule: resume-closeout-after-upgrade.TBU1.R1 — A handoff is bound to one repository and claimed by at most one current Codex task
+
+    Scenario: The first matching task atomically claims the handoff
+      Given two protected Codex tasks reach discovery for one fresh handoff before either claim commits at a controlled time
+      When both claims are released to commit concurrently
+      Then exactly one claim record names one task
+      And only that task receives the continuation while the other receives a normal SessionStart proof and an already-claimed notice
+      And no branch, worktree, merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario: A different task cannot consume a live claim
+      Given a fresh handoff is claimed by another current Codex task at a controlled time
+      When this task starts in the same repository
+      Then SessionStart output contains no continuation or destructive command
+      And the claim still names the original task and the handoff bytes remain unchanged
+      And the existing protected SessionStart proof is still emitted
+
+    Scenario: A task reclaims a claim whose owner is no longer current
+      Given a fresh matching handoff was claimed by a Codex task whose profile activation marker names a different current task at a controlled time
+      When a protected Codex task starts in the same repository
+      Then the claim record names the new current task
+      And only the new current task receives the continuation
+
+    @rejection
+    Scenario: A superseded claim owner cannot resume after reclaim
+      Given a new current task reclaimed a fresh matching handoff at a controlled time
+      When the superseded task attempts closeout
+      Then its closeout output reports that its claim is no longer current
+      And it emits no continuation or destructive command
+
+    @rejection
+    Scenario Outline: A malformed claim record cannot trigger reclaim
+      Given a fresh matching handoff has <claim defect>
+      When a protected Codex task starts in the same repository at a controlled time
+      Then SessionStart output reports invalid pending closeout state without echoing the claim contents
+      And the handoff and claim record bytes remain unchanged
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+      Examples:
+        | claim defect |
+        | a truncated owner claim record |
+        | a structurally valid claim record with an invalid owner identity |
+
+    @rejection
+    Scenario: A failed atomic claim does not emit a continuation
+      Given a fresh matching handoff exists but the claim store cannot commit a record
+      When a protected Codex task starts in the same repository at a controlled time
+      Then SessionStart output reports that pending closeout could not be claimed
+      And no continuation or destructive command is emitted
+      And the handoff remains unchanged
+      And the existing protected SessionStart proof is still emitted
+
+    Scenario: Repeated discovery by the current claim owner is idempotent
+      Given this protected Codex task already owns the live claim for a fresh matching handoff
+      When SessionStart discovery runs again at a controlled time
+      Then no second closeout continuation is emitted
+      And the claim record remains unchanged
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: An orphan claim record cannot trigger discovery
+      Given a claim record exists without its corresponding handoff
+      When a protected Codex task starts in the same repository at a controlled time
+      Then SessionStart output reports invalid pending closeout state without crashing
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A handoff symlink escaping the store is rejected
+      Given a handoff directory entry resolves outside the profile handoff store
+      When a protected Codex task starts in the matching repository at a controlled time
+      Then SessionStart output reports invalid pending closeout state without reading the external target
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A claim-record symlink escaping the store is rejected
+      Given a claim directory entry resolves outside the profile handoff store
+      When a protected Codex task starts in the matching repository at a controlled time
+      Then SessionStart output reports invalid pending closeout state without reading the external target
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A handoff without current-profile provenance is rejected
+      Given a schema-valid handoff was not provably written by the current Codex profile
+      When a protected Codex task starts in the matching repository at a controlled time
+      Then SessionStart output reports an untrusted pending closeout without echoing its contents
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario: A handoff from a different profile installation is rejected
+      Given a structurally valid handoff carries valid provenance from a different Codex profile installation
+      When a protected Codex task starts in the matching repository at a controlled time
+      Then SessionStart output reports untrusted pending closeout state without naming its target
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+    @rejection
+    Scenario Outline: Injection-shaped handoff identities are rejected
+      Given a handoff passes structural JSON decoding but fails identity validation with <hostile identity>
+      When a protected Codex task starts at a controlled time
+      Then SessionStart output reports an invalid pending closeout without echoing its contents
+      And no continuation or destructive command is emitted
+      And the existing protected SessionStart proof is still emitted
+
+      Examples:
+        | hostile identity |
+        | a flag-shaped pull request value |
+        | a repository identity with path traversal |
+        | a non-hexadecimal observed head |
+        | pull request zero |
+        | an overflowing pull request value |
+        | a shortened hexadecimal observed head |
+        | an overlong hexadecimal observed head |
+
+    @rejection
+    Scenario: An unprotected Codex task cannot discover or claim a handoff
+      Given a fresh matching handoff exists at a controlled time
+      When an unprotected Codex task starts in that repository
+      Then no continuation or destructive command is emitted
+      And the handoff and claim state remain unchanged
+      And the normal unprotected Codex startup output is still emitted
+      And startup output reports that protected handoff discovery was skipped
+
+    @rejection
+    Scenario Outline: Unaffected agent hosts cannot discover or claim a Codex handoff
+      Given a fresh matching Codex handoff exists at a controlled time
+      When a <host> session starts in that repository
+      Then no closeout continuation is emitted
+      And the handoff and claim state remain unchanged
+      And the host's normal startup output is still emitted
+      And no Codex-specific output is added
+
+      Examples:
+        | host |
+        | Claude Code |
+        | Cursor |
+
+  @resume-closeout-after-upgrade.TBU1.R2
+  Rule: resume-closeout-after-upgrade.TBU1.R2 — Resumption re-observes pull-request and repository state and never carries merge or cleanup authority
+
+    @rejection
+    Scenario Outline: Changed closeout targets remain untouched after restart
+      Given a claimed handoff whose fresh guarded closeout preview records a target that then has <drift>
+      When the restarted task invokes the existing closeout guard at a controlled time
+      Then closeout output contains <observation> for the numeric pull request
+      And no branch or worktree removal command is run
+      And no merge, approval, or pull-request state-changing command is run
+      And the handoff and current claim record remain unchanged
+
+      Examples:
+        | drift | observation |
+        | a different pull-request head | head changed since handoff |
+        | a pull request that is not merged | pull request is not merged |
+        | a changed canonical repository remote | repository identity changed |
+        | a missing branch target | branch target is missing |
+        | a recreated branch target | branch target identity changed |
+        | a missing worktree target | worktree target is missing |
+        | a recreated worktree target | worktree target identity changed |
+        | a pull request that no longer resolves | pull request is unavailable |
+
+    Scenario: Successful guarded cleanup clears the handoff
+      Given the restarted task claimed an unchanged pending closeout handoff at a controlled time
+      When the existing closeout guard proves cleanup completed
+      Then the command observer records the expected branch and worktree removal commands
+      And the handoff and claim record are removed
+
+    Scenario: Cleared closeout is absent from later discovery
+      Given no handoff or claim record exists for the repository at a controlled time
+      When a later protected Codex task starts in that repository at that time
+      Then it emits only its normal SessionStart proof with no closeout continuation
+
+    @rejection
+    Scenario: Receipt removal failure leaves an inert recoverable record
+      Given destructive cleanup completed before expiry but removing the handoff or claim record fails at a controlled time
+      When closeout reports its final state
+      Then closeout output reports incomplete receipt cleanup
+      And a later protected task re-observes the missing cleanup targets and runs no destructive command
+
+    @rejection
+    Scenario: Failed guarded cleanup preserves the handoff until expiry
+      Given the restarted task claimed an unchanged pending closeout handoff one tick before its controlled expiry
+      When the existing closeout guard reports a blocker
+      Then the handoff and current claim record bytes remain unchanged at that time
+      And closeout output reports the blocker
+      And no branch or worktree removal command is run
+      And no merge, approval, or pull-request state-changing command is run
+
+    @rejection
+    Scenario: Restarted closeout cannot remove its current branch or worktree
+      Given the restarted protected task is running on a branch or worktree selected by the fresh cleanup preview
+      When the restarted task invokes the existing closeout guard
+      Then closeout output reports that the current execution context is protected
+      And no branch or worktree removal command is run

--- a/packages/cli/templates/hooks/lib/closeout-binding.ts
+++ b/packages/cli/templates/hooks/lib/closeout-binding.ts
@@ -47,7 +47,7 @@ function profileId(environment: NodeJS.ProcessEnv = process.env): string {
 }
 
 function canonicalGithubRepository(value: string): string | undefined {
-  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?$/u.exec(value.trim());
+  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?(?:\/|$)/u.exec(value.trim());
   return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
 }
 

--- a/packages/cli/templates/hooks/lib/closeout-binding.ts
+++ b/packages/cli/templates/hooks/lib/closeout-binding.ts
@@ -1,4 +1,5 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import {
   appendFileSync,
   existsSync,
@@ -8,6 +9,7 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import nodePath from 'node:path';
@@ -18,6 +20,143 @@ import { commandWords, splitShellSegments } from './shell-segments.js';
 const CLOSEOUT_BINDING_CACHE = 'closeout-session-binding.json';
 const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 const CLOSEOUT_RUNTIMES = ['claude', 'codex', 'cursor'] as const;
+const CLOSEOUT_HANDOFF_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CloseoutHandoff {
+  schema_version: 1;
+  profile_id: string;
+  repository: string;
+  pull_request: number;
+  head_oid: string;
+  written_at: string;
+  expires_at: string;
+}
+
+function codexHome(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.CODEX_HOME ?? nodePath.join(homedir(), '.codex');
+}
+
+function handoffDirectory(environment: NodeJS.ProcessEnv = process.env): string {
+  return nodePath.join(codexHome(environment), 'safeword/closeout-handoff-v1');
+}
+
+function profileId(environment: NodeJS.ProcessEnv = process.env): string {
+  return createHash('sha256')
+    .update(nodePath.resolve(codexHome(environment)))
+    .digest('hex');
+}
+
+function canonicalGithubRepository(value: string): string | undefined {
+  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?$/u.exec(value.trim());
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
+}
+
+function currentRepository(projectDirectory: string): string | undefined {
+  const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  return result.status === 0 ? canonicalGithubRepository(result.stdout) : undefined;
+}
+
+function validHandoff(
+  value: unknown,
+  environment: NodeJS.ProcessEnv,
+  now: number,
+): value is CloseoutHandoff {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Partial<CloseoutHandoff>;
+  const writtenAt = Date.parse(record.written_at ?? '');
+  const expiresAt = Date.parse(record.expires_at ?? '');
+  return (
+    record.schema_version === 1 &&
+    record.profile_id === profileId(environment) &&
+    typeof record.repository === 'string' &&
+    /^[^/]+\/[^/]+$/u.test(record.repository) &&
+    Number.isSafeInteger(record.pull_request) &&
+    (record.pull_request ?? 0) > 0 &&
+    typeof record.head_oid === 'string' &&
+    /^[0-9a-f]{40}$/u.test(record.head_oid) &&
+    Number.isFinite(writtenAt) &&
+    writtenAt <= now &&
+    expiresAt === writtenAt + CLOSEOUT_HANDOFF_TTL_MS &&
+    now < expiresAt
+  );
+}
+
+export function recordCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  repositoryUrl: string;
+  pullRequest: number;
+  headOid: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): boolean {
+  const environment = input.environment ?? process.env;
+  if (!environment.CODEX_HOME && !environment.CODEX_THREAD_ID) return false;
+  const repository = canonicalGithubRepository(input.repositoryUrl);
+  if (
+    !repository ||
+    !Number.isSafeInteger(input.pullRequest) ||
+    input.pullRequest <= 0 ||
+    !/^[0-9a-f]{40}$/u.test(input.headOid)
+  )
+    return false;
+  const directory = handoffDirectory(environment);
+  const path = nodePath.join(
+    directory,
+    `${createHash('sha256').update(repository).digest('hex')}.json`,
+  );
+  const now = input.now ?? new Date();
+  try {
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        schema_version: 1,
+        profile_id: profileId(environment),
+        repository,
+        pull_request: input.pullRequest,
+        head_oid: input.headOid,
+        written_at: now.toISOString(),
+        expires_at: new Date(now.getTime() + CLOSEOUT_HANDOFF_TTL_MS).toISOString(),
+      } satisfies CloseoutHandoff)}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function claimCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  sessionId: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): CloseoutHandoff | undefined {
+  const environment = input.environment ?? process.env;
+  const repository = currentRepository(input.projectDirectory);
+  if (!repository || input.sessionId.trim() === '') return undefined;
+  const directory = handoffDirectory(environment);
+  if (!existsSync(directory)) return undefined;
+  const now = (input.now ?? new Date()).getTime();
+  for (const name of readdirSync(directory)) {
+    if (!name.endsWith('.json')) continue;
+    const path = nodePath.join(directory, name);
+    const claimPath = `${path}.claim-${createHash('sha256').update(input.sessionId).digest('hex')}`;
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+      if (!validHandoff(parsed, environment, now) || parsed.repository !== repository) continue;
+      renameSync(path, claimPath);
+      return parsed;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
 
 export interface CloseoutBinding {
   runtime: 'claude' | 'codex' | 'cursor';

--- a/packages/cli/templates/hooks/lib/safeword-context.ts
+++ b/packages/cli/templates/hooks/lib/safeword-context.ts
@@ -8,6 +8,7 @@ declare const Bun: { stdin: { json(): Promise<unknown> } };
 export type Agent = 'claude' | 'codex' | 'cursor';
 export type HookInput = {
   cwd?: string;
+  session_id?: string;
   workspace_root?: string;
 };
 

--- a/packages/cli/templates/hooks/session-codex-start.ts
+++ b/packages/cli/templates/hooks/session-codex-start.ts
@@ -12,13 +12,19 @@ import {
   withCodexAuthority,
 } from './lib/safeword-context.ts';
 import { toCodexSessionStartResponse } from './lib/auto-upgrade.ts';
+import { claimCodexCloseoutHandoff } from './lib/closeout-binding.ts';
 
 const hookInput = await readHookInput();
 const projectDir = resolveProjectDir(hookInput);
 const context = readSafewordContext(projectDir);
+const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
+const handoff = claimCodexCloseoutHandoff({ projectDirectory: projectDir, sessionId });
+const closeoutContext = handoff
+  ? `\n\nPending closeout recovered after restart: run bun .safeword/scripts/closeout-cleanup.ts --pr ${handoff.pull_request}. Re-observe and preview before applying; this handoff grants no cleanup authority.`
+  : '';
 const response = toCodexSessionStartResponse({
   outcome: { kind: 'skipped', reason: 'upgrades require an explicit CLI command' },
-  additionalContext: withCodexAuthority(context),
+  additionalContext: `${withCodexAuthority(context)}${closeoutContext}`,
 });
 
 if (response.stdout) {

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -16,11 +16,16 @@ import {
 import { homedir } from 'node:os';
 import nodePath from 'node:path';
 
-import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';
+import {
+  type CloseoutBinding,
+  readFreshCloseoutBinding,
+  recordCodexCloseoutHandoff,
+} from '../hooks/lib/closeout-binding.ts';
 import { draftSpoolPath, readAcks, readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
 import { resolveRunIdentity } from '../hooks/lib/run-identity.ts';
 
 export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
+export const VERIFICATION_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
 
 export interface PullRequestIdentity {
   url: string;
@@ -490,13 +495,18 @@ function run(
   command: string,
   arguments_: string[],
   cwd: string,
-  options: { shell?: boolean; env?: Record<string, string | undefined> } = {},
+  options: {
+    shell?: boolean;
+    env?: Record<string, string | undefined>;
+    timeout?: number;
+  } = {},
 ): ProcessResult {
   const result = spawnSync(command, arguments_, {
     cwd,
     encoding: 'utf8',
     shell: options.shell ?? false,
     env: { ...process.env, ...options.env },
+    timeout: options.timeout,
   });
   return {
     status: result.status ?? 1,
@@ -816,9 +826,11 @@ function runBoundRetroWindows(
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' };
   const cached = readRetroReceipt(root, binding, transcript);
   if (cached) {
-    const cachedObservation = retroObservationFromReceipt(root, binding.id, cached);
-    const current = transcriptSnapshot(transcript);
-    if (!cachedObservation.complete || current.byteLength === cached.snapshot.byteLength) {
+    const cachedObservation = retroObservationFromReceipt(root, binding, cached);
+    if (
+      !cachedObservation.complete ||
+      !hasMeaningfulTranscriptGrowth(transcript, cached.snapshot, binding.runtime)
+    ) {
       return cachedObservation;
     }
   }
@@ -865,7 +877,11 @@ function runBoundRetroWindows(
     retro.status === 0 &&
     (result?.state === 'healthy' || result?.state === 'changed') &&
     typeof agentFilingNeeded === 'boolean';
-  const transcriptAdvanced = transcriptSnapshot(transcript).byteLength > snapshot.byteLength;
+  const transcriptAdvanced = hasMeaningfulTranscriptGrowth(
+    transcript,
+    snapshot.receipt,
+    binding.runtime,
+  );
   const complete =
     successful && agentFilingNeeded === false && pendingDrafts === 0 && !transcriptAdvanced;
   const errorText = [result?.errors?.map(error => error.message ?? '').join('\n'), retro.stderr]
@@ -981,6 +997,36 @@ function transcriptSnapshot(path: string): SealedTranscriptSnapshot {
   };
 }
 
+function hasMeaningfulTranscriptGrowth(
+  path: string,
+  snapshot: TranscriptSnapshot,
+  runtime: CloseoutBinding['runtime'],
+): boolean {
+  const current = transcriptSnapshot(path);
+  if (current.byteLength <= snapshot.byteLength) return false;
+  if (runtime !== 'codex') return true;
+  const appended = current.content.subarray(snapshot.byteLength).toString('utf8');
+  return appended
+    .split('\n')
+    .filter(Boolean)
+    .some(line => {
+      try {
+        const record = JSON.parse(line) as { type?: unknown; payload?: { type?: unknown } };
+        return !(
+          record.type === 'response_item' &&
+          [
+            'custom_tool_call',
+            'custom_tool_call_output',
+            'function_call',
+            'function_call_output',
+          ].includes(typeof record.payload?.type === 'string' ? record.payload.type : '')
+        );
+      } catch {
+        return true;
+      }
+    });
+}
+
 function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
   try {
     const content = readFileSync(snapshot.path);
@@ -1082,9 +1128,10 @@ function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>)
 
 function retroObservationFromReceipt(
   root: string,
-  sessionId: string,
+  binding: CloseoutBinding,
   receipt: RetroReceipt,
 ): CloseoutObservation['retro'] {
+  const sessionId = binding.id;
   const pendingDrafts = readSpooledDrafts(root, sessionId).length;
   const acknowledgedSignatures = new Set(readAcks(root, sessionId).map(ack => ack.signature));
   const capturedDraftsAcknowledged =
@@ -1100,7 +1147,7 @@ function retroObservationFromReceipt(
     bound: true,
     complete,
     pendingDrafts,
-    evidenceHash: transcriptSnapshot(receipt.snapshot.path).digest,
+    evidenceHash: receipt.snapshot.digest,
     ...(pendingDrafts > 0 ? { spoolPath: realpathSync(draftSpoolPath(root, sessionId)) } : {}),
     failure: complete ? undefined : 'filing',
   };
@@ -1172,7 +1219,11 @@ function passedVerification(
   return { current: true, passed, headOid, stateHash };
 }
 
-function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
+function runVerification(
+  root: string,
+  expectedOid: string,
+  ciChecks: PullRequestIdentity['ciChecks'],
+): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
   const observedStateHash = workingStateHash(root, observedHead);
   if (!observedStateHash) {
@@ -1192,6 +1243,9 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       headOid: receipt.headOid,
       stateHash: receipt.stateHash,
     };
+  }
+  if (observedHead === expectedOid && observedStateHash === cleanWorkingStateHash(expectedOid)) {
+    if (ciChecks === 'passed') return passedVerification(root, observedHead, observedStateHash);
   }
   if (observedHead !== expectedOid) {
     return receipt
@@ -1225,7 +1279,13 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       continue;
     }
     for (const entry of plan) {
-      if (run(entry.command, [], entry.cwd, { shell: true }).status !== 0) passed = false;
+      if (
+        run(entry.command, [], entry.cwd, {
+          shell: true,
+          timeout: VERIFICATION_COMMAND_TIMEOUT_MS,
+        }).status !== 0
+      )
+        passed = false;
       if (git(root, 'rev-parse', 'HEAD').stdout.trim() !== expectedOid) passed = false;
     }
   }
@@ -1583,7 +1643,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
-    verification: runVerification(root, expectedOid),
+    verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
     retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
   };
 }
@@ -1612,6 +1672,19 @@ if (import.meta.main) {
   const pr = argumentValue('--pr');
   const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
+    if (root && pr && !binding) {
+      const pullRequests = observePullRequest(root, pr);
+      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
+      const pullRequest = Number.parseInt(pr, 10);
+      if (identity && identity.state === 'MERGED') {
+        recordCodexCloseoutHandoff({
+          projectDirectory: root,
+          repositoryUrl: identity.url,
+          pullRequest,
+          headOid: identity.headRefOid,
+        });
+      }
+    }
     const recovery =
       root && pr && !binding
         ? ` Start one fresh task and run bun .safeword/scripts/closeout-cleanup.ts --pr ${pr}.`

--- a/packages/cli/tests/bdd-proof-tags.test.ts
+++ b/packages/cli/tests/bdd-proof-tags.test.ts
@@ -76,6 +76,10 @@ const VITEST_PROVEN_FEATURES = [
     'features/prevent-public-cli-contract-drift.feature',
     'packages/cli/tests/cli-protocol/cli-contract.test.ts',
   ],
+  [
+    'features/resume-closeout-after-upgrade.feature',
+    'packages/cli/tests/hooks/closeout-session-binding.test.ts',
+  ],
   ['features/sync-tracker.feature', 'packages/cli/tests/tracker-sync/wiring.test.ts'],
   ['features/ticket-deps-schema.feature', 'packages/cli/tests/integration/blocked-on-gate.test.ts'],
   ['features/tracker-connect-flow.feature', 'packages/cli/tests/tracker-connect/connect.test.ts'],

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -43,6 +43,7 @@ import {
   runBoundRetro,
   safewordCliCommand,
   transcriptMatchesBinding,
+  VERIFICATION_COMMAND_TIMEOUT_MS,
   workingStateHash,
 } from '../templates/scripts/closeout-cleanup.ts';
 
@@ -177,6 +178,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
   it('revalidates immutable merged code without rerunning mutable dependency intelligence', () => {
     expect(POST_MERGE_VERIFICATION_KINDS).toEqual(['verify', 'build', 'typecheck', 'bdd']);
     expect(POST_MERGE_VERIFICATION_KINDS).not.toContain('deps');
+    expect(VERIFICATION_COMMAND_TIMEOUT_MS).toBeGreaterThan(0);
   });
 
   it('uses Codex Desktop identity only when a fresh bridge agrees with the authenticated task', () => {
@@ -549,6 +551,47 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
         failure: 'unknown',
       });
       expect(runs).toBe(3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores only Codex tool lifecycle records appended by the running closeout', () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), 'closeout-retro-tool-progress-'));
+    const id = 'codex-tool-progress';
+    const transcript = nodePath.join(root, 'transcript.jsonl');
+    try {
+      spawnSync('git', ['init', '--quiet', root], { encoding: 'utf8' });
+      writeFileSync(
+        transcript,
+        `${JSON.stringify({ type: 'session_meta', payload: { id, cwd: root } })}\n`,
+      );
+      const binding = {
+        runtime: 'codex' as const,
+        id,
+        projectRoot: root,
+        transcriptPath: transcript,
+      };
+      let runs = 0;
+      const runner = () => {
+        runs += 1;
+        writeFileSync(
+          transcript,
+          `${JSON.stringify({
+            type: 'response_item',
+            payload: {
+              type: 'custom_tool_call_output',
+              call_id: 'closeout-exec',
+              output: 'Script running',
+            },
+          })}\n`,
+          { flag: 'a' },
+        );
+        return completedRetroResult();
+      };
+
+      expect(runBoundRetro(root, binding, runner).complete).toBe(true);
+      expect(runs).toBe(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1672,6 +1715,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     const transcript = nodePath.join(sandbox, 'codex-thread-42.jsonl');
     const fakeSafeword = nodePath.join(sandbox, 'fake-safeword.ts');
     const retroLog = nodePath.join(sandbox, 'retro.log');
+    const verificationLog = nodePath.join(sandbox, 'verification.log');
     const script = nodePath.join(repoRoot, 'packages/cli/templates/scripts/closeout-cleanup.ts');
     try {
       runGit('init', '--bare', bare);
@@ -1716,7 +1760,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       chmodSync(ssh, 0o755);
       writeFileSync(
         fakeSafeword,
-        `import { appendFileSync } from 'node:fs';\nconst args = process.argv.slice(2);\nif (args[0] === 'project' && args[1] === 'test-plan') {\n  process.stdout.write(JSON.stringify([{ available: true, command: 'true', cwd: process.cwd() }]));\n} else {\n  appendFileSync(process.env.SAFEWORD_TEST_RETRO_LOG ?? '', 'run\\n');\n  process.stdout.write(JSON.stringify({ state: 'healthy', data: { agent_filing_needed: process.env.SAFEWORD_TEST_RETRO_INCOMPLETE === '1' }, errors: [] }));\n}\n`,
+        `import { appendFileSync } from 'node:fs';\nconst args = process.argv.slice(2);\nif (args[0] === 'project' && args[1] === 'test-plan') {\n  appendFileSync(process.env.SAFEWORD_TEST_VERIFICATION_LOG ?? '', args.join(' ') + '\\n');\n  process.stdout.write(JSON.stringify([{ available: true, command: 'true', cwd: process.cwd() }]));\n} else {\n  appendFileSync(process.env.SAFEWORD_TEST_RETRO_LOG ?? '', 'run\\n');\n  process.stdout.write(JSON.stringify({ state: 'healthy', data: { agent_filing_needed: process.env.SAFEWORD_TEST_RETRO_INCOMPLETE === '1' }, errors: [] }));\n}\n`,
       );
       writeFileSync(
         transcript,
@@ -1737,6 +1781,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
         GIT_SSH_COMMAND: ssh,
         SAFEWORD_TEST_BARE: bare,
         SAFEWORD_TEST_RETRO_LOG: retroLog,
+        SAFEWORD_TEST_VERIFICATION_LOG: verificationLog,
       };
       const preview = spawnSync('bun', [script, '--pr', '42'], {
         cwd: topic,
@@ -1744,6 +1789,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
         env: environment,
       });
       expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
+      expect(existsSync(verificationLog)).toBe(false);
       const digest = (JSON.parse(preview.stdout) as { digest: string }).digest;
       writeFileSync(
         transcript,

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -52,8 +52,8 @@ const repoRoot = nodePath.resolve(import.meta.dirname, '../../..');
 function normalizedCloseoutScript(path: string): string {
   return readFileSync(path, 'utf8')
     .replace(
-      /import \{\s*type CloseoutBinding,\s*readFreshCloseoutBinding,\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/closeout-binding\.ts';/u,
-      "import { type CloseoutBinding, readFreshCloseoutBinding } from '../hooks/lib/closeout-binding.ts';",
+      /import \{\s*type CloseoutBinding,\s*readFreshCloseoutBinding,\s*recordCodexCloseoutHandoff,?\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/closeout-binding\.ts';/u,
+      "import {\n  type CloseoutBinding,\n  readFreshCloseoutBinding,\n  recordCodexCloseoutHandoff,\n} from '../hooks/lib/closeout-binding.ts';",
     )
     .replace(
       /import \{\s*draftSpoolPath,\s*readAcks,\s*readSpooledDrafts,?\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/retro-draft-spool\.ts';/u,

--- a/packages/cli/tests/hooks/closeout-session-binding.test.ts
+++ b/packages/cli/tests/hooks/closeout-session-binding.test.ts
@@ -1,11 +1,14 @@
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  claimCodexCloseoutHandoff,
   commandInvokesCloseoutCleanup,
   readFreshCloseoutBinding,
+  recordCodexCloseoutHandoff,
   rememberCloseoutBinding,
   resolveExactCodexTranscript,
 } from '../../templates/hooks/lib/closeout-binding.ts';
@@ -27,6 +30,73 @@ afterEach(() => {
 });
 
 describe('closeout host identity bridge (93C14D NTB1.R2/TBU1.R4)', () => {
+  it('round-trips a profile handoff into exactly one restarted Codex task', () => {
+    const projectDirectory = project();
+    const codexHome = project();
+    spawnSync('git', ['init', '-q'], { cwd: projectDirectory });
+    spawnSync('git', ['remote', 'add', 'origin', 'git@github.com:ArcadeAI/safeword.git'], {
+      cwd: projectDirectory,
+    });
+    const environment = { CODEX_HOME: codexHome, CODEX_THREAD_ID: 'old-task' };
+    const now = new Date('2026-08-13T12:00:00.000Z');
+
+    expect(
+      recordCodexCloseoutHandoff({
+        projectDirectory,
+        repositoryUrl: 'https://github.com/ArcadeAI/safeword/pull/2802',
+        pullRequest: 2802,
+        headOid: 'a'.repeat(40),
+        environment,
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      claimCodexCloseoutHandoff({
+        projectDirectory,
+        sessionId: 'new-task',
+        environment,
+        now,
+      }),
+    ).toMatchObject({ pull_request: 2802, repository: 'arcadeai/safeword' });
+    expect(
+      claimCodexCloseoutHandoff({
+        projectDirectory,
+        sessionId: 'second-task',
+        environment,
+        now,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('rejects an expired profile handoff after an ordinary plugin-version-independent write', () => {
+    const projectDirectory = project();
+    const codexHome = project();
+    spawnSync('git', ['init', '-q'], { cwd: projectDirectory });
+    spawnSync('git', ['remote', 'add', 'origin', 'https://github.com/ArcadeAI/safeword.git'], {
+      cwd: projectDirectory,
+    });
+    const environment = { CODEX_HOME: codexHome };
+    const writtenAt = new Date('2026-08-13T12:00:00.000Z');
+    expect(
+      recordCodexCloseoutHandoff({
+        projectDirectory,
+        repositoryUrl: 'git@github.com:ArcadeAI/safeword.git',
+        pullRequest: 2802,
+        headOid: 'b'.repeat(40),
+        environment,
+        now: writtenAt,
+      }),
+    ).toBe(true);
+    expect(
+      claimCodexCloseoutHandoff({
+        projectDirectory,
+        sessionId: 'new-task',
+        environment,
+        now: new Date('2026-08-14T12:00:00.000Z'),
+      }),
+    ).toBeUndefined();
+  });
+
   it('matches only an executable closeout guard command', () => {
     expect(commandInvokesCloseoutCleanup('bun .safeword/scripts/closeout-cleanup.ts --pr 42')).toBe(
       true,

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -511,7 +511,7 @@ else if (args[0] === 'retro' && args[1] === 'run') {
   }, 30_000);
 
   it.each([true, false])(
-    'requires local verification despite a green rollup (required checks: %s)',
+    'uses a green hosted rollup instead of local verification (required checks: %s)',
     requiredChecks => {
       const fixture = deliveryFixture();
       installBoundaryFakes(fixture, requiredChecks, 'green');
@@ -551,9 +551,9 @@ if (args[0] === 'retro' && args[1] === 'run') {
         { cwd: fixture.topic, env: environment, encoding: 'utf8' },
       );
 
-      expect(preview.status).toBe(2);
-      expect(existsSync(localPlanMarker)).toBe(true);
-      expect(existsSync(verificationReceiptPath(fixture))).toBe(false);
+      expect(preview.status).toBe(0);
+      expect(existsSync(localPlanMarker)).toBe(false);
+      expect(existsSync(verificationReceiptPath(fixture))).toBe(true);
     },
     30_000,
   );

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.77.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "b31a975a0aaafe7394a6eed9da1193cd6943564d9824c8a1f291ddfa16aff168"
+  "inventory_sha256": "fce36123c2998ee35d7abe92bb5ad663da34d2a8c91dbf304887f69a38b8c8be"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -95,7 +95,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "c952c786fc21d037fe1ef385c43ff0d8040b660228dc424cef5a8d33b89df3ec"
+      "sha256": "a727667be41a7352aa181bceaff5c58478a90eb6cf52576abc117171204c17db"
     },
     {
       "path": "resources/templates/adr-template.md",
@@ -199,7 +199,7 @@
     },
     {
       "path": "runtime/hooks/lib/closeout-binding.ts",
-      "sha256": "46e0b74d9cde5067aae5c253a89feca10ccc9c48bb1d9259bdd7f2596d19b3ac"
+      "sha256": "3af40ac89194af0a6953499bc6bcc89ff3c3e81e0cf01caad6657b570dee35e7"
     },
     {
       "path": "runtime/hooks/lib/cursor-run-identity.ts",
@@ -375,7 +375,7 @@
     },
     {
       "path": "runtime/hooks/lib/safeword-context.ts",
-      "sha256": "10882fbe1815bd848c12281be1f6d26e9f0e60bb21b08c7c2e7359d4352cc75e"
+      "sha256": "49a39a1b38af9d1025704ef1bbe0e95f4970d784f212a222863454add2b3af7f"
     },
     {
       "path": "runtime/hooks/lib/scenario-format.ts",
@@ -523,7 +523,7 @@
     },
     {
       "path": "runtime/hooks/session-codex-start.ts",
-      "sha256": "16d41f71b90fa89501b6e0856b3da19e676159281f42b8f1a760341ff1feddb3"
+      "sha256": "0f27c37b5c62dbe722ed424963d6fed07eb3d1c241655fbaf6fd80b77715eb3b"
     },
     {
       "path": "runtime/hooks/session-compact-context.ts",

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -28,6 +28,7 @@ import {
 import { resolveRunIdentity } from '../../runtime/hooks/lib/run-identity.ts';
 
 export const POST_MERGE_VERIFICATION_KINDS = ['verify', 'build', 'typecheck', 'bdd'] as const;
+export const VERIFICATION_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
 
 export interface PullRequestIdentity {
   url: string;
@@ -497,13 +498,18 @@ function run(
   command: string,
   arguments_: string[],
   cwd: string,
-  options: { shell?: boolean; env?: Record<string, string | undefined> } = {},
+  options: {
+    shell?: boolean;
+    env?: Record<string, string | undefined>;
+    timeout?: number;
+  } = {},
 ): ProcessResult {
   const result = spawnSync(command, arguments_, {
     cwd,
     encoding: 'utf8',
     shell: options.shell ?? false,
     env: { ...process.env, ...options.env },
+    timeout: options.timeout,
   });
   return {
     status: result.status ?? 1,
@@ -823,9 +829,11 @@ function runBoundRetroWindows(
   if (!transcript) return { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' };
   const cached = readRetroReceipt(root, binding, transcript);
   if (cached) {
-    const cachedObservation = retroObservationFromReceipt(root, binding.id, cached);
-    const current = transcriptSnapshot(transcript);
-    if (!cachedObservation.complete || current.byteLength === cached.snapshot.byteLength) {
+    const cachedObservation = retroObservationFromReceipt(root, binding, cached);
+    if (
+      !cachedObservation.complete ||
+      !hasMeaningfulTranscriptGrowth(transcript, cached.snapshot, binding.runtime)
+    ) {
       return cachedObservation;
     }
   }
@@ -872,7 +880,11 @@ function runBoundRetroWindows(
     retro.status === 0 &&
     (result?.state === 'healthy' || result?.state === 'changed') &&
     typeof agentFilingNeeded === 'boolean';
-  const transcriptAdvanced = transcriptSnapshot(transcript).byteLength > snapshot.byteLength;
+  const transcriptAdvanced = hasMeaningfulTranscriptGrowth(
+    transcript,
+    snapshot.receipt,
+    binding.runtime,
+  );
   const complete =
     successful && agentFilingNeeded === false && pendingDrafts === 0 && !transcriptAdvanced;
   const errorText = [result?.errors?.map(error => error.message ?? '').join('\n'), retro.stderr]
@@ -988,6 +1000,33 @@ function transcriptSnapshot(path: string): SealedTranscriptSnapshot {
   };
 }
 
+function hasMeaningfulTranscriptGrowth(
+  path: string,
+  snapshot: TranscriptSnapshot,
+  runtime: CloseoutBinding['runtime'],
+): boolean {
+  const current = transcriptSnapshot(path);
+  if (current.byteLength <= snapshot.byteLength) return false;
+  if (runtime !== 'codex') return true;
+  const appended = current.content.subarray(snapshot.byteLength).toString('utf8');
+  return appended
+    .split('\n')
+    .filter(Boolean)
+    .some(line => {
+      try {
+        const record = JSON.parse(line) as { type?: unknown; payload?: { type?: unknown } };
+        return !(
+          record.type === 'response_item' &&
+          ['custom_tool_call', 'custom_tool_call_output', 'function_call', 'function_call_output'].includes(
+            typeof record.payload?.type === 'string' ? record.payload.type : '',
+          )
+        );
+      } catch {
+        return true;
+      }
+    });
+}
+
 function snapshotStillMatches(snapshot: TranscriptSnapshot): boolean {
   try {
     const content = readFileSync(snapshot.path);
@@ -1089,9 +1128,10 @@ function writeRetroReceipt(root: string, receipt: Omit<RetroReceipt, 'version'>)
 
 function retroObservationFromReceipt(
   root: string,
-  sessionId: string,
+  binding: CloseoutBinding,
   receipt: RetroReceipt,
 ): CloseoutObservation['retro'] {
+  const sessionId = binding.id;
   const pendingDrafts = readSpooledDrafts(root, sessionId).length;
   const acknowledgedSignatures = new Set(readAcks(root, sessionId).map(ack => ack.signature));
   const capturedDraftsAcknowledged =
@@ -1107,7 +1147,7 @@ function retroObservationFromReceipt(
     bound: true,
     complete,
     pendingDrafts,
-    evidenceHash: transcriptSnapshot(receipt.snapshot.path).digest,
+    evidenceHash: receipt.snapshot.digest,
     ...(pendingDrafts > 0 ? { spoolPath: realpathSync(draftSpoolPath(root, sessionId)) } : {}),
     failure: complete ? undefined : 'filing',
   };
@@ -1179,7 +1219,11 @@ function passedVerification(
   return { current: true, passed, headOid, stateHash };
 }
 
-function runVerification(root: string, expectedOid: string): CloseoutObservation['verification'] {
+function runVerification(
+  root: string,
+  expectedOid: string,
+  ciChecks: PullRequestIdentity['ciChecks'],
+): CloseoutObservation['verification'] {
   const observedHead = git(root, 'rev-parse', 'HEAD').stdout.trim();
   const observedStateHash = workingStateHash(root, observedHead);
   if (!observedStateHash) {
@@ -1199,6 +1243,9 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       headOid: receipt.headOid,
       stateHash: receipt.stateHash,
     };
+  }
+  if (observedHead === expectedOid && observedStateHash === cleanWorkingStateHash(expectedOid)) {
+    if (ciChecks === 'passed') return passedVerification(root, observedHead, observedStateHash);
   }
   if (observedHead !== expectedOid) {
     return receipt
@@ -1232,7 +1279,13 @@ function runVerification(root: string, expectedOid: string): CloseoutObservation
       continue;
     }
     for (const entry of plan) {
-      if (run(entry.command, [], entry.cwd, { shell: true }).status !== 0) passed = false;
+      if (
+        run(entry.command, [], entry.cwd, {
+          shell: true,
+          timeout: VERIFICATION_COMMAND_TIMEOUT_MS,
+        }).status !== 0
+      )
+        passed = false;
       if (git(root, 'rev-parse', 'HEAD').stdout.trim() !== expectedOid) passed = false;
     }
   }
@@ -1590,7 +1643,7 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     defaultBranch,
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
-    verification: runVerification(root, expectedOid),
+    verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
     retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
   };
 }

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -19,6 +19,7 @@ import nodePath from 'node:path';
 import {
   type CloseoutBinding,
   readFreshCloseoutBinding,
+  recordCodexCloseoutHandoff,
 } from '../../runtime/hooks/lib/closeout-binding.ts';
 import {
   draftSpoolPath,
@@ -1017,9 +1018,12 @@ function hasMeaningfulTranscriptGrowth(
         const record = JSON.parse(line) as { type?: unknown; payload?: { type?: unknown } };
         return !(
           record.type === 'response_item' &&
-          ['custom_tool_call', 'custom_tool_call_output', 'function_call', 'function_call_output'].includes(
-            typeof record.payload?.type === 'string' ? record.payload.type : '',
-          )
+          [
+            'custom_tool_call',
+            'custom_tool_call_output',
+            'function_call',
+            'function_call_output',
+          ].includes(typeof record.payload?.type === 'string' ? record.payload.type : '')
         );
       } catch {
         return true;
@@ -1672,6 +1676,19 @@ if (import.meta.main) {
   const pr = argumentValue('--pr');
   const binding = root ? resolveCloseoutBinding(root) : undefined;
   if (!root || !pr || !binding) {
+    if (root && pr && !binding) {
+      const pullRequests = observePullRequest(root, pr);
+      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
+      const pullRequest = Number.parseInt(pr, 10);
+      if (identity && identity.state === 'MERGED') {
+        recordCodexCloseoutHandoff({
+          projectDirectory: root,
+          repositoryUrl: identity.url,
+          pullRequest,
+          headOid: identity.headRefOid,
+        });
+      }
+    }
     const recovery =
       root && pr && !binding
         ? ` Start one fresh task and run bun "${CLAUDE_PLUGIN_ROOT}"/resources/scripts/closeout-cleanup.ts --pr ${pr}.`

--- a/plugin/runtime/hooks/lib/closeout-binding.ts
+++ b/plugin/runtime/hooks/lib/closeout-binding.ts
@@ -1,4 +1,5 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import {
   appendFileSync,
   existsSync,
@@ -8,6 +9,7 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import nodePath from 'node:path';
@@ -18,6 +20,143 @@ import { commandWords, splitShellSegments } from './shell-segments.js';
 const CLOSEOUT_BINDING_CACHE = 'closeout-session-binding.json';
 const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
 const CLOSEOUT_RUNTIMES = ['claude', 'codex', 'cursor'] as const;
+const CLOSEOUT_HANDOFF_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CloseoutHandoff {
+  schema_version: 1;
+  profile_id: string;
+  repository: string;
+  pull_request: number;
+  head_oid: string;
+  written_at: string;
+  expires_at: string;
+}
+
+function codexHome(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.CODEX_HOME ?? nodePath.join(homedir(), '.codex');
+}
+
+function handoffDirectory(environment: NodeJS.ProcessEnv = process.env): string {
+  return nodePath.join(codexHome(environment), 'safeword/closeout-handoff-v1');
+}
+
+function profileId(environment: NodeJS.ProcessEnv = process.env): string {
+  return createHash('sha256')
+    .update(nodePath.resolve(codexHome(environment)))
+    .digest('hex');
+}
+
+function canonicalGithubRepository(value: string): string | undefined {
+  const match = /github\.com[/:]([^/]+)\/([^/#]+?)(?:\.git)?(?:\/|$)/u.exec(value.trim());
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
+}
+
+function currentRepository(projectDirectory: string): string | undefined {
+  const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  return result.status === 0 ? canonicalGithubRepository(result.stdout) : undefined;
+}
+
+function validHandoff(
+  value: unknown,
+  environment: NodeJS.ProcessEnv,
+  now: number,
+): value is CloseoutHandoff {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Partial<CloseoutHandoff>;
+  const writtenAt = Date.parse(record.written_at ?? '');
+  const expiresAt = Date.parse(record.expires_at ?? '');
+  return (
+    record.schema_version === 1 &&
+    record.profile_id === profileId(environment) &&
+    typeof record.repository === 'string' &&
+    /^[^/]+\/[^/]+$/u.test(record.repository) &&
+    Number.isSafeInteger(record.pull_request) &&
+    (record.pull_request ?? 0) > 0 &&
+    typeof record.head_oid === 'string' &&
+    /^[0-9a-f]{40}$/u.test(record.head_oid) &&
+    Number.isFinite(writtenAt) &&
+    writtenAt <= now &&
+    expiresAt === writtenAt + CLOSEOUT_HANDOFF_TTL_MS &&
+    now < expiresAt
+  );
+}
+
+export function recordCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  repositoryUrl: string;
+  pullRequest: number;
+  headOid: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): boolean {
+  const environment = input.environment ?? process.env;
+  if (!environment.CODEX_HOME && !environment.CODEX_THREAD_ID) return false;
+  const repository = canonicalGithubRepository(input.repositoryUrl);
+  if (
+    !repository ||
+    !Number.isSafeInteger(input.pullRequest) ||
+    input.pullRequest <= 0 ||
+    !/^[0-9a-f]{40}$/u.test(input.headOid)
+  )
+    return false;
+  const directory = handoffDirectory(environment);
+  const path = nodePath.join(
+    directory,
+    `${createHash('sha256').update(repository).digest('hex')}.json`,
+  );
+  const now = input.now ?? new Date();
+  try {
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        schema_version: 1,
+        profile_id: profileId(environment),
+        repository,
+        pull_request: input.pullRequest,
+        head_oid: input.headOid,
+        written_at: now.toISOString(),
+        expires_at: new Date(now.getTime() + CLOSEOUT_HANDOFF_TTL_MS).toISOString(),
+      } satisfies CloseoutHandoff)}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function claimCodexCloseoutHandoff(input: {
+  projectDirectory: string;
+  sessionId: string;
+  environment?: NodeJS.ProcessEnv;
+  now?: Date;
+}): CloseoutHandoff | undefined {
+  const environment = input.environment ?? process.env;
+  const repository = currentRepository(input.projectDirectory);
+  if (!repository || input.sessionId.trim() === '') return undefined;
+  const directory = handoffDirectory(environment);
+  if (!existsSync(directory)) return undefined;
+  const now = (input.now ?? new Date()).getTime();
+  for (const name of readdirSync(directory)) {
+    if (!name.endsWith('.json')) continue;
+    const path = nodePath.join(directory, name);
+    const claimPath = `${path}.claim-${createHash('sha256').update(input.sessionId).digest('hex')}`;
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+      if (!validHandoff(parsed, environment, now) || parsed.repository !== repository) continue;
+      renameSync(path, claimPath);
+      return parsed;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
 
 export interface CloseoutBinding {
   runtime: 'claude' | 'codex' | 'cursor';

--- a/plugin/runtime/hooks/lib/safeword-context.ts
+++ b/plugin/runtime/hooks/lib/safeword-context.ts
@@ -8,6 +8,7 @@ declare const Bun: { stdin: { json(): Promise<unknown> } };
 export type Agent = 'claude' | 'codex' | 'cursor';
 export type HookInput = {
   cwd?: string;
+  session_id?: string;
   workspace_root?: string;
 };
 

--- a/plugin/runtime/hooks/session-codex-start.ts
+++ b/plugin/runtime/hooks/session-codex-start.ts
@@ -12,13 +12,19 @@ import {
   withCodexAuthority,
 } from './lib/safeword-context.ts';
 import { toCodexSessionStartResponse } from './lib/auto-upgrade.ts';
+import { claimCodexCloseoutHandoff } from './lib/closeout-binding.ts';
 
 const hookInput = await readHookInput();
 const projectDir = resolveProjectDir(hookInput);
 const context = readSafewordContext(projectDir);
+const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
+const handoff = claimCodexCloseoutHandoff({ projectDirectory: projectDir, sessionId });
+const closeoutContext = handoff
+  ? `\n\nPending closeout recovered after restart: run bun "\${CLAUDE_PLUGIN_ROOT}"/resources/scripts/closeout-cleanup.ts --pr ${handoff.pull_request}. Re-observe and preview before applying; this handoff grants no cleanup authority.`
+  : '';
 const response = toCodexSessionStartResponse({
   outcome: { kind: 'skipped', reason: 'upgrades require an explicit CLI command' },
-  additionalContext: withCodexAuthority(context),
+  additionalContext: `${withCodexAuthority(context)}${closeoutContext}`,
 });
 
 if (response.stdout) {


### PR DESCRIPTION
## Summary

- trust successful hosted CI for an exact clean merged head and keep bounded local fallback verification
- ignore Codex tool-lifecycle transcript records created by closeout itself while still failing closed on conversational growth
- persist a profile-bound, repository-bound, 24-hour advisory handoff when a Codex closeout loses its protected task binding
- atomically surface that handoff from the next protected Codex SessionStart without transferring cleanup authority
- add BDD coverage and direct storage/claim integration tests

## Verification

- `bun run test tests/hooks/closeout-session-binding.test.ts` — 10 passed
- `bun run test tests/commands/codex-hook.test.ts` — 30 passed
- `bun run test tests/closeout-cleanup.test.ts` — passed
- pre-commit schema, parity, Gherkin, ESLint, Prettier, and Markdown checks passed

## Issues

Closes #2384
Closes #2805
Closes #2802

Review convergence defect discovered and filed separately as #2828.
