### PR TITLE
fix: preserve detached review worker deadline

### DIFF
--- a/packages/cli/src/review/job.ts
+++ b/packages/cli/src/review/job.ts
@@ -24,7 +24,7 @@ import { type CliResult, createResult } from '../cli-protocol/result.js';
 import { retryCommand } from './command.js';
 import { isReviewKind, type ReviewKind } from './contract.js';
 import { prepareReviewPacket } from './packet.js';
-import { runBoundMs } from './runtime.js';
+import { reviewWorkerRunBoundMs } from './runtime.js';
 
 type ReviewJobState = 'launching' | 'running' | 'completed' | 'failed' | 'canceled';
 type WorkerInspection = 'match' | 'mismatch' | 'unavailable';
@@ -675,7 +675,7 @@ export async function startReviewJob(input: {
       source_fingerprint: sourceFingerprint,
       started_at: now,
       updated_at: now,
-      deadline_at: new Date(Date.now() + runBoundMs()).toISOString(),
+      deadline_at: new Date(Date.now() + reviewWorkerRunBoundMs()).toISOString(),
       pid: process.pid,
     };
     writeJob(input.cwd, record);

--- a/packages/cli/src/review/runtime.ts
+++ b/packages/cli/src/review/runtime.ts
@@ -244,6 +244,12 @@ export function runBoundMs(
   return Number.isFinite(configured) && configured > 0 ? Math.min(configured, ceiling) : ceiling;
 }
 
+export function reviewWorkerRunBoundMs(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): number {
+  return runBoundMs({ ...env, SAFEWORD_REVIEW_WORKER: '1' });
+}
+
 /**
  * The least time worth starting a route with. Below this a route cannot produce
  * a real review, so it is honestly reported as not attempted rather than

--- a/packages/cli/tests/review/job.test.ts
+++ b/packages/cli/tests/review/job.test.ts
@@ -178,6 +178,28 @@ describe('durable review jobs', () => {
     expect(result.findings[0]?.code).toBe('REVIEW_NOT_REQUESTED');
   });
 
+  it('gives a detached worker its configured background run bound', async () => {
+    const cwd = project();
+    disableCrossAgentReview(cwd);
+    vi.stubEnv('SAFEWORD_REVIEW_FOREGROUND_MS', '0');
+    vi.stubEnv('SAFEWORD_REVIEW_RUN_BOUND_MS', '600000');
+
+    await startReviewJob({ cwd, kind: 'quality-review', targets: ['input.md'] });
+
+    const jobs = nodePath.join(cwd, '.safeword', 'state', 'reviews');
+    const recordPath = readdirSync(jobs)
+      .filter(name => name.endsWith('.json'))
+      .map(name => nodePath.join(jobs, name))[0];
+    if (recordPath === undefined) throw new Error('review job record was not written');
+    const record = JSON.parse(readFileSync(recordPath, 'utf8')) as {
+      deadline_at: string;
+      started_at: string;
+    };
+    expect(Date.parse(record.deadline_at) - Date.parse(record.started_at)).toBeGreaterThanOrEqual(
+      600_000,
+    );
+  });
+
   it('collects a detached review after the initiating CLI process exits', async () => {
     const cwd = project();
     mkdirSync(nodePath.join(cwd, '.safeword'), { recursive: true });

--- a/plugin/identity.json
+++ b/plugin/identity.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "plugin_version": "0.79.2",
   "hook_manifest_sha256": "ea53d65130d73a4a438d8e9040a17462db52fa3c23e2a0331ed87268543644f4",
-  "inventory_sha256": "99d9cb5918c48583a2e85ef20a9e2bd566b969459cb25f7f8e3f1e83f7adada4"
+  "inventory_sha256": "67f53bc10c36a5be6be4bcd4c80eb1ff0a49580040c8902346d450eec569b823"
 }

--- a/plugin/inventory.json
+++ b/plugin/inventory.json
@@ -143,7 +143,7 @@
     },
     {
       "path": "runtime/cli.js",
-      "sha256": "b0f7f2a06cc493b8911216eecf0cbaec223d1b97c663f858b71c89d3e97a7299"
+      "sha256": "9e522b085971ff19889287a161c2ff93385e83232aa0f62cf252d4ecd2593e16"
     },
     {
       "path": "runtime/dispatch.js",

--- a/plugin/runtime/cli.js
+++ b/plugin/runtime/cli.js
@@ -45514,6 +45514,9 @@ function runBoundMs(env = process.env) {
   const ceiling = reviewRunCeiling(env);
   return Number.isFinite(configured) && configured > 0 ? Math.min(configured, ceiling) : ceiling;
 }
+function reviewWorkerRunBoundMs(env = process.env) {
+  return runBoundMs({ ...env, SAFEWORD_REVIEW_WORKER: "1" });
+}
 function minimumRouteMs(env = process.env) {
   return Math.min(60000, reviewTimeoutMilliseconds(env));
 }
@@ -47520,7 +47523,7 @@ async function startReviewJob(input) {
       source_fingerprint: sourceFingerprint,
       started_at: now,
       updated_at: now,
-      deadline_at: new Date(Date.now() + runBoundMs()).toISOString(),
+      deadline_at: new Date(Date.now() + reviewWorkerRunBoundMs()).toISOString(),
       pid: process.pid
     };
     writeJob(input.cwd, record3);


### PR DESCRIPTION
## Summary

- calculate durable review-job deadlines with the spawned worker runtime ceiling
- preserve configured ten-minute review bounds instead of clamping them to the foreground 270-second ceiling
- add regression coverage for the signed job deadline

## Verification

- `bun run --cwd packages/cli test tests/review/job.test.ts tests/review/runtime.test.ts` (99 passed, 2 skipped)
- ESLint on touched files
- `git diff --check`