### PR TITLE
Prevent large PR evidence from breaking advisory review

### DIFF
--- a/.github/workflows/safeword-pr-review-worker.yml
+++ b/.github/workflows/safeword-pr-review-worker.yml
@@ -90,8 +90,7 @@ jobs:
           jq -c '.[]' pull-files.json | while IFS= read -r file; do
             if jq -e '.patch != null and .status != "removed"' > /dev/null <<< "$file"; then
               blob_sha="$(jq -r .sha <<< "$file")"
-              if blob_json="$(gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha")" &&
-                full_content="$(jq -er '
+              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq -er '
                   if .encoding == "base64" and (.content | type) == "string" then
                     .content | gsub("\\n"; "")
                   elif .size == 0 then
@@ -99,8 +98,8 @@ jobs:
                   else
                     error("blob content is not available as base64")
                   end
-                ' <<< "$blob_json")"; then
-                jq --arg fullContentBase64 "$full_content" '. + {$fullContentBase64}' <<< "$file"
+                ' > full-content.base64; then
+                jq --rawfile fullContentBase64 full-content.base64 '. + {$fullContentBase64}' <<< "$file"
               else
                 jq '. + {contextUnavailable: true}' <<< "$file"
               fi

--- a/packages/cli/templates/workflows/pr-review-worker.yml
+++ b/packages/cli/templates/workflows/pr-review-worker.yml
@@ -90,8 +90,7 @@ jobs:
           jq -c '.[]' pull-files.json | while IFS= read -r file; do
             if jq -e '.patch != null and .status != "removed"' > /dev/null <<< "$file"; then
               blob_sha="$(jq -r .sha <<< "$file")"
-              if blob_json="$(gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha")" &&
-                full_content="$(jq -er '
+              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq -er '
                   if .encoding == "base64" and (.content | type) == "string" then
                     .content | gsub("\\n"; "")
                   elif .size == 0 then
@@ -99,8 +98,8 @@ jobs:
                   else
                     error("blob content is not available as base64")
                   end
-                ' <<< "$blob_json")"; then
-                jq --arg fullContentBase64 "$full_content" '. + {$fullContentBase64}' <<< "$file"
+                ' > full-content.base64; then
+                jq --rawfile fullContentBase64 full-content.base64 '. + {$fullContentBase64}' <<< "$file"
               else
                 jq '. + {contextUnavailable: true}' <<< "$file"
               fi

--- a/packages/cli/tests/pr-review/workflow-contract.test.ts
+++ b/packages/cli/tests/pr-review/workflow-contract.test.ts
@@ -214,6 +214,8 @@ describe('advisory PR review workflow contract', () => {
       workerSource.indexOf('> pull-files.json'),
     );
     expect(workerSource).toContain('fullContentBase64');
+    expect(workerSource).toContain('jq --rawfile fullContentBase64 full-content.base64');
+    expect(workerSource).not.toContain('jq --arg fullContentBase64 "$full_content"');
     expect(workerSource).toContain('contextNotApplicable: true');
     expect(workerSource).toContain('contextUnavailable: true');
 


### PR DESCRIPTION
## Root cause
Large blob contents were placed in a shell variable and passed to `jq --arg`, so sufficiently large files exceeded the operating system argument-size limit. Production scheduled runs failed with `Argument list too long`. Authentication and model access were healthy, and smaller PR inspections completed.

## Fix
- stream GitHub blob JSON directly through `jq` into a temporary evidence file
- load that evidence with `jq --rawfile` instead of a command-line argument
- pin the safe handoff in the workflow contract test

## Safety
The scheduled advisory-review workflow is manually disabled until this hotfix is remotely green and merged.

## Verification
- focused workflow contract: 6 passed
- invoked retro-relay prerequisite lane: 185 passed, 1 existing skip
- `git diff --check`: clean

Tracks #1909.