### PR TITLE
fix(hooks): use .js sibling specifiers in hook libs

### DIFF
--- a/.safeword/hooks/lib/blocked-on-gate.ts
+++ b/.safeword/hooks/lib/blocked-on-gate.ts
@@ -14,8 +14,8 @@
  * so it is unit-testable without disk.
  */
 
-import { parseFrontmatter } from './hierarchy.ts';
-import { detectPhaseAdvance } from './review-ledger.ts';
+import { parseFrontmatter } from './hierarchy.js';
+import { detectPhaseAdvance } from './review-ledger.js';
 
 /** A blocker's resolution: whether it exists in the corpus, and its status. */
 export interface BlockerStatus {

--- a/.safeword/hooks/lib/drain-retro-spool.ts
+++ b/.safeword/hooks/lib/drain-retro-spool.ts
@@ -15,7 +15,7 @@ import {
   drainAcknowledgedDrafts,
   readSpooledDrafts,
   verifyDraftBody,
-} from './retro-draft-spool.ts';
+} from './retro-draft-spool.js';
 
 export type DrainRetroSpoolResult =
   | { state: 'refused'; message: string }

--- a/.safeword/hooks/lib/principle-trace.ts
+++ b/.safeword/hooks/lib/principle-trace.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { activeLines, sectionBody } from './impl-plan.ts';
-import { resolveReviewKnowledgeSources } from './project-knowledge.ts';
+import { activeLines, sectionBody } from './impl-plan.js';
+import { resolveReviewKnowledgeSources } from './project-knowledge.js';
 
 interface PrincipleTrace {
   principle: string;

--- a/.safeword/hooks/lib/project-knowledge.ts
+++ b/.safeword/hooks/lib/project-knowledge.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync } from 'node:fs';
 
-import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.ts';
+import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.js';
 
 export type ReviewKnowledgeKey = 'principles' | 'personas' | 'surfaces';
 

--- a/packages/cli/templates/hooks/lib/blocked-on-gate.ts
+++ b/packages/cli/templates/hooks/lib/blocked-on-gate.ts
@@ -14,8 +14,8 @@
  * so it is unit-testable without disk.
  */
 
-import { parseFrontmatter } from './hierarchy.ts';
-import { detectPhaseAdvance } from './review-ledger.ts';
+import { parseFrontmatter } from './hierarchy.js';
+import { detectPhaseAdvance } from './review-ledger.js';
 
 /** A blocker's resolution: whether it exists in the corpus, and its status. */
 export interface BlockerStatus {

--- a/packages/cli/templates/hooks/lib/drain-retro-spool.ts
+++ b/packages/cli/templates/hooks/lib/drain-retro-spool.ts
@@ -15,7 +15,7 @@ import {
   drainAcknowledgedDrafts,
   readSpooledDrafts,
   verifyDraftBody,
-} from './retro-draft-spool.ts';
+} from './retro-draft-spool.js';
 
 export type DrainRetroSpoolResult =
   | { state: 'refused'; message: string }

--- a/packages/cli/templates/hooks/lib/principle-trace.ts
+++ b/packages/cli/templates/hooks/lib/principle-trace.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { activeLines, sectionBody } from './impl-plan.ts';
-import { resolveReviewKnowledgeSources } from './project-knowledge.ts';
+import { activeLines, sectionBody } from './impl-plan.js';
+import { resolveReviewKnowledgeSources } from './project-knowledge.js';
 
 interface PrincipleTrace {
   principle: string;

--- a/packages/cli/templates/hooks/lib/project-knowledge.ts
+++ b/packages/cli/templates/hooks/lib/project-knowledge.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync } from 'node:fs';
 
-import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.ts';
+import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.js';
 
 export type ReviewKnowledgeKey = 'principles' | 'personas' | 'surfaces';
 

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.7",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "cb92830efd8fa93778f89af6534e055b5fee7a99b7d87ccbe5c3b6205d6db91b"
+  "inventory_sha256": "49264b64c82569a5553f60bbb78893d40e129e1c4a4cf9283d7c21b98133a0c3"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -191,7 +191,7 @@
     },
     {
       "path": "runtime/hooks/lib/blocked-on-gate.ts",
-      "sha256": "c091b4e7232104eafac0aad9de3f5b96d0534284e3c1e2d87b4707a7c5e84554"
+      "sha256": "5d7a7d08f6b4fdb4af7c645796222b01dc13c10635a116ab6fc53f672a433c1a"
     },
     {
       "path": "runtime/hooks/lib/branch-staleness.ts",
@@ -227,7 +227,7 @@
     },
     {
       "path": "runtime/hooks/lib/drain-retro-spool.ts",
-      "sha256": "b0d8988333374f6f466c669b1f8d596b1b4936e5c93d8e7ee32d83b0cbf95589"
+      "sha256": "7c1b5a9946f4e358c9a81864358c97de46759def648fc0a70de2a15f6029839b"
     },
     {
       "path": "runtime/hooks/lib/feature-provenance.ts",
@@ -307,7 +307,7 @@
     },
     {
       "path": "runtime/hooks/lib/principle-trace.ts",
-      "sha256": "c9deeeb36c2a3259dbf0f53596861be841af3950868ddf8b612cb315e56088e2"
+      "sha256": "08244a3285824e3acbc9f538ea6b2d8cabd806f853b0fc30606f0a5abbda512f"
     },
     {
       "path": "runtime/hooks/lib/process-kill-guard.ts",
@@ -315,7 +315,7 @@
     },
     {
       "path": "runtime/hooks/lib/project-knowledge.ts",
-      "sha256": "3f4f5bb1afedf68ee4250f9fee0d4d090385246affa4be0ba1cb1f31ad877d66"
+      "sha256": "57c008564fe56d0540c01d78e65b65b9ac1a2ce8635359714d136de4af3c7f72"
     },
     {
       "path": "runtime/hooks/lib/quality-state.ts",

--- a/plugin/runtime/hooks/lib/blocked-on-gate.ts
+++ b/plugin/runtime/hooks/lib/blocked-on-gate.ts
@@ -14,8 +14,8 @@
  * so it is unit-testable without disk.
  */
 
-import { parseFrontmatter } from './hierarchy.ts';
-import { detectPhaseAdvance } from './review-ledger.ts';
+import { parseFrontmatter } from './hierarchy.js';
+import { detectPhaseAdvance } from './review-ledger.js';
 
 /** A blocker's resolution: whether it exists in the corpus, and its status. */
 export interface BlockerStatus {

--- a/plugin/runtime/hooks/lib/drain-retro-spool.ts
+++ b/plugin/runtime/hooks/lib/drain-retro-spool.ts
@@ -15,7 +15,7 @@ import {
   drainAcknowledgedDrafts,
   readSpooledDrafts,
   verifyDraftBody,
-} from './retro-draft-spool.ts';
+} from './retro-draft-spool.js';
 
 export type DrainRetroSpoolResult =
   | { state: 'refused'; message: string }

--- a/plugin/runtime/hooks/lib/principle-trace.ts
+++ b/plugin/runtime/hooks/lib/principle-trace.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import nodePath from 'node:path';
 
-import { activeLines, sectionBody } from './impl-plan.ts';
-import { resolveReviewKnowledgeSources } from './project-knowledge.ts';
+import { activeLines, sectionBody } from './impl-plan.js';
+import { resolveReviewKnowledgeSources } from './project-knowledge.js';
 
 interface PrincipleTrace {
   principle: string;

--- a/plugin/runtime/hooks/lib/project-knowledge.ts
+++ b/plugin/runtime/hooks/lib/project-knowledge.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync } from 'node:fs';
 
-import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.ts';
+import { readConfiguredPathValue, resolveConfiguredPath } from './namespace-root.js';
 
 export type ReviewKnowledgeKey = 'principles' | 'personas' | 'surfaces';
 


### PR DESCRIPTION
Closes `TJ2ZAK`.

## What was wrong

Root `tsc --noEmit -p tsconfig.json` reported two errors:

```
templates/hooks/lib/drain-retro-spool.ts(18,8): error TS5097: An import path can only end
  with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
templates/hooks/lib/project-knowledge.ts(3,64): error TS5097: ...
```

The root tsconfig includes `packages/*/src/**/*`. Once `src/commands/retro-drain.ts` and `src/commands/review-knowledge.ts` began importing those two hook libs (#3205), the libs entered the root program and their `.ts` sibling specifiers became errors.

## Why fix the specifiers, not the tsconfig

`.js` was **already the convention** in these files — 62 sibling imports use it, 6 use `.ts`. The six were the outliers, not the rule. Adding `allowImportingTsExtensions` to the root tsconfig would have silenced the symptom while preserving a convention violation that the next `src` → hook-lib import would re-expose.

## The runtime risk, checked

These libs are installed to `.safeword/hooks/lib/` and executed **directly by bun**, so a specifier that only satisfies the typechecker would break real hooks. Verified the installed hook still works end to end:

```
$ bun .safeword/hooks/lib/drain-retro-spool.ts <spool> --validated-jsonl
{"signature":"s","title":"T","body":"B","labels":["r"]}
[exit=0]
```

Bun resolves `./x.js` to the adjacent `./x.ts`, which is what the other 62 imports already rely on.

## Verification

- [x] Root `tsc --noEmit -p tsconfig.json` — clean (was 2 errors)
- [x] `packages/cli` typecheck — clean
- [x] Installed hook runs under bun and streams validated JSONL
- [x] `parity-check --mode=all` — 255 pairs, 8 contracts in sync (dogfood copies synced via `--fix`)
- [x] `tests/hooks/ tests/commands/ tests/schema.test.ts` — 144 files, 2594 passed, 4 skipped

Files touched in matched template/dogfood pairs: `blocked-on-gate.ts`, `drain-retro-spool.ts`, `principle-trace.ts`, `project-knowledge.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)