### PR TITLE
Dogfood the advisory PR reviewer

### DIFF
--- a/.github/workflows/safeword-pr-review-publisher.yml
+++ b/.github/workflows/safeword-pr-review-publisher.yml
@@ -1,0 +1,72 @@
+name: Safeword advisory PR review publisher
+
+on:
+  workflow_run:
+    workflows: [Safeword advisory PR review]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  discover-event-result:
+    if: ${{ github.event.workflow_run.event == 'pull_request_target' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      has_result: ${{ steps.artifact.outputs.has_result }}
+      pull_number: ${{ steps.artifact.outputs.pull_number }}
+    steps:
+      - id: artifact
+        name: Resolve the pull request from its trusted artifact name
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SAFEWORD_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_names="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SAFEWORD_RUN_ID/artifacts" --jq '.artifacts[].name')"
+          pull_number="$(printf '%s\n' "$artifact_names" | sed -nE 's/^safeword-pr-review(-context)?-([0-9]+)$/\2/p' | sort -u)"
+          if [ "$(printf '%s\n' "$pull_number" | sed '/^$/d' | wc -l)" != 1 ]; then
+            echo '::error::event run did not identify exactly one pull request'
+            exit 1
+          fi
+          echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
+          if printf '%s\n' "$artifact_names" | grep -qx "safeword-pr-review-$pull_number"; then
+            echo 'has_result=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_result=false' >> "$GITHUB_OUTPUT"
+          fi
+
+  publish-event-result:
+    needs: discover-event-result
+    if: ${{ needs.discover-event-result.outputs.pull_number != '' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-review-${{ needs.discover-event-result.outputs.pull_number }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Invalidate any obsolete advisory route
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SAFEWORD_PR_NUMBER: ${{ needs.discover-event-result.outputs.pull_number }}
+        run: npx --yes safeword@0.79.0 --no-input --json review-pr invalidate
+      - name: Download the JSON-only advisory handoff
+        if: needs.discover-event-result.outputs.has_result == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: safeword-pr-review-${{ needs.discover-event-result.outputs.pull_number }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Publish one ordinary pull-request comment
+        if: needs.discover-event-result.outputs.has_result == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SAFEWORD_PR_NUMBER: ${{ needs.discover-event-result.outputs.pull_number }}
+        run: npx --yes safeword@0.79.0 --no-input --json review-pr publish advisory-result.json

--- a/.github/workflows/safeword-pr-review-worker.yml
+++ b/.github/workflows/safeword-pr-review-worker.yml
@@ -1,0 +1,190 @@
+name: Safeword advisory PR review worker
+
+on:
+  workflow_call:
+    inputs:
+      pull_number:
+        required: true
+        type: number
+      cancel_in_progress:
+        required: true
+        type: boolean
+      inspect_requested:
+        required: true
+        type: boolean
+      write_requested:
+        required: true
+        type: boolean
+
+concurrency:
+  group: pr-review-${{ inputs.pull_number }}
+  cancel-in-progress: ${{ inputs.cancel_in_progress }}
+
+permissions: {}
+
+jobs:
+  invalidate:
+    if: ${{ inputs.write_requested }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Invalidate any obsolete advisory route
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SAFEWORD_PR_NUMBER: ${{ inputs.pull_number }}
+        run: npx --yes safeword@0.79.0 --no-input --json review-pr invalidate
+
+  inspect:
+    needs: invalidate
+    if: ${{ always() && inputs.inspect_requested && (needs.invalidate.result == 'success' || needs.invalidate.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: safeword-pr-review-model
+      deployment: false
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Assemble exact-head evidence as JSON
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SAFEWORD_PR_NUMBER: ${{ inputs.pull_number }}
+        run: |
+          set -euo pipefail
+          mkdir -p .safeword
+          gh api "repos/$GITHUB_REPOSITORY/contents/.safeword/config.json" --jq .content | base64 --decode > .safeword/config.json
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$SAFEWORD_PR_NUMBER" > pull.json
+          head_sha="$(jq -r .head.sha pull.json)"
+          gh api "repos/$GITHUB_REPOSITORY/issues/$SAFEWORD_PR_NUMBER/comments?per_page=100" --paginate --jq '.[]' | jq -s . > comments.json
+          reviewed_receipt_sha="$(jq -r '
+            [ .[] |
+              select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- safeword:pr-review-receipt:v1 -->"))) |
+              .body |
+              select(contains("\nRoute:")) |
+              capture("Reviewed revision: (?<sha>[0-9a-f]{40,64})").sha
+            ] | last // empty
+          ' comments.json)"
+          if [ "$reviewed_receipt_sha" = "$head_sha" ]; then
+            jq -n --slurpfile pull pull.json --arg reviewedReceiptSha "$reviewed_receipt_sha" '
+              ($pull[0]) as $pr |
+              {
+                schemaVersion: 1,
+                headSha: $pr.head.sha,
+                pullState: (if $pr.merged then "merged" elif $pr.state == "closed" then "closed" elif $pr.draft then "draft" else "ready" end),
+                markerReceiptExists: true,
+                reviewedReceiptSha: $reviewedReceiptSha,
+                artifacts: [],
+                checks: [],
+                statuses: []
+              }
+            ' > inspection-input.json
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$SAFEWORD_PR_NUMBER/files?per_page=100" --paginate --jq '.[]' | jq -s . > pull-files.json
+          jq -c '.[]' pull-files.json | while IFS= read -r file; do
+            if jq -e '.patch != null and .status != "removed"' > /dev/null <<< "$file"; then
+              blob_sha="$(jq -r .sha <<< "$file")"
+              if blob_json="$(gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha")" &&
+                full_content="$(jq -er '
+                  if .encoding == "base64" and (.content | type) == "string" then
+                    .content | gsub("\\n"; "")
+                  elif .size == 0 then
+                    ""
+                  else
+                    error("blob content is not available as base64")
+                  end
+                ' <<< "$blob_json")"; then
+                jq --arg fullContentBase64 "$full_content" '. + {$fullContentBase64}' <<< "$file"
+              else
+                jq '. + {contextUnavailable: true}' <<< "$file"
+              fi
+            else
+              printf '%s\n' "$file"
+            fi
+          done | jq -s . > pull-files-with-context.json
+          latest_head_sha="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$SAFEWORD_PR_NUMBER" --jq .head.sha)"
+          if [ "$latest_head_sha" != "$head_sha" ]; then
+            echo "Pull request head changed while evidence was assembled." >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?per_page=100" --paginate --jq '.check_runs[]' | jq -s . > check-runs.json
+          gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/status?per_page=100" --paginate --jq '.statuses[]' | jq -s . > statuses.json
+          jq -n --slurpfile files pull-files-with-context.json --slurpfile pull pull.json --slurpfile checks check-runs.json --slurpfile statuses statuses.json --slurpfile comments comments.json '
+            ($pull[0]) as $pr |
+            ([ $comments[0][] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- safeword:pr-review-receipt:v1 -->"))) ]) as $owned |
+            {
+              schemaVersion: 1,
+              headSha: $pr.head.sha,
+              pullState: (if $pr.merged then "merged" elif $pr.state == "closed" then "closed" elif $pr.draft then "draft" else "ready" end),
+              markerReceiptExists: ($owned | length > 0),
+              reviewedReceiptSha: ([$owned[].body | select(contains("\nRoute:")) | capture("Reviewed revision: (?<sha>[0-9a-f]{40,64})").sha] | last // null),
+              artifacts: [$files[0][] |
+                if .patch != null then
+                  ({kind: "text", path: .filename, content: .patch}
+                    + if .fullContentBase64 then {fullContentBase64}
+                      elif .status == "removed" then {contextNotApplicable: true}
+                      else {contextUnavailable: true}
+                      end)
+                elif (.filename | test("\\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|tgz|bz2|xz|7z|woff2?|ttf|otf|mp3|mp4|mov|avi|webm|wav|ogg|wasm|class|jar|exe|dll|so|dylib|bin)$"; "i")) then
+                  {kind: "non_text", path: .filename}
+                else
+                  {kind: "unreadable_text", path: .filename}
+                end
+              ],
+              checks: [$checks[0][] | {name, status, conclusion}],
+              statuses: [$statuses[0][] | {context, state}]
+            }
+          ' > inspection-input.json
+      - name: Inspect bounded evidence without GitHub write authority
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npx --yes safeword@0.79.0 --no-input --json review-pr inspect inspection-input.json --output advisory-result.json
+      - name: Upload the JSON-only advisory handoff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: safeword-pr-review-${{ inputs.pull_number }}
+          path: advisory-result.json
+          if-no-files-found: error
+
+  event-context:
+    if: ${{ !inputs.write_requested && !inputs.inspect_requested }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Write non-executable pull-request context
+        env:
+          SAFEWORD_PR_NUMBER: ${{ inputs.pull_number }}
+        run: |
+          jq -n --argjson pullNumber "$SAFEWORD_PR_NUMBER" '{pullNumber: $pullNumber}' > event-context.json
+      - name: Upload the JSON-only event context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: safeword-pr-review-context-${{ inputs.pull_number }}
+          path: event-context.json
+          if-no-files-found: error
+
+  publish:
+    needs: inspect
+    if: ${{ inputs.write_requested }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download the JSON-only advisory handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: safeword-pr-review-${{ inputs.pull_number }}
+      - name: Publish one ordinary pull-request comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SAFEWORD_PR_NUMBER: ${{ inputs.pull_number }}
+        run: npx --yes safeword@0.79.0 --no-input --json review-pr publish advisory-result.json

--- a/.github/workflows/safeword-pr-review.yml
+++ b/.github/workflows/safeword-pr-review.yml
@@ -1,0 +1,66 @@
+name: Safeword advisory PR review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  schedule:
+    - cron: '*/5 * * * *'
+
+permissions: {}
+
+jobs:
+  event-review:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/safeword-pr-review-worker.yml
+    secrets: inherit
+    with:
+      pull_number: ${{ github.event.pull_request.number }}
+      cancel_in_progress: ${{ github.event.action == 'converted_to_draft' }}
+      inspect_requested: ${{ github.event.action != 'converted_to_draft' }}
+      write_requested: false
+
+  discover-ready-pull-requests:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      pull_numbers: ${{ steps.discover.outputs.pull_numbers }}
+    steps:
+      - id: discover
+        name: Discover ready pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pull_numbers="$({
+            gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" --paginate --jq '.[] | select(.draft | not) | [.number, .head.sha] | @tsv' |
+              while IFS=$'\t' read -r pull_number head_sha; do
+                terminal="$(gh api "repos/$GITHUB_REPOSITORY/issues/$pull_number/comments?per_page=100" --paginate --jq "[.[] | select(.user.type == \"Bot\" and (.body | startswith(\"<!-- safeword:pr-review-receipt:v1 -->\")) and (.body | contains(\"Reviewed revision: $head_sha\")) and (.body | contains(\"\\nRoute:\")))] | length" | awk '{ total += $1 } END { print total + 0 }')"
+                if [ "$terminal" = "0" ]; then echo "$pull_number"; fi
+              done
+          } | jq -cs 'map(tonumber)')"
+          echo "pull_numbers=$pull_numbers" >> "$GITHUB_OUTPUT"
+
+  scheduled-review:
+    needs: discover-ready-pull-requests
+    if: needs.discover-ready-pull-requests.outputs.pull_numbers != '[]'
+    strategy:
+      matrix:
+        pull_number: ${{ fromJSON(needs.discover-ready-pull-requests.outputs.pull_numbers) }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/safeword-pr-review-worker.yml
+    secrets: inherit
+    with:
+      pull_number: ${{ matrix.pull_number }}
+      cancel_in_progress: false
+      inspect_requested: true
+      write_requested: true

--- a/.safeword/config.json
+++ b/.safeword/config.json
@@ -13,6 +13,21 @@
   "remoteTest": {
     "setupCommand": "bun install --frozen-lockfile"
   },
+  "prReview": {
+    "enabled": true,
+    "provider": "openai",
+    "model": "gpt-5.5",
+    "maxTotalBytes": 100000,
+    "requiredChecks": [
+      { "context": "Dogfood parity" },
+      { "context": "CLI contract" },
+      { "context": "Dependency audit" },
+      { "context": "test (node 22.23.2)" },
+      { "context": "test (node 24.18.1)" },
+      { "context": "lint" },
+      { "context": "Retro relay deployment inputs" }
+    ]
+  },
   "paths": {
     "architecture": "ARCHITECTURE.md",
     "principles": "PRINCIPLES.md"


### PR DESCRIPTION
## Summary
- enable Safeword's advisory-only PR reviewer in the Safeword repository
- use OpenAI gpt-5.5 with a 100 KB evidence ceiling
- wait for every deterministic CI context before any model call
- install the split-privilege inspection and publication workflows

## Safety and rollout
- draft until the protected `safeword-pr-review-model` environment contains `OPENAI_API_KEY` and gpt-5.5 access is confirmed
- the reviewer posts ordinary advisory comments only; it cannot approve or satisfy merge checks
- disable by setting `prReview.enabled` false and reinstalling

## Verification
- focused PR-review contracts: 23 passed
- invoked retro-relay prerequisite lane: 185 passed, 1 skipped
- `git diff --check`: clean

Tracks #1909.