### PR TITLE
Preprovision the advisory canary model fixture

### DIFF
--- a/.github/workflows/advisory-pr-review-canary.yml
+++ b/.github/workflows/advisory-pr-review-canary.yml
@@ -47,7 +47,6 @@ jobs:
           repositories: safeword-pr-review-smoke-base
           permission-actions: write
           permission-contents: write
-          permission-environments: write
           permission-issues: write
           permission-pull-requests: write
           permission-workflows: write

--- a/README.md
+++ b/README.md
@@ -526,8 +526,10 @@ The release environment named `pr-review-smoke` must define the secret
 Install that App with selected-repository access only on
 `ArcadeAI/safeword-pr-review-smoke-base` and its real fork,
 `TheMostlyGreat/safeword-pr-review-smoke-base`. The App needs Actions, Contents,
-Environments, Issues, Pull requests, and Workflows write access; the fork token
-is further restricted to Contents write. The smoke App must not have authority
+Issues, Pull requests, and Workflows write access; the fork token is further
+restricted to Contents write. Before the first run, configure a non-production
+`OPENAI_API_KEY` placeholder in the base repository's
+`safeword-pr-review-model` environment. The smoke App must not have authority
 over production repositories. The workflow mints separate installation tokens
 for the fixed repositories; GitHub revokes them at job completion, and they
 otherwise expire within one hour. Configure the environment's deployment

--- a/packages/cli/scripts/run-pr-review-disposable-smoke.ts
+++ b/packages/cli/scripts/run-pr-review-disposable-smoke.ts
@@ -388,12 +388,6 @@ export function runPrReviewDisposableSmoke(): void {
       baseGit(['push', 'origin', 'main'], directory);
     }
 
-    baseGh(['api', '--method', 'PUT', `repos/${baseRepo}/environments/safeword-pr-review-model`]);
-    baseGh(
-      ['secret', 'set', 'OPENAI_API_KEY', '--env', 'safeword-pr-review-model', '--repo', baseRepo],
-      { input: `smoke-${crypto.randomUUID()}\n` },
-    );
-
     baseGit(['checkout', '-b', branch], directory);
     writeFileSync(
       nodePath.join(directory, '.flux'),

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -118,11 +118,13 @@ describe('Claude plugin release contract', () => {
     expect(canary).toContain('owner: TheMostlyGreat');
     expect(canary.match(/repositories: safeword-pr-review-smoke-base/gu)).toHaveLength(2);
     expect(canary).not.toContain('permission-administration');
+    expect(canary).not.toContain('permission-environments');
     expect(canary).not.toContain('SAFEWORD_PR_REVIEW_SMOKE_TOKEN');
     expect(canary).toContain('SAFEWORD_PR_REVIEW_SMOKE_FORK_TOKEN');
     expect(canary).toContain('smoke:pr-review:disposable');
     expect(readme).toContain('ArcadeAI/safeword-pr-review-smoke-base');
     expect(readme).toContain('TheMostlyGreat/safeword-pr-review-smoke-base');
+    expect(readme).toContain('safeword-pr-review-model');
     expect(readme).toMatch(/must not have authority\s+over production\s+repositories/u);
     expect(readme).toMatch(/independently closes the pull\s+request/u);
   });


### PR DESCRIPTION
## Summary
- preprovision the fixed sandbox model environment once instead of mutating it with an installation token on every run
- remove environment-write authority from the short-lived canary token
- document the one-time placeholder-secret setup

## Evidence
The first live run after #3314 minted both installation tokens and updated the fixed base repository, then GitHub rejected runtime environment creation with `Resource not accessible by integration`. The fixed fixture now owns that environment and placeholder secret ahead of execution.

## Verification
- focused behavioral tests: 4/4 passed
- canary workflow release contract passed
- workflow/actionlint contract passed with invalid control rejected
- focused ESLint, formatting, and TypeScript passed
