### PR TITLE
Avoid maintainer grants in the advisory canary

### DIFF
--- a/packages/cli/scripts/run-pr-review-disposable-smoke.ts
+++ b/packages/cli/scripts/run-pr-review-disposable-smoke.ts
@@ -406,6 +406,7 @@ export function runPrReviewDisposableSmoke(): void {
       'main',
       '--head',
       `${forkOwner}:${branch}`,
+      '--no-maintainer-edit',
       '--title',
       'Exercise advisory PR review smoke',
       '--body',


### PR DESCRIPTION
## Summary
- create the sandbox fork PR without granting base maintainers edit access to the fork branch
- preserve the selected-repository App permissions already proven by the live run

## Evidence
Live canary run 32693323874 successfully minted both tokens and pushed the fork branch, then `gh pr create` failed only while attempting its default fork-collaboration grant. The canary does not need maintainer edits.

## Verification
- focused canary behavior tests: 4/4 passed
- focused ESLint, formatting, and TypeScript passed
- failed live run independently cleaned up its temporary fork branch
