### PR TITLE
chore(release): v0.78.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "safeword",
       "description": "AI coding agent workflows: BDD, auto-linting, quality reviews, debugging, and refactoring",
-      "version": "0.78.5",
+      "version": "0.78.6",
       "source": "./plugin",
       "skills": ["./skills"],
       "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "safeword",
-      "version": "0.78.5",
+      "version": "0.78.6",
       "bin": {
         "safeword": "dist/cli.js",
       },

--- a/packages/cli/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/cli/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "description": "Safeword workflow guidance and gates for Codex.",
   "author": {
     "name": "Arcade AI"

--- a/packages/cli/codex-plugin/hooks.json
+++ b/packages/cli/codex-plugin/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.5 hook codex session-start --plugin-hook",
+            "command": "bunx --bun safeword@0.78.6 hook codex session-start --plugin-hook",
             "timeout": 120,
             "statusMessage": "Loading Safeword standing instructions"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.5 hook codex pre-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.6 hook codex pre-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking Safeword edit gates"
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.5 hook codex post-tool-use --plugin-hook",
+            "command": "bunx --bun safeword@0.78.6 hook codex post-tool-use --plugin-hook",
             "timeout": 30,
             "statusMessage": "Surfacing Safeword post-tool context"
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.5 hook codex user-prompt-submit --plugin-hook",
+            "command": "bunx --bun safeword@0.78.6 hook codex user-prompt-submit --plugin-hook",
             "timeout": 30,
             "statusMessage": "Checking queued Safeword prompt context"
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx --bun safeword@0.78.5 hook codex stop --plugin-hook",
+            "command": "bunx --bun safeword@0.78.6 hook codex stop --plugin-hook",
             "timeout": 600,
             "statusMessage": "Checking Safeword stop continuation"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeword",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "description": "CLI for setting up and managing safeword development environments",
   "repository": {
     "type": "git",

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plugin_version": "0.78.5",
+  "plugin_version": "0.78.6",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "9b339fbef18dfaf7cc30fc997673030a0370bcb75df5c82136d104af25b9ecfd"
+  "inventory_sha256": "bb0e1c91173c21bd50f23eb53192fde6ad64c0bbc7e200c5b773baf1979a9774"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "c8bc6695af29a4a219ef12a367ebb4c318a9d06152f0a9efe9652bdedec62bbf"
+      "sha256": "18ff46dd3f7acfb9d5d0868cb35c9c5f4532c361d9eac5ec5413c7f511e6def4"
     },
     {
       "path": "resources/guides/architecture-guide.md",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "safeword",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- release the remote requested-revision execution contract merged in #3128
- align npm, Claude plugin, Codex plugin, hook pins, lockfile, and generated plugin metadata at 0.78.6

## Verification

- `bun install --frozen-lockfile`
- CLI build
- `bun run --cwd packages/cli generate:claude-plugin`
- `bun run --cwd packages/cli check:claude-plugin`
- remote CI is the authoritative full-suite gate (local release tests were not duplicated because another checkout owns the shared Vitest lock)