### PR TITLE
Track Codex plugin reload fixes

### DIFF
--- a/.github/changelog-snapshots/codex-plugin-hook-reload.txt
+++ b/.github/changelog-snapshots/codex-plugin-hook-reload.txt
@@ -1,0 +1,8 @@
+---
+source: https://api.github.com/repos/openai/codex/issues/17636
+source_key: codex-plugin-hook-reload
+reviewed_at: 2026-08-16T19:18:20.000Z
+---
+
+state: open
+state_reason: none

--- a/.github/changelog-snapshots/codex-removed-plugin-hooks.txt
+++ b/.github/changelog-snapshots/codex-removed-plugin-hooks.txt
@@ -1,0 +1,8 @@
+---
+source: https://api.github.com/repos/openai/codex/issues/38339
+source_key: codex-removed-plugin-hooks
+reviewed_at: 2026-08-16T19:18:20.000Z
+---
+
+state: open
+state_reason: none

--- a/.project/tickets/2HXHSV-codex-plugin-reload-watch/ticket.md
+++ b/.project/tickets/2HXHSV-codex-plugin-reload-watch/ticket.md
@@ -1,0 +1,24 @@
+---
+id: 2HXHSV
+slug: codex-plugin-reload-watch
+type: task
+phase: verify
+status: in_progress
+external_issue: https://github.com/openai/codex/issues/17636
+created: 2026-08-16T19:18:20.658Z
+last_modified: 2026-08-16T20:16:25Z
+---
+
+# Track Codex plugin reload fixes for Safeword users
+
+**Goal:** Alert maintainers when the upstream Codex plugin-reload issues close so Safeword can reassess its restart guidance.
+
+**Why:** A restart-sensitive runtime behavior can make Safeword protections appear stale or inactive after plugin changes.
+
+## Work Log
+
+- 2026-08-16T20:16:25Z Started delivery: Created branch `codex/track-codex-plugin-reload-fixes` for review and merge.
+- 2026-08-16T19:25:12Z Complete: Closure-triggered triage issues now carry Safeword’s existing `impact:high` GitHub label on both creation and update, with client-boundary coverage proving it reaches GitHub.
+- 2026-08-16T19:21:27Z Complete: Added state-only monitors for Codex #17636 and #38339. Their scheduled check now files a contextual Safeword triage issue and exits non-zero when either changes; focused monitor tests and TypeScript verification passed.
+- 2026-08-16T19:18:20Z Found: Codex issues #17636 and #38339 are open; ordinary CI will validate their committed open-state snapshots, while the weekly monitor alone reads GitHub and fails after filing contextual triage if either state changes.
+- 2026-08-16T19:18:20.658Z Started: Created ticket 2HXHSV

--- a/packages/cli/src/upstream-monitor/index.ts
+++ b/packages/cli/src/upstream-monitor/index.ts
@@ -1,7 +1,13 @@
 import { readFile } from 'node:fs/promises';
 import nodePath from 'node:path';
 
-export type MonitorSourceKey = 'claude-code' | 'codex-cli' | 'codex-project-plugins' | 'cursor';
+export type MonitorSourceKey =
+  | 'claude-code'
+  | 'codex-cli'
+  | 'codex-project-plugins'
+  | 'codex-plugin-hook-reload'
+  | 'codex-removed-plugin-hooks'
+  | 'cursor';
 
 export interface MonitorSource {
   key: MonitorSourceKey;
@@ -14,6 +20,10 @@ export interface MonitorSource {
   headline?: string;
   /** Triage checklist for the filed issue. Defaults to the changelog checklist. */
   checklist?: readonly string[];
+  /** Labels applied to the Safeword issue created from this source. */
+  labels?: readonly string[];
+  /** A change is a release-safety event: the scheduled monitor must fail after filing triage. */
+  failOnChange?: boolean;
 }
 
 export interface SourceChangeInput {
@@ -31,6 +41,7 @@ export interface SourceChange {
 
 export interface IssuePayload {
   body: string;
+  labels?: readonly string[];
   title: string;
 }
 
@@ -113,6 +124,47 @@ const MONITOR_SOURCES: readonly MonitorSource[] = [
       '- [ ] Reassess the `hasSafewordProjectMarker` guards, the packaged hook copies, and the ARCHITECTURE.md ADR "Explicit Project Enrollment for Profile-Scoped Codex Hooks".',
       '- [ ] If it shipped and the workaround is gone: delete `packages/cli/tests/codex-project-scope-tripwire.test.ts` and this monitor source.',
       '- [ ] If it did not ship: advance the snapshot and leave both tripwires in place.',
+    ],
+  },
+  // Safeword's current protection guidance tells users to restart Codex after a
+  // plugin update. These issue-state snapshots make a resolution impossible to
+  // miss, without making ordinary CI depend on GitHub's availability.
+  {
+    key: 'codex-plugin-hook-reload',
+    label: 'Codex: Hot-reload hook configuration during a live session (openai/codex#17636)',
+    platformEpic: 'QM5G9M',
+    snapshotPath: `${SNAPSHOT_DIRECTORY}/codex-plugin-hook-reload.txt`,
+    url: 'https://api.github.com/repos/openai/codex/issues/17636',
+    normalize: normalizeIssueState,
+    labels: ['impact:high'],
+    failOnChange: true,
+    headline:
+      'Safeword relies on a full Codex restart before trusting a newly installed plugin update. **openai/codex#17636** (hot-reload hook configuration) changed state.',
+    checklist: [
+      '- [ ] Read the resolution and the released Codex behavior; a closed issue alone does not prove Desktop reloads hooks in the active task.',
+      '- [ ] Reproduce installing or changing a Safeword hook in an existing Codex task, then confirm the later lifecycle event uses the new hook without a restart.',
+      '- [ ] If confirmed, reassess the “SAFEWORD PROTECTION IS UNVERIFIED” restart guidance and any restart-dependent Safeword documentation or guards.',
+      '- [ ] If not confirmed, record why the issue closure does not remove the restart requirement, advance the snapshot, and keep this tripwire.',
+      '- [ ] If the workaround is removable, delete this source, its snapshot, and the matching wiring tests in the same reviewed change.',
+    ],
+  },
+  {
+    key: 'codex-removed-plugin-hooks',
+    label: 'Codex: Removed plugin Stop hook persists until full app restart (openai/codex#38339)',
+    platformEpic: 'QM5G9M',
+    snapshotPath: `${SNAPSHOT_DIRECTORY}/codex-removed-plugin-hooks.txt`,
+    url: 'https://api.github.com/repos/openai/codex/issues/38339',
+    normalize: normalizeIssueState,
+    labels: ['impact:high'],
+    failOnChange: true,
+    headline:
+      'Safeword must not leave users with stale hooks after its plugin is removed or updated. **openai/codex#38339** (removed plugin Stop hook persists until restart) changed state.',
+    checklist: [
+      '- [ ] Read the resolution and verify that disabling or removing Safeword does not leave its old lifecycle hooks active in the current Codex process.',
+      '- [ ] Test the failure path: remove a plugin hook while a task remains open and confirm a later response neither invokes nor repeats an error for the removed hook.',
+      '- [ ] Reassess Safeword’s restart guidance alongside #17636; hot reload is not complete if stale hooks can remain active after removal.',
+      '- [ ] If the behavior is still restart-sensitive, document the evidence, advance the snapshot, and keep this tripwire.',
+      '- [ ] If the workaround is removable, delete this source, its snapshot, and the matching wiring tests in the same reviewed change.',
     ],
   },
   {
@@ -236,6 +288,7 @@ export function buildIssuePayload(change: Omit<SourceChange, 'changed'>): IssueP
   const diff = createBoundedDiff(change.previous, change.current);
   return {
     title: `[upstream-changelog] ${change.source.label} changed`,
+    ...(change.source.labels && { labels: change.source.labels }),
     body: [
       change.source.headline ?? `Upstream changelog changed for **${change.source.label}**.`,
       '',
@@ -280,7 +333,7 @@ export async function reportSourceChange(
 async function checkSource(
   source: MonitorSource,
   dependencies: MonitorDependencies,
-): Promise<ReportResult | undefined> {
+): Promise<(ReportResult & { immediateTriage: boolean }) | undefined> {
   const raw = await dependencies.fetchText(source.url);
   const liveContent = source.normalize(raw);
   const snapshotPath = nodePath.join(dependencies.rootDirectory, source.snapshotPath);
@@ -289,7 +342,7 @@ async function checkSource(
 
   if (!change.changed) return undefined;
 
-  return await reportSourceChange(
+  const report = await reportSourceChange(
     dependencies.issueClient,
     buildIssuePayload({
       current: change.current,
@@ -297,11 +350,14 @@ async function checkSource(
       source,
     }),
   );
+  return { ...report, immediateTriage: source.failOnChange === true };
 }
 
 export interface MonitorRunResult {
   reported: number;
   failed: number;
+  /** Changed sources that require the scheduled monitor to fail after filing triage. */
+  immediateTriage: number;
 }
 
 export async function runUpstreamMonitor(
@@ -310,6 +366,7 @@ export async function runUpstreamMonitor(
   const sources = dependencies.sources ?? MONITOR_SOURCES;
   let reported = 0;
   let failed = 0;
+  let immediateTriage = 0;
 
   for (const source of sources) {
     // Each source is an independent watch, so one must not be able to cancel
@@ -326,6 +383,7 @@ export async function runUpstreamMonitor(
       }
 
       reported += 1;
+      if (result.immediateTriage) immediateTriage += 1;
       dependencies.log?.(`${source.key}: ${result.action} issue #${result.issueNumber}`);
     } catch (error) {
       // Distinct from "no change" on purpose: an unchecked source is missing
@@ -338,7 +396,7 @@ export async function runUpstreamMonitor(
     }
   }
 
-  return { reported, failed };
+  return { reported, failed, immediateTriage };
 }
 
 export function createGitHubIssueClient(options: {

--- a/packages/cli/src/upstream-monitor/run.ts
+++ b/packages/cli/src/upstream-monitor/run.ts
@@ -34,7 +34,7 @@ const log = (message: string): void => {
   console.log(message);
 };
 
-const { reported, failed } = await runUpstreamMonitor({
+const { reported, failed, immediateTriage } = await runUpstreamMonitor({
   fetchText: url => fetchText(url, token),
   issueClient: createGitHubIssueClient({ fetch, owner, repo, token, log }),
   log,
@@ -42,12 +42,21 @@ const { reported, failed } = await runUpstreamMonitor({
   rootDirectory: process.cwd(),
 });
 
-console.log(`upstream changelog monitor complete; reported=${reported} failed=${failed}`);
+console.log(
+  `upstream changelog monitor complete; reported=${reported} failed=${failed} immediateTriage=${immediateTriage}`,
+);
 
 // A source that could not be checked is missing evidence, not a pass. Exit
 // non-zero so a broken watch surfaces as a red scheduled run rather than a
 // line in a log nobody reads — the same reason the tripwires exist at all.
-if (failed > 0) {
-  console.error(`${failed} upstream source(s) could not be checked; see the log above.`);
+if (failed > 0 || immediateTriage > 0) {
+  if (failed > 0) {
+    console.error(`${failed} upstream source(s) could not be checked; see the log above.`);
+  }
+  if (immediateTriage > 0) {
+    console.error(
+      `${immediateTriage} upstream issue tripwire(s) changed state; read the filed Safeword triage issue before advancing its snapshot.`,
+    );
+  }
   process.exit(1);
 }

--- a/packages/cli/tests/upstream-monitor/client.test.ts
+++ b/packages/cli/tests/upstream-monitor/client.test.ts
@@ -98,4 +98,30 @@ describe('GitHub issue client', () => {
     // timeout, turning one bad request into a whole missed run.
     expect(calls[0]?.init?.signal).toBeInstanceOf(AbortSignal);
   });
+
+  it('persists an impact label when creating or updating an urgent issue', async () => {
+    const calls: RecordedCall[] = [];
+    const fetchStub = ((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(jsonResponse({ number: 9 }));
+    }) as unknown as typeof fetch;
+    const client = createGitHubIssueClient({
+      fetch: fetchStub,
+      owner: 'ArcadeAI',
+      repo: 'safeword',
+      token: 't',
+    });
+    const payload = { title: TITLE, body: 'context', labels: ['impact:high'] };
+
+    await client.createIssue(payload);
+    await client.updateIssue(9, payload);
+
+    expect(calls.map(call => call.init?.method)).toEqual(['POST', 'PATCH']);
+    const labels = calls.map(call => {
+      const body = call.init?.body;
+      if (typeof body !== 'string') throw new TypeError('expected a JSON string request body');
+      return (JSON.parse(body) as { labels?: string[] }).labels;
+    });
+    expect(labels).toEqual([['impact:high'], ['impact:high']]);
+  });
 });

--- a/packages/cli/tests/upstream-monitor/sources.test.ts
+++ b/packages/cli/tests/upstream-monitor/sources.test.ts
@@ -151,6 +151,31 @@ describe('upstream monitor source adapters', () => {
     expect(buildIssuePayload(change).body).toContain('openai/codex#18115');
   });
 
+  it.each([
+    ['codex-plugin-hook-reload', 17_636],
+    ['codex-removed-plugin-hooks', 38_339],
+  ] as const)('treats %s closing as an immediate-triage condition', (key, issueNumber) => {
+    const source = getMonitorSource(key);
+    const snapshot = createSnapshotText(
+      source,
+      normalizeIssueState(`{"number":${issueNumber},"state":"open","state_reason":null}`),
+      '2026-08-16T00:00:00.000Z',
+    );
+
+    const change = detectSourceChange({
+      source,
+      liveContent: normalizeIssueState(
+        `{"number":${issueNumber},"state":"closed","state_reason":"completed"}`,
+      ),
+      snapshotContent: snapshot,
+    });
+
+    expect(change.changed).toBe(true);
+    expect(source.failOnChange).toBe(true);
+    expect(source.labels).toEqual(['impact:high']);
+    expect(buildIssuePayload(change).body).toContain('Safeword');
+  });
+
   it('compares live content against the snapshot body, not metadata headers', () => {
     const source = getMonitorSource('codex-cli');
     const snapshot = createSnapshotText(source, 'same body', '2026-06-25T00:00:00.000Z');

--- a/packages/cli/tests/upstream-monitor/wiring.test.ts
+++ b/packages/cli/tests/upstream-monitor/wiring.test.ts
@@ -31,6 +31,18 @@ const source = getMonitorSource('codex-project-plugins');
 
 const UPSTREAM_OPEN = '{"number":18115,"state":"open","state_reason":null}';
 const UPSTREAM_CLOSED = '{"number":18115,"state":"closed","state_reason":"completed"}';
+const PLUGIN_RELOAD_TRIPWIRES = [
+  {
+    key: 'codex-plugin-hook-reload' as const,
+    issueNumber: 17_636,
+    titleFragment: 'Hot-reload hook configuration',
+  },
+  {
+    key: 'codex-removed-plugin-hooks' as const,
+    issueNumber: 38_339,
+    titleFragment: 'Removed plugin Stop hook',
+  },
+];
 
 function recordingClient(filed: IssuePayload[]): GitHubIssueClient {
   return {
@@ -68,6 +80,8 @@ const SOURCE_KEYS: readonly MonitorSourceKey[] = [
   'claude-code',
   'codex-cli',
   'codex-project-plugins',
+  'codex-plugin-hook-reload',
+  'codex-removed-plugin-hooks',
   'cursor',
 ];
 
@@ -114,7 +128,7 @@ describe('source isolation', () => {
       sources: [broken, source],
     });
 
-    expect(result).toEqual({ reported: 1, failed: 1 });
+    expect(result).toEqual({ reported: 1, failed: 1, immediateTriage: 0 });
     expect(filed).toHaveLength(1);
     expect(filed[0]?.title).toContain('openai/codex#18115');
     // A failed source must not read as "no change" — an unchecked source is
@@ -122,6 +136,41 @@ describe('source isolation', () => {
     expect(log).toContain('claude-code: check FAILED — upstream unreachable');
     expect(log.join('\n')).not.toContain('claude-code: no change');
   });
+});
+
+describe('Codex plugin-reload issue tripwires', () => {
+  it.each(PLUGIN_RELOAD_TRIPWIRES)(
+    '$key stays quiet while open and makes a closure immediately visible',
+    async ({ key, issueNumber, titleFragment }) => {
+      const watched = getMonitorSource(key);
+      const open = `{"number":${issueNumber},"state":"open","state_reason":null}`;
+      const closed = `{"number":${issueNumber},"state":"closed","state_reason":"completed"}`;
+      const filed: IssuePayload[] = [];
+
+      const stillOpen = await runUpstreamMonitor({
+        fetchText: () => Promise.resolve(open),
+        issueClient: recordingClient(filed),
+        readText,
+        rootDirectory: repoRoot,
+        sources: [watched],
+      });
+      expect(stillOpen).toEqual({ reported: 0, failed: 0, immediateTriage: 0 });
+      expect(filed).toEqual([]);
+
+      const changed = await runUpstreamMonitor({
+        fetchText: () => Promise.resolve(closed),
+        issueClient: recordingClient(filed),
+        readText,
+        rootDirectory: repoRoot,
+        sources: [watched],
+      });
+      expect(changed).toEqual({ reported: 1, failed: 0, immediateTriage: 1 });
+      expect(filed).toHaveLength(1);
+      expect(filed[0]?.title).toContain(titleFragment);
+      expect(filed[0]?.labels).toEqual(['impact:high']);
+      expect(filed[0]?.body).toContain('restart');
+    },
+  );
 });
 
 describe('watched-issue tripwire wiring (openai/codex#18115)', () => {


### PR DESCRIPTION
## Summary

- monitor Codex #17636 and #38339 using committed open-state snapshots
- file contextual, `impact:high` Safeword triage issues and fail the scheduled monitor when either closes
- test snapshot wiring, immediate-triage behavior, and GitHub label delivery

## Why

Safeword currently needs users to restart Codex after plugin changes. An upstream fix must trigger an explicit review rather than letting restart guidance quietly become stale.

## Validation

- `bun run test tests/upstream-monitor/sources.test.ts tests/upstream-monitor/wiring.test.ts tests/upstream-monitor/client.test.ts tests/upstream-monitor/issues.test.ts`
- `bun run typecheck`