### PR TITLE
test(review): create trusted binary outside temp roots

### DIFF
--- a/packages/cli/tests/review/runtime.test.ts
+++ b/packages/cli/tests/review/runtime.test.ts
@@ -1,5 +1,5 @@
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import nodePath from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -26,7 +26,7 @@ function temporaryDirectory(): string {
 }
 
 function trustedTemporaryDirectory(): string {
-  const directory = mkdtempSync(nodePath.join(process.cwd(), '.safeword-review-runtime-'));
+  const directory = mkdtempSync(nodePath.join(homedir(), '.safeword-review-runtime-'));
   temporaryDirectories.push(directory);
   return directory;
 }


### PR DESCRIPTION
## Summary
- create the fake trusted reviewer binary under the user's home directory
- keep timeout/process-tree coverage valid when the checkout itself is under a world-writable temp root

## Verification
- npx vitest run tests/review/runtime.test.ts (19 passed)
- ESLint and Prettier
- git diff --check

## Full-suite evidence
Before this fixture fix: 7,654 passed, 5 skipped, 1 failed solely because the fake binary inherited /private/tmp ancestry and was classified not_installed.