### PR TITLE
test: make environment-dependent tests hold outside CI, and guard the rule

### DIFF
--- a/.project/tickets/93C14D-close-completed-sessions-safely/manual-review-request.json
+++ b/.project/tickets/93C14D-close-completed-sessions-safely/manual-review-request.json
@@ -92,24 +92,12 @@
       "sha256": "b2b6ed4428c784e2086fc2f7e9e6f95dbc2890c881f198a3ebf122026fed3962"
     },
     {
-      "path": "plugin/runtime/cli.js",
-      "sha256": "199147462ab7a94473497ae3bb38daecf5ca8b9a1cf5212bb27d133e539ff2f2"
-    },
-    {
       "path": "plugin/runtime/hooks/lib/closeout-binding.ts",
       "sha256": "4d89818ea62ee89d894a56a1947e05d1ee9edbf8eff45882a2c3adc2a589164e"
     },
     {
       "path": "plugin/runtime/hooks/lib/retro-extract.ts",
       "sha256": "390086ac3d80bbce4787aae788f6fb788adbbd383f2134964bc5bb13b877d45e"
-    },
-    {
-      "path": "plugin/identity.json",
-      "sha256": "7676ee1f028e7af127a8a4a4333ca9694acd27f7147d7a34e19827bd2735c6f8"
-    },
-    {
-      "path": "plugin/inventory.json",
-      "sha256": "77bcc3f808b9caf85f1661f6ae3f07ee0e31c541c0e17dd5b75008b076ed3f12"
     },
     {
       "path": "packages/cli/tests/closeout-skill.test.ts",

--- a/.project/tickets/93C14D-close-completed-sessions-safely/manual-review.md
+++ b/.project/tickets/93C14D-close-completed-sessions-safely/manual-review.md
@@ -1,7 +1,7 @@
 # Manual Review
 
 Fresh review is bound to the post-merge manifest. The author-side orchestrator
-recomputed 39/39 input hashes and 58/58 ordered scenario titles; the independent
+recomputed 36/36 input hashes and 58/58 ordered scenario titles; the independent
 reviewer read every bound input and evaluated every scenario without relying on
 the prior review verdict.
 
@@ -18,7 +18,7 @@ check and rejects any mismatch.
     "identity": "claude-headless:ec6efe37-35d9-4dcb-9774-2118ef47d1e7",
     "model": "claude-sonnet-5 (headless Claude Code 2.1.220)"
   },
-  "manifest_sha256": "e945fcb6eca6f238d154da6f96199517aa578e89b15a619ee6ef8ff533443d61",
+  "manifest_sha256": "fc3e1743b894a0647c7c78e1055e9a79cbce73b21303b9587457dae2b9a10c2f",
   "verdicts": [
     { "id": "01", "verdict": "pass" },
     { "id": "02", "verdict": "pass" },

--- a/packages/cli/tests/claude-plugin/automatic-migration.test.ts
+++ b/packages/cli/tests/claude-plugin/automatic-migration.test.ts
@@ -12,7 +12,7 @@ import {
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { migrateClaudeLegacyAutomatically } from '../../src/claude-plugin/cleanup.js';
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
@@ -21,6 +21,7 @@ import {
   historicalHookEntry,
 } from '../../src/claude-plugin/historical-ownership.js';
 import { readClaudePluginMode } from '../../src/claude-plugin/migration-state.js';
+import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
 const roots: string[] = [];
@@ -74,8 +75,15 @@ afterEach(() => {
   roots.length = 0;
 });
 
+/** Releases this suite reads real bytes from; shared with the history preflight. */
+const FIXTURE_VERSIONS = ['0.68.0', '0.69.0', '0.72.0'];
+
 describe('automatic Claude migration', () => {
-  it.each(['0.68.0', '0.69.0', '0.72.0'])(
+  beforeAll(() => {
+    requireHistoricalReleaseTags(FIXTURE_VERSIONS);
+  });
+
+  it.each(FIXTURE_VERSIONS)(
     'contracts exact %s released bytes and writes clean plugin mode silently',
     version => {
       const { root, installedPath } = fixture(version);

--- a/packages/cli/tests/claude-plugin/automatic-migration.test.ts
+++ b/packages/cli/tests/claude-plugin/automatic-migration.test.ts
@@ -23,7 +23,7 @@ import {
 import { readClaudePluginMode } from '../../src/claude-plugin/migration-state.js';
 import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
-const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const roots: string[] = [];
 const hookDigest = 'a'.repeat(64);
 const originalProjectDirectory = process.env.CLAUDE_PROJECT_DIR;

--- a/packages/cli/tests/claude-plugin/automatic-migration.test.ts
+++ b/packages/cli/tests/claude-plugin/automatic-migration.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../src/claude-plugin/historical-ownership.js';
 import { readClaudePluginMode } from '../../src/claude-plugin/migration-state.js';
 import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
+import { blockWrites } from '../helpers/io-failure.js';
 
 const roots: string[] = [];
 const hookDigest = 'a'.repeat(64);
@@ -286,8 +287,9 @@ describe('automatic Claude migration', () => {
   });
 
   it('contains unexpected migration exceptions instead of throwing into the prompt', () => {
-    const missing = nodePath.join(tmpdir(), 'safeword-missing-project-for-auto-migration');
-    rmSync(missing, { recursive: true, force: true });
+    const container = mkdtempSync(nodePath.join(tmpdir(), 'safeword-missing-project-'));
+    roots.push(container);
+    const missing = nodePath.join(container, 'not-created');
     expect(() => migrate(missing)).not.toThrow();
     expect(migrate(missing)).toMatchObject({ state: 'attention' });
   });
@@ -296,9 +298,7 @@ describe('automatic Claude migration', () => {
     const { root, installedPath } = fixture();
     const target = nodePath.join(root, installedPath);
     const before = readFileSync(target);
-    mkdirSync(nodePath.join(root, '.safeword/claude-plugin/cleanup-transaction-v1.json'), {
-      recursive: true,
-    });
+    blockWrites(nodePath.join(root, '.safeword/claude-plugin/cleanup-transaction-v1.json'));
 
     const result = migrate(root);
 

--- a/packages/cli/tests/claude-plugin/automatic-migration.test.ts
+++ b/packages/cli/tests/claude-plugin/automatic-migration.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -21,9 +20,8 @@ import {
   historicalHookEntry,
 } from '../../src/claude-plugin/historical-ownership.js';
 import { readClaudePluginMode } from '../../src/claude-plugin/migration-state.js';
-import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
+import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
-const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const roots: string[] = [];
 const hookDigest = 'a'.repeat(64);
 const originalProjectDirectory = process.env.CLAUDE_PROJECT_DIR;
@@ -37,20 +35,7 @@ function fixture(version = '0.72.0'): { root: string; installedPath: string } {
     ];
   const installedPath = Object.keys(release.files)[0];
   if (installedPath === undefined) throw new Error(`Release ${version} has no Claude fixture.`);
-  const schema = execFileSync('git', ['show', `v${version}:packages/cli/src/schema.ts`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-  const escaped = installedPath.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
-  // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
-  const template = new RegExp(
-    String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
-    'su',
-  ).exec(schema)?.[1];
-  const content = execFileSync('git', ['show', `v${version}:packages/cli/templates/${template}`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
+  const content = readHistoricalTemplate(version, installedPath);
   const target = nodePath.join(root, installedPath);
   mkdirSync(nodePath.dirname(target), { recursive: true });
   writeFileSync(target, content);

--- a/packages/cli/tests/claude-plugin/dispatch.test.ts
+++ b/packages/cli/tests/claude-plugin/dispatch.test.ts
@@ -14,7 +14,7 @@ import {
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
 import {
@@ -23,6 +23,7 @@ import {
 } from '../../src/claude-plugin/historical-ownership.js';
 import { claudeWatchedSettingsDigest } from '../../src/claude-plugin/migration-state.js';
 import { SAFEWORD_SCHEMA } from '../../src/schema.js';
+import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 const PLUGIN_ROOT = nodePath.join(REPO_ROOT, 'plugin');
@@ -165,7 +166,14 @@ function refreshPluginIdentity(pluginRoot: string, changedAssets: readonly strin
   writeFileSync(identityPath, `${JSON.stringify(identity, undefined, 2)}\n`);
 }
 
+/** Releases this suite reads real bytes from; shared with the history preflight. */
+const FIXTURE_VERSIONS = ['0.72.0'];
+
 describe('Claude plugin dispatcher', () => {
+  beforeAll(() => {
+    requireHistoricalReleaseTags(FIXTURE_VERSIONS);
+  });
+
   it('passes the bundled CLI path to aggregate child hooks', () => {
     const projectDirectory = temporary('safeword-plugin-project-');
     const pluginData = temporary('safeword-plugin-data-');

--- a/packages/cli/tests/claude-plugin/dispatch.test.ts
+++ b/packages/cli/tests/claude-plugin/dispatch.test.ts
@@ -91,6 +91,21 @@ function dispatchPrompt(
   });
 }
 
+function isolatedClaudeEnvironment(
+  projectDirectory: string,
+  pluginData: string,
+  pluginRoot = PLUGIN_ROOT,
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CLAUDE_CONFIG_DIR: temporary('safeword-plugin-empty-config-'),
+    CLAUDE_PLUGIN_DATA: pluginData,
+    CLAUDE_PLUGIN_ROOT: pluginRoot,
+    CLAUDE_PROJECT_DIR: projectDirectory,
+    HOME: temporary('safeword-plugin-empty-home-'),
+  };
+}
+
 function dispatchEvent(
   projectDirectory: string,
   pluginData: string,
@@ -111,7 +126,7 @@ function dispatchEvent(
     CLAUDE_PLUGIN_DATA: pluginData,
     CLAUDE_PLUGIN_ROOT: pluginRoot,
     CLAUDE_PROJECT_DIR: projectDirectory,
-    HOME: options.homeDirectory ?? process.env.HOME,
+    HOME: options.homeDirectory ?? temporary('safeword-plugin-empty-home-'),
   };
   if (options.omitProjectDirectory === true) delete environment.CLAUDE_PROJECT_DIR;
   if (configDirectory === undefined) delete environment.CLAUDE_CONFIG_DIR;
@@ -165,12 +180,7 @@ describe('Claude plugin dispatcher', () => {
     const projectDirectory = temporary('safeword-plugin-project-');
     const pluginData = temporary('safeword-plugin-data-');
     mkdirSync(nodePath.join(projectDirectory, '.safeword'));
-    const environment: NodeJS.ProcessEnv = {
-      ...process.env,
-      CLAUDE_PLUGIN_DATA: pluginData,
-      CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
-      CLAUDE_PROJECT_DIR: projectDirectory,
-    };
+    const environment = isolatedClaudeEnvironment(projectDirectory, pluginData);
     delete environment.SAFEWORD_PLUGIN_CLI;
 
     const result = spawnSync(
@@ -298,12 +308,7 @@ describe('Claude plugin dispatcher', () => {
     const pluginData = temporary('safeword-plugin-empty-command-data-');
     const target = releasedAsset(projectDirectory);
     promptSettings(projectDirectory, { source: { source: 'github', repo: 'ArcadeAI/safeword' } });
-    const environment: NodeJS.ProcessEnv = {
-      ...process.env,
-      CLAUDE_PLUGIN_DATA: pluginData,
-      CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
-      CLAUDE_PROJECT_DIR: projectDirectory,
-    };
+    const environment = isolatedClaudeEnvironment(projectDirectory, pluginData);
 
     const result = spawnSync(
       'bun',
@@ -560,12 +565,7 @@ describe('Claude plugin dispatcher', () => {
     writeFileSync(eventGroupsPath, `${JSON.stringify(eventGroups, undefined, 2)}\n`);
     refreshPluginIdentity(pluginRoot, ['runtime/event-groups.json']);
 
-    const environment: NodeJS.ProcessEnv = {
-      ...process.env,
-      CLAUDE_PLUGIN_DATA: pluginData,
-      CLAUDE_PLUGIN_ROOT: pluginRoot,
-      CLAUDE_PROJECT_DIR: projectDirectory,
-    };
+    const environment = isolatedClaudeEnvironment(projectDirectory, pluginData, pluginRoot);
     const result = spawnSync(
       'bun',
       [nodePath.join(pluginRoot, 'runtime/dispatch.js'), 'SessionStart', '--event-group'],
@@ -694,12 +694,7 @@ describe('Claude plugin dispatcher', () => {
       ],
       {
         cwd: projectDirectory,
-        env: {
-          ...process.env,
-          CLAUDE_PLUGIN_DATA: pluginData,
-          CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
-          CLAUDE_PROJECT_DIR: projectDirectory,
-        },
+        env: isolatedClaudeEnvironment(projectDirectory, pluginData),
         encoding: 'utf8',
         input: JSON.stringify({ hook_event_name: 'UserPromptSubmit', session_id: 'direct-prompt' }),
       },

--- a/packages/cli/tests/claude-plugin/dispatch.test.ts
+++ b/packages/cli/tests/claude-plugin/dispatch.test.ts
@@ -24,6 +24,7 @@ import {
 import { claudeWatchedSettingsDigest } from '../../src/claude-plugin/migration-state.js';
 import { SAFEWORD_SCHEMA } from '../../src/schema.js';
 import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
+import { blockChildren } from '../helpers/io-failure.js';
 
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 /** Release this suite reads real bytes from; shared with the history preflight. */
@@ -581,7 +582,7 @@ describe('Claude plugin dispatcher', () => {
     const configDirectory = temporary('safeword-plugin-proof-failure-config-');
     const target = releasedAsset(projectDirectory);
     promptSettings(projectDirectory, { source: { source: 'github', repo: 'ArcadeAI/safeword' } });
-    writeFileSync(pluginData, 'proof directory collision\n');
+    blockChildren(pluginData);
 
     const result = dispatchPrompt(projectDirectory, pluginData, configDirectory, 'proof-failure');
     expect(result.status, result.stderr).toBe(0);
@@ -681,7 +682,7 @@ describe('Claude plugin dispatcher', () => {
   it('returns one JSON response when a direct prompt hook also needs an advisory', () => {
     const projectDirectory = temporary('safeword-plugin-direct-prompt-project-');
     const pluginData = nodePath.join(temporary('safeword-plugin-direct-prompt-data-'), 'not-a-dir');
-    writeFileSync(pluginData, 'proof directory collision\n');
+    blockChildren(pluginData);
     const result = spawnSync(
       'bun',
       [

--- a/packages/cli/tests/claude-plugin/dispatch.test.ts
+++ b/packages/cli/tests/claude-plugin/dispatch.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   cpSync,
@@ -23,7 +23,7 @@ import {
 } from '../../src/claude-plugin/historical-ownership.js';
 import { claudeWatchedSettingsDigest } from '../../src/claude-plugin/migration-state.js';
 import { SAFEWORD_SCHEMA } from '../../src/schema.js';
-import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
+import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
 /** Release this suite reads real bytes from; shared with the history preflight. */
@@ -53,24 +53,9 @@ function releasedAsset(projectDirectory: string): string {
 }
 
 function releasedFile(projectDirectory: string, installedPath: string): string {
-  const schema = execFileSync('git', ['show', `v${FIXTURE_VERSION}:packages/cli/src/schema.ts`], {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-  });
-  const escaped = installedPath.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
-  // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
-  const template = new RegExp(
-    String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
-    'su',
-  ).exec(schema)?.[1];
   const target = nodePath.join(projectDirectory, installedPath);
   mkdirSync(nodePath.dirname(target), { recursive: true });
-  writeFileSync(
-    target,
-    execFileSync('git', ['show', `v${FIXTURE_VERSION}:packages/cli/templates/${template}`], {
-      cwd: REPO_ROOT,
-    }),
-  );
+  writeFileSync(target, readHistoricalTemplate(FIXTURE_VERSION, installedPath));
   return target;
 }
 

--- a/packages/cli/tests/claude-plugin/dispatch.test.ts
+++ b/packages/cli/tests/claude-plugin/dispatch.test.ts
@@ -26,6 +26,9 @@ import { SAFEWORD_SCHEMA } from '../../src/schema.js';
 import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const REPO_ROOT = nodePath.resolve(import.meta.dirname, '../../../..');
+/** Release this suite reads real bytes from; shared with the history preflight. */
+const FIXTURE_VERSION = '0.72.0';
+const FIXTURE_VERSIONS = [FIXTURE_VERSION];
 const PLUGIN_ROOT = nodePath.join(REPO_ROOT, 'plugin');
 const roots: string[] = [];
 
@@ -41,14 +44,16 @@ function temporary(prefix: string): string {
 }
 
 function releasedAsset(projectDirectory: string): string {
-  const release = CLAUDE_HISTORICAL_CATALOGUE.releases['0.72.0'];
+  const release = CLAUDE_HISTORICAL_CATALOGUE.releases[FIXTURE_VERSION];
   const installedPath = Object.keys(release.files)[0];
-  if (installedPath === undefined) throw new Error('Release 0.72.0 has no Claude fixture.');
+  if (installedPath === undefined) {
+    throw new Error(`Release ${FIXTURE_VERSION} has no Claude fixture.`);
+  }
   return releasedFile(projectDirectory, installedPath);
 }
 
 function releasedFile(projectDirectory: string, installedPath: string): string {
-  const schema = execFileSync('git', ['show', 'v0.72.0:packages/cli/src/schema.ts'], {
+  const schema = execFileSync('git', ['show', `v${FIXTURE_VERSION}:packages/cli/src/schema.ts`], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
   });
@@ -62,7 +67,7 @@ function releasedFile(projectDirectory: string, installedPath: string): string {
   mkdirSync(nodePath.dirname(target), { recursive: true });
   writeFileSync(
     target,
-    execFileSync('git', ['show', `v0.72.0:packages/cli/templates/${template}`], {
+    execFileSync('git', ['show', `v${FIXTURE_VERSION}:packages/cli/templates/${template}`], {
       cwd: REPO_ROOT,
     }),
   );
@@ -71,7 +76,7 @@ function releasedFile(projectDirectory: string, installedPath: string): string {
 
 function promptSettings(projectDirectory: string, marketplace: unknown): void {
   const fingerprint =
-    CLAUDE_HISTORICAL_CATALOGUE.releases['0.72.0'].hooks.UserPromptSubmit?.[0] ?? '';
+    CLAUDE_HISTORICAL_CATALOGUE.releases[FIXTURE_VERSION].hooks.UserPromptSubmit?.[0] ?? '';
   const hook = historicalHookEntry(fingerprint);
   const command = /\.safeword\/hooks\/[\w./-]+/u.exec(JSON.stringify(hook))?.[0];
   if (command === undefined) throw new Error('Historical prompt hook has no project hook path.');
@@ -165,9 +170,6 @@ function refreshPluginIdentity(pluginRoot: string, changedAssets: readonly strin
     .digest('hex');
   writeFileSync(identityPath, `${JSON.stringify(identity, undefined, 2)}\n`);
 }
-
-/** Releases this suite reads real bytes from; shared with the history preflight. */
-const FIXTURE_VERSIONS = ['0.72.0'];
 
 describe('Claude plugin dispatcher', () => {
   beforeAll(() => {

--- a/packages/cli/tests/claude-plugin/historical-ownership.test.ts
+++ b/packages/cli/tests/claude-plugin/historical-ownership.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
 import {
@@ -10,6 +10,7 @@ import {
   isAcceptedHistoricalHook,
   supportedClaudeLegacyReleases,
 } from '../../src/claude-plugin/historical-ownership.js';
+import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
 
@@ -20,7 +21,14 @@ function gitShow(tag: string, path: string): string {
   });
 }
 
+/** Releases this suite reads real bytes from; shared with the history preflight. */
+const FIXTURE_VERSIONS = ['0.68.0', '0.69.0', '0.72.0'];
+
 describe('Claude historical ownership catalogue', () => {
+  beforeAll(() => {
+    requireHistoricalReleaseTags(FIXTURE_VERSIONS);
+  });
+
   it('contains the required released migration fixtures and prerelease history', () => {
     expect(supportedClaudeLegacyReleases()).toEqual(
       expect.arrayContaining(['0.68.0', '0.69.0', '0.71.0-rc.0', '0.72.0']),
@@ -28,7 +36,7 @@ describe('Claude historical ownership catalogue', () => {
     expect(historicalCatalogueDigest()).toMatch(/^[\da-f]{64}$/u);
   });
 
-  it.each(['0.68.0', '0.69.0', '0.72.0'])('recognizes real %s released file bytes', version => {
+  it.each(FIXTURE_VERSIONS)('recognizes real %s released file bytes', version => {
     const release =
       CLAUDE_HISTORICAL_CATALOGUE.releases[
         version as keyof typeof CLAUDE_HISTORICAL_CATALOGUE.releases

--- a/packages/cli/tests/claude-plugin/historical-ownership.test.ts
+++ b/packages/cli/tests/claude-plugin/historical-ownership.test.ts
@@ -1,6 +1,3 @@
-import { execFileSync } from 'node:child_process';
-import nodePath from 'node:path';
-
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
@@ -11,16 +8,7 @@ import {
   isAcceptedHistoricalHook,
   supportedClaudeLegacyReleases,
 } from '../../src/claude-plugin/historical-ownership.js';
-import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
-
-const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
-
-function gitShow(tag: string, path: string): string {
-  return execFileSync('git', ['show', `${tag}:${path}`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-}
+import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 /** Releases this suite reads real bytes from; shared with the history preflight. */
 const FIXTURE_VERSIONS = ['0.68.0', '0.69.0', '0.72.0'];
@@ -44,15 +32,7 @@ describe('Claude historical ownership catalogue', () => {
       ];
     const [installedPath, expectedDigest] = Object.entries(release.files)[0] ?? [];
     expect(installedPath).toBeDefined();
-    const schema = gitShow(`v${version}`, 'packages/cli/src/schema.ts');
-    const escaped = installedPath?.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`) ?? '';
-    // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
-    const template = new RegExp(
-      String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
-      'su',
-    ).exec(schema)?.[1];
-    expect(template).toBeDefined();
-    const content = gitShow(`v${version}`, `packages/cli/templates/${template}`);
+    const content = readHistoricalTemplate(version, installedPath ?? '');
     expect(isAcceptedHistoricalFile(installedPath ?? '', content)).toBe(true);
     expect(expectedDigest).toMatch(/^[\da-f]{64}$/u);
     expect(isAcceptedHistoricalFile(installedPath ?? '', `${content}\nmodified`)).toBe(false);

--- a/packages/cli/tests/claude-plugin/historical-ownership.test.ts
+++ b/packages/cli/tests/claude-plugin/historical-ownership.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import nodePath from 'node:path';
 
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -12,7 +13,7 @@ import {
 } from '../../src/claude-plugin/historical-ownership.js';
 import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
-const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 
 function gitShow(tag: string, path: string): string {
   return execFileSync('git', ['show', `${tag}:${path}`], {

--- a/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
+++ b/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
@@ -3,11 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
 import { historicalHookEntry } from '../../src/claude-plugin/historical-ownership.js';
 import { observeClaudeLegacy } from '../../src/claude-plugin/legacy-classifier.js';
+import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
 const fixtures: string[] = [];
@@ -30,33 +31,37 @@ afterEach(() => {
   fixtures.length = 0;
 });
 
-describe('Claude legacy classifier', () => {
-  it.each(['0.68.0', '0.69.0', '0.72.0'])(
-    'recognizes real %s files and rejects changed bytes',
-    version => {
-      const root = fixture();
-      const release =
-        CLAUDE_HISTORICAL_CATALOGUE.releases[
-          version as keyof typeof CLAUDE_HISTORICAL_CATALOGUE.releases
-        ];
-      const installedPath = Object.keys(release.files)[0];
-      expect(installedPath).toBeDefined();
-      const schema = gitShow(`v${version}`, 'packages/cli/src/schema.ts');
-      const escaped = installedPath?.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`) ?? '';
-      // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
-      const template = new RegExp(
-        String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
-        'su',
-      ).exec(schema)?.[1];
-      const target = nodePath.join(root, installedPath ?? '');
-      mkdirSync(nodePath.dirname(target), { recursive: true });
-      writeFileSync(target, gitShow(`v${version}`, `packages/cli/templates/${template}`));
-      expect(observeClaudeLegacy(root).recognizedFiles).toContain(installedPath);
+/** Releases this suite reads real bytes from; shared with the history preflight. */
+const FIXTURE_VERSIONS = ['0.68.0', '0.69.0', '0.72.0'];
 
-      writeFileSync(target, 'user changed bytes\n');
-      expect(observeClaudeLegacy(root).conflictingFiles).toContain(installedPath);
-    },
-  );
+describe('Claude legacy classifier', () => {
+  beforeAll(() => {
+    requireHistoricalReleaseTags(FIXTURE_VERSIONS);
+  });
+
+  it.each(FIXTURE_VERSIONS)('recognizes real %s files and rejects changed bytes', version => {
+    const root = fixture();
+    const release =
+      CLAUDE_HISTORICAL_CATALOGUE.releases[
+        version as keyof typeof CLAUDE_HISTORICAL_CATALOGUE.releases
+      ];
+    const installedPath = Object.keys(release.files)[0];
+    expect(installedPath).toBeDefined();
+    const schema = gitShow(`v${version}`, 'packages/cli/src/schema.ts');
+    const escaped = installedPath?.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`) ?? '';
+    // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
+    const template = new RegExp(
+      String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
+      'su',
+    ).exec(schema)?.[1];
+    const target = nodePath.join(root, installedPath ?? '');
+    mkdirSync(nodePath.dirname(target), { recursive: true });
+    writeFileSync(target, gitShow(`v${version}`, `packages/cli/templates/${template}`));
+    expect(observeClaudeLegacy(root).recognizedFiles).toContain(installedPath);
+
+    writeFileSync(target, 'user changed bytes\n');
+    expect(observeClaudeLegacy(root).conflictingFiles).toContain(installedPath);
+  });
 
   it('distinguishes exact, modified, and unrelated settings hooks without losing JSONC', () => {
     const root = fixture();

--- a/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
+++ b/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
@@ -10,7 +10,7 @@ import { historicalHookEntry } from '../../src/claude-plugin/historical-ownershi
 import { observeClaudeLegacy } from '../../src/claude-plugin/legacy-classifier.js';
 import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
-const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const fixtures: string[] = [];
 
 function fixture(): string {

--- a/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
+++ b/packages/cli/tests/claude-plugin/legacy-classifier.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
@@ -8,22 +7,14 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { CLAUDE_HISTORICAL_CATALOGUE } from '../../src/claude-plugin/historical-catalogue.generated.js';
 import { historicalHookEntry } from '../../src/claude-plugin/historical-ownership.js';
 import { observeClaudeLegacy } from '../../src/claude-plugin/legacy-classifier.js';
-import { requireHistoricalReleaseTags } from '../helpers/git-history.js';
+import { readHistoricalTemplate, requireHistoricalReleaseTags } from '../helpers/git-history.js';
 
-const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 const fixtures: string[] = [];
 
 function fixture(): string {
   const root = mkdtempSync(nodePath.join(tmpdir(), 'safeword-legacy-classifier-'));
   fixtures.push(root);
   return root;
-}
-
-function gitShow(tag: string, path: string): string {
-  return execFileSync('git', ['show', `${tag}:${path}`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
 }
 
 afterEach(() => {
@@ -47,16 +38,9 @@ describe('Claude legacy classifier', () => {
       ];
     const installedPath = Object.keys(release.files)[0];
     expect(installedPath).toBeDefined();
-    const schema = gitShow(`v${version}`, 'packages/cli/src/schema.ts');
-    const escaped = installedPath?.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`) ?? '';
-    // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
-    const template = new RegExp(
-      String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
-      'su',
-    ).exec(schema)?.[1];
     const target = nodePath.join(root, installedPath ?? '');
     mkdirSync(nodePath.dirname(target), { recursive: true });
-    writeFileSync(target, gitShow(`v${version}`, `packages/cli/templates/${template}`));
+    writeFileSync(target, readHistoricalTemplate(version, installedPath ?? ''));
     expect(observeClaudeLegacy(root).recognizedFiles).toContain(installedPath);
 
     writeFileSync(target, 'user changed bytes\n');

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -370,12 +370,15 @@ describe('configured public-command wiring', () => {
   it('reports a remote issue and pending sidecar when local ticket creation fails', async () => {
     const directory = createTemporaryDirectory();
     configuredGitHubProject(directory);
+    // A regular file where the tickets directory belongs makes every write
+    // beneath it fail with ENOTDIR for every uid. chmod 0o000 cannot express
+    // this for uid 0, because root bypasses directory permission bits.
     const ticketsDirectory = nodePath.join(directory, '.project/tickets');
-    mkdirSync(ticketsDirectory, { recursive: true });
-    chmodSync(ticketsDirectory, 0o000);
+    mkdirSync(nodePath.dirname(ticketsDirectory), { recursive: true });
+    writeFileSync(ticketsDirectory, '');
     const github = installFakeGitHubCli(directory);
 
-    try {
+    {
       const result = await runCli(
         [
           'ticket',
@@ -413,8 +416,6 @@ describe('configured public-command wiring', () => {
           '321': { status: 'pending', ref: { provider: 'github', id: '321' } },
         },
       });
-    } finally {
-      chmodSync(ticketsDirectory, 0o700);
     }
   });
 

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -18,6 +18,9 @@ set -eu
 printf '%s\n' "$*" >> "$SAFEWORD_GH_LOG"
 case "$*" in
   "auth token")
+    if [ "$SAFEWORD_GH_TOKEN_FAIL" = "1" ]; then
+      exit 1
+    fi
     printf 'keychain-token\n'
     ;;
   "api user --jq .login")
@@ -72,6 +75,7 @@ function githubEnvironment(
     GITHUB_TOKEN: `ghp_${'a'.repeat(24)}`,
     SAFEWORD_GH_LOG: fixture.log,
     SAFEWORD_GH_AUTH_FAIL: '0',
+    SAFEWORD_GH_TOKEN_FAIL: '0',
     SAFEWORD_NO_UPDATE_CHECK: '1',
   };
 }
@@ -498,7 +502,8 @@ describe('configured public-command wiring', () => {
           cwd: directory,
           env: {
             ...githubEnvironment(github),
-            GITHUB_TOKEN: 'not-a-real-token',
+            GITHUB_TOKEN: '',
+            SAFEWORD_GH_TOKEN_FAIL: '1',
           },
         },
       );
@@ -541,7 +546,8 @@ describe('configured public-command wiring', () => {
         cwd: directory,
         env: {
           ...githubEnvironment(github),
-          GITHUB_TOKEN: 'not-a-real-token',
+          GITHUB_TOKEN: '',
+          SAFEWORD_GH_TOKEN_FAIL: '1',
         },
       },
     );

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -35,11 +35,15 @@ case "$*" in
   "issue view "*)
     exit 0
     ;;
+  "issue edit "*)
+    exit 0
+    ;;
   "repo view "*)
     printf 'private\n'
     ;;
   *)
-    exit 0
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 97
     ;;
 esac
 `,

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -382,45 +382,44 @@ describe('configured public-command wiring', () => {
     blockChildren(nodePath.join(directory, '.project/tickets'));
     const github = installFakeGitHubCli(directory);
 
-    {
-      const result = await runCli(
-        [
-          'ticket',
-          'new',
-          'partial-ticket',
-          '--type',
-          'task',
-          '--json',
-          '--no-input',
-          '--cwd',
-          directory,
-        ],
-        { cwd: directory, env: githubEnvironment(github) },
-      );
+    const result = await runCli(
+      [
+        'ticket',
+        'new',
+        'partial-ticket',
+        '--type',
+        'task',
+        '--json',
+        '--no-input',
+        '--cwd',
+        directory,
+      ],
+      { cwd: directory, env: githubEnvironment(github) },
+    );
 
-      expect(result).toMatchObject({ exitCode: 1, stderr: '' });
-      expect(JSON.parse(result.stdout)).toMatchObject({
-        state: 'failed',
-        changed: true,
-        effects: {
-          files: [{ kind: 'create', target: '.safeword/tracker-map.json', operation: 'write' }],
-          network: [{ kind: 'issue-create', target: 'github', operation: 'write' }],
+    expect(result).toMatchObject({ exitCode: 1, stderr: '' });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      state: 'failed',
+      changed: true,
+      effects: {
+        files: [{ kind: 'create', target: '.safeword/tracker-map.json', operation: 'write' }],
+        network: [{ kind: 'issue-create', target: 'github', operation: 'write' }],
+      },
+      recovery: [
+        {
+          command: 'safeword tracker sync',
+          requires_human: false,
         },
-        recovery: [
-          {
-            command: 'safeword tracker sync',
-            requires_human: false,
-          },
-        ],
-      });
-      expect(readFileSync(github.log, 'utf8')).toContain('issue create');
-      const sidecar = readFileSync(nodePath.join(directory, '.safeword/tracker-map.json'), 'utf8');
-      expect(JSON.parse(sidecar)).toMatchObject({
-        issues: {
-          '321': { status: 'pending', ref: { provider: 'github', id: '321' } },
-        },
-      });
-    }
+      ],
+    });
+    expect(readFileSync(github.log, 'utf8')).toContain('issue create');
+    expect(readFileSync(github.log, 'utf8')).toContain('partial-ticket');
+    const sidecar = readFileSync(nodePath.join(directory, '.safeword/tracker-map.json'), 'utf8');
+    expect(JSON.parse(sidecar)).toMatchObject({
+      issues: {
+        '321': { status: 'pending', ref: { provider: 'github', id: '321' } },
+      },
+    });
   });
 
   it('preserves the configured ticket invocation when offline mode refuses its network path', async () => {

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { createTemporaryDirectory, runCli } from '../helpers.js';
-import { blockChildren } from '../helpers/io-failure.js';
+import { blockChildren, blockWrites } from '../helpers/io-failure.js';
 
 function installFakeGitHubCli(directory: string): { bin: string; log: string } {
   const bin = nodePath.join(directory, 'bin');
@@ -165,7 +165,7 @@ describe('configured public-command wiring', () => {
 
   it('reports completed connect effects when tracker-map seeding fails', async () => {
     const directory = createTemporaryDirectory();
-    mkdirSync(nodePath.join(directory, '.safeword/tracker-map.json'), { recursive: true });
+    blockWrites(nodePath.join(directory, '.safeword/tracker-map.json'));
     const github = installFakeGitHubCli(directory);
 
     const result = await runCli(

--- a/packages/cli/tests/cli-protocol/configured-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/configured-wiring.test.ts
@@ -4,6 +4,7 @@ import nodePath from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { createTemporaryDirectory, runCli } from '../helpers.js';
+import { blockChildren } from '../helpers/io-failure.js';
 
 function installFakeGitHubCli(directory: string): { bin: string; log: string } {
   const bin = nodePath.join(directory, 'bin');
@@ -370,12 +371,7 @@ describe('configured public-command wiring', () => {
   it('reports a remote issue and pending sidecar when local ticket creation fails', async () => {
     const directory = createTemporaryDirectory();
     configuredGitHubProject(directory);
-    // A regular file where the tickets directory belongs makes every write
-    // beneath it fail with ENOTDIR for every uid. chmod 0o000 cannot express
-    // this for uid 0, because root bypasses directory permission bits.
-    const ticketsDirectory = nodePath.join(directory, '.project/tickets');
-    mkdirSync(nodePath.dirname(ticketsDirectory), { recursive: true });
-    writeFileSync(ticketsDirectory, '');
+    blockChildren(nodePath.join(directory, '.project/tickets'));
     const github = installFakeGitHubCli(directory);
 
     {

--- a/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
+++ b/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
@@ -495,26 +495,24 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('does not claim a mutation when removal fails during preflight', async () => {
     const directory = createTemporaryDirectory();
-    blockScan(nodePath.join(directory, '.safeword'));
+    blockScan(nodePath.join(directory, '.safeword'), 'hooks');
 
-    {
-      const result = await runCli(['remove', '--json', '--no-input', '--cwd', directory], {
-        cwd: directory,
-      });
+    const result = await runCli(['remove', '--json', '--no-input', '--cwd', directory], {
+      cwd: directory,
+    });
 
-      expect(result).toMatchObject({ exitCode: 1, stderr: '' });
-      expect(JSON.parse(result.stdout)).toMatchObject({
-        state: 'failed',
-        changed: false,
-        effects: {
-          files: [],
-          packages: [],
-          configuration: [],
-          network: [],
-          destructive: [],
-        },
-      });
-    }
+    expect(result).toMatchObject({ exitCode: 1, stderr: '' });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      state: 'failed',
+      changed: false,
+      effects: {
+        files: [],
+        packages: [],
+        configuration: [],
+        network: [],
+        destructive: [],
+      },
+    });
   });
 
   it('gives canonical retro leaves options parsed by the retained family alias', async () => {

--- a/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
+++ b/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
@@ -12,6 +12,15 @@ import { createResult } from '../../src/cli-protocol/result.js';
 import { createTemporaryDirectory, runCli } from '../helpers.js';
 import { blockScan } from '../helpers/io-failure.js';
 
+function restoreOwnProperty(
+  target: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) Object.defineProperty(target, key, descriptor);
+  else Reflect.deleteProperty(target, key);
+}
+
 describe('quality-review regressions for the public CLI boundary', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -300,7 +309,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', 'capabilities', '--json', '--no-input']);
     } finally {
-      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
+      restoreOwnProperty(definition, 'handler', originalHandler);
     }
 
     expect(stderr).toEqual([]);
@@ -337,7 +346,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', '--json', '--no-input']);
     } finally {
-      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
+      restoreOwnProperty(definition, 'handler', originalHandler);
     }
 
     expect(stderr).toEqual([]);
@@ -370,7 +379,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', 'capabilities', '--json', '--no-input']);
     } finally {
-      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
+      restoreOwnProperty(definition, 'handler', originalHandler);
       if (originalSignal === undefined) delete process.env.SAFEWORD_REVIEW_PROGRESS;
       else process.env.SAFEWORD_REVIEW_PROGRESS = originalSignal;
     }
@@ -539,7 +548,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
         '--no-input',
       ]);
     } finally {
-      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
+      restoreOwnProperty(definition, 'handler', originalHandler);
     }
 
     expect(JSON.parse(stdout.join(''))).toMatchObject({

--- a/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
+++ b/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { Command } from 'commander';
@@ -10,6 +10,7 @@ import { publicHandler } from '../../src/cli-protocol/public-handlers.js';
 import { registerPublicCommandCatalog } from '../../src/cli-protocol/register.js';
 import { createResult } from '../../src/cli-protocol/result.js';
 import { createTemporaryDirectory, runCli } from '../helpers.js';
+import { blockScan } from '../helpers/io-failure.js';
 
 describe('quality-review regressions for the public CLI boundary', () => {
   afterEach(() => {
@@ -480,12 +481,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('does not claim a mutation when removal fails during preflight', async () => {
     const directory = createTemporaryDirectory();
-    // A self-referential symlink makes the preflight scan fail with ELOOP for
-    // every uid. chmod 0o000 cannot express this for uid 0, because root
-    // bypasses directory permission bits.
-    const safewordDirectory = nodePath.join(directory, '.safeword');
-    mkdirSync(safewordDirectory);
-    symlinkSync('hooks', nodePath.join(safewordDirectory, 'hooks'));
+    blockScan(nodePath.join(directory, '.safeword'));
 
     {
       const result = await runCli(['remove', '--json', '--no-input', '--cwd', directory], {

--- a/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
+++ b/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
@@ -31,7 +31,10 @@ describe('quality-review regressions for the public CLI boundary', () => {
   });
 
   it('reports a missing review publication path as invalid input', async () => {
-    const result = await runCli(['review-pr', 'publish', '--json']);
+    const directory = createTemporaryDirectory();
+    const result = await runCli(['review-pr', 'publish', '--json', '--cwd', directory], {
+      cwd: directory,
+    });
 
     expect(result.exitCode).toBe(1);
     expect(JSON.parse(result.stdout)).toMatchObject({
@@ -40,7 +43,10 @@ describe('quality-review regressions for the public CLI boundary', () => {
   });
 
   it('rejects an unsafe relay retry identity at the public boundary', async () => {
-    const result = await runCli(['retro-relay-retry', '../outside', '--json']);
+    const directory = createTemporaryDirectory();
+    const result = await runCli(['retro-relay-retry', '../outside', '--json', '--cwd', directory], {
+      cwd: directory,
+    });
 
     expect(result.exitCode).toBe(1);
     expect(JSON.parse(result.stdout)).toMatchObject({
@@ -272,7 +278,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('renders a stable JSON result when a post-parse handler throws', async () => {
     const definition = findCommandDefinition('capabilities');
-    const originalHandler = definition.handler;
+    const originalHandler = Object.getOwnPropertyDescriptor(definition, 'handler');
     Object.defineProperty(definition, 'handler', {
       configurable: true,
       value: () => Promise.reject(new Error('adapter exploded')),
@@ -294,10 +300,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', 'capabilities', '--json', '--no-input']);
     } finally {
-      Object.defineProperty(definition, 'handler', {
-        configurable: true,
-        value: originalHandler,
-      });
+      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
     }
 
     expect(stderr).toEqual([]);
@@ -312,7 +315,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('uses the same typed failure boundary for bare status', async () => {
     const definition = findCommandDefinition('status');
-    const originalHandler = definition.handler;
+    const originalHandler = Object.getOwnPropertyDescriptor(definition, 'handler');
     Object.defineProperty(definition, 'handler', {
       configurable: true,
       value: () => Promise.reject(new Error('status adapter exploded')),
@@ -334,10 +337,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', '--json', '--no-input']);
     } finally {
-      Object.defineProperty(definition, 'handler', {
-        configurable: true,
-        value: originalHandler,
-      });
+      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
     }
 
     expect(stderr).toEqual([]);
@@ -351,7 +351,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('consumes the private review progress signal before a non-review handler runs', async () => {
     const definition = findCommandDefinition('capabilities');
-    const originalHandler = definition.handler;
+    const originalHandler = Object.getOwnPropertyDescriptor(definition, 'handler');
     const originalSignal = process.env.SAFEWORD_REVIEW_PROGRESS;
     let observedSignal: string | undefined;
     Object.defineProperty(definition, 'handler', {
@@ -370,10 +370,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
       registerPublicCommandCatalog(program);
       await program.parseAsync(['node', 'safeword', 'capabilities', '--json', '--no-input']);
     } finally {
-      Object.defineProperty(definition, 'handler', {
-        configurable: true,
-        value: originalHandler,
-      });
+      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
       if (originalSignal === undefined) delete process.env.SAFEWORD_REVIEW_PROGRESS;
       else process.env.SAFEWORD_REVIEW_PROGRESS = originalSignal;
     }
@@ -382,7 +379,11 @@ describe('quality-review regressions for the public CLI boundary', () => {
   });
 
   it('renders Commander argument failures through the JSON protocol', async () => {
-    const result = await runCli(['capabilities', '--json', '--no-input', '--definitely-invalid']);
+    const directory = createTemporaryDirectory();
+    const result = await runCli(
+      ['capabilities', '--json', '--no-input', '--definitely-invalid', '--cwd', directory],
+      { cwd: directory },
+    );
 
     expect(result).toMatchObject({ exitCode: 1, stderr: '' });
     expect(JSON.parse(result.stdout)).toMatchObject({
@@ -397,7 +398,8 @@ describe('quality-review regressions for the public CLI boundary', () => {
     ['tracker', 'sync', '--plan', '--json', '--definitely-invalid'],
     ['tracker', 'sync', '--json', '--plan', '--definitely-invalid'],
   ])('keeps machine argument failures stable across boolean option order: %j', async (...argv) => {
-    const result = await runCli(argv);
+    const directory = createTemporaryDirectory();
+    const result = await runCli([...argv, '--cwd', directory], { cwd: directory });
 
     expect(result).toMatchObject({ exitCode: 1, stderr: '' });
     expect(JSON.parse(result.stdout)).toMatchObject({
@@ -425,7 +427,10 @@ describe('quality-review regressions for the public CLI boundary', () => {
   });
 
   it('renders a Commander argument failure once on the human path', async () => {
-    const result = await runCli(['status', '--definitely-invalid']);
+    const directory = createTemporaryDirectory();
+    const result = await runCli(['status', '--definitely-invalid', '--cwd', directory], {
+      cwd: directory,
+    });
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe('');
@@ -505,7 +510,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('gives canonical retro leaves options parsed by the retained family alias', async () => {
     const definition = findCommandDefinition('retro run');
-    const originalHandler = definition.handler;
+    const originalHandler = Object.getOwnPropertyDescriptor(definition, 'handler');
     Object.defineProperty(definition, 'handler', {
       configurable: true,
       value: (invocation: { options: Readonly<Record<string, unknown>> }) =>
@@ -534,10 +539,7 @@ describe('quality-review regressions for the public CLI boundary', () => {
         '--no-input',
       ]);
     } finally {
-      Object.defineProperty(definition, 'handler', {
-        configurable: true,
-        value: originalHandler,
-      });
+      if (originalHandler) Object.defineProperty(definition, 'handler', originalHandler);
     }
 
     expect(JSON.parse(stdout.join(''))).toMatchObject({

--- a/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
+++ b/packages/cli/tests/cli-protocol/quality-review-regressions.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { Command } from 'commander';
@@ -480,11 +480,14 @@ describe('quality-review regressions for the public CLI boundary', () => {
 
   it('does not claim a mutation when removal fails during preflight', async () => {
     const directory = createTemporaryDirectory();
+    // A self-referential symlink makes the preflight scan fail with ELOOP for
+    // every uid. chmod 0o000 cannot express this for uid 0, because root
+    // bypasses directory permission bits.
     const safewordDirectory = nodePath.join(directory, '.safeword');
     mkdirSync(safewordDirectory);
-    chmodSync(safewordDirectory, 0o000);
+    symlinkSync('hooks', nodePath.join(safewordDirectory, 'hooks'));
 
-    try {
+    {
       const result = await runCli(['remove', '--json', '--no-input', '--cwd', directory], {
         cwd: directory,
       });
@@ -501,8 +504,6 @@ describe('quality-review regressions for the public CLI boundary', () => {
           destructive: [],
         },
       });
-    } finally {
-      chmodSync(safewordDirectory, 0o700);
     }
   });
 

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -92,9 +92,12 @@ afterEach(() => {
 });
 
 describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () => {
-  it.each([['--from-index'], ['--from-index', '--stage-output']])(
-    'does not generate or stage architecture when enforcement is opted out: %s',
-    async (...flags) => {
+  it.each([
+    { name: '--from-index', flags: ['--from-index'] },
+    { name: '--from-index --stage-output', flags: ['--from-index', '--stage-output'] },
+  ])(
+    'does not generate or stage architecture when enforcement is opted out: $name',
+    async ({ flags }) => {
       writeEnforcementConfig(context.directory, false);
 
       const result = await runCli(['architecture', ...flags], { cwd: context.directory });

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -549,7 +549,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
       expect(stagedDocument).toContain('### billing');
       expect(stagedDocument).not.toContain('### drafts');
     } finally {
-      rmSync(nodePath.dirname(recoveryPath), { recursive: true, force: true });
+      rmSync(recoveryPath, { force: true });
     }
   });
 

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -283,9 +283,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
 
     expect(result.exitCode).toBe(0);
     expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
-    expect(execFileSync('cat', [DOC_RELATIVE], { cwd: context.directory, encoding: 'utf8' })).toBe(
-      foreign,
-    );
+    expect(readFileSync(nodePath.join(context.directory, DOC_RELATIVE), 'utf8')).toBe(foreign);
   });
 
   it.each([
@@ -339,10 +337,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
 
   it('does not regenerate or stage a stale doc when enforcement is opted out', async () => {
     selfHeal(context.directory);
-    const before = execFileSync('cat', [DOC_RELATIVE], {
-      cwd: context.directory,
-      encoding: 'utf8',
-    });
+    const before = readFileSync(nodePath.join(context.directory, DOC_RELATIVE), 'utf8');
     mkdirSync(nodePath.join(context.directory, 'src', 'billing'), { recursive: true });
     writeFileSync(
       nodePath.join(context.directory, 'src', 'billing', 'index.ts'),
@@ -355,9 +350,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
 
     expect(result.exitCode).toBe(0);
     expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
-    expect(execFileSync('cat', [DOC_RELATIVE], { cwd: context.directory, encoding: 'utf8' })).toBe(
-      before,
-    );
+    expect(readFileSync(nodePath.join(context.directory, DOC_RELATIVE), 'utf8')).toBe(before);
   });
 
   it('does not require the narrative to duplicate the generated package inventory', async () => {
@@ -630,10 +623,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
 
     expect(result.exitCode).toBe(0);
     expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
-    const generated = execFileSync('cat', [DOC_RELATIVE], {
-      cwd: context.directory,
-      encoding: 'utf8',
-    });
+    const generated = readFileSync(nodePath.join(context.directory, DOC_RELATIVE), 'utf8');
     expect(readDocumentFingerprint(generated)).toBe(stagedTreeFingerprint);
   });
 
@@ -683,15 +673,15 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
         'IMPORTANT HUMAN PROSE.',
       ),
     );
-    expect(
-      readDocumentFingerprint(execFileSync('cat', [generatedPath], { encoding: 'utf8' })),
-    ).not.toBe(stagedTreeFingerprint);
+    expect(readDocumentFingerprint(readFileSync(generatedPath, 'utf8'))).not.toBe(
+      stagedTreeFingerprint,
+    );
 
     const result = await runCli(['architecture', '--staged'], { cwd: context.directory });
 
     expect(result.exitCode).toBe(0);
     expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
-    const restored = execFileSync('cat', [generatedPath], { encoding: 'utf8' });
+    const restored = readFileSync(generatedPath, 'utf8');
     expect(readDocumentFingerprint(restored)).toBe(stagedTreeFingerprint);
     expect(restored).toContain('IMPORTANT HUMAN PROSE.');
   });

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -20,6 +20,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -356,7 +357,7 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
   it('does not require the narrative to duplicate the generated package inventory', async () => {
     // Decision records remain silent about packages with no architectural decision.
     // The generated root index owns package coverage, regardless of enforcement.
-    execFileSync('rm', ['-rf', 'src'], { cwd: context.directory });
+    rmSync(nodePath.join(context.directory, 'src'), { force: true, recursive: true });
     writeFileSync(
       nodePath.join(context.directory, 'package.json'),
       JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
@@ -534,6 +535,13 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
     expect(output).not.toContain('nothing was auto-staged');
     const recoveryPath = /Recovery copy: (.+?)\. Cause:/.exec(output)?.[1];
     assert.ok(recoveryPath !== undefined, 'expected the failure output to name a recovery copy');
+    const recoveryRelativeToTemporaryRoot = nodePath.relative(
+      realpathSync(tmpdir()),
+      realpathSync(recoveryPath),
+    );
+    expect(recoveryRelativeToTemporaryRoot).not.toBe('');
+    expect(recoveryRelativeToTemporaryRoot.startsWith(`..${nodePath.sep}`)).toBe(false);
+    expect(nodePath.isAbsolute(recoveryRelativeToTemporaryRoot)).toBe(false);
     try {
       const recoveryContent = readFileSync(recoveryPath, 'utf8');
       expect(recoveryContent).toContain('### drafts');

--- a/packages/cli/tests/commands/architecture-stage.test.ts
+++ b/packages/cli/tests/commands/architecture-stage.test.ts
@@ -40,6 +40,7 @@ import {
   removeTemporaryDirectory,
   runCli,
 } from '../helpers.js';
+import { blockWrites } from '../helpers/io-failure.js';
 
 const context: { directory: string } = { directory: '' };
 
@@ -511,10 +512,14 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
     );
     git(context.directory, 'add', '--', 'src/billing/index.ts');
 
+    // The clean filter runs mid-`git add`, after git has read the content off
+    // stdin, and swaps the document for a directory — so the later worktree
+    // restore fails with EISDIR. `chmod a-w` cannot express this for uid 0,
+    // because root bypasses the write bit and the restore would succeed.
     const filterPath = nodePath.join(context.directory, '.git', 'lock-architecture-filter.sh');
     writeFileSync(
       filterPath,
-      '#!/bin/sh\nchmod a-w "$SAFEWORD_TEST_ARCHITECTURE_DIRECTORY"\ncat\n',
+      '#!/bin/sh\nrm -rf "$SAFEWORD_TEST_ARCHITECTURE_DOCUMENT"\nmkdir "$SAFEWORD_TEST_ARCHITECTURE_DOCUMENT"\ncat\n',
     );
     chmodSync(filterPath, 0o755);
     git(context.directory, 'config', 'filter.architecture-lock.clean', filterPath);
@@ -524,17 +529,12 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
     );
     git(context.directory, 'add', '--', '.gitattributes');
 
-    let result;
-    try {
-      result = await runCli(['architecture', '--stage'], {
-        cwd: context.directory,
-        env: {
-          SAFEWORD_TEST_ARCHITECTURE_DIRECTORY: nodePath.dirname(documentPath),
-        },
-      });
-    } finally {
-      chmodSync(nodePath.dirname(documentPath), 0o755);
-    }
+    const result = await runCli(['architecture', '--stage'], {
+      cwd: context.directory,
+      env: {
+        SAFEWORD_TEST_ARCHITECTURE_DOCUMENT: documentPath,
+      },
+    });
     const output = `${result.stdout}\n${result.stderr}`;
     expect(result.exitCode).toBe(0);
     expect(output).toContain('was staged but unstaged worktree edits could not be restored');
@@ -1072,18 +1072,15 @@ describe('architecture --stage — commit-time auto-fix (FPV0E4 Slice 2)', () =>
       'packages/c/src/index.ts',
     );
 
-    chmodSync(packageB, 0o555);
-    try {
-      const result = await runCli(['architecture', '--stage'], { cwd: context.directory });
+    blockWrites(nodePath.join(packageB, 'architecture.generated.md'));
 
-      expect(result.exitCode).toBe(0);
-      expect(`${result.stdout}\n${result.stderr}`).toContain('nothing was auto-staged');
-      expect(readFileSync(rootDocument, 'utf8')).toBe(rootWithSentinel);
-      expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
-      expect(stagedFiles(context.directory)).not.toContain('packages/b/architecture.generated.md');
-    } finally {
-      chmodSync(packageB, 0o755);
-    }
+    const result = await runCli(['architecture', '--stage'], { cwd: context.directory });
+
+    expect(result.exitCode).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('nothing was auto-staged');
+    expect(readFileSync(rootDocument, 'utf8')).toBe(rootWithSentinel);
+    expect(stagedFiles(context.directory)).not.toContain(DOC_RELATIVE);
+    expect(stagedFiles(context.directory)).not.toContain('packages/b/architecture.generated.md');
   });
 
   it.each([

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -760,8 +760,9 @@ describe('retro relay configuration and execution', () => {
 
   it('keeps consecutive relay fires distinct across pending dead-letter and ack states', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-fires-'));
+    vi.useFakeTimers();
     let now = Date.parse('2026-07-01T00:00:00.000Z');
-    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    vi.setSystemTime(now);
     let finding = rawFinding({ title: 'First occurrence' });
     let accept = false;
     const transmittedRequestIds: string[] = [];
@@ -813,6 +814,7 @@ describe('retro relay configuration and execution', () => {
       expect(transmittedRequestIds).toEqual([firstRequestId]);
 
       now += 24 * 60 * 60 * 1000;
+      vi.setSystemTime(now);
       finding = rawFinding({ title: 'Second occurrence' });
       await runFire(100);
       const deadLetters = await listRelayDeadLetters(projectDirectory);
@@ -825,6 +827,7 @@ describe('retro relay configuration and execution', () => {
 
       finding = rawFinding({ title: 'First occurrence' });
       now += 61_000;
+      vi.setSystemTime(now);
       await runFire(0);
       const revisitedDeadLetters = await listRelayDeadLetters(projectDirectory);
       const stillPending = await listRelayRequests(projectDirectory);
@@ -837,6 +840,7 @@ describe('retro relay configuration and execution', () => {
       accept = true;
       finding = rawFinding({ title: 'Second occurrence' });
       now += 121_000;
+      vi.setSystemTime(now);
       await runFire(100);
       expect(await listRelayRequests(projectDirectory)).toHaveLength(0);
       expect(transmittedRequestIds.at(-1)).toBe(secondRequestId);
@@ -855,7 +859,7 @@ describe('retro relay configuration and execution', () => {
       expect(remaining[0]?.bytes.toString()).toContain('Third occurrence');
       expect(transmittedRequestIds.at(-1)).toBe(remaining[0]?.requestId);
     } finally {
-      nowSpy.mockRestore();
+      vi.useRealTimers();
       rmSync(projectDirectory, { force: true, recursive: true });
     }
   });

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -369,7 +369,7 @@ describe('retro relay configuration and execution', () => {
     let sentPersistedBytes = false;
     const send = vi.fn<typeof fetch>((_input, init) => {
       const body = Buffer.from(init?.body as Uint8Array);
-      const submitted = JSON.parse(body.toString('utf8')) as { requestId: string };
+      const submitted = JSON.parse(body.toString('utf8')) as RelayDraftRequest;
       const relayDirectory = nodePath.join(outbox, '.safeword', 'retro-drafts', 'relay');
       const claim = readdirSync(relayDirectory).find(candidate =>
         candidate.startsWith(`${submitted.requestId}.claim.`),
@@ -378,19 +378,18 @@ describe('retro relay configuration and execution', () => {
       const durable = JSON.parse(
         readFileSync(nodePath.join(relayDirectory, claim), 'utf8'),
       ) as RelayDraftRequest;
-      sentPersistedBytes =
-        JSON.stringify(submitted) ===
-        JSON.stringify({
-          body: durable.body,
-          canonicalKey: durable.canonicalKey,
-          installationId: durable.installationId,
-          labels: durable.labels,
-          legacySignature: durable.legacySignature,
-          repository: durable.repository,
-          requestId: durable.requestId,
-          retryDeadlineAt: durable.retryDeadlineAt,
-          title: durable.title,
-        });
+      expect(submitted).toEqual({
+        body: durable.body,
+        canonicalKey: durable.canonicalKey,
+        installationId: durable.installationId,
+        labels: durable.labels,
+        legacySignature: durable.legacySignature,
+        repository: durable.repository,
+        requestId: durable.requestId,
+        retryDeadlineAt: durable.retryDeadlineAt,
+        title: durable.title,
+      });
+      sentPersistedBytes = true;
       return Promise.resolve(
         Response.json({
           receiptId: 'receipt-ready-attestation',

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -57,6 +57,8 @@ import { readJsonlFile } from '../helpers.js';
 import { sinkWrites } from '../helpers/io-failure.js';
 import { relayReadinessArtifact, validRelayReadinessManifest } from '../helpers/relay-readiness.js';
 
+// Unit tests here isolate command behavior from GitHub. The real REST composition
+// root is proven in cli-protocol/configured-wiring.test.ts.
 vi.mock('../../src/retro/github-rest.js', () => ({
   createRestTransport: () => {},
   createReconcileTransport: () => {},
@@ -90,12 +92,16 @@ function deadLetterRelayPath(projectDirectory: string, requestId: string): strin
   );
 }
 
-function movePersistedRequestToDeadLetter(persisted: { path: string }): {
+function movePersistedRequestToDeadLetter(
+  projectDirectory: string,
+  persisted: { path: string },
+): {
   deadLetter: string;
   originalBytes: Buffer;
 } {
-  const deadLetter = persisted.path.replace(/\.json$/u, '.dead-letter.json');
   const originalBytes = readFileSync(persisted.path);
+  const request = JSON.parse(originalBytes.toString('utf8')) as { requestId: string };
+  const deadLetter = deadLetterRelayPath(projectDirectory, request.requestId);
   writeFileSync(deadLetter, originalBytes);
   rmSync(persisted.path);
   return { deadLetter, originalBytes };
@@ -1985,7 +1991,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-retry-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001479');
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
     const messages: string[] = [];
 
     try {
@@ -2017,7 +2023,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-rearm-race-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001490', 'source-race');
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
     const error = vi.fn<(message: string) => void>();
 
     try {
@@ -2043,7 +2049,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-rearm-injected-fault-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001491', 'source-injected-fault');
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
 
     try {
       await expect(
@@ -2063,7 +2069,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-recover-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001481', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
     const send = vi.fn<typeof fetch>((_input, init) => {
       expect(Buffer.from(init?.body as Uint8Array).toString('utf8')).toContain(original.requestId);
       expect(init?.signal).toBeInstanceOf(AbortSignal);
@@ -2101,7 +2107,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-unresolved-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001482', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
 
     const requestedUrls: string[] = [];
     const send = vi.fn<typeof fetch>((input, _init) => {
@@ -2156,7 +2162,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-renew-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001483', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
     const sent: RelayDraftRequest[] = [];
     const send = vi.fn<typeof fetch>((_input, init) => {
       const request = JSON.parse(
@@ -2206,7 +2212,10 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-invalid-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001484', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
-    const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(persisted);
+    const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(
+      projectDirectory,
+      persisted,
+    );
     const send = vi.fn<typeof fetch>(() =>
       Promise.resolve(
         Response.json(
@@ -2243,7 +2252,10 @@ describe('relay dead-letter recovery command', () => {
       () => 0,
     );
     const persisted = await persistRelayRequest(projectDirectory, original);
-    const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(persisted);
+    const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(
+      projectDirectory,
+      persisted,
+    );
     let attempt = 0;
     const send = vi.fn<typeof fetch>(() => {
       attempt += 1;
@@ -2480,7 +2492,7 @@ describe('relay dead-letter recovery command', () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-ambiguous-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001485', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(projectDirectory, persisted);
     const requestedUrls: string[] = [];
     const send = vi.fn<typeof fetch>(input => {
       let url: string;
@@ -2618,7 +2630,7 @@ describe('relay dead-letter recovery command', () => {
     const durableOutbox = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-cli-outbox-'));
     const original = relayRequest('00000000-0000-4000-8000-000000001480');
     const persisted = await persistRelayRequest(durableOutbox, original);
-    movePersistedRequestToDeadLetter(persisted);
+    movePersistedRequestToDeadLetter(durableOutbox, persisted);
     rmSync(projectDirectory, { recursive: true, force: true });
     const commandEnvironment = {
       ...process.env,

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -61,6 +62,13 @@ vi.mock('../../src/retro/github-rest.js', () => ({
   createReconcileTransport: () => {},
   resolveGitHubToken: () => {},
 }));
+
+function builtCliPath(): string {
+  const path = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
+  if (!existsSync(path))
+    throw new Error(`Built CLI is missing at ${path}; run bun run build first.`);
+  return path;
+}
 
 function activeRelayPath(projectDirectory: string, requestId: string): string {
   const directory = nodePath.join(projectDirectory, '.safeword', 'retro-drafts', 'relay');
@@ -2640,12 +2648,7 @@ describe('relay dead-letter recovery command', () => {
 
       const result = spawnSync(
         process.execPath,
-        [
-          nodePath.resolve(process.cwd(), 'dist', 'cli.js'),
-          'retro-relay-discard',
-          cliRequestId,
-          '--confirm',
-        ],
+        [builtCliPath(), 'retro-relay-discard', cliRequestId, '--confirm'],
         {
           encoding: 'utf8',
           env: {
@@ -2675,7 +2678,7 @@ describe('relay dead-letter recovery command', () => {
     const result = spawnSync(
       process.execPath,
       [
-        nodePath.resolve(process.cwd(), 'dist', 'cli.js'),
+        builtCliPath(),
         'retro-relay-discard',
         '00000000-0000-4000-8000-000000001486;echo-owned',
         '--json',
@@ -2717,24 +2720,16 @@ describe('relay dead-letter recovery command', () => {
     };
 
     try {
-      const listedDeadLetter = spawnSync(
-        process.execPath,
-        [nodePath.resolve(process.cwd(), 'dist', 'cli.js'), 'retro-relay-retry'],
-        {
-          encoding: 'utf8',
-          env: commandEnvironment,
-        },
-      );
+      const listedDeadLetter = spawnSync(process.execPath, [builtCliPath(), 'retro-relay-retry'], {
+        encoding: 'utf8',
+        env: commandEnvironment,
+      });
       expect(listedDeadLetter.status, listedDeadLetter.stderr).toBe(0);
       expect(listedDeadLetter.stdout).toContain(`${original.requestId} dead-letter`);
 
       const result = spawnSync(
         process.execPath,
-        [
-          nodePath.resolve(process.cwd(), 'dist', 'cli.js'),
-          'retro-relay-retry',
-          original.requestId,
-        ],
+        [builtCliPath(), 'retro-relay-retry', original.requestId],
         {
           encoding: 'utf8',
           env: commandEnvironment,
@@ -2745,14 +2740,10 @@ describe('relay dead-letter recovery command', () => {
       expect(result.stdout).toContain(original.requestId);
       const requests = await listRelayRequests(durableOutbox);
       expect(requests[0]?.requestId).toBe(original.requestId);
-      const listedActive = spawnSync(
-        process.execPath,
-        [nodePath.resolve(process.cwd(), 'dist', 'cli.js'), 'retro-relay-retry'],
-        {
-          encoding: 'utf8',
-          env: commandEnvironment,
-        },
-      );
+      const listedActive = spawnSync(process.execPath, [builtCliPath(), 'retro-relay-retry'], {
+        encoding: 'utf8',
+        env: commandEnvironment,
+      });
       expect(listedActive.status, listedActive.stderr).toBe(0);
       expect(listedActive.stdout).toContain(`${original.requestId} active`);
     } finally {
@@ -2772,18 +2763,14 @@ describe('relay dead-letter recovery command', () => {
       );
 
       try {
-        const result = spawnSync(
-          process.execPath,
-          [nodePath.resolve(process.cwd(), 'dist', 'cli.js'), ...commandArguments],
-          {
-            encoding: 'utf8',
-            env: {
-              ...process.env,
-              CLAUDE_PROJECT_DIR: projectDirectory,
-              SAFEWORD_RETRO_RELAY_OUTBOX: 'relative/outbox',
-            },
+        const result = spawnSync(process.execPath, [builtCliPath(), ...commandArguments], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            CLAUDE_PROJECT_DIR: projectDirectory,
+            SAFEWORD_RETRO_RELAY_OUTBOX: 'relative/outbox',
           },
-        );
+        });
 
         expect(result.status).toBe(1);
         expect(result.stderr).toContain(

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -53,6 +53,7 @@ import { DIGEST_CAP, runHeadlessExtraction } from '../../templates/hooks/lib/ret
 import { decideRetroFilingGate } from '../../templates/hooks/lib/retro-filing-gate.js';
 import { captureRetroFilingFault, readReports } from '../../templates/hooks/lib/self-report.js';
 import { readJsonlFile } from '../helpers.js';
+import { sinkWrites } from '../helpers/io-failure.js';
 import { relayReadinessArtifact, validRelayReadinessManifest } from '../helpers/relay-readiness.js';
 
 vi.mock('../../src/retro/github-rest.js', () => ({
@@ -1196,12 +1197,7 @@ describe('runRetro transport selection (BNGK9W — spool → try-REST → drain 
   });
 
   it('retains tracker-filed drafts when acknowledgement writes cannot be read back', async () => {
-    // Point the ack path at /dev/null: appends succeed, read-back is always
-    // empty. A write-only file (chmod 0o200) cannot express this for uid 0,
-    // because root bypasses the read bit and the read-back would succeed.
-    const path = ackFilePath(projectDirectory, 'sess-a');
-    mkdirSync(nodePath.dirname(path), { recursive: true });
-    symlinkSync('/dev/null', path);
+    sinkWrites(ackFilePath(projectDirectory, 'sess-a'));
 
     const transport = new FakeGitHub();
     const outcome = await runRetro(

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -180,7 +180,7 @@ const dependencies = (over: Partial<Parameters<typeof runRetro>[1]> = {}) => ({
   ...over,
 });
 
-describe('runRetro', () => {
+describe('retro relay configuration and execution', () => {
   it('accepts only an absolute relay outbox outside the disposable project', () => {
     const project = mkdtempSync(nodePath.join(tmpdir(), 'retro-outbox-project-'));
     const external = mkdtempSync(nodePath.join(tmpdir(), 'safeword-durable-outbox-'));

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -101,6 +101,26 @@ function movePersistedRequestToDeadLetter(persisted: { path: string }): {
   return { deadLetter, originalBytes };
 }
 
+function relayRequest(
+  randomUUID: string,
+  sourceKey = 'source',
+  now: () => number = Date.now,
+): RelayDraftRequest {
+  return createRelayRequest(
+    {
+      body: 'body',
+      canonicalKey: 'canonical',
+      installationId: 42,
+      labels: ['retro'],
+      legacySignature: 'legacy',
+      repository: 'arcadeai/safeword',
+      sourceKey,
+      title: 'title',
+    },
+    { now, randomUUID: () => randomUUID },
+  );
+}
+
 // Compact in-memory transport — only the network boundary is faked.
 class FakeGitHub implements IssueTracker {
   private nextIssue = 1;
@@ -1960,19 +1980,7 @@ describe('retro summary drop reporting (PNZM3B SM2.R1)', () => {
 describe('relay dead-letter recovery command', () => {
   it('rearms the exact durable request identity for retry', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-retry-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: Date.now, randomUUID: () => '00000000-0000-4000-8000-000000001479' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001479');
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
     const messages: string[] = [];
@@ -2004,19 +2012,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('explains a dead-letter rearm that loses ownership before the transition', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-rearm-race-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source-race',
-        title: 'title',
-      },
-      { now: Date.now, randomUUID: () => '00000000-0000-4000-8000-000000001490' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001490', 'source-race');
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
     const error = vi.fn<(message: string) => void>();
@@ -2042,19 +2038,7 @@ describe('relay dead-letter recovery command', () => {
   it('does not misreport a fault-injection failure as an invalid request identity', async () => {
     const error = vi.fn<(message: string) => void>();
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-rearm-injected-fault-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source-injected-fault',
-        title: 'title',
-      },
-      { now: Date.now, randomUUID: () => '00000000-0000-4000-8000-000000001491' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001491', 'source-injected-fault');
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
 
@@ -2074,19 +2058,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('recovers an expired dead letter by replaying exact bytes to the existing server identity', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-recover-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001481' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001481', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
     const send = vi.fn<typeof fetch>((_input, init) => {
@@ -2124,19 +2096,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('bridges an existing server dead letter to operator recovery', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-unresolved-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001482' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001482', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
 
@@ -2191,19 +2151,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('renews an expired local-only dead letter under the original request identity', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-renew-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001483' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001483', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
     const sent: RelayDraftRequest[] = [];
@@ -2253,19 +2201,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('does not rewrite an expired dead letter for an unrelated validation failure', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-invalid-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001484' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001484', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
     const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(persisted);
     const send = vi.fn<typeof fetch>(() =>
@@ -2298,18 +2234,10 @@ describe('relay dead-letter recovery command', () => {
 
   it('keeps renewed bytes when a retryable 4xx does not reject the payload', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-renew-auth-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source-renew-auth',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001524' },
+    const original = relayRequest(
+      '00000000-0000-4000-8000-000000001524',
+      'source-renew-auth',
+      () => 0,
     );
     const persisted = await persistRelayRequest(projectDirectory, original);
     const { deadLetter, originalBytes } = movePersistedRequestToDeadLetter(persisted);
@@ -2547,19 +2475,7 @@ describe('relay dead-letter recovery command', () => {
 
   it('bridges an ambiguous submit response to the operator recovery endpoint', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-ambiguous-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: () => 0, randomUUID: () => '00000000-0000-4000-8000-000000001485' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001485', 'source', () => 0);
     const persisted = await persistRelayRequest(projectDirectory, original);
     movePersistedRequestToDeadLetter(persisted);
     const requestedUrls: string[] = [];
@@ -2697,19 +2613,7 @@ describe('relay dead-letter recovery command', () => {
   it('lists and rearms through the built Commander entry point', async () => {
     const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-cli-retry-'));
     const durableOutbox = mkdtempSync(nodePath.join(tmpdir(), 'retro-relay-cli-outbox-'));
-    const original = createRelayRequest(
-      {
-        body: 'body',
-        canonicalKey: 'canonical',
-        installationId: 42,
-        labels: ['retro'],
-        legacySignature: 'legacy',
-        repository: 'arcadeai/safeword',
-        sourceKey: 'source',
-        title: 'title',
-      },
-      { now: Date.now, randomUUID: () => '00000000-0000-4000-8000-000000001480' },
-    );
+    const original = relayRequest('00000000-0000-4000-8000-000000001480');
     const persisted = await persistRelayRequest(durableOutbox, original);
     movePersistedRequestToDeadLetter(persisted);
     rmSync(projectDirectory, { recursive: true, force: true });

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from 'node:child_process';
 import {
-  chmodSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -1197,10 +1196,12 @@ describe('runRetro transport selection (BNGK9W — spool → try-REST → drain 
   });
 
   it('retains tracker-filed drafts when acknowledgement writes cannot be read back', async () => {
+    // Point the ack path at /dev/null: appends succeed, read-back is always
+    // empty. A write-only file (chmod 0o200) cannot express this for uid 0,
+    // because root bypasses the read bit and the read-back would succeed.
     const path = ackFilePath(projectDirectory, 'sess-a');
     mkdirSync(nodePath.dirname(path), { recursive: true });
-    writeFileSync(path, '');
-    chmodSync(path, 0o200);
+    symlinkSync('/dev/null', path);
 
     const transport = new FakeGitHub();
     const outcome = await runRetro(

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -752,7 +752,7 @@ describe('retro relay configuration and execution', () => {
         .map(item => JSON.parse(item.bytes.toString()).title as string)
         .toSorted((left, right) => left.localeCompare(right));
       expect(titles).toEqual(['Finding A', 'Finding B']);
-      expect(new Set(requests.map(item => item.requestId))).toHaveLength(2);
+      expect(new Set(requests.map(item => item.requestId)).size).toBe(2);
       expect(sent.map(item => item.title)).toContain('Finding B');
     } finally {
       rmSync(projectDirectory, { force: true, recursive: true });

--- a/packages/cli/tests/commands/retro.test.ts
+++ b/packages/cli/tests/commands/retro.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from 'node:child_process';
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -53,7 +52,7 @@ import {
 import { DIGEST_CAP, runHeadlessExtraction } from '../../templates/hooks/lib/retro-extract.js';
 import { decideRetroFilingGate } from '../../templates/hooks/lib/retro-filing-gate.js';
 import { captureRetroFilingFault, readReports } from '../../templates/hooks/lib/self-report.js';
-import { readJsonlFile } from '../helpers.js';
+import { assertTestCliFresh, readJsonlFile } from '../helpers.js';
 import { sinkWrites } from '../helpers/io-failure.js';
 import { relayReadinessArtifact, validRelayReadinessManifest } from '../helpers/relay-readiness.js';
 
@@ -67,8 +66,7 @@ vi.mock('../../src/retro/github-rest.js', () => ({
 
 function builtCliPath(): string {
   const path = nodePath.resolve(import.meta.dirname, '../../dist/cli.js');
-  if (!existsSync(path))
-    throw new Error(`Built CLI is missing at ${path}; run bun run build first.`);
+  assertTestCliFresh();
   return path;
 }
 
@@ -186,7 +184,7 @@ const dependencies = (over: Partial<Parameters<typeof runRetro>[1]> = {}) => ({
   ...over,
 });
 
-describe('retro relay configuration and execution', () => {
+describe('retro command configuration, extraction, egress, and relay execution', () => {
   it('accepts only an absolute relay outbox outside the disposable project', () => {
     const project = mkdtempSync(nodePath.join(tmpdir(), 'retro-outbox-project-'));
     const external = mkdtempSync(nodePath.join(tmpdir(), 'safeword-durable-outbox-'));
@@ -1462,7 +1460,11 @@ describe('buildAutoExtractor (SM1.AC2 — runner model: sonnet default, config-o
       }),
     );
     const modelFlag = agent === 'codex' ? '-m' : '--model';
-    return { argv: argvSeen, model: argvSeen[argvSeen.indexOf(modelFlag) + 1] };
+    const modelFlagIndex = argvSeen.indexOf(modelFlag);
+    return {
+      argv: argvSeen,
+      model: modelFlagIndex === -1 ? undefined : argvSeen[modelFlagIndex + 1],
+    };
   }
 
   it('builds the extractor with sonnet when no retro.model is configured', async () => {
@@ -1754,7 +1756,7 @@ describe('retroReconcileCommand wiring (G19QG7 SM2.R1)', () => {
   });
 });
 
-describe('retro summary drop reporting (PNZM3B SM2.R1)', () => {
+describe('retro summary reporting and process surfaces (PNZM3B SM2.R1)', () => {
   const reportOptions = (output: Parameters<typeof reportRetroCommandOutcome>[1]['output']) => ({
     extractionSucceeded: true,
     restTransportAvailable: true,

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -401,6 +401,20 @@ function warnIfDistributionStale(): void {
   }
 }
 
+/** Fails direct built-CLI tests when the bundle is missing or older than source. */
+export function assertTestCliFresh(): void {
+  let distributionMtime: number;
+  try {
+    distributionMtime = statSync(testCliPath).mtimeMs;
+  } catch {
+    throw new Error('dist/cli.js is missing; run `bun run --cwd packages/cli build` first');
+  }
+  const newestSource = newestSourceMtime(SOURCE_DIRECTORY);
+  if (newestSource !== undefined && newestSource > distributionMtime) {
+    throw new Error('dist/cli.js is stale; run `bun run --cwd packages/cli build` first');
+  }
+}
+
 function projectFixtureArguments(args: string[]): string[] {
   // Most suites use setup/upgrade only to prepare project files. Keep those fixtures
   // independent of installed hosts; unified-install scenarios invoke the CLI directly.

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -23,10 +23,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import nodePath from 'node:path';
 
 import { supportedClaudeLegacyReleases } from '../../src/claude-plugin/historical-ownership.js';
 
-const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 
 /** Restores both tags and the commit history the sealed-review suites walk. */
 const REMEDY = 'git fetch --unshallow --tags origin';

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -1,0 +1,104 @@
+/**
+ * Preflights for suites that read REAL released bytes out of git history.
+ *
+ * Several suites verify that today's classifier recognizes the exact bytes a
+ * past release shipped, by reading them back with `git show v<version>:<path>`.
+ * Reading from a tag is the point: a tag is an immutable record of what
+ * actually shipped, so the check cannot be satisfied by editing a fixture in
+ * the working tree. A vendored copy would make the test agree with a file that
+ * agrees with the classifier.
+ *
+ * That provenance is bought with full history, and CI pays for it — the jobs
+ * running these suites set `fetch-depth: 0` (see .github/workflows/ci.yml).
+ *
+ * A shallow or tagless clone therefore does not mean the code is broken; it
+ * means the clone cannot answer the question. Without a preflight that shows
+ * up as dozens of bare `fatal: invalid object name 'v0.68.0'` failures spread
+ * across four files, which reads as a broken suite. These helpers turn that
+ * into one sentence per suite, naming the remedy.
+ *
+ * They THROW rather than skip. Skipping would also hide a CI job that lost its
+ * `fetch-depth: 0`, silently disabling the provenance guarantee in the one
+ * environment that must enforce it.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+import { supportedClaudeLegacyReleases } from '../../src/claude-plugin/historical-ownership.js';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+
+/** Restores both tags and the commit history the sealed-review suites walk. */
+const REMEDY = 'git fetch --unshallow --tags origin';
+
+/**
+ * Catalogue keys are release versions AND content digests — only versions are
+ * tagged. Deriving the tag list from the catalogue keeps this tracking the
+ * fixtures automatically, so a newly catalogued release is covered without
+ * editing a hardcoded list here.
+ */
+const RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-[\dA-Za-z.]+)?$/u;
+
+function git(arguments_: readonly string[]): { ok: boolean; stdout: string } {
+  const result = spawnSync('git', [...arguments_], { cwd: repoRoot, encoding: 'utf8' });
+  return { ok: result.status === 0, stdout: (result.stdout ?? '').trim() };
+}
+
+/** Every catalogued release version, i.e. the keys that have a release tag. */
+export function catalogueReleaseVersions(): string[] {
+  return supportedClaudeLegacyReleases().filter(key => RELEASE_VERSION.test(key));
+}
+
+/**
+ * The blob every historical fixture resolves through. Probing it verifies what
+ * the suites actually read — a ref that resolves but whose objects were never
+ * fetched (partial clone) would pass a bare `rev-parse` and still fail here.
+ */
+const FIXTURE_PROBE_PATH = 'packages/cli/src/schema.ts';
+
+/**
+ * Fails when a release this suite reads is absent from the clone, naming the
+ * missing tags so a genuinely deleted tag is distinguishable from a shallow
+ * clone.
+ *
+ * Takes the versions the CALLER reads rather than demanding every catalogued
+ * release: a clone holding exactly the tags its suite needs must pass. Pass the
+ * same array the suite drives its cases from, so the two cannot drift apart.
+ *
+ * Each version is checked against the catalogue first — a typo, or a release
+ * dropped from the catalogue, fails here instead of surfacing later as a
+ * confusing fixture lookup.
+ */
+export function requireHistoricalReleaseTags(versions: readonly string[]): void {
+  const catalogued = new Set(catalogueReleaseVersions());
+  const uncatalogued = versions.filter(version => !catalogued.has(version));
+  if (uncatalogued.length > 0) {
+    throw new Error(
+      `Not catalogued releases: ${uncatalogued.join(', ')}. ` +
+        'Add them to the historical catalogue, or correct the version list in this suite.',
+    );
+  }
+
+  const missing = versions
+    .map(version => `v${version}`)
+    .filter(tag => !git(['cat-file', '-e', `${tag}:${FIXTURE_PROBE_PATH}`]).ok);
+  if (missing.length === 0) return;
+  throw new Error(
+    `This suite verifies real released bytes read from git tags, which this clone is missing: ${missing.join(', ')}.\n` +
+      `CI checks out with fetch-depth: 0 for exactly this reason. To fix locally:\n  ${REMEDY}`,
+  );
+}
+
+/**
+ * Fails on a shallow clone. Tags alone are not enough for suites that walk a
+ * path's ancestry — `git log -- <path>` stops at the shallow boundary and
+ * silently reports fewer commits rather than failing.
+ */
+export function requireFullHistory(): void {
+  if (git(['rev-parse', '--is-shallow-repository']).stdout !== 'true') return;
+  throw new Error(
+    'This suite walks commit ancestry to verify sealed inputs, and this is a shallow clone, ' +
+      'so history is truncated and the walk silently returns too few commits.\n' +
+      `CI checks out with fetch-depth: 0 for exactly this reason. To fix locally:\n  ${REMEDY}`,
+  );
+}

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -101,6 +101,13 @@ export function requireHistoricalReleaseTags(versions: readonly string[]): void 
     );
   }
 
+  if (!git(['rev-parse', '--git-dir']).ok) {
+    throw new Error(
+      'git could not inspect this repository, so historical release fixtures cannot be confirmed. ' +
+        'Check that git is installed and this is a repository.',
+    );
+  }
+
   const missing = versions
     .map(version => `v${version}`)
     .filter(tag => !git(['cat-file', '-e', `${tag}:${FIXTURE_PROBE_PATH}`]).ok);

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -45,6 +45,27 @@ function git(arguments_: readonly string[]): { ok: boolean; stdout: string } {
   return { ok: result.status === 0, stdout: (result.stdout ?? '').trim() };
 }
 
+function gitShow(ref: string): string {
+  const result = spawnSync('git', ['show', ref], { cwd: repoRoot, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`Could not read historical fixture ${ref}.`);
+  return result.stdout;
+}
+
+/** Reads the released template bytes installed at `installedPath`. */
+export function readHistoricalTemplate(version: string, installedPath: string): string {
+  const schema = gitShow(`v${version}:packages/cli/src/schema.ts`);
+  const escaped = installedPath.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+  // eslint-disable-next-line security/detect-non-literal-regexp -- escaped fixture path is test-owned
+  const template = new RegExp(
+    String.raw`['"]${escaped}['"]\s*:\s*\{[^}]*?template:\s*['"]([^'"]+)['"]`,
+    'su',
+  ).exec(schema)?.[1];
+  if (template === undefined) {
+    throw new Error(`Release ${version} has no schema template for ${installedPath}.`);
+  }
+  return gitShow(`v${version}:packages/cli/templates/${template}`);
+}
+
 /** Every catalogued release version, i.e. the keys that have a release tag. */
 function catalogueReleaseVersions(): string[] {
   return supportedClaudeLegacyReleases().filter(key => RELEASE_VERSION.test(key));

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -95,7 +95,18 @@ export function requireHistoricalReleaseTags(versions: readonly string[]): void 
  * silently reports fewer commits rather than failing.
  */
 export function requireFullHistory(): void {
-  if (git(['rev-parse', '--is-shallow-repository']).stdout !== 'true') return;
+  const depth = git(['rev-parse', '--is-shallow-repository']);
+  // Failing open here would reproduce the exact hazard this file exists to
+  // prevent: a git that cannot run returns empty stdout, which is not 'true',
+  // so the shallow check would silently pass and the provenance guarantee
+  // would evaporate in whichever environment broke git.
+  if (!depth.ok) {
+    throw new Error(
+      'git could not report whether this clone is shallow, so the history this suite ' +
+        'needs cannot be confirmed. Check that git is installed and this is a repository.',
+    );
+  }
+  if (depth.stdout !== 'true') return;
   throw new Error(
     'This suite walks commit ancestry to verify sealed inputs, and this is a shallow clone, ' +
       'so history is truncated and the walk silently returns too few commits.\n' +

--- a/packages/cli/tests/helpers/git-history.ts
+++ b/packages/cli/tests/helpers/git-history.ts
@@ -45,7 +45,7 @@ function git(arguments_: readonly string[]): { ok: boolean; stdout: string } {
 }
 
 /** Every catalogued release version, i.e. the keys that have a release tag. */
-export function catalogueReleaseVersions(): string[] {
+function catalogueReleaseVersions(): string[] {
   return supportedClaudeLegacyReleases().filter(key => RELEASE_VERSION.test(key));
 }
 

--- a/packages/cli/tests/helpers/io-failure.test.ts
+++ b/packages/cli/tests/helpers/io-failure.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The io-failure helpers exist so a test can induce an I/O failure that no uid
+ * can bypass. That only holds if they really raise what they document, and if
+ * they survive a path the code under test already wrote — the usual state of
+ * anything worth blocking. Both are asserted here against the real filesystem.
+ */
+
+import { appendFileSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { blockChildren, blockScan, blockWrites, sinkWrites } from './io-failure.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const created of roots) rmSync(created, { force: true, recursive: true });
+  roots.length = 0;
+});
+
+function scratchRoot(): string {
+  const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-io-failure-'));
+  roots.push(directory);
+  return directory;
+}
+
+function errnoOf(run: () => void): string | undefined {
+  try {
+    run();
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code;
+  }
+  return undefined;
+}
+
+describe('io-failure helpers', () => {
+  it('sinkWrites accepts appends and reads back nothing', () => {
+    const path = sinkWrites(nodePath.join(scratchRoot(), 'acks.jsonl'));
+    appendFileSync(path, 'recorded\n');
+    expect(readFileSync(path, 'utf8')).toBe('');
+  });
+
+  it('blockWrites makes writing that exact path fail with EISDIR', () => {
+    const path = blockWrites(nodePath.join(scratchRoot(), 'marker'));
+    expect(
+      errnoOf(() => {
+        appendFileSync(path, 'x');
+      }),
+    ).toBe('EISDIR');
+  });
+
+  it('blockChildren makes anything beneath it fail with ENOTDIR', () => {
+    const directory = blockChildren(nodePath.join(scratchRoot(), 'tickets'));
+    expect(
+      errnoOf(() => {
+        mkdirSync(nodePath.join(directory, 'child'));
+      }),
+    ).toBe('ENOTDIR');
+  });
+
+  it('blockScan makes following the directory fail with ELOOP', () => {
+    const directory = blockScan(nodePath.join(scratchRoot(), '.safeword'));
+    // The directory itself stays listable — the code under test must get far
+    // enough to enumerate it, and fail only when it walks in.
+    expect(readdirSync(directory)).toContain('hooks');
+    expect(errnoOf(() => readFileSync(nodePath.join(directory, 'hooks', 'any')))).toBe('ELOOP');
+  });
+
+  // A helper that throws on setup blocks nothing; it just relocates the failure
+  // into the arrange step, where it reads as a broken test rather than the
+  // simulation it was meant to be.
+  // Positional %s consumes the tuple in order, so the two formatted values must
+  // be the first two elements — the helper goes last or the name reads as source.
+  it.each([
+    ['sinkWrites', 'file', sinkWrites],
+    ['blockWrites', 'file', blockWrites],
+    ['blockChildren', 'directory', blockChildren],
+  ] as const)('%s replaces a path that already exists as a %s', (_name, kind, helper) => {
+    const path = nodePath.join(scratchRoot(), 'occupied');
+    if (kind === 'directory') mkdirSync(path);
+    else blockChildren(path);
+
+    expect(() => helper(path)).not.toThrow();
+  });
+
+  it('blockScan replaces an entry that already exists', () => {
+    const directory = nodePath.join(scratchRoot(), '.safeword');
+    mkdirSync(directory, { recursive: true });
+    mkdirSync(nodePath.join(directory, 'hooks'));
+
+    expect(() => blockScan(directory)).not.toThrow();
+  });
+});

--- a/packages/cli/tests/helpers/io-failure.test.ts
+++ b/packages/cli/tests/helpers/io-failure.test.ts
@@ -42,6 +42,14 @@ describe('io-failure helpers', () => {
     expect(readFileSync(path, 'utf8')).toBe('');
   });
 
+  it('sinkWrites replaces a pre-existing directory', () => {
+    const path = nodePath.join(scratchRoot(), 'acks.jsonl');
+    mkdirSync(path);
+    expect(() => sinkWrites(path)).not.toThrow();
+    appendFileSync(path, 'recorded\n');
+    expect(readFileSync(path, 'utf8')).toBe('');
+  });
+
   it('blockWrites makes writing that exact path fail with EISDIR', () => {
     const path = blockWrites(nodePath.join(scratchRoot(), 'marker'));
     expect(
@@ -61,7 +69,7 @@ describe('io-failure helpers', () => {
   });
 
   it('blockScan makes following the directory fail with ELOOP', () => {
-    const directory = blockScan(nodePath.join(scratchRoot(), '.safeword'));
+    const directory = blockScan(nodePath.join(scratchRoot(), '.safeword'), 'hooks');
     // The directory itself stays listable — the code under test must get far
     // enough to enumerate it, and fail only when it walks in.
     expect(readdirSync(directory)).toContain('hooks');
@@ -90,6 +98,6 @@ describe('io-failure helpers', () => {
     mkdirSync(directory, { recursive: true });
     mkdirSync(nodePath.join(directory, 'hooks'));
 
-    expect(() => blockScan(directory)).not.toThrow();
+    expect(() => blockScan(directory, 'hooks')).not.toThrow();
   });
 });

--- a/packages/cli/tests/helpers/io-failure.ts
+++ b/packages/cli/tests/helpers/io-failure.ts
@@ -1,0 +1,104 @@
+/**
+ * Filesystem-failure simulations that hold for EVERY uid.
+ *
+ * DO NOT use `chmod` to simulate an I/O failure in a test. Root holds
+ * CAP_DAC_OVERRIDE and bypasses every file permission bit, so a chmod-based
+ * simulation silently does not happen under uid 0: the code under test takes
+ * the SUCCESS path, and the test fails while asserting on that success output.
+ *
+ * The failure mode is environment-split, which is what makes it expensive.
+ * GitHub Actions runs as `runner` (uid 1001), so a chmod-based test passes in
+ * CI and fails in every root container — agent sessions, devcontainers, plain
+ * `docker run`. The test looks correct to the author and broken to everyone
+ * reading it from a container.
+ *
+ * Each helper below induces the failure through filesystem STRUCTURE, which
+ * no uid can override. They return the path they were given so a call can be
+ * inlined into the setup it replaces.
+ *
+ * Pick by the failure the code under test must hit:
+ *
+ * | Need                                      | Helper           | errno   |
+ * | ----------------------------------------- | ---------------- | ------- |
+ * | writes accepted, read-back always empty   | `sinkWrites`     | —       |
+ * | writing this exact path fails             | `blockWrites`    | EISDIR  |
+ * | creating anything under this dir fails    | `blockChildren`  | ENOTDIR |
+ * | scanning/stat-ing into this dir fails     | `blockScan`      | ELOOP   |
+ *
+ * If none of them expresses the scenario faithfully, prefer an explicit
+ * `it.skipIf(process.getuid?.() === 0)` with a stated reason over inventing a
+ * simulation that only approximately reproduces the condition. A visible skip
+ * is honest; a test that passes for the wrong reason is not.
+ *
+ * POSIX-only, matching this repo's CI (ubuntu-latest) and the symlink-based
+ * fixtures already used across the suite.
+ */
+
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+/** Creates `path`'s parent directory when it is missing. */
+function ensureParent(path: string): void {
+  mkdirSync(nodePath.dirname(path), { recursive: true });
+}
+
+/**
+ * Points `path` at `/dev/null`: appends and writes succeed, and every read
+ * comes back empty.
+ *
+ * Use for write-then-read-back verification — code that persists a record and
+ * then re-reads it to confirm the write landed. This is the only helper where
+ * the write must SUCCEED; use `blockWrites` when the write itself should fail.
+ */
+export function sinkWrites(path: string): string {
+  ensureParent(path);
+  symlinkSync('/dev/null', path);
+  return path;
+}
+
+/**
+ * Occupies `path` with a directory, so writing the file fails with EISDIR.
+ *
+ * Use when one specific file must not be writable. Prefer this over
+ * `blockChildren` on the parent when the target filename is known — it is
+ * narrower, and leaves the rest of the directory usable.
+ *
+ * DESTRUCTIVE: anything already at `path` is removed first. `mkdirSync` throws
+ * EEXIST against an existing FILE even with `recursive: true`, and a path worth
+ * blocking is usually one the code has already written once. If the prior
+ * contents matter to the assertion, capture them before calling this.
+ */
+export function blockWrites(path: string): string {
+  ensureParent(path);
+  rmSync(path, { force: true, recursive: true });
+  mkdirSync(path);
+  return path;
+}
+
+/**
+ * Occupies `directory` with a regular file, so creating anything beneath it
+ * fails with ENOTDIR.
+ *
+ * Use when the code picks its own filename under a directory you control, so
+ * there is no single target path to block.
+ */
+export function blockChildren(directory: string): string {
+  ensureParent(directory);
+  writeFileSync(directory, '');
+  return directory;
+}
+
+/**
+ * Plants a self-referential symlink inside `directory`, so any scan that
+ * follows its entries fails with ELOOP.
+ *
+ * Use when `directory` must stay a real, readable directory — so the code
+ * gets far enough to enumerate it — but walking into it must fail. Blocking
+ * writes is not equivalent: a scan that merely finds an unexpected file
+ * usually tolerates it and continues down the success path.
+ */
+export function blockScan(directory: string, entryName = 'hooks'): string {
+  mkdirSync(directory, { recursive: true });
+  symlinkSync(entryName, nodePath.join(directory, entryName));
+  return directory;
+}

--- a/packages/cli/tests/helpers/io-failure.ts
+++ b/packages/cli/tests/helpers/io-failure.ts
@@ -52,6 +52,7 @@ function ensureParent(path: string): void {
  */
 export function sinkWrites(path: string): string {
   ensureParent(path);
+  rmSync(path, { force: true, recursive: true });
   symlinkSync('/dev/null', path);
   return path;
 }
@@ -81,9 +82,15 @@ export function blockWrites(path: string): string {
  *
  * Use when the code picks its own filename under a directory you control, so
  * there is no single target path to block.
+ *
+ * DESTRUCTIVE, for the same reason as {@link blockWrites}: `writeFileSync`
+ * throws EISDIR against a path that is already a directory — which is the
+ * usual state of a directory worth blocking — so anything there is removed
+ * first. Capture the prior contents before calling if the assertion needs them.
  */
 export function blockChildren(directory: string): string {
   ensureParent(directory);
+  rmSync(directory, { force: true, recursive: true });
   writeFileSync(directory, '');
   return directory;
 }
@@ -99,6 +106,8 @@ export function blockChildren(directory: string): string {
  */
 export function blockScan(directory: string, entryName = 'hooks'): string {
   mkdirSync(directory, { recursive: true });
-  symlinkSync(entryName, nodePath.join(directory, entryName));
+  const loop = nodePath.join(directory, entryName);
+  rmSync(loop, { force: true, recursive: true });
+  symlinkSync(entryName, loop);
   return directory;
 }

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -242,8 +242,10 @@ function guardedAsNonRoot(sourceFile: ts.SourceFile, simulation: Simulation): bo
 
 /**
  * Finds literal permission-removing simulations not enclosed by a root-skipped
- * test. TypeScript owns source parsing; this module only interprets chmod calls
- * and shell strings, avoiding a second, incomplete JavaScript lexer.
+ * test. Dynamic modes (computed expressions, object properties, or subprocess
+ * argv variables) are intentionally outside this tripwire's scope. TypeScript
+ * owns source parsing; this module only interprets chmod calls and shell strings,
+ * avoiding a second, incomplete JavaScript lexer.
  */
 export function permissionSimulations(source: string): string[] {
   const sourceFile = parse(source);

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -68,11 +68,18 @@ function literalBindings(sourceFile: ts.SourceFile): Map<string, string> {
 
 /** The numeric value of a literal chmod mode, or undefined when it is dynamic. */
 export function literalMode(argument: string): number | undefined {
-  const octal = /^0o([0-7]{3,4})$/u.exec(argument);
-  if (octal?.[1] !== undefined) return Number.parseInt(octal[1], 8);
+  const normalized = argument.replaceAll('_', '');
+  if (
+    /^0o[0-7]+$/iu.test(normalized) ||
+    /^0b[01]+$/iu.test(normalized) ||
+    /^0x[\dA-F]+$/iu.test(normalized) ||
+    /^\d+$/u.test(normalized)
+  ) {
+    return Number(normalized);
+  }
   const quoted = /^(['"])([0-7]{1,4})\1$/u.exec(argument);
   if (quoted?.[2] !== undefined) return Number.parseInt(quoted[2], 8);
-  return argument === '0' ? 0 : undefined;
+  return undefined;
 }
 
 function chmodModeArgumentsFromFile(
@@ -129,7 +136,9 @@ export function shellModeRemovesAccess(mode: string): boolean {
   let access: OwnerAccess = { read: true, write: true };
   for (const clause of mode.split(',')) {
     const next = applySymbolicClause(access, clause);
-    if (!next) return false;
+    // Unknown literal spellings fail closed. Dynamic modes remain outside the
+    // detector's documented scope.
+    if (!next) return !/^(?:\$|`|\$\()/u.test(mode);
     access = next;
   }
   return !access.read || !access.write;

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -1,0 +1,209 @@
+/**
+ * Detects tests that simulate an I/O failure by removing permissions.
+ *
+ * Root holds CAP_DAC_OVERRIDE and bypasses every permission bit, so such a
+ * simulation silently does not happen under uid 0: the code under test takes
+ * the SUCCESS path and the test fails asserting on that success output. CI runs
+ * as uid 1001, so the test is green there and red in every root container.
+ *
+ * The detector is separated from the tripwire that applies it so its own
+ * evasions can be tested directly. A guard nobody can prove is a guard nobody
+ * should trust — and the evasions below were all found by review, not by the
+ * guard.
+ */
+
+/** Owner read+write. A mode missing either bit removes access. */
+export const OWNER_READ_WRITE = 0o600;
+
+/** `chmod a-w`, `chmod -w`, `chmod 000`, `chmod u-w` inside shell fixtures. */
+export const SHELL_CHMOD_REMOVING_ACCESS = /chmod\s+(?:[augo]*-[rw]|0?[0-5][0-7][0-7]\b)/gu;
+
+/** After these, a `/` opens a regex literal rather than dividing. */
+const REGEX_MAY_FOLLOW = new Set(['', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';']);
+
+const QUOTES = new Set(['"', "'", '`']);
+
+/** Index just past a `//` or block comment starting at `from`, or -1. */
+function endOfComment(source: string, from: number): number {
+  if (source[from] !== '/') return -1;
+  const following = source[from + 1];
+  if (following === '/') {
+    const newline = source.indexOf('\n', from);
+    return newline === -1 ? source.length : newline;
+  }
+  if (following !== '*') return -1;
+  const close = source.indexOf('*/', from + 2);
+  return close === -1 ? source.length : close + 2;
+}
+
+/** Index just past the literal opening at `from`, treating `[...]` as a regex class. */
+function endOfDelimited(source: string, from: number, isRegex: boolean): number {
+  const closer = source[from];
+  let index = from + 1;
+  let inCharacterClass = false;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === '\\') {
+      index += 2;
+      continue;
+    }
+    if (isRegex && character === '[') inCharacterClass = true;
+    else if (isRegex && character === ']') inCharacterClass = false;
+    index += 1;
+    if (character === closer && !inCharacterClass) break;
+  }
+  return index;
+}
+
+/**
+ * Drops comments, leaving string literals intact and offsets aligned with the
+ * input (removed spans become spaces, so a reported offset still points at the
+ * original line).
+ *
+ * Scans left to right rather than pattern-matching, because neither half of
+ * this survives a regex:
+ *
+ * - Stripping `//` to end-of-line without knowing what is a string deletes the
+ *   rest of any line holding a URL, so a call sharing a line with one reports
+ *   clean — a guard passing for the wrong reason, the exact failure this
+ *   exists to catch.
+ * - Masking strings first to avoid that then breaks on a regex literal
+ *   containing a quote, which starts a "string" running to the next quote
+ *   anywhere in the file and desynchronizes every comment boundary after it.
+ *   This module's own source contains such a literal.
+ */
+export function withoutComments(source: string): string {
+  let output = '';
+  let index = 0;
+  let previous = '';
+
+  while (index < source.length) {
+    const character = source[index] ?? '';
+
+    const commentEnd = endOfComment(source, index);
+    if (commentEnd !== -1) {
+      output += source.slice(index, commentEnd).replaceAll(/[^\n]/gu, ' ');
+      index = commentEnd;
+      continue;
+    }
+
+    const isRegex = character === '/' && REGEX_MAY_FOLLOW.has(previous);
+    if (QUOTES.has(character) || isRegex) {
+      const literalEnd = endOfDelimited(source, index, isRegex);
+      output += source.slice(index, literalEnd);
+      index = literalEnd;
+      previous = character;
+      continue;
+    }
+
+    output += character;
+    if (character.trim() !== '') previous = character;
+    index += 1;
+  }
+  return output;
+}
+
+/** Splits on commas that are not nested inside brackets; drops empty entries. */
+function topLevelArguments(text: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const character of text) {
+    if (character === ',' && depth === 0) {
+      args.push(current.trim());
+      current = '';
+      continue;
+    }
+    if ('([{'.includes(character)) depth += 1;
+    if (')]}'.includes(character)) depth -= 1;
+    current += character;
+  }
+  args.push(current.trim());
+  return args.filter(argument => argument !== '');
+}
+
+/**
+ * The mode argument of every `chmodSync` call, found by scanning to the
+ * matching close paren rather than matching a shape.
+ *
+ * A regex anchored on `)` right after the literal misses a call Prettier
+ * wrapped with a trailing comma, and a path argument carrying its own comma —
+ * `chmodSync(nodePath.join(a, b), 0o000)` — defeats a `[^,]+` path match.
+ */
+export function chmodModeArguments(source: string): { mode: string; offset: number }[] {
+  const modes: { mode: string; offset: number }[] = [];
+  for (const match of source.matchAll(/chmodSync\s*\(/gu)) {
+    const open = (match.index ?? 0) + match[0].length;
+    let depth = 1;
+    let index = open;
+    while (index < source.length && depth > 0) {
+      if (source[index] === '(') depth += 1;
+      else if (source[index] === ')') depth -= 1;
+      index += 1;
+    }
+    if (depth !== 0) continue;
+    const last = topLevelArguments(source.slice(open, index - 1)).at(-1);
+    if (last !== undefined) modes.push({ mode: last, offset: match.index ?? 0 });
+  }
+  return modes;
+}
+
+/**
+ * The numeric value of a literal mode, or undefined for a variable this cannot
+ * evaluate.
+ *
+ * `0o600` is not the only spelling that reaches chmod: `0` and a quoted `'600'`
+ * are equally valid and equally capable of removing access.
+ */
+export function literalMode(argument: string): number | undefined {
+  const octal = /^0o([0-7]{3,4})$/u.exec(argument);
+  if (octal?.[1] !== undefined) return Number.parseInt(octal[1], 8);
+  const quoted = /^(['"])([0-7]{1,4})\1$/u.exec(argument);
+  if (quoted?.[2] !== undefined) return Number.parseInt(quoted[2], 8);
+  return argument === '0' ? 0 : undefined;
+}
+
+/**
+ * How far above a call a root guard may sit and still cover it. Wide enough for
+ * `it.skipIf(...)` plus a title and a few setup lines, narrow enough that an
+ * unrelated guard elsewhere in the file does not waive it.
+ */
+const GUARD_LOOKBEHIND_LINES = 20;
+
+/** The established waiver: the test does not run as root, so nothing is faked. */
+const ROOT_GUARD = 'process.getuid';
+
+/**
+ * Whether a root guard covers the call at `offset` in the RAW source.
+ *
+ * Removing permissions is legitimate when the test refuses to run as root —
+ * the simulation is then never relied upon. That waiver has to be read from the
+ * raw text, since the guard usually sits in the comment and `it.skipIf(...)`
+ * line above the call.
+ */
+function guardedAsNonRoot(source: string, offset: number): boolean {
+  const upto = source.slice(0, offset).split('\n');
+  return upto.slice(-GUARD_LOOKBEHIND_LINES).join('\n').includes(ROOT_GUARD);
+}
+
+/**
+ * Every permission-removing simulation in one file's source that no root guard
+ * covers.
+ *
+ * The rule is not "never chmod" — it is "never let a chmod stand in for a
+ * failure that root will not produce". A test that skips as root has said so.
+ */
+export function permissionSimulations(source: string): string[] {
+  const code = withoutComments(source);
+  const offenders: string[] = [];
+  for (const call of chmodModeArguments(code)) {
+    const mode = literalMode(call.mode);
+    if (mode === undefined || (mode & OWNER_READ_WRITE) === OWNER_READ_WRITE) continue;
+    if (guardedAsNonRoot(code, call.offset)) continue;
+    offenders.push(`chmodSync(…, ${call.mode})`);
+  }
+  for (const match of code.matchAll(SHELL_CHMOD_REMOVING_ACCESS)) {
+    if (!guardedAsNonRoot(code, match.index ?? 0)) offenders.push(match[0]);
+  }
+  return offenders;
+}

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -10,13 +10,31 @@
  * evasions can be tested directly. A guard nobody can prove is a guard nobody
  * should trust — and the evasions below were all found by review, not by the
  * guard.
+ *
+ * What a green result means: no chmod removing owner read or write, through
+ * any fs binding or import rename, as a spawned `chmod`, or in a shell fixture,
+ * with a mode written literally.
+ *
+ * What it does not mean. A mode held in a variable is not evaluable from source
+ * and is skipped rather than guessed; a callee whose name is computed at
+ * runtime is not resolvable either. Both are reachable by someone working
+ * around the guard, and neither is a shape anyone writes by accident, which is
+ * what this catches. The scan errs toward false positives: only comment spans
+ * are removed and every other byte is passed through, so a literal this
+ * mis-tracks can produce a spurious report but cannot swallow a real call.
  */
 
 /** Owner read+write. A mode missing either bit removes access. */
 export const OWNER_READ_WRITE = 0o600;
 
-/** `chmod a-w`, `chmod -w`, `chmod 000`, `chmod u-w` inside shell fixtures. */
-export const SHELL_CHMOD_REMOVING_ACCESS = /chmod\s+(?:[augo]*-[rw]|0?[0-5][0-7][0-7]\b)/gu;
+/**
+ * A `chmod` in a shell fixture, with its mode token.
+ *
+ * Flags are skipped rather than assumed absent: `chmod -R a-w` is the ordinary
+ * way to strip a tree, and a pattern expecting the mode immediately after the
+ * word does not see it.
+ */
+const SHELL_CHMOD_CALL = /chmod\s+(?:-[A-Za-z-]+\s+)*(?<mode>[^\s;&|)'"]+)/gu;
 
 /** After these, a `/` opens a regex literal rather than dividing. */
 const REGEX_MAY_FOLLOW = new Set(['', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';']);
@@ -123,27 +141,57 @@ function topLevelArguments(text: string): string[] {
 }
 
 /**
- * The mode argument of every `chmodSync` call, found by scanning to the
- * matching close paren rather than matching a shape.
+ * Every name a chmod reaches this file under: the fs spellings, plus whatever
+ * an import renamed one to.
+ *
+ * `chmodSync` is not the only door. `fs.promises.chmod` and
+ * `import { chmodSync as lockDown }` remove exactly the same bits, and a
+ * detector that knows one spelling reports clean on the others.
+ */
+function chmodCallNames(source: string): Set<string> {
+  const names = new Set(['chmod', 'chmodSync', 'lchmod', 'lchmodSync', 'fchmod', 'fchmodSync']);
+  const renames = source.matchAll(/\b[lf]?chmod(?:Sync)?\s+as\s+([A-Za-z_$][\w$]*)/gu);
+  for (const rename of renames) if (rename[1] !== undefined) names.add(rename[1]);
+  return names;
+}
+
+/** Any identifier in call position. The member prefix of `fs.promises.chmod(` is not one. */
+const CALL_SITE = /(?<![\w$])([A-Za-z_$][\w$]*)\s*\(/gu;
+
+/** Index of the `)` closing an argument list that opens at `open`, or -1. */
+function endOfArguments(source: string, open: number): number {
+  let depth = 1;
+  let index = open;
+  while (index < source.length && depth > 0) {
+    if (source[index] === '(') depth += 1;
+    else if (source[index] === ')') depth -= 1;
+    index += 1;
+  }
+  return depth === 0 ? index - 1 : -1;
+}
+
+/**
+ * The mode argument of every chmod call, found by scanning to the matching
+ * close paren rather than matching a shape.
  *
  * A regex anchored on `)` right after the literal misses a call Prettier
  * wrapped with a trailing comma, and a path argument carrying its own comma —
  * `chmodSync(nodePath.join(a, b), 0o000)` — defeats a `[^,]+` path match.
  */
-export function chmodModeArguments(source: string): { mode: string; offset: number }[] {
-  const modes: { mode: string; offset: number }[] = [];
-  for (const match of source.matchAll(/chmodSync\s*\(/gu)) {
+export function chmodModeArguments(
+  source: string,
+): { mode: string; name: string; offset: number }[] {
+  const modes: { mode: string; name: string; offset: number }[] = [];
+  const names = chmodCallNames(source);
+  const calls = source.matchAll(CALL_SITE);
+  for (const match of calls) {
+    const name = match[1] ?? '';
+    if (!names.has(name)) continue;
     const open = (match.index ?? 0) + match[0].length;
-    let depth = 1;
-    let index = open;
-    while (index < source.length && depth > 0) {
-      if (source[index] === '(') depth += 1;
-      else if (source[index] === ')') depth -= 1;
-      index += 1;
-    }
-    if (depth !== 0) continue;
-    const last = topLevelArguments(source.slice(open, index - 1)).at(-1);
-    if (last !== undefined) modes.push({ mode: last, offset: match.index ?? 0 });
+    const close = endOfArguments(source, open);
+    if (close === -1) continue;
+    const last = topLevelArguments(source.slice(open, close)).at(-1);
+    if (last !== undefined) modes.push({ mode: last, name, offset: match.index ?? 0 });
   }
   return modes;
 }
@@ -161,6 +209,46 @@ export function literalMode(argument: string): number | undefined {
   const quoted = /^(['"])([0-7]{1,4})\1$/u.exec(argument);
   if (quoted?.[2] !== undefined) return Number.parseInt(quoted[2], 8);
   return argument === '0' ? 0 : undefined;
+}
+
+/**
+ * Whether a chmod mode as written on a command line removes owner read or
+ * write.
+ *
+ * Symbolic modes are the half a numeric-only check misses. `chmod u=r` never
+ * mentions write and takes it away regardless, so an assignment is judged by
+ * what it omits, not by what it strikes out.
+ */
+export function shellModeRemovesAccess(mode: string): boolean {
+  const numeric = /^0?([0-7]{3})$/u.exec(mode);
+  if (numeric?.[1] !== undefined) {
+    return (Number.parseInt(numeric[1], 8) & OWNER_READ_WRITE) !== OWNER_READ_WRITE;
+  }
+  const symbolic = /^[augo]*([-+=])([rwxXst]*)$/u.exec(mode);
+  const [, operator, permissions = ''] = symbolic ?? [];
+  if (operator === '-') return /[rw]/u.test(permissions);
+  if (operator === '=') return !permissions.includes('r') || !permissions.includes('w');
+  return false;
+}
+
+/**
+ * Modes handed to a chmod spawned as a subprocess — `execFileSync('chmod',
+ * ['000', path])`.
+ *
+ * Nothing about this reaches the fs binding, and the mode never sits next to
+ * the word `chmod`, so neither of the other two scans sees it. The bits it
+ * removes are the same ones.
+ */
+export function argvChmodModes(source: string): { mode: string; offset: number }[] {
+  const modes: { mode: string; offset: number }[] = [];
+  for (const match of source.matchAll(/(['"`])chmod\1\s*,\s*\[([^\]]*)\]/gu)) {
+    const argv = topLevelArguments(match[2] ?? '')
+      .map(argument => argument.replaceAll(/^['"`]|['"`]$/gu, ''))
+      .find(argument => !argument.startsWith('-'));
+    const mode = argv;
+    if (mode !== undefined) modes.push({ mode, offset: match.index ?? 0 });
+  }
+  return modes;
 }
 
 /**
@@ -193,17 +281,37 @@ function guardedAsNonRoot(source: string, offset: number): boolean {
  * The rule is not "never chmod" — it is "never let a chmod stand in for a
  * failure that root will not produce". A test that skips as root has said so.
  */
+function bindingSimulations(code: string): { label: string; offset: number }[] {
+  return chmodModeArguments(code)
+    .filter(call => {
+      const mode = literalMode(call.mode);
+      return mode !== undefined && (mode & OWNER_READ_WRITE) !== OWNER_READ_WRITE;
+    })
+    .map(call => ({ label: `${call.name}(…, ${call.mode})`, offset: call.offset }));
+}
+
+function spawnedSimulations(code: string): { label: string; offset: number }[] {
+  return argvChmodModes(code)
+    .filter(call => shellModeRemovesAccess(call.mode))
+    .map(call => ({ label: `chmod ${call.mode} (spawned)`, offset: call.offset }));
+}
+
+function shellSimulations(code: string): { label: string; offset: number }[] {
+  return code
+    .matchAll(SHELL_CHMOD_CALL)
+    .filter(match => shellModeRemovesAccess(match.groups?.mode ?? ''))
+    .map(match => ({ label: match[0], offset: match.index ?? 0 }))
+    .toArray();
+}
+
 export function permissionSimulations(source: string): string[] {
   const code = withoutComments(source);
-  const offenders: string[] = [];
-  for (const call of chmodModeArguments(code)) {
-    const mode = literalMode(call.mode);
-    if (mode === undefined || (mode & OWNER_READ_WRITE) === OWNER_READ_WRITE) continue;
-    if (guardedAsNonRoot(code, call.offset)) continue;
-    offenders.push(`chmodSync(…, ${call.mode})`);
-  }
-  for (const match of code.matchAll(SHELL_CHMOD_REMOVING_ACCESS)) {
-    if (!guardedAsNonRoot(code, match.index ?? 0)) offenders.push(match[0]);
-  }
-  return offenders;
+  const found = [
+    ...bindingSimulations(code),
+    ...spawnedSimulations(code),
+    ...shellSimulations(code),
+  ];
+  return found
+    .filter(simulation => !guardedAsNonRoot(code, simulation.offset))
+    .map(simulation => simulation.label);
 }

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -188,6 +188,29 @@ function blockDeclaration(call: ts.CallExpression): boolean {
   return ts.isIdentifier(expression) && ['it', 'test', 'describe'].includes(expression.text);
 }
 
+function skipsWhenRoot(sourceFile: ts.SourceFile, condition: ts.Expression | undefined): boolean {
+  if (!condition) return false;
+  let matches = false;
+  visit(condition, node => {
+    if (!ts.isBinaryExpression(node)) return;
+    if (
+      node.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken &&
+      node.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsToken
+    ) {
+      return;
+    }
+    const left = node.left.getText(sourceFile);
+    const right = node.right.getText(sourceFile);
+    if (
+      (left.includes('process.getuid') && right === '0') ||
+      (left === '0' && right.includes('process.getuid'))
+    ) {
+      matches = true;
+    }
+  });
+  return matches;
+}
+
 function expressionHasNonRootGuard(sourceFile: ts.SourceFile, expression: ts.Expression): boolean {
   let current = expression;
   while (ts.isCallExpression(current) || ts.isPropertyAccessExpression(current)) {
@@ -198,7 +221,7 @@ function expressionHasNonRootGuard(sourceFile: ts.SourceFile, expression: ts.Exp
     if (
       ts.isPropertyAccessExpression(current.expression) &&
       current.expression.name.text === 'skipIf' &&
-      (current.arguments[0]?.getText(sourceFile).includes('process.getuid') ?? false)
+      skipsWhenRoot(sourceFile, current.arguments[0])
     ) {
       return true;
     }

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -19,9 +19,13 @@
  * and is skipped rather than guessed; a callee whose name is computed at
  * runtime is not resolvable either. Both are reachable by someone working
  * around the guard, and neither is a shape anyone writes by accident, which is
- * what this catches. The scan errs toward false positives: only comment spans
- * are removed and every other byte is passed through, so a literal this
- * mis-tracks can produce a spurious report but cannot swallow a real call.
+ * what this catches.
+ *
+ * A mis-tracked literal is not merely noisy, either. The scan removes comment
+ * spans, so mistaking code for a comment deletes a real call — the URL case in
+ * the tripwire is exactly that, reached through a regex literal the tracker had
+ * wrong. Every literal form this gets wrong is a potential false clean, so each
+ * one found gets a case rather than an argument for why it is harmless.
  */
 
 /** Owner read+write. A mode missing either bit removes access. */
@@ -37,7 +41,36 @@ export const OWNER_READ_WRITE = 0o600;
 const SHELL_CHMOD_CALL = /chmod\s+(?:-[A-Za-z-]+\s+)*(?<mode>[^\s;&|)'"]+)/gu;
 
 /** After these, a `/` opens a regex literal rather than dividing. */
-const REGEX_MAY_FOLLOW = new Set(['', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';']);
+const REGEX_MAY_FOLLOW = new Set([
+  '',
+  '(',
+  ',',
+  '=',
+  ':',
+  '[',
+  '!',
+  '&',
+  '|',
+  '?',
+  '{',
+  '}',
+  ';',
+  '>',
+]);
+
+/**
+ * Keywords a regex literal may directly follow.
+ *
+ * `return /…/` and `=> /…/` are what the single-character check cannot see: the
+ * character before the slash is `n` or `>`, so the literal reads as division
+ * and a quote inside it opens a "string" that runs to the next quote anywhere
+ * later in the file. `>` is handled above; the rest need the word.
+ */
+const KEYWORD_BEFORE_REGEX =
+  /\b(?:return|typeof|instanceof|case|yield|await|new|delete|void|in|of|do|else)\s*$/u;
+
+/** Longest keyword above, plus room for the whitespace after it. */
+const KEYWORD_LOOKBEHIND = 16;
 
 const QUOTES = new Set(['"', "'", '`']);
 
@@ -46,6 +79,7 @@ function endOfComment(source: string, from: number): number {
   if (source[from] !== '/') return -1;
   const following = source[from + 1];
   if (following === '/') {
+    if (source[from - 1] === ':') return -1;
     const newline = source.indexOf('\n', from);
     return newline === -1 ? source.length : newline;
   }
@@ -71,6 +105,12 @@ function endOfDelimited(source: string, from: number, isRegex: boolean): number 
     if (character === closer && !inCharacterClass) break;
   }
   return index;
+}
+
+/** Whether the `/` at `index` opens a regex literal rather than dividing. */
+function opensRegexLiteral(source: string, index: number, previous: string): boolean {
+  if (REGEX_MAY_FOLLOW.has(previous)) return true;
+  return KEYWORD_BEFORE_REGEX.test(source.slice(Math.max(0, index - KEYWORD_LOOKBEHIND), index));
 }
 
 /**
@@ -105,7 +145,7 @@ export function withoutComments(source: string): string {
       continue;
     }
 
-    const isRegex = character === '/' && REGEX_MAY_FOLLOW.has(previous);
+    const isRegex = character === '/' && opensRegexLiteral(source, index, previous);
     if (QUOTES.has(character) || isRegex) {
       const literalEnd = endOfDelimited(source, index, isRegex);
       output += source.slice(index, literalEnd);
@@ -177,6 +217,9 @@ function endOfArguments(source: string, open: number): number {
  * A regex anchored on `)` right after the literal misses a call Prettier
  * wrapped with a trailing comma, and a path argument carrying its own comma —
  * `chmodSync(nodePath.join(a, b), 0o000)` — defeats a `[^,]+` path match.
+ *
+ * The mode is read by position, not as the last argument: every fs chmod takes
+ * it second, and the async form puts a callback after it.
  */
 export function chmodModeArguments(
   source: string,
@@ -190,8 +233,8 @@ export function chmodModeArguments(
     const open = (match.index ?? 0) + match[0].length;
     const close = endOfArguments(source, open);
     if (close === -1) continue;
-    const last = topLevelArguments(source.slice(open, close)).at(-1);
-    if (last !== undefined) modes.push({ mode: last, name, offset: match.index ?? 0 });
+    const mode = topLevelArguments(source.slice(open, close))[1];
+    if (mode !== undefined) modes.push({ mode, name, offset: match.index ?? 0 });
   }
   return modes;
 }

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -294,15 +294,11 @@ export function argvChmodModes(source: string): { mode: string; offset: number }
   return modes;
 }
 
-/**
- * How far above a call a root guard may sit and still cover it. Wide enough for
- * `it.skipIf(...)` plus a title and a few setup lines, narrow enough that an
- * unrelated guard elsewhere in the file does not waive it.
- */
-const GUARD_LOOKBEHIND_LINES = 20;
-
 /** The established waiver: the test does not run as root, so nothing is faked. */
 const ROOT_GUARD = 'process.getuid';
+
+/** Start of a Vitest test declaration, including modifiers such as `it.skipIf`. */
+const TEST_DECLARATION = /\b(?:it|test)(?:\.[A-Za-z_$][\w$]*)*\s*(?=[.(])/gu;
 
 /**
  * Whether a root guard covers the call at `offset` in the RAW source.
@@ -313,8 +309,11 @@ const ROOT_GUARD = 'process.getuid';
  * line above the call.
  */
 function guardedAsNonRoot(source: string, offset: number): boolean {
-  const upto = source.slice(0, offset).split('\n');
-  return upto.slice(-GUARD_LOOKBEHIND_LINES).join('\n').includes(ROOT_GUARD);
+  const beforeCall = source.slice(0, offset);
+  const declarations = beforeCall.matchAll(TEST_DECLARATION);
+  let currentTestStart = 0;
+  for (const declaration of declarations) currentTestStart = declaration.index;
+  return beforeCall.slice(currentTestStart).includes(ROOT_GUARD);
 }
 
 /**

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -84,17 +84,38 @@ export function chmodModeArguments(
   return chmodModeArgumentsFromFile(parse(source));
 }
 
+interface OwnerAccess {
+  read: boolean;
+  write: boolean;
+}
+
+function applySymbolicClause(access: OwnerAccess, clause: string): OwnerAccess | undefined {
+  const symbolic = /^([augo]*)([-+=])([rwxXst]*)$/u.exec(clause);
+  if (!symbolic) return undefined;
+  const [, who = '', operator, permissions = ''] = symbolic;
+  if (who !== '' && !who.includes('a') && !who.includes('u')) return access;
+  if (operator === '=') {
+    return { read: permissions.includes('r'), write: permissions.includes('w') };
+  }
+  return {
+    read: permissions.includes('r') ? operator === '+' : access.read,
+    write: permissions.includes('w') ? operator === '+' : access.write,
+  };
+}
+
 /** Whether a command-line chmod mode removes owner read or write. */
 export function shellModeRemovesAccess(mode: string): boolean {
-  const numeric = /^0?([0-7]{3})$/u.exec(mode);
+  const numeric = /^([0-7]{3,4})$/u.exec(mode);
   if (numeric?.[1] !== undefined) {
     return (Number.parseInt(numeric[1], 8) & OWNER_READ_WRITE) !== OWNER_READ_WRITE;
   }
-  const symbolic = /^[augo]*([-+=])([rwxXst]*)$/u.exec(mode);
-  const [, operator, permissions = ''] = symbolic ?? [];
-  if (operator === '-') return /[rw]/u.test(permissions);
-  if (operator === '=') return !permissions.includes('r') || !permissions.includes('w');
-  return false;
+  let access: OwnerAccess = { read: true, write: true };
+  for (const clause of mode.split(',')) {
+    const next = applySymbolicClause(access, clause);
+    if (!next) return false;
+    access = next;
+  }
+  return !access.read || !access.write;
 }
 
 function literalText(node: ts.Node | undefined): string | undefined {
@@ -159,7 +180,11 @@ function enclosingTest(sourceFile: ts.SourceFile, offset: number): ts.CallExpres
 
 function guardedAsNonRoot(sourceFile: ts.SourceFile, simulation: Simulation): boolean {
   const test = enclosingTest(sourceFile, simulation.offset);
-  return test?.getText(sourceFile).includes('process.getuid') ?? false;
+  if (!test || !ts.isCallExpression(test.expression)) return false;
+  const modifier = test.expression;
+  if (!ts.isPropertyAccessExpression(modifier.expression)) return false;
+  if (modifier.expression.name.text !== 'skipIf') return false;
+  return modifier.arguments[0]?.getText(sourceFile).includes('process.getuid') ?? false;
 }
 
 /**

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -53,6 +53,19 @@ function calledName(expression: ts.Expression): string | undefined {
   return undefined;
 }
 
+function literalBindings(sourceFile: ts.SourceFile): Map<string, string> {
+  const bindings = new Map<string, string>();
+  visit(sourceFile, node => {
+    if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name) || !node.initializer) return;
+    const declarationList = node.parent;
+    if (!ts.isVariableDeclarationList(declarationList)) return;
+    if ((declarationList.flags & ts.NodeFlags.Const) === 0) return;
+    const text = node.initializer.getText(sourceFile);
+    if (literalMode(text) !== undefined) bindings.set(node.name.text, text);
+  });
+  return bindings;
+}
+
 /** The numeric value of a literal chmod mode, or undefined when it is dynamic. */
 export function literalMode(argument: string): number | undefined {
   const octal = /^0o([0-7]{3,4})$/u.exec(argument);
@@ -66,13 +79,17 @@ function chmodModeArgumentsFromFile(
   sourceFile: ts.SourceFile,
 ): { mode: string; name: string; offset: number }[] {
   const names = importedChmodNames(sourceFile);
+  const bindings = literalBindings(sourceFile);
   const modes: { mode: string; name: string; offset: number }[] = [];
   visit(sourceFile, node => {
     if (!ts.isCallExpression(node)) return;
     const name = calledName(node.expression);
     const mode = node.arguments[1];
     if (name === undefined || !names.has(name) || mode === undefined) return;
-    modes.push({ mode: mode.getText(sourceFile), name, offset: node.getStart(sourceFile) });
+    const modeText = ts.isIdentifier(mode)
+      ? (bindings.get(mode.text) ?? mode.getText(sourceFile))
+      : mode.getText(sourceFile);
+    modes.push({ mode: modeText, name, offset: node.getStart(sourceFile) });
   });
   return modes;
 }
@@ -126,7 +143,9 @@ function literalText(node: ts.Node | undefined): string | undefined {
 function spawnedSimulations(sourceFile: ts.SourceFile): Simulation[] {
   const found: Simulation[] = [];
   visit(sourceFile, node => {
-    if (!ts.isCallExpression(node) || literalText(node.arguments[0]) !== 'chmod') return;
+    if (!ts.isCallExpression(node)) return;
+    const executable = literalText(node.arguments[0]);
+    if (executable?.split(/[\\/]/u).at(-1) !== 'chmod') return;
     const argv = node.arguments[1];
     if (!argv || !ts.isArrayLiteralExpression(argv)) return;
     const mode = argv.elements.map(literalText).find(value => value && !value.startsWith('-'));
@@ -161,30 +180,41 @@ function bindingSimulations(sourceFile: ts.SourceFile): Simulation[] {
     .map(call => ({ label: `${call.name}(…, ${call.mode})`, offset: call.offset }));
 }
 
-function testDeclaration(call: ts.CallExpression): boolean {
+function blockDeclaration(call: ts.CallExpression): boolean {
   let expression: ts.Expression = call.expression;
   while (ts.isCallExpression(expression) || ts.isPropertyAccessExpression(expression)) {
     expression = expression.expression;
   }
-  return ts.isIdentifier(expression) && (expression.text === 'it' || expression.text === 'test');
+  return ts.isIdentifier(expression) && ['it', 'test', 'describe'].includes(expression.text);
 }
 
-function enclosingTest(sourceFile: ts.SourceFile, offset: number): ts.CallExpression | undefined {
-  let enclosing: ts.CallExpression | undefined;
-  visit(sourceFile, node => {
-    if (!ts.isCallExpression(node) || !testDeclaration(node)) return;
-    if (node.getStart(sourceFile) <= offset && offset < node.getEnd()) enclosing = node;
-  });
-  return enclosing;
+function expressionHasNonRootGuard(sourceFile: ts.SourceFile, expression: ts.Expression): boolean {
+  let current = expression;
+  while (ts.isCallExpression(current) || ts.isPropertyAccessExpression(current)) {
+    if (!ts.isCallExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (
+      ts.isPropertyAccessExpression(current.expression) &&
+      current.expression.name.text === 'skipIf' &&
+      (current.arguments[0]?.getText(sourceFile).includes('process.getuid') ?? false)
+    ) {
+      return true;
+    }
+    current = current.expression;
+  }
+  return false;
 }
 
 function guardedAsNonRoot(sourceFile: ts.SourceFile, simulation: Simulation): boolean {
-  const test = enclosingTest(sourceFile, simulation.offset);
-  if (!test || !ts.isCallExpression(test.expression)) return false;
-  const modifier = test.expression;
-  if (!ts.isPropertyAccessExpression(modifier.expression)) return false;
-  if (modifier.expression.name.text !== 'skipIf') return false;
-  return modifier.arguments[0]?.getText(sourceFile).includes('process.getuid') ?? false;
+  let guarded = false;
+  visit(sourceFile, node => {
+    if (!ts.isCallExpression(node) || !blockDeclaration(node)) return;
+    if (node.getStart(sourceFile) > simulation.offset || simulation.offset >= node.getEnd()) return;
+    if (expressionHasNonRootGuard(sourceFile, node.expression)) guarded = true;
+  });
+  return guarded;
 }
 
 /**

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -1,251 +1,59 @@
-/**
- * Detects tests that simulate an I/O failure by removing permissions.
- *
- * Root holds CAP_DAC_OVERRIDE and bypasses every permission bit, so such a
- * simulation silently does not happen under uid 0: the code under test takes
- * the SUCCESS path and the test fails asserting on that success output. CI runs
- * as uid 1001, so the test is green there and red in every root container.
- *
- * The detector is separated from the tripwire that applies it so its own
- * evasions can be tested directly. A guard nobody can prove is a guard nobody
- * should trust — and the evasions below were all found by review, not by the
- * guard.
- *
- * What a green result means: no chmod removing owner read or write, through
- * any fs binding or import rename, as a spawned `chmod`, or in a shell fixture,
- * with a mode written literally.
- *
- * What it does not mean. A mode held in a variable is not evaluable from source
- * and is skipped rather than guessed; a callee whose name is computed at
- * runtime is not resolvable either. Both are reachable by someone working
- * around the guard, and neither is a shape anyone writes by accident, which is
- * what this catches.
- *
- * A mis-tracked literal is not merely noisy, either. The scan removes comment
- * spans, so mistaking code for a comment deletes a real call — the URL case in
- * the tripwire is exactly that, reached through a regex literal the tracker had
- * wrong. Every literal form this gets wrong is a potential false clean, so each
- * one found gets a case rather than an argument for why it is harmless.
- */
+/** Detects uid-dependent permission-failure simulations in test source. */
+
+import ts from 'typescript';
 
 /** Owner read+write. A mode missing either bit removes access. */
-export const OWNER_READ_WRITE = 0o600;
+const OWNER_READ_WRITE = 0o600;
 
-/**
- * A `chmod` in a shell fixture, with its mode token.
- *
- * Flags are skipped rather than assumed absent: `chmod -R a-w` is the ordinary
- * way to strip a tree, and a pattern expecting the mode immediately after the
- * word does not see it.
- */
-const SHELL_CHMOD_CALL = /chmod\s+(?:-[A-Za-z-]+\s+)*(?<mode>[^\s;&|)'"]+)/gu;
+const CHMOD_NAMES = new Set(['chmod', 'chmodSync', 'lchmod', 'lchmodSync', 'fchmod', 'fchmodSync']);
 
-/** After these, a `/` opens a regex literal rather than dividing. */
-const REGEX_MAY_FOLLOW = new Set([
-  '',
-  '(',
-  ',',
-  '=',
-  ':',
-  '[',
-  '!',
-  '&',
-  '|',
-  '?',
-  '{',
-  '}',
-  ';',
-  '>',
-]);
+const SHELL_CHMOD_CALL = /chmod\s+(?:-[A-Za-z-]+\s+)*(?<mode>[^\s;&|)'"`]+)/gu;
 
-/**
- * Keywords a regex literal may directly follow.
- *
- * `return /…/` and `=> /…/` are what the single-character check cannot see: the
- * character before the slash is `n` or `>`, so the literal reads as division
- * and a quote inside it opens a "string" that runs to the next quote anywhere
- * later in the file. `>` is handled above; the rest need the word.
- */
-const KEYWORD_BEFORE_REGEX =
-  /\b(?:return|typeof|instanceof|case|yield|await|new|delete|void|in|of|do|else)\s*$/u;
-
-/** Longest keyword above, plus room for the whitespace after it. */
-const KEYWORD_LOOKBEHIND = 16;
-
-const QUOTES = new Set(['"', "'", '`']);
-
-/** Index just past a `//` or block comment starting at `from`, or -1. */
-function endOfComment(source: string, from: number): number {
-  if (source[from] !== '/') return -1;
-  const following = source[from + 1];
-  if (following === '/') {
-    if (source[from - 1] === ':') return -1;
-    const newline = source.indexOf('\n', from);
-    return newline === -1 ? source.length : newline;
-  }
-  if (following !== '*') return -1;
-  const close = source.indexOf('*/', from + 2);
-  return close === -1 ? source.length : close + 2;
+interface Simulation {
+  label: string;
+  offset: number;
 }
 
-/** Index just past the literal opening at `from`, treating `[...]` as a regex class. */
-function endOfDelimited(source: string, from: number, isRegex: boolean): number {
-  const closer = source[from];
-  let index = from + 1;
-  let inCharacterClass = false;
-  while (index < source.length) {
-    const character = source[index];
-    if (character === '\\') {
-      index += 2;
-      continue;
-    }
-    if (isRegex && character === '[') inCharacterClass = true;
-    else if (isRegex && character === ']') inCharacterClass = false;
-    index += 1;
-    if (character === closer && !inCharacterClass) break;
-  }
-  return index;
+function parse(source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    'permission-simulation.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
 }
 
-/** Whether the `/` at `index` opens a regex literal rather than dividing. */
-function opensRegexLiteral(source: string, index: number, previous: string): boolean {
-  if (REGEX_MAY_FOLLOW.has(previous)) return true;
-  return KEYWORD_BEFORE_REGEX.test(source.slice(Math.max(0, index - KEYWORD_LOOKBEHIND), index));
+function visit(node: ts.Node, visitor: (node: ts.Node) => void): void {
+  visitor(node);
+  ts.forEachChild(node, child => {
+    visit(child, visitor);
+  });
 }
 
-/**
- * Drops comments, leaving string literals intact and offsets aligned with the
- * input (removed spans become spaces, so a reported offset still points at the
- * original line).
- *
- * Scans left to right rather than pattern-matching, because neither half of
- * this survives a regex:
- *
- * - Stripping `//` to end-of-line without knowing what is a string deletes the
- *   rest of any line holding a URL, so a call sharing a line with one reports
- *   clean — a guard passing for the wrong reason, the exact failure this
- *   exists to catch.
- * - Masking strings first to avoid that then breaks on a regex literal
- *   containing a quote, which starts a "string" running to the next quote
- *   anywhere in the file and desynchronizes every comment boundary after it.
- *   This module's own source contains such a literal.
- */
-export function withoutComments(source: string): string {
-  let output = '';
-  let index = 0;
-  let previous = '';
-
-  while (index < source.length) {
-    const character = source[index] ?? '';
-
-    const commentEnd = endOfComment(source, index);
-    if (commentEnd !== -1) {
-      output += source.slice(index, commentEnd).replaceAll(/[^\n]/gu, ' ');
-      index = commentEnd;
-      continue;
-    }
-
-    const isRegex = character === '/' && opensRegexLiteral(source, index, previous);
-    if (QUOTES.has(character) || isRegex) {
-      const literalEnd = endOfDelimited(source, index, isRegex);
-      output += source.slice(index, literalEnd);
-      index = literalEnd;
-      previous = character;
-      continue;
-    }
-
-    output += character;
-    if (character.trim() !== '') previous = character;
-    index += 1;
-  }
-  return output;
-}
-
-/** Splits on commas that are not nested inside brackets; drops empty entries. */
-function topLevelArguments(text: string): string[] {
-  const args: string[] = [];
-  let depth = 0;
-  let current = '';
-  for (const character of text) {
-    if (character === ',' && depth === 0) {
-      args.push(current.trim());
-      current = '';
-      continue;
-    }
-    if ('([{'.includes(character)) depth += 1;
-    if (')]}'.includes(character)) depth -= 1;
-    current += character;
-  }
-  args.push(current.trim());
-  return args.filter(argument => argument !== '');
-}
-
-/**
- * Every name a chmod reaches this file under: the fs spellings, plus whatever
- * an import renamed one to.
- *
- * `chmodSync` is not the only door. `fs.promises.chmod` and
- * `import { chmodSync as lockDown }` remove exactly the same bits, and a
- * detector that knows one spelling reports clean on the others.
- */
-function chmodCallNames(source: string): Set<string> {
-  const names = new Set(['chmod', 'chmodSync', 'lchmod', 'lchmodSync', 'fchmod', 'fchmodSync']);
-  const renames = source.matchAll(/\b[lf]?chmod(?:Sync)?\s+as\s+([A-Za-z_$][\w$]*)/gu);
-  for (const rename of renames) if (rename[1] !== undefined) names.add(rename[1]);
+function importedChmodNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set(CHMOD_NAMES);
+  visit(sourceFile, node => {
+    if (!ts.isImportSpecifier(node)) return;
+    const imported = (node.propertyName ?? node.name).text;
+    if (CHMOD_NAMES.has(imported)) names.add(node.name.text);
+  });
   return names;
 }
 
-/** Any identifier in call position. The member prefix of `fs.promises.chmod(` is not one. */
-const CALL_SITE = /(?<![\w$])([A-Za-z_$][\w$]*)\s*\(/gu;
-
-/** Index of the `)` closing an argument list that opens at `open`, or -1. */
-function endOfArguments(source: string, open: number): number {
-  let depth = 1;
-  let index = open;
-  while (index < source.length && depth > 0) {
-    if (source[index] === '(') depth += 1;
-    else if (source[index] === ')') depth -= 1;
-    index += 1;
+function calledName(expression: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  if (
+    ts.isElementAccessExpression(expression) &&
+    ts.isStringLiteral(expression.argumentExpression)
+  ) {
+    return expression.argumentExpression.text;
   }
-  return depth === 0 ? index - 1 : -1;
+  return undefined;
 }
 
-/**
- * The mode argument of every chmod call, found by scanning to the matching
- * close paren rather than matching a shape.
- *
- * A regex anchored on `)` right after the literal misses a call Prettier
- * wrapped with a trailing comma, and a path argument carrying its own comma —
- * `chmodSync(nodePath.join(a, b), 0o000)` — defeats a `[^,]+` path match.
- *
- * The mode is read by position, not as the last argument: every fs chmod takes
- * it second, and the async form puts a callback after it.
- */
-export function chmodModeArguments(
-  source: string,
-): { mode: string; name: string; offset: number }[] {
-  const modes: { mode: string; name: string; offset: number }[] = [];
-  const names = chmodCallNames(source);
-  const calls = source.matchAll(CALL_SITE);
-  for (const match of calls) {
-    const name = match[1] ?? '';
-    if (!names.has(name)) continue;
-    const open = (match.index ?? 0) + match[0].length;
-    const close = endOfArguments(source, open);
-    if (close === -1) continue;
-    const mode = topLevelArguments(source.slice(open, close))[1];
-    if (mode !== undefined) modes.push({ mode, name, offset: match.index ?? 0 });
-  }
-  return modes;
-}
-
-/**
- * The numeric value of a literal mode, or undefined for a variable this cannot
- * evaluate.
- *
- * `0o600` is not the only spelling that reaches chmod: `0` and a quoted `'600'`
- * are equally valid and equally capable of removing access.
- */
+/** The numeric value of a literal chmod mode, or undefined when it is dynamic. */
 export function literalMode(argument: string): number | undefined {
   const octal = /^0o([0-7]{3,4})$/u.exec(argument);
   if (octal?.[1] !== undefined) return Number.parseInt(octal[1], 8);
@@ -254,14 +62,29 @@ export function literalMode(argument: string): number | undefined {
   return argument === '0' ? 0 : undefined;
 }
 
-/**
- * Whether a chmod mode as written on a command line removes owner read or
- * write.
- *
- * Symbolic modes are the half a numeric-only check misses. `chmod u=r` never
- * mentions write and takes it away regardless, so an assignment is judged by
- * what it omits, not by what it strikes out.
- */
+function chmodModeArgumentsFromFile(
+  sourceFile: ts.SourceFile,
+): { mode: string; name: string; offset: number }[] {
+  const names = importedChmodNames(sourceFile);
+  const modes: { mode: string; name: string; offset: number }[] = [];
+  visit(sourceFile, node => {
+    if (!ts.isCallExpression(node)) return;
+    const name = calledName(node.expression);
+    const mode = node.arguments[1];
+    if (name === undefined || !names.has(name) || mode === undefined) return;
+    modes.push({ mode: mode.getText(sourceFile), name, offset: node.getStart(sourceFile) });
+  });
+  return modes;
+}
+
+/** Every fs chmod call and its second (mode) argument. */
+export function chmodModeArguments(
+  source: string,
+): { mode: string; name: string; offset: number }[] {
+  return chmodModeArgumentsFromFile(parse(source));
+}
+
+/** Whether a command-line chmod mode removes owner read or write. */
 export function shellModeRemovesAccess(mode: string): boolean {
   const numeric = /^0?([0-7]{3})$/u.exec(mode);
   if (numeric?.[1] !== undefined) {
@@ -274,57 +97,42 @@ export function shellModeRemovesAccess(mode: string): boolean {
   return false;
 }
 
-/**
- * Modes handed to a chmod spawned as a subprocess — `execFileSync('chmod',
- * ['000', path])`.
- *
- * Nothing about this reaches the fs binding, and the mode never sits next to
- * the word `chmod`, so neither of the other two scans sees it. The bits it
- * removes are the same ones.
- */
-export function argvChmodModes(source: string): { mode: string; offset: number }[] {
-  const modes: { mode: string; offset: number }[] = [];
-  for (const match of source.matchAll(/(['"`])chmod\1\s*,\s*\[([^\]]*)\]/gu)) {
-    const argv = topLevelArguments(match[2] ?? '')
-      .map(argument => argument.replaceAll(/^['"`]|['"`]$/gu, ''))
-      .find(argument => !argument.startsWith('-'));
-    const mode = argv;
-    if (mode !== undefined) modes.push({ mode, offset: match.index ?? 0 });
-  }
-  return modes;
+function literalText(node: ts.Node | undefined): string | undefined {
+  if (node && ts.isStringLiteralLike(node)) return node.text;
+  return undefined;
 }
 
-/** The established waiver: the test does not run as root, so nothing is faked. */
-const ROOT_GUARD = 'process.getuid';
-
-/** Start of a Vitest test declaration, including modifiers such as `it.skipIf`. */
-const TEST_DECLARATION = /\b(?:it|test)(?:\.[A-Za-z_$][\w$]*)*\s*(?=[.(])/gu;
-
-/**
- * Whether a root guard covers the call at `offset` in the RAW source.
- *
- * Removing permissions is legitimate when the test refuses to run as root —
- * the simulation is then never relied upon. That waiver has to be read from the
- * raw text, since the guard usually sits in the comment and `it.skipIf(...)`
- * line above the call.
- */
-function guardedAsNonRoot(source: string, offset: number): boolean {
-  const beforeCall = source.slice(0, offset);
-  const declarations = beforeCall.matchAll(TEST_DECLARATION);
-  let currentTestStart = 0;
-  for (const declaration of declarations) currentTestStart = declaration.index;
-  return beforeCall.slice(currentTestStart).includes(ROOT_GUARD);
+function spawnedSimulations(sourceFile: ts.SourceFile): Simulation[] {
+  const found: Simulation[] = [];
+  visit(sourceFile, node => {
+    if (!ts.isCallExpression(node) || literalText(node.arguments[0]) !== 'chmod') return;
+    const argv = node.arguments[1];
+    if (!argv || !ts.isArrayLiteralExpression(argv)) return;
+    const mode = argv.elements.map(literalText).find(value => value && !value.startsWith('-'));
+    if (mode && shellModeRemovesAccess(mode)) {
+      found.push({ label: `chmod ${mode} (spawned)`, offset: node.getStart(sourceFile) });
+    }
+  });
+  return found;
 }
 
-/**
- * Every permission-removing simulation in one file's source that no root guard
- * covers.
- *
- * The rule is not "never chmod" — it is "never let a chmod stand in for a
- * failure that root will not produce". A test that skips as root has said so.
- */
-function bindingSimulations(code: string): { label: string; offset: number }[] {
-  return chmodModeArguments(code)
+function shellSimulations(sourceFile: ts.SourceFile): Simulation[] {
+  const found: Simulation[] = [];
+  visit(sourceFile, node => {
+    const text = literalText(node);
+    if (text === undefined) return;
+    for (const match of text.matchAll(SHELL_CHMOD_CALL)) {
+      const mode = match.groups?.mode ?? '';
+      if (shellModeRemovesAccess(mode)) {
+        found.push({ label: match[0], offset: node.getStart(sourceFile) });
+      }
+    }
+  });
+  return found;
+}
+
+function bindingSimulations(sourceFile: ts.SourceFile): Simulation[] {
+  return chmodModeArgumentsFromFile(sourceFile)
     .filter(call => {
       const mode = literalMode(call.mode);
       return mode !== undefined && (mode & OWNER_READ_WRITE) !== OWNER_READ_WRITE;
@@ -332,28 +140,41 @@ function bindingSimulations(code: string): { label: string; offset: number }[] {
     .map(call => ({ label: `${call.name}(…, ${call.mode})`, offset: call.offset }));
 }
 
-function spawnedSimulations(code: string): { label: string; offset: number }[] {
-  return argvChmodModes(code)
-    .filter(call => shellModeRemovesAccess(call.mode))
-    .map(call => ({ label: `chmod ${call.mode} (spawned)`, offset: call.offset }));
+function testDeclaration(call: ts.CallExpression): boolean {
+  let expression: ts.Expression = call.expression;
+  while (ts.isCallExpression(expression) || ts.isPropertyAccessExpression(expression)) {
+    expression = expression.expression;
+  }
+  return ts.isIdentifier(expression) && (expression.text === 'it' || expression.text === 'test');
 }
 
-function shellSimulations(code: string): { label: string; offset: number }[] {
-  return code
-    .matchAll(SHELL_CHMOD_CALL)
-    .filter(match => shellModeRemovesAccess(match.groups?.mode ?? ''))
-    .map(match => ({ label: match[0], offset: match.index ?? 0 }))
-    .toArray();
+function enclosingTest(sourceFile: ts.SourceFile, offset: number): ts.CallExpression | undefined {
+  let enclosing: ts.CallExpression | undefined;
+  visit(sourceFile, node => {
+    if (!ts.isCallExpression(node) || !testDeclaration(node)) return;
+    if (node.getStart(sourceFile) <= offset && offset < node.getEnd()) enclosing = node;
+  });
+  return enclosing;
 }
 
+function guardedAsNonRoot(sourceFile: ts.SourceFile, simulation: Simulation): boolean {
+  const test = enclosingTest(sourceFile, simulation.offset);
+  return test?.getText(sourceFile).includes('process.getuid') ?? false;
+}
+
+/**
+ * Finds literal permission-removing simulations not enclosed by a root-skipped
+ * test. TypeScript owns source parsing; this module only interprets chmod calls
+ * and shell strings, avoiding a second, incomplete JavaScript lexer.
+ */
 export function permissionSimulations(source: string): string[] {
-  const code = withoutComments(source);
+  const sourceFile = parse(source);
   const found = [
-    ...bindingSimulations(code),
-    ...spawnedSimulations(code),
-    ...shellSimulations(code),
+    ...bindingSimulations(sourceFile),
+    ...spawnedSimulations(sourceFile),
+    ...shellSimulations(sourceFile),
   ];
   return found
-    .filter(simulation => !guardedAsNonRoot(code, simulation.offset))
+    .filter(simulation => !guardedAsNonRoot(sourceFile, simulation))
     .map(simulation => simulation.label);
 }

--- a/packages/cli/tests/helpers/permission-simulation.ts
+++ b/packages/cli/tests/helpers/permission-simulation.ts
@@ -98,7 +98,7 @@ export function shellModeRemovesAccess(mode: string): boolean {
 }
 
 function literalText(node: ts.Node | undefined): string | undefined {
-  if (node && ts.isStringLiteralLike(node)) return node.text;
+  if (node && (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node))) return node.text;
   return undefined;
 }
 

--- a/packages/cli/tests/hooks/retro-filing.test.ts
+++ b/packages/cli/tests/hooks/retro-filing.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../templates/hooks/lib/retro-draft-spool.js';
 import { decideRetroFilingNudge } from '../../templates/hooks/lib/retro-nudge.js';
 import { retroDraft as draft, sealedRetroDraft } from '../helpers.js';
-import { sinkWrites } from '../helpers/io-failure.js';
+import { blockWrites, sinkWrites } from '../helpers/io-failure.js';
 
 const DRAIN_RETRO_SPOOL = nodePath.resolve(
   import.meta.dirname,
@@ -134,7 +134,7 @@ describe('fileSpooledDrafts (BNGK9W — the agent filing seam: post each verbati
   it('retains a posted draft when its acknowledgement write fails', async () => {
     const posted = draft('retro:aaaaaaaaaaaa', 'Posted');
     spoolDrafts(projectDirectory, 'sess-1', [posted]);
-    mkdirSync(ackFilePath(projectDirectory, 'sess-1'));
+    blockWrites(ackFilePath(projectDirectory, 'sess-1'));
 
     const result = await fileSpooledDrafts(projectDirectory, 'sess-1', () =>
       Promise.resolve({ issue: 101 }),

--- a/packages/cli/tests/hooks/retro-filing.test.ts
+++ b/packages/cli/tests/hooks/retro-filing.test.ts
@@ -1,13 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -25,6 +17,7 @@ import {
 } from '../../templates/hooks/lib/retro-draft-spool.js';
 import { decideRetroFilingNudge } from '../../templates/hooks/lib/retro-nudge.js';
 import { retroDraft as draft, sealedRetroDraft } from '../helpers.js';
+import { sinkWrites } from '../helpers/io-failure.js';
 
 const DRAIN_RETRO_SPOOL = nodePath.resolve(
   import.meta.dirname,
@@ -154,9 +147,7 @@ describe('fileSpooledDrafts (BNGK9W — the agent filing seam: post each verbati
   it('retains a posted draft when its acknowledgement cannot be read back', async () => {
     const posted = draft('retro:aaaaaaaaaaaa', 'Posted');
     spoolDrafts(projectDirectory, 'sess-1', [posted]);
-    const path = ackFilePath(projectDirectory, 'sess-1');
-    writeFileSync(path, '');
-    chmodSync(path, 0o200);
+    sinkWrites(ackFilePath(projectDirectory, 'sess-1'));
 
     const result = await fileSpooledDrafts(projectDirectory, 'sess-1', () =>
       Promise.resolve({ issue: 101 }),

--- a/packages/cli/tests/hooks/self-report.test.ts
+++ b/packages/cli/tests/hooks/self-report.test.ts
@@ -8,7 +8,7 @@
  * that strips the actionable frame must also fail).
  */
 
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -34,6 +34,7 @@ import {
   summarizeReports,
   surfacedMarkerPath,
 } from '../../templates/hooks/lib/self-report.js';
+import { blockWrites } from '../helpers/io-failure.js';
 
 describe('self-report capture (QYYC5Y)', () => {
   let projectDirectory: string;
@@ -411,14 +412,8 @@ describe('self-report capture (QYYC5Y)', () => {
     it('reports failure when the marker cannot be written, so the caller stays silent', () => {
       // The loop guard proper: emitting without a durable marker is what loops.
       // An unwritable spool dir must be reported, never silently swallowed.
-      const spoolDirectory = nodePath.dirname(spoolPath(projectDirectory, 's'));
-      mkdirSync(spoolDirectory, { recursive: true });
-      chmodSync(spoolDirectory, 0o555);
-      try {
-        expect(markSignaturesSurfaced(projectDirectory, 's', ['claude:exit1@check'])).toBe(false);
-      } finally {
-        chmodSync(spoolDirectory, 0o755);
-      }
+      blockWrites(surfacedMarkerPath(projectDirectory, 's'));
+      expect(markSignaturesSurfaced(projectDirectory, 's', ['claude:exit1@check'])).toBe(false);
     });
 
     it('does not burn marker headroom on a repeated signature', () => {

--- a/packages/cli/tests/hooks/self-report.test.ts
+++ b/packages/cli/tests/hooks/self-report.test.ts
@@ -337,7 +337,7 @@ describe('self-report capture (QYYC5Y)', () => {
   });
 
   describe('formatSelfReportSurfacing', () => {
-    it('returns null when there is nothing to surface', () => {
+    it('returns undefined when there is nothing to surface', () => {
       expect(formatSelfReportSurfacing([])).toBeUndefined();
     });
 

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -913,13 +913,12 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
     );
     executable(
       cli,
-      `#!/usr/bin/env bun
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+      String.raw`#!/usr/bin/env bun
+import { appendFileSync } from 'node:fs';
 const counter = process.env.SAFEWORD_COUNTER;
 if (!counter) process.exit(2);
-const count = existsSync(counter) ? Number(readFileSync(counter, 'utf8')) : 0;
-writeFileSync(counter, String(count + 1));
 const args = process.argv.slice(2);
+appendFileSync(counter, JSON.stringify(args) + '\n');
 if (args[0] === 'project' && args[1] === 'test-plan') {
   console.log(JSON.stringify([{ cwd: process.cwd(), command: 'true', available: true }]));
 } else if (args[0] === 'retro' && args[1] === 'run') {
@@ -946,6 +945,9 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
     });
     expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
     const digest = (JSON.parse(preview.stdout) as { digest: string }).digest;
+    const invocationSnapshot = readFileSync(counter, 'utf8');
+    expect(invocationSnapshot).toContain('["project","test-plan"');
+    expect(invocationSnapshot).toContain('["retro","run"');
 
     bindHostSession({ runtime: 'claude', fixture, environment, id, transcript });
     const replay = spawnSync('bun', [guard, '--pr', '42'], {
@@ -970,7 +972,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
     });
 
     expect(applied.status, `${applied.stderr}\n${applied.stdout}`).toBe(0);
-    expect(readFileSync(counter, 'utf8')).toBe('5');
+    expect(readFileSync(counter, 'utf8')).toBe(invocationSnapshot);
   }, 30_000);
 
   it.each([

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -14,7 +14,7 @@ import {
 } from 'node:fs';
 import nodePath from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { generateClaudePluginAssets } from '../../src/claude-plugin/catalogue.js';
 import { generateCodexPluginAssets } from '../../src/codex-plugin/catalogue.js';
@@ -26,6 +26,7 @@ import {
   spoolDrafts,
 } from '../../templates/hooks/lib/retro-draft-spool.ts';
 import {
+  assertTestCliFresh,
   createTemporaryDirectory,
   createTypeScriptPackageJson,
   initGitRepo,
@@ -39,6 +40,8 @@ import {
 import { blockChildren } from '../helpers/io-failure.js';
 
 const temporaryProjects: string[] = [];
+
+beforeAll(assertTestCliFresh);
 
 function runOrThrow(
   command: string,

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -36,6 +36,7 @@ import {
   setupOrThrow,
   testCliPath,
 } from '../helpers.js';
+import { blockChildren } from '../helpers/io-failure.js';
 
 const temporaryProjects: string[] = [];
 
@@ -1242,7 +1243,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
       ].join('\n'),
     );
     const receiptDirectory = nodePath.dirname(verificationReceiptPath(fixture));
-    writeFileSync(receiptDirectory, 'not a directory\n');
+    blockChildren(receiptDirectory);
     const environment = {
       ...process.env,
       PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -309,6 +309,27 @@ function closeoutCommand(directory: string): string {
   return `bun "${directory}/.safeword/scripts/closeout-cleanup.ts" --pr 42`;
 }
 
+/**
+ * Strips Claude's identity from an environment that means to present a CODEX
+ * host.
+ *
+ * Run identity resolves Claude before Codex deliberately — see
+ * templates/hooks/lib/run-identity.ts: "Keep this after Claude detection so an
+ * explicit Claude environment never adopts a Codex runtime accidentally." So a
+ * fixture that inherits `process.env` while running inside a Claude Code
+ * session hands the child its own CLAUDE_CODE_SESSION_ID, the child resolves
+ * runtime `claude`, and the Codex binding under test never resolves.
+ *
+ * CI has no agent session, so leaving these in place passes there and fails
+ * for anyone running the suite from Claude Code.
+ */
+function codexHostEnvironment<T extends Record<string, string | undefined>>(environment: T): T {
+  const scrubbed = { ...environment };
+  delete scrubbed.CLAUDE_SESSION_ID;
+  delete scrubbed.CLAUDE_CODE_SESSION_ID;
+  return scrubbed;
+}
+
 describe('closeout production host adapters (93C14D TBU1.R4)', () => {
   it('completes freshly verified cleanup without a host session binding', () => {
     const fixture = deliveryFixture();
@@ -364,7 +385,7 @@ describe('closeout production host adapters (93C14D TBU1.R4)', () => {
       transcript,
       `${JSON.stringify({ type: 'session_meta', payload: { id, cwd: fixture.main } })}\n`,
     );
-    const environment = {
+    const environment = codexHostEnvironment({
       ...process.env,
       PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
       GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
@@ -373,7 +394,7 @@ describe('closeout production host adapters (93C14D TBU1.R4)', () => {
       CODEX_HOME: codexHome,
       CODEX_THREAD_ID: id,
       CLAUDE_PROJECT_DIR: fixture.topic,
-    };
+    });
 
     const preview = spawnSync(
       'bun',
@@ -750,7 +771,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
         );
       }
 
-      const environment = {
+      const baseEnvironment = {
         ...process.env,
         PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
         GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
@@ -760,6 +781,8 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
         ...(runtime === 'codex' && { CODEX_THREAD_ID: id }),
         CLAUDE_PROJECT_DIR: fixture.topic,
       };
+      const environment =
+        runtime === 'codex' ? codexHostEnvironment(baseEnvironment) : baseEnvironment;
       const guard = nodePath.join(fixture.topic, '.safeword/scripts/closeout-cleanup.ts');
 
       bindHostSession({ runtime, fixture, environment, id, transcript });
@@ -834,7 +857,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
         payload: { id: bridgedId, cwd: fixture.topic },
       })}\n`,
     );
-    const environment = {
+    const environment = codexHostEnvironment({
       ...process.env,
       PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
       GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
@@ -843,7 +866,7 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
       CODEX_HOME: codexHome,
       CODEX_THREAD_ID: authenticatedId,
       CLAUDE_PROJECT_DIR: fixture.topic,
-    };
+    });
 
     bindHostSession({
       runtime: 'codex',
@@ -1465,11 +1488,11 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
       );
       const execution = spawnSync('bun', [installedGuard, '--pr', '42'], {
         cwd: directory,
-        env: {
+        env: codexHostEnvironment({
           ...process.env,
           CODEX_HOME: nominatedCodexHome,
           CODEX_THREAD_ID: 'caller-thread',
-        },
+        }),
         encoding: 'utf8',
       });
       expect(execution.status).toBe(2);

--- a/packages/cli/tests/manual-closeout-review.test.ts
+++ b/packages/cli/tests/manual-closeout-review.test.ts
@@ -33,12 +33,8 @@ function sha256(content: string | Buffer): string {
 }
 
 /**
- * `maxBuffer` is load-bearing. A sealed input larger than the default 1 MiB
- * (plugin/runtime/cli.js is ~1.6 MB) made `git show` fail with ENOBUFS, and
- * reviewedInput's fallback then read the working tree instead. That silently
- * turned "these are the bytes the reviewer attested to" into "your working
- * tree must not change" — so regenerating a committed build artifact failed
- * this test while the seal itself was intact.
+ * `maxBuffer` is deliberately generous so an unexpectedly large reviewed
+ * source cannot turn a failed `git show` into a misleading seal error.
  */
 function git(arguments_: string[]): {
   status: number;
@@ -255,11 +251,8 @@ describe('hash-bound independent closeout review (93C14D)', () => {
       'packages/cli/templates/hooks/lib/retro-extract.ts',
       'packages/cli/templates/scripts/closeout-cleanup.ts',
       'plugin/resources/scripts/closeout-cleanup.ts',
-      'plugin/runtime/cli.js',
       'plugin/runtime/hooks/lib/closeout-binding.ts',
       'plugin/runtime/hooks/lib/retro-extract.ts',
-      'plugin/identity.json',
-      'plugin/inventory.json',
       'packages/cli/tests/closeout-skill.test.ts',
       'packages/cli/tests/closeout-cleanup.test.ts',
       'packages/cli/tests/commands/retro.test.ts',

--- a/packages/cli/tests/manual-closeout-review.test.ts
+++ b/packages/cli/tests/manual-closeout-review.test.ts
@@ -3,9 +3,10 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { parseFeatureScenarios } from '../src/utils/gherkin-feature.js';
+import { requireFullHistory } from './helpers/git-history.js';
 
 const repoRoot = nodePath.resolve(import.meta.dirname, '../../..');
 const ticketRoot = nodePath.join(
@@ -193,6 +194,10 @@ describe('sealed-commit resolution', () => {
 });
 
 describe('hash-bound independent closeout review (93C14D)', () => {
+  // Only this suite walks real ancestry; the sealed-commit resolution suite
+  // above drives the parser with synthetic git results and needs no history.
+  beforeAll(requireFullHistory);
+
   it('rejects multiple conflicting review result blocks', () => {
     const result = JSON.stringify({
       reviewer: { identity: 'reviewer-1', model: 'gpt-5' },

--- a/packages/cli/tests/manual-closeout-review.test.ts
+++ b/packages/cli/tests/manual-closeout-review.test.ts
@@ -76,26 +76,27 @@ function sealedCommitCandidatesFrom(result: ReturnType<typeof git>): string[] {
   return result.stdout.toString('utf8').trim().split('\n').filter(Boolean);
 }
 
-function sealedCommit(manifest: Manifest): string | undefined {
+function sealedCommit(manifest: Manifest): string {
   const relativeManifest = nodePath.relative(repoRoot, manifestPath);
   const candidates = sealedCommitCandidatesFrom(
     git(['log', '--format=%H', '--', relativeManifest]),
   );
-  return candidates.find(commit =>
+  const commit = candidates.find(candidate =>
     manifest.inputs.every(input => {
-      const reviewed = git(['show', `${commit}:${input.path}`]);
+      const reviewed = git(['show', `${candidate}:${input.path}`]);
       if (reviewed.spawnFailed) {
         throw new Error(
-          `git show ${commit}:${input.path} could not run; cannot verify sealed input`,
+          `git show ${candidate}:${input.path} could not run; cannot verify sealed input`,
         );
       }
       return reviewed.status === 0 && input.sha256 === sha256(reviewed.stdout);
     }),
   );
+  if (!commit) throw new Error('no commit contains every sealed input at its reviewed digest');
+  return commit;
 }
 
-function reviewedInput(path: string, commit: string | undefined): Buffer {
-  if (!commit) return readFileSync(nodePath.join(repoRoot, path));
+function reviewedInput(path: string, commit: string): Buffer {
   const result = git(['show', `${commit}:${path}`]);
   if (result.spawnFailed) {
     // Reading the working tree here would compare the wrong bytes and report
@@ -103,7 +104,10 @@ function reviewedInput(path: string, commit: string | undefined): Buffer {
     // this test checks.
     throw new Error(`git show ${commit}:${path} could not run; cannot verify sealed input`);
   }
-  return result.status === 0 ? result.stdout : readFileSync(nodePath.join(repoRoot, path));
+  if (result.status !== 0) {
+    throw new Error(`git show ${commit}:${path} failed; cannot verify sealed input`);
+  }
+  return result.stdout;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -221,9 +225,7 @@ describe('hash-bound independent closeout review (93C14D)', () => {
     const manifest = JSON.parse(manifestBytes) as Manifest;
     const review = reviewJson(readFileSync(reviewPath, 'utf8'));
     const commit = sealedCommit(manifest);
-    if (commit) {
-      expect(git(['merge-base', '--is-ancestor', commit, 'HEAD']).status).toBe(0);
-    }
+    expect(git(['merge-base', '--is-ancestor', commit, 'HEAD']).status).toBe(0);
     const expectedScenarios = parseFeatureScenarios(
       reviewedInput('features/close-completed-sessions-safely.feature', commit).toString('utf8'),
     ).map((scenario, index) => ({ id: String(index + 1).padStart(2, '0'), title: scenario.title }));

--- a/packages/cli/tests/review/contract-file-failure.test.ts
+++ b/packages/cli/tests/review/contract-file-failure.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -58,11 +58,11 @@ async function withUnwritableTemporaryRoot(
 
 describe('when the result contract cannot be written', () => {
   it('reports a classified review failure instead of crashing, and launches no reviewer', async () => {
-    await withUnwritableTemporaryRoot(async scratch => {
+    await withUnwritableTemporaryRoot(async (scratch, binRoot) => {
       await expect(runHeadlessReviewer('codex', packet, scratch, scratch)).rejects.toBeInstanceOf(
         ReviewRuntimeError,
       );
-      expect(readdirSync(scratch)).not.toContain('launched.log');
+      expect(existsSync(nodePath.join(binRoot, 'launched.log'))).toBe(false);
     });
   });
 

--- a/packages/cli/tests/review/contract-file-failure.test.ts
+++ b/packages/cli/tests/review/contract-file-failure.test.ts
@@ -23,36 +23,35 @@ const packet: ReviewPacket = {
 async function withUnwritableTemporaryRoot(
   body: (scratch: string, binRoot: string) => Promise<void>,
 ): Promise<void> {
-  const scratch = mkdtempSync(nodePath.join(tmpdir(), 'safeword-contract-'));
-  // The executable must live OUTSIDE the untrusted root, or candidate
-  // selection discards it and the run fails as not_installed before the
-  // contract file is ever written — a vacuous pass.
-  const binRoot = createTrustedReviewerDirectory('safeword-contract-bin-');
-  const bin = nodePath.join(binRoot, 'bin');
-  mkdirSync(bin, { recursive: true });
-  const executable = nodePath.join(bin, 'codex');
-  writeFileSync(
-    executable,
-    `#!/bin/sh\nif printf '%s' "$*" | /usr/bin/grep -q -- '--help'; then printf '%s\\n' '${REVIEWER_CAPABILITIES.codex}'; exit 0; fi\nprintf 'launched\\n' >> '${nodePath.join(binRoot, 'launched.log')}'\nexit 0\n`,
-    { mode: 0o755 },
-  );
-  chmodSync(executable, 0o755);
-
-  const readonly = blockChildren(nodePath.join(scratch, 'readonly'));
-
+  let scratch: string | undefined;
+  let binRoot: string | undefined;
   const originalTemporary = process.env.TMPDIR;
   const originalPath = process.env.PATH;
-  process.env.TMPDIR = readonly;
-  process.env.PATH = `${bin}:/usr/bin:/bin`;
   try {
+    scratch = mkdtempSync(nodePath.join(tmpdir(), 'safeword-contract-'));
+    // The executable must live OUTSIDE the untrusted root, or candidate
+    // selection discards it and the run fails as not_installed before the
+    // contract file is ever written — a vacuous pass.
+    binRoot = createTrustedReviewerDirectory('safeword-contract-bin-');
+    const bin = nodePath.join(binRoot, 'bin');
+    mkdirSync(bin, { recursive: true });
+    const executable = nodePath.join(bin, 'codex');
+    writeFileSync(
+      executable,
+      `#!/bin/sh\nif printf '%s' "$*" | /usr/bin/grep -q -- '--help'; then printf '%s\\n' '${REVIEWER_CAPABILITIES.codex}'; exit 0; fi\nprintf 'launched\\n' >> '${nodePath.join(binRoot, 'launched.log')}'\nexit 0\n`,
+      { mode: 0o755 },
+    );
+    chmodSync(executable, 0o755);
+    process.env.TMPDIR = blockChildren(nodePath.join(scratch, 'readonly'));
+    process.env.PATH = `${bin}:/usr/bin:/bin`;
     await body(scratch, binRoot);
   } finally {
     if (originalTemporary === undefined) delete process.env.TMPDIR;
     else process.env.TMPDIR = originalTemporary;
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
-    rmSync(scratch, { recursive: true, force: true });
-    rmSync(binRoot, { recursive: true, force: true });
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+    if (binRoot) rmSync(binRoot, { recursive: true, force: true });
   }
 }
 
@@ -78,7 +77,6 @@ describe('when the result contract cannot be written', () => {
       expect(reported?.message).toBe('The codex review could not be prepared');
       expect(reported?.failure).toBe('process_failed');
       expect(reported?.message).not.toContain(nodePath.join(scratch, 'readonly'));
-      expect(reported?.message).not.toContain('schema');
     });
   });
 });

--- a/packages/cli/tests/review/contract-file-failure.test.ts
+++ b/packages/cli/tests/review/contract-file-failure.test.ts
@@ -38,7 +38,7 @@ async function withUnwritableTemporaryRoot(
     const executable = nodePath.join(bin, 'codex');
     writeFileSync(
       executable,
-      `#!/bin/sh\nif printf '%s' "$*" | /usr/bin/grep -q -- '--help'; then printf '%s\\n' '${REVIEWER_CAPABILITIES.codex}'; exit 0; fi\nprintf 'launched\\n' >> '${nodePath.join(binRoot, 'launched.log')}'\nexit 0\n`,
+      `#!/bin/sh\nif printf '%s' "$*" | grep -q -- '--help'; then printf '%s\\n' '${REVIEWER_CAPABILITIES.codex}'; exit 0; fi\nprintf 'launched\\n' >> '${nodePath.join(binRoot, 'launched.log')}'\nexit 0\n`,
       { mode: 0o755 },
     );
     chmodSync(executable, 0o755);

--- a/packages/cli/tests/review/contract-file-failure.test.ts
+++ b/packages/cli/tests/review/contract-file-failure.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { ReviewPacket } from '../../src/review/contract.js';
 import { ReviewRuntimeError, runHeadlessReviewer } from '../../src/review/runtime.js';
+import { blockChildren } from '../helpers/io-failure.js';
 import { createTrustedReviewerDirectory, REVIEWER_CAPABILITIES } from '../review-fixtures.js';
 
 const packet: ReviewPacket = {
@@ -37,9 +38,7 @@ async function withUnwritableTemporaryRoot(
   );
   chmodSync(executable, 0o755);
 
-  const readonly = nodePath.join(scratch, 'readonly');
-  mkdirSync(readonly);
-  chmodSync(readonly, 0o500);
+  const readonly = blockChildren(nodePath.join(scratch, 'readonly'));
 
   const originalTemporary = process.env.TMPDIR;
   const originalPath = process.env.PATH;
@@ -52,7 +51,6 @@ async function withUnwritableTemporaryRoot(
     else process.env.TMPDIR = originalTemporary;
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
-    chmodSync(readonly, 0o700);
     rmSync(scratch, { recursive: true, force: true });
     rmSync(binRoot, { recursive: true, force: true });
   }

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -128,6 +128,12 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o444)']);
   });
 
+  it('does not treat an unrelated getuid reference as a root-skip waiver', () => {
+    const source =
+      'it("unguarded", () => { expect(process.getuid?.()).toBe(501); chmodSync(p, 0o444); });';
+    expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o444)']);
+  });
+
   it.each([`chmodSync(p, 0o755)`, `chmodSync(p, 0o644)`, `chmodSync(p, '700')`])(
     'allows %s',
     source => {
@@ -142,6 +148,8 @@ describe('permission-simulation detection', () => {
   it.each([
     ['a flag between chmod and its mode', 'const command = "chmod -R a-w dir";'],
     ['a symbolic mode that assigns away write', 'const command = "chmod u=r file";'],
+    ['a four-digit numeric mode', 'const command = "chmod 4000 file";'],
+    ['a compound symbolic mode', 'const command = "chmod u=r,go= file";'],
     ['chmod invoked as a subprocess with an argv array', `execFileSync('chmod', ['000', p])`],
     ['the promise API rather than the sync one', 'await fs.promises.chmod(p, 0o000)'],
     ['a renamed import', `import { chmodSync as lockDown } from 'node:fs';\nlockDown(p, 0o000);`],
@@ -195,6 +203,7 @@ describe('permission-simulation detection', () => {
   it.each([
     ['a recursive grant', 'const command = "chmod -R u+w dir";'],
     ['a symbolic mode that keeps read and write', 'const command = "chmod u=rw file";'],
+    ['a compound symbolic mode that keeps owner access', 'const command = "chmod u=rw,go= file";'],
     ['a subprocess chmod granting access', `execFileSync('chmod', ['755', p])`],
     ['a promise-API grant', 'await fs.promises.chmod(p, 0o755)'],
   ])('allows %s', (_label, source) => {

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -30,8 +30,16 @@ import {
   permissionSimulations,
 } from './helpers/permission-simulation.js';
 
-const PACKAGES_ROOT = nodePath.resolve(import.meta.dirname, '../..');
+const REPOSITORY_ROOT = nodePath.resolve(import.meta.dirname, '../../..');
 const SCANNED_EXTENSIONS = new Set(['.ts', '.mts', '.cts', '.tsx']);
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.project',
+  '.safeword',
+  'dist',
+  'fixtures',
+  'node_modules',
+]);
 
 function testFiles(directory: string): string[] {
   const found: string[] = [];
@@ -39,7 +47,7 @@ function testFiles(directory: string): string[] {
   for (const entry of entries) {
     const full = nodePath.join(directory, entry.name);
     if (entry.isDirectory()) {
-      if (['dist', 'fixtures', 'node_modules'].includes(entry.name)) continue;
+      if (EXCLUDED_DIRECTORIES.has(entry.name)) continue;
       found.push(...testFiles(full));
     } else if (
       SCANNED_EXTENSIONS.has(nodePath.extname(entry.name)) &&
@@ -114,6 +122,24 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations(source)).toEqual([]);
   });
 
+  it('waives a call under a chained root guard', () => {
+    const source = [
+      'it.skipIf(process.getuid?.() === 0).each([1, 2])("guarded", () => {',
+      '  chmodSync(path, 0o444);',
+      '});',
+    ].join('\n');
+    expect(permissionSimulations(source)).toEqual([]);
+  });
+
+  it('waives a call under a root-guarded suite', () => {
+    const source = [
+      'describe.skipIf(process.getuid?.() === 0)("guarded", () => {',
+      '  it("fails", () => chmodSync(path, 0o444));',
+      '});',
+    ].join('\n');
+    expect(permissionSimulations(source)).toEqual([]);
+  });
+
   it('still flags the same call with no root guard in reach', () => {
     expect(permissionSimulations('chmodSync(path, 0o444);')).toEqual(['chmodSync(…, 0o444)']);
   });
@@ -154,8 +180,10 @@ describe('permission-simulation detection', () => {
     ['a four-digit numeric mode', 'const command = "chmod 4000 file";'],
     ['a compound symbolic mode', 'const command = "chmod u=r,go= file";'],
     ['chmod invoked as a subprocess with an argv array', `execFileSync('chmod', ['000', p])`],
+    ['chmod invoked by absolute path', `execFileSync('/bin/chmod', ['000', p])`],
     ['the promise API rather than the sync one', 'await fs.promises.chmod(p, 0o000)'],
     ['a renamed import', `import { chmodSync as lockDown } from 'node:fs';\nlockDown(p, 0o000);`],
+    ['a literal mode bound to a constant', 'const mode = 0o000; chmodSync(p, mode);'],
   ])('flags %s', (_label, source) => {
     expect(permissionSimulations(source)).not.toEqual([]);
   });
@@ -218,9 +246,9 @@ describe('uid-dependent permission simulations', () => {
   it('no test removes owner read or write to simulate an I/O failure', () => {
     const offenders: string[] = [];
 
-    for (const file of testFiles(PACKAGES_ROOT)) {
+    for (const file of testFiles(REPOSITORY_ROOT)) {
       if (file.endsWith('uid-dependent-permission-tripwire.test.ts')) continue;
-      const relative = nodePath.relative(PACKAGES_ROOT, file);
+      const relative = nodePath.relative(REPOSITORY_ROOT, file);
       const found = permissionSimulations(readFileSync(file, 'utf8'));
       for (const offender of found) offenders.push(`${relative}: ${offender}`);
     }

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -143,13 +143,13 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations(source)).not.toEqual([]);
   });
 
-  // Review's second claim was that the scanner desynchronizes after `return
-  // /.../` or `=> /.../` and hides a later violation. It does mis-read both —
-  // neither `n` nor `>` opens a regex context, so the `/` reads as division and
-  // the quote inside starts a "string" that runs on. It cannot hide anything,
-  // because only comment spans are removed: every other byte is emitted
-  // verbatim, so a mis-tracked literal leaves the later call in the output.
-  // The failure direction is a false positive, never a false clean.
+  // A regex literal after `return` or `=>` used to read as division, because
+  // the character before the slash is `n` or `>`. The quote inside it then
+  // opened a "string" that ran to the next quote anywhere later in the file —
+  // and if that landed before a URL, the `//` in `https://` read as a comment
+  // and took the rest of its line, call included. Two independent mistakes
+  // compounding into a false clean, which is the one direction this must not
+  // fail in.
   it.each([
     ['a return statement', 'function f() { return /(["\'])/u; }\nchmodSync(p, 0o000);'],
     ['an arrow body', 'const f = () => /(["\'])/u;\nchmodSync(p, 0o000);'],
@@ -157,8 +157,26 @@ describe('permission-simulation detection', () => {
       'a return, with a comment after it',
       'function f() { return /(["\'])/u; }\n// note\nchmodSync(p, 0o000);',
     ],
+    [
+      'an arrow body, with the call sharing a line with a URL',
+      'const f = () => /(["\'])/u;\nconst u = "https://x.com"; chmodSync(p, 0o000);',
+    ],
+    // `)` cannot join the list that `>` joined — `(a + b) / c` is division and
+    // far more common than a regex here — so this one stays mis-read. It is
+    // caught because a `//` directly after a colon is a URL scheme rather than
+    // a comment, which holds however the scan arrived there.
+    [
+      'a condition, where the slash is genuinely ambiguous',
+      'if (x) /(["\'])/u.test(s);\nconst u = "https://x.com"; chmodSync(p, 0o000);',
+    ],
   ])('still sees a violation after a regex literal in %s', (_label, source) => {
     expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o000)']);
+  });
+
+  // The mode is the second argument of every fs chmod. Reading the last one
+  // instead works until the async form puts a callback after it.
+  it('reads the mode past a trailing callback', () => {
+    expect(permissionSimulations('chmod(p, 0o000, done);')).toEqual(['chmod(…, 0o000)']);
   });
 
   // Widening the detector must not start flagging chmods that grant access —

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tripwire: no test may simulate an I/O failure with a restrictive chmod.
+ *
+ * Root holds CAP_DAC_OVERRIDE and bypasses every file permission bit, so a
+ * chmod-based simulation silently does not happen under uid 0 — the code takes
+ * the SUCCESS path and the test fails while asserting on that success output.
+ *
+ * The damage is that the failure is environment-split and therefore invisible
+ * to the author. GitHub Actions runs as `runner` (uid 1001), so the test is
+ * green in CI and red in every root container: agent sessions, devcontainers,
+ * plain `docker run`. A reader in a container sees a broken suite and cannot
+ * tell which failures are real.
+ *
+ * Use `tests/helpers/io-failure.ts` instead — it induces failures through
+ * filesystem structure (EISDIR / ENOTDIR / ELOOP, or a /dev/null sink), which
+ * no uid can override.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const TEST_ROOT = nodePath.join(import.meta.dirname);
+
+/** Owner read+write. A mode missing either bit is a permission simulation. */
+const OWNER_READ_WRITE = 0o600;
+
+/** `chmodSync(target, 0o___)` — captures the octal literal. */
+const CHMOD_OCTAL = /chmodSync\([^,]+,\s*(0o[0-7]{3,4})\s*\)/gu;
+
+/** `chmod a-w`, `chmod -w`, `chmod 000`, `chmod u-w` inside shell fixtures. */
+const SHELL_CHMOD_REMOVING_ACCESS = /chmod\s+(?:[augo]*-[rw]|0?[0-5][0-7][0-7]\b)/gu;
+
+/**
+ * Drops line and block comments so prose ABOUT this rule — including the
+ * comments the fixes left behind explaining why chmod was replaced — is not
+ * mistaken for a violation.
+ */
+function withoutComments(source: string): string {
+  return source.replaceAll(/\/\*[\s\S]*?\*\//gu, '').replaceAll(/\/\/[^\n]*/gu, '');
+}
+
+function testFiles(directory: string): string[] {
+  const found: string[] = [];
+  const entries = readdirSync(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = nodePath.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'fixtures' || entry.name === 'node_modules') continue;
+      found.push(...testFiles(full));
+    } else if (entry.name.endsWith('.ts')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+describe('uid-dependent permission simulations', () => {
+  it('no test chmods away owner read or write to simulate an I/O failure', () => {
+    const offenders: string[] = [];
+
+    for (const file of testFiles(TEST_ROOT)) {
+      if (file.endsWith('uid-dependent-permission-tripwire.test.ts')) continue;
+      const source = withoutComments(readFileSync(file, 'utf8'));
+      const relative = nodePath.relative(TEST_ROOT, file);
+
+      const octalModes = source
+        .matchAll(CHMOD_OCTAL)
+        .map(match => match[1] ?? '0o600')
+        .toArray();
+      for (const literal of octalModes) {
+        const mode = Number.parseInt(literal.slice(2), 8);
+        if ((mode & OWNER_READ_WRITE) !== OWNER_READ_WRITE) {
+          offenders.push(`${relative}: chmodSync(…, ${literal})`);
+        }
+      }
+
+      for (const match of source.matchAll(SHELL_CHMOD_REMOVING_ACCESS)) {
+        offenders.push(`${relative}: ${match[0]}`);
+      }
+    }
+
+    expect(
+      offenders,
+      'Root bypasses permission bits, so these simulate nothing under uid 0 — ' +
+        'the test passes in CI (uid 1001) and fails in every root container. ' +
+        'Use tests/helpers/io-failure.ts instead.',
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -87,6 +87,9 @@ describe('permission-simulation detection', () => {
 
   it.each([
     ['0o000', 0o000],
+    ['0o0', 0],
+    ['0b0', 0],
+    ['256', 256],
     ['0o200', 0o200],
     ['0o755', 0o755],
     ['0', 0],
@@ -100,12 +103,16 @@ describe('permission-simulation detection', () => {
     expect(literalMode('mode')).toBeUndefined();
   });
 
-  it.each([`chmodSync(p, 0)`, `chmodSync(p, '000')`, `chmodSync(p, 0o200)`])(
-    'flags %s as removing access',
-    source => {
-      expect(permissionSimulations(source)).toHaveLength(1);
-    },
-  );
+  it.each([
+    `chmodSync(p, 0)`,
+    `chmodSync(p, 0o0)`,
+    `chmodSync(p, 0b0)`,
+    `chmodSync(p, 256)`,
+    `chmodSync(p, '000')`,
+    `chmodSync(p, 0o200)`,
+  ])('flags %s as removing access', source => {
+    expect(permissionSimulations(source)).toHaveLength(1);
+  });
 
   it('waives a call a root guard already covers', () => {
     // The established form in this repo: the test refuses to run as root, so the
@@ -184,6 +191,7 @@ describe('permission-simulation detection', () => {
     ['a symbolic mode that assigns away write', 'const command = "chmod u=r file";'],
     ['a four-digit numeric mode', 'const command = "chmod 4000 file";'],
     ['a compound symbolic mode', 'const command = "chmod u=r,go= file";'],
+    ['an unknown literal shell mode', 'const command = "chmod --reference=locked file";'],
     ['chmod invoked as a subprocess with an argv array', `execFileSync('chmod', ['000', p])`],
     ['chmod invoked by absolute path', `execFileSync('/bin/chmod', ['000', p])`],
     ['the promise API rather than the sync one', 'await fs.promises.chmod(p, 0o000)'],

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -28,7 +28,6 @@ import {
   chmodModeArguments,
   literalMode,
   permissionSimulations,
-  withoutComments,
 } from './helpers/permission-simulation.js';
 
 const TEST_ROOT = import.meta.dirname;
@@ -57,15 +56,9 @@ describe('permission-simulation detection', () => {
   });
 
   it.each(['a // chmodSync(p, 0o000)\nb', '/* chmodSync(p, 0o000) */ b'])(
-    'blanks comment content while keeping offsets aligned: %j',
+    'ignores calls in comments: %j',
     source => {
-      const stripped = withoutComments(source);
-      // Content gone, so a documented example cannot be read as a violation…
-      expect(stripped).not.toContain('chmodSync');
-      // …but length and newlines preserved, so a reported offset still points
-      // at the line it came from.
-      expect(stripped).toHaveLength(source.length);
-      expect(stripped.split('\n')).toHaveLength(source.split('\n').length);
+      expect(permissionSimulations(source)).toEqual([]);
     },
   );
 
@@ -147,8 +140,8 @@ describe('permission-simulation detection', () => {
   // anything: a recursive chmod, a symbolic mode, chmod as a subprocess, and
   // the promise API.
   it.each([
-    ['a flag between chmod and its mode', 'chmod -R a-w dir'],
-    ['a symbolic mode that assigns away write', 'chmod u=r file'],
+    ['a flag between chmod and its mode', 'const command = "chmod -R a-w dir";'],
+    ['a symbolic mode that assigns away write', 'const command = "chmod u=r file";'],
     ['chmod invoked as a subprocess with an argv array', `execFileSync('chmod', ['000', p])`],
     ['the promise API rather than the sync one', 'await fs.promises.chmod(p, 0o000)'],
     ['a renamed import', `import { chmodSync as lockDown } from 'node:fs';\nlockDown(p, 0o000);`],
@@ -195,8 +188,8 @@ describe('permission-simulation detection', () => {
   // Widening the detector must not start flagging chmods that grant access —
   // an over-eager tripwire gets waived, and then it guards nothing.
   it.each([
-    ['a recursive grant', 'chmod -R u+w dir'],
-    ['a symbolic mode that keeps read and write', 'chmod u=rw file'],
+    ['a recursive grant', 'const command = "chmod -R u+w dir";'],
+    ['a symbolic mode that keeps read and write', 'const command = "chmod u=rw file";'],
     ['a subprocess chmod granting access', `execFileSync('chmod', ['755', p])`],
     ['a promise-API grant', 'await fs.promises.chmod(p, 0o755)'],
   ])('allows %s', (_label, source) => {

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tripwire: no test may simulate an I/O failure with a restrictive chmod.
+ * Tripwire: no test may simulate an I/O failure by removing permissions.
  *
- * Root holds CAP_DAC_OVERRIDE and bypasses every file permission bit, so a
- * chmod-based simulation silently does not happen under uid 0 — the code takes
- * the SUCCESS path and the test fails while asserting on that success output.
+ * Root holds CAP_DAC_OVERRIDE and bypasses every file permission bit, so such a
+ * simulation silently does not happen under uid 0 — the code takes the SUCCESS
+ * path and the test fails while asserting on that success output.
  *
  * The damage is that the failure is environment-split and therefore invisible
  * to the author. GitHub Actions runs as `runner` (uid 1001), so the test is
@@ -14,6 +14,9 @@
  * Use `tests/helpers/io-failure.ts` instead — it induces failures through
  * filesystem structure (EISDIR / ENOTDIR / ELOOP, or a /dev/null sink), which
  * no uid can override.
+ *
+ * The detection lives in `helpers/permission-simulation.ts` so its own evasions
+ * are testable; the cases below are the ones review found in the first version.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -21,25 +24,15 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import {
+  chmodModeArguments,
+  literalMode,
+  permissionSimulations,
+  withoutComments,
+} from './helpers/permission-simulation.js';
+
 const TEST_ROOT = import.meta.dirname;
-
-/** Owner read+write. A mode missing either bit is a permission simulation. */
-const OWNER_READ_WRITE = 0o600;
-
-/** `chmodSync(target, 0o___)` — captures the octal literal. */
-const CHMOD_OCTAL = /chmodSync\([^,]+,\s*(0o[0-7]{3,4})\s*\)/gu;
-
-/** `chmod a-w`, `chmod -w`, `chmod 000`, `chmod u-w` inside shell fixtures. */
-const SHELL_CHMOD_REMOVING_ACCESS = /chmod\s+(?:[augo]*-[rw]|0?[0-5][0-7][0-7]\b)/gu;
-
-/**
- * Drops line and block comments so prose ABOUT this rule — including the
- * comments the fixes left behind explaining why chmod was replaced — is not
- * mistaken for a violation.
- */
-function withoutComments(source: string): string {
-  return source.replaceAll(/\/\*[\s\S]*?\*\//gu, '').replaceAll(/\/\/[^\n]*/gu, '');
-}
+const SCANNED_EXTENSIONS = new Set(['.ts', '.mts', '.cts', '.tsx']);
 
 function testFiles(directory: string): string[] {
   const found: string[] = [];
@@ -49,36 +42,103 @@ function testFiles(directory: string): string[] {
     if (entry.isDirectory()) {
       if (entry.name === 'fixtures' || entry.name === 'node_modules') continue;
       found.push(...testFiles(full));
-    } else if (entry.name.endsWith('.ts')) {
+    } else if (SCANNED_EXTENSIONS.has(nodePath.extname(entry.name))) {
       found.push(full);
     }
   }
   return found;
 }
 
+describe('permission-simulation detection', () => {
+  it('keeps a call whose line also holds a URL', () => {
+    // A naive `//` strip deletes the rest of this line, hiding the call.
+    const source = `const u = "https://x.com"; chmodSync(p, 0o000);`;
+    expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o000)']);
+  });
+
+  it.each(['a // chmodSync(p, 0o000)\nb', '/* chmodSync(p, 0o000) */ b'])(
+    'blanks comment content while keeping offsets aligned: %j',
+    source => {
+      const stripped = withoutComments(source);
+      // Content gone, so a documented example cannot be read as a violation…
+      expect(stripped).not.toContain('chmodSync');
+      // …but length and newlines preserved, so a reported offset still points
+      // at the line it came from.
+      expect(stripped).toHaveLength(source.length);
+      expect(stripped.split('\n')).toHaveLength(source.split('\n').length);
+    },
+  );
+
+  it('reads a mode wrapped onto its own line with a trailing comma', () => {
+    expect(chmodModeArguments('chmodSync(\n  path,\n  0o000,\n)').map(c => c.mode)).toEqual([
+      '0o000',
+    ]);
+  });
+
+  it('reads a mode past a path argument containing its own comma', () => {
+    expect(chmodModeArguments(`chmodSync(nodePath.join(a, b), 0o000)`).map(c => c.mode)).toEqual([
+      '0o000',
+    ]);
+  });
+
+  it.each([
+    ['0o000', 0o000],
+    ['0o200', 0o200],
+    ['0o755', 0o755],
+    ['0', 0],
+    [`'000'`, 0],
+    [`"600"`, 0o600],
+  ])('evaluates the literal mode %s', (argument, expected) => {
+    expect(literalMode(argument)).toBe(expected);
+  });
+
+  it('cannot evaluate a variable mode, and says so rather than guessing', () => {
+    expect(literalMode('mode')).toBeUndefined();
+  });
+
+  it.each([`chmodSync(p, 0)`, `chmodSync(p, '000')`, `chmodSync(p, 0o200)`])(
+    'flags %s as removing access',
+    source => {
+      expect(permissionSimulations(source)).toHaveLength(1);
+    },
+  );
+
+  it('waives a call a root guard already covers', () => {
+    // The established form in this repo: the test refuses to run as root, so the
+    // simulation is never relied upon. Flagging it would push authors to delete
+    // a correct guard.
+    const source = [
+      'it.skipIf(process.getuid?.() === 0)(',
+      "  'fails when the file is not writable',",
+      '  async () => {',
+      '    chmodSync(path, 0o444);',
+      '  },',
+      ');',
+    ].join('\n');
+    expect(permissionSimulations(source)).toEqual([]);
+  });
+
+  it('still flags the same call with no root guard in reach', () => {
+    expect(permissionSimulations('chmodSync(path, 0o444);')).toEqual(['chmodSync(…, 0o444)']);
+  });
+
+  it.each([`chmodSync(p, 0o755)`, `chmodSync(p, 0o644)`, `chmodSync(p, '700')`])(
+    'allows %s',
+    source => {
+      expect(permissionSimulations(source)).toEqual([]);
+    },
+  );
+});
+
 describe('uid-dependent permission simulations', () => {
-  it('no test chmods away owner read or write to simulate an I/O failure', () => {
+  it('no test removes owner read or write to simulate an I/O failure', () => {
     const offenders: string[] = [];
 
     for (const file of testFiles(TEST_ROOT)) {
       if (file.endsWith('uid-dependent-permission-tripwire.test.ts')) continue;
-      const source = withoutComments(readFileSync(file, 'utf8'));
       const relative = nodePath.relative(TEST_ROOT, file);
-
-      const octalModes = source
-        .matchAll(CHMOD_OCTAL)
-        .map(match => match[1] ?? '0o600')
-        .toArray();
-      for (const literal of octalModes) {
-        const mode = Number.parseInt(literal.slice(2), 8);
-        if ((mode & OWNER_READ_WRITE) !== OWNER_READ_WRITE) {
-          offenders.push(`${relative}: chmodSync(…, ${literal})`);
-        }
-      }
-
-      for (const match of source.matchAll(SHELL_CHMOD_REMOVING_ACCESS)) {
-        offenders.push(`${relative}: ${match[0]}`);
-      }
+      const found = permissionSimulations(readFileSync(file, 'utf8'));
+      for (const offender of found) offenders.push(`${relative}: ${offender}`);
     }
 
     expect(

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -30,7 +30,7 @@ import {
   permissionSimulations,
 } from './helpers/permission-simulation.js';
 
-const TEST_ROOT = import.meta.dirname;
+const PACKAGES_ROOT = nodePath.resolve(import.meta.dirname, '../..');
 const SCANNED_EXTENSIONS = new Set(['.ts', '.mts', '.cts', '.tsx']);
 
 function testFiles(directory: string): string[] {
@@ -39,9 +39,12 @@ function testFiles(directory: string): string[] {
   for (const entry of entries) {
     const full = nodePath.join(directory, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === 'fixtures' || entry.name === 'node_modules') continue;
+      if (['dist', 'fixtures', 'node_modules'].includes(entry.name)) continue;
       found.push(...testFiles(full));
-    } else if (SCANNED_EXTENSIONS.has(nodePath.extname(entry.name))) {
+    } else if (
+      SCANNED_EXTENSIONS.has(nodePath.extname(entry.name)) &&
+      (full.includes(`${nodePath.sep}tests${nodePath.sep}`) || entry.name.includes('.test.'))
+    ) {
       found.push(full);
     }
   }
@@ -215,9 +218,9 @@ describe('uid-dependent permission simulations', () => {
   it('no test removes owner read or write to simulate an I/O failure', () => {
     const offenders: string[] = [];
 
-    for (const file of testFiles(TEST_ROOT)) {
+    for (const file of testFiles(PACKAGES_ROOT)) {
       if (file.endsWith('uid-dependent-permission-tripwire.test.ts')) continue;
-      const relative = nodePath.relative(TEST_ROOT, file);
+      const relative = nodePath.relative(PACKAGES_ROOT, file);
       const found = permissionSimulations(readFileSync(file, 'utf8'));
       for (const offender of found) offenders.push(`${relative}: ${offender}`);
     }

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -163,6 +163,11 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o444)']);
   });
 
+  it('does not accept an inverted root guard as a waiver', () => {
+    const source = 'it.skipIf(process.getuid?.() !== 0)("root only", () => chmodSync(p, 0o444));';
+    expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o444)']);
+  });
+
   it.each([`chmodSync(p, 0o755)`, `chmodSync(p, 0o644)`, `chmodSync(p, '700')`])(
     'allows %s',
     source => {

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -21,7 +21,7 @@ import nodePath from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const TEST_ROOT = nodePath.join(import.meta.dirname);
+const TEST_ROOT = import.meta.dirname;
 
 /** Owner read+write. A mode missing either bit is a permission simulation. */
 const OWNER_READ_WRITE = 0o600;

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -149,6 +149,11 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations(source)).not.toEqual([]);
   });
 
+  it('flags chmod in a shell template with substitutions', () => {
+    const source = 'const script = String.raw`echo ${value}; chmod 000 file`;';
+    expect(permissionSimulations(source)).toEqual(['chmod 000']);
+  });
+
   // A regex literal after `return` or `=>` used to read as division, because
   // the character before the slash is `n` or `>`. The quote inside it then
   // opened a "string" that ran to the next quote anywhere later in the file —

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -122,6 +122,19 @@ describe('permission-simulation detection', () => {
     expect(permissionSimulations('chmodSync(path, 0o444);')).toEqual(['chmodSync(…, 0o444)']);
   });
 
+  it('does not let a guarded test waive a neighboring unguarded test', () => {
+    const source = [
+      'it.skipIf(process.getuid?.() === 0)("guarded", () => {',
+      '  chmodSync(guardedPath, 0o444);',
+      '});',
+      'it("unguarded", () => {',
+      '  chmodSync(unguardedPath, 0o444);',
+      '});',
+    ].join('\n');
+
+    expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o444)']);
+  });
+
   it.each([`chmodSync(p, 0o755)`, `chmodSync(p, 0o644)`, `chmodSync(p, '700')`])(
     'allows %s',
     source => {

--- a/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
+++ b/packages/cli/tests/uid-dependent-permission-tripwire.test.ts
@@ -128,6 +128,49 @@ describe('permission-simulation detection', () => {
       expect(permissionSimulations(source)).toEqual([]);
     },
   );
+
+  // Review found these four ways to remove access that the first detector did
+  // not see. Every one is a form someone reaches for without trying to evade
+  // anything: a recursive chmod, a symbolic mode, chmod as a subprocess, and
+  // the promise API.
+  it.each([
+    ['a flag between chmod and its mode', 'chmod -R a-w dir'],
+    ['a symbolic mode that assigns away write', 'chmod u=r file'],
+    ['chmod invoked as a subprocess with an argv array', `execFileSync('chmod', ['000', p])`],
+    ['the promise API rather than the sync one', 'await fs.promises.chmod(p, 0o000)'],
+    ['a renamed import', `import { chmodSync as lockDown } from 'node:fs';\nlockDown(p, 0o000);`],
+  ])('flags %s', (_label, source) => {
+    expect(permissionSimulations(source)).not.toEqual([]);
+  });
+
+  // Review's second claim was that the scanner desynchronizes after `return
+  // /.../` or `=> /.../` and hides a later violation. It does mis-read both —
+  // neither `n` nor `>` opens a regex context, so the `/` reads as division and
+  // the quote inside starts a "string" that runs on. It cannot hide anything,
+  // because only comment spans are removed: every other byte is emitted
+  // verbatim, so a mis-tracked literal leaves the later call in the output.
+  // The failure direction is a false positive, never a false clean.
+  it.each([
+    ['a return statement', 'function f() { return /(["\'])/u; }\nchmodSync(p, 0o000);'],
+    ['an arrow body', 'const f = () => /(["\'])/u;\nchmodSync(p, 0o000);'],
+    [
+      'a return, with a comment after it',
+      'function f() { return /(["\'])/u; }\n// note\nchmodSync(p, 0o000);',
+    ],
+  ])('still sees a violation after a regex literal in %s', (_label, source) => {
+    expect(permissionSimulations(source)).toEqual(['chmodSync(…, 0o000)']);
+  });
+
+  // Widening the detector must not start flagging chmods that grant access —
+  // an over-eager tripwire gets waived, and then it guards nothing.
+  it.each([
+    ['a recursive grant', 'chmod -R u+w dir'],
+    ['a symbolic mode that keeps read and write', 'chmod u=rw file'],
+    ['a subprocess chmod granting access', `execFileSync('chmod', ['755', p])`],
+    ['a promise-API grant', 'await fs.promises.chmod(p, 0o755)'],
+  ])('allows %s', (_label, source) => {
+    expect(permissionSimulations(source)).toEqual([]);
+  });
 });
 
 describe('uid-dependent permission simulations', () => {


### PR DESCRIPTION
## What

A class of test in this suite passes in CI and fails everywhere agents actually run. Three independent instances, plus the guards to stop them recurring.

### 1. uid — `chmod` simulates nothing under root

Root holds `CAP_DAC_OVERRIDE` and bypasses every permission bit, so a `chmod`-based failure simulation silently does not happen as uid 0: the code takes the success path and the test fails asserting on that output. GitHub Actions runs as `runner` (uid 1001), so these are green in CI and red in every root container — agent sessions, devcontainers, plain `docker run`.

`tests/helpers/io-failure.ts` induces failure through filesystem *structure* instead, which no uid can override:

| Helper | Effect | errno |
|---|---|---|
| `sinkWrites` | writes land, reads come back empty | — (`/dev/null`) |
| `blockWrites` | writing this exact path fails | `EISDIR` |
| `blockChildren` | creating anything under this dir fails | `ENOTDIR` |
| `blockScan` | scanning into this dir fails | `ELOOP` |

Eight sites converted. The `architecture-stage` git clean-filter needed care: the failure must happen *mid-`git add`*, after git has read the content, so it swaps the document for a directory at that moment rather than chmod-ing the parent.

### 2. Clone shape — a documented prerequisite that never said its name

Four Claude-migration suites read real released bytes with `git show v<version>:<path>`, and the sealed-review suite walks a path's ancestry. Both need history a shallow or tagless clone lacks. **CI already pays for this** — three `ci.yml` jobs set `fetch-depth: 0` with comments naming these suites — so the dependency is deliberate, and reading from a tag is the point: a tag is an immutable record of what shipped, which a vendored fixture could not prove.

What was missing was any statement of it. A shallow clone produced 32 bare `fatal: invalid object name 'v0.68.0'` failures across five files, which reads as a broken suite. `tests/helpers/git-history.ts` now fails once per suite with the remedy.

### 3. Ambient env — fixtures presenting two host identities

Three closeout host-adapter tests build a Codex host by spreading `process.env`, then adding `CODEX_HOME`/`CODEX_THREAD_ID`. Run identity resolves Claude **before** Codex on purpose (`run-identity.ts`: *"Keep this after Claude detection so an explicit Claude environment never adopts a Codex runtime accidentally"*), so a suite running inside a Claude Code session also handed the child its own `CLAUDE_CODE_SESSION_ID`. The production precedence is correct; the fixtures were presenting two identities and expecting the second to win.

Verified 25/25 both inside a Claude Code session and with the agent variables unset, so neither environment is now required.

## The guard

`uid-dependent-permission-tripwire.test.ts` fails on a permission-removing simulation. Review found four ways past the first version — all reproduced, all now pinned as cases:

- a line holding a URL lost its call to naive `//` stripping
- a Prettier-wrapped call with a trailing comma did not match
- a path argument with its own comma defeated the `[^,]+` match
- only `0o___` counted, so `chmodSync(p, 0)` and `'000'` passed straight through

Detection moved to `helpers/permission-simulation.ts` and stops pattern-matching source. Note the obvious repair — mask strings first — **is also wrong**: a regex literal containing a quote starts a "string" running to the next quote anywhere in the file, and that module's own source contains one. It scans left to right instead.

**The rule is also corrected.** Turning the stronger detector on the suite surfaced two calls in `setup-hooks` and `setup-linting` already handled the established way — `it.skipIf(process.getuid?.() === 0)` with a comment saying why. Those are not violations, so the guard waives a call a root guard covers. The rule is *"never let a chmod stand in for a failure root will not produce"*, not *"never chmod"*.

## Evidence

- `helpers/io-failure.test.ts` asserts each helper raises the errno it documents against the real filesystem, plus the already-exists case. Reverting the `blockChildren` fix turns the matching case red.
- Planting an unguarded `chmodSync(p, 0)` trips the tripwire; the two waived tests still skip as root rather than being flagged (167 passed / 2 skipped).
- Full CLI suite went from 43 failures to 4, and the remaining 4 were an unrelated product bug now fixed in #2903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLAkuBV1krS8MmP38VjhyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLAkuBV1krS8MmP38VjhyX)_