### PR TITLE
docs(release): name the generated Codex skills as a release-tracked artifact

### DIFF
--- a/.claude/skills/versioning/SKILL.md
+++ b/.claude/skills/versioning/SKILL.md
@@ -78,11 +78,22 @@ The publish path is CI-driven via OIDC trusted publishing. Tag push → GitHub A
 
 1. **Decide the bump** using rules above. Patch / Minor / Major.
 
-2. **Bump version in all four release-tracked artifacts** (pre-commit and release-contract tests enforce the Codex match):
+2. **Bump version in all five release-tracked artifacts** (pre-commit and release-contract tests enforce the Codex match):
    - `packages/cli/package.json` → `version`
    - `.claude-plugin/marketplace.json` → `plugins[0].version`
    - `packages/cli/codex-plugin/.codex-plugin/plugin.json` → `version`
    - `packages/cli/codex-plugin/hooks.json` → all five `bunx` commands pin `safeword@<version>`
+   - `packages/cli/codex-plugin/skills/**` → **generated**, never hand-edited:
+
+     ```bash
+     bun run --cwd packages/cli generate:codex-plugin
+     ```
+
+     Codex's skills embed `bunx --bun safeword@<version>` because that plugin has
+     no project-local `.safeword/hooks` to call (V2AH4B). Skip the regeneration
+     and the release ships skills pinned to the previous version. Verify with
+     `grep -r "safeword@<previous-version>" packages/cli/codex-plugin` — it must
+     return nothing.
 
    Then **regenerate the lockfile** so `bun.lock`'s `packages/cli` workspace
    version tracks `package.json` — otherwise it drifts and CI's lockfile-drift

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (567)
+## Tickets (568)
 
 ### 001
 
@@ -1769,7 +1769,7 @@
   Let retro file process-level friction under a leak-proof `process/<slug>` surface and report every egress drop, so silence means clean instead of secretly lossy.
   → `.project/tickets/PNZM3B-retro-process-surface`
 - **Stop the retro relay wiring test failing under CI load (PTJQ6X)** (in_progress, epic: —)
-  Give the `[ORR-001]` relay wiring scenario a delivery budget wide enough that it tests delivery semantics rather than machine speed, by setting `deadlineMs` on its relay config instead of inheriting production's 500ms default
+  Make `[ORR-001]` in `packages/retro-relay/tests/cli-wiring.integration.test.ts` survive a single transient first-attempt delivery failure, so it stops reddening CI on commits that cannot have caused it
   → `.project/tickets/PTJQ6X-relay-scenario-fixed-clock`
 - **Centralize and harden the test/build resolver (polyglot, nested, multi-runner) (Q4FX8Y)** (done, epic: —)
   One resolver decides what test/build commands to run for a repo — correct across polyglot monorepos (run **every** detected suite, not first-match), nested/sub-package manifests, and languages with multiple runners — consumed identically by `/verify`, `/audit`, and the stop-hook `test-runner.ts` without drift.
@@ -1808,6 +1808,8 @@
 - **Rename DEV persona code to TB across the corpus (R4S85Y)** (done, epic: —)
   Eliminate the redundant DEV persona code by renaming DEV<n> -> TB<n> (828 occ) and Agent-Driven Developer (DEV) -> Technical Builder (TB) (2 occ) across 103 files, clearing the E009 drift by elimination and making a personas.md DEV entry unnecessary
   → `.project/tickets/R4S85Y-rename-dev-persona-to-tb`
+- **Protect review fallback boundaries for builders (R7K2QP)** (—, epic: —)
+  → `.project/tickets/R7K2QP-protect-review-fallback-boundaries`
 - **Stop-hook escalation path may be dead (0/10 BLOCKED) — revalidate post-F14BG2, recalibrate if needed (RAS9N8)** (pending, epic: —)
   Determine whether the Stop-hook escalation path (`BLOCKED`) is actually reachable in practice, and if it isn't, recalibrate within the existing binary-verdict architecture so genuine blockers surface instead of everything defaulting to `CONFIDENT`.
   → `.project/tickets/RAS9N8-stop-hook-escalation-calibration`

--- a/.project/tickets/R7K2QP-protect-review-fallback-boundaries/ticket.md
+++ b/.project/tickets/R7K2QP-protect-review-fallback-boundaries/ticket.md
@@ -1,3 +1,11 @@
+---
+id: R7K2QP
+slug: protect-review-fallback-boundaries
+type: task
+created: 2026-08-09T08:39:54.000Z
+last_modified: 2026-08-20T14:31:00.000Z
+---
+
 # Protect review fallback boundaries for builders
 
 ## Goal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,12 +134,15 @@ Use for project-owned tickets, learnings, and supporting product context. Instal
 
 ### Version Management
 
-When bumping the CLI version, update all **four release-tracked artifacts**:
+When bumping the CLI version, update all **five release-tracked artifacts**:
 
 1. `packages/cli/package.json` — source of truth for npm
 2. `.claude-plugin/marketplace.json` → `plugins[0].version` — source of truth for Claude Code plugin
 3. `packages/cli/codex-plugin/.codex-plugin/plugin.json` → `version` — source of truth for Codex plugin
 4. `packages/cli/codex-plugin/hooks.json` — all five `bunx` commands pin `safeword@<version>`
+5. `packages/cli/codex-plugin/skills/**` — **generated**, never hand-edited. Regenerate with `bun run generate:codex-plugin` from `packages/cli`
+
+Artifact 5 is easy to miss because it is generated rather than edited: Codex's skills have no project-local `.safeword/hooks` to call, so their review and helper invocations embed `bunx --bun safeword@<version>` directly (ticket V2AH4B). A bump that skips the regeneration ships skills pinned to the previous version. `test:release` fails loudly on the mismatch, so this is a checklist gap rather than a release risk.
 
 Do NOT add version to `plugin/.claude-plugin/plugin.json` — per Claude Code docs, relative-path plugins use the marketplace entry only. Pre-commit and release-contract tests block a mismatch between the CLI, plugin manifests, and Codex hook commands.
 


### PR DESCRIPTION
Closes `AMK8BC`. Two small fixes surfaced while cutting 0.78.7.

## The release checklist was one artifact short

`AGENTS.md` and the `versioning` skill both say **four** release-tracked artifacts. As of #3205, Codex's generated skills embed `bunx --bun safeword@<version>` — that plugin has no project-local `.safeword/hooks` to call (V2AH4B) — which makes `packages/cli/codex-plugin/skills/**` a fifth.

This is not theoretical: the 0.78.7 release needed **nine** generated skill files regenerated beyond the four the checklist names. `test:release` fails loudly if you forget, so it was a documentation gap rather than a release risk — but the next person following the checklist literally would hit a red CI and not know why.

Both lists now say five, with the regeneration command and a `grep` verification step.

## A ticket was invisible to the index

`R7K2QP-protect-review-fallback-boundaries` had **no frontmatter at all**, so `project sync-tickets` skipped it with `missing id: in frontmatter` and it never appeared in `INDEX.md`. It has been unlisted since it was added on 2026-08-09.

Added only the fields derivable from git — `id`, `slug`, `type`, `created` — and deliberately **left `status` unset** so the index renders `—` rather than me inventing state for a ticket I did not write. Someone who knows its real state should set it. Body untouched.

Ticket count: 567 → 568.

## Verification

- [x] `parity-check --mode=all` — 255 pairs, 8 contracts in sync
- [x] `sync-tickets` no longer reports any skipped ticket
- [x] Root `AGENTS.md` confirmed distinct from `templates/AGENTS.md` (repo instructions vs. customer template), so the release list correctly lives only in the former
- [x] `.claude/skills/versioning/SKILL.md` confirmed repo-local — no template mirror, no parity obligation

🤖 Generated with [Claude Code](https://claude.com/claude-code)