### PR TITLE
fix(verify): keep a Python typecheck target

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,4 +7,4 @@ warn_unreachable = True
 ignore_missing_imports = True
 show_error_codes = True
 pretty = True
-exclude = ^experiments/
+exclude = ^experiments/(gepa-review-spec/|python-skill-eval/(control/|solution\.py$|grade\.py$|ref/gather_leak\.py$))

--- a/packages/cli/tests/test-plan/repo-contract.test.ts
+++ b/packages/cli/tests/test-plan/repo-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveTestPlan } from '../../src/test-plan/resolve';
+import { repoRoot } from '../helpers';
+
+describe('repository test-plan contract', () => {
+  it('does not exclude the entire Python experiment tree from MyPy', () => {
+    const plan = resolveTestPlan(repoRoot, {
+      kind: 'typecheck',
+      isToolAvailable: () => true,
+    });
+    const config = readFileSync(nodePath.join(repoRoot, 'mypy.ini'), 'utf8');
+
+    expect(plan.some(entry => entry.language === 'python' && entry.command === 'mypy .')).toBe(
+      true,
+    );
+    expect(config).not.toContain('exclude = ^experiments/\n');
+  });
+});


### PR DESCRIPTION
## Summary
- narrow the repository MyPy exclusions so the maintained typed reference remains discoverable
- add a repository-level test-plan contract preventing a blanket Python exclusion

## Verification
- mypy . (1 source file, green)
- 80 focused test-plan tests
- ESLint and Prettier on the new regression
- git diff --check