### PR TITLE
Fix paid canary sequencing after the first attempt

### DIFF
--- a/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-development-canary.test.ts
+++ b/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-development-canary.test.ts
@@ -842,6 +842,73 @@ describe("Terra canary write-side attempt lifecycle", () => {
     });
   });
 
+  test("completes a recorded provider journal on the second attempt", async () => {
+    const directory = outputDirectory();
+    const upstream = fakeUpstream();
+    await initializeCanary({ binding: BINDING, outputDirectory: directory, upstream });
+    await runCanaryAttempt({
+      attemptId: "attempt-1",
+      binding: BINDING,
+      dispatch: async () => validDispatchEvidence(),
+      intentId: "intent-1",
+      outputDirectory: directory,
+      upstream,
+    });
+
+    const result = await runCanaryAttempt({
+      attemptId: "attempt-2",
+      binding: BINDING,
+      dispatch: async (context) => {
+        const recorder = await createCanaryProviderRecorder(context);
+        const rawUsage = {
+          input_tokens: 10,
+          input_tokens_details: { cached_tokens: 2 },
+          output_tokens: 3,
+        };
+        const rawBody = JSON.stringify({
+          id: "resp-terra-attempt-2",
+          model: "gpt-5.6-terra",
+          output: [],
+          service_tier: "default",
+          status: "completed",
+          usage: rawUsage,
+        });
+        await recorder.recordIntent({
+          endpoint: "https://api.openai.com/v1/responses",
+          intentId: "turn-intent-attempt-2",
+          requestBody: { model: "gpt-5.6-terra" },
+          requestedModel: "gpt-5.6-terra",
+          requestedServiceTier: "default",
+          stage: "repository-reading",
+        });
+        await recorder.recordResponse({
+          errorMessage: null,
+          errorName: null,
+          httpStatus: 200,
+          intentId: "turn-intent-attempt-2",
+          nativeUsage: rawUsage,
+          outcome: "response",
+          rawBody,
+          requestId: "req-terra-attempt-2",
+          responseId: "resp-terra-attempt-2",
+          returnedModel: "gpt-5.6-terra",
+          returnedServiceTier: "default",
+          stage: "repository-reading",
+        });
+        return recorder.complete();
+      },
+      intentId: "intent-2",
+      outputDirectory: directory,
+      upstream,
+    });
+
+    expect(result).toMatchObject({
+      attemptId: "attempt-2",
+      sequence: 2,
+      startedAttempts: 2,
+    });
+  });
+
   test("serializes overlapping provider journal appends without losing records", async () => {
     const directory = outputDirectory();
     mkdirSync(directory, { recursive: true });

--- a/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-development-canary.ts
+++ b/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-development-canary.ts
@@ -587,7 +587,7 @@ export async function completeCanaryProviderJournal(
     intent?.kind !== "attempt-intent" ||
     intent.attemptId !== input.attemptId ||
     intent.intentId !== input.intentId ||
-    intent.sequence !== input.sequence
+    intent.sequence !== 1
   ) {
     throw new Error("provider turn journal has an invalid attempt intent");
   }

--- a/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-real-recorder-qualification.json
+++ b/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-real-recorder-qualification.json
@@ -1,13 +1,13 @@
 {
   "adapterCommit": "e1d54b2d12e4a97fba84e8302de31bfe8b60ba17",
   "adapterTag": "terra-adapter-v1",
-  "harnessCommit": "f43a5c9d37cf736fa8e4776940c1c08bec072ba5",
-  "harnessTag": "terra-harness-v11",
-  "qualifiedAt": "2026-08-15T06:57:02Z",
+  "harnessCommit": "634770cd82b5bab4cd7e9351708170135550866e",
+  "harnessTag": "terra-harness-v12",
+  "qualifiedAt": "2026-08-19T14:34:11Z",
   "result": "passed",
   "sha256": {
     "terra-canary-evidence.ts": "5204848ba339d6859399ab42cf258b3897dda3d85df7d0db7d57367f2b70615d",
-    "terra-development-canary.ts": "49b3dfd0574ac4abdd51b40f7dd112ab170afa7a31a18bfa2ae92d93b5706dd1",
+    "terra-development-canary.ts": "e4e397081312bf70ab3ae23b335d7aea36a15d84e4fd800aa3c455877779ce4f",
     "terra-github-authorization.ts": "f166a0f9b765a977a6f58c919d0aa04c3e00a0a69679a73659a6888d54364fc5",
     "terra-github-upstream.ts": "a04b0366536fa5af605b6b3f67033815b67b6d2422ca83d720645db50274e09c",
     "terra-live-launcher.ts": "3229eb33bc37796f2ad5d15f7667e8e159de8d6df7cdfd77da60c55099e25113",

--- a/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-real-recorder-wiring.test.ts
+++ b/.project/tickets/Y4ZAAY-prove-cross-provider-review-before-scaling-spend/terra-real-recorder-wiring.test.ts
@@ -24,8 +24,8 @@ describe("real Terra recorder wiring", () => {
     expect(qualification).toMatchObject({
       adapterCommit: "e1d54b2d12e4a97fba84e8302de31bfe8b60ba17",
       adapterTag: "terra-adapter-v1",
-      harnessCommit: "f43a5c9d37cf736fa8e4776940c1c08bec072ba5",
-      harnessTag: "terra-harness-v11",
+      harnessCommit: "634770cd82b5bab4cd7e9351708170135550866e",
+      harnessTag: "terra-harness-v12",
       result: "passed",
       verificationCommand:
         "Y4ZAAY_ADAPTER_ROOT=<pinned-adapter> bun terra-real-recorder-wiring.fixture.ts",


### PR DESCRIPTION
## What changed

- keep provider-journal sequencing local to each attempt
- cover a complete second attempt through the recorder and accounting lifecycle
- retain a successful qualification against the pinned Terra adapter for `terra-harness-v12`

## Why

The provider journal always begins at sequence 1, but completion compared that local record sequence with the outer canary attempt number. Attempt 1 therefore passed while attempt 2 completed its provider calls and then failed accounting.

## Impact

Later paid canary attempts can complete without weakening journal ordering, route validation, or durable accounting. The failed development run remains untouched and will be replaced by a fresh output identity.

## Verification

- ticket-local Vitest suite with pinned adapter: 214 passed
- real pinned-adapter recorder fixture: passed
- pre-commit contracts, ESLint, and Prettier: passed
