### PR TITLE
Run requested revisions remotely with least privilege

### DIFF
--- a/.github/workflows/safeword-remote-tests.yml
+++ b/.github/workflows/safeword-remote-tests.yml
@@ -1,0 +1,119 @@
+name: Safeword remote tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Full commit SHA to test
+        required: true
+        type: string
+      lane:
+        description: Safeword test lane
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate request
+        id: validate
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          LANE: ${{ inputs.lane }}
+        run: |
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          [[ "$LANE" == "done" || "$LANE" == "full" ]] || exit 1
+
+      - name: Check out requested revision
+        id: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.target_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify checked-out revision
+        id: verify
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          observed_sha="$(git rev-parse HEAD)"
+          echo "observed_sha=$observed_sha" >> "$GITHUB_OUTPUT"
+          [[ "$observed_sha" == "$TARGET_SHA" ]]
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.2
+        with:
+          bun-version-file: package.json
+
+      - name: Run requested test lane
+        id: tests
+        env:
+          LANE: ${{ inputs.lane }}
+        run: bunx safeword@0.78.3 project test --lane "$LANE" --execution local
+
+      - name: Write remote test result
+        id: report
+        if: always()
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          LANE: ${{ inputs.lane }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          OBSERVED_SHA: ${{ steps.verify.outputs.observed_sha }}
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+        run: |
+          node <<'NODE'
+          const { env } = process;
+          const validSha = /^[0-9a-f]{40}$/.test(env.TARGET_SHA ?? '');
+          const validLane = env.LANE === 'done' || env.LANE === 'full';
+          let status;
+          let rejectedReason = null;
+          if (!validSha || !validLane) {
+            status = 'rejected';
+            rejectedReason = validSha ? 'invalid_lane' : 'invalid_target_sha';
+          } else if (env.VALIDATION_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.CHECKOUT_OUTCOME === 'failure') {
+            status = 'rejected';
+            rejectedReason = 'checkout_unavailable';
+          } else if (env.CHECKOUT_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.VERIFY_OUTCOME === 'failure') {
+            status = 'rejected';
+            rejectedReason = 'head_mismatch';
+          } else if (env.VERIFY_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.TEST_OUTCOME === 'success') {
+            status = 'passed';
+          } else if (env.TEST_OUTCOME === 'failure') {
+            status = 'failed';
+          } else {
+            status = 'incomplete';
+          }
+          const result = {
+            schema_version: 1,
+            status,
+            lane: validLane ? env.LANE : null,
+            requested_sha: validSha ? env.TARGET_SHA : null,
+            observed_sha: env.OBSERVED_SHA || null,
+            rejected_reason: rejectedReason,
+          };
+          require('node:fs').writeFileSync(
+            'safeword-remote-test-result.json',
+            `${JSON.stringify(result)}\n`,
+          );
+          NODE
+
+      - name: Upload remote test result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: safeword-remote-test-result
+          path: safeword-remote-test-result.json
+          if-no-files-found: error

--- a/.project/tickets/BR373S-protect-remote-test-runners/dimensions.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/dimensions.md
@@ -1,0 +1,10 @@
+# Dimensions: Run the requested revision remotely with least privilege
+
+| Dimension | Partitions | Boundary |
+| --- | --- | --- |
+| Requested revision | resolvable full commit SHA; unresolvable full SHA; invalid value | 40 lowercase hexadecimal characters |
+| Test lane | `done`; `full`; unsupported value | closed two-value set |
+| Workflow authority | admitted minimum; write permission; persisted credential; mutable action; Safeword secret | exact closed release contract |
+
+Authority and dependency violations are representative release-admission rows,
+not runtime threat defenses.

--- a/.project/tickets/BR373S-protect-remote-test-runners/impl-plan.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/impl-plan.md
@@ -1,0 +1,170 @@
+# Impl Plan: Run the requested revision remotely with least privilege
+
+**Status:** implemented
+**Planned on:** 2026-08-17
+
+## Approach
+
+Build one manual GitHub Actions workflow and prove its three observable
+boundaries: request validation, checkout/result reporting, and job authority.
+The local harness executes the workflow's real shell steps and replaces only
+the two GitHub-owned boundaries: checkout and the test process. It can therefore
+make checkout succeed at the requested SHA or fail because that SHA is
+unavailable without claiming to emulate the `actions/checkout` implementation.
+
+Build in three slices:
+
+1. Add the candidate workflow as an existing-style schema-catalogued,
+   always-omitted asset, so ordinary install cannot publish it. The single
+   `workflow_dispatch` declares required string inputs with no defaults, passes
+   them through exact `env:` bindings, and validates a lowercase
+   40-hex SHA and the `done | full` lane, checks out that SHA with explicit
+   `fetch-depth: 1` and `persist-credentials: false`, verifies
+   `git rev-parse HEAD` exactly equals
+   the requested SHA, sets up Bun, and invokes
+   `bunx safeword@0.78.3 project test --lane <lane> --execution local`.
+   Every workflow-context value consumed by shell is bound through that step's
+   `env:`; no `run:` body contains a `${{ }}` expression. An `if: always()`
+   report step writes `safeword-remote-test-result.json` and a pinned
+   `actions/upload-artifact` step, also guarded by `if: always()`, publishes it under the fixed artifact name
+   `safeword-remote-test-result`. The JSON has exactly
+   `schema_version`, `status`, `lane`, `requested_sha`, `observed_sha`, and
+   `rejected_reason`. Status is
+   `rejected` when validation or checkout fails, `passed` when tests pass, and
+   `failed` when tests run and fail. A test outcome other than `success` or
+   `failure` is `incomplete`, never a test conclusion. Invalid values are not echoed: their JSON
+   field is `null` and `rejected_reason` is `invalid_target_sha` or
+   `invalid_lane`.
+   Checkout rejection retains the already-valid request, has no test result or
+   substitute revision, and uses `checkout_unavailable`; a HEAD mismatch uses
+   `head_mismatch` and also includes the observed HEAD as diagnostic evidence.
+   A completed result contains the observed workspace HEAD; `status` itself is
+   the test conclusion. Failure before the report
+   artifact is published is an ordinary workflow infrastructure failure, not a
+   fabricated Safeword result. The integration
+   harness observes that invalid input starts neither checkout nor tests, an
+   unavailable SHA starts checkout but not tests, and a temporary source
+   repository with a later main tip exposes a temporary ref at the requested
+   ancestor; a `file://` depth-one clone of that ref is detached and the ref is
+   removed, leaving exactly that one checked-out commit. A second fixture
+   checks out the wrong commit and
+   fails closed before tests, and pass/fail reports the HEAD the test process saw.
+2. Add a small release-time workflow contract evaluator beside template/schema
+   validation, plus the repository's pinned actionlint v1.7.12 check. It accepts
+   exactly one `workflow_dispatch` trigger, required/no-default workflow inputs and their exact `env:` bindings, checkout `ref:` to the
+   requested-SHA input, effective top-level and job permissions of exactly
+   `contents: read`, checkout with a full immutable action SHA and
+   `fetch-depth: 1`, `persist-credentials: false`, and every additional remote action at a full
+   immutable SHA. It rejects job-level reusable workflows, local or Docker
+   actions, any `secrets:` key, and any `secrets.*` expression anywhere in the
+   document. It forbids `continue-on-error`, permits `if:` only as `always()` on
+   the report and upload steps, and pins the result filename, exact JSON keys
+   and rejection-reason enum, fixed artifact name, upload path, upload action
+   SHA, upload condition, and the four-value status enum; rejects `${{ }}` inside
+   every `run:` body; and requires each input or step outcome used by shell to
+   arrive through the same step's `env:`. The report shell recomputes invalid
+   input reasons from those bindings; failed validation steps need no outputs.
+   It does not require a remote runtime dependency merely as a proxy
+   for runtime setup. Table-driven unit tests remove or misbind `ref:` and each
+   input, add job-level write permission and secret references in `env:`,
+   `with:`, and `run:`, add a trigger or `continue-on-error`, change a step
+   condition or result status, inline a workflow expression in `run:`, remove checkout,
+   remove the permissions declaration, persist credentials, and replace each
+   action SHA with a mutable ref. A wiring test reads the real template through
+   its schema entry.
+3. Add Cucumber steps that reuse the integration and contract harnesses, then
+   remove `@wip`. Run the feature lane, focused Vitest tests, schema-registration
+   test, typecheck, and lint. GRDXXA subsequently records pinned actionlint and
+   four exact-byte GitHub runs—a passing `done` lane and failing `full` lane
+   against a non-tip ancestor SHA, unavailable checkout, and invalid-input
+   rejection—before the bytes are admitted for customer installation.
+
+Primary proofs by scenario:
+
+| Scenario behavior | Primary proof |
+| --- | --- |
+| Invalid SHA or lane | Actual validation shell; checkout and test recorders remain untouched; result JSON is `rejected` and omits the invalid value |
+| Unavailable SHA | Checkout boundary returns unavailable; test recorder remains untouched; result JSON is `rejected` with no observed SHA |
+| Checkout/request divergence | Checkout recorder prepares the shallow workspace at a different SHA; the actual verification shell reads HEAD, writes `head_mismatch` with requested and observed SHAs, and starts no tests |
+| Passing, failing, or cancelled exact SHA | A two-commit source repository is shallow-cloned at its non-tip ancestor; actual verification and reporting shells read that HEAD and the test recorder observes the same working tree and a `passed`, `failed`, or `incomplete` result |
+| `done`, `full`, or unsupported lane | Actual runner shell reaches the recording Safeword process with exactly one supported lane, or does not start it |
+| Input wiring and minimum runner contract | Semantic mutation table covers exact input/env/ref bindings and authority; schema-to-template wiring test covers the shipped bytes |
+| GitHub-owned workflow semantics | GRDXXA's four exact-byte runs before release admission |
+
+## Decisions
+
+### Recorded Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Use GitHub-native controls | One workflow with inline validation, exact checkout, pinned actions, and explicit read-only permissions | The agreed non-malicious customer boundary needs no custom trust service or API pre-check |
+| Make outcomes machine-readable | Upload one fixed-name JSON artifact with `rejected`, `passed`, `failed`, or `incomplete`; use a closed rejection-reason enum | Consumers never mistake cancellation for a test conclusion; missing artifact means reporting infrastructure failed |
+| Exercise boundaries, not a GitHub emulator | Read ordered `run:` scripts and their literal `env:` keys from the real YAML; supply dispatch inputs and step outcomes at the boundary; execute the scripts in a real temporary Git workspace | This proves Safeword-owned behavior deterministically while GRDXXA proves GitHub expression, `uses:`, and `if: always()` semantics against exact bytes |
+| Pin runner protocol v1 | Use the current published-release candidate, `safeword@0.78.3`, and change workflow bytes only through FFXB81 | Installed customer workflows need stable, reviewable commands rather than `latest`; npm and its transitive dependency resolution are explicitly outside this non-malicious boundary |
+
+The CLI already defines `project test`, lanes `done | full`, and execution modes
+`local | remote-preferred`; a focused source-contract test anchors the workflow
+argv to that catalogue as a drift warning; GRDXXA's real runs prove the published
+0.78.3 command. Version 0.78.3 is already published, so exact-byte
+admission does not depend on publishing the release under construction. Existing customer copies remain
+pinned and operable; FFXB81 owns any later opt-in workflow upgrade.
+
+Remote runs intentionally use the admitted workflow protocol version rather
+than whichever Safeword happens to be installed on the dispatching laptop or in
+the customer lockfile. That makes equal workflow bytes execute equal runner
+logic; project test commands still come from the checked-out revision.
+
+The workflow is reversible for a customer because it is optional and removable.
+Its published protocol version is a compatibility commitment, not a reversible
+implementation detail. No ADR is needed for this single optional workflow.
+
+BR373S defines result-artifact schema v1. S2TF4J consumes it for dispatch result
+reporting; future schema changes require coordination with that ticket's parser
+and the managed workflow upgrade path.
+
+## Design alignment
+
+| Principle | Consequence | Proof |
+| --- | --- | --- |
+| 1. Structure enforces; instructions suggest | The schema catalogues but omits the candidate until explicit lifecycle code installs admitted bytes | [Focused contract evidence](.project/tickets/BR373S-protect-remote-test-runners/test-definitions.md#rule-remote-runnertbu1r3-repository-code-receives-only-the-admitted-read-only-authority-and-immutable-workflow-dependencies) |
+| 5. Correct and safe; then clear; then simple | One workflow, one small evaluator, and four result states | [Complete RED/GREEN/REFACTOR ledger](.project/tickets/BR373S-protect-remote-test-runners/test-definitions.md) |
+
+The always-omitted generator is an existing schema capability already used for
+explicit-command-only assets. The evaluator belongs beside schema/template
+validation rather than in the runtime execution-choice module.
+
+## Known deviations
+
+- The contract evaluator is implemented and exercised by focused Vitest and
+  Cucumber coverage, but BR373S does not call it from a production admission
+  path. GRDXXA owns exact-byte release admission; dispatch and artifact
+  consumption remain assigned to their companion tickets.
+- Local tests do not emulate GitHub expression, step-condition, or action
+  internals. They read the real YAML's shell and environment declarations, then
+  provide boundary outcomes. GRDXXA proves the remaining GitHub semantics with
+  exact candidate bytes before release admission.
+- Empty-value cases drive the validation shell directly. GitHub rejects truly
+  absent required inputs before creating a run; that platform rejection starts
+  neither checkout nor tests and has no Safeword result because no job existed.
+- The workflow pins the Safeword package version, not every transitive npm
+  artifact. This is acceptable under the explicit non-malicious environment
+  assumption.
+- Result reporting remains in the test job. Isolating it from malicious test
+  code would require a second job, but customer code and maintainers are an
+  explicit non-adversarial boundary for this ticket.
+- Job timeout and concurrency remain customer policy; this ticket changes
+  correctness and repository authority only.
+- The checked-out revision's project test configuration must remain readable by
+  runner protocol v1. A future incompatible project-config format activates the
+  managed workflow upgrade path rather than silently changing installed bytes.
+
+## Doc impact
+
+skip: BR373S remains unavailable until GRDXXA admission and HWZZJ8 public wiring;
+HWZZJ8 owns customer documentation.
+
+## Assessment triggers
+
+- Customer code or repository maintainers become an adversarial boundary.
+- A second workflow version activates FFXB81's upgrade path.
+- GitHub changes dispatch, token permissions, checkout inputs, or action syntax.

--- a/.project/tickets/BR373S-protect-remote-test-runners/spec.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/spec.md
@@ -1,125 +1,93 @@
-# Spec: Protect remote test runners before repository code runs
-
-<!--
-Product-framing spec for a feature ticket. The engineering contract
-(scope / out_of_scope / done_when) lives in ticket.md frontmatter; this
-file holds the *why and who*. The bdd intake flow authors it before
-engineering scope. Fill each section, then delete the
-guidance comments.
--->
+# Spec: Run the requested revision remotely with least privilege
 
 ## Intent
 
-<!-- One or two sentences: what this feature is for and why it matters.
-This is the single source of truth for motivation — ticket.md drops its
-**Why:** line and points here. -->
+Make remote results trustworthy enough for ordinary customer-owned CI: run the
+requested immutable revision with read-only repository access and report which
+revision actually ran.
+
+This feature assumes the customer's repository code and GitHub environment are
+not malicious. It prevents accidental privilege and revision mistakes; it does
+not defend a customer from their own code, maintainers, workflows, or secrets.
 
 ## Intake Brief
 
-<!-- The decide-to-build framing for substantial features (advisory — write
-`skip: <reason>` on any line that doesn't apply). Intent above is the positive
-"why"; this is who asked, the cost of NOT doing it, and how reversible it is.
-If cost-of-inaction is low and reversibility is high, ask whether this is a
-feature at all, or a leaner task. -->
-
-- **Requested by:** <who asked for this — distinct from the persona it serves>
-- **Cost of inaction:** <what changes, breaks, or is lost if we don't build it>
-- **Reversibility:** <how hard to undo once shipped — one-way or two-way door; cross-cutting changes (data model, public API, migration) count as one-way>
+- **Requested by:** Alex, while simplifying optional remote testing for Safeword customers.
+- **Cost of inaction:** Safeword could report a result for a different revision than the one requested, or install a workflow with broader repository authority than its test job needs.
+- **Reversibility:** Customers can disable or remove the optional workflow. A shipped workflow's pinned Safeword command is a compatibility commitment and changes only through the managed workflow-upgrade path.
 
 ## References
 
-<!-- Related tickets, prior art, designs, external docs. Optional. -->
+- [Parent remote-testing contract](../BBNZ68-offload-tests-without-blocking-local-work/spec.md)
+- [GitHub manual workflow dispatch](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)
+- [GitHub Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
+
+## Product Inspiration
+
+### GitHub Actions — make the ordinary secure path sufficient
+
+- **Checked:** 2026-08-17.
+- **Customer-value evidence:** GitHub natively supports manually dispatched workflows, explicit token permissions, immutable commit-SHA action references, and checkout without persisted credentials.
+- **Principle borrowed:** Prefer the platform's small, legible safety controls over a custom trust subsystem.
+- **Boundary not copied:** Organization-wide policy enforcement and hostile-code threat modeling solve a broader problem than this customer-owned, non-malicious CI lane.
+- **Decision:** Keep exact target checkout, `contents: read`, immutable action pins, and `persist-credentials: false`; omit custom pre-check, cryptography, branch-race, and adversarial-code machinery.
 
 ## Personas
 
-<!-- The personas this feature serves, referenced by name or code from
-the configured personas file (e.g., Platform Operator (PLO)). Add new
-personas to that file — don't invent them here. -->
+- Technical Builder (TBU)
 
 ## Surfaces
 
-<!-- Optional: supported product, agent, runtime, protocol, client, or
-deployment contexts this feature affects. Prefer names from the configured
-surfaces file. Use spec-local names only for one-off contexts.
-
 Affected:
-- <surface name>
+
+- GitHub Actions Execution Sandbox
 
 Unaffected:
-- <surface name> — <reason>
 
-Each affected surface should be covered by at least one saved scenario tagged
-`@surface.<slug>` (OpenAI Codex -> `@surface.openai-codex`) or carry
-`skip: <reason>` on the Affected line. -->
+- Agent runtimes — they consume the same Safeword result and add no runner authority.
 
 ## Vocabulary
 
-<!-- Domain terms specific to this feature, consistent with
-the configured glossary file. Optional. -->
+- **Requested revision:** The 40-character lowercase hexadecimal commit SHA selected and recorded by Safeword before dispatch.
+- **Additional remote action:** Any remote `uses:` action other than checkout. None is required by policy, but each one present must use an immutable commit SHA.
+- **Safeword-provided secret:** Any `secrets:` declaration or mapping, or any
+  `secrets.*` expression—including `secrets.GITHUB_TOKEN`—introduced by the
+  bundled workflow. GitHub's automatic token supplied through `contents: read`
+  permissions is platform-provided and needs no secret expression.
 
 ## Jobs To Be Done
 
-<!--
-One persona per JTBD, in the form "When I …, I want …, so I can …". If two
-personas share a motivation, write two JTBDs. The heading id is
-<slug>.<persona-code><n> (e.g., oauth-flow.PLO1). Add as many as the
-feature needs. If there is genuinely no persona-facing job (internal
-plumbing), write `skip: <reason>` here instead.
+### remote-runner.TBU1 — Trust which revision passed remotely
 
-Uncomment and customize:
+**Persona:** Technical Builder (TBU)
 
-### oauth-flow.PLO1 — Rotate credentials without a flag day
+> When I offload tests to my repository's GitHub Actions runner, I want the job
+> to test the exact revision Safeword requested with only read access, so I can
+> use the result without wondering whether CI tested different code or received
+> unnecessary authority.
 
-**Persona:** Platform Operator (PLO)
+#### remote-runner.TBU1.R1 — The remote job tests and reports the exact requested commit
 
-> When I rotate a server's API key, I want the previous key to keep working
-> for a short grace period, so I can roll the change across my fleet without
-> coordinated downtime.
+#### remote-runner.TBU1.R2 — The remote job runs only the requested supported test lane
 
-Numbered Rules — one testable business invariant per Rule, id <jtbd-id>.R<n>,
-stated generally in product language (the invariant a persona relies on), NOT
-implementation ("returns 204" belongs in a scenario's Then). Each define-behavior
-scenario nests under the Rule it proves. Numbered Rules need a `.feature`
-scenario source; the legacy test-definitions.md path stays Acceptance-Criteria-
-only. If a JTBD has no user-observable behavior to enumerate, write
-`skip: <reason>` under it instead.
-
-Legacy alternative (soft-deprecated): a JTBD may instead declare Acceptance
-Criteria — one observable capability per `#### <jtbd-id>.AC<n>`. Still accepted;
-one criteria kind per JTBD, never both.
-
-#### oauth-flow.PLO1.R1 — A rotated key's predecessor keeps authenticating for a bounded grace window
-
-#### oauth-flow.PLO1.R2 — Every currently-issued key is visible to the operator as live, grace, or expired
--->
+#### remote-runner.TBU1.R3 — Repository code receives only the admitted read-only authority and immutable workflow dependencies
 
 ## Rave Moment
 
-<!-- Optional, and only for the highest persona-facing surface in the tree (the
-epic if there is one, else this feature). Child features under an epic that
-already named one inherit it — skip here; internal/plumbing work skips entirely.
-Advisory; never blocks intake exit. The one moment a persona would tell a peer
-about: name the moment, the expectation it beats, and the one sentence they'd
-repeat. Aim for awe, not "fine." If nothing clears the expectation bar, write
-`skip: table-stakes`.
-
-### <slug> — <the moment in a few words>
-
-- **Moment:** <the specific beat they'd screenshot or recount>
-- **Beats:** <the dread / status-quo pain / competitor clunk it's measured against>
-- **They'd say:** "<the one repeatable, status-conferring sentence>"
--->
+skip: inherited from the parent epic.
 
 ## Outcomes
 
-<!-- Observable results that tell us the JTBDs are satisfied — the product
-counterpart to ticket.md's done_when. -->
+- A passing or failing remote result identifies the exact full commit SHA that was checked out.
+- The job runs the requested `done` or `full` Safeword test lane and rejects any other lane before checkout.
+- The workflow grants only `contents: read`, does not persist checkout credentials, and receives no Safeword-provided secret.
 
 ## Open Questions
 
-<!-- Unresolved questions surfaced during intake — the spec's running list of
-what we don't know yet (the equivalent of Example Mapping's red "question"
-cards). Add one per line as they come up; before advancing to define-behavior,
-resolve each (answer it, then delete the line) or record `defer: <reason>` for
-a deliberate punt. A long unresolved list means intake isn't done — keep
-converging. Delete this comment when you add real questions. -->
+None.
+
+## Boundary
+
+GRDXXA proves the released workflow is the admitted artifact. HWZZJ8 proves that
+same artifact is installed without replacing customer-owned bytes. This ticket
+proves only the admitted workflow's revision, lane, and job-authority behavior.

--- a/.project/tickets/BR373S-protect-remote-test-runners/test-definitions.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/test-definitions.md
@@ -1,0 +1,69 @@
+# Test Definitions: Run the requested revision remotely with least privilege
+
+Feature source: `packages/cli/features/run-requested-revision-remotely.feature`
+
+This file is the RED/GREEN/REFACTOR ledger.
+
+## Rule: remote-runner.TBU1.R1 — The remote job tests and reports the exact requested commit
+
+### Scenario Outline: The requested commit is reported for a passing or failing test
+
+- [x] RED 4f2c0656e
+- [x] GREEN de51cadc7
+- [x] REFACTOR 85c32e375
+
+### Scenario Outline: An invalid commit value starts no repository test
+
+- [x] RED 8b46efc07
+- [x] GREEN 5f7df0aae
+- [x] REFACTOR skip: the invalid-value table shares one real validation and reporting path without duplication
+
+### Scenario: An unavailable requested commit is never replaced by another revision
+
+- [x] RED 9be579aa5
+- [x] GREEN 4a32f7884
+- [x] REFACTOR skip: the unavailable checkout path already reuses the workflow's validation and reporting scripts directly
+
+### Scenario: A checkout that lands on another commit is rejected before tests
+
+- [x] RED 885075cfc
+- [x] GREEN c44d1f079
+- [x] REFACTOR e6780bd37
+
+### Scenario: Cancellation is not reported as a request rejection or test conclusion
+
+- [x] RED 885075cfc
+- [x] GREEN b7555495f
+- [x] REFACTOR e6780bd37
+
+## Rule: remote-runner.TBU1.R2 — The remote job runs only the requested supported test lane
+
+### Scenario Outline: A supported lane runs its matching Safeword test plan
+
+- [x] RED 517c3f3d6
+- [x] GREEN 58e0e34e6
+- [x] REFACTOR skip: the green change already extracted one focused test-command recorder and left no second abstraction to justify
+
+### Scenario Outline: An unsupported lane starts no repository test
+
+- [x] RED 511fdb58a
+- [x] GREEN 95d872710
+- [x] REFACTOR skip: invalid revisions and unsupported lanes now share one real rejected-input execution path
+
+## Rule: remote-runner.TBU1.R3 — Repository code receives only the admitted read-only authority and immutable workflow dependencies
+
+### Scenario: The bundled workflow is accepted under the minimum runner contract
+
+- [x] RED 9a0a300be
+- [x] GREEN 9cc75716c
+- [x] REFACTOR skip: the evaluator is already split only along the four contract boundaries it enforces
+
+### Scenario Outline: A workflow outside the minimum authority contract is rejected
+
+- [x] RED 49c40316d
+- [x] GREEN 2fdacafa5
+- [x] REFACTOR skip: all seven mutations exercise the same evaluator without scenario-specific policy branches
+
+## Cross-scenario refactor
+
+- [x] cross-scenario e6780bd37

--- a/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
@@ -3,7 +3,7 @@ id: BR373S
 slug: protect-remote-test-runners
 type: feature
 phase: verify
-status: in_progress
+status: done
 phase_anchors:
   - define-behavior: .project/tickets/BR373S-protect-remote-test-runners/spec.md
   - scenario-gate: packages/cli/features/run-requested-revision-remotely.feature
@@ -24,7 +24,7 @@ done_when:
   - Workflow permissions are exactly contents read, actions are pinned, checkout credentials are not persisted, and Safeword supplies no secret
 parent: BBNZ68
 created: 2026-08-09T21:20:39.486Z
-last_modified: 2026-08-18T07:17:53-07:00
+last_modified: 2026-08-18T08:22:00-07:00
 ---
 
 # Run the requested revision remotely with least privilege
@@ -53,3 +53,4 @@ last_modified: 2026-08-18T07:17:53-07:00
 - 2026-08-17T22:33:00-07:00 Reconciled implementation with the approved plan after independent quality review. The workflow and evaluator match the three Rules; release admission remains with GRDXXA, and adversarial customer-code isolation remains explicitly out of scope. Advanced to verification.
 - 2026-08-17T23:01:40-07:00 Verification recorded: focused BR373S tests, acceptance scenarios, actionlint, build, lint, and ticket-scoped audit checks pass. Completion remains blocked by the umbrella branch's broader PR scope, 10 repository-wide Vitest failures, unfinished repository-wide BDD features, and 11 principle-trace errors in sibling active tickets.
 - 2026-08-18T07:17:53-07:00 Isolated BR373S onto current main in its own branch/worktree. Fixed the acceptance harness to resolve the workflow template from its module rather than the caller's working directory. Focused tests, full tests, full acceptance, builds, lint, typecheck, actionlint, audit, and PR scope are green.
+- 2026-08-18T08:22:00-07:00 Done: verification evidence is complete and the isolated PR is ready for its merge gate.

--- a/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
@@ -9,7 +9,7 @@ phase_anchors:
   - scenario-gate: packages/cli/features/run-requested-revision-remotely.feature
   - plan-implementation: .project/tickets/BR373S-protect-remote-test-runners/impl-plan.md
   - implement: packages/cli/src/test-execution/remote-workflow-contract.ts
-  - verify: .project/tickets/BR373S-protect-remote-test-runners/verify.md
+  - verify: .project/tickets/BR373S-protect-remote-test-runners/test-definitions.md
 scope:
   - Exact requested-commit checkout and reporting
   - Validation of the requested done or full test lane

--- a/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
@@ -2,23 +2,28 @@
 id: BR373S
 slug: protect-remote-test-runners
 type: feature
-phase: intake
+phase: verify
 status: in_progress
 scope:
-  - Trusted workflow pre-checks, least privilege, and authoritative remote result evidence
+  - Exact requested-commit checkout and reporting
+  - Validation of the requested done or full test lane
+  - Read-only workflow permissions, immutable action pins, and non-persisted checkout credentials
 out_of_scope:
   - CLI preference, installation reconciliation, and dispatch transport
-depends_on: [X2Z8MN]
+  - Defending customers from their own code, maintainers, workflows, or secrets
+  - Branch-tip revalidation, workflow self-authentication, custom cryptography, and pre-check APIs
 done_when:
-  - The managed runner validates trusted inputs before repository code and exposes no Safeword-provided secret
+  - The job checks out and reports the exact full commit SHA requested by Safeword
+  - Only the requested done or full lane reaches checkout and execution
+  - Workflow permissions are exactly contents read, actions are pinned, checkout credentials are not persisted, and Safeword supplies no secret
 parent: BBNZ68
 created: 2026-08-09T21:20:39.486Z
-last_modified: 2026-08-09T21:20:59Z
+last_modified: 2026-08-18T07:17:53-07:00
 ---
 
-# Protect remote test runners before repository code runs
+# Run the requested revision remotely with least privilege
 
-**Goal:** Ensure the managed GitHub Actions runner validates trusted inputs, uses least privilege, and reports authoritative remote results.
+**Goal:** Run the requested immutable revision in the customer's GitHub Actions environment with only the authority ordinary tests need.
 
 **See:** [spec.md](./spec.md) for personas, jobs-to-be-done, and outcomes.
 
@@ -26,3 +31,19 @@ last_modified: 2026-08-09T21:20:59Z
 
 - 2026-08-09T21:20:39.486Z Started: Created ticket BR373S
 - 2026-08-09T21:20:59Z Scoped: Owns the remote workflow security boundary required by dispatch and result evidence.
+- 2026-08-17T00:00:00-07:00 Intake reframed: assume customer code and its GitHub environment are non-malicious; retain only exact-revision correctness and least privilege. Awaiting confirmation of the narrowed job before rewriting Rules and engineering scope.
+- 2026-08-17T00:00:00-07:00 Job, GitHub-native inspiration, and three Rules confirmed: exact revision, supported lane, and read-only execution. Proposed the corresponding minimal engineering contract and removed the obsolete dependency on the workflow-lifecycle epic.
+- 2026-08-17T00:00:00-07:00 Engineering scope confirmed. Advanced to behavior definition with the non-malicious customer-code assumption explicit and adversarial runner machinery excluded.
+- 2026-08-17T00:00:00-07:00 Behavior set confirmed: six representative scenarios cover exact SHA success/rejection, both supported lanes/unsupported rejection, and minimum/broader workflow authority. Advanced to scenario quality review.
+- 2026-08-17T00:00:00-07:00 Scenario gate approved by an independent cross-agent Claude review after tightening false-green rejection, exact revision boundaries, lane selection, and the symmetric minimum-authority contract. No build-only kill risk remains; advanced to implementation planning.
+- 2026-08-17T00:00:00-07:00 Plan review requested two corrections: prove unavailable checkout without a false-green structural assertion, and distinguish rejected requests from completed test results. Revised the plan around a checkout boundary recorder and explicit rejected/passed/failed summaries; removed the unnecessary requirement that a workflow contain a remote runtime dependency.
+- 2026-08-17T00:00:00-07:00 A second plan review found the exact-revision proof could echo its own requested input. Corrected it to read and compare `git rev-parse HEAD` in a real temporary Git workspace, including a divergent-HEAD fail-closed case; clarified the harness boundary, protocol-version choice, and zero-secret rule.
+- 2026-08-17T00:00:00-07:00 A third plan review found checkout `ref:` and input-expression wiring were not yet statically pinned. Extended the small semantic contract to require exact input/env/ref bindings and effective job permissions, made divergent HEAD explicitly rejected, and required non-tip SHAs in release admission runs.
+- 2026-08-17T00:00:00-07:00 A fourth plan review found inline workflow expressions could make the local harness rewrite rather than execute real shell. Required all context through exact step `env:` bindings and forbade expressions in `run:`; added an explicit runner-error state and four focused live admission cases. Confirmed `safeword@0.78.3` is already published, removing the alleged publish/admission loop.
+- 2026-08-17T00:00:00-07:00 A fifth plan review exposed two final contracts: checkout workspace depth and the machine-readable result channel. Fixed checkout at one commit, replaced prose/extra error state with one closed JSON artifact (`rejected | passed | failed`), made workflow inputs required without defaults, and kept infrastructure failure as absence of a Safeword result.
+- 2026-08-17T00:00:00-07:00 A sixth plan review found failed jobs could skip artifact upload and permissive step controls could bypass rejection. Required `always()` on report/upload, prohibited every other condition and `continue-on-error`, fixed the trigger, simplified JSON to one status plus a closed rejection-reason enum, and made the local non-tip shallow fixture match checkout.
+- 2026-08-17T00:00:00-07:00 A seventh plan review found cancellation had no honest result state. Added only `incomplete`, specified a buildable shallow non-tip fixture and validation-reason recomputation, and assigned the artifact schema to BR373S with S2TF4J as its consumer.
+- 2026-08-17T00:00:00-07:00 Implementation plan approved by independent cross-agent Claude/Opus review. Recorded the plan stamp and advanced into outside-in TDD.
+- 2026-08-17T22:33:00-07:00 Reconciled implementation with the approved plan after independent quality review. The workflow and evaluator match the three Rules; release admission remains with GRDXXA, and adversarial customer-code isolation remains explicitly out of scope. Advanced to verification.
+- 2026-08-17T23:01:40-07:00 Verification recorded: focused BR373S tests, acceptance scenarios, actionlint, build, lint, and ticket-scoped audit checks pass. Completion remains blocked by the umbrella branch's broader PR scope, 10 repository-wide Vitest failures, unfinished repository-wide BDD features, and 11 principle-trace errors in sibling active tickets.
+- 2026-08-18T07:17:53-07:00 Isolated BR373S onto current main in its own branch/worktree. Fixed the acceptance harness to resolve the workflow template from its module rather than the caller's working directory. Focused tests, full tests, full acceptance, builds, lint, typecheck, actionlint, audit, and PR scope are green.

--- a/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/ticket.md
@@ -4,6 +4,12 @@ slug: protect-remote-test-runners
 type: feature
 phase: verify
 status: in_progress
+phase_anchors:
+  - define-behavior: .project/tickets/BR373S-protect-remote-test-runners/spec.md
+  - scenario-gate: packages/cli/features/run-requested-revision-remotely.feature
+  - plan-implementation: .project/tickets/BR373S-protect-remote-test-runners/impl-plan.md
+  - implement: packages/cli/src/test-execution/remote-workflow-contract.ts
+  - verify: .project/tickets/BR373S-protect-remote-test-runners/verify.md
 scope:
   - Exact requested-commit checkout and reporting
   - Validation of the requested done or full test lane

--- a/.project/tickets/BR373S-protect-remote-test-runners/verify.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/verify.md
@@ -30,3 +30,4 @@ Audit passed — BR373S's diff-scoped architecture, config, learning, test-quali
 - Full tests: retro-relay 185 passed / 1 skipped; CLI 8,204 passed / 7 skipped.
 - Full acceptance: 1,484 passed / 3 skipped; 68,189 steps passed / 4 skipped.
 - `actionlint`, ESLint, Gherkin lint, TypeScript typecheck, and both package builds pass.
+- Historical RED/GREEN/REFACTOR hashes in the ledger remain on the original umbrella branch; importing that ancestry would reintroduce 67 unrelated commits, so this isolated branch relies on the fully green executable evidence above.

--- a/.project/tickets/BR373S-protect-remote-test-runners/verify.md
+++ b/.project/tickets/BR373S-protect-remote-test-runners/verify.md
@@ -1,0 +1,32 @@
+# Verification: Run the requested revision remotely with least privilege
+
+## Verify Checklist
+
+**Test Suite:** ✓ 8389/8389 tests pass
+**Gherkin:** ✅ Acceptance lane passes
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 28 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** BBNZ68 (siblings: 1/3 done)
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — not persona-facing
+**Surface Evidence:** ✅ 1/1 affected surfaces have recorded proof
+**Evidence limits:** ✅ None
+
+Audit passed — BR373S's diff-scoped architecture, config, learning, test-quality, documentation, principle, and domain checks pass.
+
+## Surface Evidence
+
+| Affected surface | Proof command | Result |
+| --- | --- | --- |
+| GitHub Actions Execution Sandbox | Focused contract/BDD lanes plus full Vitest and acceptance lanes | ✅ 30/30 focused contract tests, 29/29 focused scenarios, 8,389 full-suite tests, and 1,484/1,484 executed acceptance scenarios pass |
+
+## Verification Evidence
+
+- Focused contract tests: 30 passed.
+- Focused BR373S acceptance: 29 scenarios and 1,325 steps passed from the repository root.
+- Full tests: retro-relay 185 passed / 1 skipped; CLI 8,204 passed / 7 skipped.
+- Full acceptance: 1,484 passed / 3 skipped; 68,189 steps passed / 4 skipped.
+- `actionlint`, ESLint, Gherkin lint, TypeScript typecheck, and both package builds pass.

--- a/packages/cli/features/run-requested-revision-remotely.feature
+++ b/packages/cli/features/run-requested-revision-remotely.feature
@@ -1,0 +1,114 @@
+Feature: Run the requested revision remotely with least privilege
+  Customer-owned GitHub Actions should run the requested Safeword test lane
+  against the requested immutable commit without unnecessary repository authority.
+  A deterministic recording runner resolves the admitted workflow job and observes
+  checkout inputs, repository process starts, and result evidence. A semantic workflow
+  contract evaluator checks the bundled workflow's authority and dependencies.
+
+  @remote-runner.TBU1.R1 @surface.github-actions-execution-sandbox
+  Rule: remote-runner.TBU1.R1 — The remote job tests and reports the exact requested commit
+
+    Scenario Outline: The requested commit is reported for a passing or failing test
+      Given a remote test request names a valid full commit SHA that is not a branch tip
+      When the remote test job runs a test plan that <behavior>
+      Then the requested SHA, observed checkout ref, and reported revision are identical
+      And the reported conclusion is <conclusion>
+
+      Examples:
+        | behavior | conclusion |
+        | passes   | passed     |
+        | fails    | failed     |
+
+    @rejection
+    Scenario Outline: An invalid commit value starts no repository test
+      Given a remote test request names <invalid-revision>
+      When the remote test job evaluates the request
+      Then no repository checkout or test command runs
+      And the job fails without reporting a test result
+
+      Examples:
+        | invalid-revision                              |
+        | the branch name `main`                        |
+        | the tag name `v1.2.3`                         |
+        | the abbreviated SHA `0123456`                 |
+        | exactly 39 lowercase hexadecimal characters  |
+        | exactly 41 lowercase hexadecimal characters  |
+        | exactly 40 uppercase hexadecimal characters  |
+        | 39 lowercase hexadecimal characters plus `g` |
+        | no revision                                   |
+
+    @rejection
+    Scenario: An unavailable requested commit is never replaced by another revision
+      Given a remote test request names a full commit SHA unavailable to checkout
+      When the remote test job attempts the request
+      Then the job fails without running tests or reporting a substitute revision
+
+    Scenario: A checkout that lands on another commit is rejected before tests
+      Given checkout lands on a different commit than the valid requested SHA
+      When the remote test job verifies the checkout
+      Then no repository test command runs
+      And the result rejects the checkout with both commit SHAs
+
+    Scenario Outline: Cancellation is not reported as a request rejection or test conclusion
+      Given a valid remote test request is cancelled during <phase>
+      When the remote test job reports the interrupted request
+      Then the reported conclusion is incomplete
+      And the result has no rejection reason
+
+      Examples:
+        | phase                 |
+        | validation            |
+        | checkout              |
+        | revision verification |
+
+  @remote-runner.TBU1.R2 @surface.github-actions-execution-sandbox
+  Rule: remote-runner.TBU1.R2 — The remote job runs only the requested supported test lane
+
+    Scenario Outline: A supported lane runs its matching Safeword test plan
+      Given a remote test request selects the <lane> lane
+      When the remote test job executes the request
+      Then the <lane> Safeword test-plan lane runs
+      And no other Safeword test-plan lane runs
+
+      Examples:
+        | lane |
+        | done |
+        | full |
+
+    @rejection
+    Scenario Outline: An unsupported lane starts no repository test
+      Given a remote test request selects the lane value "<lane>"
+      When the remote test job evaluates the request
+      Then no repository checkout or test command runs
+      And the job fails without reporting a test result
+
+      Examples:
+        | lane         |
+        | smoke        |
+        | DONE         |
+        |              |
+        | done --watch |
+
+  @remote-runner.TBU1.R3 @surface.github-actions-execution-sandbox
+  Rule: remote-runner.TBU1.R3 — Repository code receives only the admitted read-only authority and immutable workflow dependencies
+
+    Scenario: The bundled workflow is accepted under the minimum runner contract
+      Given the bundled managed remote test workflow candidate
+      When the runner contract evaluates the candidate
+      Then the candidate is accepted under the minimum runner contract
+
+    @rejection
+    Scenario Outline: A workflow outside the minimum authority contract is rejected
+      Given a candidate remote test workflow <violation>
+      When the runner contract evaluates the candidate
+      Then the candidate is rejected as outside the minimum runner contract
+
+      Examples:
+        | violation |
+        | declares no token permissions |
+        | grants repository write permission |
+        | omits checkout |
+        | persists the checkout credential |
+        | references checkout by a mutable version |
+        | references an additional remote action by a mutable version |
+        | passes a Safeword-provided secret to the job |

--- a/packages/cli/features/steps/run-requested-revision-remotely.steps.ts
+++ b/packages/cli/features/steps/run-requested-revision-remotely.steps.ts
@@ -1,0 +1,264 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+import { After, Given, Then, When } from '@cucumber/cucumber';
+
+import type { SafewordWorld } from '../../../../steps/world.js';
+import { evaluateRemoteTestWorkflow } from '../../src/test-execution/remote-workflow-contract.js';
+import {
+  evaluateCancelledRequest,
+  evaluateInvalidRevision,
+  evaluateUnavailableRevision,
+  evaluateUnsupportedLane,
+  type RejectedRequestObservation,
+  REMOTE_WORKFLOW_TEMPLATE,
+  RemoteWorkflowHarness,
+  type RemoteWorkflowObservation,
+} from './support/remote-workflow-harness.js';
+
+interface RemoteRevisionWorld extends SafewordWorld {
+  contractCandidate?: string;
+  contractResult?: { accepted: boolean; violations: string[] };
+  requestedSha?: string;
+  invalidRevision?: string;
+  rejection?: Omit<RejectedRequestObservation, 'result'> & {
+    result?: RejectedRequestObservation['result'];
+  };
+  unavailableSha?: string;
+  unavailable?: RejectedRequestObservation;
+  harness?: RemoteWorkflowHarness;
+  observation?: RemoteWorkflowObservation;
+  selectedLane?: string;
+  executedLanes?: string[];
+  divergent?: RejectedRequestObservation;
+  reportedResult?: RemoteWorkflowObservation['result'];
+  cancelledPhase?: 'validation' | 'checkout' | 'revision verification';
+}
+
+function bundledWorkflow(): string {
+  return readFileSync(REMOTE_WORKFLOW_TEMPLATE, 'utf8');
+}
+
+function mutateWorkflow(source: string, violation: string): string {
+  switch (violation) {
+    case 'declares no token permissions': {
+      return source.replace(/permissions:\n {2}contents: read\n\n/u, '');
+    }
+    case 'grants repository write permission': {
+      return source.replace('contents: read', 'contents: write');
+    }
+    case 'omits checkout': {
+      return source.replace(
+        / {6}- name: Check out requested revision[\s\S]*?(?= {6}- name: Verify)/u,
+        '',
+      );
+    }
+    case 'persists the checkout credential': {
+      return source.replace('persist-credentials: false', 'persist-credentials: true');
+    }
+    case 'references checkout by a mutable version': {
+      return source.replace(/actions\/checkout@[0-9a-f]{40}/u, 'actions/checkout@v7');
+    }
+    case 'references an additional remote action by a mutable version': {
+      return source.replace(/oven-sh\/setup-bun@[0-9a-f]{40}/u, 'oven-sh/setup-bun@v2');
+    }
+    case 'passes a Safeword-provided secret to the job': {
+      return source.replace(
+        '    runs-on: ubuntu-latest',
+        '    runs-on: ubuntu-latest\n    env:\n      SAFEWORD_TOKEN: ${{ secrets.SAFEWORD_TOKEN }}',
+      );
+    }
+    default: {
+      throw new Error(`Unknown workflow contract violation: ${violation}`);
+    }
+  }
+}
+
+Given('the bundled managed remote test workflow candidate', function (this: RemoteRevisionWorld) {
+  this.contractCandidate = bundledWorkflow();
+});
+
+Given(/^a candidate remote test workflow (.+)$/, function (this: RemoteRevisionWorld, violation) {
+  this.contractCandidate = mutateWorkflow(bundledWorkflow(), violation);
+});
+
+Given(
+  /^a remote test request selects the (done|full) lane$/,
+  function (this: RemoteRevisionWorld, lane: string) {
+    this.selectedLane = lane;
+    this.harness = new RemoteWorkflowHarness();
+  },
+);
+
+Given(
+  'checkout lands on a different commit than the valid requested SHA',
+  function (this: RemoteRevisionWorld) {
+    this.harness = new RemoteWorkflowHarness();
+  },
+);
+
+Given(
+  /^a valid remote test request is cancelled during (validation|checkout|revision verification)$/,
+  function (this: RemoteRevisionWorld, phase: 'validation' | 'checkout' | 'revision verification') {
+    this.cancelledPhase = phase;
+  },
+);
+
+Given(
+  'a remote test request selects the lane value {string}',
+  function (this: RemoteRevisionWorld, lane: string) {
+    this.selectedLane = lane;
+  },
+);
+
+Given(
+  'a remote test request names a full commit SHA unavailable to checkout',
+  function (this: RemoteRevisionWorld) {
+    this.unavailableSha = 'fedcba9876543210fedcba9876543210fedcba98';
+  },
+);
+
+Given(
+  /^a remote test request names (?!a valid full commit SHA|a full commit SHA unavailable)(.+)$/,
+  function (this: RemoteRevisionWorld, invalidRevision: string) {
+    this.invalidRevision = invalidRevision;
+  },
+);
+
+After(function (this: RemoteRevisionWorld) {
+  this.harness?.dispose();
+});
+
+Given(
+  'a remote test request names a valid full commit SHA that is not a branch tip',
+  function (this: RemoteRevisionWorld) {
+    this.harness = new RemoteWorkflowHarness();
+    this.requestedSha = this.harness.requestedSha;
+  },
+);
+
+When(
+  'the remote test job runs a test plan that {word}',
+  function (this: RemoteRevisionWorld, behavior: string) {
+    assert.ok(behavior === 'passes' || behavior === 'fails');
+    assert.ok(this.harness);
+    this.observation = this.harness.run(behavior);
+  },
+);
+
+When('the remote test job evaluates the request', function (this: RemoteRevisionWorld) {
+  if (this.invalidRevision !== undefined) {
+    this.rejection = evaluateInvalidRevision(this.invalidRevision);
+    return;
+  }
+  assert.notEqual(this.selectedLane, undefined);
+  this.rejection = evaluateUnsupportedLane(this.selectedLane ?? '');
+});
+
+When('the remote test job attempts the request', function (this: RemoteRevisionWorld) {
+  assert.ok(this.unavailableSha);
+  this.unavailable = evaluateUnavailableRevision(this.unavailableSha);
+});
+
+When('the remote test job verifies the checkout', function (this: RemoteRevisionWorld) {
+  assert.ok(this.harness);
+  this.divergent = this.harness.runDivergentCheckout();
+});
+
+When('the remote test job reports the interrupted request', function (this: RemoteRevisionWorld) {
+  assert.ok(this.cancelledPhase);
+  this.reportedResult = evaluateCancelledRequest(this.cancelledPhase);
+});
+
+When('the remote test job executes the request', function (this: RemoteRevisionWorld) {
+  assert.ok(this.selectedLane);
+  assert.ok(this.selectedLane === 'done' || this.selectedLane === 'full');
+  assert.ok(this.harness);
+  this.executedLanes = this.harness.run('passes', this.selectedLane).executedLanes;
+});
+
+When('the runner contract evaluates the candidate', function (this: RemoteRevisionWorld) {
+  assert.ok(this.contractCandidate);
+  this.contractResult = evaluateRemoteTestWorkflow(this.contractCandidate);
+});
+
+Then(
+  'the requested SHA, observed checkout ref, and reported revision are identical',
+  function (this: RemoteRevisionWorld) {
+    assert.ok(this.observation);
+    assert.equal(this.observation.requestedSha, this.requestedSha);
+    assert.equal(this.observation.checkoutRef, this.requestedSha);
+    assert.equal(this.observation.result.observed_sha, this.requestedSha);
+  },
+);
+
+Then('no repository checkout or test command runs', function (this: RemoteRevisionWorld) {
+  assert.equal(this.rejection?.checkoutCount, 0);
+  assert.equal(this.rejection?.testCount, 0);
+});
+
+Then('the job fails without reporting a test result', function (this: RemoteRevisionWorld) {
+  assert.ok(this.rejection?.result);
+  assert.equal(this.rejection.result.status, 'rejected');
+  assert.ok(!this.rejection.result.observed_sha);
+});
+
+Then(
+  'the job fails without running tests or reporting a substitute revision',
+  function (this: RemoteRevisionWorld) {
+    assert.equal(this.unavailable?.checkoutCount, 1);
+    assert.equal(this.unavailable?.testCount, 0);
+    assert.equal(this.unavailable?.result.status, 'rejected');
+    assert.equal(this.unavailable?.result.rejected_reason, 'checkout_unavailable');
+    assert.equal(this.unavailable?.result.requested_sha, this.unavailableSha);
+    assert.ok(!this.unavailable?.result.observed_sha);
+  },
+);
+
+Then('the reported conclusion is {word}', function (this: RemoteRevisionWorld, conclusion: string) {
+  assert.equal(this.observation?.result.status ?? this.reportedResult?.status, conclusion);
+});
+
+Then('no repository test command runs', function (this: RemoteRevisionWorld) {
+  assert.equal(this.divergent?.testCount, 0);
+});
+
+Then('the result rejects the checkout with both commit SHAs', function (this: RemoteRevisionWorld) {
+  const result = this.divergent?.result;
+  assert.equal(result?.status, 'rejected');
+  assert.equal(result?.rejected_reason, 'head_mismatch');
+  assert.ok(result?.requested_sha);
+  assert.ok(result.observed_sha);
+  assert.notEqual(result.requested_sha, result.observed_sha);
+});
+
+Then('the result has no rejection reason', function (this: RemoteRevisionWorld) {
+  assert.ok(this.reportedResult);
+  assert.ok(!this.reportedResult.rejected_reason);
+});
+
+Then(
+  /^the (done|full) Safeword test-plan lane runs$/,
+  function (this: RemoteRevisionWorld, lane: string) {
+    assert.deepEqual(this.executedLanes, [lane]);
+  },
+);
+
+Then('no other Safeword test-plan lane runs', function (this: RemoteRevisionWorld) {
+  assert.deepEqual(this.executedLanes, [this.selectedLane]);
+});
+
+Then(
+  'the candidate is accepted under the minimum runner contract',
+  function (this: RemoteRevisionWorld) {
+    assert.deepEqual(this.contractResult, { accepted: true, violations: [] });
+  },
+);
+
+Then(
+  'the candidate is rejected as outside the minimum runner contract',
+  function (this: RemoteRevisionWorld) {
+    assert.equal(this.contractResult?.accepted, false);
+    assert.ok(this.contractResult.violations.length > 0);
+  },
+);

--- a/packages/cli/features/steps/support/remote-workflow-harness.ts
+++ b/packages/cli/features/steps/support/remote-workflow-harness.ts
@@ -1,0 +1,393 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodeOs from 'node:os';
+import nodePath from 'node:path';
+
+import { parse } from 'yaml';
+
+interface WorkflowStep {
+  id?: string;
+  run?: string;
+  uses?: string;
+}
+
+interface WorkflowDocument {
+  jobs?: { test?: { steps?: WorkflowStep[] } };
+}
+
+export interface RemoteWorkflowResult {
+  schema_version: 1;
+  status: 'rejected' | 'passed' | 'failed' | 'incomplete';
+  lane: 'done' | 'full' | null;
+  requested_sha: string | null;
+  observed_sha: string | null;
+  rejected_reason:
+    'invalid_target_sha' | 'invalid_lane' | 'checkout_unavailable' | 'head_mismatch' | null;
+}
+
+export interface RemoteWorkflowObservation {
+  requestedSha: string;
+  checkoutRef: string;
+  executedLanes: string[];
+  result: RemoteWorkflowResult;
+}
+
+export interface RejectedRequestObservation {
+  checkoutCount: number;
+  testCount: number;
+  result: RemoteWorkflowResult;
+}
+
+export const REMOTE_WORKFLOW_TEMPLATE = nodePath.resolve(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'templates',
+  'workflows',
+  'remote-tests.yml',
+);
+
+function git(cwd: string, ...arguments_: string[]): string {
+  return execFileSync('git', arguments_, { cwd, encoding: 'utf8' }).trim();
+}
+
+function workflowScripts(): Map<string, string> {
+  return new Map(
+    workflowSteps()
+      .filter((step): step is WorkflowStep & { id: string; run: string } =>
+        Boolean(step.id && step.run),
+      )
+      .map(step => [step.id, step.run]),
+  );
+}
+
+function workflowSteps(): WorkflowStep[] {
+  const workflow = parse(readFileSync(REMOTE_WORKFLOW_TEMPLATE, 'utf8')) as WorkflowDocument;
+  return workflow.jobs?.test?.steps ?? [];
+}
+
+function runShell(script: string, cwd: string, env: NodeJS.ProcessEnv): number {
+  return (
+    spawnSync('/bin/bash', ['-e', '-c', script], {
+      cwd,
+      env: { ...process.env, ...env },
+      encoding: 'utf8',
+    }).status ?? 1
+  );
+}
+
+function createNonTipCheckout(root: string): {
+  workspace: string;
+  divergentWorkspace: string;
+  requestedSha: string;
+} {
+  const source = nodePath.join(root, 'source');
+  const workspace = nodePath.join(root, 'workspace');
+  const divergentWorkspace = nodePath.join(root, 'divergent-workspace');
+  mkdirSync(source);
+  git(source, 'init', '-q', '-b', 'main');
+  git(source, 'config', 'user.email', 'remote-tests@example.com');
+  git(source, 'config', 'user.name', 'Remote tests');
+  writeFileSync(nodePath.join(source, 'fixture.txt'), 'requested\n');
+  git(source, 'add', 'fixture.txt');
+  git(source, 'commit', '-q', '-m', 'requested');
+  const requestedSha = git(source, 'rev-parse', 'HEAD');
+  writeFileSync(nodePath.join(source, 'fixture.txt'), 'later tip\n');
+  git(source, 'commit', '-q', '-am', 'later tip');
+  execFileSync('git', ['clone', '-q', '--depth', '1', `file://${source}`, divergentWorkspace], {
+    encoding: 'utf8',
+  });
+  git(source, 'branch', 'requested-fixture', requestedSha);
+  execFileSync(
+    'git',
+    ['clone', '-q', '--depth', '1', '--branch', 'requested-fixture', `file://${source}`, workspace],
+    { encoding: 'utf8' },
+  );
+  git(workspace, 'checkout', '-q', '--detach');
+  git(workspace, 'branch', '-D', 'requested-fixture');
+  return { workspace, divergentWorkspace, requestedSha };
+}
+
+function runTestLane(
+  root: string,
+  workspace: string,
+  script: string,
+  behavior: 'passes' | 'fails',
+  lane: 'done' | 'full',
+): { status: number; executedLanes: string[] } {
+  const binaryDirectory = nodePath.join(root, 'bin');
+  const testArguments = nodePath.join(root, 'test-arguments');
+  mkdirSync(binaryDirectory);
+  const bunx = nodePath.join(binaryDirectory, 'bunx');
+  writeFileSync(
+    bunx,
+    `#!/bin/sh\nprintf '%s\\n' --safeword-invocation-- "$@" >> "$SAFEWORD_TEST_ARGUMENTS"\nexit ${behavior === 'passes' ? '0' : '1'}\n`,
+  );
+  chmodSync(bunx, 0o755);
+  const status = runShell(script, workspace, {
+    LANE: lane,
+    PATH: `${binaryDirectory}:${process.env.PATH ?? ''}`,
+    SAFEWORD_TEST_ARGUMENTS: testArguments,
+  });
+  const invocations = readFileSync(testArguments, 'utf8')
+    .split('--safeword-invocation--\n')
+    .filter(Boolean)
+    .map(invocation => invocation.trim().split('\n'));
+  const executedLanes = invocations.flatMap(arguments_ => {
+    const laneIndex = arguments_.indexOf('--lane');
+    const executedLane = laneIndex === -1 ? undefined : arguments_[laneIndex + 1];
+    return executedLane ? [executedLane] : [];
+  });
+  return { status, executedLanes };
+}
+
+function invalidRevisionValue(description: string): string {
+  if (description.startsWith('the branch name')) return 'main';
+  if (description.startsWith('the tag name')) return 'v1.2.3';
+  if (description.startsWith('the abbreviated SHA')) return '0123456';
+  if (description.startsWith('exactly 39 lowercase')) return 'a'.repeat(39);
+  if (description.startsWith('exactly 41 lowercase')) return 'a'.repeat(41);
+  if (description.startsWith('exactly 40 uppercase')) return 'A'.repeat(40);
+  if (description.startsWith('39 lowercase')) return `${'a'.repeat(39)}g`;
+  if (description === 'no revision') return '';
+  throw new Error(`Unknown invalid revision description: ${description}`);
+}
+
+function readResult(root: string): RemoteWorkflowResult {
+  return JSON.parse(
+    readFileSync(nodePath.join(root, 'safeword-remote-test-result.json'), 'utf8'),
+  ) as RemoteWorkflowResult;
+}
+
+interface RejectionRun {
+  checkoutCount: number;
+  testCount: number;
+  failed: boolean;
+  validationOutcome: string;
+  checkoutOutcome: string;
+}
+
+interface RejectionContext {
+  root: string;
+  targetSha: string;
+  lane: string;
+  checkoutAvailable: boolean;
+  checkoutDiverged?: boolean;
+}
+
+function observeDivergentVerification(
+  step: WorkflowStep,
+  run: RejectionRun,
+  context: RejectionContext,
+): boolean {
+  if (step.id !== 'verify' || !step.run || !context.checkoutDiverged) return false;
+  const githubOutput = nodePath.join(context.root, 'github-output');
+  writeFileSync(githubOutput, '');
+  run.failed =
+    runShell(step.run, context.root, {
+      TARGET_SHA: context.targetSha,
+      GITHUB_OUTPUT: githubOutput,
+    }) !== 0;
+  return true;
+}
+
+function observeStep(step: WorkflowStep, run: RejectionRun, context: RejectionContext): void {
+  if (step.id === 'validate' && step.run) {
+    run.failed =
+      runShell(step.run, context.root, {
+        TARGET_SHA: context.targetSha,
+        LANE: context.lane,
+      }) !== 0;
+    run.validationOutcome = run.failed ? 'failure' : 'success';
+  } else if (step.uses?.startsWith('actions/checkout@')) {
+    run.checkoutCount += 1;
+    run.failed = !context.checkoutAvailable;
+    run.checkoutOutcome = run.failed ? 'failure' : 'success';
+  } else if (observeDivergentVerification(step, run, context)) {
+    return;
+  } else if (step.id === 'tests') {
+    run.testCount += 1;
+  }
+}
+
+function observeUntilFailure(
+  root: string,
+  targetSha: string,
+  lane: string,
+  checkoutAvailable: boolean,
+  checkoutDiverged = false,
+): RejectionRun {
+  const run: RejectionRun = {
+    checkoutCount: 0,
+    testCount: 0,
+    failed: false,
+    validationOutcome: 'skipped',
+    checkoutOutcome: 'skipped',
+  };
+  const context = { root, targetSha, lane, checkoutAvailable, checkoutDiverged };
+  for (const step of workflowSteps()) {
+    if (step.id === 'report' || run.failed) continue;
+    observeStep(step, run, context);
+  }
+  return run;
+}
+
+function evaluateRejectedInput(
+  targetSha: string,
+  lane: string,
+  checkoutAvailable = true,
+): RejectedRequestObservation {
+  const root = mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'safeword-rejected-input-'));
+  try {
+    const scripts = workflowScripts();
+    const report = scripts.get('report');
+    if (!report) throw new Error('Remote workflow scripts are incomplete.');
+    const run = observeUntilFailure(root, targetSha, lane, checkoutAvailable);
+    if (!run.failed) throw new Error('Rejected remote test request reached the test lane.');
+    const reportStatus = runShell(report, root, {
+      TARGET_SHA: targetSha,
+      LANE: lane,
+      VALIDATION_OUTCOME: run.validationOutcome,
+      CHECKOUT_OUTCOME: run.checkoutOutcome,
+      VERIFY_OUTCOME: 'skipped',
+      OBSERVED_SHA: '',
+      TEST_OUTCOME: 'skipped',
+    });
+    if (reportStatus !== 0) throw new Error('Result reporting failed.');
+    return {
+      checkoutCount: run.checkoutCount,
+      testCount: run.testCount,
+      result: readResult(root),
+    };
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+export function evaluateInvalidRevision(description: string): RejectedRequestObservation {
+  return evaluateRejectedInput(invalidRevisionValue(description), 'done');
+}
+
+export function evaluateUnsupportedLane(lane: string): RejectedRequestObservation {
+  return evaluateRejectedInput('0123456789abcdef0123456789abcdef01234567', lane);
+}
+
+export function evaluateUnavailableRevision(targetSha: string): RejectedRequestObservation {
+  return evaluateRejectedInput(targetSha, 'done', false);
+}
+
+export function evaluateCancelledRequest(
+  phase: 'validation' | 'checkout' | 'revision verification',
+): RemoteWorkflowResult {
+  const root = mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'safeword-cancelled-validation-'));
+  try {
+    const report = workflowScripts().get('report');
+    if (!report) throw new Error('Remote workflow report script is missing.');
+    const status = runShell(report, root, {
+      TARGET_SHA: '0123456789abcdef0123456789abcdef01234567',
+      LANE: 'done',
+      VALIDATION_OUTCOME: phase === 'validation' ? 'cancelled' : 'success',
+      CHECKOUT_OUTCOME: phase === 'checkout' ? 'cancelled' : 'success',
+      VERIFY_OUTCOME: phase === 'revision verification' ? 'cancelled' : 'skipped',
+      OBSERVED_SHA: '',
+      TEST_OUTCOME: 'skipped',
+    });
+    if (status !== 0) throw new Error('Result reporting failed.');
+    return readResult(root);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+export class RemoteWorkflowHarness {
+  readonly #root = mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'safeword-remote-workflow-'));
+  readonly #workspace: string;
+  readonly #divergentWorkspace: string;
+  readonly requestedSha: string;
+
+  constructor() {
+    const checkout = createNonTipCheckout(this.#root);
+    this.#workspace = checkout.workspace;
+    this.#divergentWorkspace = checkout.divergentWorkspace;
+    this.requestedSha = checkout.requestedSha;
+  }
+
+  runDivergentCheckout(): RejectedRequestObservation {
+    const scripts = workflowScripts();
+    const verify = scripts.get('verify');
+    const report = scripts.get('report');
+    if (!verify || !report) throw new Error('Remote workflow scripts are incomplete.');
+    const run = observeUntilFailure(
+      this.#divergentWorkspace,
+      this.requestedSha,
+      'done',
+      true,
+      true,
+    );
+    if (!run.failed) throw new Error('Divergent checkout passed revision verification.');
+    const githubOutput = nodePath.join(this.#divergentWorkspace, 'github-output');
+    const observedSha = readFileSync(githubOutput, 'utf8').trim().split('=', 2)[1] ?? '';
+    const reportStatus = runShell(report, this.#divergentWorkspace, {
+      TARGET_SHA: this.requestedSha,
+      LANE: 'done',
+      VALIDATION_OUTCOME: 'success',
+      CHECKOUT_OUTCOME: 'success',
+      VERIFY_OUTCOME: 'failure',
+      OBSERVED_SHA: observedSha,
+      TEST_OUTCOME: 'skipped',
+    });
+    if (reportStatus !== 0) throw new Error('Result reporting failed.');
+    return {
+      checkoutCount: run.checkoutCount,
+      testCount: run.testCount,
+      result: readResult(this.#divergentWorkspace),
+    };
+  }
+
+  run(
+    behavior: 'passes' | 'fails',
+    lane: RemoteWorkflowResult['lane'] = 'done',
+  ): RemoteWorkflowObservation {
+    if (!lane) throw new Error('A supported lane is required.');
+    const scripts = workflowScripts();
+    const verify = scripts.get('verify');
+    const tests = scripts.get('tests');
+    const report = scripts.get('report');
+    if (!verify || !tests || !report) throw new Error('Remote workflow scripts are incomplete.');
+
+    const githubOutput = nodePath.join(this.#root, 'github-output');
+    writeFileSync(githubOutput, '');
+    const verifyStatus = runShell(verify, this.#workspace, {
+      TARGET_SHA: this.requestedSha,
+      GITHUB_OUTPUT: githubOutput,
+    });
+    if (verifyStatus !== 0) throw new Error('Revision verification failed.');
+    const observedSha = readFileSync(githubOutput, 'utf8').trim().split('=', 2)[1];
+
+    const testRun = runTestLane(this.#root, this.#workspace, tests, behavior, lane);
+    const reportStatus = runShell(report, this.#workspace, {
+      TARGET_SHA: this.requestedSha,
+      LANE: lane,
+      VALIDATION_OUTCOME: 'success',
+      CHECKOUT_OUTCOME: 'success',
+      VERIFY_OUTCOME: 'success',
+      OBSERVED_SHA: observedSha,
+      TEST_OUTCOME: testRun.status === 0 ? 'success' : 'failure',
+    });
+    if (reportStatus !== 0) throw new Error('Result reporting failed.');
+    const result = JSON.parse(
+      readFileSync(nodePath.join(this.#workspace, 'safeword-remote-test-result.json'), 'utf8'),
+    ) as RemoteWorkflowResult;
+    return {
+      requestedSha: this.requestedSha,
+      checkoutRef: git(this.#workspace, 'rev-parse', 'HEAD'),
+      executedLanes: testRun.executedLanes,
+      result,
+    };
+  }
+
+  dispose(): void {
+    rmSync(this.#root, { force: true, recursive: true });
+  }
+}

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1206,6 +1206,14 @@ export const SAFEWORD_SCHEMA: SafewordSchema = {
     // Full uninstall removes it only while it still matches Safeword's template.
     '.jscpd.json': { template: '.jscpd.json' },
 
+    // Explicit remote-test setup owns publication; ordinary reconciliation
+    // catalogues these bytes without installing them.
+    '.github/workflows/safeword-remote-tests.yml': {
+      template: 'workflows/remote-tests.yml',
+      generator: (): undefined => undefined,
+      dogfoodParity: true,
+    },
+
     // Package-owned Codex runtime adapters. Their generator intentionally
     // returns undefined: the plugin CLI executes them from the npm package,
     // never from a customer repository.

--- a/packages/cli/src/test-execution/remote-workflow-contract.ts
+++ b/packages/cli/src/test-execution/remote-workflow-contract.ts
@@ -1,0 +1,276 @@
+import { createHash } from 'node:crypto';
+
+import { parseDocument } from 'yaml';
+
+export interface RemoteWorkflowContractResult {
+  accepted: boolean;
+  violations: string[];
+}
+
+type Mapping = Record<string, unknown>;
+
+const FULL_SHA = /^[0-9a-f]{40}$/u;
+const CHECKOUT = 'actions/checkout';
+const CHECKOUT_ACTION = 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0';
+const SETUP_BUN_ACTION = 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6';
+const INPUT_SHA = '${{ inputs.target_sha }}';
+const INPUT_LANE = '${{ inputs.lane }}';
+const RESULT_FILE = 'safeword-remote-test-result.json';
+const UPLOAD_ACTION = 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a';
+const VALIDATE_COMMAND =
+  '[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1\n' +
+  '[[ "$LANE" == "done" || "$LANE" == "full" ]] || exit 1\n';
+const VERIFY_COMMAND =
+  'observed_sha="$(git rev-parse HEAD)"\n' +
+  'echo "observed_sha=$observed_sha" >> "$GITHUB_OUTPUT"\n' +
+  '[[ "$observed_sha" == "$TARGET_SHA" ]]\n';
+const REPORT_COMMAND_SHA256 = 'b1cba179d7c3921553cb748e1c1759e2711f7aeef977317ec71515c6bd3608c9';
+
+function mapping(value: unknown): Mapping | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Mapping)
+    : undefined;
+}
+
+function hasExactKeys(value: Mapping | undefined, expected: string[]): boolean {
+  const actual = Object.keys(value ?? {});
+  return actual.length === expected.length && actual.every(key => expected.includes(key));
+}
+
+function hasExactEntries(value: Mapping | undefined, expected: Mapping): boolean {
+  return (
+    hasExactKeys(value, Object.keys(expected)) &&
+    Object.entries(expected).every(([key, expectedValue]) => value?.[key] === expectedValue)
+  );
+}
+
+function actionReference(value: unknown): { owner: string; revision: string } | undefined {
+  if (typeof value !== 'string' || value.startsWith('./') || value.startsWith('docker://')) {
+    return undefined;
+  }
+  const separator = value.lastIndexOf('@');
+  if (separator < 1) return undefined;
+  return { owner: value.slice(0, separator), revision: value.slice(separator + 1) };
+}
+
+function dispatchViolations(workflow: Mapping): string[] {
+  const trigger = mapping(workflow.on);
+  const inputs = mapping(mapping(trigger?.workflow_dispatch)?.inputs);
+  const invalidInput = ['lane', 'target_sha'].some(name => {
+    const input = mapping(inputs?.[name]);
+    return input?.required !== true || input.type !== 'string' || 'default' in (input ?? {});
+  });
+  return [
+    ...(hasExactKeys(trigger, ['workflow_dispatch']) ? [] : ['manual_dispatch_only']),
+    ...(hasExactKeys(inputs, ['lane', 'target_sha']) && !invalidInput ? [] : ['required_inputs']),
+  ];
+}
+
+function jobViolations(workflow: Mapping): { job: Mapping | undefined; violations: string[] } {
+  const permissions = mapping(workflow.permissions);
+  const jobs = mapping(workflow.jobs);
+  const job = mapping(jobs?.test);
+  const readOnly = hasExactKeys(permissions, ['contents']) && permissions?.contents === 'read';
+  const fixedWorkflow = hasExactKeys(workflow, ['name', 'on', 'permissions', 'jobs']);
+  const singleJob =
+    hasExactKeys(jobs, ['test']) &&
+    job !== undefined &&
+    hasExactKeys(job, ['runs-on', 'steps']) &&
+    job['runs-on'] === 'ubuntu-latest';
+  return {
+    job,
+    violations: [
+      ...(readOnly ? [] : ['contents_read_only']),
+      ...(fixedWorkflow ? [] : ['fixed_workflow_shape']),
+      ...(singleJob ? [] : ['single_read_only_job']),
+    ],
+  };
+}
+
+function checkoutViolations(checkout: Mapping | undefined): string[] {
+  if (!checkout) return ['checkout_required'];
+  const with_ = mapping(checkout.with);
+  return [
+    ...(with_?.['persist-credentials'] === false ? [] : ['checkout_credentials']),
+    ...(with_?.ref === INPUT_SHA ? [] : ['exact_checkout_ref']),
+    ...(with_?.['fetch-depth'] === 1 ? [] : ['shallow_checkout']),
+    ...(hasExactEntries(with_, {
+      ref: INPUT_SHA,
+      'fetch-depth': 1,
+      'persist-credentials': false,
+    })
+      ? []
+      : ['exact_checkout_options']),
+  ];
+}
+
+function actionViolations(job: Mapping | undefined): string[] {
+  const rawSteps = Array.isArray(job?.steps) ? job.steps : [];
+  const steps = rawSteps.map(step => mapping(step));
+  const actionSteps = steps.filter(step => step?.uses !== undefined);
+  const actions = actionSteps.map(step => actionReference(step?.uses));
+  const checkoutSteps = steps.filter(step => actionReference(step?.uses)?.owner === CHECKOUT);
+  return [
+    ...(steps.includes(undefined) ? ['valid_steps'] : []),
+    ...(actionSteps.length === actions.filter(Boolean).length ? [] : ['remote_actions_only']),
+    ...(actions.some(action => !action || !FULL_SHA.test(action.revision))
+      ? ['immutable_actions']
+      : []),
+    ...checkoutViolations(checkoutSteps.length === 1 ? checkoutSteps[0] : undefined),
+  ];
+}
+
+function workflowSteps(job: Mapping | undefined): Mapping[] {
+  if (!Array.isArray(job?.steps)) return [];
+  return job.steps.map(step => mapping(step)).filter(step => step !== undefined);
+}
+
+function stepById(steps: Mapping[], id: string): Mapping | undefined {
+  return steps.find(step => step.id === id);
+}
+
+interface StepShape {
+  id?: string;
+  uses?: string;
+  keys: string[];
+  with?: Mapping;
+}
+
+const STEP_SHAPES: StepShape[] = [
+  { id: 'validate', keys: ['name', 'id', 'env', 'run'] },
+  { id: 'checkout', uses: CHECKOUT_ACTION, keys: ['name', 'id', 'uses', 'with'] },
+  { id: 'verify', keys: ['name', 'id', 'env', 'run'] },
+  {
+    uses: SETUP_BUN_ACTION,
+    keys: ['name', 'uses', 'with'],
+    with: { 'bun-version-file': 'package.json' },
+  },
+  { id: 'tests', keys: ['name', 'id', 'env', 'run'] },
+  { id: 'report', keys: ['name', 'id', 'if', 'env', 'run'] },
+  { uses: UPLOAD_ACTION, keys: ['name', 'if', 'uses', 'with'] },
+];
+
+function hasFixedStepShape(steps: Mapping[]): boolean {
+  return (
+    steps.length === STEP_SHAPES.length &&
+    STEP_SHAPES.every((expected, index) => {
+      const step = steps[index];
+      if (!step) return false;
+      return (
+        step?.id === expected.id &&
+        step.uses === expected.uses &&
+        hasExactKeys(step, [...expected.keys]) &&
+        (!expected.with || hasExactEntries(mapping(step.with), expected.with))
+      );
+    })
+  );
+}
+
+function inputBindingViolations(steps: Mapping[]): string[] {
+  const validate = stepById(steps, 'validate');
+  const verify = stepById(steps, 'verify');
+  const tests = stepById(steps, 'tests');
+  const report = stepById(steps, 'report');
+  const valid =
+    hasExactEntries(mapping(validate?.env), { TARGET_SHA: INPUT_SHA, LANE: INPUT_LANE }) &&
+    hasExactEntries(mapping(verify?.env), { TARGET_SHA: INPUT_SHA }) &&
+    hasExactEntries(mapping(tests?.env), { LANE: INPUT_LANE }) &&
+    hasExactEntries(mapping(report?.env), {
+      TARGET_SHA: INPUT_SHA,
+      LANE: INPUT_LANE,
+      VALIDATION_OUTCOME: '${{ steps.validate.outcome }}',
+      CHECKOUT_OUTCOME: '${{ steps.checkout.outcome }}',
+      VERIFY_OUTCOME: '${{ steps.verify.outcome }}',
+      OBSERVED_SHA: '${{ steps.verify.outputs.observed_sha }}',
+      TEST_OUTCOME: '${{ steps.tests.outcome }}',
+    });
+  return valid ? [] : ['exact_input_bindings'];
+}
+
+function hasInvalidCondition(steps: Mapping[]): boolean {
+  return steps.some(step => {
+    const expected = step.id === 'report' || step.uses === UPLOAD_ACTION ? 'always()' : undefined;
+    return step.if !== expected;
+  });
+}
+
+function hasUnsafeShell(steps: Mapping[]): boolean {
+  return steps.some(step => typeof step.run === 'string' && step.run.includes('${{'));
+}
+
+function commandViolations(steps: Mapping[]): string[] {
+  const testRun = stepById(steps, 'tests')?.run;
+  const violations = [
+    ...(stepById(steps, 'validate')?.run === VALIDATE_COMMAND ? [] : ['fixed_validation']),
+    ...(stepById(steps, 'verify')?.run === VERIFY_COMMAND ? [] : ['fixed_revision_verification']),
+  ];
+  return testRun === 'bunx safeword@0.78.3 project test --lane "$LANE" --execution local'
+    ? violations
+    : [...violations, 'fixed_test_command'];
+}
+
+function executionViolations(steps: Mapping[]): string[] {
+  return [
+    ...(steps.some(step => step['continue-on-error'] !== undefined) ? ['fail_stop'] : []),
+    ...(hasInvalidCondition(steps) ? ['fixed_conditions'] : []),
+    ...(hasUnsafeShell(steps) ? ['shell_env_only'] : []),
+    ...commandViolations(steps),
+    ...(hasFixedStepShape(steps) ? [] : ['fixed_step_shape']),
+  ];
+}
+
+function hasFixedUpload(steps: Mapping[]): boolean {
+  const uploadWith = mapping(steps.find(step => step.uses === UPLOAD_ACTION)?.with);
+  return hasExactEntries(uploadWith, {
+    name: 'safeword-remote-test-result',
+    path: RESULT_FILE,
+    'if-no-files-found': 'error',
+  });
+}
+
+function resultViolations(steps: Mapping[]): string[] {
+  const reportRun = stepById(steps, 'report')?.run;
+  const reportValid =
+    typeof reportRun === 'string' &&
+    createHash('sha256').update(reportRun).digest('hex') === REPORT_COMMAND_SHA256;
+  return reportValid && hasFixedUpload(steps) ? [] : ['fixed_result_protocol'];
+}
+
+function hasSecretsKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(item => hasSecretsKey(item));
+  const object = mapping(value);
+  return object
+    ? Object.entries(object).some(([key, child]) => key === 'secrets' || hasSecretsKey(child))
+    : false;
+}
+
+function hasSecretExpression(value: unknown): boolean {
+  if (typeof value === 'string') return /\$\{\{[\s\S]*\bsecrets\s*[.()[\]]/iu.test(value);
+  if (Array.isArray(value)) return value.some(item => hasSecretExpression(item));
+  const object = mapping(value);
+  return object ? Object.values(object).some(child => hasSecretExpression(child)) : false;
+}
+
+function secretViolations(workflow: Mapping): string[] {
+  return hasSecretsKey(workflow) || hasSecretExpression(workflow) ? ['secret_free'] : [];
+}
+
+export function evaluateRemoteTestWorkflow(source: string): RemoteWorkflowContractResult {
+  const document = parseDocument(source, { uniqueKeys: true });
+  const workflow = document.errors.length === 0 ? mapping(document.toJS()) : undefined;
+  if (!workflow) return { accepted: false, violations: ['invalid_yaml'] };
+
+  const job = jobViolations(workflow);
+  const steps = workflowSteps(job.job);
+  const violations = [
+    ...dispatchViolations(workflow),
+    ...job.violations,
+    ...actionViolations(job.job),
+    ...inputBindingViolations(steps),
+    ...executionViolations(steps),
+    ...resultViolations(steps),
+    ...secretViolations(workflow),
+  ];
+  const uniqueViolations = [...new Set(violations)];
+  return { accepted: uniqueViolations.length === 0, violations: uniqueViolations };
+}

--- a/packages/cli/templates/workflows/remote-tests.yml
+++ b/packages/cli/templates/workflows/remote-tests.yml
@@ -1,0 +1,119 @@
+name: Safeword remote tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Full commit SHA to test
+        required: true
+        type: string
+      lane:
+        description: Safeword test lane
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate request
+        id: validate
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          LANE: ${{ inputs.lane }}
+        run: |
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          [[ "$LANE" == "done" || "$LANE" == "full" ]] || exit 1
+
+      - name: Check out requested revision
+        id: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.target_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify checked-out revision
+        id: verify
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          observed_sha="$(git rev-parse HEAD)"
+          echo "observed_sha=$observed_sha" >> "$GITHUB_OUTPUT"
+          [[ "$observed_sha" == "$TARGET_SHA" ]]
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.2
+        with:
+          bun-version-file: package.json
+
+      - name: Run requested test lane
+        id: tests
+        env:
+          LANE: ${{ inputs.lane }}
+        run: bunx safeword@0.78.3 project test --lane "$LANE" --execution local
+
+      - name: Write remote test result
+        id: report
+        if: always()
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          LANE: ${{ inputs.lane }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          OBSERVED_SHA: ${{ steps.verify.outputs.observed_sha }}
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+        run: |
+          node <<'NODE'
+          const { env } = process;
+          const validSha = /^[0-9a-f]{40}$/.test(env.TARGET_SHA ?? '');
+          const validLane = env.LANE === 'done' || env.LANE === 'full';
+          let status;
+          let rejectedReason = null;
+          if (!validSha || !validLane) {
+            status = 'rejected';
+            rejectedReason = validSha ? 'invalid_lane' : 'invalid_target_sha';
+          } else if (env.VALIDATION_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.CHECKOUT_OUTCOME === 'failure') {
+            status = 'rejected';
+            rejectedReason = 'checkout_unavailable';
+          } else if (env.CHECKOUT_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.VERIFY_OUTCOME === 'failure') {
+            status = 'rejected';
+            rejectedReason = 'head_mismatch';
+          } else if (env.VERIFY_OUTCOME !== 'success') {
+            status = 'incomplete';
+          } else if (env.TEST_OUTCOME === 'success') {
+            status = 'passed';
+          } else if (env.TEST_OUTCOME === 'failure') {
+            status = 'failed';
+          } else {
+            status = 'incomplete';
+          }
+          const result = {
+            schema_version: 1,
+            status,
+            lane: validLane ? env.LANE : null,
+            requested_sha: validSha ? env.TARGET_SHA : null,
+            observed_sha: env.OBSERVED_SHA || null,
+            rejected_reason: rejectedReason,
+          };
+          require('node:fs').writeFileSync(
+            'safeword-remote-test-result.json',
+            `${JSON.stringify(result)}\n`,
+          );
+          NODE
+
+      - name: Upload remote test result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: safeword-remote-test-result
+          path: safeword-remote-test-result.json
+          if-no-files-found: error

--- a/packages/cli/tests/test-execution/remote-workflow-contract.test.ts
+++ b/packages/cli/tests/test-execution/remote-workflow-contract.test.ts
@@ -1,0 +1,222 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { SAFEWORD_SCHEMA } from '../../src/schema';
+import { evaluateRemoteTestWorkflow } from '../../src/test-execution/remote-workflow-contract';
+
+const workflowPath = nodePath.join(process.cwd(), 'templates', 'workflows', 'remote-tests.yml');
+const workflow = readFileSync(workflowPath, 'utf8');
+const dogfoodWorkflow = readFileSync(
+  nodePath.join(process.cwd(), '..', '..', '.github', 'workflows', 'safeword-remote-tests.yml'),
+  'utf8',
+);
+
+function replace(from: string | RegExp, to: string): string {
+  const candidate = workflow.replace(from, () => to);
+  expect(candidate).not.toBe(workflow);
+  return candidate;
+}
+
+describe('remote workflow contract', () => {
+  it('accepts the schema-catalogued bundled workflow', () => {
+    const definition = SAFEWORD_SCHEMA.managedFiles['.github/workflows/safeword-remote-tests.yml'];
+
+    expect(definition?.template).toBe('workflows/remote-tests.yml');
+    expect(definition?.generator).toBeTypeOf('function');
+    expect(definition?.generator?.({} as never)).toBeUndefined();
+    expect(evaluateRemoteTestWorkflow(workflow)).toEqual({ accepted: true, violations: [] });
+    expect(dogfoodWorkflow).toBe(workflow);
+    expect(evaluateRemoteTestWorkflow(dogfoodWorkflow)).toEqual({ accepted: true, violations: [] });
+  });
+
+  it.each([
+    [
+      'adds a trigger',
+      'on:\n  workflow_dispatch:',
+      'on:\n  push:\n  workflow_dispatch:',
+      'manual_dispatch_only',
+    ],
+    [
+      'adds workflow defaults',
+      'permissions:',
+      'defaults:\n  run:\n    shell: sh\n\npermissions:',
+      'fixed_workflow_shape',
+    ],
+    [
+      'defaults an input',
+      '        required: true\n        type: string',
+      '        required: true\n        default: main\n        type: string',
+      'required_inputs',
+    ],
+    [
+      'misbinds validation input',
+      'TARGET_SHA: ${{ inputs.target_sha }}',
+      'TARGET_SHA: ${{ inputs.lane }}',
+      'exact_input_bindings',
+    ],
+    [
+      'removes request validation',
+      '[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1',
+      'true',
+      'fixed_validation',
+    ],
+    [
+      'misbinds checkout ref',
+      'ref: ${{ inputs.target_sha }}',
+      'ref: ${{ github.sha }}',
+      'exact_checkout_ref',
+    ],
+    [
+      'adds a checkout option',
+      '          fetch-depth: 1',
+      '          fetch-depth: 1\n          submodules: recursive',
+      'exact_checkout_options',
+    ],
+    [
+      'overrides job permissions',
+      '    runs-on: ubuntu-latest',
+      '    permissions:\n      contents: write\n    runs-on: ubuntu-latest',
+      'single_read_only_job',
+    ],
+    [
+      'adds a job environment',
+      '    runs-on: ubuntu-latest',
+      '    runs-on: ubuntu-latest\n    env:\n      NODE_OPTIONS: --require ./forge.js',
+      'single_read_only_job',
+    ],
+    [
+      'changes the runner label',
+      '    runs-on: ubuntu-latest',
+      '    runs-on: self-hosted',
+      'single_read_only_job',
+    ],
+    [
+      'uses a local action',
+      'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+      './setup-bun',
+      'remote_actions_only',
+    ],
+    [
+      'uses a reusable workflow',
+      '    runs-on: ubuntu-latest',
+      '    uses: owner/repository/.github/workflows/test.yml@0123456789012345678901234567890123456789',
+      'single_read_only_job',
+    ],
+    [
+      'continues after a failed test',
+      '        id: tests',
+      '        id: tests\n        continue-on-error: true',
+      'fail_stop',
+    ],
+    [
+      'changes a step condition',
+      '        if: always()',
+      '        if: success()',
+      'fixed_conditions',
+    ],
+    [
+      'injects an expression into shell',
+      'run: bunx safeword@0.78.3',
+      'run: echo "${{ inputs.lane }}" && bunx safeword@0.78.3',
+      'shell_env_only',
+    ],
+    [
+      'changes the test command',
+      'project test --lane "$LANE" --execution local',
+      'project test --lane full --execution local',
+      'fixed_test_command',
+    ],
+    [
+      'fabricates the verified revision',
+      'observed_sha="$(git rev-parse HEAD)"',
+      'observed_sha="$TARGET_SHA"',
+      'fixed_revision_verification',
+    ],
+    [
+      'adds an execution step',
+      '      - name: Run requested test lane',
+      '      - name: Change revision\n        run: git checkout main\n\n      - name: Run requested test lane',
+      'fixed_step_shape',
+    ],
+    [
+      'changes a result key',
+      '            schema_version: 1,',
+      '            version: 1,',
+      'fixed_result_protocol',
+    ],
+    [
+      'overrides the computed result',
+      "          require('node:fs').writeFileSync(",
+      "          result.status = 'passed';\n          require('node:fs').writeFileSync(",
+      'fixed_result_protocol',
+    ],
+    [
+      'changes the artifact name',
+      '          name: safeword-remote-test-result',
+      '          name: other-result',
+      'fixed_result_protocol',
+    ],
+    [
+      'changes the artifact path',
+      '          path: safeword-remote-test-result.json',
+      '          path: other-result.json',
+      'fixed_result_protocol',
+    ],
+    [
+      'references the whole secrets context',
+      '    runs-on: ubuntu-latest',
+      '    env:\n      ALL_SECRETS: ${{ toJSON(secrets) }}\n    runs-on: ubuntu-latest',
+      'secret_free',
+    ],
+    [
+      'references an uppercase secrets context',
+      '    runs-on: ubuntu-latest',
+      '    env:\n      TOKEN: ${{ SECRETS.GITHUB_TOKEN }}\n    runs-on: ubuntu-latest',
+      'secret_free',
+    ],
+    [
+      'references a secret with bracket notation',
+      '    runs-on: ubuntu-latest',
+      "    env:\n      TOKEN: ${{ secrets['SAFEWORD_TOKEN'] }}\n    runs-on: ubuntu-latest",
+      'secret_free',
+    ],
+    [
+      'references a secret after a literal brace',
+      '    runs-on: ubuntu-latest',
+      "    env:\n      TOKEN: ${{ format('{0}', secrets.TOKEN) }}\n    runs-on: ubuntu-latest",
+      'secret_free',
+    ],
+  ])('rejects a candidate that %s', (_label, from, to, violation) => {
+    const result = evaluateRemoteTestWorkflow(replace(from, to));
+
+    expect(result.accepted).toBe(false);
+    expect(result.violations).toContain(violation);
+  });
+
+  it('rejects a candidate that runs tests before revision verification', () => {
+    const candidate = workflow.replace(
+      /( {6}- name: Verify checked-out revision[\s\S]*?)( {6}- name: Set up Bun[\s\S]*?)(?= {6}- name: Write remote test result)/u,
+      (_match, verify: string, tests: string) => `${tests}${verify}`,
+    );
+
+    expect(candidate).not.toBe(workflow);
+    expect(evaluateRemoteTestWorkflow(candidate).violations).toContain('fixed_step_shape');
+  });
+
+  it('allows comments that describe the secret-free contract', () => {
+    const candidate = workflow.replace(
+      'permissions:',
+      '# No secrets are passed to this job.\npermissions:',
+    );
+
+    expect(evaluateRemoteTestWorkflow(candidate)).toEqual({ accepted: true, violations: [] });
+  });
+
+  it('allows descriptions that name the secret-free contract', () => {
+    const candidate = workflow.replace('Full commit SHA to test', 'Full commit SHA; no secrets');
+
+    expect(evaluateRemoteTestWorkflow(candidate)).toEqual({ accepted: true, violations: [] });
+  });
+});

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.5",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "0fb182395398c7b5d10014e1a6a91379e7f33564eac839c0dbfd4a094159b853"
+  "inventory_sha256": "9b339fbef18dfaf7cc30fc997673030a0370bcb75df5c82136d104af25b9ecfd"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "52d9bee714c545f5608a286c1cbef29ac34c51549ddda257eb475207a41637af"
+      "sha256": "1aabe6be254a5b2ff4151abff2efdb5936af9c85e70d4fa569492b02928f0a64"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -13720,6 +13720,13 @@ ${NAMESPACE_GITIGNORE_PATTERNS}
     },
     managedFiles: {
       ".jscpd.json": { template: ".jscpd.json" },
+      ".github/workflows/safeword-remote-tests.yml": {
+        template: "workflows/remote-tests.yml",
+        generator: () => {
+          return;
+        },
+        dogfoodParity: true
+      },
       ...CODEX_RUNTIME_ASSETS,
       "features/safeword-lane.feature": bddLaneFile("cucumber/safeword-lane.feature"),
       "steps/world.ts": bddLaneFile("cucumber/world.ts"),


### PR DESCRIPTION
## What changed

- add the optional Safeword remote-test workflow and catalogue it without installing it during ordinary reconciliation
- enforce exact requested-commit checkout, allowlisted `done`/`full` lanes, read-only repository permission, immutable action pins, and non-persisted checkout credentials
- emit a closed machine-readable result for rejected, passed, failed, and interrupted runs
- add semantic workflow-contract tests and executable BDD coverage using real temporary Git repositories and shell execution
- make the acceptance harness resolve its workflow fixture relative to the module so it works from both the repository root and `packages/cli`

## Why

Remote testing should free a contributor's laptop without testing the wrong revision or granting a test job more repository authority than it needs. This PR isolates BR373S from the larger remote-testing umbrella branch so its behavior and review scope stand alone.

## Impact

This establishes the least-privilege runner contract and bundled workflow bytes. Installation, dispatch, recovery, and customer-facing configuration remain owned by the sibling remote-testing tickets.

## Validation

- full tests: 8,389 passed; 8 skipped
- full acceptance: 1,484 passed; 3 skipped; 68,189 steps passed
- focused workflow contract: 30 passed
- focused BR373S acceptance: 29 scenarios passed
- ESLint, Gherkin lint, TypeScript typecheck, both package builds, actionlint, schema-drift gate, and diff-scoped audit pass
