### PR TITLE
chore(release): v0.78.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.1",
+      "version": "0.78.2",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.1 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.2 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.1 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.2 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.1 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.2 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.1 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.2 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.1 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.2 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.1",
+  "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "702c472cb036542c59a724c0a6fddc643bc05ce774506c1d612bb655fff512a3"
+  "inventory_sha256": "380cb6f7763e30a146f9db9df7d30b622ab29173913a878ad2e01a7602f828cc"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "9a5d1773138bf2ea3c5c31784de81a6cba20b175f229625a257967bd0e5453d1"
+      "sha256": "1baf85b46a78f61dd56bcb188bb58cda8e66338d2a614437b838b46267b76e42"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "type": "module"
 }


### PR DESCRIPTION
## Release

Patch release for the truthful Codex protection-status hotfix merged in #2962.

## Artifacts

- CLI package: 0.78.2
- Claude marketplace and generated plugin catalogue: 0.78.2
- Codex plugin manifest: 0.78.2
- All five Codex hook commands pinned to safeword@0.78.2

## Verification

- Headless Codex activation and release contracts: 5/5 passed.
- Authenticated Codex live smoke with gpt-5.6-terra: 8 passed; 9 unrelated live routes explicitly skipped.
- Typecheck, formatting, generated-plugin integrity, and version alignment passed.
- Product hotfix PR #2962 passed the complete GitHub CI matrix on Node 22 and Node 24 before merge.

After this release PR is green and merged, tag v0.78.2 on the merge commit to trigger the OIDC publish workflow.