### PR TITLE
chore(release): v0.78.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.2",
+      "version": "0.78.3",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.78.2",
+      "version": "0.78.3",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.2 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.3 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.2 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.3 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.2 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.3 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.2 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.3 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.2 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.3 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.2",
+  "plugin_version": "0.78.3",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "1756edc5dcde22ff8e704c092a54708340aa58ae82f879bc0e4e16e354291939"
+  "inventory_sha256": "c0a7fa9e51d58f0e6da07254dfae5110243d280b52f2f323c9f99ec5770b2cff"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "1baf85b46a78f61dd56bcb188bb58cda8e66338d2a614437b838b46267b76e42"
+      "sha256": "6a5a2d05459bed4e96e27bd36c473456bedc58ef371423c8537a35790c132aa4"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "type": "module"
 }


### PR DESCRIPTION
## Release

Patch release for the shared run-identity helper installation fix.

## Version synchronization

- CLI package, Claude marketplace, Codex manifest, and all five Codex hook pins: `0.78.3`
- Lockfile workspace metadata and generated Claude plugin artifacts refreshed

## Validation

- Codex activation proof: 5/5
- Release contracts: 36/36
- Frozen install and Claude plugin release contract
- Authenticated Codex live smoke: 5 files passed; unavailable Claude/cross-agent routes explicitly skipped
