### PR TITLE
Keep the advisory review canary independent of personal credentials

### DIFF
--- a/.github/workflows/advisory-pr-review-canary.yml
+++ b/.github/workflows/advisory-pr-review-canary.yml
@@ -37,9 +37,35 @@ jobs:
       - name: Install dependencies without repository authority
         run: bun install --frozen-lockfile
 
+      - name: Mint short-lived base-owner token
+        id: base-owner-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY }}
+          owner: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_OWNER }}
+          permission-actions: write
+          permission-administration: write
+          permission-contents: write
+          permission-environments: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - name: Mint short-lived fork-owner token
+        id: fork-owner-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY }}
+          owner: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER }}
+          permission-administration: write
+          permission-contents: write
+
       - name: Prove fork-event and scheduled advisory semantics
         run: bun run --cwd packages/cli smoke:pr-review:disposable
         env:
-          GH_TOKEN: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_TOKEN }}
+          GH_TOKEN: ${{ steps.base-owner-token.outputs.token }}
+          SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN: ${{ steps.fork-owner-token.outputs.token }}
           SAFEWORD_PR_REVIEW_SMOKE_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_OWNER }}
           SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER }}

--- a/.github/workflows/advisory-pr-review-canary.yml
+++ b/.github/workflows/advisory-pr-review-canary.yml
@@ -43,9 +43,9 @@ jobs:
         with:
           client-id: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID }}
           private-key: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY }}
-          owner: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_OWNER }}
+          owner: ArcadeAI
+          repositories: safeword-pr-review-smoke-base
           permission-actions: write
-          permission-administration: write
           permission-contents: write
           permission-environments: write
           permission-issues: write
@@ -58,8 +58,8 @@ jobs:
         with:
           client-id: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID }}
           private-key: ${{ secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY }}
-          owner: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER }}
-          permission-administration: write
+          owner: TheMostlyGreat
+          repositories: safeword-pr-review-smoke-base
           permission-contents: write
 
       - name: Prove fork-event and scheduled advisory semantics
@@ -67,5 +67,3 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.base-owner-token.outputs.token }}
           SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN: ${{ steps.fork-owner-token.outputs.token }}
-          SAFEWORD_PR_REVIEW_SMOKE_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_OWNER }}
-          SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER: ${{ vars.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER }}

--- a/.project/tickets/V1TBJ0-automate-review-canary-with-short-lived-credentials/ticket.md
+++ b/.project/tickets/V1TBJ0-automate-review-canary-with-short-lived-credentials/ticket.md
@@ -1,0 +1,53 @@
+---
+id: V1TBJ0
+slug: automate-review-canary-with-short-lived-credentials
+type: task
+phase: intake
+status: in_progress
+created: 2026-08-23T09:48:04.810Z
+last_modified: 2026-08-23T09:48:04.810Z
+---
+
+# Keep the advisory review canary independent of personal credentials
+
+**Goal:** Use short-lived GitHub App installation tokens for both disposable sandbox owners.
+
+**Why:** The canary currently depends on one missing long-lived personal token, while the production App lacks the necessary sandbox authority.
+
+## Scope
+
+- Mint separate short-lived installation tokens for the base and fork sandbox owners.
+- Route each repository operation through the token for the owner it mutates.
+- Keep the existing create, exercise, and permanent-cleanup canary behavior.
+- Document a dedicated smoke App rather than widening the production Safeword App.
+
+## Out of Scope
+
+- Changing the automatic advisory reviewer or its customer-facing workflows.
+- Reusing the production Safeword App.
+- Granting the smoke App access to production repositories.
+- Replacing the disposable GitHub compatibility proof with a simulated test.
+
+## Acceptance Criteria
+
+- The canary generates one installation token for each configured sandbox owner.
+- No long-lived personal access token is stored or consumed by the workflow.
+- Base and fork mutations use their corresponding owner token, including cleanup.
+- Missing either token fails before creating a repository.
+- Existing deterministic workflow-contract checks and the full repository suite pass.
+- The live canary creates, exercises, and deletes both disposable repositories.
+
+## Design Notes
+
+GitHub documents that installation tokens expire after one hour and that creating an
+organization repository requires repository Administration write permission. Creating a
+fork with an installation token additionally requires Contents read and an all-repositories
+installation on both source and destination accounts. The dedicated smoke App therefore
+uses all-repositories installations only on the two sandbox owners; it is not installed on
+production owners.
+
+## Work Log
+
+- 2026-08-23T09:48:04.810Z Started: Created ticket V1TBJ0
+- 2026-08-23 Verified the existing Safeword App is unsuitable: it is installed only on
+  ArcadeAI for selected repositories and grants only Issues write plus Metadata read.

--- a/.project/tickets/V1TBJ0-automate-review-canary-with-short-lived-credentials/ticket.md
+++ b/.project/tickets/V1TBJ0-automate-review-canary-with-short-lived-credentials/ticket.md
@@ -8,17 +8,18 @@ created: 2026-08-23T09:48:04.810Z
 last_modified: 2026-08-23T09:48:04.810Z
 ---
 
-# Keep the advisory review canary independent of personal credentials
+# Keep the advisory review canary isolated from production repositories
 
-**Goal:** Use short-lived GitHub App installation tokens for both disposable sandbox owners.
+**Goal:** Use short-lived GitHub App installation tokens against one fixed sandbox fork pair.
 
 **Why:** The canary currently depends on one missing long-lived personal token, while the production App lacks the necessary sandbox authority.
 
 ## Scope
 
-- Mint separate short-lived installation tokens for the base and fork sandbox owners.
-- Route each repository operation through the token for the owner it mutates.
-- Keep the existing create, exercise, and permanent-cleanup canary behavior.
+- Mint separate short-lived installation tokens restricted to the fixed base and fork repositories.
+- Route each repository operation through the token for the repository it mutates.
+- Update the fixed base fixture, exercise a temporary fork branch and pull request, and clean up
+  those temporary resources independently.
 - Document a dedicated smoke App rather than widening the production Safeword App.
 
 ## Out of Scope
@@ -30,21 +31,21 @@ last_modified: 2026-08-23T09:48:04.810Z
 
 ## Acceptance Criteria
 
-- The canary generates one installation token for each configured sandbox owner.
+- The canary generates one installation token for each fixed sandbox repository.
 - No long-lived personal access token is stored or consumed by the workflow.
-- Base and fork mutations use their corresponding owner token, including cleanup.
+- Base and fork mutations use their corresponding repository token, including cleanup.
 - Missing either token fails before creating a repository.
 - Existing deterministic workflow-contract checks and the full repository suite pass.
-- The live canary creates, exercises, and deletes both disposable repositories.
+- The live canary exercises the fixed fork pair and independently attempts pull-request, branch,
+  and local cleanup even when an earlier cleanup action fails.
 
 ## Design Notes
 
-GitHub documents that installation tokens expire after one hour and that creating an
-organization repository requires repository Administration write permission. Creating a
-fork with an installation token additionally requires Contents read and an all-repositories
-installation on both source and destination accounts. The dedicated smoke App therefore
-uses all-repositories installations only on the two sandbox owners; it is not installed on
-production owners.
+GitHub documents that installation tokens expire after one hour. The dedicated smoke App is
+installed for selected-repository access only on
+`ArcadeAI/safeword-pr-review-smoke-base` and its real fork,
+`TheMostlyGreat/safeword-pr-review-smoke-base`. The workflow cannot choose a different
+repository at runtime, and neither installation grants the App production authority.
 
 ## Work Log
 

--- a/README.md
+++ b/README.md
@@ -520,21 +520,30 @@ Keep the customer workflow disabled until a live smoke passes where it will run.
 
 ### Maintainer compatibility proof
 
-The release environment named `pr-review-smoke` must define
-`SAFEWORD_PR_REVIEW_SMOKE_TOKEN`. Its account needs narrowly scoped authority to
-create and permanently delete public repositories under two dedicated sandbox
-owners, manage their Actions environments and secrets, and create a fork from
-one owner into the other. It must not have authority over production
-repositories. Both repository variables, `SAFEWORD_PR_REVIEW_SMOKE_OWNER` and
+The release environment named `pr-review-smoke` must define the secret
+`SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY` and the variable
+`SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID` for a dedicated smoke-only GitHub App.
+Install that App for all repositories on both dedicated sandbox owners. Its
+base-owner installation needs Actions, Administration, Contents, Environments,
+Issues, Pull requests, and Workflows write access. Its fork-owner installation
+needs Administration and Contents write access. The smoke App must not have authority over production
+repositories. Do not install it on production owners.
+
+Both owner variables, `SAFEWORD_PR_REVIEW_SMOKE_OWNER` and
 `SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER`, are required and must name different
-sandbox owners. Configure the environment's deployment policies to allow only
-release tags and the default branch.
+sandbox owners. The workflow mints separate installation tokens for the two
+owners; GitHub revokes them at job completion, and they otherwise expire within
+one hour. Configure the environment's deployment policies to allow only release
+tags and the default branch.
 
 Run the same proof locally with:
 
 ```bash
 bun run --cwd packages/cli smoke:pr-review:disposable
 ```
+
+For a local run, set `GH_TOKEN` to a base-owner installation token and
+`SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN` to a fork-owner installation token.
 
 Each daily canary or manual proof creates
 `safeword-pr-review-smoke-<unique-id>` in both owners, exercises a real fork pull

--- a/README.md
+++ b/README.md
@@ -523,18 +523,15 @@ Keep the customer workflow disabled until a live smoke passes where it will run.
 The release environment named `pr-review-smoke` must define the secret
 `SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY` and the variable
 `SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID` for a dedicated smoke-only GitHub App.
-Install that App for all repositories on both dedicated sandbox owners. Its
-base-owner installation needs Actions, Administration, Contents, Environments,
-Issues, Pull requests, and Workflows write access. Its fork-owner installation
-needs Administration and Contents write access. The smoke App must not have authority over production
-repositories. Do not install it on production owners.
-
-Both owner variables, `SAFEWORD_PR_REVIEW_SMOKE_OWNER` and
-`SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER`, are required and must name different
-sandbox owners. The workflow mints separate installation tokens for the two
-owners; GitHub revokes them at job completion, and they otherwise expire within
-one hour. Configure the environment's deployment policies to allow only release
-tags and the default branch.
+Install that App with selected-repository access only on
+`ArcadeAI/safeword-pr-review-smoke-base` and its real fork,
+`TheMostlyGreat/safeword-pr-review-smoke-base`. The App needs Actions, Contents,
+Environments, Issues, Pull requests, and Workflows write access; the fork token
+is further restricted to Contents write. The smoke App must not have authority
+over production repositories. The workflow mints separate installation tokens
+for the fixed repositories; GitHub revokes them at job completion, and they
+otherwise expire within one hour. Configure the environment's deployment
+policies to allow only the default branch.
 
 Run the same proof locally with:
 
@@ -545,14 +542,13 @@ bun run --cwd packages/cli smoke:pr-review:disposable
 For a local run, set `GH_TOKEN` to a base-owner installation token and
 `SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN` to a fork-owner installation token.
 
-Each daily canary or manual proof creates
-`safeword-pr-review-smoke-<unique-id>` in both owners, exercises a real fork pull
-request plus the canonical scheduled-call projection, and then permanently
-deletes both repositories. Set
-`SAFEWORD_KEEP_PR_REVIEW_SMOKE=1` only while debugging. When GitHub Actions
-semantics change, update the pinned actionlint version and checksum in CI, run
-`check:pr-review-workflows`, run this disposable proof, and record both results
-in the compatibility ticket before release.
+Each daily canary or manual proof updates the fixed base fixture, creates a
+temporary branch in the fixed fork, exercises a real fork pull request plus the
+canonical scheduled-call projection, and then independently closes the pull
+request, deletes the temporary branch, and removes its local checkout. When
+GitHub Actions semantics change, update the pinned actionlint version and
+checksum in CI, run `check:pr-review-workflows`, run this proof, and record both
+results in the compatibility ticket before release.
 
 ---
 

--- a/packages/cli/scripts/run-pr-review-disposable-smoke.ts
+++ b/packages/cli/scripts/run-pr-review-disposable-smoke.ts
@@ -7,6 +7,7 @@ import { createPrReviewSmokeFixture } from '../src/pr-review/smoke-fixture.js';
 
 interface CommandOptions {
   cwd?: string;
+  env?: NodeJS.ProcessEnv;
   input?: string;
   quiet?: boolean;
 }
@@ -38,7 +39,7 @@ function command(executable: string, arguments_: string[], options: CommandOptio
   const result = spawnSync(executable, arguments_, {
     cwd: options.cwd,
     encoding: 'utf8',
-    env: process.env,
+    env: { ...process.env, ...options.env },
     input: options.input,
     maxBuffer: 16 * 1024 * 1024,
   });
@@ -51,15 +52,18 @@ function command(executable: string, arguments_: string[], options: CommandOptio
   return result.stdout.trim();
 }
 
-function gh(arguments_: string[], options?: CommandOptions): string {
-  return command('gh', arguments_, options);
+function gh(arguments_: string[], options: CommandOptions = {}, token?: string): string {
+  return command('gh', arguments_, {
+    ...options,
+    env: token === undefined ? options.env : { ...options.env, GH_TOKEN: token },
+  });
 }
 
-function ghJson(path: string): unknown {
+function ghJson(path: string, token?: string): unknown {
   let lastError: unknown;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
-      return JSON.parse(gh(['api', path], { quiet: true })) as unknown;
+      return JSON.parse(gh(['api', path], { quiet: true }, token)) as unknown;
     } catch (error) {
       lastError = error;
       pause(attempt * 1000);
@@ -78,9 +82,9 @@ function waitFor<T>(description: string, probe: () => T | undefined, seconds = 3
   throw new Error(`timed out waiting for ${description}`);
 }
 
-function repoExists(repo: string): boolean {
+function repoExists(repo: string, token?: string): boolean {
   try {
-    ghJson(`repos/${repo}`);
+    ghJson(`repos/${repo}`, token);
     return true;
   } catch {
     return false;
@@ -208,20 +212,34 @@ function writeFixture(directory: string): void {
   }
 }
 
-function cleanupFixture(
-  baseRepo: string,
-  forkRepo: string,
-  directory: string,
-  baseCreated: boolean,
-  forkCreated: boolean,
-): void {
+interface CleanupFixtureInput {
+  baseCreated: boolean;
+  baseRepo: string;
+  baseToken: string;
+  directory: string;
+  forkCreated: boolean;
+  forkRepo: string;
+  forkToken: string;
+}
+
+function cleanupFixture(input: CleanupFixtureInput): void {
+  const { baseCreated, baseRepo, baseToken, directory, forkCreated, forkRepo, forkToken } = input;
   if (process.env.SAFEWORD_KEEP_PR_REVIEW_SMOKE === '1') {
     console.log(`Keeping ${baseRepo} and ${forkRepo}`);
     return;
   }
-  if (forkCreated) gh(['repo', 'delete', forkRepo, '--yes']);
-  if (baseCreated) gh(['repo', 'delete', baseRepo, '--yes']);
+  if (forkCreated) gh(['repo', 'delete', forkRepo, '--yes'], {}, forkToken);
+  if (baseCreated) gh(['repo', 'delete', baseRepo, '--yes'], {}, baseToken);
   rmSync(directory, { force: true, recursive: true });
+}
+
+function gitAuthentication(token: string): NodeJS.ProcessEnv {
+  const basicCredential = Buffer.from(`x-access-token:${token}`).toString('base64');
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${basicCredential}`,
+  };
 }
 
 function verifyResult(
@@ -269,6 +287,11 @@ export function runPrReviewDisposableSmoke(): void {
   if (baseOwner.toLowerCase() === forkOwner.toLowerCase()) {
     throw new Error('base and fork owners must differ to prove pull_request_target fork behavior');
   }
+  const baseToken = (process.env.GH_TOKEN || '').trim();
+  const forkToken = (process.env.SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN || '').trim();
+  if (!baseToken || !forkToken) {
+    throw new Error('GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required');
+  }
 
   const suffix = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
   const repoName = `safeword-pr-review-smoke-${suffix}`;
@@ -298,7 +321,10 @@ export function runPrReviewDisposableSmoke(): void {
     command('git', ['remote', 'add', 'origin', `https://github.com/${baseRepo}.git`], {
       cwd: directory,
     });
-    command('git', ['push', '--set-upstream', 'origin', 'main'], { cwd: directory });
+    command('git', ['push', '--set-upstream', 'origin', 'main'], {
+      cwd: directory,
+      env: gitAuthentication(baseToken),
+    });
 
     gh(['api', '--method', 'PUT', `repos/${baseRepo}/environments/safeword-pr-review-model`]);
     gh(
@@ -306,8 +332,8 @@ export function runPrReviewDisposableSmoke(): void {
       { input: `smoke-${crypto.randomUUID()}\n` },
     );
 
-    gh(['repo', 'fork', baseRepo, '--clone=false', '--fork-name', repoName]);
-    waitFor('fork creation', () => (repoExists(forkRepo) ? true : undefined));
+    gh(['repo', 'fork', baseRepo, '--clone=false', '--fork-name', repoName], {}, forkToken);
+    waitFor('fork creation', () => (repoExists(forkRepo, forkToken) ? true : undefined));
     forkCreated = true;
 
     command('git', ['checkout', '-b', 'smoke-fork-change'], { cwd: directory });
@@ -316,6 +342,7 @@ export function runPrReviewDisposableSmoke(): void {
     command('git', ['commit', '-m', 'Exercise fork advisory review'], { cwd: directory });
     command('git', ['push', `https://github.com/${forkRepo}.git`, 'HEAD:smoke-fork-change'], {
       cwd: directory,
+      env: gitAuthentication(forkToken),
     });
     const pullUrl = gh([
       'pr',
@@ -393,7 +420,15 @@ export function runPrReviewDisposableSmoke(): void {
       }),
     );
   } finally {
-    cleanupFixture(baseRepo, forkRepo, directory, baseCreated, forkCreated);
+    cleanupFixture({
+      baseCreated,
+      baseRepo,
+      baseToken,
+      directory,
+      forkCreated,
+      forkRepo,
+      forkToken,
+    });
   }
 }
 

--- a/packages/cli/scripts/run-pr-review-disposable-smoke.ts
+++ b/packages/cli/scripts/run-pr-review-disposable-smoke.ts
@@ -5,12 +5,20 @@ import nodePath from 'node:path';
 
 import { createPrReviewSmokeFixture } from '../src/pr-review/smoke-fixture.js';
 
-interface CommandOptions {
+export interface CommandOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   input?: string;
   quiet?: boolean;
 }
+
+export type SmokeCommandExecutor = (
+  executable: string,
+  arguments_: string[],
+  options?: CommandOptions,
+) => string;
+
+type GhClient = (arguments_: string[], options?: CommandOptions) => string;
 
 interface Job {
   name: string;
@@ -52,18 +60,49 @@ function command(executable: string, arguments_: string[], options: CommandOptio
   return result.stdout.trim();
 }
 
-function gh(arguments_: string[], options: CommandOptions = {}, token?: string): string {
-  return command('gh', arguments_, {
-    ...options,
-    env: token === undefined ? options.env : { ...options.env, GH_TOKEN: token },
-  });
+function gitAuthentication(token: string): NodeJS.ProcessEnv {
+  const basicCredential = Buffer.from(`x-access-token:${token}`).toString('base64');
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${basicCredential}`,
+  };
 }
 
-function ghJson(path: string, token?: string): unknown {
+export function createSmokeCommandClients(
+  execute: SmokeCommandExecutor,
+  baseToken: string,
+  forkToken: string,
+): {
+  baseGh: GhClient;
+  baseGit: (arguments_: string[], cwd: string) => string;
+  forkGh: GhClient;
+  forkGit: (arguments_: string[], cwd: string) => string;
+} {
+  const githubClient =
+    (token: string): GhClient =>
+    (arguments_, options = {}) =>
+      execute('gh', arguments_, {
+        ...options,
+        env: { ...options.env, GH_TOKEN: token },
+      });
+  const gitClient =
+    (token: string) =>
+    (arguments_: string[], cwd: string): string =>
+      execute('git', arguments_, { cwd, env: gitAuthentication(token) });
+  return {
+    baseGh: githubClient(baseToken),
+    baseGit: gitClient(baseToken),
+    forkGh: githubClient(forkToken),
+    forkGit: gitClient(forkToken),
+  };
+}
+
+function ghJson(path: string, ghClient: GhClient): unknown {
   let lastError: unknown;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
-      return JSON.parse(gh(['api', path], { quiet: true }, token)) as unknown;
+      return JSON.parse(ghClient(['api', path], { quiet: true })) as unknown;
     } catch (error) {
       lastError = error;
       pause(attempt * 1000);
@@ -82,16 +121,8 @@ function waitFor<T>(description: string, probe: () => T | undefined, seconds = 3
   throw new Error(`timed out waiting for ${description}`);
 }
 
-function repoExists(repo: string, token?: string): boolean {
-  try {
-    ghJson(`repos/${repo}`, token);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function serializedInConcurrencyGroup(
+  ghClient: GhClient,
   repo: string,
   pullNumber: number,
   eventRunId: number,
@@ -99,7 +130,7 @@ function serializedInConcurrencyGroup(
 ): boolean {
   try {
     const group = JSON.parse(
-      gh(
+      ghClient(
         [
           'api',
           '-H',
@@ -122,9 +153,15 @@ function serializedInConcurrencyGroup(
   }
 }
 
-function latestRun(repo: string, workflow: string, event: string): Run | undefined {
+function latestRun(
+  ghClient: GhClient,
+  repo: string,
+  workflow: string,
+  event: string,
+): Run | undefined {
   const response = ghJson(
     `repos/${repo}/actions/workflows/${workflow}/runs?event=${event}&per_page=10`,
+    ghClient,
   ) as { workflow_runs: Record<string, unknown>[] };
   const run = response.workflow_runs[0];
   if (run === undefined) return undefined;
@@ -136,17 +173,21 @@ function latestRun(repo: string, workflow: string, event: string): Run | undefin
   };
 }
 
-function jobs(repo: string, runId: number): Job[] {
-  return (ghJson(`repos/${repo}/actions/runs/${runId}/jobs?per_page=100`) as { jobs: Job[] }).jobs;
+function jobs(ghClient: GhClient, repo: string, runId: number): Job[] {
+  return (
+    ghJson(`repos/${repo}/actions/runs/${runId}/jobs?per_page=100`, ghClient) as {
+      jobs: Job[];
+    }
+  ).jobs;
 }
 
-function waitForSuccess(repo: string, runId: number): void {
+function waitForSuccess(ghClient: GhClient, repo: string, runId: number): void {
   let minimumAttempt = 1;
   for (let retry = 0; retry <= 1; retry += 1) {
     const run = waitFor(
       `workflow run ${runId}`,
       () => {
-        const value = ghJson(`repos/${repo}/actions/runs/${runId}`) as Run;
+        const value = ghJson(`repos/${repo}/actions/runs/${runId}`, ghClient) as Run;
         return value.status === 'completed' && value.run_attempt >= minimumAttempt
           ? value
           : undefined;
@@ -154,7 +195,7 @@ function waitForSuccess(repo: string, runId: number): void {
       600,
     );
     if (run.conclusion === 'success') return;
-    const detail = gh(['run', 'view', String(runId), '--repo', repo, '--log-failed'], {
+    const detail = ghClient(['run', 'view', String(runId), '--repo', repo, '--log-failed'], {
       quiet: true,
     });
     const infrastructureFailure =
@@ -163,7 +204,7 @@ function waitForSuccess(repo: string, runId: number): void {
       );
     if (retry === 0 && infrastructureFailure) {
       minimumAttempt = run.run_attempt + 1;
-      gh(['run', 'rerun', String(runId), '--repo', repo, '--failed']);
+      ghClient(['run', 'rerun', String(runId), '--repo', repo, '--failed']);
       continue;
     }
     throw new Error(`workflow run ${runId} concluded ${run.conclusion}\n${detail}`);
@@ -171,19 +212,19 @@ function waitForSuccess(repo: string, runId: number): void {
   throw new Error(`workflow run ${runId} exhausted its infrastructure retry`);
 }
 
-function snapshot(repo: string, pullNumber: number, headSha: string): string {
-  const pull = ghJson(`repos/${repo}/pulls/${pullNumber}`) as {
+function snapshot(ghClient: GhClient, repo: string, pullNumber: number, headSha: string): string {
+  const pull = ghJson(`repos/${repo}/pulls/${pullNumber}`, ghClient) as {
     mergeable: boolean | undefined;
     mergeable_state: string;
   };
-  const reviews = ghJson(`repos/${repo}/pulls/${pullNumber}/reviews?per_page=100`) as {
+  const reviews = ghJson(`repos/${repo}/pulls/${pullNumber}/reviews?per_page=100`, ghClient) as {
     id: number;
     state: string;
   }[];
-  const statuses = ghJson(`repos/${repo}/commits/${headSha}/status`) as {
+  const statuses = ghJson(`repos/${repo}/commits/${headSha}/status`, ghClient) as {
     statuses: { context: string; state: string }[];
   };
-  const checks = ghJson(`repos/${repo}/commits/${headSha}/check-runs`) as {
+  const checks = ghJson(`repos/${repo}/commits/${headSha}/check-runs`, ghClient) as {
     check_runs: { conclusion?: string; name: string; status: string }[];
   };
   return JSON.stringify({
@@ -212,45 +253,88 @@ function writeFixture(directory: string): void {
   }
 }
 
-interface CleanupFixtureInput {
-  baseCreated: boolean;
+interface CleanupSmokeResourcesInput {
+  baseGh: GhClient;
+  baseRepo: string;
+  branch?: string;
+  directory: string;
+  forkGh: GhClient;
+  forkRepo: string;
+  pullNumber?: number;
+  removeDirectory?: (directory: string) => void;
+}
+
+export function cleanupSmokeResources(input: CleanupSmokeResourcesInput): Error[] {
+  const errors: Error[] = [];
+  const attempt = (description: string, action: () => void): void => {
+    try {
+      action();
+    } catch (error) {
+      errors.push(
+        new Error(`${description}: ${error instanceof Error ? error.message : String(error)}`),
+      );
+    }
+  };
+  if (input.pullNumber !== undefined) {
+    attempt('close pull request', () => {
+      input.baseGh(['pr', 'close', String(input.pullNumber), '--repo', input.baseRepo]);
+    });
+  }
+  if (input.branch !== undefined) {
+    attempt('delete fork branch', () => {
+      input.forkGh([
+        'api',
+        '--method',
+        'DELETE',
+        `repos/${input.forkRepo}/git/refs/heads/${input.branch}`,
+      ]);
+    });
+  }
+  attempt('remove local fixture', () => {
+    const removeDirectory =
+      input.removeDirectory ??
+      (directory => {
+        rmSync(directory, { force: true, recursive: true });
+      });
+    removeDirectory(input.directory);
+  });
+  return errors;
+}
+
+export function resolveSmokeConfig(environment: NodeJS.ProcessEnv): {
   baseRepo: string;
   baseToken: string;
-  directory: string;
-  forkCreated: boolean;
+  forkOwner: string;
   forkRepo: string;
   forkToken: string;
-}
-
-function cleanupFixture(input: CleanupFixtureInput): void {
-  const { baseCreated, baseRepo, baseToken, directory, forkCreated, forkRepo, forkToken } = input;
-  if (process.env.SAFEWORD_KEEP_PR_REVIEW_SMOKE === '1') {
-    console.log(`Keeping ${baseRepo} and ${forkRepo}`);
-    return;
+} {
+  const baseToken = (environment.GH_TOKEN || '').trim();
+  const forkToken = (environment.SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN || '').trim();
+  if (!baseToken || !forkToken) {
+    throw new Error('GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required');
   }
-  if (forkCreated) gh(['repo', 'delete', forkRepo, '--yes'], {}, forkToken);
-  if (baseCreated) gh(['repo', 'delete', baseRepo, '--yes'], {}, baseToken);
-  rmSync(directory, { force: true, recursive: true });
-}
-
-function gitAuthentication(token: string): NodeJS.ProcessEnv {
-  const basicCredential = Buffer.from(`x-access-token:${token}`).toString('base64');
   return {
-    GIT_CONFIG_COUNT: '1',
-    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
-    GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${basicCredential}`,
+    baseRepo: 'ArcadeAI/safeword-pr-review-smoke-base',
+    baseToken,
+    forkOwner: 'TheMostlyGreat',
+    forkRepo: 'TheMostlyGreat/safeword-pr-review-smoke-base',
+    forkToken,
   };
 }
 
-function verifyResult(
-  repo: string,
-  pullNumber: number,
-  headSha: string,
-  before: string,
-  runIds: number[],
-): string {
+interface VerifyResultInput {
+  before: string;
+  ghClient: GhClient;
+  headSha: string;
+  pullNumber: number;
+  repo: string;
+  runIds: number[];
+}
+
+function verifyResult(input: VerifyResultInput): string {
+  const { before, ghClient, headSha, pullNumber, repo, runIds } = input;
   for (const runId of runIds) {
-    const artifacts = ghJson(`repos/${repo}/actions/runs/${runId}/artifacts`) as {
+    const artifacts = ghJson(`repos/${repo}/actions/runs/${runId}/artifacts`, ghClient) as {
       total_count: number;
     };
     if (artifacts.total_count !== 1) {
@@ -259,7 +343,7 @@ function verifyResult(
   }
 
   const comments = (
-    ghJson(`repos/${repo}/issues/${pullNumber}/comments?per_page=100`) as {
+    ghJson(`repos/${repo}/issues/${pullNumber}/comments?per_page=100`, ghClient) as {
       body: string;
       html_url: string;
     }[]
@@ -267,7 +351,7 @@ function verifyResult(
   if (comments.length !== 1 || !comments[0]?.body.includes(`Reviewed revision: ${headSha}`)) {
     throw new Error('publication did not reconcile exactly one current ordinary issue comment');
   }
-  const after = snapshot(repo, pullNumber, headSha);
+  const after = snapshot(ghClient, repo, pullNumber, headSha);
   if (after !== before) {
     throw new Error(
       `advisory smoke changed merge state, reviews, checks, or statuses\nbefore=${before}\nafter=${after}`,
@@ -277,74 +361,49 @@ function verifyResult(
 }
 
 export function runPrReviewDisposableSmoke(): void {
-  const baseOwner = (process.env.SAFEWORD_PR_REVIEW_SMOKE_OWNER || '').trim();
-  const forkOwner = (process.env.SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER || '').trim();
-  if (!baseOwner || !forkOwner) {
-    throw new Error(
-      'SAFEWORD_PR_REVIEW_SMOKE_OWNER and SAFEWORD_PR_REVIEW_SMOKE_FORK_OWNER must name two dedicated sandbox owners',
-    );
-  }
-  if (baseOwner.toLowerCase() === forkOwner.toLowerCase()) {
-    throw new Error('base and fork owners must differ to prove pull_request_target fork behavior');
-  }
-  const baseToken = (process.env.GH_TOKEN || '').trim();
-  const forkToken = (process.env.SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN || '').trim();
-  if (!baseToken || !forkToken) {
-    throw new Error('GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required');
-  }
+  const { baseRepo, baseToken, forkOwner, forkRepo, forkToken } = resolveSmokeConfig(process.env);
+  const { baseGh, baseGit, forkGh, forkGit } = createSmokeCommandClients(
+    command,
+    baseToken,
+    forkToken,
+  );
 
   const suffix = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
-  const repoName = `safeword-pr-review-smoke-${suffix}`;
-  const baseRepo = `${baseOwner}/${repoName}`;
-  const forkRepo = `${forkOwner}/${repoName}`;
+  const branch = `safeword-pr-review-smoke-${suffix}`;
   const directory = mkdtempSync(nodePath.join(tmpdir(), 'safeword-pr-review-smoke-'));
-  let baseCreated = false;
-  let forkCreated = false;
+  let branchPushed = false;
+  let failure: unknown;
+  let output: string | undefined;
+  let pullNumber: number | undefined;
 
   try {
-    console.log(`Creating disposable fixture ${baseRepo}`);
-    gh([
-      'repo',
-      'create',
-      baseRepo,
-      '--public',
-      '--description',
-      'Disposable Safeword release smoke',
-    ]);
-    baseCreated = true;
+    console.log(`Updating fixed sandbox fixture ${baseRepo}`);
+    baseGit(['clone', `https://github.com/${baseRepo}.git`, directory], tmpdir());
+    baseGit(['config', 'user.name', 'Safeword smoke'], directory);
+    baseGit(['config', 'user.email', 'smoke@safeword.dev'], directory);
     writeFixture(directory);
-    command('git', ['init', '--initial-branch=main'], { cwd: directory });
-    command('git', ['config', 'user.name', 'Safeword smoke'], { cwd: directory });
-    command('git', ['config', 'user.email', 'smoke@safeword.dev'], { cwd: directory });
-    command('git', ['add', '.'], { cwd: directory });
-    command('git', ['commit', '-m', 'Add advisory PR review smoke fixture'], { cwd: directory });
-    command('git', ['remote', 'add', 'origin', `https://github.com/${baseRepo}.git`], {
-      cwd: directory,
-    });
-    command('git', ['push', '--set-upstream', 'origin', 'main'], {
-      cwd: directory,
-      env: gitAuthentication(baseToken),
-    });
+    baseGit(['add', '.'], directory);
+    if (baseGit(['status', '--porcelain'], directory) !== '') {
+      baseGit(['commit', '-m', 'Update advisory PR review smoke fixture'], directory);
+      baseGit(['push', 'origin', 'main'], directory);
+    }
 
-    gh(['api', '--method', 'PUT', `repos/${baseRepo}/environments/safeword-pr-review-model`]);
-    gh(
+    baseGh(['api', '--method', 'PUT', `repos/${baseRepo}/environments/safeword-pr-review-model`]);
+    baseGh(
       ['secret', 'set', 'OPENAI_API_KEY', '--env', 'safeword-pr-review-model', '--repo', baseRepo],
       { input: `smoke-${crypto.randomUUID()}\n` },
     );
 
-    gh(['repo', 'fork', baseRepo, '--clone=false', '--fork-name', repoName], {}, forkToken);
-    waitFor('fork creation', () => (repoExists(forkRepo, forkToken) ? true : undefined));
-    forkCreated = true;
-
-    command('git', ['checkout', '-b', 'smoke-fork-change'], { cwd: directory });
-    writeFileSync(nodePath.join(directory, '.flux'), 'require_human_review = true\n');
-    command('git', ['add', '.flux'], { cwd: directory });
-    command('git', ['commit', '-m', 'Exercise fork advisory review'], { cwd: directory });
-    command('git', ['push', `https://github.com/${forkRepo}.git`, 'HEAD:smoke-fork-change'], {
-      cwd: directory,
-      env: gitAuthentication(forkToken),
-    });
-    const pullUrl = gh([
+    baseGit(['checkout', '-b', branch], directory);
+    writeFileSync(
+      nodePath.join(directory, '.flux'),
+      `require_human_review = true\nsmoke_run = ${suffix}\n`,
+    );
+    baseGit(['add', '.flux'], directory);
+    baseGit(['commit', '-m', 'Exercise fork advisory review'], directory);
+    forkGit(['push', `https://github.com/${forkRepo}.git`, `HEAD:refs/heads/${branch}`], directory);
+    branchPushed = true;
+    const pullUrl = baseGh([
       'pr',
       'create',
       '--repo',
@@ -352,40 +411,45 @@ export function runPrReviewDisposableSmoke(): void {
       '--base',
       'main',
       '--head',
-      `${forkOwner}:smoke-fork-change`,
+      `${forkOwner}:${branch}`,
       '--title',
       'Exercise advisory PR review smoke',
       '--body',
       'Disposable release compatibility proof.',
     ]);
-    const pullNumber = Number(
-      gh(['pr', 'view', pullUrl, '--repo', baseRepo, '--json', 'number', '--jq', '.number']),
+    const createdPullNumber = Number(
+      baseGh(['pr', 'view', pullUrl, '--repo', baseRepo, '--json', 'number', '--jq', '.number']),
     );
-    const headSha = (ghJson(`repos/${baseRepo}/pulls/${pullNumber}`) as { head: { sha: string } })
-      .head.sha;
+    if (!Number.isSafeInteger(createdPullNumber) || createdPullNumber <= 0) {
+      throw new Error(`GitHub returned invalid pull request number: ${createdPullNumber}`);
+    }
+    pullNumber = createdPullNumber;
+    const headSha = (
+      ghJson(`repos/${baseRepo}/pulls/${createdPullNumber}`, baseGh) as { head: { sha: string } }
+    ).head.sha;
 
     const eventRun = waitFor('fork pull_request_target run', () =>
-      latestRun(baseRepo, 'safeword-pr-review.yml', 'pull_request_target'),
+      latestRun(baseGh, baseRepo, 'safeword-pr-review.yml', 'pull_request_target'),
     );
-    waitForSuccess(baseRepo, eventRun.id);
+    waitForSuccess(baseGh, baseRepo, eventRun.id);
     const before = waitFor('stable pre-publication mergeability', () => {
-      const value = snapshot(baseRepo, pullNumber, headSha);
+      const value = snapshot(baseGh, baseRepo, createdPullNumber, headSha);
       return (JSON.parse(value) as { mergeableState: string }).mergeableState === 'unknown'
         ? undefined
         : value;
     });
     const publisherRun = waitFor('trusted fork-event publisher', () =>
-      latestRun(baseRepo, 'safeword-pr-review-publisher.yml', 'workflow_run'),
+      latestRun(baseGh, baseRepo, 'safeword-pr-review-publisher.yml', 'workflow_run'),
     );
     waitFor('trusted publication job', () =>
-      jobs(baseRepo, publisherRun.id).some(
+      jobs(baseGh, baseRepo, publisherRun.id).some(
         job => job.name === 'publish-event-result' && job.status === 'in_progress',
       )
         ? true
         : undefined,
     );
 
-    gh([
+    baseGh([
       'workflow',
       'run',
       'safeword-pr-review-smoke-sweep.yml',
@@ -394,42 +458,65 @@ export function runPrReviewDisposableSmoke(): void {
       '--ref',
       'main',
       '-f',
-      `pull_number=${pullNumber}`,
+      `pull_number=${createdPullNumber}`,
     ]);
     const sweepRun = waitFor('manual scheduled-call projection', () =>
-      latestRun(baseRepo, 'safeword-pr-review-smoke-sweep.yml', 'workflow_dispatch'),
+      latestRun(baseGh, baseRepo, 'safeword-pr-review-smoke-sweep.yml', 'workflow_dispatch'),
     );
     waitFor('two serialized per-PR concurrency leases', () =>
-      serializedInConcurrencyGroup(baseRepo, pullNumber, publisherRun.id, sweepRun.id)
+      serializedInConcurrencyGroup(
+        baseGh,
+        baseRepo,
+        createdPullNumber,
+        publisherRun.id,
+        sweepRun.id,
+      )
         ? true
         : undefined,
     );
 
-    waitForSuccess(baseRepo, publisherRun.id);
-    waitForSuccess(baseRepo, sweepRun.id);
-    const comment = verifyResult(baseRepo, pullNumber, headSha, before, [eventRun.id, sweepRun.id]);
-
-    console.log(
-      JSON.stringify({
-        comment,
-        eventRun: eventRun.id,
-        forkPullRequest: pullUrl,
-        publisherRun: publisherRun.id,
-        serialized: true,
-        sweepRun: sweepRun.id,
-      }),
-    );
-  } finally {
-    cleanupFixture({
-      baseCreated,
-      baseRepo,
-      baseToken,
-      directory,
-      forkCreated,
-      forkRepo,
-      forkToken,
+    waitForSuccess(baseGh, baseRepo, publisherRun.id);
+    waitForSuccess(baseGh, baseRepo, sweepRun.id);
+    const comment = verifyResult({
+      before,
+      ghClient: baseGh,
+      headSha,
+      pullNumber: createdPullNumber,
+      repo: baseRepo,
+      runIds: [eventRun.id, sweepRun.id],
     });
+
+    output = JSON.stringify({
+      comment,
+      eventRun: eventRun.id,
+      forkPullRequest: pullUrl,
+      publisherRun: publisherRun.id,
+      serialized: true,
+      sweepRun: sweepRun.id,
+    });
+  } catch (error) {
+    failure = error;
   }
+
+  const cleanupErrors = cleanupSmokeResources({
+    baseGh,
+    baseRepo,
+    branch: branchPushed ? branch : undefined,
+    directory,
+    forkGh,
+    forkRepo,
+    pullNumber,
+  });
+  const errors = [failure, ...cleanupErrors].filter(
+    (error): error is Error => error instanceof Error,
+  );
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'advisory PR review smoke failed');
+  }
+  if (output === undefined) {
+    throw new Error('advisory PR review smoke completed without a result');
+  }
+  console.log(output);
 }
 
 if (import.meta.main) runPrReviewDisposableSmoke();

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -103,10 +103,6 @@ describe('Claude plugin release contract', () => {
       nodePath.join(REPO_ROOT, '.github/workflows/advisory-pr-review-canary.yml'),
       'utf8',
     );
-    const runner = readFileSync(
-      nodePath.join(CLI_ROOT, 'scripts/run-pr-review-disposable-smoke.ts'),
-      'utf8',
-    );
     const readme = readFileSync(nodePath.join(REPO_ROOT, 'README.md'), 'utf8');
 
     expect(canary).toContain('workflow_dispatch:');
@@ -118,14 +114,16 @@ describe('Claude plugin release contract', () => {
     expect(canary.match(/actions\/create-github-app-token@/gu)).toHaveLength(2);
     expect(canary).toContain('vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID');
     expect(canary).toContain('secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY');
+    expect(canary).toContain('owner: ArcadeAI');
+    expect(canary).toContain('owner: TheMostlyGreat');
+    expect(canary.match(/repositories: safeword-pr-review-smoke-base/gu)).toHaveLength(2);
+    expect(canary).not.toContain('permission-administration');
     expect(canary).not.toContain('SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
     expect(canary).toContain('SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN');
     expect(canary).toContain('smoke:pr-review:disposable');
-    expect(runner).toContain('must name two dedicated sandbox owners');
-    expect(runner).toContain('GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required');
-    expect(readme).toContain('SAFEWORD_PR_REVIEW_SMOKE_OWNER');
-    expect(readme).toMatch(/must not have authority over production\s+repositories/u);
-    expect(readme).toContain('SAFEWORD_KEEP_PR_REVIEW_SMOKE=1');
-    expect(readme).toMatch(/permanently\s+deletes both repositories/u);
+    expect(readme).toContain('ArcadeAI/safeword-pr-review-smoke-base');
+    expect(readme).toContain('TheMostlyGreat/safeword-pr-review-smoke-base');
+    expect(readme).toMatch(/must not have authority\s+over production\s+repositories/u);
+    expect(readme).toMatch(/independently closes the pull\s+request/u);
   });
 });

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -114,9 +114,15 @@ describe('Claude plugin release contract', () => {
     expect(canary).toContain("github.event_name == 'schedule'");
     expect(canary).toContain('github.event.repository.default_branch');
     expect(canary).toContain('environment: pr-review-smoke');
-    expect(canary).toContain('secrets.SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
+    expect(canary).toContain('actions/create-github-app-token@');
+    expect(canary.match(/actions\/create-github-app-token@/gu)).toHaveLength(2);
+    expect(canary).toContain('vars.SAFEWORD_PR_REVIEW_SMOKE_APP_CLIENT_ID');
+    expect(canary).toContain('secrets.SAFEWORD_PR_REVIEW_SMOKE_APP_PRIVATE_KEY');
+    expect(canary).not.toContain('SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
+    expect(canary).toContain('SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN');
     expect(canary).toContain('smoke:pr-review:disposable');
     expect(runner).toContain('must name two dedicated sandbox owners');
+    expect(runner).toContain('GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required');
     expect(readme).toContain('SAFEWORD_PR_REVIEW_SMOKE_OWNER');
     expect(readme).toMatch(/must not have authority over production\s+repositories/u);
     expect(readme).toContain('SAFEWORD_KEEP_PR_REVIEW_SMOKE=1');

--- a/packages/cli/tests/pr-review/disposable-smoke.test.ts
+++ b/packages/cli/tests/pr-review/disposable-smoke.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SmokeCommandExecutor } from '../../scripts/run-pr-review-disposable-smoke.js';
+import {
+  cleanupSmokeResources,
+  createSmokeCommandClients,
+  resolveSmokeConfig,
+} from '../../scripts/run-pr-review-disposable-smoke.js';
+
+describe('advisory PR review disposable smoke boundary', () => {
+  it('binds both tokens to the fixed sandbox repositories', () => {
+    const config = resolveSmokeConfig({
+      GH_TOKEN: 'base-token',
+      SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN: 'fork-token',
+    });
+
+    expect(config).toEqual({
+      baseRepo: 'ArcadeAI/safeword-pr-review-smoke-base',
+      baseToken: 'base-token',
+      forkOwner: 'TheMostlyGreat',
+      forkRepo: 'TheMostlyGreat/safeword-pr-review-smoke-base',
+      forkToken: 'fork-token',
+    });
+  });
+
+  it('fails before any command when either installation token is missing', () => {
+    expect(() => resolveSmokeConfig({ GH_TOKEN: 'base-token' })).toThrow(
+      'GH_TOKEN and SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN are required',
+    );
+  });
+
+  it('routes GitHub and Git mutations through the token for their repository', () => {
+    const execute = vi.fn<SmokeCommandExecutor>(() => 'ok');
+    const clients = createSmokeCommandClients(execute, 'base-token', 'fork-token');
+
+    clients.baseGh(['api', 'repos/ArcadeAI/safeword-pr-review-smoke-base']);
+    clients.forkGh(['api', 'repos/TheMostlyGreat/safeword-pr-review-smoke-base']);
+    clients.baseGit(['push', 'origin', 'main'], '/base');
+    clients.forkGit(['push', 'origin', 'smoke'], '/fork');
+
+    expect(execute).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['api', 'repos/ArcadeAI/safeword-pr-review-smoke-base'],
+      expect.objectContaining({ env: expect.objectContaining({ GH_TOKEN: 'base-token' }) }),
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      ['api', 'repos/TheMostlyGreat/safeword-pr-review-smoke-base'],
+      expect.objectContaining({ env: expect.objectContaining({ GH_TOKEN: 'fork-token' }) }),
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['push', 'origin', 'main'],
+      expect.objectContaining({ cwd: '/base' }),
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      4,
+      'git',
+      ['push', 'origin', 'smoke'],
+      expect.objectContaining({ cwd: '/fork' }),
+    );
+    expect(execute.mock.calls[2]?.[2]?.env?.GIT_CONFIG_VALUE_0).toContain(
+      Buffer.from('x-access-token:base-token').toString('base64'),
+    );
+    expect(execute.mock.calls[3]?.[2]?.env?.GIT_CONFIG_VALUE_0).toContain(
+      Buffer.from('x-access-token:fork-token').toString('base64'),
+    );
+  });
+
+  it('attempts every cleanup action and reports all failures', () => {
+    const baseGh = vi.fn(() => {
+      throw new Error('close failed');
+    });
+    const forkGh = vi.fn(() => {
+      throw new Error('branch failed');
+    });
+    const removeDirectory = vi.fn(() => {
+      throw new Error('directory failed');
+    });
+
+    const errors = cleanupSmokeResources({
+      baseGh,
+      baseRepo: 'ArcadeAI/safeword-pr-review-smoke-base',
+      branch: 'smoke-branch',
+      directory: '/tmp/smoke',
+      forkGh,
+      forkRepo: 'TheMostlyGreat/safeword-pr-review-smoke-base',
+      pullNumber: 42,
+      removeDirectory,
+    });
+
+    expect(baseGh).toHaveBeenCalledWith([
+      'pr',
+      'close',
+      '42',
+      '--repo',
+      'ArcadeAI/safeword-pr-review-smoke-base',
+    ]);
+    expect(forkGh).toHaveBeenCalledWith([
+      'api',
+      '--method',
+      'DELETE',
+      'repos/TheMostlyGreat/safeword-pr-review-smoke-base/git/refs/heads/smoke-branch',
+    ]);
+    expect(removeDirectory).toHaveBeenCalledWith('/tmp/smoke');
+    expect(errors.map(error => error.message)).toEqual([
+      'close pull request: close failed',
+      'delete fork branch: branch failed',
+      'remove local fixture: directory failed',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- mint separate one-hour GitHub App installation tokens restricted to a fixed base repository and its real fork
- route base and fork mutations, Git pushes, and cleanup through the matching repository token
- exercise a temporary fork branch and pull request, then independently close the PR, delete the branch, and remove the local checkout
- keep the smoke App isolated from production repositories

## Verification
- focused behavioral tests: 4/4 passed
- canary workflow release contract passed
- TypeScript typecheck passed
- focused ESLint passed
- generated workflows and fixed fixture passed actionlint; deliberately invalid control failed
- missing either installation token fails before any command

## Live setup
- dedicated App `Safeword PR Review Smoke` installed with selected-repository access only on `ArcadeAI/safeword-pr-review-smoke-base` and `TheMostlyGreat/safeword-pr-review-smoke-base`
- App client ID and private key stored in the `pr-review-smoke` GitHub Actions environment
- environment deployment policy restricted to `main`
