### PR TITLE
Block high-severity dependency advisories before they reach production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,25 @@ jobs:
       - name: Check public CLI contract
         run: bun run check:cli-contract
 
+  dependency-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Block high and critical advisories
+        # Lower-severity advisories stay visible to local and repository audits
+        # without letting an unpatchable development-only advisory halt delivery.
+        run: bun audit --audit-level high
+
   test:
     name: test (node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -319,7 +338,10 @@ jobs:
 
   deploy-retro-relay:
     name: Deploy Retro Relay
-    needs: [dogfood-parity, test, lint, relay-inputs]
+    # High and critical advisories block automatic production delivery. The
+    # environment-protected deploy-retro-relay workflow stays the manual
+    # break-glass path for an urgent relay security fix.
+    needs: [dogfood-parity, dependency-audit, test, lint, relay-inputs]
     if: github.ref == 'refs/heads/main' && needs.relay-inputs.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     environment: retro-relay-production

--- a/packages/cli/tests/retro-relay-deploy-workflow.test.ts
+++ b/packages/cli/tests/retro-relay-deploy-workflow.test.ts
@@ -53,7 +53,13 @@ describe('Retro Relay deployment workflow', () => {
     const deployment = workflow.jobs['deploy-retro-relay'];
     expect(deployment).toBeDefined();
     if (deployment === undefined) throw new Error('missing deploy-retro-relay job');
-    expect(deployment.needs).toEqual(['dogfood-parity', 'test', 'lint', 'relay-inputs']);
+    expect(deployment.needs).toEqual([
+      'dogfood-parity',
+      'dependency-audit',
+      'test',
+      'lint',
+      'relay-inputs',
+    ]);
     expect(deployment.environment).toBe('retro-relay-production');
     expect(deployment.if).toContain("github.ref == 'refs/heads/main'");
     expect(source).toContain('git diff --name-only "$BEFORE" "$SHA"');


### PR DESCRIPTION
Replaces #2813, which was overtaken by main. Closes #2808.

## Why

#2813 set a `nanoid` override to patched `3.3.18` to clear a transitive advisory. That fix **already landed on main** on Aug 15 via #2262 — main carries the identical override and `bun audit --audit-level high` reports no vulnerabilities. #2813 is now 617 commits behind and would regress the CLI version (0.78.6 → 0.78.0) and the BDD lane scripts if merged.

What #2813 had that main still lacks is the *durable* part: a CI gate so the next advisory is caught automatically. This PR salvages just that.

## What this does

- Adds a `dependency-audit` job running `bun audit --audit-level high`.
- Gates `deploy-retro-relay` on it, so a high or critical advisory can't ride out to production. The environment-protected deploy workflow remains the manual break-glass path.

Scoped to high/critical deliberately: an unpatchable development-only advisory shouldn't halt delivery, and lower severities stay visible to local audits.

## What I deliberately left out

#2813's `nanoid` tripwire test. The latest `3.x` is `3.3.18`, so postcss's `^3.3.16` resolves to the patched release unaided — the override is now a harmless floor rather than the fix. A test asserting the override equals `3.3.18` would fail the next legitimate patch bump to `3.3.19`. The audit gate covers the same regression without pinning brittleness.

Also left out: #2813's relay-input hardening and workflow-helper refactors, which are a separate concern from the audit gate.

## Verification

- `bun audit --audit-level high` on this branch: **No vulnerabilities found**
- `ci.yml` parses; `deploy-retro-relay` needs resolve to `[dogfood-parity, dependency-audit, test, lint, relay-inputs]`
- Workflow contract tests pass (3 files, 5 tests) — includes the updated `needs` assertion in `retro-relay-deploy-workflow.test.ts`
- `prettier --check` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)