### PR TITLE
Say when a review was not independent

### DIFF
--- a/.claude/skills/quality-review/SKILL.md
+++ b/.claude/skills/quality-review/SKILL.md
@@ -184,14 +184,25 @@ Each pass:
    Claude-authored work prefers headless Codex; Codex-authored work prefers
    headless Claude. The coordinator uses a neutral snapshot, checks reviewer
    provenance, preserves the exact preferred-route failure, and records any
-   permitted same-agent fallback as `independence: degraded` while presenting
-   it to people as standard coverage. Treat its typed result as the
-   review verdict. Only when the typed result is
+   permitted same-agent fallback as `independence: degraded`. Treat its typed
+   result as the review verdict. Only when the typed result is
    `REVIEW_ROUTES_EXHAUSTED`, invoke `/finish-review` immediately with the
    original result and the same accepted targets. For every other result,
    return it unchanged. The canonical fallback may use one host-native
    subagent, but do not invent another private route or mint independent
    evidence yourself.
+
+   **Say when a review was not independent.** If the typed result carries
+   `independence: degraded`, state that plainly in your own report — one line,
+   naming the actual reviewer and that it was not independent — before any
+   finding. A degraded review is the same agent grading its own work, and a
+   reader who cannot tell it apart from a real second opinion will trust it as
+   one. Never describe a degraded result as independent, cross-agent, or
+   standard coverage. Say nothing extra when independence is intact.
+
+   The quiet-by-default rule below governs setup advice — recovery commands and
+   install hints. It never licenses withholding the independence of the review
+   itself.
 
    Keep optional setup advice quiet by default. When the user asks
    `Show review coverage details.`, report the typed result's achieved coverage,

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -1849,7 +1849,7 @@
   → `.project/tickets/R4S85Y-rename-dev-persona-to-tb`
 - **Protect review fallback boundaries for builders (R7K2QP)** (—, epic: —)
   → `.project/tickets/R7K2QP-protect-review-fallback-boundaries`
-- **Say when a review was not independent (R9TLC3)** (todo, epic: —)
+- **Say when a review was not independent (R9TLC3)** (done, epic: —)
   Make `independence: degraded` visible to the person reading the verdict.
   → `.project/tickets/R9TLC3-surface-degraded-review-independence`
 - **Stop-hook escalation path may be dead (0/10 BLOCKED) — revalidate post-F14BG2, recalibrate if needed (RAS9N8)** (pending, epic: —)

--- a/.project/tickets/INDEX.md
+++ b/.project/tickets/INDEX.md
@@ -5,7 +5,7 @@
 
 <!-- prettier-ignore-start -->
 
-## Tickets (580)
+## Tickets (581)
 
 ### 001
 
@@ -1681,7 +1681,7 @@
 - **Strengthen behavior proof for Safeword users (K78FJ3)** (in_progress, epic: —)
   Review every shipped BDD scenario against the scenario-gate rubric and record actionable findings.
   → `.project/tickets/K78FJ3-review-bdd-scenario-semantics`
-- **Keep unmappable namespace-root calls working in generated Codex skills (K7XQ2M)** (todo, epic: —)
+- **Keep unmappable namespace-root calls working in generated Codex skills (K7XQ2M)** (done, epic: —)
   Make the namespace-root rewrite honour preserve-on-anything-unrecognised on every branch.
   → `.project/tickets/K7XQ2M-preserve-unmappable-namespace-root-calls`
 - **Surface reply format before Claude responds (K8D3M4)** (done, epic: —)
@@ -1789,7 +1789,7 @@
 - **Ship a clean release for safeword users (P2JDY5)** (done, epic: —)
   Audit and reconcile every change merged since v0.69.0, apply justified behavior-preserving refactors, verify release readiness, and close completed tracking items.
   → `.project/tickets/P2JDY5-release-readiness-v0-70`
-- **Keep table alignment intact in generated Codex skills (P4NDV8)** (todo, epic: —)
+- **Keep table alignment intact in generated Codex skills (P4NDV8)** (done, epic: —)
   Stop the Markdown table normalizer from changing how tables render.
   → `.project/tickets/P4NDV8-keep-table-alignment-in-codex-skills`
 - **Lint files changed by shell commands, not just file-tool edits (P6PN58)** (in_progress, epic: —)
@@ -1910,6 +1910,9 @@
 - **Numbered Rule tier between JTBD and scenarios (V0NHT6)** (done, epic: —)
   Add an optional numbered-Rule tier (`<jtbd-id>.R<#>`) to the scenario lineage so specs carry an invariant catalog with stable IDs, tier-aware checks, and expressiveness for Arcade's existing rule-numbered corpus (issue #649).
   → `.project/tickets/V0NHT6-rule-tier`
+- **Keep the advisory review canary isolated from production repositories (V1TBJ0)** (in_progress, epic: —)
+  Use short-lived GitHub App installation tokens against one fixed sandbox fork pair.
+  → `.project/tickets/V1TBJ0-automate-review-canary-with-short-lived-credentials`
 - **Python pack: scaffold generic import-linter config (audit arch check out of the box) (V4MATC)** (done, epic: —)
   A freshly set-up Python project runs a real lint-imports cycle check under /audit with zero manual configuration (parity with JS depcruise)
   → `.project/tickets/V4MATC-python-importlinter-scaffold`

--- a/.project/tickets/K7XQ2M-preserve-unmappable-namespace-root-calls/ticket.md
+++ b/.project/tickets/K7XQ2M-preserve-unmappable-namespace-root-calls/ticket.md
@@ -2,8 +2,8 @@
 id: K7XQ2M
 slug: preserve-unmappable-namespace-root-calls
 type: task
-phase: intake
-status: todo
+phase: done
+status: done
 related: [KEQQGN]
 scope:
   - preserve a namespace-root invocation whenever the rewrite cannot map its arguments
@@ -60,3 +60,7 @@ it reads as proof of an invariant it does not exercise.
 
 Finding 2 of an independent cross-agent Codex review of `catalogue.ts` on main,
 plus a review of PR #3262; both confirmed by hand-tracing the regex.
+
+## Work Log
+
+- 2026-08-24T05:36:22.457Z Phase: intake → done

--- a/.project/tickets/P4NDV8-keep-table-alignment-in-codex-skills/ticket.md
+++ b/.project/tickets/P4NDV8-keep-table-alignment-in-codex-skills/ticket.md
@@ -2,8 +2,8 @@
 id: P4NDV8
 slug: keep-table-alignment-in-codex-skills
 type: task
-phase: intake
-status: todo
+phase: done
+status: done
 scope:
   - preserve each column's alignment colons when normalizing table widths
   - cover left, right, and centre aligned delimiter rows with a regression test
@@ -43,3 +43,7 @@ colons while normalizing widths.
 
 Finding 1 of an independent cross-agent Codex review of `catalogue.ts` on main;
 independently raised by a second reviewer on PR #3262.
+
+## Work Log
+
+- 2026-08-24T05:36:53.716Z Phase: intake → done

--- a/.project/tickets/R9TLC3-surface-degraded-review-independence/ticket.md
+++ b/.project/tickets/R9TLC3-surface-degraded-review-independence/ticket.md
@@ -2,8 +2,8 @@
 id: R9TLC3
 slug: surface-degraded-review-independence
 type: task
-phase: intake
-status: todo
+phase: done
+status: done
 related: [ZRV8D5, DR6M6N]
 scope:
   - tell the reader when a review was not independent, at the point of use
@@ -59,3 +59,37 @@ the healthy path.
 
 Diagnosed this session by differential-testing the Codex dispatch with and
 without `--output-schema`, then tracing the resolved CLI to a stale artifact.
+
+## Resolution — delivered differently than Direction stated
+
+Direction proposed a CLI qualifier line. That was **not** the route taken.
+
+Investigation found the CLI already tells the truth: `degradedDescription` in
+`review/coordinator.ts` emits a `warning`-severity `REVIEW_INDEPENDENCE_DEGRADED`
+finding reading "This review was not independent: the same agent (X) checked its
+own work". The suppression lived one layer up, in this skill's own guidance,
+which instructed agents to present a same-agent fallback "to people as standard
+coverage" — and paired it with "keep optional setup advice quiet by default",
+which read as licence to bury the independence signal too.
+
+A CLI change would also have reversed `clarify-review-coverage.NTB1.R1`, a
+codified feature titled "Make review coverage clear without false alarms", whose
+Examples pin the exact strings `Review complete — standard coverage.` versus
+`… independent coverage.`. Reversing a delivered spec under a different ticket's
+authority was the wrong call for a wording fix.
+
+Shipped instead: the "as standard coverage" clause is removed from
+`quality-review/SKILL.md`, replaced with an explicit instruction to state
+degraded independence plainly and never call it independent, cross-agent, or
+standard coverage; and the quiet-by-default sentence now scopes itself to
+recovery commands and install hints, never the review's independence. Applied
+across all five parity copies plus the regenerated Claude/Codex plugin assets
+and historical catalogue.
+
+`review-presentation.ts` and `clarify-review-coverage.feature` are unchanged, so
+NTB1 stands as specified. The premortem's alert-fatigue mitigation still holds:
+one line, never a block, nothing on the healthy path.
+
+## Work Log
+
+- 2026-08-24T06:03:14.948Z Phase: intake → done

--- a/.safeword/skills/quality-review/SKILL.md
+++ b/.safeword/skills/quality-review/SKILL.md
@@ -184,14 +184,25 @@ Each pass:
    Claude-authored work prefers headless Codex; Codex-authored work prefers
    headless Claude. The coordinator uses a neutral snapshot, checks reviewer
    provenance, preserves the exact preferred-route failure, and records any
-   permitted same-agent fallback as `independence: degraded` while presenting
-   it to people as standard coverage. Treat its typed result as the
-   review verdict. Only when the typed result is
+   permitted same-agent fallback as `independence: degraded`. Treat its typed
+   result as the review verdict. Only when the typed result is
    `REVIEW_ROUTES_EXHAUSTED`, invoke `/finish-review` immediately with the
    original result and the same accepted targets. For every other result,
    return it unchanged. The canonical fallback may use one host-native
    subagent, but do not invent another private route or mint independent
    evidence yourself.
+
+   **Say when a review was not independent.** If the typed result carries
+   `independence: degraded`, state that plainly in your own report — one line,
+   naming the actual reviewer and that it was not independent — before any
+   finding. A degraded review is the same agent grading its own work, and a
+   reader who cannot tell it apart from a real second opinion will trust it as
+   one. Never describe a degraded result as independent, cross-agent, or
+   standard coverage. Say nothing extra when independence is intact.
+
+   The quiet-by-default rule below governs setup advice — recovery commands and
+   install hints. It never licenses withholding the independence of the review
+   itself.
 
    Keep optional setup advice quiet by default. When the user asks
    `Show review coverage details.`, report the typed result's achieved coverage,

--- a/packages/cli/codex-plugin/skills/quality-review/SKILL.md
+++ b/packages/cli/codex-plugin/skills/quality-review/SKILL.md
@@ -189,14 +189,25 @@ Each pass:
    Claude-authored work prefers headless Codex; Codex-authored work prefers
    headless Claude. The coordinator uses a neutral snapshot, checks reviewer
    provenance, preserves the exact preferred-route failure, and records any
-   permitted same-agent fallback as `independence: degraded` while presenting
-   it to people as standard coverage. Treat its typed result as the
-   review verdict. Only when the typed result is
+   permitted same-agent fallback as `independence: degraded`. Treat its typed
+   result as the review verdict. Only when the typed result is
    `REVIEW_ROUTES_EXHAUSTED`, invoke `$safeword:finish-review` immediately with the
    original result and the same accepted targets. For every other result,
    return it unchanged. The canonical fallback may use one host-native
    subagent, but do not invent another private route or mint independent
    evidence yourself.
+
+   **Say when a review was not independent.** If the typed result carries
+   `independence: degraded`, state that plainly in your own report — one line,
+   naming the actual reviewer and that it was not independent — before any
+   finding. A degraded review is the same agent grading its own work, and a
+   reader who cannot tell it apart from a real second opinion will trust it as
+   one. Never describe a degraded result as independent, cross-agent, or
+   standard coverage. Say nothing extra when independence is intact.
+
+   The quiet-by-default rule below governs setup advice — recovery commands and
+   install hints. It never licenses withholding the independence of the review
+   itself.
 
    Keep optional setup advice quiet by default. When the user asks
    `Show review coverage details.`, report the typed result's achieved coverage,

--- a/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
+++ b/packages/cli/src/claude-plugin/historical-catalogue.generated.ts
@@ -46,7 +46,7 @@ export const CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/lint/SKILL.md':
         'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
-        'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
+        '75dcf079f5ac19a7a6dffca382b535ab12a637a8645fd5a8b482b2a1684a6d69',
       '.claude/skills/refactor/SKILL.md':
         'a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e',
       '.claude/skills/retro-filer/SKILL.md':

--- a/packages/cli/templates/skills/quality-review/SKILL.md
+++ b/packages/cli/templates/skills/quality-review/SKILL.md
@@ -184,14 +184,25 @@ Each pass:
    Claude-authored work prefers headless Codex; Codex-authored work prefers
    headless Claude. The coordinator uses a neutral snapshot, checks reviewer
    provenance, preserves the exact preferred-route failure, and records any
-   permitted same-agent fallback as `independence: degraded` while presenting
-   it to people as standard coverage. Treat its typed result as the
-   review verdict. Only when the typed result is
+   permitted same-agent fallback as `independence: degraded`. Treat its typed
+   result as the review verdict. Only when the typed result is
    `REVIEW_ROUTES_EXHAUSTED`, invoke `/finish-review` immediately with the
    original result and the same accepted targets. For every other result,
    return it unchanged. The canonical fallback may use one host-native
    subagent, but do not invent another private route or mint independent
    evidence yourself.
+
+   **Say when a review was not independent.** If the typed result carries
+   `independence: degraded`, state that plainly in your own report — one line,
+   naming the actual reviewer and that it was not independent — before any
+   finding. A degraded review is the same agent grading its own work, and a
+   reader who cannot tell it apart from a real second opinion will trust it as
+   one. Never describe a degraded result as independent, cross-agent, or
+   standard coverage. Say nothing extra when independence is intact.
+
+   The quiet-by-default rule below governs setup advice — recovery commands and
+   install hints. It never licenses withholding the independence of the review
+   itself.
 
    Keep optional setup advice quiet by default. When the user asks
    `Show review coverage details.`, report the typed result's achieved coverage,

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.79.0",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "0ec643be19930a1997054ea6a29a19c3c2c509449fc5987e08d385a010c2af65"
+  "inventory_sha256": "2a4bf91a4ce6ad8ec80427d19434b09734c045ec451012160a4eed63ddd0bd77"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -143,11 +143,11 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "667cb628eccffbc4e097454ef0ac1baac12e2d78a42f07d98b9738e162be9f1f"
+      "sha256": "f41c5aeefb0e91db0abc86aea661e2e33f9f04efdadd283d904ae0e53c3115fe"
     },
     {
       "path": "runtime/dispatch.js",
-      "sha256": "7fc0d20b2e2f1548141699d11425d0d6b5d201be1203fc9dffe388536253341a"
+      "sha256": "f864b11f4bc3f82d0536ec9b89f7241653699f96f164a832300582d3b61f5113"
     },
     {
       "path": "runtime/event-groups.json",
@@ -663,7 +663,7 @@
     },
     {
       "path": "skills/quality-review/SKILL.md",
-      "sha256": "244fee019f778dc69dc0f9778071f7a017490116bd9202cb6bc08a39f7ca5c1c"
+      "sha256": "b2ecd3aa13aa2bdad59008f3027c81f6e6c42e7a03d3cf33ebb138f2f7647f7e"
     },
     {
       "path": "skills/refactor/SKILL.md",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -596,7 +596,7 @@ var init_historical_catalogue_generated = __esm(() => {
         ".claude/skills/finish-review/REVIEWER.md": "0ecee21a63f91e09d3136f62cf8f7590ba9a640b85cad7b7b35c1ae334ff43c2",
         ".claude/skills/finish-review/SKILL.md": "e9ed5d198994b6cca12c62b1a4c13a1db2d82d65fc8a9173a41c5b5cf312cd52",
         ".claude/skills/lint/SKILL.md": "fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19",
-        ".claude/skills/quality-review/SKILL.md": "b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a",
+        ".claude/skills/quality-review/SKILL.md": "75dcf079f5ac19a7a6dffca382b535ab12a637a8645fd5a8b482b2a1684a6d69",
         ".claude/skills/refactor/SKILL.md": "a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e",
         ".claude/skills/retro-filer/SKILL.md": "ea126f3805a2befefb4db2011439f075ebfd6eca31b78bd5f284ac11d667b4f0",
         ".claude/skills/retro/SKILL.md": "166e5109193bad4c26e060f6841d71c03f9155c7e74e1853c43b99b01c25d379",

--- a/plugin/runtime/dispatch.js
+++ b/plugin/runtime/dispatch.js
@@ -1800,7 +1800,7 @@ var CLAUDE_HISTORICAL_CATALOGUE = {
       '.claude/skills/lint/SKILL.md':
         'fdde749fe9ce764f6f9325f963c092d457960494fe78dd04d65d53a50e7cfd19',
       '.claude/skills/quality-review/SKILL.md':
-        'b940905d31cd4931665e023a65824a923a2bd5d7f590358355576cff8f3bc42a',
+        '75dcf079f5ac19a7a6dffca382b535ab12a637a8645fd5a8b482b2a1684a6d69',
       '.claude/skills/refactor/SKILL.md':
         'a51a858fb13b50cbc86789edbde8a39e364b5cdd7d5d3b025d555d90b221760e',
       '.claude/skills/retro-filer/SKILL.md':

--- a/plugin/skills/quality-review/SKILL.md
+++ b/plugin/skills/quality-review/SKILL.md
@@ -184,14 +184,25 @@ Each pass:
    Claude-authored work prefers headless Codex; Codex-authored work prefers
    headless Claude. The coordinator uses a neutral snapshot, checks reviewer
    provenance, preserves the exact preferred-route failure, and records any
-   permitted same-agent fallback as `independence: degraded` while presenting
-   it to people as standard coverage. Treat its typed result as the
-   review verdict. Only when the typed result is
+   permitted same-agent fallback as `independence: degraded`. Treat its typed
+   result as the review verdict. Only when the typed result is
    `REVIEW_ROUTES_EXHAUSTED`, invoke `/finish-review` immediately with the
    original result and the same accepted targets. For every other result,
    return it unchanged. The canonical fallback may use one host-native
    subagent, but do not invent another private route or mint independent
    evidence yourself.
+
+   **Say when a review was not independent.** If the typed result carries
+   `independence: degraded`, state that plainly in your own report — one line,
+   naming the actual reviewer and that it was not independent — before any
+   finding. A degraded review is the same agent grading its own work, and a
+   reader who cannot tell it apart from a real second opinion will trust it as
+   one. Never describe a degraded result as independent, cross-agent, or
+   standard coverage. Say nothing extra when independence is intact.
+
+   The quiet-by-default rule below governs setup advice — recovery commands and
+   install hints. It never licenses withholding the independence of the review
+   itself.
 
    Keep optional setup advice quiet by default. When the user asks
    `Show review coverage details.`, report the typed result's achieved coverage,


### PR DESCRIPTION
Closes **R9TLC3**, and closes **K7XQ2M** / **P4NDV8** as delivered in #3369.

## The problem

A degraded review is the same agent grading its own work. The CLI already says so — `degradedDescription` in `review/coordinator.ts` emits a `warning`-severity `REVIEW_INDEPENDENCE_DEGRADED` finding reading *"This review was not independent: the same agent (X) checked its own work"*.

The suppression lived one layer up, in the `quality-review` skill's own guidance, which told agents to record a same-agent fallback as `independence: degraded` **"while presenting it to people as standard coverage"** — paired with *"keep optional setup advice quiet by default"*, which read as licence to bury the independence signal along with the install hints.

**Observed cost.** A stale local `node_modules/safeword` build stripped `--output-schema` from the Codex dispatch, so Codex returned findings the validator rejected as `invalid_output`. Three consecutive reviews silently fell back to Claude reviewing Claude's own work — each reported as normal coverage. The skew was only caught by reading the raw result envelope by hand.

## The change

The "as standard coverage" clause is gone. In its place: state degraded independence plainly, name the actual reviewer, and never call it independent, cross-agent, or standard coverage. Nothing extra when independence is intact. The quiet-by-default sentence now scopes itself explicitly to recovery commands and install hints, never the review's independence.

## Deliberately not a CLI change

`clarify-review-coverage.NTB1.R1` is a codified feature titled *"Make review coverage clear without false alarms"*, whose Examples pin the exact rendered strings (`Review complete — standard coverage.` vs `… independent coverage.`). Reversing a delivered spec under a different ticket's authority was the wrong call for a wording fix.

`review-presentation.ts` and `clarify-review-coverage.feature` are **untouched** — NTB1 stands as specified. R9TLC3 carries a Resolution section recording that this shipped differently from its own stated Direction, and why.

## Scope

All five parity copies of the skill, plus three regenerated artifacts:

- `generate:codex-plugin` and `generate:claude-plugin` — plugin skill assets
- `generate:claude-historical-catalogue` — fingerprints skill content; **only the release lane catches this one**
- `plugin/runtime/{cli,dispatch}.js` — bundles that embed those fingerprints

## Verification

- release lane (`vitest.release.config.ts`): 10 files, 40 tests passed
- `eslint . && lint:gherkin && tsc --noEmit`: clean
- generators re-run after rebase: zero drift (idempotent)

`tests/review/` shows `probe_timed_out` failures under load. Baselined on clean `main` — the same tests fail there. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)