### PR TITLE
chore(tickets): file KEQQGN for unbounded Codex reference-path rewriting

### DIFF
--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (570)
+## Tickets (572)
 
 ### 001
 
@@ -620,6 +620,9 @@
 - **Keep advisory reviews current without repeated noise (Z7M7Y3)** (in_progress, epic: trustworthy-advisory-pr-review)
   Preserve trustworthy freshness while reducing repeated review work and finding noise across revisions.
   → `.project/tickets/Z7M7Y3-keep-advisory-reviews-current-without-repeated-noise`
+- **Give automatic PR reviews enough context (ZA6DGD)** (in_progress, epic: —)
+  Reduce patch-only false findings by reviewing each changed patch with bounded full-file context from the exact PR head
+  → `.project/tickets/ZA6DGD-give-automatic-pr-reviews-enough-context`
 
 ### phase-step-enforcement
 
@@ -1666,6 +1669,9 @@
 - **Make project knowledge shape and challenge feature delivery (KD4C2A)** (done, epic: —)
   Ship a proportional project-knowledge thread from feature discovery through independent review, verification, and objective audit.
   → `.project/tickets/KD4C2A-principles-flow-spike`
+- **Bound the Codex reference-path rewrite to real Markdown links (KEQQGN)** (in_progress, epic: —)
+  Make adaptSkillBody rewrite only genuine relative reference links, leaving already-prefixed paths, URLs, and prose mentions alone
+  → `.project/tickets/KEQQGN-reference-rewrite-boundaries`
 - **Keep every public CLI command consistent for users and agents (KJKGDM)** (in_progress, epic: —)
   Make every public command discoverable, machine-safe, option-accurate, and canonically documented without deleting retained aliases.
   external issue: https://github.com/ArcadeAI/safeword/issues/2251

--- a/.project/tickets/KEQQGN-reference-rewrite-boundaries/ticket.md
+++ b/.project/tickets/KEQQGN-reference-rewrite-boundaries/ticket.md
@@ -1,0 +1,87 @@
+---
+id: KEQQGN
+slug: reference-rewrite-boundaries
+type: task
+phase: intake
+status: in_progress
+created: 2026-08-20T23:06:48.319Z
+last_modified: 2026-08-20T23:06:48.319Z
+---
+
+# Bound the Codex reference-path rewrite to real Markdown links
+
+**Goal:** Make adaptSkillBody rewrite only genuine relative reference links, leaving already-prefixed paths, URLs, and prose mentions alone
+
+**Why:** The rewrite is an unrestricted global substring replace, so any occurrence of a sibling reference filename is rewritten - an already-prefixed references/NAME.md becomes references/references/NAME.md, a URL ending in that filename is corrupted, and prose mentions are silently turned into paths. Raised twice by independent Codex review
+
+## The mechanism
+
+`adaptSkillBody` in `packages/cli/src/codex-plugin/catalogue.ts`:
+
+```ts
+for (const referenceName of referenceNames) {
+  adapted = adapted.split(referenceName).join(`references/${referenceName}`);
+}
+```
+
+`referenceNames` are the sibling `.md` filenames in a skill directory. The
+replacement is unanchored and unconditional: every occurrence of that filename
+anywhere in the body is rewritten, with no notion of whether it is a link, a
+URL, or ordinary prose.
+
+## Reproduced
+
+A fixture skill whose sibling reference is `TDD.md`, generated at `1.2.3`:
+
+| Source line | Generated |
+| --- | --- |
+| `Plain link: TDD.md` | `Plain link: references/TDD.md` ✅ intended |
+| `Already prefixed: references/TDD.md` | `references/references/TDD.md` ❌ |
+| `In a URL: https://example.com/docs/TDD.md` | `.../docs/references/TDD.md` ❌ |
+| `In prose: the TDD.md file explains it` | `the references/TDD.md file explains it` ❌ |
+
+A fourth hazard is order-dependence: sibling names where one is a substring of
+another (`TDD.md` inside `X-TDD.md`) would corrupt the longer name when the
+shorter is replaced first.
+
+## Not currently reachable
+
+Verified against the real corpus on 2026-08-20:
+
+- No `references/references/` anywhere in `packages/cli/codex-plugin/`.
+- No `https?://…\.md` URLs in `templates/skills/`.
+- No sibling reference filename is a substring of another in any skill.
+
+So nothing ships broken today. The hazard is that all three preconditions are
+ordinary things to write — a doc author adding a URL to an upstream `.md`, or
+pre-writing a `references/` path, silently corrupts the generated Codex skill.
+
+## Provenance
+
+Raised twice by independent Codex review, in two separate sessions, against
+different file sets. It was set aside the first time as pre-existing and
+out-of-scope for the change under review — which was true both times, and is
+why it needs its own ticket rather than a third dismissal.
+
+## Direction
+
+Rewrite only genuine relative reference links. Minimum viable shape:
+
+- Skip an occurrence already preceded by `references/`.
+- Skip occurrences inside an absolute URL.
+- Require a path boundary before the filename, so a longer token containing it
+  is not matched.
+- Process sibling names longest-first to remove the substring ordering hazard.
+
+A stricter alternative is to parse Markdown link targets and rewrite only those,
+which is more correct but heavier than this corpus needs.
+
+## Out of scope
+
+- Workflow invocation rewriting (`adaptWorkflowInvocations`) — separate pass,
+  already boundary-aware.
+- Whether references should live in a subdirectory at all.
+
+## Work Log
+
+- 2026-08-20T23:06:48.319Z Started: Created ticket KEQQGN


### PR DESCRIPTION
Files `KEQQGN`. No code change — the third finding from the independent Codex review of #3205's refactor, raised twice now and set aside twice.

## The mechanism

`adaptSkillBody`:

```ts
for (const referenceName of referenceNames) {
  adapted = adapted.split(referenceName).join(`references/${referenceName}`);
}
```

Unanchored, unconditional. Every occurrence of a sibling reference filename is rewritten regardless of whether it's a link, a URL, or prose.

## Reproduced

Fixture skill with sibling reference `TDD.md`:

| Source | Generated |
| --- | --- |
| `Plain link: TDD.md` | `references/TDD.md` ✅ intended |
| `Already prefixed: references/TDD.md` | `references/references/TDD.md` ❌ |
| `In a URL: https://example.com/docs/TDD.md` | `.../docs/references/TDD.md` ❌ |
| `In prose: the TDD.md file explains it` | `the references/TDD.md file explains it` ❌ |

Plus an order hazard: sibling names where one contains another (`TDD.md` inside `X-TDD.md`) corrupt the longer when the shorter is replaced first.

## Not reachable today — verified

- No `references/references/` anywhere in `packages/cli/codex-plugin/`
- No `https?://….md` URLs in `templates/skills/`
- No sibling reference filename is a substring of another

Nothing ships broken. The concern is that all three preconditions are ordinary things to write — adding a URL to an upstream `.md`, or pre-writing a `references/` path, silently corrupts the generated Codex skill with no error.

## Why file it now

Raised by independent review in two separate sessions against different file sets. Both times I judged it pre-existing and out of scope for the change under review — correct both times, and exactly why it needs a ticket instead of a third dismissal.

## Direction recorded

Skip occurrences already preceded by `references/`, skip those inside absolute URLs, require a path boundary before the filename, and process sibling names longest-first. A stricter alternative — parse Markdown link targets and rewrite only those — is more correct but heavier than this corpus needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)