### PR TITLE
Detect Pipenv tooling in Python projects

### DIFF
--- a/packages/cli/src/packs/python/index.ts
+++ b/packages/cli/src/packs/python/index.ts
@@ -14,7 +14,13 @@ export const pythonPack: LanguagePack = {
   extensions: ['.py', '.pyi'],
 
   detect(cwd: string): boolean {
-    return existsInTree(cwd, 'pyproject.toml') || existsInTree(cwd, 'requirements.txt');
+    return (
+      existsInTree(cwd, 'pyproject.toml') ||
+      existsInTree(cwd, 'requirements.txt') ||
+      existsInTree(cwd, 'Pipfile') ||
+      existsInTree(cwd, 'setup.py') ||
+      existsInTree(cwd, 'setup.cfg')
+    );
   },
 
   setup(_cwd: string, _ctx: SetupContext): SetupResult {

--- a/packages/cli/src/packs/types.ts
+++ b/packages/cli/src/packs/types.ts
@@ -16,7 +16,7 @@
  */
 export interface Languages {
   javascript: boolean; // package.json exists
-  python: boolean; // pyproject.toml OR requirements.txt exists
+  python: boolean; // a supported Python manifest exists
   golang: boolean; // go.mod exists
   rust: boolean; // Cargo.toml exists
   sql: boolean; // dbt_project.yml (or other SQL tool markers) exists

--- a/packages/cli/tests/commands/python-tool-readiness.test.ts
+++ b/packages/cli/tests/commands/python-tool-readiness.test.ts
@@ -180,12 +180,40 @@ dependencies = ["ruff", "mypy", "deadcode"]
     );
 
     const result = await runCli(['doctor', '--json', '--offline'], { cwd: projectDirectory });
-    const output = JSON.parse(result.stdout) as {
-      findings: { code: string }[];
-    };
-
+    const output = JSON.parse(result.stdout) as { findings: { code: string }[] };
     expect(output.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ code: 'MISSING_PYTHON_TOOL' })]),
+    );
+  });
+
+  it('reports missing tools from a nested Python manifest', async () => {
+    writeTestFile(
+      projectDirectory,
+      'apps/api/pyproject.toml',
+      `[project]
+name = "api"
+version = "0.1.0"
+dependencies = ["ruff"]
+`,
+    );
+
+    const result = await runCli(['doctor', '--json', '--offline'], { cwd: projectDirectory });
+    const output = JSON.parse(result.stdout) as {
+      findings: { code: string; message: string }[];
+    };
+
+    expect(result.exitCode).toBe(2);
+    expect(output.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'MISSING_PYTHON_TOOL',
+          message: 'mypy is not declared for this Python project.',
+        }),
+        expect.objectContaining({
+          code: 'MISSING_PYTHON_TOOL',
+          message: 'deadcode is not declared for this Python project.',
+        }),
+      ]),
     );
   });
 
@@ -203,12 +231,38 @@ deadcode = "*"
     );
 
     const result = await runCli(['doctor', '--json', '--offline'], { cwd: projectDirectory });
-    const output = JSON.parse(result.stdout) as {
-      findings: { code: string }[];
-    };
-
+    const output = JSON.parse(result.stdout) as { findings: { code: string }[] };
     expect(output.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ code: 'MISSING_PYTHON_TOOL' })]),
+    );
+  });
+
+  it('reports missing tools from a Pipenv project', async () => {
+    writeTestFile(
+      projectDirectory,
+      'Pipfile',
+      `[packages]
+ruff = "*"
+`,
+    );
+
+    const result = await runCli(['doctor', '--json', '--offline'], { cwd: projectDirectory });
+    const output = JSON.parse(result.stdout) as {
+      findings: { code: string; message: string }[];
+    };
+
+    expect(result.exitCode).toBe(2);
+    expect(output.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'MISSING_PYTHON_TOOL',
+          message: 'mypy is not declared for this Python project.',
+        }),
+        expect.objectContaining({
+          code: 'MISSING_PYTHON_TOOL',
+          message: 'deadcode is not declared for this Python project.',
+        }),
+      ]),
     );
   });
 

--- a/packages/cli/tests/commands/setup-python-phase2.test.ts
+++ b/packages/cli/tests/commands/setup-python-phase2.test.ts
@@ -15,7 +15,6 @@ import {
   createSafewordBasePackageJson,
   createTemporaryDirectory,
   initGitRepo,
-  isUvInstalled,
   readTestFile,
   removeTemporaryDirectory,
   runCli,
@@ -181,6 +180,7 @@ describe('Suite 2: Architecture Validation', () => {
       // Act
       await runCli(['setup'], {
         cwd: state.projectDirectory,
+        env: SKIP_INSTALL_ENV,
         timeout: TIMEOUT_SETUP,
       });
 
@@ -331,8 +331,6 @@ strict = true
 // Test Suite 6: Auto-Install Python Tools
 // =============================================================================
 
-const IS_UV_AVAILABLE = isUvInstalled();
-
 describe('Suite 6: Auto-Install Python Tools', () => {
   it(
     'Test 6.1: Shows install message for pip projects (no auto-install)',
@@ -356,10 +354,9 @@ describe('Suite 6: Auto-Install Python Tools', () => {
     TIMEOUT_SETUP,
   );
 
-  it.skipIf(!IS_UV_AVAILABLE)(
-    'Test 6.2: Auto-installs tools for uv projects',
+  it(
+    'Test 6.2: Shows the uv recovery command when installation is skipped',
     async () => {
-      // Arrange - uv project with uv.lock
       createPythonProjectReadyForSetup(state.projectDirectory, { manager: 'uv' });
       initGitRepo(state.projectDirectory);
 
@@ -370,7 +367,6 @@ describe('Suite 6: Auto-Install Python Tools', () => {
         env: SKIP_INSTALL_ENV,
       });
 
-      // Explicit no-install mode reports the exact recovery command without network access.
       expect(result.stdout).toContain('Install Python tools: uv add --dev');
       expect(result.stdout).not.toContain('Python tools installed');
     },
@@ -426,7 +422,7 @@ dev = ["ruff>=0.8.0"]
       writeTestFile(
         state.projectDirectory,
         'bin/uv',
-        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$SAFEWORD_UV_LOG"\n',
+        '#!/bin/sh\nprintf "%s|%s\\n" "$PWD" "$*" >> "$SAFEWORD_UV_LOG"\n',
       );
       chmodSync(uv, 0o755);
 
@@ -441,7 +437,10 @@ dev = ["ruff>=0.8.0"]
       });
 
       expect(result.exitCode).toBe(2);
-      expect(readFileSync(log, 'utf8')).toContain('add --dev');
+      expect(existsSync(log)).toBe(true);
+      expect(readFileSync(log, 'utf8')).toContain(
+        `${nodePath.join(state.projectDirectory, 'apps/worker')}|add --dev ruff mypy deadcode`,
+      );
       expect(result.stdout).toContain('pip install');
       expect(result.stdout).toContain('Configuration is healthy');
     },
@@ -449,24 +448,9 @@ dev = ["ruff>=0.8.0"]
   );
 
   it(
-    'Test 6.4: Shows poetry install command for poetry projects',
+    'Test 6.5: Shows poetry install command for poetry projects',
     async () => {
-      // Arrange - poetry project with invalid config (python key not allowed)
-      // This makes poetry fail immediately with "Additional properties are not allowed"
-      writeTestFile(
-        state.projectDirectory,
-        'pyproject.toml',
-        `[project]
-name = "test"
-version = "0.1.0"
-
-[tool.poetry]
-name = "test"
-python = "^3.12"
-`,
-      );
-      // Note: Invalid poetry config ensures immediate failure (no network calls)
-      createSafewordBasePackageJson(state.projectDirectory);
+      createPythonProjectReadyForSetup(state.projectDirectory, { manager: 'poetry' });
       initGitRepo(state.projectDirectory);
 
       // Act
@@ -476,19 +460,15 @@ python = "^3.12"
         env: SKIP_INSTALL_ENV,
       });
 
-      // Assert - Poetry project detected, shows poetry command in fallback
-      // (install fails without poetry.lock, so fallback shown)
       expect(result.stdout).toMatch(/poetry add/);
     },
     TIMEOUT_SETUP,
   );
 
   it(
-    'Test 6.5: Shows pipenv install command for pipenv projects',
+    'Test 6.6: Shows pipenv install command for pipenv projects',
     async () => {
-      // Arrange - pipenv project
       createPythonProjectReadyForSetup(state.projectDirectory, { manager: 'pipenv' });
-      writeTestFile(state.projectDirectory, 'Pipfile', '[invalid\n');
       initGitRepo(state.projectDirectory);
 
       // Act

--- a/packages/cli/tests/test-plan/resolve.test.ts
+++ b/packages/cli/tests/test-plan/resolve.test.ts
@@ -87,6 +87,7 @@ describe('resolveTestPlan — every detected language appears (no first-match)',
       '.safeword/config.json': JSON.stringify({ installedPacks: ['typescript'] }),
       'package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
       'experiments/gepa/requirements.txt': 'gepa==0.1.1\n',
+      'experiments/gepa/tests/test_gepa.py': 'def test_gepa(): pass\n',
     });
 
     const plan = resolveTestPlan(root, { kind: 'verify', isToolAvailable: allTools });

--- a/packages/cli/tests/utils/python-setup.test.ts
+++ b/packages/cli/tests/utils/python-setup.test.ts
@@ -4,7 +4,7 @@
  * Tests for package manager detection and dependency installation logic.
  */
 
-import { symlinkSync } from 'node:fs';
+import { chmodSync, existsSync, symlinkSync } from 'node:fs';
 import nodePath from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -22,7 +22,6 @@ import {
   createPythonProject,
   createTemporaryDirectory,
   isPoetryInstalled,
-  isUvInstalled,
   readTestFile,
   removeTemporaryDirectory,
   writeTestFile,
@@ -431,21 +430,40 @@ describe('installPythonDependencies', () => {
     expect(installPythonDependencies(context.projectDirectory, ['ruff'])).toBe(false);
   });
 
-  // Conditional tests - only run if package manager is available
-  const IS_UV_AVAILABLE = isUvInstalled();
   const IS_POETRY_AVAILABLE = isPoetryInstalled();
 
-  it.skipIf(!IS_UV_AVAILABLE)('installs tools with uv', () => {
+  it('invokes uv in the project directory without using the network', () => {
     createPythonProject(context.projectDirectory, { manager: 'uv' });
+    const bin = nodePath.join(context.projectDirectory, 'bin');
+    const log = nodePath.join(context.projectDirectory, 'uv.log');
+    const originalPath = process.env.PATH;
+    const originalSkipInstall = process.env.SAFEWORD_SKIP_INSTALL;
+    const originalLog = process.env.SAFEWORD_UV_LOG;
 
-    // This actually runs uv add --dev ruff
-    const isResult = installPythonDependencies(context.projectDirectory, ['ruff']);
+    writeTestFile(
+      context.projectDirectory,
+      'bin/uv',
+      '#!/bin/sh\nprintf "%s|%s\\n" "$PWD" "$*" >> "$SAFEWORD_UV_LOG"\n',
+    );
+    chmodSync(nodePath.join(bin, 'uv'), 0o755);
+    process.env.PATH = `${bin}:${originalPath ?? ''}`;
+    process.env.SAFEWORD_UV_LOG = log;
+    delete process.env.SAFEWORD_SKIP_INSTALL;
 
-    expect(isResult).toBe(true);
-
-    // Verify ruff is now in pyproject.toml
-    const pyproject = readTestFile(context.projectDirectory, 'pyproject.toml');
-    expect(pyproject).toContain('ruff');
+    try {
+      expect(installPythonDependencies(context.projectDirectory, ['ruff'])).toBe(true);
+      expect(existsSync(log)).toBe(true);
+      expect(readTestFile(context.projectDirectory, 'uv.log')).toContain(
+        `${context.projectDirectory}|add --dev ruff`,
+      );
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalSkipInstall === undefined) delete process.env.SAFEWORD_SKIP_INSTALL;
+      else process.env.SAFEWORD_SKIP_INSTALL = originalSkipInstall;
+      if (originalLog === undefined) delete process.env.SAFEWORD_UV_LOG;
+      else process.env.SAFEWORD_UV_LOG = originalLog;
+    }
   });
 
   // Poetry test disabled: poetry add is too slow/unreliable for CI

--- a/packages/cli/tests/utils/shallow-detection.test.ts
+++ b/packages/cli/tests/utils/shallow-detection.test.ts
@@ -185,6 +185,12 @@ describe('findFileMatchingInTree', () => {
 // =============================================================================
 
 describe('detectLanguages with subdirectories', () => {
+  it.each(['Pipfile', 'setup.py', 'setup.cfg'])('detects Python projects with %s', manifest => {
+    writeTestFile(shared.projectDirectory, manifest, '');
+
+    expect(detectLanguages(shared.projectDirectory).python).toBe(true);
+  });
+
   it('detects Python in subdirectory', () => {
     writeTestFile(shared.projectDirectory, 'dbt/pyproject.toml', '[project]\nname = "test"\n');
     const languages = detectLanguages(shared.projectDirectory);

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "d6763de07b827c69904fd7869ed359a0c0cced4698430d87f5f31cded19a1f9a"
+  "inventory_sha256": "e58301e3230572fdfefe0ca79c9abad1b5b227a807c34eac333c3c889ddd6e26"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "e855c0bf55da3e08c82fcfa8a1e210008cb032330564de5cd1a637d99a4ed8c7"
+      "sha256": "38005cc21088cba1b22fc0a13059857bd2498b8a3fa871b0030b7d3c259cb8b5"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -20894,7 +20894,7 @@ var init_python = __esm(() => {
     name: "Python",
     extensions: [".py", ".pyi"],
     detect(cwd) {
-      return existsInTree(cwd, "pyproject.toml") || existsInTree(cwd, "requirements.txt");
+      return existsInTree(cwd, "pyproject.toml") || existsInTree(cwd, "requirements.txt") || existsInTree(cwd, "Pipfile") || existsInTree(cwd, "setup.py") || existsInTree(cwd, "setup.cfg");
     },
     setup(_cwd, _ctx) {
       return setupPythonTooling();


### PR DESCRIPTION
## What changed

- Detect Pipenv and legacy setuptools manifests when identifying Python projects.
- Add focused readiness coverage for nested manifests and Pipenv projects.
- Make Python setup tests deterministic by replacing host and network dependencies with local shims.

## Why

The Python tool readiness check already parses these manifests, but Pipenv projects were not recognized as Python projects. That allowed projects missing `mypy` and `deadcode` to skip the warning.

## Impact

Pipenv, `setup.py`, and `setup.cfg` projects now receive the same Python tooling readiness checks as `pyproject.toml` and requirements-based projects.

## Validation

- `bun run test tests/commands/python-tool-readiness.test.ts tests/commands/setup-python-phase2.test.ts tests/test-plan/resolve.test.ts tests/utils/python-setup.test.ts tests/utils/shallow-detection.test.ts`
- `bun run typecheck`
- `bunx eslint packages/cli/src/packs/python/index.ts packages/cli/src/packs/types.ts packages/cli/tests/commands/python-tool-readiness.test.ts packages/cli/tests/commands/setup-python-phase2.test.ts packages/cli/tests/test-plan/resolve.test.ts packages/cli/tests/utils/python-setup.test.ts packages/cli/tests/utils/shallow-detection.test.ts`
- `bunx prettier --check packages/cli/src/packs/python/index.ts packages/cli/src/packs/types.ts packages/cli/tests/commands/python-tool-readiness.test.ts packages/cli/tests/commands/setup-python-phase2.test.ts packages/cli/tests/test-plan/resolve.test.ts packages/cli/tests/utils/python-setup.test.ts packages/cli/tests/utils/shallow-detection.test.ts`