### PR TITLE
Fix shared run identity helper installation

### DIFF
--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1577,7 +1577,6 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
 export type ProjectSurface = 'core' | 'cursor';
 
 const CURSOR_PROJECT_PATHS = new Set([
-  '.safeword/hooks/lib/cursor-run-identity.ts',
   '.safeword/hooks/lib/cursor-state.ts',
   '.safeword/hooks/session-cursor-auto-upgrade.ts',
 ]);

--- a/packages/cli/tests/cli-protocol/lifecycle-status-observation.test.ts
+++ b/packages/cli/tests/cli-protocol/lifecycle-status-observation.test.ts
@@ -31,6 +31,14 @@ vi.mock('../../src/codex-plugin/operations.js', async () => {
 });
 
 describe('lifecycle profile observation', () => {
+  it('installs the shared proof-identity bridge for a Codex-only project', () => {
+    const schema = projectLifecycleSchema(createTemporaryDirectory(), ['codex']);
+
+    expect(schema.ownedFiles['.safeword/hooks/lib/cursor-run-identity.ts']).toEqual({
+      template: 'hooks/lib/cursor-run-identity.ts',
+    });
+  });
+
   it('observes selected independent profiles when project configuration is absent', async () => {
     const surfaces = await observeLifecycleSurfaces(createTemporaryDirectory(), [
       'claude',

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "86546083f9af7442e4bdfcac75a0bc2e11cadf68b628b984a02a1d680b204397"
+  "inventory_sha256": "1756edc5dcde22ff8e704c092a54708340aa58ae82f879bc0e4e16e354291939"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "bc9688d269a6718408f7410b76d69c96eff7bb62a4aff811683ab2bd3eb818fb"
+      "sha256": "84de1e336cfa66543d7a4d2c80a953b6880716d9481928e24f3bfd2bc3d4aa9c"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -19030,7 +19030,6 @@ ${durableNamespaceDirectories(ctx).map((dir) => `${dir}/`).join(`
     packages: typescriptPackages
   };
   CURSOR_PROJECT_PATHS = new Set([
-    ".safeword/hooks/lib/cursor-run-identity.ts",
     ".safeword/hooks/lib/cursor-state.ts",
     ".safeword/hooks/session-cursor-auto-upgrade.ts"
   ]);


### PR DESCRIPTION
## Summary

- install the shared run-identity helper for Codex-only projects
- prevent the skill-invocation logger from importing a missing module
- add Codex-only lifecycle coverage

## Root cause

The helper was classified as Cursor-only even though core and Codex hooks import it.

## Validation

- `bun run test packages/cli/tests/cli-protocol/lifecycle-status-observation.test.ts`
- `bun run test packages/cli/tests/schema.test.ts`
- fresh Codex-only install and `quality-review` invocation check