### PR TITLE
Clarify preserved workspace Cucumber harnesses

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,9 @@
     ".safeword/**",
     "plugin/**",
     "packages/cli/templates/**",
+    "packages/cli/tests/fixtures/bdd-proof-corpus/actor-adapter.ts",
+    "packages/cli/tests/fixtures/bdd-proof-corpus/fixture-runner.ts",
+    "packages/cli/tests/fixtures/retry-safe-relay-cucumber.mjs",
     "packages/cli/src/claude-plugin/runtime/dispatch.ts",
     "experiments/**",
     "packages/cli/vitest.live.config.ts",
@@ -11,6 +14,7 @@
   ],
   "ignoreBinaries": [
     "hook",
+    "where.exe",
     "shfmt",
     "dot",
     "shellcheck",
@@ -31,7 +35,8 @@
     "SessionStart",
     "principles",
     "project",
-    "UserPromptSubmit"
+    "UserPromptSubmit",
+    "EXPL123"
   ],
   "ignoreDependencies": [
     "safeword",

--- a/packages/cli/src/claude-plugin/hook-manifest.ts
+++ b/packages/cli/src/claude-plugin/hook-manifest.ts
@@ -17,9 +17,9 @@ import { createHash } from 'node:crypto';
 
 import { SETTINGS_HOOKS } from '../templates/config.js';
 
-export const PROJECT_HOOK_ROOT = '"$CLAUDE_PROJECT_DIR"/.safeword/hooks';
-export const PLUGIN_HOOK_ROOT = '"${CLAUDE_PLUGIN_ROOT}"/runtime/hooks';
-export const PLUGIN_DISPATCH = 'bun "${CLAUDE_PLUGIN_ROOT}"/runtime/dispatch.js';
+const PROJECT_HOOK_ROOT = '"$CLAUDE_PROJECT_DIR"/.safeword/hooks';
+const PLUGIN_HOOK_ROOT = '"${CLAUDE_PLUGIN_ROOT}"/runtime/hooks';
+const PLUGIN_DISPATCH = 'bun "${CLAUDE_PLUGIN_ROOT}"/runtime/dispatch.js';
 
 export function adaptHookValue(value: unknown): unknown {
   if (typeof value === 'string') {
@@ -76,7 +76,7 @@ function pluginHookEntries(
   return wrapHookCommands(entries, event);
 }
 
-export function pluginHooks(): Record<string, unknown> {
+function pluginHooks(): Record<string, unknown> {
   const adapted = adaptHookValue(SETTINGS_HOOKS) as Record<string, unknown>;
   const withSetup = {
     ...adapted,

--- a/packages/cli/src/claude-plugin/migration-state.ts
+++ b/packages/cli/src/claude-plugin/migration-state.ts
@@ -234,28 +234,6 @@ export function writeClaudePluginMode(cwd: string, marker: ClaudePluginModeV2): 
   });
 }
 
-export function readClaudeMigrationAttention(cwd: string): ClaudeMigrationAttentionV1 | undefined {
-  const path = nodePath.join(cwd, CLAUDE_MIGRATION_SCHEMA.paths.attention);
-  if (!existsSync(path)) return undefined;
-  try {
-    const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<ClaudeMigrationAttentionV1>;
-    if (
-      value.schema_version !== 1 ||
-      !validDigest(value.state_digest) ||
-      typeof value.plugin_version !== 'string' ||
-      !validDigest(value.catalogue_sha256) ||
-      !validDigest(value.watched_settings_sha256) ||
-      typeof value.classification !== 'string' ||
-      typeof value.advisory !== 'string'
-    ) {
-      return undefined;
-    }
-    return value as ClaudeMigrationAttentionV1;
-  } catch {
-    return undefined;
-  }
-}
-
 export function writeClaudeMigrationAttention(
   cwd: string,
   attention: ClaudeMigrationAttentionV1,

--- a/packages/cli/src/cli-protocol/catalog.ts
+++ b/packages/cli/src/cli-protocol/catalog.ts
@@ -685,9 +685,9 @@ export const commandCatalog: readonly CommandDefinition[] = [
   ...HIDDEN_COMMANDS,
 ];
 
-export type InvocationClassification = 'public' | 'retained-alias' | 'internal';
-export type InvocationVisibility = 'public' | 'hidden';
-export type InvocationKind = 'command' | 'family' | 'default' | 'argv-rewrite';
+type InvocationClassification = 'public' | 'retained-alias' | 'internal';
+type InvocationVisibility = 'public' | 'hidden';
+type InvocationKind = 'command' | 'family' | 'default' | 'argv-rewrite';
 
 export interface InvocationContract {
   readonly route: string;

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -60,6 +60,7 @@ import {
 import { buildIndexConflictListMessage } from './utils/ticket-index-warnings.js';
 import { formatTicketReference } from './utils/ticket-reference.js';
 import { findDanglingDependencies, findTicketsInCycles } from './utils/ticket-relations.js';
+import { WORKSPACE_ROOTS } from './utils/workspace-roots.js';
 import { VERSION } from './version.js';
 
 /**
@@ -204,6 +205,11 @@ function findCucumberHarnessAdvisories(
   if (existingCucumberHarness === undefined) return [];
 
   if (scaffoldBddLane) {
+    if (isWorkspaceCucumberHarness(existingCucumberHarness)) {
+      return [
+        `A workspace Cucumber harness (${existingCucumberHarness}) is preserved alongside Safeword's root starter lane. This is informational: Safeword does not remove or modify project test infrastructure. The starter lane reads the default workspace features directories; set paths.features / paths.steps only when this harness uses nonstandard locations.`,
+      ];
+    }
     return [buildLeftoverLaneAdvisory(cwd, existingCucumberHarness)];
   }
 
@@ -216,6 +222,10 @@ function findCucumberHarnessAdvisories(
   return [
     `Detected a cucumber harness (${existingCucumberHarness}) but paths.features is not set in .safeword/config.json — project codify, project lint-gherkin, and doctor cannot see your suite. Add e.g. "paths": { "features": "tests/behaviors", "steps": "tests/steps" } (paths.steps only matters when the scaffolded runner reads relocated TypeScript steps).`,
   ];
+}
+
+function isWorkspaceCucumberHarness(evidence: string): boolean {
+  return WORKSPACE_ROOTS.some(root => evidence.startsWith(`${root}/`));
 }
 
 /** Enumerate the starter-lane leftovers (files/deps/script) from schema constants. */

--- a/packages/cli/src/test-execution/mode.ts
+++ b/packages/cli/src/test-execution/mode.ts
@@ -1,5 +1,5 @@
 export type ExecutionMode = 'local' | 'remote-preferred';
-export type ExecutionModeSource = 'command' | 'personal' | 'project' | 'built-in';
+type ExecutionModeSource = 'command' | 'personal' | 'project' | 'built-in';
 
 export interface ExecutionModeInput {
   readonly command?: ExecutionMode;

--- a/packages/cli/tests/commands/check-cucumber-advisories.test.ts
+++ b/packages/cli/tests/commands/check-cucumber-advisories.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   createTemporaryDirectory,
   createTypeScriptPackageJson,
+  CUSTOMER_CUCUMBER_MJS,
   HOST_CUCUMBER_YAML,
   readTestFile,
   removeTemporaryDirectory,
@@ -174,6 +175,35 @@ describe('check enumerates a leftover duplicate scaffold without touching it (TB
     () => {
       expect(readTestFile(directory, 'cucumber.mjs')).toBe(cucumberMjsBefore);
       expect(readTestFile(directory, 'features/safeword-lane.feature')).toBe(starterFeatureBefore);
+    },
+    TIMEOUT_QUICK,
+  );
+});
+
+describe('check distinguishes a workspace Cucumber harness from a leftover root lane', () => {
+  let directory: string;
+  let output: string;
+
+  beforeAll(async () => {
+    directory = createTemporaryDirectory();
+    createTypeScriptPackageJson(directory);
+    await setupOrThrow(directory);
+    writeTestFile(directory, 'packages/cli/cucumber.mjs', CUSTOMER_CUCUMBER_MJS);
+
+    output = await runCheck(directory);
+  }, TIMEOUT_BUN_INSTALL);
+
+  afterAll(() => {
+    removeTemporaryDirectory(directory);
+  });
+
+  it(
+    'reports a workspace harness as preserved infrastructure rather than a duplicate root lane',
+    () => {
+      expect(output).toContain('packages/cli/cucumber.mjs');
+      expect(output).toContain('workspace Cucumber harness');
+      expect(output).not.toContain('Duplicate BDD lane');
+      expect(output).not.toContain('delete the leftovers');
     },
     TIMEOUT_QUICK,
   );

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "e58301e3230572fdfefe0ca79c9abad1b5b227a807c34eac333c3c889ddd6e26"
+  "inventory_sha256": "0282b02cd10f159fc72b6725ecb00b9d9af871119351cc9a2201d7204cffaf12"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "38005cc21088cba1b22fc0a13059857bd2498b8a3fa871b0030b7d3c259cb8b5"
+      "sha256": "7562bea513a6a2b3a42667306170d75ba6619833069db55208f032b9af0b0a1f"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -32980,6 +32980,11 @@ function findCucumberHarnessAdvisories(cwd, { existingCucumberHarness, scaffoldB
   if (existingCucumberHarness === undefined)
     return [];
   if (scaffoldBddLane) {
+    if (isWorkspaceCucumberHarness(existingCucumberHarness)) {
+      return [
+        `A workspace Cucumber harness (${existingCucumberHarness}) is preserved alongside Safeword's root starter lane. This is informational: Safeword does not remove or modify project test infrastructure. The starter lane reads the default workspace features directories; set paths.features / paths.steps only when this harness uses nonstandard locations.`
+      ];
+    }
     return [buildLeftoverLaneAdvisory(cwd, existingCucumberHarness)];
   }
   if (readConfiguredPath(cwd, "features") !== undefined || hasDefaultExecutableFeatureFiles(cwd)) {
@@ -32988,6 +32993,9 @@ function findCucumberHarnessAdvisories(cwd, { existingCucumberHarness, scaffoldB
   return [
     `Detected a cucumber harness (${existingCucumberHarness}) but paths.features is not set in .safeword/config.json \u2014 project codify, project lint-gherkin, and doctor cannot see your suite. Add e.g. "paths": { "features": "tests/behaviors", "steps": "tests/steps" } (paths.steps only matters when the scaffolded runner reads relocated TypeScript steps).`
   ];
+}
+function isWorkspaceCucumberHarness(evidence) {
+  return WORKSPACE_ROOTS.some((root) => evidence.startsWith(`${root}/`));
 }
 function buildLeftoverLaneAdvisory(cwd, evidence) {
   const leftovers = BDD_LANE_FILE_PATHS.filter((filePath) => exists(nodePath47.join(cwd, filePath)));
@@ -33309,6 +33317,7 @@ var init_health = __esm(() => {
   init_personas();
   init_repo_path();
   init_scenario_coverage();
+  init_workspace_roots();
   init_version();
   PATH_ONLY_KNOWLEDGE_KEYS = ["principles", "surfaces"];
   CONFIGURED_KNOWLEDGE_KEYS = [


### PR DESCRIPTION
## Summary
- Report workspace Cucumber harnesses as preserved project infrastructure rather than duplicate root BDD lanes.
- Keep root-level duplicate-lane remediation unchanged.
- Remove confirmed dead code and configure static analysis for dynamically loaded BDD fixtures.

## Root cause
The health check treated any detected harness alongside Safeword's root starter lane as a leftover root lane. In a monorepo, a package-level Cucumber configuration is independent project test infrastructure and must not be presented as removable.

## Validation
- `bun run test tests/commands/check-cucumber-advisories.test.ts`
- `bun run test tests/utils/cucumber-lane-detection.test.ts`
- `bun run test tests/test-execution/mode.test.ts`
- `bun run test tests/review/runtime.test.ts tests/review/attempt-deadline.test.ts tests/review/process-abandonment.test.ts`
- `bun run test tests/codex-plugin/profile-proof.test.ts tests/commands/codex-hook.test.ts`
- `bun run test tests/cli-protocol/catalog.test.ts`
- `bun run --cwd packages/cli typecheck`
- Root and CLI-package BDD lanes
- `git diff --check`