### PR TITLE
refactor: collapse the duplication in the relay HTTP router

### DIFF
--- a/packages/retro-relay/src/http-server.ts
+++ b/packages/retro-relay/src/http-server.ts
@@ -197,6 +197,25 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
     if (ownsProcessLock) processLock?.release();
   });
 
+  const recordReconciliationOutcome = (entry: {
+    receiptId: string;
+    subject: string;
+    disposition: string;
+    alert?: boolean;
+  }): void => {
+    observability.logs.push({
+      event: 'retro_reconciliation',
+      receiptId: entry.receiptId,
+      subject: entry.subject,
+      disposition: entry.disposition,
+      ...(entry.alert === true && { alert: true }),
+    });
+    observability.metrics.push({
+      metric: 'retro_reconciliation_outcome',
+      disposition: entry.disposition,
+    });
+  };
+
   // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- A single composition-root router keeps the public contract visible.
   async function handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
     try {
@@ -271,14 +290,9 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
         const decodedReceipt = decodePathSegment(reconciliation[1]);
         try {
           const receipt = await service.reconcile(principal, decodedReceipt);
-          observability.logs.push({
-            event: 'retro_reconciliation',
+          recordReconciliationOutcome({
             receiptId: decodedReceipt,
             subject: principal.subject,
-            disposition: 'adopted',
-          });
-          observability.metrics.push({
-            metric: 'retro_reconciliation_outcome',
             disposition: 'adopted',
           });
           sendJson(response, 200, receipt);
@@ -288,16 +302,11 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
               ? error.details.disposition
               : undefined;
           if (disposition !== undefined) {
-            observability.logs.push({
-              event: 'retro_reconciliation',
+            recordReconciliationOutcome({
               receiptId: decodedReceipt,
               subject: principal.subject,
               disposition,
               alert: true,
-            });
-            observability.metrics.push({
-              metric: 'retro_reconciliation_outcome',
-              disposition,
             });
           }
           throw error;
@@ -309,14 +318,9 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
         const decodedReceipt = decodePathSegment(recovery[1]);
         try {
           const recovered = await service.recover(principal, decodedReceipt);
-          observability.logs.push({
-            event: 'retro_reconciliation',
+          recordReconciliationOutcome({
             receiptId: decodedReceipt,
             subject: principal.subject,
-            disposition: recovered.disposition,
-          });
-          observability.metrics.push({
-            metric: 'retro_reconciliation_outcome',
             disposition: recovered.disposition,
           });
           sendJson(response, 200, recovered.receipt);
@@ -326,16 +330,11 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
               ? error.details.disposition
               : undefined;
           if (disposition !== undefined) {
-            observability.logs.push({
-              event: 'retro_reconciliation',
+            recordReconciliationOutcome({
               receiptId: decodedReceipt,
               subject: principal.subject,
               disposition,
               alert: true,
-            });
-            observability.metrics.push({
-              metric: 'retro_reconciliation_outcome',
-              disposition,
             });
           }
           throw error;

--- a/packages/retro-relay/src/http-server.ts
+++ b/packages/retro-relay/src/http-server.ts
@@ -216,6 +216,28 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
     });
   };
 
+  const respondWithReconciliation = async (
+    response: ServerResponse,
+    receiptId: string,
+    subject: string,
+    run: () => Promise<{ disposition: string; receipt: unknown }>,
+  ): Promise<void> => {
+    try {
+      const { disposition, receipt } = await run();
+      recordReconciliationOutcome({ receiptId, subject, disposition });
+      sendJson(response, 200, receipt);
+    } catch (error) {
+      const disposition =
+        error instanceof RelayError && typeof error.details?.disposition === 'string'
+          ? error.details.disposition
+          : undefined;
+      if (disposition !== undefined) {
+        recordReconciliationOutcome({ receiptId, subject, disposition, alert: true });
+      }
+      throw error;
+    }
+  };
+
   // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- A single composition-root router keeps the public contract visible.
   async function handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
     try {
@@ -288,57 +310,19 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
       const reconciliation = /^\/v1\/retro-filings\/([^/]+)\/reconcile$/u.exec(url.pathname);
       if (request.method === 'POST' && reconciliation?.[1] !== undefined) {
         const decodedReceipt = decodePathSegment(reconciliation[1]);
-        try {
-          const receipt = await service.reconcile(principal, decodedReceipt);
-          recordReconciliationOutcome({
-            receiptId: decodedReceipt,
-            subject: principal.subject,
-            disposition: 'adopted',
-          });
-          sendJson(response, 200, receipt);
-        } catch (error) {
-          const disposition =
-            error instanceof RelayError && typeof error.details?.disposition === 'string'
-              ? error.details.disposition
-              : undefined;
-          if (disposition !== undefined) {
-            recordReconciliationOutcome({
-              receiptId: decodedReceipt,
-              subject: principal.subject,
-              disposition,
-              alert: true,
-            });
-          }
-          throw error;
-        }
+        await respondWithReconciliation(response, decodedReceipt, principal.subject, async () => ({
+          disposition: 'adopted',
+          receipt: await service.reconcile(principal, decodedReceipt),
+        }));
         return;
       }
       const recovery = /^\/v1\/retro-filings\/([^/]+)\/recover$/u.exec(url.pathname);
       if (request.method === 'POST' && recovery?.[1] !== undefined) {
         const decodedReceipt = decodePathSegment(recovery[1]);
-        try {
+        await respondWithReconciliation(response, decodedReceipt, principal.subject, async () => {
           const recovered = await service.recover(principal, decodedReceipt);
-          recordReconciliationOutcome({
-            receiptId: decodedReceipt,
-            subject: principal.subject,
-            disposition: recovered.disposition,
-          });
-          sendJson(response, 200, recovered.receipt);
-        } catch (error) {
-          const disposition =
-            error instanceof RelayError && typeof error.details?.disposition === 'string'
-              ? error.details.disposition
-              : undefined;
-          if (disposition !== undefined) {
-            recordReconciliationOutcome({
-              receiptId: decodedReceipt,
-              subject: principal.subject,
-              disposition,
-              alert: true,
-            });
-          }
-          throw error;
-        }
+          return { disposition: recovered.disposition, receipt: recovered.receipt };
+        });
         return;
       }
       const status = /^\/v1\/retro-filings\/([^/]+)$/u.exec(url.pathname);

--- a/packages/retro-relay/src/http-server.ts
+++ b/packages/retro-relay/src/http-server.ts
@@ -16,6 +16,12 @@ import {
 const RELAY_API_VERSION = '1';
 const RELAY_API_VERSION_HEADER = 'x-safeword-relay-api-version';
 
+const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
+const DEFAULT_MAX_REQUESTS_PER_WINDOW = 60;
+const DEFAULT_RATE_WINDOW_MS = 60_000;
+const DEFAULT_MAINTENANCE_INTERVAL_MS = 60_000;
+const SOCKET_TIMEOUT_MS = 10_000;
+
 async function readJson(request: IncomingMessage, maximumBytes: number): Promise<unknown> {
   const contentLength = Number(request.headers['content-length'] ?? '0');
   if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
@@ -157,9 +163,10 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
     faults: serviceFaults,
     ...(input.now !== undefined && { now: input.now }),
   });
-  const maxBodyBytes = input.resourceLimits?.maxBodyBytes ?? 256 * 1024;
-  const maxRequestsPerWindow = input.resourceLimits?.maxRequestsPerWindow ?? 60;
-  const rateWindowMs = input.resourceLimits?.windowMs ?? 60_000;
+  const maxBodyBytes = input.resourceLimits?.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const maxRequestsPerWindow =
+    input.resourceLimits?.maxRequestsPerWindow ?? DEFAULT_MAX_REQUESTS_PER_WINDOW;
+  const rateWindowMs = input.resourceLimits?.windowMs ?? DEFAULT_RATE_WINDOW_MS;
   const rateWindows = new Map<string, { count: number; startedAt: number }>();
   const consumeRequestCapacity = (credentialId: string): boolean => {
     const now = (input.now?.() ?? new Date()).getTime();
@@ -203,14 +210,14 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
   const server = createServer((request, response) => {
     void handle(request, response);
   });
-  server.requestTimeout = 10_000;
-  server.headersTimeout = 10_000;
+  server.requestTimeout = SOCKET_TIMEOUT_MS;
+  server.headersTimeout = SOCKET_TIMEOUT_MS;
   const maintenanceTimer =
     input.mode === 'spike'
       ? undefined
       : setInterval(() => {
           void maintain();
-        }, input.maintenanceIntervalMs ?? 60_000);
+        }, input.maintenanceIntervalMs ?? DEFAULT_MAINTENANCE_INTERVAL_MS);
   maintenanceTimer?.unref();
   server.once('close', () => {
     if (maintenanceTimer !== undefined) clearInterval(maintenanceTimer);

--- a/packages/retro-relay/src/http-server.ts
+++ b/packages/retro-relay/src/http-server.ts
@@ -7,7 +7,11 @@ import type { PayloadKeyring } from './payload.js';
 import { ProcessLock } from './process-lock.js';
 import { type RelayFaults, RelayService } from './service.js';
 import type { RelayStore } from './store.js';
-import { type FileRetroDraftRequest, isTerminalReceiptState } from './types.js';
+import {
+  type FileRetroDraftRequest,
+  isTerminalReceiptState,
+  type RelayPrincipal,
+} from './types.js';
 
 const RELAY_API_VERSION = '1';
 const RELAY_API_VERSION_HEADER = 'x-safeword-relay-api-version';
@@ -238,6 +242,47 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
     }
   };
 
+  const respondWithSubmission = async (
+    request: IncomingMessage,
+    response: ServerResponse,
+    principal: RelayPrincipal,
+  ): Promise<void> => {
+    const requestedVersion = Reflect.get(request.headers, RELAY_API_VERSION_HEADER);
+    if (requestedVersion !== undefined && requestedVersion !== RELAY_API_VERSION) {
+      throw new RelayError(400, 'unsupported relay API version', {
+        supportedVersion: RELAY_API_VERSION,
+      });
+    }
+    const receipt = await service.submit(
+      principal,
+      (await readJson(request, maxBodyBytes)) as FileRetroDraftRequest,
+    );
+    observability.logs.push({
+      event: 'retro_filing',
+      harness: principal.harness,
+      requestId: receipt.requestId,
+      state: receipt.state,
+    });
+    observability.metrics.push({
+      metric: 'retro_filing_outcome',
+      requestId: receipt.requestId,
+      state: receipt.state,
+    });
+    try {
+      afterReceiptCommit?.();
+    } catch {
+      response.destroy();
+      return;
+    }
+    const terminal = isTerminalReceiptState(receipt.state);
+    if (!terminal) response.setHeader('retry-after', '1');
+    let statusCode = 202;
+    if (receipt.state === 'filed') statusCode = 201;
+    else if (terminal) statusCode = 200;
+    response.setHeader(RELAY_API_VERSION_HEADER, RELAY_API_VERSION);
+    sendJson(response, statusCode, receipt);
+  };
+
   // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- A single composition-root router keeps the public contract visible.
   async function handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
     try {
@@ -271,40 +316,7 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
         return;
       }
       if (request.method === 'POST' && url.pathname === '/v1/retro-filings') {
-        const requestedVersion = Reflect.get(request.headers, RELAY_API_VERSION_HEADER);
-        if (requestedVersion !== undefined && requestedVersion !== RELAY_API_VERSION) {
-          throw new RelayError(400, 'unsupported relay API version', {
-            supportedVersion: RELAY_API_VERSION,
-          });
-        }
-        const receipt = await service.submit(
-          principal,
-          (await readJson(request, maxBodyBytes)) as FileRetroDraftRequest,
-        );
-        observability.logs.push({
-          event: 'retro_filing',
-          harness: principal.harness,
-          requestId: receipt.requestId,
-          state: receipt.state,
-        });
-        observability.metrics.push({
-          metric: 'retro_filing_outcome',
-          requestId: receipt.requestId,
-          state: receipt.state,
-        });
-        try {
-          afterReceiptCommit?.();
-        } catch {
-          response.destroy();
-          return;
-        }
-        const terminal = isTerminalReceiptState(receipt.state);
-        if (!terminal) response.setHeader('retry-after', '1');
-        let statusCode = 202;
-        if (receipt.state === 'filed') statusCode = 201;
-        else if (terminal) statusCode = 200;
-        response.setHeader(RELAY_API_VERSION_HEADER, RELAY_API_VERSION);
-        sendJson(response, statusCode, receipt);
+        await respondWithSubmission(request, response, principal);
         return;
       }
       const reconciliation = /^\/v1\/retro-filings\/([^/]+)\/reconcile$/u.exec(url.pathname);

--- a/packages/retro-relay/src/http-server.ts
+++ b/packages/retro-relay/src/http-server.ts
@@ -57,6 +57,22 @@ function decodePathSegment(value: string): string {
   }
 }
 
+const RECONCILE_ROUTE = /^\/v1\/retro-filings\/([^/]+)\/reconcile$/u;
+const RECOVER_ROUTE = /^\/v1\/retro-filings\/([^/]+)\/recover$/u;
+const RECEIPT_ROUTE = /^\/v1\/retro-filings\/([^/]+)$/u;
+
+/** Returns the decoded receipt id when the request matches the route, else undefined. */
+function matchReceiptRoute(
+  requestMethod: string | undefined,
+  pathname: string,
+  expectedMethod: string,
+  pattern: RegExp,
+): string | undefined {
+  if (requestMethod !== expectedMethod) return undefined;
+  const segment = pattern.exec(pathname)?.[1];
+  return segment === undefined ? undefined : decodePathSegment(segment);
+}
+
 export interface RelayServerFaults extends RelayFaults {
   afterReceiptCommit?: () => void;
 }
@@ -319,27 +335,25 @@ export async function startRelayServer(input: RelayServerOptions): Promise<{
         await respondWithSubmission(request, response, principal);
         return;
       }
-      const reconciliation = /^\/v1\/retro-filings\/([^/]+)\/reconcile$/u.exec(url.pathname);
-      if (request.method === 'POST' && reconciliation?.[1] !== undefined) {
-        const decodedReceipt = decodePathSegment(reconciliation[1]);
-        await respondWithReconciliation(response, decodedReceipt, principal.subject, async () => ({
+      const toReconcile = matchReceiptRoute(request.method, url.pathname, 'POST', RECONCILE_ROUTE);
+      if (toReconcile !== undefined) {
+        await respondWithReconciliation(response, toReconcile, principal.subject, async () => ({
           disposition: 'adopted',
-          receipt: await service.reconcile(principal, decodedReceipt),
+          receipt: await service.reconcile(principal, toReconcile),
         }));
         return;
       }
-      const recovery = /^\/v1\/retro-filings\/([^/]+)\/recover$/u.exec(url.pathname);
-      if (request.method === 'POST' && recovery?.[1] !== undefined) {
-        const decodedReceipt = decodePathSegment(recovery[1]);
-        await respondWithReconciliation(response, decodedReceipt, principal.subject, async () => {
-          const recovered = await service.recover(principal, decodedReceipt);
+      const toRecover = matchReceiptRoute(request.method, url.pathname, 'POST', RECOVER_ROUTE);
+      if (toRecover !== undefined) {
+        await respondWithReconciliation(response, toRecover, principal.subject, async () => {
+          const recovered = await service.recover(principal, toRecover);
           return { disposition: recovered.disposition, receipt: recovered.receipt };
         });
         return;
       }
-      const status = /^\/v1\/retro-filings\/([^/]+)$/u.exec(url.pathname);
-      if (request.method === 'GET' && status?.[1] !== undefined) {
-        const receipt = service.status(principal, decodePathSegment(status[1]));
+      const toRead = matchReceiptRoute(request.method, url.pathname, 'GET', RECEIPT_ROUTE);
+      if (toRead !== undefined) {
+        const receipt = service.status(principal, toRead);
         if (!isTerminalReceiptState(receipt.state)) {
           response.setHeader('retry-after', '1');
         }


### PR DESCRIPTION
## What

Five behaviour-preserving steps on `packages/retro-relay/src/http-server.ts`. One file, no behaviour change.

| Commit | Smell | Refactoring |
|---|---|---|
| `2c21706` | Duplicated observability writes (4 sites) | Extract `recordReconciliationOutcome` |
| `6b22afb` | `/reconcile` and `/recover` bodies structurally identical | Extract `respondWithReconciliation` |
| `0c865db` | 37-line submit route inline in the router | Extract `respondWithSubmission` |
| `a3fe0d0` | Regex + exec + method check + decode repeated 3× | Extract `matchReceiptRoute`, name the patterns |
| `aecf138` | Unexplained numeric defaults | Name 5 constants |

`handle` goes from 165 lines to 73. Net diff is **+16 lines** — the extracted helpers cost signature boilerplate, which is why that is stated rather than claimed as a shrink.

## Behaviour preservation

Each step was committed only after its own green run of the relay suite (170 passed / 1 skipped throughout).

Two things worth a reviewer's attention:

- `matchReceiptRoute` now skips the regex `exec` when the method does not match, which the original always ran. Safe **only** because none of the three patterns carries the `g` flag — no `lastIndex` state to disturb. All three are `/…/u`.
- Malformed-path cases were traced through both versions — `GET /v1/retro-filings/%/reconcile`, `POST /v1/retro-filings/%` — with identical outcomes, including which paths decode and which 404 first.

## Wiring

`relay.integration.test.ts` exercises submit / reconcile / recover / status / health against a **real SQLite `RelayStore`**, mocking only the GitHub REST boundary.

## Known, deliberately unaddressed

The `complexity` / `cognitive-complexity` suppression on `handle` stays. I attempted removal twice: complexity fell 27 → 21 (cognitive 22 → 19) against a ceiling of 10. Closing that gap needs a route-table redesign, which contradicts the suppression's own stated rationale — *"a single composition-root router keeps the public contract visible."* That is a design call, not a refactor, so both attempts were reverted rather than forced.

An independent review of this file also surfaced a **pre-existing** startup-cleanup bug that this branch neither introduced nor touches. It is fixed separately in #2904 rather than folded in here, since a behaviour change does not belong in a behaviour-preserving branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLAkuBV1krS8MmP38VjhyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLAkuBV1krS8MmP38VjhyX)_