### PR TITLE
Make ticket folder resolution consistent

### DIFF
--- a/packages/cli/src/commands/codify.ts
+++ b/packages/cli/src/commands/codify.ts
@@ -20,6 +20,7 @@ import {
   type ParsedScenario,
   parseScenarios,
 } from '../utils/test-skeleton.js';
+import { findTicketFolderMatches } from '../utils/ticket-folder-matches.js';
 
 export interface CodifyOptions {
   /** Output format: `vitest` (default) or `gherkin`. */
@@ -184,8 +185,8 @@ function resolveTicketDirectory(cwd: string, ticket: string): string | undefined
     return undefined;
   }
   // Exact id wins over a `${id}-slug` prefix, independent of readdir order.
-  const match =
-    entries.find(name => name === ticket) ?? entries.find(name => name.startsWith(`${ticket}-`));
+  const matches = findTicketFolderMatches(entries, ticket);
+  const match = matches.exact[0] ?? matches.slugged[0];
   return match === undefined ? undefined : nodePath.join(ticketsRoot, match);
 }
 

--- a/packages/cli/src/commands/codify.ts
+++ b/packages/cli/src/commands/codify.ts
@@ -20,7 +20,7 @@ import {
   type ParsedScenario,
   parseScenarios,
 } from '../utils/test-skeleton.js';
-import { findTicketFolderMatches } from '../utils/ticket-folder-matches.js';
+import { findTicketFolderMatch } from '../utils/ticket-folder-matches.js';
 
 export interface CodifyOptions {
   /** Output format: `vitest` (default) or `gherkin`. */
@@ -184,9 +184,7 @@ function resolveTicketDirectory(cwd: string, ticket: string): string | undefined
   } catch {
     return undefined;
   }
-  // Exact id wins over a `${id}-slug` prefix, independent of readdir order.
-  const matches = findTicketFolderMatches(entries, ticket);
-  const match = matches.exact[0] ?? matches.slugged[0];
+  const match = findTicketFolderMatch(entries, ticket);
   return match === undefined ? undefined : nodePath.join(ticketsRoot, match);
 }
 

--- a/packages/cli/src/tracker-sync/resolve-by-key.ts
+++ b/packages/cli/src/tracker-sync/resolve-by-key.ts
@@ -11,7 +11,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { findTicketFolderMatches } from '../utils/ticket-folder-matches.js';
+import { findTicketFolderMatch } from '../utils/ticket-folder-matches.js';
 import type { TrackerMap } from './tracker-map.js';
 
 /**
@@ -27,12 +27,13 @@ export function normalizeTrackerKey(key: string): string {
 function resolveTicketFolder(ticketsDirectory: string, ticketId: string): string | undefined {
   let entries: string[];
   try {
-    entries = readdirSync(ticketsDirectory);
+    entries = readdirSync(ticketsDirectory, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name);
   } catch {
     return undefined;
   }
-  const matches = findTicketFolderMatches(entries, ticketId);
-  const match = matches.all[0];
+  const match = findTicketFolderMatch(entries, ticketId);
   return match === undefined ? undefined : nodePath.join(ticketsDirectory, match);
 }
 

--- a/packages/cli/src/tracker-sync/resolve-by-key.ts
+++ b/packages/cli/src/tracker-sync/resolve-by-key.ts
@@ -11,6 +11,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
+import { findTicketFolderMatches } from '../utils/ticket-folder-matches.js';
 import type { TrackerMap } from './tracker-map.js';
 
 /**
@@ -30,7 +31,8 @@ function resolveTicketFolder(ticketsDirectory: string, ticketId: string): string
   } catch {
     return undefined;
   }
-  const match = entries.find(name => name === ticketId || name.startsWith(`${ticketId}-`));
+  const matches = findTicketFolderMatches(entries, ticketId);
+  const match = matches.all[0];
   return match === undefined ? undefined : nodePath.join(ticketsDirectory, match);
 }
 

--- a/packages/cli/src/utils/epic-linker.test.ts
+++ b/packages/cli/src/utils/epic-linker.test.ts
@@ -7,7 +7,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { linkChildToEpic, parseChildrenList } from './epic-linker.js';
 
 function writeEpic(cwd: string, id: string, children: string[]): void {
-  const dir = nodePath.join(cwd, '.project', 'tickets', `${id}-epic`);
+  writeEpicAt(cwd, `${id}-epic`, id, children);
+}
+
+function writeEpicAt(cwd: string, folder: string, id: string, children: string[]): void {
+  const dir = nodePath.join(cwd, '.project', 'tickets', folder);
   mkdirSync(dir, { recursive: true });
   const quoted = children.map(child => `'${child}'`).join(', ');
   const list = `[${quoted}]`;
@@ -52,6 +56,28 @@ describe('linkChildToEpic', () => {
     const result = linkChildToEpic(cwd, 'CHILD2', 'EPIC01');
     expect(result.ok).toBe(true);
     expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['CHILD1', 'CHILD2']);
+  });
+
+  it('links to the exact epic folder when a slugged candidate also exists', () => {
+    writeEpic(cwd, 'EPIC01', []);
+    writeEpicAt(cwd, 'EPIC01', 'EPIC01', []);
+
+    expect(linkChildToEpic(cwd, 'CHILD1', 'EPIC01').ok).toBe(true);
+
+    const exactContent = readFileSync(
+      nodePath.join(cwd, '.project', 'tickets', 'EPIC01', 'ticket.md'),
+      'utf8',
+    );
+    expect(parseChildrenList(exactContent)).toEqual(['CHILD1']);
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual([]);
+  });
+
+  it('ignores matching files when resolving the epic folder', () => {
+    writeEpic(cwd, 'EPIC01', []);
+    writeFileSync(nodePath.join(cwd, '.project', 'tickets', 'EPIC01'), 'not a ticket folder');
+
+    expect(linkChildToEpic(cwd, 'CHILD1', 'EPIC01').ok).toBe(true);
+    expect(readEpicChildren(cwd, 'EPIC01')).toEqual(['CHILD1']);
   });
 
   // epic-child-linker.TB1.AC4.linking_twice_adds_at_most_once

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -14,7 +14,7 @@ import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from
 import nodePath from 'node:path';
 
 import { resolveTicketsDirectory } from './configured-paths.js';
-import { findTicketFolderMatches } from './ticket-folder-matches.js';
+import { findTicketFolderMatch } from './ticket-folder-matches.js';
 
 export type LinkResult = { ok: true } | { ok: false; reason: string };
 
@@ -79,7 +79,10 @@ function readTicketFileOrUndefined(ticketPath: string): string | undefined {
 function resolveTicketFolderById(cwd: string, id: string): string | undefined {
   const ticketsDirectory = resolveTicketsDirectory(cwd);
   if (!existsSync(ticketsDirectory)) return undefined;
-  const match = findTicketFolderMatches(readdirSync(ticketsDirectory), id).all[0];
+  const names = readdirSync(ticketsDirectory, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name);
+  const match = findTicketFolderMatch(names, id);
   return match === undefined ? undefined : nodePath.join(ticketsDirectory, match);
 }
 

--- a/packages/cli/src/utils/epic-linker.ts
+++ b/packages/cli/src/utils/epic-linker.ts
@@ -14,6 +14,7 @@ import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from
 import nodePath from 'node:path';
 
 import { resolveTicketsDirectory } from './configured-paths.js';
+import { findTicketFolderMatches } from './ticket-folder-matches.js';
 
 export type LinkResult = { ok: true } | { ok: false; reason: string };
 
@@ -78,12 +79,8 @@ function readTicketFileOrUndefined(ticketPath: string): string | undefined {
 function resolveTicketFolderById(cwd: string, id: string): string | undefined {
   const ticketsDirectory = resolveTicketsDirectory(cwd);
   if (!existsSync(ticketsDirectory)) return undefined;
-  for (const entry of readdirSync(ticketsDirectory)) {
-    if (entry === id || entry.startsWith(`${id}-`)) {
-      return nodePath.join(ticketsDirectory, entry);
-    }
-  }
-  return undefined;
+  const match = findTicketFolderMatches(readdirSync(ticketsDirectory), id).all[0];
+  return match === undefined ? undefined : nodePath.join(ticketsDirectory, match);
 }
 
 function isEpicTicket(content: string): boolean {

--- a/packages/cli/src/utils/ticket-folder-matches.test.ts
+++ b/packages/cli/src/utils/ticket-folder-matches.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { findTicketFolderMatches } from './ticket-folder-matches.js';
+
+describe('findTicketFolderMatches', () => {
+  it('separates exact and slugged matches while preserving their input order', () => {
+    expect(findTicketFolderMatches(['ABC-second', 'ABC', 'OTHER', 'ABC-first'], 'ABC')).toEqual({
+      all: ['ABC-second', 'ABC', 'ABC-first'],
+      exact: ['ABC'],
+      slugged: ['ABC-second', 'ABC-first'],
+    });
+  });
+
+  it('matches ticket IDs case-sensitively', () => {
+    expect(findTicketFolderMatches(['abc', 'abc-lower', 'ABC-upper'], 'ABC')).toEqual({
+      all: ['ABC-upper'],
+      exact: [],
+      slugged: ['ABC-upper'],
+    });
+  });
+});

--- a/packages/cli/src/utils/ticket-folder-matches.test.ts
+++ b/packages/cli/src/utils/ticket-folder-matches.test.ts
@@ -1,21 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { findTicketFolderMatches } from './ticket-folder-matches.js';
+import { findTicketFolderMatch } from './ticket-folder-matches.js';
 
-describe('findTicketFolderMatches', () => {
-  it('separates exact and slugged matches while preserving their input order', () => {
-    expect(findTicketFolderMatches(['ABC-second', 'ABC', 'OTHER', 'ABC-first'], 'ABC')).toEqual({
-      all: ['ABC-second', 'ABC', 'ABC-first'],
-      exact: ['ABC'],
-      slugged: ['ABC-second', 'ABC-first'],
-    });
+describe('findTicketFolderMatch', () => {
+  it('prefers an exact match over slugged candidates', () => {
+    expect(findTicketFolderMatch(['ABC-second', 'ABC', 'ABCD', 'ABC-first'], 'ABC')).toBe('ABC');
   });
 
   it('matches ticket IDs case-sensitively', () => {
-    expect(findTicketFolderMatches(['abc', 'abc-lower', 'ABC-upper'], 'ABC')).toEqual({
-      all: ['ABC-upper'],
-      exact: [],
-      slugged: ['ABC-upper'],
-    });
+    expect(findTicketFolderMatch(['abc', 'abc-lower', 'ABC-upper'], 'ABC')).toBe('ABC-upper');
+  });
+
+  it('requires a hyphen before the slug', () => {
+    expect(findTicketFolderMatch(['ABCD'], 'ABC')).toBeUndefined();
   });
 });

--- a/packages/cli/src/utils/ticket-folder-matches.ts
+++ b/packages/cli/src/utils/ticket-folder-matches.ts
@@ -1,0 +1,25 @@
+export type TicketFolderMatches = {
+  all: string[];
+  exact: string[];
+  slugged: string[];
+};
+
+/** Classify case-sensitive `{id}` and `{id}-{slug}` folder-name matches. */
+export function findTicketFolderMatches(names: string[], ticketId: string): TicketFolderMatches {
+  const all: string[] = [];
+  const exact: string[] = [];
+  const slugged: string[] = [];
+  const slugPrefix = `${ticketId}-`;
+
+  for (const name of names) {
+    if (name === ticketId) {
+      all.push(name);
+      exact.push(name);
+    } else if (name.startsWith(slugPrefix)) {
+      all.push(name);
+      slugged.push(name);
+    }
+  }
+
+  return { all, exact, slugged };
+}

--- a/packages/cli/src/utils/ticket-folder-matches.ts
+++ b/packages/cli/src/utils/ticket-folder-matches.ts
@@ -1,25 +1,16 @@
-export type TicketFolderMatches = {
-  all: string[];
-  exact: string[];
-  slugged: string[];
-};
-
-/** Classify case-sensitive `{id}` and `{id}-{slug}` folder-name matches. */
-export function findTicketFolderMatches(names: string[], ticketId: string): TicketFolderMatches {
-  const all: string[] = [];
-  const exact: string[] = [];
-  const slugged: string[] = [];
+/** Resolve a case-sensitive `{id}` or `{id}-{slug}` candidate, preferring the exact id. */
+export function findTicketFolderMatch(names: string[], ticketId: string): string | undefined {
+  let sluggedMatch: string | undefined;
   const slugPrefix = `${ticketId}-`;
 
   for (const name of names) {
     if (name === ticketId) {
-      all.push(name);
-      exact.push(name);
-    } else if (name.startsWith(slugPrefix)) {
-      all.push(name);
-      slugged.push(name);
+      return name;
+    }
+    if (sluggedMatch === undefined && name.startsWith(slugPrefix)) {
+      sluggedMatch = name;
     }
   }
 
-  return { all, exact, slugged };
+  return sluggedMatch;
 }

--- a/packages/cli/tests/commands/codify.test.ts
+++ b/packages/cli/tests/commands/codify.test.ts
@@ -150,6 +150,24 @@ describe('safeword codify', () => {
   );
 
   it(
+    'uses the exact ticket folder when a slugged candidate also exists',
+    async () => {
+      scaffoldTicket(temporaryDirectory, TWO_SCENARIOS);
+      writeTestFile(
+        temporaryDirectory,
+        `.safeword-project/tickets/${TICKET_ID}-other/test-definitions.md`,
+        '# Test Definitions\n\nNo scenarios here.\n',
+      );
+
+      const result = await runCli(['codify', TICKET_ID], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(0);
+      expect(countTests(result.stdout)).toBe(2);
+    },
+    TIMEOUT_QUICK,
+  );
+
+  it(
     'codify.TB1.AC3.out_writes_the_file',
     async () => {
       scaffoldTicket(temporaryDirectory, TWO_SCENARIOS);

--- a/packages/cli/tests/tracker-sync/resolve-by-key.test.ts
+++ b/packages/cli/tests/tracker-sync/resolve-by-key.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
@@ -39,6 +39,24 @@ describe('tracker-key → local-folder join reader (tracker-identity-and-join.SM
     expect(resolveFolderByTrackerKey(ticketsDirectory, map, 'ENG-45')).toBe(expected);
   });
 
+  it('prefers the exact ticket folder when a slugged candidate also exists', () => {
+    folder('ENG-45-login-bug');
+    const expected = folder('ENG-45');
+    const map = new TrackerMap();
+    map.record('ENG-45', { provider: 'linear', id: 'ENG-45' });
+
+    expect(resolveFolderByTrackerKey(ticketsDirectory, map, 'ENG-45')).toBe(expected);
+  });
+
+  it('ignores matching files when resolving a ticket folder', () => {
+    const expected = folder('ENG-45-login-bug');
+    writeFileSync(nodePath.join(ticketsDirectory, 'ENG-45'), 'not a ticket folder');
+    const map = new TrackerMap();
+    map.record('ENG-45', { provider: 'linear', id: 'ENG-45' });
+
+    expect(resolveFolderByTrackerKey(ticketsDirectory, map, 'ENG-45')).toBe(expected);
+  });
+
   // SM1.AC1.both_key_shapes_resolve — GitHub "#123" and Linear "ENG-45" each to their own folder
   it('resolves both GitHub and Linear key shapes to their own folders', () => {
     const gh = folder('123-gh-bug');
@@ -70,7 +88,7 @@ describe('tracker-key → local-folder join reader (tracker-identity-and-join.SM
   });
 
   // SM1.AC1.stale_map_entry_not_found — mapped but the folder no longer exists
-  it('returns null (not a dangling path) when the mapped folder is gone', () => {
+  it('returns undefined when the mapped folder is gone', () => {
     const map = new TrackerMap();
     map.record('ENG-45', { provider: 'linear', id: 'ENG-45' });
     // deliberately do NOT create the folder

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "3c7d5a075a568fab6651ebc6493e98dc0f5b4bb54962a87dc1eafccfdc88c6a1"
+  "inventory_sha256": "d6763de07b827c69904fd7869ed359a0c0cced4698430d87f5f31cded19a1f9a"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "8da007a5767a0fac4ae83ad642a510c8c9cf51b9ed5cbf09f8c271583a1ded8b"
+      "sha256": "e855c0bf55da3e08c82fcfa8a1e210008cb032330564de5cd1a637d99a4ed8c7"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -4657,6 +4657,21 @@ var init_ticket_writer = __esm(() => {
   WINDOWS_RESERVED_DEVICE_WITH_EXTENSION = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])\./i;
 });
 
+// src/utils/ticket-folder-matches.ts
+function findTicketFolderMatch(names, ticketId) {
+  let sluggedMatch;
+  const slugPrefix = `${ticketId}-`;
+  for (const name of names) {
+    if (name === ticketId) {
+      return name;
+    }
+    if (sluggedMatch === undefined && name.startsWith(slugPrefix)) {
+      sluggedMatch = name;
+    }
+  }
+  return sluggedMatch;
+}
+
 // src/tracker-sync/resolve-by-key.ts
 function normalizeTrackerKey(key) {
   return key.startsWith("#") ? key.slice(1) : key;
@@ -4864,12 +4879,9 @@ function resolveTicketFolderById(cwd, id) {
   const ticketsDirectory = resolveTicketsDirectory(cwd);
   if (!existsSync12(ticketsDirectory))
     return;
-  for (const entry of readdirSync7(ticketsDirectory)) {
-    if (entry === id || entry.startsWith(`${id}-`)) {
-      return nodePath19.join(ticketsDirectory, entry);
-    }
-  }
-  return;
+  const names = readdirSync7(ticketsDirectory, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  const match = findTicketFolderMatch(names, id);
+  return match === undefined ? undefined : nodePath19.join(ticketsDirectory, match);
 }
 function isEpicTicket(content) {
   return /^type:\s*epic\s*$/m.test(content);
@@ -42356,7 +42368,7 @@ function resolveTicketDirectory(cwd, ticket) {
   } catch {
     return;
   }
-  const match = entries.find((name) => name === ticket) ?? entries.find((name) => name.startsWith(`${ticket}-`));
+  const match = findTicketFolderMatch(entries, ticket);
   return match === undefined ? undefined : nodePath74.join(ticketsRoot, match);
 }
 function fail2(message) {


### PR DESCRIPTION
## Summary

- centralize case-sensitive ticket folder matching across tracker lookup, Codify, and epic linking
- prefer an exact ticket ID over slugged candidates consistently
- ignore regular files when resolving ticket folders
- add real-filesystem and built-CLI regression coverage for each affected caller

## Why

Ticket folder matching was duplicated across three callers with different selection policies. That made exact-vs-slugged resolution dependent on the caller and, in two paths, allowed matching files to impersonate ticket directories.

## Impact

Ticket resolution is now predictable across the CLI while retaining the existing `{id}` and `{id}-{slug}` naming forms. No configuration or migration is required.

## Validation

- focused Vitest: 5 files, 34 tests passed
- TypeScript typecheck passed
- ESLint passed
- independent Safeword quality review approved
