### PR TITLE
Accept the advisory canary receipt fast path

### DIFF
--- a/packages/cli/src/pr-review/smoke-fixture.ts
+++ b/packages/cli/src/pr-review/smoke-fixture.ts
@@ -65,10 +65,12 @@ fi
   inspect.env.GITHUB_TOKEN = '${{ github.token }}';
   inspect.env.SAFEWORD_PR_NUMBER = '${{ inputs.pull_number }}';
   inspect.run = `
-full_content="$(jq -r '.artifacts[] | select(.kind == "text" and .path == ".flux") | .fullContentBase64 // empty' inspection-input.json | base64 --decode)"
-if [ "$full_content" != 'require_human_review = true' ]; then
-  echo '::error::full-file context did not match the exact fork blob'
-  exit 1
+if ! jq -e '.markerReceiptExists == true and .reviewedReceiptSha == .headSha' inspection-input.json >/dev/null; then
+  full_content="$(jq -r '.artifacts[] | select(.kind == "text" and .path == ".flux") | .fullContentBase64 // empty' inspection-input.json | base64 --decode)"
+  if [ "$full_content" != 'require_human_review = true' ]; then
+    echo '::error::full-file context did not match the exact fork blob'
+    exit 1
+  fi
 fi
 if [ -z "$OPENAI_API_KEY" ]; then
   echo '::error::inspection job did not receive its environment-scoped secret'

--- a/packages/cli/tests/pr-review/smoke-fixture.test.ts
+++ b/packages/cli/tests/pr-review/smoke-fixture.test.ts
@@ -71,6 +71,9 @@ describe('disposable advisory PR review fixture', () => {
       SAFEWORD_PR_NUMBER: '${{ inputs.pull_number }}',
     });
     expect(fixtureInspect.run).toContain('inspection-input.json');
+    expect(fixtureInspect.run).toContain(
+      '.markerReceiptExists == true and .reviewedReceiptSha == .headSha',
+    );
     expect(fixtureInspect.run).toContain('full-file context did not match the exact fork blob');
     expect(fixtureInspect.run).toContain("grep -q 'HTTP 403'");
     for (const [job, name] of [


### PR DESCRIPTION
## Summary
- accept the canonical current-head receipt path in the scheduled canary inspection
- retain the exact `.flux` full-content assertion for fresh inspections
- continue probing secret isolation and denied write authority on both paths

## Evidence
Live run 32698465286 correctly bound to PR #4 and its fresh scheduled run. The scheduled worker found the current event-review receipt and intentionally returned no artifacts; the smoke-only assertion incorrectly required fresh file evidence anyway.

## Verification
- smoke fixture and canary behavior tests: 8/8 passed
- workflow/actionlint contract passed with invalid control rejected
- focused ESLint, formatting, and TypeScript passed
- failed live run closed its PR and cleaned up its temporary branch
