### PR TITLE
Ignore Go checker build artifact

### DIFF
--- a/experiments/go-skill-directive/checker/.gitignore
+++ b/experiments/go-skill-directive/checker/.gitignore
@@ -1,1 +1,1 @@
-checkbin
+/checker


### PR DESCRIPTION
## Summary

Ignore the local `checker` binary emitted by the repository-authoritative `go build ./...` lane so verification does not dirty its own worktree.

## Verification

- `go build ./...`
- `git status --short` reports only the intended `.gitignore` change
- `git diff --check`
