### PR TITLE
chore(release): v0.78.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.4",
+      "version": "0.78.5",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.78.4",
+      "version": "0.78.5",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.4 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.5 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.4 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.5 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.4 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.5 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.4 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.5 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.4 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.5 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.4",
+  "plugin_version": "0.78.5",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "24bbf74d6198ef5a0335934fbf137578bf22b5243bbd88c948ed18e28d308870"
+  "inventory_sha256": "0fb182395398c7b5d10014e1a6a91379e7f33564eac839c0dbfd4a094159b853"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "f9bced48a5a60263d29ecc79e1804283eceda76611aab148d6335d2fd4755a6f"
+      "sha256": "c8bc6695af29a4a219ef12a367ebb4c318a9d06152f0a9efe9652bdedec62bbf"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "type": "module"
 }


### PR DESCRIPTION
## Release v0.78.5

Patch release for the Codex Desktop hook-review ordering correction.

- tells Desktop users to review newly installed hooks under Settings > Hooks before restarting
- keeps terminal TUI users on the supported /hooks review path
- synchronizes CLI, Claude marketplace, Codex plugin, pinned hook, generated identity, and lockfile versions

## Validation

- implementation PR #3104: all hosted CI checks green
- release suite: 36 passed
- headless Codex activation check: 5 passed
- authenticated packaged Codex live smoke: passed
- CLI and plugin release contract: consistent