### PR TITLE
Allow the canary to push workflow fixture branches

### DIFF
--- a/.github/workflows/advisory-pr-review-canary.yml
+++ b/.github/workflows/advisory-pr-review-canary.yml
@@ -60,6 +60,7 @@ jobs:
           owner: TheMostlyGreat
           repositories: safeword-pr-review-smoke-base
           permission-contents: write
+          permission-workflows: write
 
       - name: Prove fork-event and scheduled advisory semantics
         run: bun run --cwd packages/cli smoke:pr-review:disposable

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Install that App with selected-repository access only on
 `ArcadeAI/safeword-pr-review-smoke-base` and its real fork,
 `TheMostlyGreat/safeword-pr-review-smoke-base`. The App needs Actions, Contents,
 Issues, Pull requests, and Workflows write access; the fork token is further
-restricted to Contents write. Before the first run, configure a non-production
+restricted to Contents and Workflows write. Before the first run, configure a non-production
 `OPENAI_API_KEY` placeholder in the base repository's
 `safeword-pr-review-model` environment. The smoke App must not have authority
 over production repositories. The workflow mints separate installation tokens

--- a/packages/cli/tests/claude-plugin-release.release.test.ts
+++ b/packages/cli/tests/claude-plugin-release.release.test.ts
@@ -117,6 +117,7 @@ describe('Claude plugin release contract', () => {
     expect(canary).toContain('owner: ArcadeAI');
     expect(canary).toContain('owner: TheMostlyGreat');
     expect(canary.match(/repositories: safeword-pr-review-smoke-base/gu)).toHaveLength(2);
+    expect(canary.match(/permission-workflows: write/gu)).toHaveLength(2);
     expect(canary).not.toContain('permission-administration');
     expect(canary).not.toContain('permission-environments');
     expect(canary).not.toContain('SAFEWORD_PR_REVIEW_SMOKE_TOKEN');


### PR DESCRIPTION
## Summary
- request Workflows write on the short-lived fork token because the fixed fixture branch contains workflow files
- keep the token restricted to the single selected sandbox repository
- pin the permission in the workflow contract and documentation

## Evidence
Live canary run 32691912884 minted both tokens, cloned the fixed fixture, and failed only when GitHub rejected the fork push because its token omitted Workflows permission.

## Verification
- canary workflow release contract passed
- workflow/actionlint contract passed with invalid control rejected
- focused ESLint, formatting, and TypeScript passed
