### PR TITLE
chore(release): v0.78.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.77.0",
+      "version": "0.78.0",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.77.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.0 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.77.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.0 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.77.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.0 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.77.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.0 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.77.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.0 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.77.0",
+  "plugin_version": "0.78.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "fce36123c2998ee35d7abe92bb5ad663da34d2a8c91dbf304887f69a38b8c8be"
+  "inventory_sha256": "87f19e10d10020e85a88ce70ce992f70de86b659d70d7b2ef0cb2fb4d4899277"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "7d18236896c04691fe7628a61c0affa21016833815b2c1adf1e7ee64f5ea66e0"
+      "sha256": "9035147df5c64c9c0de40ab559848ba28fe0e117e82e73def79328982170a0d0"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- release Safeword 0.78.0
- publish resilient Codex closeout handoff and green hosted-CI closeout support
- synchronize CLI, Claude plugin, Codex plugin, hook pins, generated catalogue, and lockfile

## Verification

- Codex headless activation: 5/5
- release contract: 36/36
- full GitHub CI required before merge