### PR TITLE
Preserve failed and interrupted lint status

### DIFF
--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -16,37 +16,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -56,3 +69,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/.cursor/commands/lint.md
+++ b/.cursor/commands/lint.md
@@ -11,37 +11,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -51,3 +64,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/.safeword/skills/lint/SKILL.md
+++ b/.safeword/skills/lint/SKILL.md
@@ -16,37 +16,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -56,3 +69,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/packages/cli/codex-plugin/skills/lint/SKILL.md
+++ b/packages/cli/codex-plugin/skills/lint/SKILL.md
@@ -14,37 +14,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -54,3 +67,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/packages/cli/templates/commands/lint.md
+++ b/packages/cli/templates/commands/lint.md
@@ -11,37 +11,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -51,3 +64,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/packages/cli/templates/skills/lint/SKILL.md
+++ b/packages/cli/templates/skills/lint/SKILL.md
@@ -16,37 +16,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -56,3 +69,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean

--- a/packages/cli/tests/skills/lint-skill-exit-status.test.ts
+++ b/packages/cli/tests/skills/lint-skill-exit-status.test.ts
@@ -38,20 +38,32 @@ function writeExecutable(directory: string, name: string, body: string): void {
 
 function runLintInstructions(
   relativePath: string,
-  options: { hasGoManifest?: boolean } = {},
-): { status: number | null; goCommands: string[] } {
+  options: { hasGoManifest?: boolean; hasTypeScript?: boolean; lintStatus?: number } = {},
+): { status: number | null; bunCommands: string[]; goCommands: string[] } {
   const projectDirectory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-lint-skill-'));
   const binDirectory = nodePath.join(projectDirectory, 'fake-bin');
+  const bunCommandsPath = nodePath.join(projectDirectory, 'bun-commands.log');
   const goCommandsPath = nodePath.join(projectDirectory, 'go-commands.log');
 
   try {
     mkdirSync(binDirectory);
     writeFileSync(nodePath.join(projectDirectory, 'package.json'), '{"scripts":{}}\n');
+    if (options.hasTypeScript)
+      writeFileSync(nodePath.join(projectDirectory, 'tsconfig.json'), '{}\n');
     if (options.hasGoManifest)
       writeFileSync(nodePath.join(projectDirectory, 'go.mod'), 'module example\n');
 
-    writeExecutable(binDirectory, 'bun', 'exit 0');
-    writeExecutable(binDirectory, 'bunx', 'exit 0');
+    writeExecutable(
+      binDirectory,
+      'bun',
+      String.raw`printf '%s\n' "$*" >> "${bunCommandsPath}"
+if [ "$*" = "run lint" ]; then exit ${options.lintStatus ?? 0}; fi`,
+    );
+    writeExecutable(
+      binDirectory,
+      'bunx',
+      String.raw`printf 'bunx %s\n' "$*" >> "${bunCommandsPath}"`,
+    );
     writeExecutable(
       binDirectory,
       'golangci-lint',
@@ -66,6 +78,9 @@ function runLintInstructions(
 
     return {
       status: result.status,
+      bunCommands: existsSync(bunCommandsPath)
+        ? readFileSync(bunCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
+        : [],
       goCommands: existsSync(goCommandsPath)
         ? readFileSync(goCommandsPath, 'utf8').trim().split('\n').filter(Boolean)
         : [],
@@ -80,7 +95,28 @@ describe('lint instructions exit status (#1701)', () => {
     const result = runLintInstructions(relativePath);
 
     expect(result.status).toBe(0);
+    expect(result.bunCommands).toEqual(['run lint', 'run format --if-present']);
     expect(result.goCommands).toEqual([]);
+  });
+
+  it.each(LINT_SURFACES)('%s preserves a lint failure after running later checks', relativePath => {
+    const result = runLintInstructions(relativePath, {
+      hasTypeScript: true,
+      lintStatus: 1,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.bunCommands).toEqual([
+      'run lint',
+      'run format --if-present',
+      'bunx tsc --noEmit',
+    ]);
+  });
+
+  it.each(LINT_SURFACES)('%s preserves an interrupted lint status', relativePath => {
+    const result = runLintInstructions(relativePath, { lintStatus: 130 });
+
+    expect(result.status).toBe(130);
   });
 
   it.each(LINT_SURFACES)(


### PR DESCRIPTION
## Summary

- preserve the first non-zero lint status while still running independent checks
- retain interrupted status instead of reporting a false clean result
- keep Claude, Cursor, Codex, template, and dogfood surfaces in parity

## Verification

- `npx vitest run tests/skills/lint-skill-exit-status.test.ts` (20/20 passed)
- formatting and `git diff --check` passed
