### PR TITLE
Scope BDD health diagnostics to current work

### DIFF
--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -356,12 +356,13 @@ const CURRENT_WORK_BASE_REFS = [
   'refs/heads/master',
 ] as const;
 
-/** Read Git output without letting optional advisory scope affect health. */
+/** Read Git output without letting a failed scope probe crash health. */
 function readGit(cwd: string, args: readonly string[]): string | undefined {
   try {
     return execFileSync('git', args, {
       cwd,
       encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch {
@@ -379,9 +380,9 @@ function currentWorkPathsWithHead(cwd: string): string[] | undefined {
   const baseReference = CURRENT_WORK_BASE_REFS.find(
     candidate => readGit(cwd, ['rev-parse', '--verify', '--quiet', candidate]) !== undefined,
   );
-  if (baseReference === undefined) return [];
+  if (baseReference === undefined) return undefined;
   const mergeBase = readGit(cwd, ['merge-base', 'HEAD', baseReference])?.trim();
-  if (mergeBase === undefined || mergeBase === '') return [];
+  if (mergeBase === undefined || mergeBase === '') return undefined;
   const committed = readGit(cwd, [
     'diff',
     '--relative',
@@ -407,10 +408,9 @@ function currentWorkPathsWithoutHead(cwd: string): string[] | undefined {
 }
 
 /**
- * Current branch + worktree paths, or undefined outside Git. Projects without
- * Git have no diff scope, so they retain the existing whole-project diagnostic.
- * Within Git, an unavailable base produces an empty scope: BDD diagnostics are
- * advisory and must not turn status/install into a repository-health gate.
+ * Current branch + worktree paths, or undefined when no trustworthy scope can
+ * be derived. An unavailable Git base retains the whole-project diagnostic so
+ * exit-code-affecting Gherkin validation is never silently skipped.
  */
 function currentWorkPaths(cwd: string): string[] | undefined {
   if (readGit(cwd, ['rev-parse', '--is-inside-work-tree'])?.trim() !== 'true') return undefined;
@@ -418,10 +418,10 @@ function currentWorkPaths(cwd: string): string[] | undefined {
   const hasHead = readGit(cwd, ['rev-parse', '--verify', '--quiet', 'HEAD^{commit}']);
   const changedPaths =
     hasHead === undefined ? currentWorkPathsWithoutHead(cwd) : currentWorkPathsWithHead(cwd);
-  if (changedPaths === undefined) return [];
+  if (changedPaths === undefined) return undefined;
 
   const untracked = readGit(cwd, ['ls-files', '--others', '--exclude-standard', '-z']);
-  if (untracked === undefined) return [];
+  if (untracked === undefined) return undefined;
   const paths = new Set(changedPaths);
   addNulSeparatedPaths(paths, untracked);
   return [...paths];

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -9,6 +9,7 @@
  * issues.
  */
 
+import { execFileSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -36,7 +37,9 @@ import {
 } from './utils/configured-paths.js';
 import { createProjectContext } from './utils/context.js';
 import {
+  collectExecutableFeatureFiles,
   createPhaseAnchorEnvironment,
+  featureSourceFileName,
   findFeatureSourcePath,
   hasDefaultExecutableFeatureFiles,
 } from './utils/feature-source.js';
@@ -327,14 +330,14 @@ function archAlignmentHasContent(implPlanContent: string): boolean {
 
 /**
  * Surface scenario-lineage coverage gaps as non-blocking advisories (ticket
- * XT1FFM). Scoped to `status: in_progress` tickets that carry a spec.md —
- * which excludes done predecessors whose pre-scheme scenarios are the
+ * XT1FFM). In a Git worktree, scoped to the current diff's in-progress tickets
+ * and feature sources; projects without Git retain the original whole-project
+ * view. This excludes done predecessors whose pre-scheme scenarios are the
  * out-of-scope migration case (epic DZ2NM5/D5), and keeps the report focused
- * on the work the developer is actually building. Each in-progress ticket's
- * feature source or legacy (spec.md, test-definitions.md) pair is cross-referenced
- * into uncovered ACs, stale AC refs, and orphan scenarios. Coverage gaps stay
- * zero-exit advisories; invalid Gherkin is a health issue because the source
- * cannot be read.
+ * on the work the developer is actually building. Each selected ticket's feature
+ * source or legacy (spec.md, test-definitions.md) pair is cross-referenced into
+ * uncovered ACs, stale AC refs, and orphan scenarios. Coverage gaps stay zero-exit
+ * advisories; invalid Gherkin is a health issue because the source cannot be read.
  */
 interface CoverageDiagnostics {
   issues: string[];
@@ -345,13 +348,160 @@ function emptyCoverageDiagnostics(): CoverageDiagnostics {
   return { issues: [], advisories: [] };
 }
 
+const CURRENT_WORK_BASE_REFS = [
+  'refs/remotes/origin/HEAD',
+  'refs/remotes/origin/main',
+  'refs/remotes/origin/master',
+  'refs/heads/main',
+  'refs/heads/master',
+] as const;
+
+/** Read Git output without letting optional advisory scope affect health. */
+function readGit(cwd: string, args: readonly string[]): string | undefined {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function addNulSeparatedPaths(target: Set<string>, output: string): void {
+  for (const path of output.split('\0')) {
+    if (path !== '') target.add(path);
+  }
+}
+
+function currentWorkPathsWithHead(cwd: string): string[] | undefined {
+  const baseReference = CURRENT_WORK_BASE_REFS.find(
+    candidate => readGit(cwd, ['rev-parse', '--verify', '--quiet', candidate]) !== undefined,
+  );
+  if (baseReference === undefined) return [];
+  const mergeBase = readGit(cwd, ['merge-base', 'HEAD', baseReference])?.trim();
+  if (mergeBase === undefined || mergeBase === '') return [];
+  const committed = readGit(cwd, [
+    'diff',
+    '--relative',
+    '--name-only',
+    '-z',
+    `${mergeBase}...HEAD`,
+  ]);
+  const working = readGit(cwd, ['diff', '--relative', '--name-only', '-z', 'HEAD']);
+  if (committed === undefined || working === undefined) return undefined;
+
+  const paths = new Set<string>();
+  addNulSeparatedPaths(paths, committed);
+  addNulSeparatedPaths(paths, working);
+  return [...paths];
+}
+
+function currentWorkPathsWithoutHead(cwd: string): string[] | undefined {
+  const staged = readGit(cwd, ['diff', '--cached', '--name-only', '-z']);
+  if (staged === undefined) return undefined;
+  const paths = new Set<string>();
+  addNulSeparatedPaths(paths, staged);
+  return [...paths];
+}
+
+/**
+ * Current branch + worktree paths, or undefined outside Git. Projects without
+ * Git have no diff scope, so they retain the existing whole-project diagnostic.
+ * Within Git, an unavailable base produces an empty scope: BDD diagnostics are
+ * advisory and must not turn status/install into a repository-health gate.
+ */
+function currentWorkPaths(cwd: string): string[] | undefined {
+  if (readGit(cwd, ['rev-parse', '--is-inside-work-tree'])?.trim() !== 'true') return undefined;
+
+  const hasHead = readGit(cwd, ['rev-parse', '--verify', '--quiet', 'HEAD^{commit}']);
+  const changedPaths =
+    hasHead === undefined ? currentWorkPathsWithoutHead(cwd) : currentWorkPathsWithHead(cwd);
+  if (changedPaths === undefined) return [];
+
+  const untracked = readGit(cwd, ['ls-files', '--others', '--exclude-standard', '-z']);
+  if (untracked === undefined) return [];
+  const paths = new Set(changedPaths);
+  addNulSeparatedPaths(paths, untracked);
+  return [...paths];
+}
+
+function ticketIdsFromChangedPaths(paths: readonly string[], ticketPrefix: string): Set<string> {
+  const ticketIds = new Set<string>();
+  for (const path of paths) {
+    if (!path.startsWith(ticketPrefix)) continue;
+    const [ticketId] = path.slice(ticketPrefix.length).split('/', 1);
+    if (ticketId !== undefined && ticketId !== '') ticketIds.add(ticketId);
+  }
+  return ticketIds;
+}
+
+interface ChangedFeatureSources {
+  paths: ReadonlySet<string>;
+  fileNames: ReadonlySet<string>;
+}
+
+function addTicketsForChangedFeatureSources(
+  cwd: string,
+  ticketsRoot: string,
+  featureFiles: readonly string[],
+  changedFeatures: ChangedFeatureSources,
+  ticketIds: Set<string>,
+): void {
+  for (const ticketId of listTicketIds(ticketsRoot)) {
+    const featurePath = findFeatureSourcePath(cwd, ticketId, featureFiles);
+    if (
+      (featurePath !== undefined && changedFeatures.paths.has(featurePath)) ||
+      (featurePath === undefined &&
+        changedFeatures.fileNames.has(featureSourceFileName(cwd, ticketId)))
+    ) {
+      ticketIds.add(ticketId);
+    }
+  }
+}
+
+/** The tickets whose metadata or executable feature source enters current work. */
+function currentWorkCoverageTicketIds(
+  cwd: string,
+  ticketsRoot: string,
+  featureFiles: readonly string[],
+): string[] {
+  const paths = currentWorkPaths(cwd);
+  if (paths === undefined) return listTicketIds(ticketsRoot);
+  if (paths.length === 0) return [];
+
+  const ticketsRelative = toRepoRelativePath(cwd, ticketsRoot).split(nodePath.sep).join('/');
+  if (ticketsRelative === '..' || ticketsRelative.startsWith('../')) return [];
+  const ticketPrefix = `${ticketsRelative}/`;
+  const changedFeatures: ChangedFeatureSources = {
+    paths: new Set(
+      paths.filter(path => path.endsWith('.feature')).map(path => nodePath.resolve(cwd, path)),
+    ),
+    fileNames: new Set(
+      paths.filter(path => path.endsWith('.feature')).map(path => nodePath.basename(path)),
+    ),
+  };
+  const ticketIds = ticketIdsFromChangedPaths(paths, ticketPrefix);
+  if (changedFeatures.paths.size === 0) return [...ticketIds];
+
+  addTicketsForChangedFeatureSources(cwd, ticketsRoot, featureFiles, changedFeatures, ticketIds);
+  return [...ticketIds];
+}
+
 function findCoverageDiagnostics(cwd: string): CoverageDiagnostics {
   const ticketsRoot = resolveTicketsDirectory(cwd);
   const all = emptyCoverageDiagnostics();
   const configuredFeatures = readConfiguredPath(cwd, 'features');
   const anchorEnvironment = createPhaseAnchorEnvironment(cwd, configuredFeatures);
-  for (const ticketId of listTicketIds(ticketsRoot)) {
-    const ticketDiagnostics = coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId);
+  const featureFiles = collectExecutableFeatureFiles(cwd);
+  for (const ticketId of currentWorkCoverageTicketIds(cwd, ticketsRoot, featureFiles)) {
+    const ticketDiagnostics = coverageDiagnosticsForTicket(
+      cwd,
+      ticketsRoot,
+      ticketId,
+      featureFiles,
+    );
     all.issues.push(...ticketDiagnostics.issues);
     all.advisories.push(...ticketDiagnostics.advisories);
     const anchorAdvisory = phaseAnchorAdvisoryForTicket(
@@ -398,6 +548,7 @@ function coverageDiagnosticsForTicket(
   cwd: string,
   ticketsRoot: string,
   ticketId: string,
+  featureFiles: readonly string[],
 ): CoverageDiagnostics {
   const ticketDirectory = nodePath.join(ticketsRoot, ticketId);
   const ticketContent = readFileSafe(nodePath.join(ticketDirectory, 'ticket.md'));
@@ -407,7 +558,7 @@ function coverageDiagnosticsForTicket(
   const specContent = readFileSafe(nodePath.join(ticketDirectory, 'spec.md'));
   if (specContent === undefined) return emptyCoverageDiagnostics();
 
-  const featureSource = readFeatureSource(cwd, ticketId);
+  const featureSource = readFeatureSource(cwd, ticketId, featureFiles);
   try {
     const report =
       featureSource === undefined
@@ -488,8 +639,12 @@ interface FeatureSource {
   content: string;
 }
 
-function readFeatureSource(cwd: string, ticketFolder: string): FeatureSource | undefined {
-  const featurePath = findFeatureSourcePath(cwd, ticketFolder);
+function readFeatureSource(
+  cwd: string,
+  ticketFolder: string,
+  featureFiles: readonly string[],
+): FeatureSource | undefined {
+  const featurePath = findFeatureSourcePath(cwd, ticketFolder, featureFiles);
   const content = featurePath === undefined ? undefined : readFileSafe(featurePath);
   return featurePath === undefined || content === undefined
     ? undefined

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -32,7 +32,7 @@ export function featureSourceFileName(cwd: string, ticketFolder: string): string
 export function findFeatureSourcePath(
   cwd: string,
   ticketFolder: string,
-  featureFiles = collectExecutableFeatureFiles(cwd),
+  featureFiles: readonly string[] = collectExecutableFeatureFiles(cwd),
 ): string | undefined {
   const fileName = featureSourceFileName(cwd, ticketFolder);
   return featureFiles.find(path => nodePath.basename(path) === fileName);

--- a/packages/cli/src/utils/feature-source.ts
+++ b/packages/cli/src/utils/feature-source.ts
@@ -25,9 +25,17 @@ function slugForTicket(cwd: string, ticketFolder: string): string {
  * the Cucumber lane: all feature files under root `features/`, then under each
  * direct workspace package's `features/` directory in stable order.
  */
-export function findFeatureSourcePath(cwd: string, ticketFolder: string): string | undefined {
-  const fileName = `${slugForTicket(cwd, ticketFolder)}.feature`;
-  return collectExecutableFeatureFiles(cwd, fileName)[0];
+export function featureSourceFileName(cwd: string, ticketFolder: string): string {
+  return `${slugForTicket(cwd, ticketFolder)}.feature`;
+}
+
+export function findFeatureSourcePath(
+  cwd: string,
+  ticketFolder: string,
+  featureFiles = collectExecutableFeatureFiles(cwd),
+): string | undefined {
+  const fileName = featureSourceFileName(cwd, ticketFolder);
+  return featureFiles.find(path => nodePath.basename(path) === fileName);
 }
 
 /** Build the ticket-invariant feature ownership policy once per tree/config. */

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -4,6 +4,7 @@
  * Tests for `safeword check` command.
  */
 
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync, unlinkSync } from 'node:fs';
 import nodePath from 'node:path';
 
@@ -1154,6 +1155,115 @@ describe('Test Suite 8: Health Check', () => {
 
       expect(result.exitCode).toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/COV002/);
+    });
+  });
+
+  describe('Diff-scoped BDD diagnostics', () => {
+    const SPEC_ONE_AC = [
+      '# Spec',
+      '',
+      '## Jobs To Be Done',
+      '',
+      '### demo.TB1 — Trace',
+      '',
+      '**Persona:** TB',
+      '',
+      '#### demo.TB1.AC1 — capability one',
+      '',
+    ].join('\n');
+
+    function git(...args: string[]): void {
+      execFileSync('git', args, { cwd: temporaryDirectory, stdio: 'pipe' });
+    }
+
+    function writeFeatureTicket(folder: string, feature: string): void {
+      writeTestFile(
+        temporaryDirectory,
+        `.project/tickets/${folder}/ticket.md`,
+        [
+          '---',
+          `id: ${folder.split('-', 1)[0]}`,
+          'type: feature',
+          'phase: implement',
+          'status: in_progress',
+          '---',
+          '',
+        ].join('\n'),
+      );
+      writeTestFile(temporaryDirectory, `.project/tickets/${folder}/spec.md`, SPEC_ONE_AC);
+      writeTestFile(
+        temporaryDirectory,
+        `features/${feature}.feature`,
+        [
+          'Feature: Demo',
+          '',
+          '  Scenario: missing lineage',
+          '    Given a',
+          '    When b',
+          '    Then c',
+          '',
+        ].join('\n'),
+      );
+    }
+
+    async function setUpCurrentWork(): Promise<void> {
+      await createConfiguredProject(temporaryDirectory);
+      writeFeatureTicket('BACKGROUND1-background', 'background');
+      writeFeatureTicket('FOCUS1-focused', 'focused');
+      git('init', '--initial-branch=main');
+      git('config', 'user.email', 'health@example.test');
+      git('config', 'user.name', 'Health Test');
+      git('add', '.');
+      git('commit', '-m', 'baseline');
+      git('checkout', '-b', 'health-scope');
+    }
+
+    it('ignores unrelated in-progress lineage and anchor drift for a comment-only diff', async () => {
+      await setUpCurrentWork();
+
+      writeTestFile(temporaryDirectory, 'README.md', '# Comment-only change\n');
+
+      const unrelated = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(unrelated.exitCode).toBe(0);
+      expect(`${unrelated.stdout}\n${unrelated.stderr}`).not.toMatch(/BACKGROUND1|FOCUS1/);
+    });
+
+    it('reports only the ticket that owns a changed feature source', async () => {
+      await setUpCurrentWork();
+
+      writeTestFile(
+        temporaryDirectory,
+        'features/focused.feature',
+        [
+          'Feature: Demo',
+          '',
+          '  Scenario: still missing lineage',
+          '    Given a',
+          '    When b',
+          '    Then c',
+          '',
+        ].join('\n'),
+      );
+
+      const focused = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+      const combined = `${focused.stdout}\n${focused.stderr}`;
+
+      expect(focused.exitCode).toBe(2);
+      expect(combined).toMatch(/FOCUS1/);
+      expect(combined).not.toMatch(/BACKGROUND1/);
+    });
+
+    it('keeps a ticket in scope when the current diff deletes its feature source', async () => {
+      await setUpCurrentWork();
+      unlinkSync(nodePath.join(temporaryDirectory, 'features', 'focused.feature'));
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+      const combined = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.exitCode).toBe(0);
+      expect(combined).toMatch(/FOCUS1/);
+      expect(combined).not.toMatch(/BACKGROUND1/);
     });
   });
 

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -1173,7 +1173,14 @@ describe('Test Suite 8: Health Check', () => {
     ].join('\n');
 
     function git(...args: string[]): void {
-      execFileSync('git', args, { cwd: temporaryDirectory, stdio: 'pipe' });
+      execFileSync(
+        'git',
+        ['-c', 'commit.gpgsign=false', '-c', 'core.excludesFile=/dev/null', ...args],
+        {
+          cwd: temporaryDirectory,
+          stdio: 'pipe',
+        },
+      );
     }
 
     function writeFeatureTicket(folder: string, feature: string): void {
@@ -1206,11 +1213,11 @@ describe('Test Suite 8: Health Check', () => {
       );
     }
 
-    async function setUpCurrentWork(): Promise<void> {
+    async function setUpCurrentWork(initialBranch = 'main'): Promise<void> {
       await createConfiguredProject(temporaryDirectory);
       writeFeatureTicket('BACKGROUND1-background', 'background');
       writeFeatureTicket('FOCUS1-focused', 'focused');
-      git('init', '--initial-branch=main');
+      git('init', `--initial-branch=${initialBranch}`);
       git('config', 'user.email', 'health@example.test');
       git('config', 'user.name', 'Health Test');
       git('add', '.');
@@ -1264,6 +1271,15 @@ describe('Test Suite 8: Health Check', () => {
       expect(result.exitCode).toBe(0);
       expect(combined).toMatch(/FOCUS1/);
       expect(combined).not.toMatch(/BACKGROUND1/);
+    });
+
+    it('retains validation when a Git repository has no known base branch', async () => {
+      await setUpCurrentWork('develop');
+
+      const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
+
+      expect(result.exitCode).toBe(2);
+      expect(`${result.stdout}\n${result.stderr}`).toMatch(/FOCUS1/);
     });
   });
 

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -1217,11 +1217,11 @@ describe('Test Suite 8: Health Check', () => {
       await createConfiguredProject(temporaryDirectory);
       writeFeatureTicket('BACKGROUND1-background', 'background');
       writeFeatureTicket('FOCUS1-focused', 'focused');
-      git('branch', '-M', initialBranch);
       git('config', 'user.email', 'health@example.test');
       git('config', 'user.name', 'Health Test');
       git('add', '.');
       git('commit', '-m', 'baseline');
+      git('branch', '-M', initialBranch);
       git('checkout', '-b', 'health-scope');
     }
 
@@ -1274,7 +1274,8 @@ describe('Test Suite 8: Health Check', () => {
     });
 
     it('retains validation when a Git repository has no known base branch', async () => {
-      await setUpCurrentWork('develop');
+      // This deliberately non-conventional name must remain absent from the base-ref list.
+      await setUpCurrentWork('zz-no-base');
 
       const result = await runCli(['check', '--offline'], { cwd: temporaryDirectory });
 

--- a/packages/cli/tests/commands/check.test.ts
+++ b/packages/cli/tests/commands/check.test.ts
@@ -1217,7 +1217,7 @@ describe('Test Suite 8: Health Check', () => {
       await createConfiguredProject(temporaryDirectory);
       writeFeatureTicket('BACKGROUND1-background', 'background');
       writeFeatureTicket('FOCUS1-focused', 'focused');
-      git('init', `--initial-branch=${initialBranch}`);
+      git('branch', '-M', initialBranch);
       git('config', 'user.email', 'health@example.test');
       git('config', 'user.name', 'Health Test');
       git('add', '.');

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "0282b02cd10f159fc72b6725ecb00b9d9af871119351cc9a2201d7204cffaf12"
+  "inventory_sha256": "bb11c9d8fcfa333d7ecc2d3cb5d6ae8a1b34de9b4af9795282c28e188721a8c1"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "7562bea513a6a2b3a42667306170d75ba6619833069db55208f032b9af0b0a1f"
+      "sha256": "16f6db9f69d0a9daf9339d02103e3b807ad6ad020bbb22c6693dd1ed7357057b"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -22963,9 +22963,12 @@ function slugForTicket(cwd, ticketFolder) {
   const dashIndex = ticketFolder.indexOf("-");
   return dashIndex === -1 ? ticketFolder : ticketFolder.slice(dashIndex + 1);
 }
-function findFeatureSourcePath(cwd, ticketFolder) {
-  const fileName = `${slugForTicket(cwd, ticketFolder)}.feature`;
-  return collectExecutableFeatureFiles(cwd, fileName)[0];
+function featureSourceFileName(cwd, ticketFolder) {
+  return `${slugForTicket(cwd, ticketFolder)}.feature`;
+}
+function findFeatureSourcePath(cwd, ticketFolder, featureFiles = collectExecutableFeatureFiles(cwd)) {
+  const fileName = featureSourceFileName(cwd, ticketFolder);
+  return featureFiles.find((path4) => nodePath46.basename(path4) === fileName);
 }
 function createPhaseAnchorEnvironment(cwd, configuredFeatures) {
   const featureRoots = ["features"];
@@ -32909,6 +32912,7 @@ function buildIndexConflictListMessage(paths) {
 var SYNCTICKETS_QUIET_COMMAND = "`safeword project sync-tickets --quiet`";
 
 // src/health.ts
+import { execFileSync as execFileSync7 } from "child_process";
 import { readdirSync as readdirSync19 } from "fs";
 import nodePath47 from "path";
 function findMissingFiles(cwd, actions) {
@@ -33066,13 +33070,115 @@ function archAlignmentHasContent(implPlanContent) {
 function emptyCoverageDiagnostics() {
   return { issues: [], advisories: [] };
 }
+function readGit(cwd, args) {
+  try {
+    return execFileSync7("git", args, {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+  } catch {
+    return;
+  }
+}
+function addNulSeparatedPaths(target, output) {
+  for (const path4 of output.split("\x00")) {
+    if (path4 !== "")
+      target.add(path4);
+  }
+}
+function currentWorkPathsWithHead(cwd) {
+  const baseReference = CURRENT_WORK_BASE_REFS.find((candidate) => readGit(cwd, ["rev-parse", "--verify", "--quiet", candidate]) !== undefined);
+  if (baseReference === undefined)
+    return;
+  const mergeBase = readGit(cwd, ["merge-base", "HEAD", baseReference])?.trim();
+  if (mergeBase === undefined || mergeBase === "")
+    return;
+  const committed = readGit(cwd, [
+    "diff",
+    "--relative",
+    "--name-only",
+    "-z",
+    `${mergeBase}...HEAD`
+  ]);
+  const working = readGit(cwd, ["diff", "--relative", "--name-only", "-z", "HEAD"]);
+  if (committed === undefined || working === undefined)
+    return;
+  const paths = new Set;
+  addNulSeparatedPaths(paths, committed);
+  addNulSeparatedPaths(paths, working);
+  return [...paths];
+}
+function currentWorkPathsWithoutHead(cwd) {
+  const staged = readGit(cwd, ["diff", "--cached", "--name-only", "-z"]);
+  if (staged === undefined)
+    return;
+  const paths = new Set;
+  addNulSeparatedPaths(paths, staged);
+  return [...paths];
+}
+function currentWorkPaths(cwd) {
+  if (readGit(cwd, ["rev-parse", "--is-inside-work-tree"])?.trim() !== "true")
+    return;
+  const hasHead = readGit(cwd, ["rev-parse", "--verify", "--quiet", "HEAD^{commit}"]);
+  const changedPaths = hasHead === undefined ? currentWorkPathsWithoutHead(cwd) : currentWorkPathsWithHead(cwd);
+  if (changedPaths === undefined)
+    return;
+  const untracked = readGit(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
+  if (untracked === undefined)
+    return;
+  const paths = new Set(changedPaths);
+  addNulSeparatedPaths(paths, untracked);
+  return [...paths];
+}
+function ticketIdsFromChangedPaths(paths, ticketPrefix) {
+  const ticketIds = new Set;
+  for (const path4 of paths) {
+    if (!path4.startsWith(ticketPrefix))
+      continue;
+    const [ticketId] = path4.slice(ticketPrefix.length).split("/", 1);
+    if (ticketId !== undefined && ticketId !== "")
+      ticketIds.add(ticketId);
+  }
+  return ticketIds;
+}
+function addTicketsForChangedFeatureSources(cwd, ticketsRoot, featureFiles, changedFeatures, ticketIds) {
+  for (const ticketId of listTicketIds(ticketsRoot)) {
+    const featurePath = findFeatureSourcePath(cwd, ticketId, featureFiles);
+    if (featurePath !== undefined && changedFeatures.paths.has(featurePath) || featurePath === undefined && changedFeatures.fileNames.has(featureSourceFileName(cwd, ticketId))) {
+      ticketIds.add(ticketId);
+    }
+  }
+}
+function currentWorkCoverageTicketIds(cwd, ticketsRoot, featureFiles) {
+  const paths = currentWorkPaths(cwd);
+  if (paths === undefined)
+    return listTicketIds(ticketsRoot);
+  if (paths.length === 0)
+    return [];
+  const ticketsRelative = toRepoRelativePath(cwd, ticketsRoot).split(nodePath47.sep).join("/");
+  if (ticketsRelative === ".." || ticketsRelative.startsWith("../"))
+    return [];
+  const ticketPrefix = `${ticketsRelative}/`;
+  const changedFeatures = {
+    paths: new Set(paths.filter((path4) => path4.endsWith(".feature")).map((path4) => nodePath47.resolve(cwd, path4))),
+    fileNames: new Set(paths.filter((path4) => path4.endsWith(".feature")).map((path4) => nodePath47.basename(path4)))
+  };
+  const ticketIds = ticketIdsFromChangedPaths(paths, ticketPrefix);
+  if (changedFeatures.paths.size === 0)
+    return [...ticketIds];
+  addTicketsForChangedFeatureSources(cwd, ticketsRoot, featureFiles, changedFeatures, ticketIds);
+  return [...ticketIds];
+}
 function findCoverageDiagnostics(cwd) {
   const ticketsRoot = resolveTicketsDirectory(cwd);
   const all = emptyCoverageDiagnostics();
   const configuredFeatures = readConfiguredPath(cwd, "features");
   const anchorEnvironment = createPhaseAnchorEnvironment(cwd, configuredFeatures);
-  for (const ticketId of listTicketIds(ticketsRoot)) {
-    const ticketDiagnostics = coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId);
+  const featureFiles = collectExecutableFeatureFiles(cwd);
+  for (const ticketId of currentWorkCoverageTicketIds(cwd, ticketsRoot, featureFiles)) {
+    const ticketDiagnostics = coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId, featureFiles);
     all.issues.push(...ticketDiagnostics.issues);
     all.advisories.push(...ticketDiagnostics.advisories);
     const anchorAdvisory = phaseAnchorAdvisoryForTicket(cwd, ticketsRoot, ticketId, anchorEnvironment);
@@ -33093,7 +33199,7 @@ function phaseAnchorAdvisoryForTicket(cwd, ticketsRoot, ticketId, anchorEnvironm
     return;
   return `${formatCoverageTicketLabel(ticketId, content)}: ${verdict.reason} The anchor is the exited phase's artifact \u2014 boundary checks verify it against the tree.`;
 }
-function coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId) {
+function coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId, featureFiles) {
   const ticketDirectory = nodePath47.join(ticketsRoot, ticketId);
   const ticketContent = readFileSafe(nodePath47.join(ticketDirectory, "ticket.md"));
   if (ticketContent === undefined || !isInProgress(ticketContent))
@@ -33101,7 +33207,7 @@ function coverageDiagnosticsForTicket(cwd, ticketsRoot, ticketId) {
   const specContent = readFileSafe(nodePath47.join(ticketDirectory, "spec.md"));
   if (specContent === undefined)
     return emptyCoverageDiagnostics();
-  const featureSource = readFeatureSource(cwd, ticketId);
+  const featureSource = readFeatureSource(cwd, ticketId, featureFiles);
   try {
     const report = featureSource === undefined ? buildCoverageReport(specContent, readFileSafe(nodePath47.join(ticketDirectory, "test-definitions.md"))) : buildCoverageReportFromFeature(specContent, featureSource.content);
     const surfaceReport = featureSource === undefined ? undefined : buildSurfaceCoverageReportFromFeature(specContent, featureSource.content);
@@ -33139,8 +33245,8 @@ function formatFeatureLineageIssues(cwd, ticketId, featureSource, ticketContent)
   const relativePath = nodePath47.relative(cwd, featureSource.path);
   return findFeatureLineageIssues(featureSource.content).map((issue2) => `${label}: ${relativePath}: ${issue2}`);
 }
-function readFeatureSource(cwd, ticketFolder) {
-  const featurePath = findFeatureSourcePath(cwd, ticketFolder);
+function readFeatureSource(cwd, ticketFolder, featureFiles) {
+  const featurePath = findFeatureSourcePath(cwd, ticketFolder, featureFiles);
   const content = featurePath === undefined ? undefined : readFileSafe(featurePath);
   return featurePath === undefined || content === undefined ? undefined : { path: featurePath, content };
 }
@@ -33296,7 +33402,7 @@ async function checkHealth(cwd, options = {}) {
     missingPythonTools
   };
 }
-var PATH_ONLY_KNOWLEDGE_KEYS, CONFIGURED_KNOWLEDGE_KEYS;
+var PATH_ONLY_KNOWLEDGE_KEYS, CONFIGURED_KNOWLEDGE_KEYS, CURRENT_WORK_BASE_REFS;
 var init_health = __esm(() => {
   init_phase_provenance();
   init_delivery_schema();
@@ -33325,6 +33431,13 @@ var init_health = __esm(() => {
     "principles",
     "surfaces",
     "glossary"
+  ];
+  CURRENT_WORK_BASE_REFS = [
+    "refs/remotes/origin/HEAD",
+    "refs/remotes/origin/main",
+    "refs/remotes/origin/master",
+    "refs/heads/main",
+    "refs/heads/master"
   ];
 });
 
@@ -41409,7 +41522,7 @@ __export(exports_architecture, {
   architectureStage: () => architectureStage,
   architecture: () => architecture
 });
-import { execFileSync as execFileSync7 } from "child_process";
+import { execFileSync as execFileSync8 } from "child_process";
 import {
   copyFileSync as copyFileSync2,
   lstatSync as lstatSync16,
@@ -41624,7 +41737,7 @@ function withGitIndexSnapshot(cwd, gitContext, useSnapshot) {
   const sourceIndexEnvironment = sourceIndexFile === undefined ? undefined : { ...process10.env, GIT_INDEX_FILE: sourceIndexFile };
   try {
     assertNoGitlinks(gitContext, sourceIndexEnvironment);
-    execFileSync7("git", [
+    execFileSync8("git", [
       "checkout-index",
       "--all",
       "--force",
@@ -41644,7 +41757,7 @@ function withGitIndexSnapshot(cwd, gitContext, useSnapshot) {
 }
 function assertNoGitlinks(gitContext, sourceIndexEnvironment) {
   const pathArguments = gitContext.projectRelativeDirectory === "" ? [] : [gitContext.projectRelativeDirectory];
-  const entries = execFileSync7("git", ["ls-files", "--stage", "-z", "--full-name", "--", ...pathArguments], {
+  const entries = execFileSync8("git", ["ls-files", "--stage", "-z", "--full-name", "--", ...pathArguments], {
     cwd: gitContext.rootDirectory,
     encoding: "utf8",
     ...sourceIndexEnvironment && { env: sourceIndexEnvironment },
@@ -41658,7 +41771,7 @@ function assertNoGitlinks(gitContext, sourceIndexEnvironment) {
 function resolveGitContext(cwd) {
   let rootDirectory;
   try {
-    rootDirectory = execFileSync7("git", ["rev-parse", "--show-toplevel"], {
+    rootDirectory = execFileSync8("git", ["rev-parse", "--show-toplevel"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -41895,7 +42008,7 @@ function readDivergentWorktreeContent(cwd, destination) {
   let indexContent;
   try {
     const projectRelativePath = relativePath.replaceAll("\\", "/");
-    indexContent = execFileSync7("git", ["show", `:./${projectRelativePath}`], {
+    indexContent = execFileSync8("git", ["show", `:./${projectRelativePath}`], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -41906,7 +42019,7 @@ function readDivergentWorktreeContent(cwd, destination) {
 function stageDocument(cwd, result) {
   try {
     const relativePath = nodePath72.relative(cwd, result.path);
-    execFileSync7("git", ["add", "--", relativePath], { cwd, stdio: "ignore" });
+    execFileSync8("git", ["add", "--", relativePath], { cwd, stdio: "ignore" });
     return;
   } catch (error_) {
     return errorMessage2(error_);
@@ -41920,7 +42033,7 @@ function isPotentialArchitectureInput(path4) {
 }
 function nulSeparatedGitPaths(cwd, args) {
   try {
-    return execFileSync7("git", args, {
+    return execFileSync8("git", args, {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -46937,14 +47050,14 @@ var init_review_pr_publication = __esm(() => {
 });
 
 // src/codex-plugin/project-directory.ts
-import { execFileSync as execFileSync8 } from "child_process";
+import { execFileSync as execFileSync9 } from "child_process";
 import nodePath85 from "path";
 function resolveCodexProjectDirectory(cwd = process.cwd(), environment = process.env) {
   const configuredProject = environment.CLAUDE_PROJECT_DIR?.trim();
   if (configuredProject)
     return nodePath85.resolve(configuredProject);
   try {
-    const root = execFileSync8("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+    const root = execFileSync9("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5000
@@ -56850,9 +56963,9 @@ var init_retro = __esm(() => {
 });
 
 // templates/hooks/lib/ledger-git.ts
-import { execFileSync as execFileSync9 } from "child_process";
+import { execFileSync as execFileSync10 } from "child_process";
 function git(cwd, args, input) {
-  return execFileSync9("git", args, {
+  return execFileSync10("git", args, {
     cwd,
     input,
     encoding: "utf8",
@@ -56868,7 +56981,7 @@ function resolveCommitSha(cwd, sha) {
 }
 function isAncestorOfHead(cwd, sha) {
   try {
-    execFileSync9("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
+    execFileSync10("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
       cwd,
       stdio: "pipe"
     });
@@ -57342,13 +57455,13 @@ var exports_boundary = {};
 __export(exports_boundary, {
   boundary: () => boundary
 });
-import { execFileSync as execFileSync10 } from "child_process";
+import { execFileSync as execFileSync11 } from "child_process";
 import { appendFileSync as appendFileSync3, existsSync as existsSync45, mkdirSync as mkdirSync17 } from "fs";
 import nodePath93 from "path";
 import process20 from "process";
 function tryGit(cwd, args) {
   try {
-    return execFileSync10("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return execFileSync11("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
   } catch {
     return;
   }


### PR DESCRIPTION
# Scope BDD health diagnostics to current work

## What changed

- Limit lineage and phase-anchor health diagnostics in Git worktrees to tickets and feature sources touched by the current branch or worktree diff.
- Include deleted feature sources when selecting their still-active ticket.
- Preserve the prior whole-project diagnostic behavior outside Git.

## Why

`install` and `status` previously scanned every in-progress ticket, producing unrelated lineage and phase-anchor noise during ordinary work such as comment-only changes.

## Validation

- `bun run test tests/commands/check.test.ts --reporter=dot`
- `bun run --cwd packages/cli test:bdd`
- Targeted ESLint and Prettier checks
- `git diff --check`
