### PR TITLE
Repair a mismatched Claude marketplace instead of refusing to install

### DIFF
--- a/packages/cli/src/claude-plugin/profile.ts
+++ b/packages/cli/src/claude-plugin/profile.ts
@@ -34,6 +34,7 @@ const CLAUDE_COMMAND_TIMEOUT_MS = 30_000;
 const MAXIMUM_CLAUDE_OUTPUT_BYTES = 10 * 1024 * 1024;
 const MARKETPLACE_NAME = 'safeword';
 const MARKETPLACE_BASE = 'https://github.com/ArcadeAI/safeword.git';
+const MARKETPLACE_REPO = 'ArcadeAI/safeword';
 
 export type ClaudePluginScope = 'project' | 'user';
 
@@ -357,13 +358,29 @@ function marketplaceSource(entry: JsonObject): {
       kind = undefined;
     }
   }
-  return { url, ref, kind };
+  return { url: url ?? gitHubShorthandUrl(kind, source.repo), ref, kind };
+}
+
+/**
+ * `claude plugin marketplace add ArcadeAI/safeword` — the form the Claude Code
+ * docs lead with — registers a GitHub shorthand source carrying a `repo` and
+ * neither a URL nor a ref. Resolve it to the repository it names so the
+ * same-repository comparison recognises it. The absent ref still leaves it
+ * unpinned, which marketplaceReferenceStatus reports as repairable rather than
+ * untrusted (issue #3338).
+ */
+function gitHubShorthandUrl(kind: unknown, repo: unknown): unknown {
+  if (kind !== 'github' || typeof repo !== 'string') return undefined;
+  return repo.toLowerCase() === MARKETPLACE_REPO.toLowerCase() ? MARKETPLACE_BASE : repo;
 }
 
 function marketplaceSourceStatus(entry: JsonObject): MarketplaceSourceStatus {
   const { url, ref, kind } = marketplaceSource(entry);
   if (url !== MARKETPLACE_BASE) return 'conflict';
-  if (kind !== undefined && (typeof kind !== 'string' || !['url', 'git'].includes(kind))) {
+  if (
+    kind !== undefined &&
+    (typeof kind !== 'string' || !['url', 'git', 'github'].includes(kind))
+  ) {
     return 'conflict';
   }
   return marketplaceReferenceStatus(ref);
@@ -371,8 +388,15 @@ function marketplaceSourceStatus(entry: JsonObject): MarketplaceSourceStatus {
 
 function marketplaceReferenceStatus(ref: unknown): MarketplaceSourceStatus {
   if (ref === 'stable') return 'current';
+  // Same repository, no pinned ref: the registration tracks a default branch
+  // rather than a promoted tag. That is a reason to re-add the canonical pinned
+  // source, not to refuse the install and strand the project (issue #3338).
+  if (ref === undefined) return 'stale';
   if (typeof ref !== 'string' || !ref.startsWith('v')) return 'conflict';
-  const version = ref.slice(1);
+  return marketplaceTagStatus(ref.slice(1));
+}
+
+function marketplaceTagStatus(version: string): MarketplaceSourceStatus {
   if (!isSafePackageVersion(version)) return 'conflict';
   if (version === VERSION) {
     return VERSION.includes('-') ? 'current' : 'stale';
@@ -538,13 +562,28 @@ function observeMarketplace(
   };
 }
 
+function describeMarketplaceSource(entry: JsonObject | undefined): string | undefined {
+  if (entry === undefined) return undefined;
+  const { url, ref } = marketplaceSource(entry);
+  if (typeof url !== 'string') return undefined;
+  return typeof ref === 'string' ? `${url}#${ref}` : url;
+}
+
 function assertTrustedMarketplace(observation: MarketplaceObservation): void {
-  if (observation.declarationStatus === 'conflict' || observation.sharedStatus === 'conflict') {
-    throw new ClaudeProfileError(
-      'CLAUDE_MARKETPLACE_CONFLICT',
-      `Claude marketplace ${MARKETPLACE_NAME} has an untrusted source or version; expected ${officialMarketplaceSource()} or an older valid tag from the same repository.`,
-    );
+  if (observation.declarationStatus !== 'conflict' && observation.sharedStatus !== 'conflict') {
+    return;
   }
+  // Name the offending registration: the untrusted source usually lives in a
+  // different scope than the one being installed, so "expected X" alone does not
+  // say which entry to repair.
+  const offending = describeMarketplaceSource(
+    observation.declarationStatus === 'conflict' ? observation.declaration : observation.shared,
+  );
+  const found = offending === undefined ? '' : ` Found ${offending}.`;
+  throw new ClaudeProfileError(
+    'CLAUDE_MARKETPLACE_CONFLICT',
+    `Claude marketplace ${MARKETPLACE_NAME} has an untrusted source or version; expected ${officialMarketplaceSource()} or an older valid tag from the same repository.${found} Safeword changed nothing.`,
+  );
 }
 
 function marketplaceIsCurrent(observation: MarketplaceObservation): boolean {

--- a/packages/cli/tests/claude-plugin/profile-install.test.ts
+++ b/packages/cli/tests/claude-plugin/profile-install.test.ts
@@ -27,7 +27,11 @@ interface FixtureState {
   readonly largePluginInventory?: boolean;
   readonly marketplaceAddPersists?: boolean;
   readonly marketplaceDeclared?: boolean;
+  /** Raw `extraKnownMarketplaces.safeword.source` value, for non-canonical shapes. */
+  readonly marketplaceDeclaredSource?: Record<string, unknown>;
   readonly marketplaceListedReference?: string | false;
+  /** Raw `plugin marketplace list --json` entry, for non-canonical source shapes. */
+  readonly marketplaceListedSource?: Record<string, unknown>;
   readonly omittedUserScope?: boolean;
   readonly oversizedPluginInventory?: boolean;
   readonly oversizedVersionOutput?: boolean;
@@ -154,8 +158,19 @@ function fixture(
     state,
   );
   writePluginListOverride(pluginListOverride, state, installPath, project);
+  const listingOverride = nodePath.join(root, 'marketplace-listing.json');
+  if (state.marketplaceListedSource !== undefined) {
+    writeFileSync(
+      listingOverride,
+      `${JSON.stringify([{ name: 'safeword', ...state.marketplaceListedSource }])}\n`,
+    );
+  }
   const declaration: Record<string, unknown> = {
-    source: { source: 'git', url: 'https://github.com/ArcadeAI/safeword.git', ref },
+    source: state.marketplaceDeclaredSource ?? {
+      source: 'git',
+      url: 'https://github.com/ArcadeAI/safeword.git',
+      ref,
+    },
   };
   if (autoUpdate !== undefined) declaration.autoUpdate = autoUpdate;
   const settings = {
@@ -178,7 +193,7 @@ function fixture(
   const persistMarketplace =
     state.marketplaceAddPersists === false
       ? ':'
-      : `printf '%s\\n' ${JSON.stringify(OFFICIAL_MARKETPLACE_REF)} > ${JSON.stringify(marketplaceState)}\nprintf '%s\\n' ${JSON.stringify(persistedMarketplaceSettings)} > ${JSON.stringify(settingsPath)}`;
+      : `rm -f ${JSON.stringify(listingOverride)}\nprintf '%s\\n' ${JSON.stringify(OFFICIAL_MARKETPLACE_REF)} > ${JSON.stringify(marketplaceState)}\nprintf '%s\\n' ${JSON.stringify(persistedMarketplaceSettings)} > ${JSON.stringify(settingsPath)}`;
   const executable = nodePath.join(bin, 'claude');
   writeFileSync(
     executable,
@@ -188,7 +203,9 @@ printf '%s\n' "$*" >> ${JSON.stringify(log)}
 case "$*" in
   '--version') ${versionCommand(state, pluginListOverride)} ;;
   'plugin marketplace list --json')
-    if [ -f ${JSON.stringify(marketplaceState)} ]; then
+    if [ -f ${JSON.stringify(listingOverride)} ]; then
+      cat ${JSON.stringify(listingOverride)}
+    elif [ -f ${JSON.stringify(marketplaceState)} ]; then
       marketplace_ref=$(cat ${JSON.stringify(marketplaceState)})
       printf '[{"name":"safeword","source":{"url":"https://github.com/ArcadeAI/safeword.git","ref":"%s"}}]\n' "$marketplace_ref"
     else
@@ -439,6 +456,62 @@ describe('Claude marketplace update enrollment', () => {
     expect(readFileSync(settingsPath, 'utf8')).toBe(before);
     expect(readFileSync(log, 'utf8')).not.toContain('plugin marketplace add');
     expect(readFileSync(log, 'utf8')).not.toContain('plugin list --json');
+  });
+
+  it('repairs a GitHub-shorthand registration of the same repository instead of refusing', () => {
+    // `claude plugin marketplace add ArcadeAI/safeword` is the form the Claude
+    // Code docs lead with; refusing the install strands the project (#3338).
+    const { log, project, settingsPath } = fixture(true, 'stable', undefined, {
+      marketplaceListedSource: { source: 'github', repo: 'ArcadeAI/safeword' },
+    });
+
+    const result = installClaudePlugin(project);
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+      extraKnownMarketplaces: Record<string, unknown>;
+    };
+
+    expect(result.state, JSON.stringify(result)).toBe('action_required');
+    expect(readFileSync(log, 'utf8')).toContain(
+      `plugin marketplace add https://github.com/ArcadeAI/safeword.git#${OFFICIAL_MARKETPLACE_REF} --scope project`,
+    );
+    expect(result.effects?.configuration).toContainEqual({
+      kind: 'update',
+      target: 'safeword',
+      operation: 'project',
+    });
+    expect(settings.extraKnownMarketplaces.safeword).toBeDefined();
+  });
+
+  it('repairs a project declaration that names the same repository without a ref', () => {
+    const { log, project } = fixture(true, 'stable', undefined, {
+      marketplaceDeclaredSource: {
+        source: 'git',
+        url: 'https://github.com/ArcadeAI/safeword.git',
+      },
+    });
+
+    const result = installClaudePlugin(project);
+
+    expect(result.state, JSON.stringify(result)).toBe('action_required');
+    expect(readFileSync(log, 'utf8')).toContain(
+      `plugin marketplace add https://github.com/ArcadeAI/safeword.git#${OFFICIAL_MARKETPLACE_REF} --scope project`,
+    );
+  });
+
+  it('still refuses a marketplace registered from a different repository, changing nothing', () => {
+    const { log, project, settingsPath } = fixture(true, 'stable', undefined, {
+      marketplaceListedSource: { source: 'github', repo: 'attacker/safeword' },
+    });
+    const before = readFileSync(settingsPath, 'utf8');
+
+    const result = installClaudePlugin(project);
+
+    expect(result.state).toBe('failed');
+    expect(result.errors[0]?.code).toBe('CLAUDE_MARKETPLACE_CONFLICT');
+    expect(result.errors[0]?.message).toContain('attacker/safeword');
+    expect(result.errors[0]?.message).toContain('Safeword changed nothing.');
+    expect(readFileSync(settingsPath, 'utf8')).toBe(before);
+    expect(readFileSync(log, 'utf8')).not.toContain('plugin marketplace add');
   });
 
   it('accepts Claude-owned cache metadata beside an otherwise verified plugin', () => {

--- a/packages/website/src/content/docs/getting-started/quick-start.mdx
+++ b/packages/website/src/content/docs/getting-started/quick-start.mdx
@@ -25,6 +25,8 @@ You use Claude Code, Cursor, or Codex the same way you always have. Type a promp
   <TabItem label="Claude Code">
     **Install the native plugin for this project.** Run `safeword install --agents=claude`, then `/reload-plugins` inside Claude Code. Project scope is the default and records activation in `.claude/settings.json`; use `safeword install --agents=claude --scope user` when you intentionally want Safeword active across every project in your Claude profile.
 
+    **Hosted sessions (Claude Code on the web) install the same way.** `/plugin` is terminal-only, and declaring the plugin in `.claude/settings.json` does not install it — a hosted session that only has the declaration starts with no Safeword skills or hooks and says nothing about it. `safeword install --agents=claude` is the non-interactive install path: it registers the marketplace, installs the plugin into the host registry, and needs no interactive command. Run it from the session terminal, then resume the session to load the plugin.
+
     **Your agent gets namespaced Safeword workflows.** Native skills use names such as `/safeword:bdd`, `/safeword:verify`, and `/safeword:explain` instead of project-local Safeword skill files.
 
     **Every edit gets linted automatically.** After your agent writes or modifies a file, Safeword runs your linter. If there are issues, your agent sees them immediately and fixes them—before you even notice.

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.78.8",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "e2460e1e793cc67d074f40c8b06501b9c6a17dad423a59605aacc5ead9ee503b"
+  "inventory_sha256": "3406533b398de483905a4a33966fb71acb851ace8c7d68683ac4ebe0e9da33f4"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -143,7 +143,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "ff9cadcb27da4c70036197e473cfe8b9bd34dfbdd9a8a86e834157b18d799e75"
+      "sha256": "667cb628eccffbc4e097454ef0ac1baac12e2d78a42f07d98b9738e162be9f1f"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -34642,13 +34642,18 @@ function marketplaceSource(entry) {
       kind = undefined;
     }
   }
-  return { url, ref, kind };
+  return { url: url ?? gitHubShorthandUrl(kind, source.repo), ref, kind };
+}
+function gitHubShorthandUrl(kind, repo) {
+  if (kind !== "github" || typeof repo !== "string")
+    return;
+  return repo.toLowerCase() === MARKETPLACE_REPO.toLowerCase() ? MARKETPLACE_BASE : repo;
 }
 function marketplaceSourceStatus(entry) {
   const { url, ref, kind } = marketplaceSource(entry);
   if (url !== MARKETPLACE_BASE)
     return "conflict";
-  if (kind !== undefined && (typeof kind !== "string" || !["url", "git"].includes(kind))) {
+  if (kind !== undefined && (typeof kind !== "string" || !["url", "git", "github"].includes(kind))) {
     return "conflict";
   }
   return marketplaceReferenceStatus(ref);
@@ -34656,9 +34661,13 @@ function marketplaceSourceStatus(entry) {
 function marketplaceReferenceStatus(ref) {
   if (ref === "stable")
     return "current";
+  if (ref === undefined)
+    return "stale";
   if (typeof ref !== "string" || !ref.startsWith("v"))
     return "conflict";
-  const version2 = ref.slice(1);
+  return marketplaceTagStatus(ref.slice(1));
+}
+function marketplaceTagStatus(version2) {
   if (!isSafePackageVersion(version2))
     return "conflict";
   if (version2 === VERSION) {
@@ -34761,10 +34770,21 @@ function observeMarketplace(cwd, scope, effects) {
     sharedStatus: shared === undefined ? undefined : marketplaceSourceStatus(shared)
   };
 }
+function describeMarketplaceSource(entry) {
+  if (entry === undefined)
+    return;
+  const { url, ref } = marketplaceSource(entry);
+  if (typeof url !== "string")
+    return;
+  return typeof ref === "string" ? `${url}#${ref}` : url;
+}
 function assertTrustedMarketplace(observation) {
-  if (observation.declarationStatus === "conflict" || observation.sharedStatus === "conflict") {
-    throw new ClaudeProfileError("CLAUDE_MARKETPLACE_CONFLICT", `Claude marketplace ${MARKETPLACE_NAME} has an untrusted source or version; expected ${officialMarketplaceSource()} or an older valid tag from the same repository.`);
+  if (observation.declarationStatus !== "conflict" && observation.sharedStatus !== "conflict") {
+    return;
   }
+  const offending = describeMarketplaceSource(observation.declarationStatus === "conflict" ? observation.declaration : observation.shared);
+  const found = offending === undefined ? "" : ` Found ${offending}.`;
+  throw new ClaudeProfileError("CLAUDE_MARKETPLACE_CONFLICT", `Claude marketplace ${MARKETPLACE_NAME} has an untrusted source or version; expected ${officialMarketplaceSource()} or an older valid tag from the same repository.${found} Safeword changed nothing.`);
 }
 function marketplaceIsCurrent(observation) {
   return observation.declarationStatus === "current" && observation.sharedStatus === "current";
@@ -35078,7 +35098,7 @@ function uninstallClaudePlugin(cwd, scope = "project") {
     });
   }
 }
-var MINIMUM_CLAUDE_VERSION, CLAUDE_COMMAND_TIMEOUT_MS = 30000, MAXIMUM_CLAUDE_OUTPUT_BYTES, MARKETPLACE_NAME = "safeword", MARKETPLACE_BASE = "https://github.com/ArcadeAI/safeword.git", ClaudeProfileError, DIAGNOSTIC_FAILURES;
+var MINIMUM_CLAUDE_VERSION, CLAUDE_COMMAND_TIMEOUT_MS = 30000, MAXIMUM_CLAUDE_OUTPUT_BYTES, MARKETPLACE_NAME = "safeword", MARKETPLACE_BASE = "https://github.com/ArcadeAI/safeword.git", MARKETPLACE_REPO = "ArcadeAI/safeword", ClaudeProfileError, DIAGNOSTIC_FAILURES;
 var init_profile = __esm(() => {
   init_main();
   init_result();


### PR DESCRIPTION
Fixes #3338. Addresses the documentation half of #3332.

## The bug

`claude plugin marketplace add ArcadeAI/safeword` — the GitHub shorthand the Claude Code docs lead with, and the form a person types from memory — registers this source:

```json
{ "source": "github", "repo": "ArcadeAI/safeword" }
```

No URL, no ref. Safeword's source check compared the absent URL against the canonical one, saw a mismatch, and classified the marketplace as **untrusted** — a hard failure on every subsequent `safeword install --agents=claude`, with no path forward from the obvious command.

## The fix

- Resolve the GitHub shorthand to the repository it names, so the same-repository comparison recognises it.
- Treat a registration that names Safeword's own repository **without a pinned ref** as repairable: re-add the canonical `#stable` source instead of refusing. The install then comes from the promoted tag, which is strictly safer than leaving an unpinned default-branch registration in place.
- A registration naming a **different repository** still fails hard, changes nothing, and now names the offending source in the message so the operator can find the entry — it usually lives in a different scope than the one being installed.

## Verification

Against the exact reproduction in #3338, on Claude Code 2.1.226 with an isolated `CLAUDE_CONFIG_DIR`:

- **Before:** `safeword install --agents claude` fails with `CLAUDE_MARKETPLACE_CONFLICT`.
- **After:** the marketplace is repaired, the plugin installs into the host registry, and `enabledPlugins` and `extraKnownMarketplaces` survive intact.

Three tests cover the shorthand repair, the unpinned-declaration repair, and the still-refused foreign repository.

## On the "silent deletion" in #3338

I could not reproduce the key deletion, and there is no code path in Safeword that writes `enabledPlugins` or `extraKnownMarketplaces` as empty containers — the only project-settings writes are the hook merge (which spreads `...existing`) and the auto-update enable (which adds two keys). In the mismatch case the install threw before writing anything at all. The deletion is likely host-side or specific to the hosted environment; this PR removes the condition that triggers it either way.

## On #3332

A non-interactive install path already exists and works: `safeword install --agents=claude` runs exactly the two commands the reporter verified by hand. Confirmed in an isolated config — marketplace registered, plugin written to `installed_plugins.json`, project declaration written. The real defect is discovery and silence, so the quick-start now states that the declaration alone does not install, that `/plugin` is terminal-only, and that this command is the hosted path.

The remaining item from #3332 — a `SessionStart` hook so the install travels with the checkout — is a feature-sized decision and is **not** in this PR.

## Test note

The local full-directory run is noisy on this machine (lock, review-wiring, and machine-contract suites time out under contention, and the failing set differs run to run). The `claude-plugin` suite — the changed area — passes clean, and main at the base SHA is CI-green, so CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)