### PR TITLE
Preserve the exact advisory canary fixture

### DIFF
--- a/packages/cli/scripts/run-pr-review-disposable-smoke.ts
+++ b/packages/cli/scripts/run-pr-review-disposable-smoke.ts
@@ -389,11 +389,9 @@ export function runPrReviewDisposableSmoke(): void {
     }
 
     baseGit(['checkout', '-b', branch], directory);
-    writeFileSync(
-      nodePath.join(directory, '.flux'),
-      `require_human_review = true\nsmoke_run = ${suffix}\n`,
-    );
-    baseGit(['add', '.flux'], directory);
+    writeFileSync(nodePath.join(directory, '.flux'), 'require_human_review = true\n');
+    writeFileSync(nodePath.join(directory, '.safeword-smoke-run'), `${suffix}\n`);
+    baseGit(['add', '.flux', '.safeword-smoke-run'], directory);
     baseGit(['commit', '-m', 'Exercise fork advisory review'], directory);
     forkGit(['push', `https://github.com/${forkRepo}.git`, `HEAD:refs/heads/${branch}`], directory);
     branchPushed = true;


### PR DESCRIPTION
## Summary
- keep `.flux` at the exact one-line content asserted by the real review worker
- put the per-run nonce in a separate file so every canary still creates a unique commit

## Evidence
Live canary run 32695015418 successfully created the cross-fork PR and entered the real review workflow. The worker then correctly rejected `.flux` because the canary had appended its nonce to that contract fixture.

## Verification
- focused canary behavior tests: 4/4 passed
- focused ESLint, formatting, and TypeScript passed
- failed live run closed its PR and cleaned up its temporary branch
