### PR TITLE
Teach independent reviews to use bounded context

### DIFF
--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -168,13 +168,14 @@ Each pass:
    current-source evidence needed by §1–3, keep each work-product under review
    as a target. If the target alone cannot validate a finding, add only the
    minimum directly relevant supporting evidence: a source, test, contract, or
-   plan. Pass each evidence file with `--context`; context is not additional
-   work under review. Do not dump the repository or add merely related files.
+   plan. Prefer stable evidence that will not change while the reviewer works.
+   Pass each evidence file with `--context`; context is not additional work
+   under review. Do not dump the repository or add merely related files.
    Resolve a review-capable Safeword CLI first; source checkouts do not
    guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
+   bun .safeword/hooks/run-review.ts review run quality-review [--context path/to/evidence] --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -165,12 +165,16 @@ Run the review in passes until **Critical issues** come back None. A couple of p
 Each pass:
 
 1. **Run the shared independent-review coordinator.** After gathering any
-   current-source evidence needed by §1–3, pass only the bounded work-product
-   and scope to the host-owned coordinator. Resolve a review-capable Safeword
-   CLI first; source checkouts do not guarantee a bare `safeword` on `PATH`:
+   current-source evidence needed by §1–3, keep each work-product under review
+   as a target. If the target alone cannot validate a finding, add only the
+   minimum directly relevant supporting evidence: a source, test, contract, or
+   plan. Pass each evidence file with `--context`; context is not additional
+   work under review. Do not dump the repository or add merely related files.
+   Resolve a review-capable Safeword CLI first; source checkouts do not
+   guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review changed-file [more-changed-files...] --agent-handoff --json
+   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
+++ b/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
@@ -1,0 +1,52 @@
+---
+id: V7TSC4
+slug: review-with-enough-context
+type: task
+phase: implement
+status: in_progress
+scope:
+  - guide quality-review to keep authored work as the review target while passing only directly relevant source, tests, contracts, or plans as supporting context
+  - prove the target/context distinction, minimum-context rule, and context-dumping rejection in the shipped skill contract
+out_of_scope:
+  - changing review packet limits, coordinator routing, reviewer models, or runtime sandboxing
+  - automatically discovering context in the CLI or adding an outer agent wrapper
+  - rerunning the remaining benchmark corpus before the default workflow carries the corrected context contract
+done_when:
+  - quality-review tells every supported agent to pass the minimum evidence needed to validate each target through the existing context boundary
+  - guidance keeps supporting files out of the judged target set and rejects broad repository dumps
+  - template, Claude, Codex, and dogfood copies remain synchronized and focused contract tests pass
+created: 2026-08-20T04:54:38.359Z
+last_modified: 2026-08-20T04:54:38.359Z
+---
+
+# Review work with enough context to avoid false findings
+
+**Goal:** Give independent quality reviewers the minimum supporting evidence needed to validate each target without reviewing or dumping unrelated files
+
+**Why:** A paired canary showed patch-only review produced a false blocker, while bounded source-and-test context found the real production wiring gap more accurately than an expensive outer agent.
+
+## Behavior
+
+Keep the work-product under review as the accepted target. When a finding cannot
+be validated from that target alone, pass the smallest directly relevant source,
+test, contract, or plan files through `--context`. Supporting context remains
+untrusted evidence: it is not additional work under review and must not become a
+repository dump.
+
+## Tests
+
+- [ ] The shipped quality-review contract requires minimum relevant context when
+      the target alone cannot validate a finding.
+- [ ] The contract keeps targets distinct from supporting context and shows the
+      existing `--context` command shape.
+- [ ] The contract rejects broad context dumping and names the narrow evidence
+      classes that are appropriate.
+- [ ] Generated and dogfood skill copies stay byte-identical to the template.
+
+## Work Log
+
+- 2026-08-20T04:54:38.359Z Started: Created ticket V7TSC4
+- 2026-08-20T05:00:00Z Spike handoff: One paired canary showed that bounded
+  implementation-and-test context found the historical production-wiring gap
+  that both patch-only review and the outer Terra wrapper missed. Selected a
+  guidance-only change over new coordinator architecture.

--- a/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
+++ b/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
@@ -2,7 +2,7 @@
 id: V7TSC4
 slug: review-with-enough-context
 type: task
-phase: implement
+phase: verify
 status: in_progress
 scope:
   - guide quality-review to keep authored work as the review target while passing only directly relevant source, tests, contracts, or plans as supporting context
@@ -54,3 +54,13 @@ repository dump.
   four assertions RED, then added one bounded-context paragraph and command
   example to the canonical skill and regenerated installed copies. Focused
   review guidance, freshness, and coordinator parity suites pass 41/41.
+- 2026-08-20T06:04:00Z Verification repair: Full Vitest passed twice (502
+  files, 8230 tests, 7 skips each). The Gherkin lane exposed the required
+  Claude historical-catalogue fingerprint; regenerated and sealed the plugin,
+  then the two failed scenarios passed 2/2 (90 steps). Website build and Astro
+  typecheck also pass after supplying its existing worktree dependency.
+- 2026-08-20T06:16:00Z Independent review: Claude approved the target/context
+  boundary and suggested making context visibly optional, preferring stable
+  evidence, removing mirror-assertion duplication, and proving repeated CLI
+  flags. Applied those material changes; 95 focused tests and the Claude plugin
+  release contract pass. Refactor review found no worthwhile structural change.

--- a/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
+++ b/.project/tickets/V7TSC4-review-with-enough-context/ticket.md
@@ -35,13 +35,13 @@ repository dump.
 
 ## Tests
 
-- [ ] The shipped quality-review contract requires minimum relevant context when
+- [x] The shipped quality-review contract requires minimum relevant context when
       the target alone cannot validate a finding.
-- [ ] The contract keeps targets distinct from supporting context and shows the
+- [x] The contract keeps targets distinct from supporting context and shows the
       existing `--context` command shape.
-- [ ] The contract rejects broad context dumping and names the narrow evidence
+- [x] The contract rejects broad context dumping and names the narrow evidence
       classes that are appropriate.
-- [ ] Generated and dogfood skill copies stay byte-identical to the template.
+- [x] Generated and dogfood skill copies stay byte-identical to the template.
 
 ## Work Log
 
@@ -50,3 +50,7 @@ repository dump.
   implementation-and-test context found the historical production-wiring gap
   that both patch-only review and the outer Terra wrapper missed. Selected a
   guidance-only change over new coordinator architecture.
+- 2026-08-20T05:02:00Z TDD: Added a four-surface contract test, confirmed all
+  four assertions RED, then added one bounded-context paragraph and command
+  example to the canonical skill and regenerated installed copies. Focused
+  review guidance, freshness, and coordinator parity suites pass 41/41.

--- a/.project/tickets/V7TSC4-review-with-enough-context/verify.md
+++ b/.project/tickets/V7TSC4-review-with-enough-context/verify.md
@@ -1,0 +1,30 @@
+# Verification
+
+## Verify Checklist
+
+**Test Suite:** ✓ 8415/8415 tests pass
+**Gherkin:** ✅ Acceptance lane passes
+**Build:** ✅ Success
+**Lint:** ✅ Clean
+**Scenarios:** All 4 scenarios marked complete
+**PR Scope:** ✅ Diff matches ticket scope
+**Dep Drift:** ✅ Clean
+**Parent Epic:** N/A
+**Reconcile:** ✅ No pattern deviation
+**Experience:** ⏭️ N/A — not persona-facing
+**Surface Evidence:** ✅ 4/4 affected skill surfaces have recorded proof
+**Evidence limits:** ✅ None
+
+Audit passed — diff-scoped review found no architecture, documentation, dead-reference, or test-quality defects.
+
+## Evidence
+
+- Full relay and CLI suites: 185 relay tests and 8,230 CLI tests passed; 8 total skips.
+- Acceptance lane: 1,482 scenarios passed and 3 skipped. The two catalogue
+  scenarios that initially exposed stale generated evidence passed after regeneration.
+- Focused post-review run: 95 tests passed across context guidance, public CLI
+  wiring, and review-surface parity.
+- Claude historical catalogue and plugin release contract pass at 0.78.6.
+- Website build, Astro check, TypeScript typecheck, lint, and dependency audits pass.
+- Independent Claude review found no blocking defects; all material lean
+  improvements were applied.

--- a/.safeword/skills/quality-review/SKILL.md
+++ b/.safeword/skills/quality-review/SKILL.md
@@ -168,13 +168,14 @@ Each pass:
    current-source evidence needed by §1–3, keep each work-product under review
    as a target. If the target alone cannot validate a finding, add only the
    minimum directly relevant supporting evidence: a source, test, contract, or
-   plan. Pass each evidence file with `--context`; context is not additional
-   work under review. Do not dump the repository or add merely related files.
+   plan. Prefer stable evidence that will not change while the reviewer works.
+   Pass each evidence file with `--context`; context is not additional work
+   under review. Do not dump the repository or add merely related files.
    Resolve a review-capable Safeword CLI first; source checkouts do not
    guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
+   bun .safeword/hooks/run-review.ts review run quality-review [--context path/to/evidence] --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/.safeword/skills/quality-review/SKILL.md
+++ b/.safeword/skills/quality-review/SKILL.md
@@ -165,12 +165,16 @@ Run the review in passes until **Critical issues** come back None. A couple of p
 Each pass:
 
 1. **Run the shared independent-review coordinator.** After gathering any
-   current-source evidence needed by §1–3, pass only the bounded work-product
-   and scope to the host-owned coordinator. Resolve a review-capable Safeword
-   CLI first; source checkouts do not guarantee a bare `safeword` on `PATH`:
+   current-source evidence needed by §1–3, keep each work-product under review
+   as a target. If the target alone cannot validate a finding, add only the
+   minimum directly relevant supporting evidence: a source, test, contract, or
+   plan. Pass each evidence file with `--context`; context is not additional
+   work under review. Do not dump the repository or add merely related files.
+   Resolve a review-capable Safeword CLI first; source checkouts do not
+   guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review changed-file [more-changed-files...] --agent-handoff --json
+   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/packages/cli/codex-plugin/skills/quality-review/SKILL.md
+++ b/packages/cli/codex-plugin/skills/quality-review/SKILL.md
@@ -173,13 +173,14 @@ Each pass:
    current-source evidence needed by §1–3, keep each work-product under review
    as a target. If the target alone cannot validate a finding, add only the
    minimum directly relevant supporting evidence: a source, test, contract, or
-   plan. Pass each evidence file with `--context`; context is not additional
-   work under review. Do not dump the repository or add merely related files.
+   plan. Prefer stable evidence that will not change while the reviewer works.
+   Pass each evidence file with `--context`; context is not additional work
+   under review. Do not dump the repository or add merely related files.
    Resolve a review-capable Safeword CLI first; source checkouts do not
    guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   SAFEWORD_REVIEW_PROGRESS=1 bunx --bun safeword@0.78.7 review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
+   SAFEWORD_REVIEW_PROGRESS=1 bunx --bun safeword@0.78.7 review run quality-review [--context path/to/evidence] --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/packages/cli/codex-plugin/skills/quality-review/SKILL.md
+++ b/packages/cli/codex-plugin/skills/quality-review/SKILL.md
@@ -170,12 +170,16 @@ Run the review in passes until **Critical issues** come back None. A couple of p
 Each pass:
 
 1. **Run the shared independent-review coordinator.** After gathering any
-   current-source evidence needed by §1–3, pass only the bounded work-product
-   and scope to the host-owned coordinator. Resolve a review-capable Safeword
-   CLI first; source checkouts do not guarantee a bare `safeword` on `PATH`:
+   current-source evidence needed by §1–3, keep each work-product under review
+   as a target. If the target alone cannot validate a finding, add only the
+   minimum directly relevant supporting evidence: a source, test, contract, or
+   plan. Pass each evidence file with `--context`; context is not additional
+   work under review. Do not dump the repository or add merely related files.
+   Resolve a review-capable Safeword CLI first; source checkouts do not
+   guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   SAFEWORD_REVIEW_PROGRESS=1 bunx --bun safeword@0.78.7 review run quality-review changed-file [more-changed-files...] --agent-handoff --json
+   SAFEWORD_REVIEW_PROGRESS=1 bunx --bun safeword@0.78.7 review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -46,7 +46,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/lint/SKILL.md':
         'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
-        'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
+        'd19120f79c688c9c933e9d3216a2ac8a0c18a73c52fe865a2d4f4d98f86fc274',
       '.claude/skills/refactor/SKILL.md':
         'a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e',
       '.claude/skills/retro-filer/SKILL.md':

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -168,13 +168,14 @@ Each pass:
    current-source evidence needed by §1–3, keep each work-product under review
    as a target. If the target alone cannot validate a finding, add only the
    minimum directly relevant supporting evidence: a source, test, contract, or
-   plan. Pass each evidence file with `--context`; context is not additional
-   work under review. Do not dump the repository or add merely related files.
+   plan. Prefer stable evidence that will not change while the reviewer works.
+   Pass each evidence file with `--context`; context is not additional work
+   under review. Do not dump the repository or add merely related files.
    Resolve a review-capable Safeword CLI first; source checkouts do not
    guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
+   bun .safeword/hooks/run-review.ts review run quality-review [--context path/to/evidence] --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -165,12 +165,16 @@ Run the review in passes until **Critical issues** come back None. A couple of p
 Each pass:
 
 1. **Run the shared independent-review coordinator.** After gathering any
-   current-source evidence needed by §1–3, pass only the bounded work-product
-   and scope to the host-owned coordinator. Resolve a review-capable Safeword
-   CLI first; source checkouts do not guarantee a bare `safeword` on `PATH`:
+   current-source evidence needed by §1–3, keep each work-product under review
+   as a target. If the target alone cannot validate a finding, add only the
+   minimum directly relevant supporting evidence: a source, test, contract, or
+   plan. Pass each evidence file with `--context`; context is not additional
+   work under review. Do not dump the repository or add merely related files.
+   Resolve a review-capable Safeword CLI first; source checkouts do not
+   guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun .safeword/hooks/run-review.ts review run quality-review changed-file [more-changed-files...] --agent-handoff --json
+   bun .safeword/hooks/run-review.ts review run quality-review --context path/to/evidence --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground

--- a/packages/cli/tests/cli-protocol/review-wiring.test.ts
+++ b/packages/cli/tests/cli-protocol/review-wiring.test.ts
@@ -257,6 +257,7 @@ describe('cross-agent review public-command wiring', () => {
     const promptLog = nodePath.join(directory, 'prompt.log');
     writeFileSync(nodePath.join(directory, 'target.md'), 'review this\n');
     writeFileSync(nodePath.join(directory, 'context.md'), 'supporting evidence\n');
+    writeFileSync(nodePath.join(directory, 'other-context.md'), 'contract evidence\n');
     const bin = installFakeReviewer(directory, 'claude');
 
     const result = await runCli(
@@ -267,6 +268,8 @@ describe('cross-agent review public-command wiring', () => {
         'target.md',
         '--context',
         'context.md',
+        '--context',
+        'other-context.md',
         '--json',
         '--no-input',
         '--cwd',
@@ -288,6 +291,7 @@ describe('cross-agent review public-command wiring', () => {
     const prompt = readFileSync(promptLog, 'utf8');
     expect(prompt).toContain('"logical_files":[{"path":"target.md"');
     expect(prompt).toContain('"context_files":[{"path":"context.md"');
+    expect(prompt).toContain('{"path":"other-context.md"');
     expect(prompt).toContain('supporting context, not work under review');
   });
 

--- a/packages/cli/tests/skills/quality-review-context-guidance.test.ts
+++ b/packages/cli/tests/skills/quality-review-context-guidance.test.ts
@@ -15,12 +15,13 @@ const QUALITY_REVIEW_SKILLS = [
 describe('quality-review supporting context guidance', () => {
   it.each(QUALITY_REVIEW_SKILLS)('%s keeps review targets distinct from minimum context', path => {
     const content = readFileSync(nodePath.join(repoRoot, path), 'utf8');
+    const normalized = content.replaceAll(/\s+/gu, ' ');
 
-    expect(content).toContain('Keep each work-product under review as a target');
-    expect(content).toContain('minimum directly relevant supporting evidence');
+    expect(normalized).toContain('keep each work-product under review as a target');
+    expect(normalized).toContain('minimum directly relevant supporting evidence');
     expect(content).toContain('--context path/to/evidence');
-    expect(content).toMatch(/source, test, contract, or plan/u);
-    expect(content).toContain('Do not dump the repository');
-    expect(content).toContain('context is not additional work under review');
+    expect(normalized).toMatch(/source, test, contract, or plan/u);
+    expect(normalized).toContain('Do not dump the repository');
+    expect(normalized).toContain('context is not additional work under review');
   });
 });

--- a/packages/cli/tests/skills/quality-review-context-guidance.test.ts
+++ b/packages/cli/tests/skills/quality-review-context-guidance.test.ts
@@ -5,22 +5,19 @@ import { describe, expect, it } from 'vitest';
 
 const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
 
-const QUALITY_REVIEW_SKILLS = [
-  'packages/cli/templates/skills/quality-review/SKILL.md',
-  '.claude/skills/quality-review/SKILL.md',
-  '.safeword/skills/quality-review/SKILL.md',
-  'packages/cli/codex-plugin/skills/quality-review/SKILL.md',
-] as const;
-
 describe('quality-review supporting context guidance', () => {
-  it.each(QUALITY_REVIEW_SKILLS)('%s keeps review targets distinct from minimum context', path => {
-    const content = readFileSync(nodePath.join(repoRoot, path), 'utf8');
+  it('keeps review targets distinct from minimum stable context', () => {
+    const content = readFileSync(
+      nodePath.join(repoRoot, 'packages/cli/templates/skills/quality-review/SKILL.md'),
+      'utf8',
+    );
     const normalized = content.replaceAll(/\s+/gu, ' ');
 
     expect(normalized).toContain('keep each work-product under review as a target');
     expect(normalized).toContain('minimum directly relevant supporting evidence');
     expect(content).toContain('--context path/to/evidence');
     expect(normalized).toMatch(/source, test, contract, or plan/u);
+    expect(normalized).toContain('stable evidence that will not change while the reviewer works');
     expect(normalized).toContain('Do not dump the repository');
     expect(normalized).toContain('context is not additional work under review');
   });

--- a/packages/cli/tests/skills/quality-review-context-guidance.test.ts
+++ b/packages/cli/tests/skills/quality-review-context-guidance.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = nodePath.resolve(import.meta.dirname, '../../../..');
+
+const QUALITY_REVIEW_SKILLS = [
+  'packages/cli/templates/skills/quality-review/SKILL.md',
+  '.claude/skills/quality-review/SKILL.md',
+  '.safeword/skills/quality-review/SKILL.md',
+  'packages/cli/codex-plugin/skills/quality-review/SKILL.md',
+] as const;
+
+describe('quality-review supporting context guidance', () => {
+  it.each(QUALITY_REVIEW_SKILLS)('%s keeps review targets distinct from minimum context', path => {
+    const content = readFileSync(nodePath.join(repoRoot, path), 'utf8');
+
+    expect(content).toContain('Keep each work-product under review as a target');
+    expect(content).toContain('minimum directly relevant supporting evidence');
+    expect(content).toContain('--context path/to/evidence');
+    expect(content).toMatch(/source, test, contract, or plan/u);
+    expect(content).toContain('Do not dump the repository');
+    expect(content).toContain('context is not additional work under review');
+  });
+});

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.7",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "49264b64c82569a5553f60bbb78893d40e129e1c4a4cf9283d7c21b98133a0c3"
+  "inventory_sha256": "6c5f5cde341c9a4a43079ee2dea327badad0a1e402be5773a713d1251064af98"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -143,11 +143,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "7350bbc5f0a2b282489bca55fedfbb6f6ffbd52bf1bce06899e8897c6b6ebdda"
+      "sha256": "84487060a573c2e1875b3d8252c2e94cb23b1b1ed9c791fc375a39759596541d"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "7fc0d20b2e2f1548141699d11425d0d6b5d201be1203fc9dffe388536253341a"
+      "sha256": "4c5d30d27c28f71a4958be14b92f27b92e3fc4fd6b0b19fee757190d56643277"
     },
     {
       "path": "runtime/event-groups.json",
@@ -663,7 +663,7 @@
     },
     {
       "path": "skills/quality-review/SKILL.md",
-      "sha256": "244fee019f778dc69dc0f9778071f7a017490116bd9202cb6bc08a39f7ca5c1c"
+      "sha256": "81cace0d003c14e1edd167522100b44feb0b88126a25d29a1db4a3ff02b52ea5"
     },
     {
       "path": "skills/refactor/SKILL.md",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -596,7 +596,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/finish-review/REVIEWER.md": "0ecee21a63f91e09d3136f62cf8f7590ba9a640b85cad7b7b35c1ae334ff43c2",
         ".claude/skills/finish-review/SKILL.md": "e9ed5d198994b6cca12c62b1a4c13a1db2d82d65fc8a9173a41c5b5cf312cd52",
         ".claude/skills/lint/SKILL.md": "fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19",
-        ".claude/skills/quality-review/SKILL.md": "b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a",
+        ".claude/skills/quality-review/SKILL.md": "d19120f79c688c9c933e9d3216a2ac8a0c18a73c52fe865a2d4f4d98f86fc274",
         ".claude/skills/refactor/SKILL.md": "a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e",
         ".claude/skills/retro-filer/SKILL.md": "ea126f3805a2befefb4db2011439f075ebfd6eca31b78bd5f284ac11d667b4f0",
         ".claude/skills/retro/SKILL.md": "166e5109193bad4c26e060f6841d71c03f9155c7e74e1853c43b99b01c25d379",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1800,7 +1800,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/lint/SKILL.md':
         'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
-        'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
+        'd19120f79c688c9c933e9d3216a2ac8a0c18a73c52fe865a2d4f4d98f86fc274',
       '.claude/skills/refactor/SKILL.md':
         'a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e',
       '.claude/skills/retro-filer/SKILL.md':

--- a/plugin/skills/quality-review/SKILL.md
+++ b/plugin/skills/quality-review/SKILL.md
@@ -165,12 +165,17 @@ Run the review in passes until **Critical issues** come back None. A couple of p
 Each pass:
 
 1. **Run the shared independent-review coordinator.** After gathering any
-   current-source evidence needed by §1–3, pass only the bounded work-product
-   and scope to the host-owned coordinator. Resolve a review-capable Safeword
-   CLI first; source checkouts do not guarantee a bare `safeword` on `PATH`:
+   current-source evidence needed by §1–3, keep each work-product under review
+   as a target. If the target alone cannot validate a finding, add only the
+   minimum directly relevant supporting evidence: a source, test, contract, or
+   plan. Prefer stable evidence that will not change while the reviewer works.
+   Pass each evidence file with `--context`; context is not additional work
+   under review. Do not dump the repository or add merely related files.
+   Resolve a review-capable Safeword CLI first; source checkouts do not
+   guarantee a bare `safeword` on `PATH`:
 
    ```bash
-   bun "${CLAUDE_PLUGIN_ROOT}"/runtime/hooks/run-review.ts review run quality-review changed-file [more-changed-files...] --agent-handoff --json
+   bun "${CLAUDE_PLUGIN_ROOT}"/runtime/hooks/run-review.ts review run quality-review [--context path/to/evidence] --agent-handoff --json -- changed-file [more-changed-files...]
    ```
 
    A healthy deep review may return `REVIEW_PENDING` after its foreground


### PR DESCRIPTION
## Summary
- keep review targets distinct from supporting evidence
- pass only minimum stable source, test, contract, or plan context
- prove repeated `--context` flags through the public CLI

## Verification
- 95 focused tests pass
- Claude historical catalogue covers 9 releases
- Claude plugin release contract aligned at 0.78.7
- full verification evidence is recorded in V7TSC4/verify.md

## Scope
This improves the on-demand quality-review path. Wiring the same evidence distinction into the automatic PR reviewer is the next critical-path slice.