### PR TITLE
Keep reviews focused on authored changes

### DIFF
--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/dimensions.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/dimensions.md
@@ -1,0 +1,75 @@
+# Behavioral Dimensions: Keep reviews focused on authored changes
+
+The review result changes only at the boundary where an individual target
+exceeds the existing per-file packet limit. These independent dimensions select
+the smallest set of representative behavioral scenarios.
+
+| Dimension | Partitions | Boundary / edge | Covered by scenario |
+| --- | --- | --- | --- |
+| Target size | below limit · exactly 262144 bytes · **one byte over** | multibyte UTF-8 character counts differ from raw byte counts; generated status does not alter an in-limit target | generated below-boundary; multibyte boundary; oversized scenarios |
+| Generated classification | literal `true` · unset / false / set / `TRUE` / `True` / `yes` / whitespace-padded value / malformed output / command failure | only Git's literal lower-case `true` in one valid record is an exception; malformed lookup has its own recovery code | generated oversized target; non-true outline; malformed and lookup-failure rejections |
+| Multiple generated candidates | every lookup valid · **one malformed lookup in either order** | discovery is atomic; no early exclusion leaks from a partial batch | multi-target lookup-failure outline |
+| Preflight precedence | one failure · unmarked oversized plus attribute-resolution failure in either order | unavailable classification wins so the outcome cannot vary by iteration order | precedence outline |
+| Eligible target set | authored target remains · **none remains** | every supplied target is omitted | generated target leaves authored input; all targets excluded |
+| Result scope | no reduction · named generated exclusions | `excluded_targets` has exact duplicate-free canonical project-relative membership in supplied-target order after packet finalization; preflight failures omit it | multiple generated oversized targets; repeated path; alias paths; post-launch failure; special paths |
+| Input validity | every oversize target marked · **one unmarked target** | mixed input must fail atomically before reviewer launch | mixed generated and unmarked input |
+| Aggregate bound | four individually valid 262144-byte multibyte UTF-8 files · **the same four plus one byte** | generated omission cannot reset the pre-existing aggregate cap, count characters instead of bytes, or mask individual-limit precedence | aggregate boundary success; aggregate overflow rejection |
+| Failure result | target-too-large · packet-too-large · no-eligible-targets | nonzero JSON envelope contains the exact `errors[0].code` and no successful-scope field | all rejection scenarios |
+| Target path syntax | ordinary · nested with spaces · option-like · **outside project** | Git receives every project-relative path as one literal NUL-delimited stdin value, never shell or pathspec syntax; outside targets never reach it | special-path and outside-project outlines |
+| Capture stability | captured target unchanged · **replaced before attribute lookup** | a changed target fails before either classification or review | target-changed rejection |
+| Submitted target set | eligible target exists · **empty input** · all targets omitted | every no-eligible path reports the same no-review failure | empty targets; all generated oversized targets |
+| Existing target validity | regular UTF-8 file · **directory / invalid UTF-8** | generated classification never bypasses earlier containment or text validation | generated-marker validation outline |
+| Repository metadata | runtime artifact marked · marker absent | Safeword dogfood path is classified by the same mechanism | generated runtime metadata |
+
+## Partitioning notes
+
+- The normal bounded-file path is unchanged and covered by the existing packet
+  suite; this ticket focuses on the new over-limit boundary.
+- Valid unset, false, set-without-value, and other values are deliberately
+  treated like unmarked input. A Git command failure, an incomplete record, a
+  duplicate record, or delimiter-breaking output is not an attribute value: it
+  fails with `REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE`, so recovery does not
+  misdiagnose the repository toolchain. The packet seam forces both cases
+  without depending on a machine's Git installation.
+- The aggregate packet limit remains unchanged. Combining it with generated
+  omission would test an existing invariant rather than the new decision, so a
+  focused unit regression retains coverage at the packet boundary.
+- Existing `packet.test.ts` coverage continues to reject missing, non-regular,
+  symlink-escaping, non-UTF-8, and read-racing targets. This ticket adds the
+  new capture-to-attribute race because generated classification introduces the
+  only new preflight boundary after capture.
+- A classification response is valid only when it carries exactly one record
+  that names the requested canonical path. Multiple, foreign, missing, or
+  delimiter-corrupt records are attribute-resolution failures, not a generated
+  declaration.
+- Every generated classification uses one process contract: `git -C
+  project-root check-attr -z --stdin linguist-generated`, with exactly one
+  NUL-terminated canonical project-relative path in stdin and exactly one
+  matching UTF-8 response tuple: canonical path, `linguist-generated`, value,
+  each NUL-terminated with no trailing bytes. No target path is placed in argv
+  or a shell string.
+- The content digest captured for each target is compared immediately before
+  Git classification and immediately before reviewer launch. Post-launch route
+  failures retain finalized scope for auditability; only failed preflight has
+  no trustworthy scope to report.
+- Preflight first captures and validates every target, then resolves every
+  needed generated attribute. `REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE` takes
+  precedence over `REVIEW_TARGET_TOO_LARGE` in a mixed batch because Safeword
+  cannot safely complete classification; the rule is independent of input order.
+
+## Test layers
+
+- **Unit:** real temporary Git repositories exercise attribute lookup and
+  packet selection without mocking its filesystem or Git boundary.
+- **Command / acceptance:** a fake reviewer process verifies that the public
+  command receives exactly the eligible files with their raw contents intact,
+  reports an exact ordered exclusion list, and never launches on
+  aggregate-overflow, all-excluded, or unmarked oversized input. A fake Git
+  executable proves that special paths cross as literal NUL-delimited stdin
+  values, while outside and symlink-escaping or newly changed paths are
+  rejected before attribute lookup. The asserted JSON
+  envelope is the CLI's user-visible contract.
+- **Metadata:** `git check-attr` against the dogfood artifact proves the
+  shipped repository declaration is present; the command-level arbitrary-path
+  fixture proves packet selection actually follows the Git attribute rather
+  than a hard-coded runtime path.

--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/figure-it-out.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/figure-it-out.md
@@ -1,0 +1,84 @@
+# Figure It Out: Bound generated review inputs without hiding scope
+
+- [x] Phase 1: Frame the decision in one sentence
+- [x] Phase 2: Generate 2-3 concrete options
+- [x] Phase 3a: Enumerate relevant research domains (multiple)
+- [x] Phase 3b: Research each named domain
+- [x] Phase 4: Debate, steelman both sides, commit to one
+
+## Frame
+
+Should `safeword review run` reject every oversized target, or omit only
+repository-declared generated targets while making the reduced review scope
+visible? The choice is wrong if it weakens the packet bound or lets a caller
+mistake an omitted file for a reviewed one.
+
+## Options
+
+1. **Keep rejecting every oversized target.** The packet builder keeps its
+   current one-rule limit and a generated runtime artifact still blocks the
+   entire review.
+2. **Omit only explicitly generated oversized targets (recommended).** Read
+   Git's `linguist-generated=true` attribute for an oversized target, retain
+   every eligible target, and publish the omitted paths in the result.
+3. **Truncate or guess.** Include a prefix of oversized files or infer
+   generated status from paths, extensions, or sizes.
+
+## Research plan and evidence
+
+| Domain | Question | Evidence | Finding |
+| --- | --- | --- | --- |
+| Review correctness and scope traceability | Can a review be useful while some changed files remain visible as unreviewed? | [GitHub review guidance](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request) | A review must remain accountable for its file scope, so the result must name every omission. |
+| Generated-artifact classification | Is there a stable, project-owned source of truth rather than a filename heuristic? | [Git attributes](https://git-scm.com/docs/gitattributes); [GitHub generated files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) | `linguist-generated=true` is explicit, path-scoped, and already used by this repository. |
+| Packet containment and resource bounds | Can an omission preserve the security and size invariants of the current review system? | `DR6M6N` scope and `packages/cli/src/review/packet.ts` | The individual and aggregate limits stay unchanged; unmarked oversized input remains a hard rejection. |
+| Operational recovery | What happens when no eligible source remains? | `packages/cli/src/review/coordinator.ts` routing contract | An empty packet must fail before a reviewer launches; it cannot earn an approval. |
+
+## Debate and decision
+
+**Steelman option 1:** It is the smallest and safest policy: every supplied
+target is either in the packet or causes a hard stop. It loses because a known
+deterministic output blocks independent review of the authored inputs without
+improving review accuracy.
+
+**Steelman option 3:** Truncation or a heuristic would make more commands
+complete. It loses because a partial source has no honest review meaning, while
+filename guesses make exclusion non-deterministic and easy to misuse.
+
+Option 2 is correct because it preserves both existing byte limits and the
+unmarked-file failure; it is elegant because one Git-owned marker decides the
+exception; and it has low ongoing cost because the result already has findings
+and machine-readable data.
+
+> Recommend **explicit attribute-based omission** because it is the only
+> option that keeps bounded packets while making every exception auditable.
+> The hard-reject option was close on simplicity but loses on reviewing real
+> authored changes. Cite: [Git attributes](https://git-scm.com/docs/gitattributes).
+>
+> **Premortem:** A maintainer marks real source as generated and it is skipped;
+> mitigate by accepting no heuristics, reporting every excluded path, rejecting
+> all-excluded input, and proving unmarked oversized input still fails.
+>
+> **Next:** Add packet-selection tests in `packages/cli/tests/review/packet.test.ts` before changing `packages/cli/src/review/packet.ts`.
+
+## Follow-up: isolation and resource bounds
+
+Plan review found that a normal `git check-attr`, including `--cached` and
+`--source=HEAD`, still lets `.git/info/attributes` override a checked-in
+`.gitattributes` marker. The final boundary is a disposable bare Git directory
+with the real repository's object database supplied as an alternate and
+`check-attr --source=<HEAD-commit>`. Its empty `info/attributes`, disabled
+system/global configuration, and committed tree make the policy input
+immutable: neither local Git overrides nor a working-tree attribute rewrite
+can alter classification. A local experiment on 2026-08-12 proved the
+isolated query returns committed `true` when both the live `.gitattributes`
+and real repository info attribute say `false`.
+
+For content safety, reading and hashing every oversized target would keep
+memory bounded but leaves I/O unbounded for a sparse or arbitrarily large
+artifact. The chosen policy therefore uses `lstat`/containment metadata before
+classification and never reads an oversized target that is ultimately omitted.
+UTF-8 validation applies to content that enters the packet, not a file whose
+bytes are deliberately kept outside the reviewer boundary. This keeps the
+existing 256 KiB per-target resource bound meaningful while retaining the
+regular-file, containment, committed explicit-marker, and visible-scope
+safeguards.

--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/impl-plan.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/impl-plan.md
@@ -1,0 +1,142 @@
+# Impl Plan: Keep reviews focused on authored changes
+
+**Status:** planned
+**Planned on:** 2026-08-12
+
+## Approach
+
+The riskiest assumption is that a packet can ask Git for generated status
+without weakening the existing containment, byte-limit, or source-stability
+guarantees. Prove that first with a real temporary Git repository, a fake
+reviewer process, and exact JSON assertions for an oversized generated target
+beside an authored target. This is a command-level integration test: it
+exercises the actual `safeword review run --json` entry point, filesystem,
+Git, packet builder, coordinator, and result rendering while faking only the
+reviewer subprocess.
+
+1. **Define preflight result types and Git attribute parser.** In
+   `packages/cli/src/review/packet.ts`, capture and validate all source targets
+   before classification. For each target at or below the individual limit,
+   read through a descriptor with a hard bounded byte count, then validate
+   UTF-8 and retain its immutable digest. For each oversized regular contained
+   target, retain only normalized path and metadata: never load, decode, or
+   hash its content. Resolve the project `HEAD` commit, then classify oversized
+   canonical targets through `git --git-dir <temporary-bare-dir> -c
+   core.attributesFile=/dev/null check-attr --source=<HEAD-commit> -z --stdin
+   linguist-generated`, with the real object database supplied only as Git's
+   alternate object directory, system/global configuration disabled, and
+   NUL-terminated project-relative paths. The temporary bare Git directory has
+   no project `info/attributes`; the `--source` tree makes committed
+   `.gitattributes` immutable policy input. Parse only exact UTF-8 triples
+   (`path`, `linguist-generated`, `value`) and retain only literal `true`.
+   Compare each bounded eligible snapshot's digest immediately before this
+   lookup, so a same-size, timestamp-restored replacement cannot reach Git.
+   Re-`lstat` and re-resolve every oversized candidate after the lookup; reject
+   an inode/type replacement (including atomically replaced, same-sized,
+   timestamp-restored regular
+   replacement) or a newly escaping path before finalizing an
+   exclusion, still without reading candidate bytes.
+   A typed packet failure owns every stable public code. Primary proof: focused
+   `packet.test.ts` cases using temporary Git repositories and byte buffers for
+   the exact tuple grammar, multibyte limits, aliases, special paths, malformed
+   output, external-attribute isolation, committed-tree lookup, timeout and
+   output limits,
+   eligible-target lookup avoidance, a sparse target whose content read count
+   remains zero, post-lookup target replacement, hard-link path semantics, and
+   order-independent error priority.
+   These pure-ish integration tests are the fastest way to prove the exhaustive
+   parser/limit matrix.
+2. **Build the reduced packet without bypasses.** Keep normal valid targets in
+   their immutable snapshot, omit only oversized literal-true targets, and
+   retain ordered, canonical exclusions. Normalize and deduplicate review
+   targets before any capture, size accounting, or Git lookup. Recheck bounded eligible snapshots a
+   second time immediately before launch; reject empty eligible input, all
+   invalid preflight, source races, and aggregate overflow before a reviewer
+   runs. Source drift remains a preflight failure and therefore has no finalized
+   scope; every result after reviewer launch retains the finalized scope.
+   Primary proof: packet tests plus a command integration fixture that
+   records both packet content and whether a reviewer process was launched.
+3. **Make typed preflight failures public.** Have the public review handler
+   translate packet failures into canonical failed result envelopes. Every
+   coordinator result after the packet has finalized—approved, changes
+   requested, timeout, route exhaustion, or degraded fallback—
+   adds exact `data.excluded_targets` and a scoped explanation. Failed preflight
+   results never expose partial exclusions.
+   Primary proof: command integration tests invoke the built CLI with `--json`
+   and assert stdout, stderr, exit status, `errors[0].code`, ordered data, and
+   reviewer-launch logs.
+4. **Propagate reduced scope through every successful route.** Reuse one result
+   projection helper from primary, alternate-model, and degraded fallback
+   success paths. Supporting proof: coordinator tests exercise the primary and
+   fallback result shapes so a route cannot drop exclusions.
+5. **Dogfood and document the policy.** Mark `plugin/runtime/**` as
+   `linguist-generated=true`, assert the shipped attribute through Git, and add
+   the CLI reference note that an explicitly generated oversized artifact is
+   excluded and reported rather than silently reviewed. Run the generated
+   plugin parity check after the source changes. This covers Safeword CLI,
+   Claude Code, and OpenAI Codex because each invokes the one shared command;
+   Cursor stays on the same CLI contract without a host-specific change.
+
+Use two complementary test boundaries: temporary real Git repositories prove
+the isolated committed-tree `check-attr -z --stdin` executable, argv, stdin,
+output framing, and immunity to working-tree, `.git/info`, global, and system
+overrides; an injected Git
+process-result boundary produces exit failures and malformed byte streams that
+real Git cannot safely generate. The latter is the sole mocked process
+boundary, never a packet or coordinator mock. A sparse-file fixture proves an
+oversized generated target is classified from metadata without an unbounded
+read.
+
+The feature file remains the behavior source; its dense byte, process, and
+security matrix is proven by focused Vitest command and packet tests rather
+than duplicating process fixtures in Cucumber step glue. Add `@proof.vitest`
+before GREEN so the normal Cucumber lane does not treat the deliberate
+Vitest-backed scenarios as undefined steps.
+
+## Decisions
+
+### Implementation Inspiration
+
+<!-- prettier-ignore -->
+| Reference | Checked on | Source version | Target version | Evidence of fit | Principle to borrow | Mismatch / license / security boundary |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Git check-attr manual](https://git-scm.com/docs/git-check-attr) | 2026-08-12 | Git 2.52.0 manual | local Git CLI | documents `--stdin -z` input and the exact NUL-delimited path/attribute/value output tuple | use the tool's machine protocol rather than path arguments or line parsing | documentation only; execute local Git with captured bounded buffers, never source external code |
+| [Node child_process documentation](https://nodejs.org/api/child_process.html) | 2026-08-12 | Node 26.7 docs | Node 24.16 runtime | distinguishes direct process invocation from shell-based `exec` | pass fixed argv and bytes directly, never interpolate target paths in a shell | API docs only; no new dependency and no externally supplied command |
+
+**Decision impact:** changed: packet selection now delegates explicit generated classification to Git's NUL-safe protocol while retaining Safeword-owned containment and result contracts.
+**Decision informed:** Explicit generated-target classification
+
+### Recorded Decisions
+
+| Decision | Choice | Alternatives considered | Rejected because |
+| --- | --- | --- |
+| Explicit generated-target classification | Batch oversized canonical paths through an isolated bare Git directory's committed `HEAD` tree, NUL-safe `check-attr`, and global/system attributes disabled; only exact committed `true` is eligible for omission | normal project Git invocation; live worktree attributes; filename/extension heuristic; Git argv paths; truncate content; always reject | normal Git inherits `.git/info` and external config; live files can drift mid-preflight; heuristics and truncation hide scope; argv paths mishandle special names; always rejecting leaves #2121 unresolved |
+| Resource-bound oversized classification | Validate regularity and containment from metadata, then classify an oversized target without loading its bytes | stream/hash every target; decode a prefix; accept unbounded `readFile` | a full stream bounds memory but not I/O; a prefix cannot establish UTF-8 correctness; the withheld target has no packet content to validate |
+| Preflight failure boundary | Typed packet error becomes a failed `review run --json` result before reviewer launch; attribute failure wins, then the first supplied normalized target failure supplies the code | raw thrown error; opaque aggregate error; treat Git failure as unmarked | raw errors break machine clients; target order is explicit and reproducible; misclassification hides broken repository metadata |
+| Reduced-scope projection | Add ordered `data.excluded_targets` to every result after packet finalization through one shared projection helper; preflight failures have none | free-form finding only; report it only on approval; duplicate route-specific additions | prose is not stable machine data; route failures also need auditable scope; route copies drift |
+
+## Design alignment
+
+| Principle | Consequence | Proof | Conflict |
+| --- | --- | --- |
+| Optimize for the NTB without constraining the TBU | A builder gets a clear JSON error or visible reduced scope without manually curating generated output; exact omitted paths preserve technical control | CLI command integration assertions for envelope, exit code, and `excluded_targets` | |
+| Structure enforces; instructions suggest | Packet selection and typed errors make invalid input impossible to review instead of relying on reviewers to notice omissions | packet and command tests prove no reviewer launch on every rejection path | |
+| Correct and safe; then clear; then simple | Reuse the existing packet/coordinator boundary, a direct Git subprocess, and a small result projection rather than heuristics or a new abstraction layer | parser, containment, source-race, and parity regressions | |
+
+Honors the accepted **Host-owned cross-agent adversarial review coordinator** decision in `ARCHITECTURE.md`: the change stays inside `packages/cli/src/review/`, preserves bounded snapshots and typed results, and does not add a host-specific review path. No new ADR is warranted: the policy is reversible, local to the existing coordinator, and follows that recorded architecture.
+
+## Known deviations
+
+skip: no deviations planned. Git is a required part of the repository-reviewed workflow; if attribute lookup is unavailable or malformed, the design fails closed with a typed recovery result rather than adding a fallback classifier.
+
+## Doc impact
+
+- Update `packages/website/src/content/docs/reference/cli.mdx` in build step 5: explain that `review run` may omit only explicitly Git-marked oversized artifacts and reports the exact reduced scope in JSON.
+- Update `packages/website/src/content/docs/reference/hooks-and-skills.mdx` in build step 5: preserve the coordinator's bounded-packet explanation while naming the transparent generated-artifact exception.
+
+## Assessment triggers
+
+- Git changes the documented `check-attr --stdin -z` tuple protocol or removes a supported local installation path.
+- Review packets commonly contain generated artifacts that are large but intentionally need review, suggesting explicit per-command inclusion policy rather than a marker-only exception.
+- Another host or a non-Git project becomes a supported review surface, requiring a repository-owned classification source other than `.gitattributes`.
+- Result consumers need the excluded scope outside JSON, such as a structured review receipt or UI surface.

--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/spec.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/spec.md
@@ -1,0 +1,153 @@
+# Spec: Keep reviews focused on authored changes
+
+<!-- safeword:inspiration-contract:v1 -->
+
+## Intent
+
+Independent reviews should remain bounded without making a builder manually
+remove deterministic generated output from every review command. The command
+must make its reduced scope explicit so a successful review is never mistaken
+for inspection of every supplied target.
+
+## Intake Brief
+
+- **Requested by:** Safeword Maintainer through retro issue #2121.
+- **Cost of inaction:** A normal changed-file review fails when generated runtime output exceeds the packet limit, forcing repeated, error-prone manual curation before independent review can begin.
+- **Reversibility:** Two-way door — this changes local review input selection and result reporting without a public data migration or external API.
+
+## References
+
+- [Issue #2121](https://github.com/ArcadeAI/safeword/issues/2121) — original field report.
+- [DR6M6N](../DR6M6N-reliable-reviews-for-real-packets/ticket.md) — the completed bounded-packet and review-routing contract; this ticket preserves its limits.
+- [Git attributes documentation](https://git-scm.com/docs/gitattributes) — repositories can apply explicit, path-scoped attributes with well-defined precedence.
+- [GitHub generated-file documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) — `linguist-generated` is the explicit repository signal for generated output.
+- [GitHub pull-request review guidance](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request) — review remains file-accountable, so excluded paths must stay visible.
+
+## Personas
+
+- Technical Builder (TBU)
+- Safeword Maintainer (SWM)
+
+## Surfaces
+
+Affected:
+
+- Safeword CLI — owns review-packet construction and the machine-readable result.
+- Claude Code — invokes the independent-review workflow.
+- OpenAI Codex — invokes the independent-review workflow.
+
+Unaffected:
+
+- Cursor — it consumes the same CLI contract but has no host-specific code path in this change.
+
+## Vocabulary
+
+- **Generated target:** A supplied review target whose valid Git attribute
+  record has the literal lower-case text `true` for `linguist-generated` in
+  the repository's current `HEAD` tree. The lookup uses isolated, empty Git
+  metadata, so working-tree attribute edits, project `.git/info/attributes`,
+  global attributes, and system attributes do not participate. Git's unset, false,
+  set-without-value, and other valid values are not generated exceptions;
+  missing, duplicate, or malformed records are a lookup failure.
+- **Canonical target path:** The lexical, normalized project-relative path
+  obtained from a supplied target before any filesystem operation. This one
+  identity is used for containment, validation, capture, Git lookup,
+  deduplication, reviewer packet paths, and reporting. Distinct hard links
+  remain distinct target paths; only duplicate lexical paths and lexical
+  aliases collapse.
+- **Reduced scope:** The eligible targets actually presented to a reviewer after explicitly generated oversized targets are omitted.
+- **Individual packet limit:** At most 262144 bytes of a target's raw file
+  contents. The existing 1048576-byte aggregate limit likewise measures the
+  raw contents of all eligible targets, not packet framing.
+
+## Product Inspiration
+
+<!-- prettier-ignore -->
+| Reference | Checked on | Source version / edition | Customer-value evidence | Principle to borrow | Non-copy boundary | Decision impact |
+| --- | --- | --- | --- | --- | --- | --- |
+| [GitHub generated-file handling](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) | 2026-08-12 | current documentation | generated paths are an explicit repository-owned classification and are hidden by default rather than silently treated as authored source | use an explicit source-of-truth marker and make the review scope visible | do not copy GitHub's UI behavior or broad language heuristics | retain hard packet limits but allow only explicit generated targets to be omitted and report them |
+
+## Jobs To Be Done
+
+### focused-review.TBU1 — Start an independent review without hand-curating generated output
+
+**Persona:** Technical Builder (TBU)
+
+> When my change includes a large deterministic generated artifact, I want the
+> review command to focus on the authored inputs and show what it left out, so
+> I can start a useful independent review without concealing its limits.
+
+#### focused-review.TBU1.R1 — An explicitly generated oversized target is excluded only from the reviewer packet and remains visible in the result
+
+#### focused-review.TBU1.R2 — An oversized target without an explicit generated marker still prevents the review from running
+
+### focused-review.SWM1 — Keep generated-review policy deterministic and auditable
+
+**Persona:** Safeword Maintainer (SWM)
+
+> When I maintain generated plugin outputs, I want their generated status to be
+> declared in repository metadata and exercised by dogfood tests, so review
+> behavior is stable and does not depend on filename guesses.
+
+#### focused-review.SWM1.R1 — A review with no eligible targets reports that condition rather than asking a reviewer to approve an empty packet
+
+#### focused-review.SWM1.R2 — Safeword's own generated runtime outputs use the same repository marker the command reads
+
+## Rave Moment
+
+skip: internal CLI behavior; transparent bounded review is table stakes rather than a shareable moment.
+
+## Outcomes
+
+- A review with an explicit generated oversized target reaches its independent reviewer with every eligible authored target.
+- The successful machine-readable result exposes `excluded_targets` as the
+  exact, duplicate-free project-relative paths it omitted, in supplied-target
+  order. Any route outcome after packet scope is finalized carries the same
+  field; a failed preflight never emits it.
+- A caller receives a distinct machine-readable failure before reviewer launch
+  when an oversized target is unmarked or when every supplied target was
+  excluded, including a nonzero command result with the relevant error code.
+- A Git attribute command failure or malformed record is a distinct preflight
+  failure (`REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE`), never silently reclassified
+  as an unmarked target; valid non-true attribute values remain unmarked.
+- A Git attribute lookup has a bounded execution time and captured output. A
+  timeout or output-limit breach is the same closed
+  `REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE` preflight failure.
+- Preflight reads at most the existing individual packet limit from any
+  eligible target. It validates regular-file and containment invariants for
+  every target before classification, but uses metadata rather than reading or
+  decoding an oversized target that may be omitted. Eligible content snapshots
+  remain UTF-8 validated and are checked for source drift before attribute
+  lookup and reviewer launch; a drift is a preflight failure with no finalized
+  reduced scope.
+- An oversized candidate is revalidated after attribute lookup and before its
+  exclusion becomes final. A replacement, type change, or newly escaping path
+  fails closed before reviewer launch without ever reading the candidate bytes.
+- Generated classification evaluates the immutable committed Git tree. A
+  working-tree attribute rewrite cannot alter an in-progress review or create
+  an omission before its marker is committed.
+- A generated classification record must be exactly one well-formed record for
+  the canonical target path; a missing, duplicate, mismatched, or extra record
+  is malformed rather than permission to omit anything. The record is exactly
+  three UTF-8 NUL-terminated fields in order: canonical path,
+  `linguist-generated`, and value, with no trailing bytes.
+- Preflight evaluates every target before deciding its result. If an oversized
+  unmarked target and an attribute-resolution failure coexist,
+  `REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE` wins regardless of supplied order.
+  Otherwise, every target is still evaluated and the first supplied normalized
+  target with a failure supplies the deterministic error code.
+- A valid, contained oversized target is classified even when an earlier target
+  has another failure; a target that fails containment or regular-file
+  validation is never sent to Git attribute lookup.
+- Duplicate and lexical-alias review targets collapse before packet capture,
+  aggregate accounting, classification, and result reporting. Containment
+  applies after full lexical normalization.
+- Eligible canonical paths retain first-supplied order in the reviewer packet;
+  generated omissions do not reorder the remaining eligible paths.
+- The repository explicitly marks its generated plugin runtime output, and a regression proves the marker is honored.
+
+## Open Questions
+
+None. Safeword already uses the marker in `.gitattributes`; the implementation
+must apply the same explicit committed-tree meaning to its generated runtime
+outputs without inheriting local Git overrides.

--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/test-definitions.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/test-definitions.md
@@ -1,0 +1,286 @@
+# Test Definitions: Keep reviews focused on authored changes
+
+Feature source:
+`packages/cli/features/keep-reviews-focused-on-authored-inputs.feature`
+
+R/G/R ledger. Given/When/Then live in the feature source. Focused Vitest
+packet and command tests provide the deterministic seams; Cucumber proves the
+builder-visible command path with a real temporary project and fake reviewer.
+
+## Rule: focused-review.TBU1.R1
+
+### Scenario: Generated artifacts one byte over the per-target packet limit leave authored input reviewable and visible
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A repeated generated target has one ordered exclusion
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Generated path aliases have one canonical ordered exclusion
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A generated target at the individual packet boundary remains reviewable
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A generated target below the individual packet limit remains reviewable
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A repeated eligible target is reviewed and aggregate-counted once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An eligible lexical alias is reviewed and aggregate-counted once
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Lexical normalization defines target identity before intermediate symlink traversal
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An eligible target at the packet boundary does not require Git attribute resolution
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: focused-review.TBU1.R2
+
+### Scenario: A non-true generated attribute does not launch a reviewer
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Unavailable Git attribute resolution does not permit omission
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A bounded Git attribute lookup failure does not permit omission
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An eligible target changed after bounded capture does not reach attribute lookup
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An eligible target changed after oversized classification cannot reach a reviewer
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A generated marker cannot bypass non-regular target validation
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An oversized generated sparse target is omitted without reading or decoding its bytes
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An oversized generated target changed after metadata validation fails before omission
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Non-attribute target failures are reported in supplied order
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Successful generated classification does not change the first supplied target failure
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Full preflight classifies a valid oversized target after an earlier invalid target
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Malformed Git attribute output does not permit omission
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A multi-target attribute failure is atomic in either supplied order
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Attribute-resolution failure takes precedence over an unmarked oversized target in either order
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The public CLI reports each preflight failure as a JSON envelope
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Mixed marked and unmarked oversized targets fail atomically
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Generated omission retains a review exactly at the aggregate packet limit
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Generated omission cannot weaken the aggregate packet limit
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: focused-review.SWM1.R1
+
+### Scenario: All generated oversized targets stop before reviewer launch
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: An empty submitted target list stops before reviewer launch
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+## Rule: focused-review.SWM1.R2
+
+### Scenario: A Git-marked generated target is selected without a path heuristic
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Git attribute lookup safely keeps generated paths project-relative
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Git attribute lookup preserves special generated paths as one literal NUL-delimited stdin value
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Git attribute lookup preserves a generated filename containing an actual newline code point
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Project Git info attributes cannot override a committed generated marker
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Attribute classification ignores a working-tree marker removal
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Attribute classification ignores an uncommitted marker addition
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: External Git attributes cannot create a generated exception
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Hostile project Git configuration and inherited environment cannot redirect committed classification
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Distinct hard-linked generated targets remain distinct exclusions
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: The CLI returns the reduced scope in its JSON stdout envelope
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A reviewer failure after packet finalization reports the reduced scope
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A target outside the project cannot reach Git attribute lookup
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: A project-relative symlink escaping the project cannot reach Git attribute lookup
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+### Scenario: Safeword's generated plugin runtime declares the same marker
+
+- [ ] RED
+- [ ] GREEN
+- [ ] REFACTOR
+
+---
+
+## Feature-level cross-scenario refactor
+
+- [ ] cross-scenario

--- a/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/ticket.md
+++ b/.project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/ticket.md
@@ -1,0 +1,59 @@
+---
+id: CKWE2D
+slug: keep-reviews-focused-on-authored-inputs
+type: feature
+phase: plan-implementation
+phase_anchors:
+  - define-behavior: .project/tickets/CKWE2D-keep-reviews-focused-on-authored-inputs/spec.md
+  - scenario-gate: packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
+  - plan-implementation: packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
+status: in_progress
+scope:
+  - recognise an oversized target only when the repository explicitly marks it linguist-generated=true
+  - review every remaining bounded authored target and report each omitted generated target in the command result
+  - mark Safeword's generated plugin runtime outputs so dogfood reviews use the same explicit contract
+out_of_scope:
+  - truncating an oversized file or inferring generated status from a filename, extension, or size
+  - skipping unmarked oversized targets, changing review-policy semantics, or weakening packet containment checks
+done_when:
+  - an oversized linguist-generated target no longer prevents a review of eligible authored targets
+  - the result exposes the excluded paths and never claims they were reviewed
+  - an unmarked oversized target and an all-excluded target still fail before any reviewer runs
+  - packet, coordinator, public-command, and generated-artifact metadata regressions prove the contract
+external_issue: https://github.com/ArcadeAI/safeword/issues/2121
+inspiration_contract: v1
+inspiration_contract_scaffold: v1
+created: 2026-08-12T15:10:06.430Z
+last_modified: 2026-08-12T16:31:10Z
+---
+
+# Keep reviews focused on authored changes
+
+**Goal:** Let independent reviews automatically exclude explicitly generated oversized artifacts while reporting the reduced scope.
+
+**See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
+
+## Work Log
+
+- 2026-08-12T15:10:06.430Z Started: Created ticket CKWE2D
+- 2026-08-12T15:10:35Z Revalidated #2121: `prepareReviewPacket` still rejects every target above 262144 bytes, including explicitly generated runtime output.
+- 2026-08-12T15:10:35Z Figure-it-out: chose explicit `linguist-generated=true` omission with a visible reduced-scope result; retained hard failures for unmarked or all-excluded inputs.
+- 2026-08-12T15:15:23Z Define-behavior: corrected the spec to distinguish Safeword's existing marker convention from the new runtime-output classification.
+- 2026-08-12T15:20:34Z Scenario review: degraded Codex review requested changes. Addressed both blockers (attribute-driven command proof and complete exclusion reporting) plus boundary, false/unset, mixed-input, and typed-failure coverage; re-review required.
+- 2026-08-12T15:22:18Z Scenario re-review: corrected the arbitrary-target setup and added lookup-failure, invalid-attribute, exact-byte-boundary, and concrete plugin-runtime assertions; re-review required.
+- 2026-08-12T15:24:46Z Scenario re-review: added the preserved aggregate-limit rejection and made successful exclusions plus failed preflights exact JSON contracts, including option-like and nested paths; re-review required.
+- 2026-08-12T15:27:32Z Scenario re-review: added duplicate-target de-duplication, exact aggregate boundaries, success status, literal Git-value semantics, and outside-project rejection before attribute lookup; re-review required.
+- 2026-08-12T15:30:10Z Scenario re-review: strengthened successful packets to exact reviewer contents, split aggregate boundary success from failure, and added observable no-Git checks for lexical and symlink project escapes; re-review required.
+- 2026-08-12T15:32:09Z Scenario re-review: removed the contradictory success/rejection tag and added canonical alias plus explicit non-literal Git-value coverage; re-review required.
+- 2026-08-12T15:34:49Z Scenario re-review: fixed aggregate fixtures to individually valid exact byte distributions, made Git command failure a distinct public preflight error, and pinned canonical paths passed to attribute lookup; re-review required.
+- 2026-08-12T15:37:14Z Scenario re-review: added below-limit generated inclusion, argv-safe Git proof, raw-content preservation, and malformed-record failures; re-review required.
+- 2026-08-12T15:39:08Z Scenario re-review: changed individual and aggregate boundaries to multibyte UTF-8 byte fixtures and required original content for every successful reviewer packet; re-review required.
+- 2026-08-12T15:42:01Z Scenario re-review: added capture-to-attribute TOCTOU refusal and NUL-safe newline-path behavior; recorded the unchanged packet-validation coverage as an inherited guard.
+- 2026-08-12T15:45:36Z Scenario re-review: made inherited directory and UTF-8 validation explicit for marked targets, added the post-lookup race, and made special Git paths literal NUL-delimited stdin values.
+- 2026-08-12T15:48:22Z Scenario re-review: made all preflight failures omit reduced-scope data, added zero-target failure, hardened same-size timestamp-restored races, and required one exact attribute record per canonical path.
+- 2026-08-12T15:51:09Z Scenario re-review: standardized one NUL-stdin Git protocol, made alias and malformed tuple cases exact, added two-target failure atomicity, and pinned the public CLI JSON envelope.
+- 2026-08-12T15:53:41Z Scenario re-review: specified the exact three-field UTF-8 NUL tuple and expanded malformed output coverage to invalid bytes, empty/surplus fields, and trailing data.
+- 2026-08-12T15:58:31Z Scenario review timed out on the primary route but returned actionable degraded findings. Defined order-independent attribute-failure precedence and added public JSON-envelope failure coverage; final re-review required.
+- 2026-08-12T16:03:02Z Define-behavior → scenario-gate → plan-implementation: the final bounded review approved the scenarios. Claude timed out, and the accepted typed Codex fallback is recorded as degraded (`author=codex`, `reviewer=codex`, `independence=degraded`).
+- 2026-08-12T16:07:36Z Plan review requested changes. Added content-backed stability checks before Git and launch, separated real Git protocol tests from injected malformed-result tests, and made post-launch results retain finalized reduced scope; re-review required.
+- 2026-08-12T16:31:10Z Revalidated the plan with local Git experiments: normal, cached, and `--source=HEAD` project lookups inherit `.git/info/attributes`. Reframed generated classification around an isolated bare Git directory and the committed `HEAD` tree, which rejects local overrides and working-tree marker drift. Repeated scenario reviews remain degraded because the preferred Claude route timed out; the latest pass added canonical lexical identity, order preservation, and bounded Git lookup coverage. Ticket remains at the scenario gate pending a fresh independent approval before RED tests and implementation.

--- a/packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
+++ b/packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
@@ -1,0 +1,511 @@
+@proof.vitest @surface.safeword-cli @surface.claude-code @surface.openai-codex
+Feature: Keep reviews focused on authored changes
+
+  Independent review preserves its bounded packet while treating explicitly
+  declared generated output as visible reduced scope rather than a reason to
+  abandon every eligible authored input.
+
+  @focused-review.TBU1.R1
+  Rule: focused-review.TBU1.R1 — An explicitly generated oversized target is excluded only from the reviewer packet and remains visible in the result
+
+    Scenario: Generated artifacts one byte over the per-target packet limit leave authored input reviewable and visible
+      Given a review has one authored target and two generated targets each one byte over the per-target packet limit
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the authored target with its original raw content
+      And excluded_targets exactly names both generated target paths in supplied order
+      And the command exits successfully with no errors
+
+    Scenario: A repeated generated target has one ordered exclusion
+      Given a review has one authored target and the same oversized generated target twice
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names the repeated generated target once
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario: Generated path aliases have one canonical ordered exclusion
+      Given a review has one authored target and the same generated oversized target supplied first as generated/../generated/output.js and then as generated/output.js
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names generated/output.js once
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario: A generated target at the individual packet boundary remains reviewable
+      Given a review has a generated target with 131072 two-byte UTF-8 characters and exactly 262144 raw content bytes
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the generated target with its original raw content
+      And the result has no excluded_targets
+      And the command exits successfully with no errors
+
+    Scenario: A generated target below the individual packet limit remains reviewable
+      Given a review has a generated target with 262143 raw content bytes
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the generated target with its original raw content
+      And the result has no excluded_targets
+      And the command exits successfully with no errors
+
+    Scenario: A repeated eligible target is reviewed and aggregate-counted once
+      Given a review has four eligible targets each with exactly 262144 raw content bytes and repeats the first target
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly four eligible targets with their original raw content in first-supplied canonical order
+      And the result has no excluded_targets
+      And the command exits successfully with no errors
+
+    Scenario: An eligible lexical alias is reviewed and aggregate-counted once
+      Given a review has four eligible targets each with exactly 262144 raw content bytes and supplies the first target again as nested/../first-target.js
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly four eligible targets with their original raw content in first-supplied canonical order
+      And the result has no excluded_targets
+      And the command exits successfully with no errors
+
+    Scenario Outline: Lexical normalization defines target identity before intermediate symlink traversal
+      Given a review supplies a generated oversized target as link/../generated/output.js
+      And link is an intermediate symlink pointing <destination>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then Git attribute lookup, excluded_targets, and reviewer packet paths use generated/output.js without link
+      And the command exits successfully with no errors
+
+      Examples:
+        | destination              |
+        | another in-project path  |
+        | a path outside the project |
+
+    Scenario: An eligible target at the packet boundary does not require Git attribute resolution
+      Given a review has a target with exactly 262144 raw content bytes
+      And Git attribute resolution would exit unsuccessfully if called
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the target with its original raw content
+      And Git attribute lookup is never called
+      And the command exits successfully with no errors
+
+  @focused-review.TBU1.R2
+  Rule: focused-review.TBU1.R2 — An oversized target without an explicit generated marker still prevents the review from running
+
+    @rejection
+    Scenario Outline: A non-true generated attribute does not launch a reviewer
+      Given a review has an oversized target with linguist-generated <attribute>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_TOO_LARGE
+      And the failed result has no excluded_targets
+
+      Examples:
+        | attribute |
+        | false              |
+        | unset              |
+        | set-without-value  |
+        | TRUE               |
+        | True               |
+        | yes                |
+        | true-with-whitespace |
+
+    @rejection
+    Scenario: Unavailable Git attribute resolution does not permit omission
+      Given a review has an oversized target and Git attribute resolution exits unsuccessfully
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario Outline: A bounded Git attribute lookup failure does not permit omission
+      Given a review has an oversized target and Git attribute resolution <failure>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE
+      And the failed result has no excluded_targets
+
+      Examples:
+        | failure                                      |
+        | exceeds its configured execution timeout     |
+        | exceeds its configured captured output limit |
+
+    @rejection
+    Scenario: An eligible target changed after bounded capture does not reach attribute lookup
+      Given a review has an eligible target replaced after bounded packet capture with different content of the same byte length and restored timestamp
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_CHANGED
+      And Git attribute lookup is never called
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario: An eligible target changed after oversized classification cannot reach a reviewer
+      Given a review has one eligible target and one oversized target marked generated
+      And Git attribute lookup has classified the oversized target
+      And the eligible target is atomically replaced after Git attribute lookup with different content of the same byte length and restored timestamp
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_CHANGED
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario Outline: A generated marker cannot bypass non-regular target validation
+      Given a review has an oversized target marked generated that is <defect>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code <error_code>
+      And Git attribute lookup is never called
+      And the failed result has no excluded_targets
+
+      Examples:
+        | defect       | error_code               |
+        | a directory   | REVIEW_TARGET_NOT_REGULAR |
+        | a named pipe  | REVIEW_TARGET_NOT_REGULAR |
+
+    Scenario: An oversized generated sparse target is omitted without reading or decoding its bytes
+      Given a review has one authored target and an 8 GiB sparse target marked generated
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the authored target with its original raw content
+      And excluded_targets exactly names the sparse generated target
+      And the command reads no bytes from the sparse generated target
+      And the command exits successfully with no errors
+
+    @rejection
+    Scenario Outline: An oversized generated target changed after metadata validation fails before omission
+      Given a review has one authored target and an oversized target marked generated
+      And the generated target changes after metadata validation to <replacement>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code <error_code>
+      And the command reads no bytes from the changed generated target
+      And the failed result has no excluded_targets
+
+      Examples:
+        | replacement                       | error_code                         |
+        | a named pipe                       | REVIEW_TARGET_CHANGED               |
+        | a symlink escaping the project     | REVIEW_TARGET_OUTSIDE_PROJECT       |
+        | an atomically replaced same-sized regular file with a restored timestamp | REVIEW_TARGET_CHANGED |
+        | an in-place size change             | REVIEW_TARGET_CHANGED               |
+
+    @rejection
+    Scenario Outline: Non-attribute target failures are reported in supplied order
+      Given a review submits the exact target sequence <first_target> then <second_target>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code <error_code>
+      And Git attribute lookup is never called
+      And the failed result has no excluded_targets
+
+      Examples:
+        | first_target             | second_target             | error_code                         |
+        | an outside-project target | a named pipe              | REVIEW_TARGET_OUTSIDE_PROJECT       |
+        | a named pipe              | an outside-project target | REVIEW_TARGET_NOT_REGULAR           |
+
+    Scenario Outline: Successful generated classification does not change the first supplied target failure
+      Given a review submits the exact target sequence <first_target> then <second_target>
+      And Git attribute lookup completes successfully for every valid oversized target
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code <error_code>
+      And Git attribute lookup receives each valid oversized target once
+      And the failed result has no excluded_targets
+
+      Examples:
+        | first_target                              | second_target                         | error_code                         |
+        | invalid UTF-8 text                         | an oversized unmarked target          | REVIEW_TARGET_INVALID_TEXT          |
+        | an oversized unmarked target               | invalid UTF-8 text                    | REVIEW_TARGET_TOO_LARGE             |
+        | eligible targets exceeding aggregate size  | an oversized unmarked target          | REVIEW_PACKET_TOO_LARGE             |
+        | an oversized unmarked target               | eligible targets exceeding aggregate size | REVIEW_TARGET_TOO_LARGE          |
+
+    Scenario: Full preflight classifies a valid oversized target after an earlier invalid target
+      Given a review submits a named pipe followed by an oversized target marked generated
+      And Git attribute lookup completes successfully for the valid oversized target
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_NOT_REGULAR
+      And metadata validation runs once for each submitted target
+      And Git attribute lookup receives only the valid oversized target
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario Outline: Malformed Git attribute output does not permit omission
+      Given a review has an oversized target and Git attribute resolution returns <malformation>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE
+      And the failed result has no excluded_targets
+
+      Examples:
+        | malformation        |
+        | no complete record  |
+        | duplicate records   |
+        | a missing tuple field |
+        | a missing NUL terminator |
+        | the wrong attribute name |
+        | one record for a different path |
+        | one matching record and one unrelated extra record |
+        | invalid UTF-8 bytes |
+        | an empty path field |
+        | an empty attribute field |
+        | an empty value field |
+        | a surplus NUL-delimited field |
+        | trailing non-NUL bytes |
+
+    @rejection
+    Scenario Outline: A multi-target attribute failure is atomic in either supplied order
+      Given a review has two oversized targets in <order>, one marked generated and one with malformed Git attribute output
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE
+      And the failed result has no excluded_targets
+
+      Examples:
+        | order                     |
+        | generated then malformed  |
+        | malformed then generated  |
+
+    @rejection
+    Scenario Outline: Attribute-resolution failure takes precedence over an unmarked oversized target in either order
+      Given a review has an oversized unmarked target and an oversized target with Git attribute resolution failure in <order>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE
+      And the failed result has no excluded_targets
+
+      Examples:
+        | order                                      |
+        | unmarked then attribute-resolution failure |
+        | attribute-resolution failure then unmarked |
+
+    @rejection
+    Scenario Outline: The public CLI reports each preflight failure as a JSON envelope
+      Given <preflight_failure>
+      And an independent reviewer is available
+      When a builder runs `safeword review run quality-review --json --cwd project-root`
+      Then stdout is the versioned JSON result envelope whose errors[0].code is <error_code>
+      And stdout has no data.excluded_targets
+      And stderr is empty
+      And the command exits nonzero
+
+      Examples:
+        | preflight_failure                                           | error_code                           |
+        | an oversized target without a generated marker              | REVIEW_TARGET_TOO_LARGE              |
+        | an oversized target with Git attribute resolution failure   | REVIEW_TARGET_ATTRIBUTE_UNAVAILABLE  |
+        | no submitted targets                                        | REVIEW_NO_ELIGIBLE_TARGETS           |
+        | a target outside the project                                | REVIEW_TARGET_OUTSIDE_PROJECT        |
+        | a named pipe target                                         | REVIEW_TARGET_NOT_REGULAR            |
+        | a target that changes after bounded capture                 | REVIEW_TARGET_CHANGED                |
+        | invalid UTF-8 text                                          | REVIEW_TARGET_INVALID_TEXT           |
+        | eligible targets exceeding the aggregate packet limit       | REVIEW_PACKET_TOO_LARGE              |
+
+    @rejection
+    Scenario: Mixed marked and unmarked oversized targets fail atomically
+      Given a review has an authored target, an oversized generated target, and an oversized unmarked target
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_TOO_LARGE
+      And the failed result has no excluded_targets
+
+    Scenario: Generated omission retains a review exactly at the aggregate packet limit
+      Given a review has an oversized target marked generated and four eligible targets each with 131072 two-byte UTF-8 characters and 262144 raw content bytes
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the reviewer receives exactly the eligible targets
+      And the reviewer receives each eligible target's original raw content
+      And excluded_targets exactly names the generated target
+      And the command exits successfully with no errors
+
+    @rejection
+    Scenario: Generated omission cannot weaken the aggregate packet limit
+      Given a review has an oversized target marked generated, four eligible targets each with 131072 two-byte UTF-8 characters and 262144 raw content bytes, and one eligible target of one raw content byte
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_PACKET_TOO_LARGE
+      And the failed result has no excluded_targets
+
+  @focused-review.SWM1.R1
+  Rule: focused-review.SWM1.R1 — A review with no eligible targets reports that condition rather than asking a reviewer to approve an empty packet
+
+    @rejection
+    Scenario: All generated oversized targets stop before reviewer launch
+      Given a review has only oversized targets marked generated
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_NO_ELIGIBLE_TARGETS
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario: An empty submitted target list stops before reviewer launch
+      Given a review has no submitted targets
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_NO_ELIGIBLE_TARGETS
+      And the failed result has no excluded_targets
+
+  @focused-review.SWM1.R2
+  Rule: focused-review.SWM1.R2 — Safeword's own generated runtime outputs use the same repository marker the command reads
+
+    Scenario: A Git-marked generated target is selected without a path heuristic
+      Given a review has one authored target and an oversized arbitrary target marked generated by Git attributes
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then the result exposes the arbitrary target in excluded_targets
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario Outline: Git attribute lookup safely keeps generated paths project-relative
+      Given a review has one authored target and a generated oversized target at <path>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names <path>
+      And the reviewer receives exactly the authored target with its original raw content
+      And Git attribute lookup receives the canonical project-relative path <path>
+      And Git attribute lookup runs through isolated empty Git metadata against the committed project tree without a shell
+      And Git attribute lookup supplies <path> as one literal NUL-terminated stdin field
+      And the command exits successfully with no errors
+
+      Examples:
+        | path                      |
+        | nested/generated file.js  |
+        | --generated-output.js     |
+
+    Scenario Outline: Git attribute lookup preserves special generated paths as one literal NUL-delimited stdin value
+      Given a review has one authored target and a generated oversized target at <path>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names <path>
+      And the reviewer receives exactly the authored target with its original raw content
+      And Git attribute lookup supplies <path> as one literal NUL-terminated stdin field and returns exactly one UTF-8 NUL-terminated tuple of canonical path, linguist-generated, and value
+      And the command exits successfully with no errors
+
+      Examples:
+        | path                                  |
+        | :(top)generated-output.js              |
+
+    Scenario: Git attribute lookup preserves a generated filename containing an actual newline code point
+      Given a review has one authored target and a generated oversized target whose filename contains an actual U+000A code point
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then Git attribute lookup sends and receives the target as exact NUL-delimited UTF-8 bytes
+      And excluded_targets exactly names the generated target
+      And the command exits successfully with no errors
+
+    Scenario: Project Git info attributes cannot override a committed generated marker
+      Given a review project HEAD .gitattributes marks an oversized target generated
+      And the project's .git/info/attributes marks the same target false
+      And global and system Git attributes mark the same target false
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names the generated target
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario: Attribute classification ignores a working-tree marker removal
+      Given a review project HEAD .gitattributes marks an oversized target generated
+      And the project working-tree .gitattributes is atomically replaced with an equally sized unmarked file before classification
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names the generated target
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    @rejection
+    Scenario: Attribute classification ignores an uncommitted marker addition
+      Given a review project HEAD .gitattributes leaves an oversized target unmarked
+      And the project working-tree .gitattributes is atomically replaced with an equally sized generated marker before classification
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_TOO_LARGE
+      And the failed result has no excluded_targets
+
+    @rejection
+    Scenario: External Git attributes cannot create a generated exception
+      Given a review project has an oversized target without a .gitattributes generated marker
+      And the project's .git/info/attributes and global Git attributes mark that target generated
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_TOO_LARGE
+      And the failed result has no excluded_targets
+
+    Scenario: Hostile project Git configuration and inherited environment cannot redirect committed classification
+      Given a review project HEAD .gitattributes marks an oversized target generated
+      And project Git configuration and inherited environment variables redirect attribute and object lookup to hostile values
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names the generated target
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario: Distinct hard-linked generated targets remain distinct exclusions
+      Given a review has one authored target and two distinct hard-linked oversized targets marked generated
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then excluded_targets exactly names both hard-link target paths in supplied order
+      And the reviewer receives exactly the authored target with its original raw content
+      And the command exits successfully with no errors
+
+    Scenario: The CLI returns the reduced scope in its JSON stdout envelope
+      Given a review has one authored target and one oversized target marked generated
+      And an independent reviewer is available
+      When a builder runs `safeword review run quality-review --json --cwd project-root` with both targets
+      Then stdout is the versioned JSON result envelope whose data.excluded_targets exactly names the generated target
+      And stderr is empty
+      And the command exits successfully with no errors
+
+    Scenario: A reviewer failure after packet finalization reports the reduced scope
+      Given a review has one authored target and one oversized target marked generated
+      And the independent reviewer fails after receiving its packet
+      When a builder runs `safeword review run quality-review --json --cwd project-root` with both targets
+      Then stdout is the versioned JSON result envelope whose errors[0].code is REVIEW_ROUTES_EXHAUSTED and whose data.excluded_targets exactly names the generated target
+      And stderr is empty
+      And the command exits nonzero
+
+    @rejection
+    Scenario Outline: A target outside the project cannot reach Git attribute lookup
+      Given a review has a target path outside the project at <path>
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_OUTSIDE_PROJECT
+      And Git attribute lookup is never called
+      And the failed result has no excluded_targets
+
+      Examples:
+        | path                           |
+        | ../outside-file.js             |
+        | nested/../../outside-file.js   |
+        | /tmp/outside-file.js           |
+
+    @rejection
+    Scenario: A project-relative symlink escaping the project cannot reach Git attribute lookup
+      Given a review has a project-relative symlinked target resolving outside the project
+      And an independent reviewer is available
+      When a builder runs the public review command
+      Then no reviewer is asked to review it
+      And the command exits nonzero with errors[0].code REVIEW_TARGET_OUTSIDE_PROJECT
+      And Git attribute lookup is never called
+      And the failed result has no excluded_targets
+
+    Scenario: Safeword's generated plugin runtime declares the same marker
+      Given Safeword's plugin/runtime/cli.js generated output
+      When its Git attributes are checked
+      Then plugin/runtime/cli.js resolves linguist-generated to true

--- a/packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
+++ b/packages/cli/features/keep-reviews-focused-on-authored-inputs.feature
@@ -1,4 +1,4 @@
-@proof.vitest @surface.safeword-cli @surface.claude-code @surface.openai-codex
+@wip @surface.safeword-cli @surface.claude-code @surface.openai-codex
 Feature: Keep reviews focused on authored changes
 
   Independent review preserves its bounded packet while treating explicitly


### PR DESCRIPTION
## Summary

- preserve the CKWE2D behavior specification, scenarios, decision record, and implementation plan
- define an explicit `linguist-generated=true` exclusion rule for independently reviewed artifacts
- require visible exclusion accounting in review packets

## Validation

- `bun packages/cli/src/cli.ts lint-gherkin`
- Markdown formatting and diff checks

## Intentionally draft

This is a planning/BDD package only; production implementation and proof mappings are intentionally not included. Safeword also reports missing early-phase provenance and an unchecked ledger item, which should be resolved before this moves forward.