### PR TITLE
Keep focused verification responsive for developers

### DIFF
--- a/.project/tickets/WZF6JF-keep-focused-verification-responsive/design.md
+++ b/.project/tickets/WZF6JF-keep-focused-verification-responsive/design.md
@@ -1,0 +1,97 @@
+# Test-capacity responsiveness decision
+
+**Status:** Decided
+**Date:** 2026-08-12
+
+## Decision frame
+
+How should the package test runner give a focused validation request a prompt, actionable result while preserving the repository-wide rule that no two Vitest processes run concurrently?
+
+## Research plan
+
+| Domain | Question to answer |
+| --- | --- |
+| Node process control and filesystem coordination | Can the lock holder be safely paused, cancelled, or otherwise preempted without orphaning a test process? |
+| Vitest execution model | Does Vitest provide a supported way to insert or prioritize another run without a second process? |
+| Scheduling and recovery UX | Which response makes a blocked focused run predictable and recoverable without pretending it executed? |
+
+## Candidate directions
+
+1. Bounded fail-fast: return promptly with the live owner and a retry action; preserve the existing global exclusive lock.
+2. FIFO queue: admit waiters fairly after the current owner, but retain the wait for a long full suite.
+3. Cooperative preemption: interrupt a lower-priority full suite when a focused run arrives, then resume/retry it later.
+
+## Research findings
+
+- Node can abort or terminate a child process, but its synchronous child APIs wait until a SIGTERM-handling child exits. A lock holder therefore cannot safely guarantee prompt, cross-worktree preemption. [Node child-process docs](https://nodejs.org/api/child_process.html)
+- Vitest exposes worker and file-parallelism controls inside a run, but its CLI models `run` and `watch` as whole-run operations. It offers no documented mechanism to inject a focused request into an already-running process. [Vitest CLI](https://vitest.dev/guide/cli)
+- Long-running work should state what is happening and how to recover; an indeterminate wait gives no useful decision point. [Apple progress guidance](https://developer.apple.com/design/human-interface-guidelines/progress-indicators)
+
+## Decision
+
+Recommend **a short default fail-fast wait with an explicit longer-wait override** because it gives the blocked developer a prompt, truthful recovery path while preserving the one-Vitest invariant. FIFO queueing is useful for fairness but does not solve the long-owner latency and is already tracked in #2200. Cooperative preemption was rejected: it needs cross-worktree cancellation and can discard or orphan another suite's evidence.
+
+**Premortem:** six months from now this fails if the shorter default causes background verification to abandon too often; mitigate it now by naming the current owner and retaining `SAFEWORD_TEST_LOCK_MAX_WAIT_MS` as the explicit opt-in for a longer wait.
+
+**Next:** write the failing default-wait integration test in `packages/cli/tests/test-runner-lock.test.ts`.
+
+## Revalidation: 2026-08-13
+
+The decision remains live: current `HEAD` still has the 20-minute generic cap, and
+12 fresh retro reports collapsed into canonical issue #1484. The worktree-scoped
+change remains the smallest correct response.
+
+- **Process safety:** Node documents that `spawnSync()` blocks until the child exits or
+  is terminated; terminating a sibling worktree's run is therefore not a safe,
+  prompt scheduler. [Node child-process documentation](https://nodejs.org/api/child_process.html)
+- **Test-run model:** Vitest's CLI exposes controls for a run's own workers and
+  file parallelism, not an API for admitting a focused request into a different
+  active run. [Vitest CLI](https://vitest.dev/guide/cli)
+
+Steelman FIFO: it improves fairness among waiters but still leaves the developer
+waiting for a long owner and remains separately tracked by #2200. Preemption is
+more responsive in theory, but it risks interrupting or orphaning another
+worktree's evidence. A bounded, owner-aware fail-fast is correct, minimal, and
+preserves the repository's no-concurrent-Vitest invariant.
+
+**Premortem:** the short default could cause unattended work to stop too often;
+the explicit `SAFEWORD_TEST_LOCK_MAX_WAIT_MS` override retains a deliberate
+long-wait escape hatch.
+
+**Next:** run the scoped independent quality review, then rerun verification when
+the shared test capacity is available.
+
+## Revalidation: 2026-08-14
+
+### Figure-It-Out rerun
+
+- **Frame:** choose a response to a blocked focused package-test request that
+  stays safe if another worktree owns the only permitted Vitest run; the choice
+  is wrong if it starts a second run, interrupts valid evidence, or leaves the
+  developer without a clear next action.
+- **Options:** bounded owner-aware fail-fast; FIFO scheduling; cooperative
+  preemption.
+- **Research domains:** Node process termination semantics, Vitest's documented
+  concurrency model, and recovery ergonomics for a blocked developer.
+- **Evidence:** Node documents that a delivered kill signal is not proof a child
+  exited, and that children of children are not terminated by killing their
+  parent. Vitest documents worker and file parallelism *within* one run, with no
+  cross-process priority or admission mechanism. [Node child-process
+  docs](https://nodejs.org/api/child_process.html) · [Vitest
+  parallelism](https://vitest.dev/guide/parallelism) · [Vitest
+  maxWorkers](https://vitest.dev/config/maxworkers)
+
+**Decision:** retain the 60-second, owner-aware fail-fast. FIFO is the strongest
+alternative for fairness but still makes an interactive request wait behind a
+long owner and remains correctly scoped to #2200. Preemption loses because a
+signal cannot safely establish that another worktree's runner and its children
+stopped; it risks corrupting or orphaning its evidence. The bounded wait is the
+smallest option that is both truthful and preserves the one-Vitest invariant.
+
+**Premortem:** if unattended verification begins to give up too often, the
+60-second default will look too aggressive; the existing
+`SAFEWORD_TEST_LOCK_MAX_WAIT_MS` override lets callers deliberately choose a
+longer wait without weakening the safe default.
+
+**Next:** run the focused lock-runner integration test, then the task's full
+verification and diff audit while the shared lane is free.

--- a/.project/tickets/WZF6JF-keep-focused-verification-responsive/ticket.md
+++ b/.project/tickets/WZF6JF-keep-focused-verification-responsive/ticket.md
@@ -1,0 +1,43 @@
+---
+id: WZF6JF
+slug: keep-focused-verification-responsive
+type: task
+phase: verify
+status: in_progress
+created: 2026-08-12T14:09:53.488Z
+last_modified: 2026-08-14T16:36:25Z
+external_issue: https://github.com/ArcadeAI/safeword/issues/1484
+---
+
+# Keep focused verification responsive for developers
+
+**Goal:** Give a developer a prompt, actionable outcome when a focused Vitest run is blocked by another worktree, without ever running a second Vitest process.
+
+**Why:** A global serialized test lane currently leaves small validation runs waiting behind unrelated full suites for many minutes.
+
+## Work Log
+
+- 2026-08-12T14:09:53.488Z Started: Created ticket WZF6JF
+- 2026-08-12T14:12:54Z Decision: use bounded fail-fast with an actionable owner-aware error; FIFO is separately tracked by #2200 and preemption would risk another worktree's process and test evidence.
+- 2026-08-12T14:16:48Z Implemented: reduced the default wait to 60 seconds and report the lock owner plus the documented longer-wait override; focused lock coverage passed after RED/GREEN cycles.
+- 2026-08-12T14:57:25Z Verified: full suite (7,560 passing, 5 skipped), BDD lane (1,530 passing scenarios, 3 skipped), build, typecheck, dependency audit, and diff audit passed. The ticket remains in progress until its focused diff is separated from pre-existing worktree changes.
+- 2026-08-13T15:15:41Z Revalidated #1484: the base runner still waits 20 minutes with a generic cap error, while 12 new reports reproduced the same cross-worktree contention. The bounded fail-fast decision remains relevant; live Vitest/Cucumber processes in other worktrees mean verification will resume after the shared lane is free.
+- 2026-08-14T16:06:28Z Revalidated #1484 again: `origin/main` still uses the 20-minute generic cap, and no Vitest/Cucumber owner is live. Re-ran Figure-It-Out with current Node and Vitest documentation; bounded owner-aware fail-fast remains the smallest safe decision. Resuming verification.
+- 2026-08-14T16:36:25Z Verification: focused lock coverage (14/14), lint, build, typecheck, and the lock-runner diff audit passed. The authoritative suites have unrelated current-worktree failures (three Vitest and one Cucumber); dependency audit reports the separately tracked NanoID advisory. Keep the ticket in verify until the scoped files are separated and a clean-worktree run is available.
+
+## Scope
+
+Improve the response when a focused package test run cannot acquire the shared Vitest capacity. The behavior must remain safe across worktrees.
+
+**Out of Scope:** Running concurrent Vitest processes, changing test assertions or suite selection, and implementing the already-tracked FIFO fairness work in #2200.
+
+**Done When:**
+
+- [x] A blocked focused test reports a prompt, actionable outcome instead of silently waiting behind an unrelated full suite.
+- [x] The runner never starts build or Vitest without holding the machine-wide lock.
+- [x] The behavior is covered by real child-process integration tests.
+
+**Tests:**
+
+- [x] Integration: a live lock owner produces the actionable blocked outcome and starts no child command.
+- [x] Integration: an available lock still builds and runs Vitest serially.

--- a/.project/tickets/WZF6JF-keep-focused-verification-responsive/verify.md
+++ b/.project/tickets/WZF6JF-keep-focused-verification-responsive/verify.md
@@ -1,0 +1,20 @@
+## Verify Checklist
+
+**Test Suite:** ❌ Scoped lock coverage: 14/14 tests pass. Full suite: 7,670 passed, 5 skipped, 3 unrelated failures — the untracked CKWE2D feature lacks a BDD-proof manifest entry, and two review-surface fixture tests cannot resolve a review-capable CLI.
+**Gherkin:** ❌ Full lane: 1,484 scenarios and 65,244 steps passed; 3 scenarios and 4 steps skipped; 1 unrelated failure in `native-claude-plugin.feature` expects `legacy\n` but receives `legacy\nplugin\n`.
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 0 scenarios marked complete (task has no `test-definitions.md`; the two lock integration checks are complete)
+**PR Scope:** ❌ Piggybacked changes: the branch and worktree contain pre-existing unrelated files; stage only WZF6JF's runner, configuration, test, ticket, and log files before review.
+**Dep Drift:** ⚠️ `bun audit` reports the separately tracked high-severity NanoID advisory; no dependency changed in this ticket.
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — internal CLI plumbing
+**Surface Evidence:** ⏭️ N/A — no persona-facing surface
+**Evidence limits:** ⚠️ The shared worktree contains incomplete CKWE2D artifacts and unrelated native-plugin/review-fixture regressions, so full-suite failures cannot be attributed to WZF6JF.
+
+Audit completed — the diff-scoped lock-runner review has no architecture, dependency-cruiser, duplication, or test-quality finding. The audit's only principle-trace errors belong to the unrelated CKWE2D ticket.
+
+## Agent's next actions
+
+- Separate only WZF6JF's runner, configuration, test, ticket, and log files, then re-run the full suite and BDD lane from a clean worktree before requesting review or marking the ticket done.

--- a/.safeword/logs/ticket-WZF6JF-keep-focused-verification-responsive.md
+++ b/.safeword/logs/ticket-WZF6JF-keep-focused-verification-responsive.md
@@ -1,0 +1,32 @@
+# Work Log: Keep focused verification responsive for developers
+
+**Anchored to:** `.project/tickets/WZF6JF-keep-focused-verification-responsive/ticket.md`
+
+---
+
+## Session: 2026-08-12
+
+- [14:09] Started task WZF6JF from #1484 after revalidation. Nine fresh retro reports are exact duplicates of this still-open low-risk/high-impact issue.
+- [14:10] Confirmed the current runner already fails closed after a 20-minute lock wait; it does not start a concurrent build or Vitest process. The remaining problem is responsiveness, not lock safety.
+- [14:10] Figure-it-out investigation plan: compare bounded fail-fast, FIFO queueing, and cooperative preemption. Research Node child-process control and file-lock safety, Vitest’s supported concurrency model, and developer feedback/cancellation patterns. Decide on correctness against the one-Vitest invariant, then smallest maintenance cost.
+- [14:12] Figure-it-out research: Node supports child abort/termination, but a synchronous child can remain alive after SIGTERM; preempting another worktree is therefore unsafe. Vitest documents worker/file parallelism only within a run, not priority injection into an active run. Progress guidance favors a prompt actionable state over an indeterminate wait. Recommend a short default wait with an explicit opt-in longer budget.
+- [14:13] Extracted the existing lock-wait policy into `scripts/lib/test-lock-config.mjs` without changing its 20-minute value; focused real-child lock coverage stayed green (13 tests).
+- [14:14] RED: a new policy test expected a 60-second default and failed with the prior 1,200,000 ms value. GREEN: changed only the default to 60 seconds; focused coverage passed (14 tests).
+- [14:16] RED: the existing cap test was extended to require the live owner and recovery override; it failed because the runner printed only the generic cap error. GREEN: added one shared owner-detail reader and the truthful recovery sentence; focused coverage passed (14 tests).
+- [14:16] TDD review: both proofs are atomic and observable. The recovery assertion uses a real runner process with fake executable boundaries, and the existing concurrent-run test continues to prove a free lock serializes build and Vitest. No refactor needed beyond the shared owner-detail reader.
+- [14:57] Verification: full suite passed (489 files, 7,560 passed, 5 skipped); BDD passed (1,530 scenarios and 67,262 steps passed, 3 scenarios and 4 steps skipped); build, typecheck, and `bun audit` passed. Diff audit found no violations. Kept the ticket in progress because the shared branch/worktree has unrelated existing changes that must be split before a focused review.
+
+## Session: 2026-08-13
+
+- [15:15] Revalidated #1484 after triaging the new retro wave. Twelve exact reports were closed as duplicates of the canonical low-risk/high-impact issue. `HEAD` still has a 20-minute generic lock cap; this task's scoped diff keeps the one-Vitest invariant while returning a 60-second owner-aware recovery outcome. Other worktrees currently hold Vitest/Cucumber capacity, so do not start a competing verification process.
+- [15:17] Re-ran the figure-it-out evidence against current Node and Vitest documentation, retaining bounded owner-aware fail-fast over FIFO/preemption. Started one scoped independent quality review; its coordinator remains live. The shared package-test lock is currently owned by a separate worktree, so current-run verification is deliberately deferred rather than queued behind it.
+- [15:19] The single quality-review coordinator exited without a typed terminal result or review id. Recorded this fresh manifestation on #2449 and did not start a replacement, per review-lifecycle policy. Existing full verification remains valid for the unchanged code; a new deterministic run waits for the live lock owner to finish.
+
+## Session: 2026-08-14
+
+- [16:06] Revalidated #1484 against `origin/main`: the shipped runner still has a 20-minute generic lock cap. No Vitest/Cucumber owner or package-test lock is currently live.
+- [16:06] Re-ran Figure-It-Out. Node documents that killing a child is not proof it or its descendants exited; Vitest exposes only in-run worker/file concurrency. Retained bounded owner-aware fail-fast over FIFO (#2200) and preemption; updated the decision record with current sources.
+- [16:08] Focused proof passed: `bun run --cwd packages/cli test tests/test-runner-lock.test.ts` completed 14/14 tests. Root lint, build, and typecheck also passed.
+- [16:18] Full Vitest suite completed with 7,670 passing and 5 skipped, but failed on three unrelated current-worktree conditions: CKWE2D's untracked feature is absent from the BDD proof manifest, and two review-surface fixtures cannot resolve a review-capable CLI. Did not modify either source.
+- [16:22] Audit invocation and diff code-quality lane passed for the lock-runner scope. Principle-trace failures name only CKWE2D. `bun audit` reports the separately tracked high-severity NanoID advisory.
+- [16:36] Full Cucumber lane completed 1,484 scenarios / 65,244 steps passed with one unrelated native Claude-plugin expectation failure (`legacy\\n` expected; `legacy\\nplugin\\n` received). Ticket remains at verify: scoped implementation is green, but shared-worktree evidence cannot clear the full-suite gate.

--- a/packages/cli/scripts/lib/test-lock-config.d.mts
+++ b/packages/cli/scripts/lib/test-lock-config.d.mts
@@ -1,0 +1,8 @@
+export const defaultMaximumLockWaitMilliseconds: number;
+
+export function resolveSafeIntegerEnvironmentVariable(
+  name: string,
+  fallback: number,
+  minimum: number,
+  allowZero?: boolean,
+): number;

--- a/packages/cli/scripts/lib/test-lock-config.mjs
+++ b/packages/cli/scripts/lib/test-lock-config.mjs
@@ -1,0 +1,15 @@
+import process from 'node:process';
+
+/** Keep focused feedback prompt; callers can explicitly opt into a longer wait. */
+export const defaultMaximumLockWaitMilliseconds = 60_000;
+
+export function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  const isValid = Number.isSafeInteger(parsed) && (allowZero ? parsed >= 0 : parsed > 0);
+  return isValid ? Math.max(parsed, minimum) : fallback;
+}

--- a/packages/cli/scripts/run-vitest-with-build-lock.mjs
+++ b/packages/cli/scripts/run-vitest-with-build-lock.mjs
@@ -20,6 +20,10 @@ import { tmpdir } from 'node:os';
 import nodePath from 'node:path';
 import process from 'node:process';
 
+import {
+  defaultMaximumLockWaitMilliseconds,
+  resolveSafeIntegerEnvironmentVariable,
+} from './lib/test-lock-config.mjs';
 import { environmentPathKey, resolveTestRunnerInvocation } from './test-runner-executable.mjs';
 
 const scriptDirectory = import.meta.dirname;
@@ -64,7 +68,6 @@ const childEnvironment = {
 };
 const lockParent = nodePath.join(tmpdir(), 'safeword-test-locks');
 const lockName = 'safeword-package-test';
-const defaultMaximumLockWaitMilliseconds = 20 * 60 * 1000;
 const defaultLockStatusIntervalMilliseconds = 30_000;
 const initialLockStatusDelayMilliseconds = 1000;
 const usesCustomLockDirectory = Boolean(process.env.SAFEWORD_TEST_LOCK_DIR);
@@ -82,17 +85,6 @@ const maximumTransitionWaitMilliseconds = 30_000;
 const lockOwnerKind = 'safeword-package-test-lock';
 const transitionOwnerKind = 'safeword-package-test-transition';
 const transitionRecoveryOwnerKind = 'safeword-package-test-transition-recovery';
-
-function resolveSafeIntegerEnvironmentVariable(name, fallback, minimum, allowZero = true) {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === '') {
-    return fallback;
-  }
-
-  const parsed = Number(raw);
-  const isValid = Number.isSafeInteger(parsed) && (allowZero ? parsed >= 0 : parsed > 0);
-  return isValid ? Math.max(parsed, minimum) : fallback;
-}
 
 const maximumLockWaitMilliseconds = resolveSafeIntegerEnvironmentVariable(
   'SAFEWORD_TEST_LOCK_MAX_WAIT_MS',
@@ -235,16 +227,24 @@ function formatElapsedWait(milliseconds) {
   return minutes === 0 ? `${seconds}s` : `${minutes}m ${seconds}s`;
 }
 
-function reportLockWait(waitedMilliseconds) {
+function currentLockOwnerDetails() {
   // The owner may release or replace the lock between our EEXIST check and
-  // this diagnostic read. Waiting remains correct even without metadata.
+  // this diagnostic read. Diagnostics remain useful even without metadata.
   const { owner } = readOwner();
+  return {
+    checkoutRoot:
+      typeof owner.checkoutRoot === 'string' && owner.checkoutRoot !== ''
+        ? owner.checkoutRoot
+        : undefined,
+    pid: isUsableOwnerPid(owner.pid) ? owner.pid : undefined,
+  };
+}
 
-  const ownerPid = isUsableOwnerPid(owner.pid) ? `owner PID ${owner.pid}` : 'owner PID unavailable';
+function reportLockWait(waitedMilliseconds) {
+  const { checkoutRoot, pid } = currentLockOwnerDetails();
+  const ownerPid = pid === undefined ? 'owner PID unavailable' : `owner PID ${pid}`;
   const ownerCheckout =
-    typeof owner.checkoutRoot === 'string' && owner.checkoutRoot !== ''
-      ? `checkout ${owner.checkoutRoot}`
-      : 'checkout unavailable';
+    checkoutRoot === undefined ? 'checkout unavailable' : `checkout ${checkoutRoot}`;
   console.error(
     `Waiting for safeword package test lock (${formatElapsedWait(waitedMilliseconds)} elapsed; ${ownerPid}; ${ownerCheckout}).`,
   );
@@ -495,8 +495,11 @@ function acquireLock() {
     }
 
     if (waitedMilliseconds >= maximumLockWaitMilliseconds) {
+      const { checkoutRoot, pid } = currentLockOwnerDetails();
+      const ownerPid = pid === undefined ? 'unavailable' : `PID ${pid}`;
+      const ownerCheckout = checkoutRoot ?? 'an unavailable checkout';
       console.error(
-        `Could not acquire safeword package test lock at ${lockDirectory} after waiting ${formatElapsedWait(maximumLockWaitMilliseconds)}; no test was started. A transition may be blocked at ${transitionDirectory}. Remove either directory only if you are sure no package test is running.`,
+        `Could not acquire safeword package test lock at ${lockDirectory} after waiting ${formatElapsedWait(maximumLockWaitMilliseconds)}; no test was started. The active owner is ${ownerPid} in ${ownerCheckout}. A transition may be blocked at ${transitionDirectory}. Re-run after it finishes, set SAFEWORD_TEST_LOCK_MAX_WAIT_MS to a larger positive millisecond value, or remove either directory only if you are sure no package test is running.`,
       );
       return false;
     }

--- a/packages/cli/tests/test-runner-lock.test.ts
+++ b/packages/cli/tests/test-runner-lock.test.ts
@@ -14,6 +14,7 @@ import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { defaultMaximumLockWaitMilliseconds } from '../scripts/lib/test-lock-config.mjs';
 import {
   environmentPathKey,
   resolveTestRunnerInvocation,
@@ -128,6 +129,12 @@ async function copyRunnerToCheckout(temporaryDirectory: string, name: string) {
   writeFileSync(
     nodePath.join(checkoutCliRoot, 'package.json'),
     `${JSON.stringify({ files: ['dist'] })}\n`,
+  );
+  const copiedConfigDirectory = nodePath.join(scriptDirectory, 'lib');
+  await mkdir(copiedConfigDirectory, { recursive: true });
+  copyFileSync(
+    nodePath.join(cliRoot, 'scripts', 'lib', 'test-lock-config.mjs'),
+    nodePath.join(copiedConfigDirectory, 'test-lock-config.mjs'),
   );
   return copiedRunnerPath;
 }
@@ -594,6 +601,10 @@ describe('package test runner lock (379)', () => {
       expect(result.stderr).toContain('Package snapshot entry contains a symbolic link: publish');
     },
   );
+
+  it('limits the default wait so locked focused verification stays actionable', () => {
+    expect(defaultMaximumLockWaitMilliseconds).toBe(60_000);
+  });
 
   it('serializes build and vitest for concurrent focused test commands', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
@@ -1318,11 +1329,15 @@ describe('package test runner lock (379)', () => {
     }
   });
 
-  it('fails without starting a test after the configured wait cap', async () => {
+  it('names the active owner and recovery when the wait cap expires', async () => {
     const temporaryDirectory = makeTemporaryDirectory();
     const { binaryDirectory, logPath } = await createFakeTestBinaries(temporaryDirectory);
     const lockDirectory = nodePath.join(temporaryDirectory, 'lock');
-    await seedOwnerFile(lockDirectory, { createdAt: new Date().toISOString(), pid: process.pid });
+    await seedOwnerFile(lockDirectory, {
+      checkoutRoot: '/worktrees/full-suite',
+      createdAt: new Date().toISOString(),
+      pid: process.pid,
+    });
 
     const result = await runNodeScript(runnerPath, ['tests/wait-cap.test.ts'], {
       ...process.env,
@@ -1332,7 +1347,10 @@ describe('package test runner lock (379)', () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('after waiting 0ms; no test was started.');
+    expect(result.stderr).toContain('Could not acquire safeword package test lock');
+    expect(result.stderr).toContain(
+      `The active owner is PID ${process.pid} in /worktrees/full-suite.`,
+    );
     expect(existsSync(logPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- reduce the default focused-test lock wait from 20 minutes to 60 seconds
- identify the lock owner and provide an explicit wait override in timeout errors
- cover default configuration and actionable timeout feedback

## Validation

- `bun run test tests/test-runner-lock.test.ts --reporter=dot` (50 passed)
- `bun run --cwd packages/cli typecheck`
- ESLint, Prettier, and diff checks on the changed files

## Note

This preserves the existing WZF6JF work as a focused draft. Its verification record calls out an earlier scope concern for reviewers to resolve.