### PR TITLE
chore(tickets): file P6PN58 for auto-lint skipping shell-driven edits

### DIFF
--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (569)
+## Tickets (570)
 
 ### 001
 
@@ -1759,6 +1759,9 @@
 - **Ship a clean release for safeword users (P2JDY5)** (done, epic: —)
   Audit and reconcile every change merged since v0.69.0, apply justified behavior-preserving refactors, verify release readiness, and close completed tracking items.
   → `.project/tickets/P2JDY5-release-readiness-v0-70`
+- **Lint files changed by shell commands, not just file-tool edits (P6PN58)** (in_progress, epic: —)
+  Give auto-lint a path-discovery fallback so a file edited through a shell command gets linted on all three hosts, matching the coverage quality hooks already have
+  → `.project/tickets/P6PN58-lint-skips-shell-edits`
 - **Reconcile arcade `.project/` and architecture-tracking conventions with safeword (P8RJ4M)** (done, epic: —)
   Decide how safeword behaves for customers who also run arcade — specifically how shared inputs (personas, glossary) and architecture-tracking patterns reconcile when both tools want to author or read the same project knowledge.
   → `.project/tickets/P8RJ4M`

--- a/.project/tickets/P6PN58-lint-skips-shell-edits/ticket.md
+++ b/.project/tickets/P6PN58-lint-skips-shell-edits/ticket.md
@@ -1,0 +1,90 @@
+---
+id: P6PN58
+slug: lint-skips-shell-edits
+type: task
+phase: intake
+status: in_progress
+created: 2026-08-20T15:46:36.381Z
+last_modified: 2026-08-20T15:46:36.381Z
+---
+
+# Lint files changed by shell commands, not just file-tool edits
+
+**Goal:** Give auto-lint a path-discovery fallback so a file edited through a shell command gets linted on all three hosts, matching the coverage quality hooks already have
+
+**Why:** post-tool-lint keys off tool_input.file_path, which only exists for file-edit tools; a shell command carries no file_path so the hook exits silently and the edit ships unlinted. All three hosts share the gap while their quality hooks already cover shell, so the asymmetry looks unintended
+
+## The mechanism
+
+`post-tool-lint.ts` resolves its target as:
+
+```ts
+const file = input.tool_input?.file_path ?? input.tool_input?.notebook_path;
+if (!file || !(await Bun.file(file).exists())) process.exit(0);
+```
+
+A shell tool invocation carries a command string, not a `file_path`, so the hook
+exits silently at that guard. Nothing is linted and nothing is reported — the
+edit simply passes unchecked.
+
+## Per-host state (verified 2026-08-20)
+
+| Host | Lint on file-tool edit | Lint on shell-driven edit | Quality hook covers shell |
+| --- | --- | --- | --- |
+| Claude | yes — `PostToolUse` matcher `Edit\|Write\|MultiEdit\|NotebookEdit` | **no** — `Bash` absent from the matcher | yes — `post-tool-quality` matches `...\|Bash` |
+| Codex | yes — `apply_patch` targets are expanded and linted individually | **no** — any non-`apply_patch` tool forwards `rawInput`, which has no `file_path` | yes — `codex/post-tool-quality.ts` runs on the same `PostToolUse` |
+| Cursor | yes — `afterFileEdit` lints `file_path` | **no** — shell edits arrive via `beforeShellExecution` / `postToolUse`, neither of which lints | yes — `cursor/post-tool-quality.ts` matches `Write\|Shell` |
+
+Confirmed the Claude gap is shipped, not just local: `plugin/hooks/hooks.json`
+carries the same `Edit|Write|MultiEdit|NotebookEdit` matcher for
+`post-tool-lint` and `Edit|Write|MultiEdit|NotebookEdit|Bash` for
+`post-tool-quality`.
+
+Codex is the strongest of the three — `postToolLintInputs` expands a multi-file
+`apply_patch` into one lint input per target path — but it still degrades to the
+unlintable raw input for `Bash`.
+
+None of the three `post-tool-quality` hooks call `lintFile` (verified: zero
+references in all three), so quality coverage is not a substitute.
+
+## Why it matters
+
+The gap is invisible in exactly the way that causes damage: the hook does not
+warn that it skipped: it exits 0. An agent editing via `sed`, `python3`, or a
+heredoc gets the same silence as a clean lint result and reasonably concludes
+the edit was checked.
+
+Observed in this session — the `.js` sibling-specifier conversion (`TJ2ZAK`) was
+applied through a Bash script, received no lint feedback, and the resulting
+stale plugin runtime was caught only by CI failing `lint` and `CLI contract`.
+Same shape as [[4F9S56]]: a checker that reports success over ground it never
+examined.
+
+## Options
+
+1. **Path-discovery fallback.** When `file_path` is absent, lint the working
+   tree's changed set (`git diff --name-only HEAD` plus untracked). Bounded, no
+   new host wiring, and fixes all three hosts through the shared hook. Needs a
+   cap so a large diff cannot stall the tool loop.
+2. **Per-host command parsing.** Extract target paths from the shell command
+   itself. More precise, but a parser for arbitrary shell is a losing game.
+3. **Report the skip.** Leave coverage as-is but emit "not linted — no file path
+   in this tool call". Cheapest; converts a silent gap into a visible one
+   without new machinery.
+
+Option 3 is the minimum honest fix; option 1 is what actually closes it.
+
+## Out of scope
+
+- Changing which lint rules run.
+- `pre-tool-quality` / gate behaviour on shell commands.
+- Whether agents should edit files through shell at all.
+
+## Notes
+
+Agent Parity applies: the fix belongs in the shared hook plus each host's
+adapter, and template/dogfood pairs must stay byte-identical.
+
+## Work Log
+
+- 2026-08-20T15:46:36.381Z Started: Created ticket P6PN58


### PR DESCRIPTION
Files `P6PN58`. No code change — a ticket documenting a gap confirmed across all three hosts.

## The mechanism

`post-tool-lint.ts` resolves its target as:

```ts
const file = input.tool_input?.file_path ?? input.tool_input?.notebook_path;
if (!file || !(await Bun.file(file).exists())) process.exit(0);
```

A shell tool invocation carries a command string, not a `file_path`. The hook exits `0` at that guard — nothing linted, nothing reported.

## Per-host state (verified)

| Host | Lint on file-tool edit | Lint on shell-driven edit | Quality hook covers shell |
| --- | --- | --- | --- |
| Claude | yes — matcher `Edit\|Write\|MultiEdit\|NotebookEdit` | **no** — `Bash` absent | yes — `post-tool-quality` matches `...\|Bash` |
| Codex | yes — `apply_patch` targets expanded and linted individually | **no** — non-`apply_patch` forwards raw input with no `file_path` | yes |
| Cursor | yes — `afterFileEdit` lints `file_path` | **no** — shell reaches `beforeShellExecution` / `postToolUse`, neither lints | yes — matcher `Write\|Shell` |

Two things worth calling out:

- **Codex is the strongest** of the three. `postToolLintInputs` expands a multi-file `apply_patch` into one lint input per target path — better than Claude's single-file handling. It still degrades to unlintable raw input for `Bash`.
- **The Claude gap ships.** `plugin/hooks/hooks.json` carries the same `Edit|Write|MultiEdit|NotebookEdit` matcher for `post-tool-lint`, and `...|Bash` for `post-tool-quality`. Not a local-config artifact.

None of the three `post-tool-quality` hooks call `lintFile` (zero references in all three), so quality coverage is not a substitute.

## Why it matters

The hook doesn't warn that it skipped — it exits `0`. An agent editing via `sed`, `python3`, or a heredoc gets the same silence as a clean lint result.

This is not hypothetical: the `TJ2ZAK` specifier conversion in #3252 was applied through a Bash script, received no lint feedback, and the resulting stale plugin runtime was caught only when CI failed `lint` and `CLI contract`. Same shape as `4F9S56` — a checker reporting success over ground it never examined.

## Options recorded

1. **Path-discovery fallback** — when `file_path` is absent, lint the changed set from `git diff --name-only HEAD` plus untracked. Fixes all three hosts through the shared hook; needs a cap so a large diff can't stall the tool loop.
2. **Per-host command parsing** — precise, but parsing arbitrary shell is a losing game.
3. **Report the skip** — keep coverage as-is, emit "not linted — no file path in this tool call". Cheapest; makes the gap visible.

Option 3 is the minimum honest fix; option 1 actually closes it. No option chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)