### PR TITLE
fix(lint): refresh bundled plugin catalogue

### DIFF
--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.76.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "717cfb466919616e504e9d3e2d23da4120c834c7ba95d6f2dab3d4522d4b08f1"
+  "inventory_sha256": "6db160a5ae0d533b2f111316196488afaf037669760d3a8e2ab95a4b1a1e2c93"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -139,11 +139,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "9459a7e602241a022b358a37e70b4b6ca9365a2f7fbf0ba8a16accd286f0433c"
+      "sha256": "7a486487bf1ae1624c0e563d0aaaeec35ac3064ed3183ad28bca179d1ae64fc3"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "07813c507e06ee3129fb2018ee36297553ba75eff4fc08a6ffa55b8223d83636"
+      "sha256": "349e57a04c9f3cdf5d00d79f5ded084a7e65a80450e2da0ae5aef6e92f3ff846"
     },
     {
       "path": "runtime/event-groups.json",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -6107,7 +6107,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/figure-it-out/SKILL.md": "18e2b44e9a91562079b3e1f52fcd9f952b5f57a0f0e7647b0273809848a75c0d",
         ".claude/skills/finish-review/REVIEWER.md": "0ecee21a63f91e09d3136f62cf8f7590ba9a640b85cad7b7b35c1ae334ff43c2",
         ".claude/skills/finish-review/SKILL.md": "8ff3fbeb2ba9eb6f9278bea718aacd747682dae4245bdb87356988c53611a69b",
-        ".claude/skills/lint/SKILL.md": "208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66",
+        ".claude/skills/lint/SKILL.md": "749fa65b78979eee163ea6fd151d5f48eb145b33680a45f04f15fcf4a4eb36b2",
         ".claude/skills/quality-review/SKILL.md": "5e480b2d38b704ed221cddeab938dea0ac3c904c6745147eb192e42ffb4d3bbb",
         ".claude/skills/refactor/SKILL.md": "a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e",
         ".claude/skills/retro-filer/SKILL.md": "ea126f3805a2befefb4db2011439f075ebfd6eca31b78bd5f284ac11d667b4f0",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1785,7 +1785,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/finish-review/SKILL.md':
         '8ff3fbeb2ba9eb6f9278bea718aacd747682dae4245bdb87356988c53611a69b',
       '.claude/skills/lint/SKILL.md':
-        '208ec54032cabdcb532d1070e5ef5f1fcd6f0f0bfe8daf08e4ecf007aa285f66',
+        '749fa65b78979eee163ea6fd151d5f48eb145b33680a45f04f15fcf4a4eb36b2',
       '.claude/skills/quality-review/SKILL.md':
         '5e480b2d38b704ed221cddeab938dea0ac3c904c6745147eb192e42ffb4d3bbb',
       '.claude/skills/refactor/SKILL.md':


### PR DESCRIPTION
## Summary
- rebuild Claude plugin runtime after updating the historical lint-skill fingerprint
- reseal generated inventory and identity metadata

## Verification
- bun run --cwd packages/cli check:claude-plugin
- npx vitest run tests/skills/lint-skill-exit-status.test.ts (20 passed)
- git diff --check