### PR TITLE
chore(release): v0.78.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.3",
+      "version": "0.78.4",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.78.3",
+      "version": "0.78.4",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.3 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.4 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.3 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.4 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.3 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.4 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.3 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.4 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.3 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.4 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.3",
+  "plugin_version": "0.78.4",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "5867746f25e91971f921cde9ecf03ccae33e8290b036b6d877a034a0ef7e47ed"
+  "inventory_sha256": "0e01d233d52bb48d13dc681f5ef1a0f1db1b58fcbc4b61b41b537fede666d3a0"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "6a5a2d05459bed4e96e27bd36c473456bedc58ef371423c8537a35790c132aa4"
+      "sha256": "f9bced48a5a60263d29ecc79e1804283eceda76611aab148d6335d2fd4755a6f"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "type": "module"
 }


### PR DESCRIPTION
## Release v0.78.4

Patch release for resumed Codex task protection after Safeword upgrades.

- synchronizes CLI, Claude marketplace, Codex plugin, and pinned hook versions
- regenerates the Claude plugin release identity and inventory
- updates the workspace lockfile version

## Validation

- implementation PR #3099: all required CI checks green
- release suite: 36 passed
- headless Codex activation check: 5 passed
- authenticated Codex live smoke: 8 passed, 9 unrelated routes explicitly skipped
- CLI release contract: consistent