### PR TITLE
Hotfix: allow verified cleanup across session changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.0",
+      "version": "0.78.1",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/.safeword/scripts/closeout-cleanup.ts
+++ b/.safeword/scripts/closeout-cleanup.ts
@@ -17,7 +17,6 @@ import nodePath from 'node:path';
 import {
   type CloseoutBinding,
   readFreshCloseoutBinding,
-  recordCodexCloseoutHandoff,
   resolveExactCodexTranscript,
 } from '../hooks/lib/closeout-binding.ts';
 import { draftSpoolPath, readAcks, readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
@@ -106,6 +105,7 @@ export interface CleanupPlan {
   retroStateHash: string;
   retro?: { spoolPath: string };
   blockers: string[];
+  advisories: string[];
   completed: string[];
   operations: CleanupOperation[];
 }
@@ -122,7 +122,11 @@ function block(plan: CleanupPlan, message: string): void {
   if (!plan.blockers.includes(message)) plan.blockers.push(message);
 }
 
-const RETROSPECTIVE_BLOCKERS = new Set([
+function advise(plan: CleanupPlan, message: string): void {
+  if (!plan.advisories.includes(message)) plan.advisories.push(message);
+}
+
+const RETROSPECTIVE_MESSAGES = new Set([
   'retrospective extraction failed; resolve the extraction failure',
   'retrospective filing failed; resolve the filing failure',
   'the current session retrospective is incomplete',
@@ -130,7 +134,7 @@ const RETROSPECTIVE_BLOCKERS = new Set([
 ]);
 
 function hasCleanupAuthorizationBlocker(plan: CleanupPlan): boolean {
-  return plan.blockers.some(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker));
+  return plan.blockers.some(blocker => !RETROSPECTIVE_MESSAGES.has(blocker));
 }
 
 function collectPrerequisiteBlockers(
@@ -143,13 +147,13 @@ function collectPrerequisiteBlockers(
   if (!observation.verification.current) block(plan, 'local verification is stale');
   if (!observation.verification.passed) block(plan, 'local verification failed');
   if (!observation.retro.bound)
-    block(plan, 'the current host session binding is missing or expired');
+    advise(plan, 'the current host session binding is missing or expired');
   if (observation.retro.failure === 'extraction') {
-    block(plan, 'retrospective extraction failed; resolve the extraction failure');
+    advise(plan, 'retrospective extraction failed; resolve the extraction failure');
   } else if (observation.retro.failure === 'filing') {
     block(plan, 'retrospective filing failed; resolve the filing failure');
   } else if (!observation.retro.complete) {
-    block(plan, 'the current session retrospective is incomplete');
+    advise(plan, 'the current session retrospective is incomplete');
   }
   if (observation.retro.pendingDrafts > 0)
     block(plan, 'the current session filing spool has pending drafts');
@@ -277,6 +281,7 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
     stateHash: observation.verification.stateHash,
     retroStateHash: observation.retro.evidenceHash,
     blockers: [],
+    advisories: [],
     completed: [],
     operations: [],
     ...(observation.retro.spoolPath ? { retro: { spoolPath: observation.retro.spoolPath } } : {}),
@@ -318,10 +323,16 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
 }
 
 export function cleanupPlanDigest(plan: CleanupPlan): string {
-  const { retroStateHash: _retroStateHash, retro: _retro, blockers, ...stableAuthorization } = plan;
+  const {
+    retroStateHash: _retroStateHash,
+    retro: _retro,
+    advisories: _advisories,
+    blockers,
+    ...stableAuthorization
+  } = plan;
   const authorization = {
     ...stableAuthorization,
-    blockers: blockers.filter(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker)),
+    blockers: blockers.filter(blocker => !RETROSPECTIVE_MESSAGES.has(blocker)),
   };
   return createHash('sha256').update(JSON.stringify(authorization)).digest('hex');
 }
@@ -1607,7 +1618,11 @@ export function retroForMergedPullRequest(
   return runRetro(root, binding);
 }
 
-function observeCloseout(root: string, pr: string, binding: CloseoutBinding): CloseoutObservation {
+function observeCloseout(
+  root: string,
+  pr: string,
+  binding: CloseoutBinding | undefined,
+): CloseoutObservation {
   const mutableTargets = observeMutableCleanupTargets(root, pr);
   const identity = mutableTargets.pullRequests[0];
   const expectedOid = identity?.headRefOid ?? '';
@@ -1623,7 +1638,9 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
     verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
-    retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
+    retro: binding
+      ? retroForMergedPullRequest(root, binding, mutableTargets.pullRequests)
+      : { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' },
   };
 }
 
@@ -1646,37 +1663,13 @@ function argumentValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function closeoutRecoveryCommand(pr: string): string {
-  const script = process.env.CLAUDE_PLUGIN_ROOT
-    ? `"${process.env.CLAUDE_PLUGIN_ROOT}/resources/scripts/closeout-cleanup.ts"`
-    : '.safeword/scripts/closeout-cleanup.ts';
-  return `bun ${script} --pr ${pr}`;
-}
-
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const requestedPr = argumentValue('--pr');
   const pr = requestedPr && /^[1-9]\d*$/u.test(requestedPr) ? requestedPr : undefined;
   const binding = root ? resolveCloseoutBinding(root) : undefined;
-  if (!root || !pr || !binding) {
-    if (root && pr && !binding) {
-      const pullRequests = observePullRequest(root, pr);
-      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
-      const pullRequest = Number.parseInt(pr, 10);
-      if (identity && identity.state === 'MERGED') {
-        recordCodexCloseoutHandoff({
-          projectDirectory: root,
-          repositoryUrl: `https://github.com/${identity.headOwner}/${identity.headRepository}`,
-          pullRequest,
-          headOid: identity.headRefOid,
-        });
-      }
-    }
-    const recovery =
-      root && pr && !binding ? ` Start one fresh task and run ${closeoutRecoveryCommand(pr)}.` : '';
-    console.error(
-      `closeout blocked: repository, --pr, and a fresh host session binding are required.${recovery}`,
-    );
+  if (!root || !pr) {
+    console.error('closeout blocked: repository and a positive numeric --pr are required.');
     process.exit(2);
   }
   const observation = observeCloseout(root, pr, binding);

--- a/features/close-completed-sessions-safely.feature
+++ b/features/close-completed-sessions-safely.feature
@@ -206,13 +206,14 @@ Feature: Close completed sessions safely
       When closeout refreshes the retrospective and applies the preview
       Then cleanup completes with the previewed exact targets
 
-    @rejection @surface.claude-code @surface.openai-codex @surface.cursor
-    Scenario: Appended session friction refreshes retro before cleanup
+    @surface.claude-code @surface.openai-codex @surface.cursor
+    Scenario: Appended session friction remains advisory during cleanup
       Given an authorized cleanup preview with a completed retrospective
       And the bound transcript grows append-only before apply
       And the mandatory refreshed retrospective reports unresolved work
       When closeout refreshes the retrospective and applies the preview
-      Then cleanup is blocked without mutating any target
+      Then cleanup completes with the previewed exact targets
+      And the incomplete retrospective is reported as an advisory
 
     @proof.vitest @rejection @surface.claude-code @surface.openai-codex @surface.cursor
     Scenario Outline: Every transcript mutation invalidates the retrospective snapshot

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.0 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.1 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.0 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.1 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.0 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.1 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.0 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.1 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.0 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.1 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/features/steps/close-completed-sessions-safely.steps.ts
+++ b/packages/cli/features/steps/close-completed-sessions-safely.steps.ts
@@ -14,6 +14,7 @@ import type { SafewordWorld } from './world.js';
 interface CloseoutWorld extends SafewordWorld {
   closeoutObservation?: CloseoutObservation;
   closeoutOperations?: CleanupOperation[];
+  closeoutAdvisories?: string[];
   closeoutResult?: ReturnType<typeof applyCleanupPlan>;
 }
 
@@ -99,6 +100,7 @@ When(
     const plan = buildCleanupPlan(preview);
     const refreshed = this.closeoutObservation;
     assert.ok(refreshed);
+    this.closeoutAdvisories = buildCleanupPlan(refreshed).advisories;
     let current: CloseoutObservation = refreshed;
 
     this.closeoutResult = applyCleanupPlan({
@@ -127,10 +129,6 @@ Then('cleanup completes with the previewed exact targets', function (this: Close
   );
 });
 
-Then('cleanup is blocked without mutating any target', function (this: CloseoutWorld) {
-  assert.equal(this.closeoutResult?.applied, false);
-  assert.deepEqual(this.closeoutOperations, []);
-  assert.ok(
-    this.closeoutResult?.blockers.includes('the current session retrospective is incomplete'),
-  );
+Then('the incomplete retrospective is reported as an advisory', function (this: CloseoutWorld) {
+  assert.ok(this.closeoutAdvisories?.includes('the current session retrospective is incomplete'));
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/packages/cli/templates/scripts/closeout-cleanup.ts
+++ b/packages/cli/templates/scripts/closeout-cleanup.ts
@@ -17,7 +17,6 @@ import nodePath from 'node:path';
 import {
   type CloseoutBinding,
   readFreshCloseoutBinding,
-  recordCodexCloseoutHandoff,
   resolveExactCodexTranscript,
 } from '../hooks/lib/closeout-binding.ts';
 import { draftSpoolPath, readAcks, readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';
@@ -106,6 +105,7 @@ export interface CleanupPlan {
   retroStateHash: string;
   retro?: { spoolPath: string };
   blockers: string[];
+  advisories: string[];
   completed: string[];
   operations: CleanupOperation[];
 }
@@ -122,7 +122,11 @@ function block(plan: CleanupPlan, message: string): void {
   if (!plan.blockers.includes(message)) plan.blockers.push(message);
 }
 
-const RETROSPECTIVE_BLOCKERS = new Set([
+function advise(plan: CleanupPlan, message: string): void {
+  if (!plan.advisories.includes(message)) plan.advisories.push(message);
+}
+
+const RETROSPECTIVE_MESSAGES = new Set([
   'retrospective extraction failed; resolve the extraction failure',
   'retrospective filing failed; resolve the filing failure',
   'the current session retrospective is incomplete',
@@ -130,7 +134,7 @@ const RETROSPECTIVE_BLOCKERS = new Set([
 ]);
 
 function hasCleanupAuthorizationBlocker(plan: CleanupPlan): boolean {
-  return plan.blockers.some(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker));
+  return plan.blockers.some(blocker => !RETROSPECTIVE_MESSAGES.has(blocker));
 }
 
 function collectPrerequisiteBlockers(
@@ -143,13 +147,13 @@ function collectPrerequisiteBlockers(
   if (!observation.verification.current) block(plan, 'local verification is stale');
   if (!observation.verification.passed) block(plan, 'local verification failed');
   if (!observation.retro.bound)
-    block(plan, 'the current host session binding is missing or expired');
+    advise(plan, 'the current host session binding is missing or expired');
   if (observation.retro.failure === 'extraction') {
-    block(plan, 'retrospective extraction failed; resolve the extraction failure');
+    advise(plan, 'retrospective extraction failed; resolve the extraction failure');
   } else if (observation.retro.failure === 'filing') {
     block(plan, 'retrospective filing failed; resolve the filing failure');
   } else if (!observation.retro.complete) {
-    block(plan, 'the current session retrospective is incomplete');
+    advise(plan, 'the current session retrospective is incomplete');
   }
   if (observation.retro.pendingDrafts > 0)
     block(plan, 'the current session filing spool has pending drafts');
@@ -277,6 +281,7 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
     stateHash: observation.verification.stateHash,
     retroStateHash: observation.retro.evidenceHash,
     blockers: [],
+    advisories: [],
     completed: [],
     operations: [],
     ...(observation.retro.spoolPath ? { retro: { spoolPath: observation.retro.spoolPath } } : {}),
@@ -318,10 +323,16 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
 }
 
 export function cleanupPlanDigest(plan: CleanupPlan): string {
-  const { retroStateHash: _retroStateHash, retro: _retro, blockers, ...stableAuthorization } = plan;
+  const {
+    retroStateHash: _retroStateHash,
+    retro: _retro,
+    advisories: _advisories,
+    blockers,
+    ...stableAuthorization
+  } = plan;
   const authorization = {
     ...stableAuthorization,
-    blockers: blockers.filter(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker)),
+    blockers: blockers.filter(blocker => !RETROSPECTIVE_MESSAGES.has(blocker)),
   };
   return createHash('sha256').update(JSON.stringify(authorization)).digest('hex');
 }
@@ -1607,7 +1618,11 @@ export function retroForMergedPullRequest(
   return runRetro(root, binding);
 }
 
-function observeCloseout(root: string, pr: string, binding: CloseoutBinding): CloseoutObservation {
+function observeCloseout(
+  root: string,
+  pr: string,
+  binding: CloseoutBinding | undefined,
+): CloseoutObservation {
   const mutableTargets = observeMutableCleanupTargets(root, pr);
   const identity = mutableTargets.pullRequests[0];
   const expectedOid = identity?.headRefOid ?? '';
@@ -1623,7 +1638,9 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
     verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
-    retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
+    retro: binding
+      ? retroForMergedPullRequest(root, binding, mutableTargets.pullRequests)
+      : { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' },
   };
 }
 
@@ -1646,37 +1663,13 @@ function argumentValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function closeoutRecoveryCommand(pr: string): string {
-  const script = process.env.CLAUDE_PLUGIN_ROOT
-    ? `"${process.env.CLAUDE_PLUGIN_ROOT}/resources/scripts/closeout-cleanup.ts"`
-    : '.safeword/scripts/closeout-cleanup.ts';
-  return `bun ${script} --pr ${pr}`;
-}
-
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const requestedPr = argumentValue('--pr');
   const pr = requestedPr && /^[1-9]\d*$/u.test(requestedPr) ? requestedPr : undefined;
   const binding = root ? resolveCloseoutBinding(root) : undefined;
-  if (!root || !pr || !binding) {
-    if (root && pr && !binding) {
-      const pullRequests = observePullRequest(root, pr);
-      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
-      const pullRequest = Number.parseInt(pr, 10);
-      if (identity && identity.state === 'MERGED') {
-        recordCodexCloseoutHandoff({
-          projectDirectory: root,
-          repositoryUrl: `https://github.com/${identity.headOwner}/${identity.headRepository}`,
-          pullRequest,
-          headOid: identity.headRefOid,
-        });
-      }
-    }
-    const recovery =
-      root && pr && !binding ? ` Start one fresh task and run ${closeoutRecoveryCommand(pr)}.` : '';
-    console.error(
-      `closeout blocked: repository, --pr, and a fresh host session binding are required.${recovery}`,
-    );
+  if (!root || !pr) {
+    console.error('closeout blocked: repository and a positive numeric --pr are required.');
     process.exit(2);
   }
   const observation = observeCloseout(root, pr, binding);

--- a/packages/cli/tests/closeout-cleanup.test.ts
+++ b/packages/cli/tests/closeout-cleanup.test.ts
@@ -55,6 +55,7 @@ function normalizedCloseoutScript(path: string): string {
       /import \{\s*type CloseoutBinding,\s*readFreshCloseoutBinding,\s*recordCodexCloseoutHandoff,\s*resolveExactCodexTranscript,?\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/closeout-binding\.ts';/u,
       "import {\n  type CloseoutBinding,\n  readFreshCloseoutBinding,\n  recordCodexCloseoutHandoff,\n  resolveExactCodexTranscript,\n} from '../hooks/lib/closeout-binding.ts';",
     )
+    .replace('../../runtime/hooks/lib/closeout-binding.ts', '../hooks/lib/closeout-binding.ts')
     .replace(
       /import \{\s*draftSpoolPath,\s*readAcks,\s*readSpooledDrafts,?\s*\} from '\.\.\/\.\.\/runtime\/hooks\/lib\/retro-draft-spool\.ts';/u,
       "import { draftSpoolPath, readAcks, readSpooledDrafts } from '../hooks/lib/retro-draft-spool.ts';",
@@ -936,7 +937,7 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     expect(cleanupPlanDigest(later)).toBe(cleanupPlanDigest(first));
   });
 
-  it('exposes pending filing recovery without changing cleanup authorization', () => {
+  it('blocks cleanup while exposing the pending filing recovery path', () => {
     const pendingRetro = {
       ...safeObservation().retro,
       complete: false,
@@ -1166,21 +1167,6 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       'local verification failed',
     ],
     [
-      'missing session binding',
-      { retro: { ...safeObservation().retro, bound: false } },
-      'the current host session binding is missing or expired',
-    ],
-    [
-      'incomplete retro',
-      { retro: { ...safeObservation().retro, complete: false } },
-      'the current session retrospective is incomplete',
-    ],
-    [
-      'failed retro extraction',
-      { retro: { ...safeObservation().retro, complete: false, failure: 'extraction' } },
-      'retrospective extraction failed; resolve the extraction failure',
-    ],
-    [
       'failed retro filing',
       { retro: { ...safeObservation().retro, complete: false, failure: 'filing' } },
       'retrospective filing failed; resolve the filing failure',
@@ -1207,6 +1193,33 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
       });
       expect(result.applied).toBe(false);
       expect(executions).toBe(0);
+    },
+  );
+
+  it.each([
+    [
+      'missing session binding',
+      { retro: { ...safeObservation().retro, bound: false } },
+      'the current host session binding is missing or expired',
+    ],
+    [
+      'incomplete retro',
+      { retro: { ...safeObservation().retro, complete: false } },
+      'the current session retrospective is incomplete',
+    ],
+    [
+      'failed retro extraction',
+      { retro: { ...safeObservation().retro, complete: false, failure: 'extraction' } },
+      'retrospective extraction failed; resolve the extraction failure',
+    ],
+  ] satisfies [string, Partial<CloseoutObservation>, string][])(
+    '%s is advisory for cleanup',
+    (_name, overrides, expectedAdvisory) => {
+      const plan = buildCleanupPlan(safeObservation(overrides));
+
+      expect(plan.blockers).toEqual([]);
+      expect(plan.advisories).toContain(expectedAdvisory);
+      expect(plan.operations).toHaveLength(3);
     },
   );
 
@@ -1317,29 +1330,22 @@ describe('closeout cleanup guard (93C14D TBU1.R2/R3)', () => {
     expect(result.applied).toBe(true);
   });
 
-  it('blocks transcript growth until refreshed retrospective work is complete', () => {
+  it('reports transcript growth as advisory without changing cleanup authorization', () => {
     const preview = safeObservation();
     const plan = buildCleanupPlan(preview);
-    const execute = () => {
-      throw new Error('must not execute');
-    };
+    const refreshed = buildCleanupPlan(
+      safeObservation({
+        retro: {
+          ...preview.retro,
+          complete: false,
+          evidenceHash: 'retro-appended-not-reviewed',
+        },
+      }),
+    );
 
-    const result = applyCleanupPlan({
-      plan,
-      digest: cleanupPlanDigest(plan),
-      observe: () =>
-        safeObservation({
-          retro: {
-            ...preview.retro,
-            complete: false,
-            evidenceHash: 'retro-appended-not-reviewed',
-          },
-        }),
-      execute,
-    });
-
-    expect(result.applied).toBe(false);
-    expect(result.blockers).toContain('the current session retrospective is incomplete');
+    expect(refreshed.blockers).toEqual([]);
+    expect(refreshed.advisories).toContain('the current session retrospective is incomplete');
+    expect(cleanupPlanDigest(refreshed)).toBe(cleanupPlanDigest(plan));
   });
 
   it('invalidates stale digests and changed observations before mutation', () => {

--- a/packages/cli/tests/integration/closeout-host-adapters.test.ts
+++ b/packages/cli/tests/integration/closeout-host-adapters.test.ts
@@ -310,49 +310,45 @@ function closeoutCommand(directory: string): string {
 }
 
 describe('closeout production host adapters (93C14D TBU1.R4)', () => {
-  it('hands a blocked Codex closeout to exactly one restarted task through shipped hooks', () => {
+  it('completes freshly verified cleanup without a host session binding', () => {
     const fixture = deliveryFixture();
     installBoundaryFakes(fixture);
     const codexHome = nodePath.join(nodePath.dirname(fixture.bare), 'codex-home');
     const environment = {
       ...process.env,
       PATH: `${fixture.bin}:${process.env.PATH ?? ''}`,
+      GIT_SSH_COMMAND: nodePath.join(fixture.bin, 'ssh'),
+      SAFEWORD_TEST_BARE: fixture.bare,
+      SAFEWORD_CLI: boundarySafewordCli(fixture),
       CODEX_HOME: codexHome,
       CODEX_THREAD_ID: '',
       CLAUDE_PROJECT_DIR: fixture.topic,
     };
     const guard = nodePath.join(fixture.topic, '.safeword/scripts/closeout-cleanup.ts');
-    const blocked = spawnSync('bun', [guard, '--pr', '42'], {
+    const preview = spawnSync('bun', [guard, '--pr', '42'], {
       cwd: fixture.topic,
       env: environment,
       encoding: 'utf8',
     });
-    expect(blocked.status, `${blocked.stderr}\n${blocked.stdout}`).toBe(2);
-    const handoffDirectory = nodePath.join(codexHome, 'safeword', 'closeout-handoff-v1');
-    expect(
-      existsSync(handoffDirectory),
-      JSON.stringify({ stderr: blocked.stderr, stdout: blocked.stdout }),
-    ).toBe(true);
-
-    const sessionHook = nodePath.join(
-      repoRoot,
-      'packages/cli/templates/hooks/session-codex-start.ts',
+    expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
+    const previewResult = JSON.parse(preview.stdout) as {
+      digest: string;
+      plan: { blockers: string[]; advisories: string[] };
+    };
+    expect(previewResult.plan.blockers).toEqual([]);
+    expect(previewResult.plan.advisories).toContain(
+      'the current host session binding is missing or expired',
     );
-    const restart = (sessionId: string) =>
-      spawnSync('bun', [sessionHook], {
-        cwd: fixture.topic,
-        env: environment,
-        input: JSON.stringify({ session_id: sessionId, cwd: fixture.topic }),
-        encoding: 'utf8',
-      });
-    const first = restart('restarted-task');
-    expect(first.status, first.stderr).toBe(0);
-    expect(first.stdout).toContain('Pending closeout recovered after restart');
-    expect(first.stdout).toContain('--pr 42');
+    const handoffDirectory = nodePath.join(codexHome, 'safeword', 'closeout-handoff-v1');
+    expect(existsSync(handoffDirectory)).toBe(false);
 
-    const second = restart('another-task');
-    expect(second.status, second.stderr).toBe(0);
-    expect(second.stdout).toContain('Pending closeout recovered after restart');
+    const apply = spawnSync('bun', [guard, '--pr', '42', '--yes', '--plan', previewResult.digest], {
+      cwd: fixture.topic,
+      env: environment,
+      encoding: 'utf8',
+    });
+    expect(apply.status, `${apply.stderr}\n${apply.stdout}`).toBe(0);
+    expect(existsSync(fixture.topic)).toBe(false);
   });
 
   it('binds the authenticated Codex Desktop task across linked worktrees without a hook bridge', () => {
@@ -862,13 +858,15 @@ if (args[0] === 'project' && args[1] === 'test-plan') {
       { cwd: fixture.topic, env: environment, encoding: 'utf8' },
     );
 
-    expect(preview.status).toBe(2);
-    expect(preview.stderr).toContain('a fresh host session binding are required');
-    expect(preview.stderr).toContain(
-      'Start one fresh task and run bun .safeword/scripts/closeout-cleanup.ts --pr 42',
-    );
-    expect(preview.stdout).toBe('');
-    expect(existsSync(verificationReceiptPath(fixture))).toBe(false);
+    expect(preview.status, `${preview.stderr}\n${preview.stdout}`).toBe(0);
+    const plan = (
+      JSON.parse(preview.stdout) as {
+        plan: { blockers: string[]; advisories: string[] };
+      }
+    ).plan;
+    expect(plan.blockers).toEqual([]);
+    expect(plan.advisories).toContain('the current host session binding is missing or expired');
+    expect(existsSync(verificationReceiptPath(fixture))).toBe(true);
     expect(existsSync(fixture.topic)).toBe(true);
   }, 30_000);
 

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.0",
+  "plugin_version": "0.78.1",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "7f4bb3830f1d8dc5f5e019cf9f77a2d7898e07d0c53f8ec22d13ad40d59bde92"
+  "inventory_sha256": "c6ee6fc0f24d49e5d506adfe5d7de8b1a9140552b32613a8c5ebbc1acc5bdb0d"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "9035147df5c64c9c0de40ab559848ba28fe0e117e82e73def79328982170a0d0"
+      "sha256": "9a5d1773138bf2ea3c5c31784de81a6cba20b175f229625a257967bd0e5453d1"
     },
     {
       "path": "resources/guides/architecture-guide.md",
@@ -95,7 +95,7 @@
     },
     {
       "path": "resources/scripts/closeout-cleanup.ts",
-      "sha256": "a50f2b543b5ccf9a3a4daba42e569129bcef864329c5fb2b8f37461866ad04e8"
+      "sha256": "fdeec3e0de6ab4775c8c6a7c4b51e138d90c6f69c3f13ab53a0a62821677aa09"
     },
     {
       "path": "resources/templates/adr-template.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "type": "module"
 }

--- a/plugin/resources/scripts/closeout-cleanup.ts
+++ b/plugin/resources/scripts/closeout-cleanup.ts
@@ -17,7 +17,6 @@ import nodePath from 'node:path';
 import {
   type CloseoutBinding,
   readFreshCloseoutBinding,
-  recordCodexCloseoutHandoff,
   resolveExactCodexTranscript,
 } from '../../runtime/hooks/lib/closeout-binding.ts';
 import {
@@ -110,6 +109,7 @@ export interface CleanupPlan {
   retroStateHash: string;
   retro?: { spoolPath: string };
   blockers: string[];
+  advisories: string[];
   completed: string[];
   operations: CleanupOperation[];
 }
@@ -126,7 +126,11 @@ function block(plan: CleanupPlan, message: string): void {
   if (!plan.blockers.includes(message)) plan.blockers.push(message);
 }
 
-const RETROSPECTIVE_BLOCKERS = new Set([
+function advise(plan: CleanupPlan, message: string): void {
+  if (!plan.advisories.includes(message)) plan.advisories.push(message);
+}
+
+const RETROSPECTIVE_MESSAGES = new Set([
   'retrospective extraction failed; resolve the extraction failure',
   'retrospective filing failed; resolve the filing failure',
   'the current session retrospective is incomplete',
@@ -134,7 +138,7 @@ const RETROSPECTIVE_BLOCKERS = new Set([
 ]);
 
 function hasCleanupAuthorizationBlocker(plan: CleanupPlan): boolean {
-  return plan.blockers.some(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker));
+  return plan.blockers.some(blocker => !RETROSPECTIVE_MESSAGES.has(blocker));
 }
 
 function collectPrerequisiteBlockers(
@@ -147,13 +151,13 @@ function collectPrerequisiteBlockers(
   if (!observation.verification.current) block(plan, 'local verification is stale');
   if (!observation.verification.passed) block(plan, 'local verification failed');
   if (!observation.retro.bound)
-    block(plan, 'the current host session binding is missing or expired');
+    advise(plan, 'the current host session binding is missing or expired');
   if (observation.retro.failure === 'extraction') {
-    block(plan, 'retrospective extraction failed; resolve the extraction failure');
+    advise(plan, 'retrospective extraction failed; resolve the extraction failure');
   } else if (observation.retro.failure === 'filing') {
     block(plan, 'retrospective filing failed; resolve the filing failure');
   } else if (!observation.retro.complete) {
-    block(plan, 'the current session retrospective is incomplete');
+    advise(plan, 'the current session retrospective is incomplete');
   }
   if (observation.retro.pendingDrafts > 0)
     block(plan, 'the current session filing spool has pending drafts');
@@ -281,6 +285,7 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
     stateHash: observation.verification.stateHash,
     retroStateHash: observation.retro.evidenceHash,
     blockers: [],
+    advisories: [],
     completed: [],
     operations: [],
     ...(observation.retro.spoolPath ? { retro: { spoolPath: observation.retro.spoolPath } } : {}),
@@ -322,10 +327,16 @@ export function buildCleanupPlan(observation: CloseoutObservation): CleanupPlan 
 }
 
 export function cleanupPlanDigest(plan: CleanupPlan): string {
-  const { retroStateHash: _retroStateHash, retro: _retro, blockers, ...stableAuthorization } = plan;
+  const {
+    retroStateHash: _retroStateHash,
+    retro: _retro,
+    advisories: _advisories,
+    blockers,
+    ...stableAuthorization
+  } = plan;
   const authorization = {
     ...stableAuthorization,
-    blockers: blockers.filter(blocker => !RETROSPECTIVE_BLOCKERS.has(blocker)),
+    blockers: blockers.filter(blocker => !RETROSPECTIVE_MESSAGES.has(blocker)),
   };
   return createHash('sha256').update(JSON.stringify(authorization)).digest('hex');
 }
@@ -1611,7 +1622,11 @@ export function retroForMergedPullRequest(
   return runRetro(root, binding);
 }
 
-function observeCloseout(root: string, pr: string, binding: CloseoutBinding): CloseoutObservation {
+function observeCloseout(
+  root: string,
+  pr: string,
+  binding: CloseoutBinding | undefined,
+): CloseoutObservation {
   const mutableTargets = observeMutableCleanupTargets(root, pr);
   const identity = mutableTargets.pullRequests[0];
   const expectedOid = identity?.headRefOid ?? '';
@@ -1627,7 +1642,9 @@ function observeCloseout(root: string, pr: string, binding: CloseoutBinding): Cl
     protection: observeCurrentProtection(root, identity, mutableTargets.remoteResolution),
     deliveryWorktreePath: nodePath.resolve(root),
     verification: runVerification(root, expectedOid, identity?.ciChecks ?? 'unknown'),
-    retro: retroForMergedPullRequest(root, binding, mutableTargets.pullRequests),
+    retro: binding
+      ? retroForMergedPullRequest(root, binding, mutableTargets.pullRequests)
+      : { bound: false, complete: false, pendingDrafts: 0, evidenceHash: '' },
   };
 }
 
@@ -1650,37 +1667,13 @@ function argumentValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function closeoutRecoveryCommand(pr: string): string {
-  const script = process.env.CLAUDE_PLUGIN_ROOT
-    ? `"${process.env.CLAUDE_PLUGIN_ROOT}/resources/scripts/closeout-cleanup.ts"`
-    : '"${CLAUDE_PLUGIN_ROOT}"/resources/scripts/closeout-cleanup.ts';
-  return `bun ${script} --pr ${pr}`;
-}
-
 if (import.meta.main) {
   const root = resolveRepositoryRoot(process.cwd());
   const requestedPr = argumentValue('--pr');
   const pr = requestedPr && /^[1-9]\d*$/u.test(requestedPr) ? requestedPr : undefined;
   const binding = root ? resolveCloseoutBinding(root) : undefined;
-  if (!root || !pr || !binding) {
-    if (root && pr && !binding) {
-      const pullRequests = observePullRequest(root, pr);
-      const identity = pullRequests.length === 1 ? pullRequests[0] : undefined;
-      const pullRequest = Number.parseInt(pr, 10);
-      if (identity && identity.state === 'MERGED') {
-        recordCodexCloseoutHandoff({
-          projectDirectory: root,
-          repositoryUrl: `https://github.com/${identity.headOwner}/${identity.headRepository}`,
-          pullRequest,
-          headOid: identity.headRefOid,
-        });
-      }
-    }
-    const recovery =
-      root && pr && !binding ? ` Start one fresh task and run ${closeoutRecoveryCommand(pr)}.` : '';
-    console.error(
-      `closeout blocked: repository, --pr, and a fresh host session binding are required.${recovery}`,
-    );
+  if (!root || !pr) {
+    console.error('closeout blocked: repository and a positive numeric --pr are required.');
     process.exit(2);
   }
   const observation = observeCloseout(root, pr, binding);


### PR DESCRIPTION
## Summary

- allow cleanup preview/apply without a fresh host-session binding when every repository safety check passes
- report missing binding, incomplete retrospective, and extraction failure as explicit advisories
- continue blocking filing failures and pending drafts so cleanup cannot delete recovery data
- ship as patch release 0.78.1 across npm, Claude plugin, and Codex plugin manifests

## Root cause

Closeout already separated retrospective state from its cleanup authorization digest, but the CLI exited before repository observation without a session binding and the final plan still classified session/retro messages as fatal blockers.

## Verification

- `bun run lint`
- `bun run test tests/closeout-cleanup.test.ts` — 94 passed
- `bun run test tests/closeout-cleanup.test.ts tests/integration/closeout-host-adapters.test.ts` — 120 passed after final focused corrections
- full suite — 7,869 passed; one dependency-readiness failure because `packages/retro-relay/dist` was absent
- built `packages/retro-relay`, reran the exact failed Cucumber case — passed

Addresses #2928 (temporary hotfix; durable host-neutral closeout remains open)
Related: #2814