### PR TITLE
Preserve exact PR evidence bytes in advisory review

### DIFF
--- a/.github/workflows/safeword-pr-review-worker.yml
+++ b/.github/workflows/safeword-pr-review-worker.yml
@@ -90,7 +90,7 @@ jobs:
           jq -c '.[]' pull-files.json | while IFS= read -r file; do
             if jq -e '.patch != null and .status != "removed"' > /dev/null <<< "$file"; then
               blob_sha="$(jq -r .sha <<< "$file")"
-              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq -er '
+              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq --join-output --exit-status '
                   if .encoding == "base64" and (.content | type) == "string" then
                     .content | gsub("\\n"; "")
                   elif .size == 0 then

--- a/packages/cli/templates/workflows/pr-review-worker.yml
+++ b/packages/cli/templates/workflows/pr-review-worker.yml
@@ -90,7 +90,7 @@ jobs:
           jq -c '.[]' pull-files.json | while IFS= read -r file; do
             if jq -e '.patch != null and .status != "removed"' > /dev/null <<< "$file"; then
               blob_sha="$(jq -r .sha <<< "$file")"
-              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq -er '
+              if gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" | jq --join-output --exit-status '
                   if .encoding == "base64" and (.content | type) == "string" then
                     .content | gsub("\\n"; "")
                   elif .size == 0 then

--- a/packages/cli/tests/pr-review/workflow-contract.test.ts
+++ b/packages/cli/tests/pr-review/workflow-contract.test.ts
@@ -215,6 +215,8 @@ describe('advisory PR review workflow contract', () => {
     );
     expect(workerSource).toContain('fullContentBase64');
     expect(workerSource).toContain('jq --rawfile fullContentBase64 full-content.base64');
+    expect(workerSource).toContain("| jq --join-output --exit-status '");
+    expect(workerSource).not.toContain("| jq -er '");
     expect(workerSource).not.toContain('jq --arg fullContentBase64 "$full_content"');
     expect(workerSource).toContain('contextNotApplicable: true');
     expect(workerSource).toContain('contextUnavailable: true');


### PR DESCRIPTION
## Root cause
The file-backed large-evidence fix correctly avoided the OS argument limit, but plain `jq` output added a trailing newline. Safeword intentionally requires canonical base64, so every text blob was rejected as missing evidence. The successful sweep therefore produced incomplete receipts instead of useful model reviews.

## Fix
- use `jq --join-output --exit-status` to preserve exact canonical base64 bytes without a newline
- retain file-backed `jq --rawfile` ingestion, so large evidence still avoids argv limits
- pin both invariants in the workflow contract

## Safety
The scheduled advisory-review workflow is manually disabled until this follow-up is remotely green and merged.

## Verification
- focused workflow contract: 6 passed
- invoked retro-relay prerequisite lane: 185 passed, 1 existing skip
- `git diff --check`: clean

Tracks #1909.