### PR TITLE
Sync lint skill into Claude plugin runtime

### DIFF
--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -44,7 +44,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/finish-review/SKILL.md':
         '8ff3fbeb2ba9eb6f9278bea718aacd747682dae4245bdb87356988c53611a69b',
       '.claude/skills/lint/SKILL.md':
-        '208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66',
+        '749fa65b78979eee163ea6fd151d5f48eb145b33680a45f04f15fcf4a4eb36b2',
       '.claude/skills/quality-review/SKILL.md':
         '5e480b2d38b704ed221cddeab938dea0ac3c904c6745147eb192e42ffb4d3bbb',
       '.claude/skills/refactor/SKILL.md':

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "cececb26df617d1bb84304494cb77370a7297147ce83718151ffca1ecff1f0f8"
+  "inventory_sha256": "717cfb466919616e504e9d3e2d23da4120c834c7ba95d6f2dab3d4522d4b08f1"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -651,7 +651,7 @@
     },
     {
       "path": "skills/lint/SKILL.md",
-      "sha256": "208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66"
+      "sha256": "749fa65b78979eee163ea6fd151d5f48eb145b33680a45f04f15fcf4a4eb36b2"
     },
     {
       "path": "skills/quality-review/SKILL.md",

--- a/plugin/skills/lint/SKILL.md
+++ b/plugin/skills/lint/SKILL.md
@@ -16,37 +16,50 @@ Run the full linting and formatting suite for the detected project type(s).
 Run these commands based on project type. All detected languages run for polyglot projects.
 
 ```bash
+lint_status=0
+run_lint_step() {
+  "$@" 2>&1
+  step_status=$?
+  if [ "$step_status" -ne 0 ] && [ "$lint_status" -eq 0 ]; then
+    lint_status="$step_status"
+  fi
+}
+
 # Python linting (if pyproject.toml or requirements.txt exists)
 ([ -f pyproject.toml ] || [ -f requirements.txt ]) && {
   # Ruff - fix code quality issues
-  ruff check --fix . 2>&1 || true
+  run_lint_step ruff check --fix .
   # Ruff - format all files
-  ruff format . 2>&1 || true
+  run_lint_step ruff format .
   # mypy - type check
-  mypy . 2>&1 || true
+  run_lint_step mypy .
 }
 
 # JS/TS linting (if package.json exists)
 [ -f package.json ] && {
   # ESLint - use lint:eslint if exists (projects with existing linter), else lint
   if grep -q '"lint:eslint"' package.json 2> /dev/null; then
-    bun run lint:eslint 2>&1 || true
+    run_lint_step bun run lint:eslint
   else
-    bun run lint 2>&1 || true
+    run_lint_step bun run lint
   fi
   # Prettier - format all files
-  bun run format --if-present 2>&1 || true
+  run_lint_step bun run format --if-present
   # TypeScript type check (if tsconfig.json exists)
-  [ -f tsconfig.json ] && bunx tsc --noEmit 2>&1 || true
+  if [ -f tsconfig.json ]; then
+    run_lint_step bunx tsc --noEmit
+  fi
 }
 
 # Go linting (if go.mod exists)
 if [ -f go.mod ]; then
   # golangci-lint - fix and report issues
-  golangci-lint run --fix ./... 2>&1 || true
+  run_lint_step golangci-lint run --fix ./...
   # golangci-lint - format
-  golangci-lint fmt ./... 2>&1 || true
+  run_lint_step golangci-lint fmt ./...
 fi
+
+exit "$lint_status"
 ```
 
 ## Summary
@@ -56,3 +69,4 @@ After running, report:
 1. Any linting errors that couldn't be auto-fixed (Ruff, ESLint, or golangci-lint)
 2. Any formatting issues
 3. Type errors (mypy or TypeScript)
+4. Interrupted checks as unverified, never clean


### PR DESCRIPTION
## Summary

- regenerate the native Claude plugin after the lint status fix
- update sealed inventory and identity digests
- record the new lint-skill fingerprint in the historical catalogue

## Verification

- `bun run check:claude-plugin`
- `npx vitest run tests/skills/lint-skill-exit-status.test.ts` (20/20 passed)
- `git diff --check`
